### PR TITLE
Add GitHub Actions CI configuration for NVIDIA self-hosted runners

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,3 @@
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+
+jobs:
+  cpu:
+    runs-on: linux-amd64-cpu8
+    steps:
+      - name: Get PR info
+        id: get-pr-info
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+
+      - name: Run wheel build
+        run: |
+          echo "Building wheels..."
+          # Add your wheel build commands here
+
+      - name: Run doc build
+        run: |
+          echo "Building documentation..."
+          # Add your doc build commands here
+
+  gpu:
+    runs-on: linux-amd64-gpu-rtxpro6000-latest-2
+    steps:
+      - name: Get PR info
+        id: get-pr-info
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+
+      - name: Verify GPU availability
+        run: |
+          echo "Verifying GPU access..."
+          nvidia-smi
+
+      - name: Run world model diffusion
+        run: |
+          echo "Running world model diffusion workloads..."
+          # Add your world model diffusion commands here

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>nv-gha-runners/renovate-config"
+  ]
+}


### PR DESCRIPTION
Configure CI workflows to use NVIDIA's self-hosted GPU and CPU runners:
- Add copy-pr-bot configuration to enable automated PR branch syncing
- Add CI workflow with CPU job for wheel builds and doc builds
- Add CI workflow with GPU job for world model diffusion (2x RTX Pro 6000)
- Add Renovate configuration for automated dependency updates

The CPU job uses linux-amd64-cpu8 runners for build tasks, while the GPU job uses linux-amd64-gpu-rtxpro6000-latest-2 runners with 2x RTX Pro 6000 GPUs for world model diffusion workloads.