### PR TITLE
Fully align with I4 perf.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -qq \
         iputils-ping \
         curl \
         git \
+        openssh-client \
         ca-certificates \
         tmux \
         screen \

--- a/flashdreams/examples/run_alpadreams.py
+++ b/flashdreams/examples/run_alpadreams.py
@@ -241,17 +241,16 @@ def main() -> None:
         print(
             f"autoregressive_index: {i}, num_frames: {num_frames}, start: {start}, end: {end}"
         )
-        generated_video.append(
-            pipeline.generate(
-                autoregressive_index=i,
-                cache=cache,
-                hdmap=hdmap_videos_t[:, :, start:end],
-            ).cpu()
+        video_chunk = pipeline.generate(
+            autoregressive_index=i,
+            cache=cache,
+            hdmap=hdmap_videos_t[:, :, start:end],
         )
-        start = end
         stats = pipeline.finalize(i, cache)
         if stats is not None:
             stats_history.append({"autoregressive_index": i, **stats})
+        generated_video.append(video_chunk.cpu())
+        start = end
 
     video = torch.cat(generated_video, dim=2)  # [B, V, T, C, H, W]
     generated_num_frames = video.shape[2]
@@ -279,7 +278,20 @@ def main() -> None:
                 json.dump(stats_history, f, indent=2)
             print(f"saved per-AR-step stats to {stats_path}")
 
+    # Drop captured CUDA graphs / private mempools BEFORE NCCL teardown so
+    # they don't hold workspace buffers across the destroy. Otherwise the
+    # private mempool can outlive the communicator and rank-0's destroy
+    # can hang waiting for already-exited peers.
+    del cache
+    del pipeline
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    # Hold every rank here until rank 0 finishes its mp4 encode. Without
+    # this barrier rank>0 races to destroy_process_group() and exits while
+    # rank 0 is still encoding; rank 0's later destroy then deadlocks
+    # trying to talk to peers that no longer exist.
     if torch.distributed.is_initialized():
+        torch.distributed.barrier()
         torch.distributed.destroy_process_group()
 
 

--- a/flashdreams/examples/run_causal_wan21.py
+++ b/flashdreams/examples/run_causal_wan21.py
@@ -223,7 +223,20 @@ def main() -> None:
                 json.dump(stats_history, f, indent=2)
             print(f"saved per-AR-step stats to {stats_path}")
 
+    # Drop captured CUDA graphs / private mempools BEFORE NCCL teardown so
+    # they don't hold workspace buffers across the destroy. Otherwise the
+    # private mempool can outlive the communicator and rank-0's destroy
+    # can hang waiting for already-exited peers.
+    del cache
+    del pipeline
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    # Hold every rank here until rank 0 finishes its mp4 encode. Without
+    # this barrier rank>0 races to destroy_process_group() and exits while
+    # rank 0 is still encoding; rank 0's later destroy then deadlocks
+    # trying to talk to peers that no longer exist.
     if torch.distributed.is_initialized():
+        torch.distributed.barrier()
         torch.distributed.destroy_process_group()
 
 

--- a/flashdreams/examples/run_causal_wan21.py
+++ b/flashdreams/examples/run_causal_wan21.py
@@ -193,10 +193,11 @@ def main() -> None:
     for i in range(args.total_blocks):
         num_frames = pipeline.get_num_output_frames(i)
         print(f"autoregressive_index: {i}, num_frames: {num_frames}")
-        chunks.append(pipeline.generate(i, cache).cpu())
+        video_chunk = pipeline.generate(i, cache)
         stats = pipeline.finalize(i, cache)
         if stats is not None:
             stats_history.append({"autoregressive_index": i, **stats})
+        chunks.append(video_chunk.cpu())
     generated_video = torch.cat(chunks, dim=1)  # [B, T, C, H, W]
     print("end of streaming inference, generated_video.shape:", generated_video.shape)
 

--- a/flashdreams/examples/run_causal_wan22.py
+++ b/flashdreams/examples/run_causal_wan22.py
@@ -171,7 +171,20 @@ def main() -> None:
                 json.dump(stats_history, f, indent=2)
             print(f"saved per-AR-step stats to {stats_path}")
 
+    # Drop captured CUDA graphs / private mempools BEFORE NCCL teardown so
+    # they don't hold workspace buffers across the destroy. Otherwise the
+    # private mempool can outlive the communicator and rank-0's destroy
+    # can hang waiting for already-exited peers.
+    del cache
+    del pipeline
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    # Hold every rank here until rank 0 finishes its mp4 encode. Without
+    # this barrier rank>0 races to destroy_process_group() and exits while
+    # rank 0 is still encoding; rank 0's later destroy then deadlocks
+    # trying to talk to peers that no longer exist.
     if torch.distributed.is_initialized():
+        torch.distributed.barrier()
         torch.distributed.destroy_process_group()
 
 

--- a/flashdreams/examples/run_causal_wan22.py
+++ b/flashdreams/examples/run_causal_wan22.py
@@ -142,10 +142,11 @@ def main() -> None:
     for i in range(args.total_blocks):
         num_frames = pipeline.get_num_output_frames(i)
         print(f"autoregressive_index: {i}, num_frames: {num_frames}")
-        chunks.append(pipeline.generate(i, cache).cpu())
+        video_chunk = pipeline.generate(i, cache)
         stats = pipeline.finalize(i, cache)
         if stats is not None:
             stats_history.append({"autoregressive_index": i, **stats})
+        chunks.append(video_chunk.cpu())
     generated_video = torch.cat(chunks, dim=1)  # [B, T, C, H, W]
     print("end of streaming inference, generated_video.shape:", generated_video.shape)
 

--- a/flashdreams/examples/run_lingbot_world.py
+++ b/flashdreams/examples/run_lingbot_world.py
@@ -221,17 +221,16 @@ def main() -> None:
             poses=camera_poses_t[:, :, start:end],
             world_scale=float(trans_normalizer),
         )
-        generated_video.append(
-            pipeline.generate(
-                autoregressive_index=i,
-                cache=cache,
-                input=camctrl_input,
-            ).cpu()
+        video_chunk = pipeline.generate(
+            autoregressive_index=i,
+            cache=cache,
+            input=camctrl_input,
         )
-        start = end
         stats = pipeline.finalize(i, cache)
         if stats is not None:
             stats_history.append({"autoregressive_index": i, **stats})
+        generated_video.append(video_chunk.cpu())
+        start = end
 
     video = torch.cat(generated_video, dim=2)  # [B, V, T, C, H, W]
     print("end of streaming inference, generated_video.shape:", video.shape)

--- a/flashdreams/examples/run_lingbot_world.py
+++ b/flashdreams/examples/run_lingbot_world.py
@@ -255,7 +255,20 @@ def main() -> None:
                 json.dump(stats_history, f, indent=2)
             print(f"saved per-AR-step stats to {stats_path}")
 
+    # Drop captured CUDA graphs / private mempools BEFORE NCCL teardown so
+    # they don't hold workspace buffers across the destroy. Otherwise the
+    # private mempool can outlive the communicator and rank-0's destroy
+    # can hang waiting for already-exited peers.
+    del cache
+    del pipeline
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    # Hold every rank here until rank 0 finishes its mp4 encode. Without
+    # this barrier rank>0 races to destroy_process_group() and exits while
+    # rank 0 is still encoding; rank 0's later destroy then deadlocks
+    # trying to talk to peers that no longer exist.
     if torch.distributed.is_initialized():
+        torch.distributed.barrier()
         torch.distributed.destroy_process_group()
 
 

--- a/flashdreams/examples/run_wan21.py
+++ b/flashdreams/examples/run_wan21.py
@@ -154,12 +154,14 @@ def main() -> None:
 
         cache = pipeline.initialize_cache(text=[prompt])
 
-    generated_video = pipeline.generate(autoregressive_index=0, cache=cache).cpu()
-    print("Generated video shape:", generated_video.shape)
-
+    generated_video = pipeline.generate(autoregressive_index=0, cache=cache)
     # Single-AR-step rollouts don't need finalize; run it for API
-    # symmetry (and to log this step's per-stage profiling).
+    # symmetry (and to log this step's per-stage profiling). Call it
+    # before .cpu() so the host sync from the device->host copy isn't
+    # attributed to the "finalize" stage in the per-AR-step timing.
     stats = pipeline.finalize(autoregressive_index=0, cache=cache)
+    generated_video = generated_video.cpu()
+    print("Generated video shape:", generated_video.shape)
 
     # Save the generated video
     canvas = rearrange(generated_video, "t c h w -> t h w c")

--- a/flashdreams/flashdreams/core/distributed/context_parallel.py
+++ b/flashdreams/flashdreams/core/distributed/context_parallel.py
@@ -10,7 +10,9 @@ from torch.distributed import (
 )
 
 
-def split_inputs_cp(x: Tensor, seq_dim: int, cp_group: ProcessGroup) -> Tensor:
+def split_inputs_cp(
+    x: Tensor, seq_dim: int, cp_group: ProcessGroup | None = None
+) -> Tensor:
     """
     Split input tensor along the sequence dimension for context parallelism.
 
@@ -29,6 +31,9 @@ def split_inputs_cp(x: Tensor, seq_dim: int, cp_group: ProcessGroup) -> Tensor:
     Raises:
         AssertionError: If the sequence dimension is not divisible by the number of ranks.
     """
+    if cp_group is None:
+        return x
+
     cp_size = cp_group.size()
     if seq_dim < 0:
         seq_dim = x.ndim + seq_dim  # bring it to positive dimension
@@ -49,7 +54,9 @@ def split_inputs_cp(x: Tensor, seq_dim: int, cp_group: ProcessGroup) -> Tensor:
     return x.contiguous()
 
 
-def cat_outputs_cp(x: Tensor, seq_dim: int, cp_group: ProcessGroup) -> Tensor:
+def cat_outputs_cp(
+    x: Tensor, seq_dim: int, cp_group: ProcessGroup | None = None
+) -> Tensor:
     """
     Concatenate outputs from different ranks in the checkpoint parallelism group.
 
@@ -67,6 +74,9 @@ def cat_outputs_cp(x: Tensor, seq_dim: int, cp_group: ProcessGroup) -> Tensor:
     Raises:
         RuntimeError: If the gather operation fails.
     """
+    if cp_group is None:
+        return x
+
     x = x.contiguous()
 
     # Get the world size (number of processes in the group)
@@ -89,7 +99,7 @@ T = TypeVar("T")
 
 
 def split_inputs_cp_object_list(
-    object_list: list[T], cp_group: ProcessGroup
+    object_list: list[T], cp_group: ProcessGroup | None = None
 ) -> list[T]:
     """
     Split input object list for context parallelism.
@@ -107,6 +117,9 @@ def split_inputs_cp_object_list(
     Raises:
         AssertionError: If the sequence dimension is not divisible by the number of ranks.
     """
+    if cp_group is None:
+        return object_list
+
     cp_size = cp_group.size()
     n_objects = len(object_list)
     assert n_objects % cp_size == 0, f"{n_objects} cannot divide cp_size {cp_size}"
@@ -118,7 +131,9 @@ def split_inputs_cp_object_list(
     return object_list[start_idx:end_idx]
 
 
-def cat_outputs_cp_object_list(object_list: list[T], cp_group: ProcessGroup) -> list[T]:
+def cat_outputs_cp_object_list(
+    object_list: list[T], cp_group: ProcessGroup | None = None
+) -> list[T]:
     """
     Concatenate outputs from different ranks in the context parallelism group.
 
@@ -132,6 +147,9 @@ def cat_outputs_cp_object_list(object_list: list[T], cp_group: ProcessGroup) -> 
     Returns:
         A list of objects that is the concatenation of objects from all ranks in the cp_group.
     """
+    if cp_group is None:
+        return object_list
+
     # Get the world size (number of processes in the group)
     world_size = get_world_size(cp_group)
 

--- a/flashdreams/flashdreams/infra/cuda_graph.py
+++ b/flashdreams/flashdreams/infra/cuda_graph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, Optional
 
 import torch
+from torch.utils._pytree import tree_flatten, tree_unflatten
 
 
 class CUDAGraphWrapper:
@@ -12,22 +13,43 @@ class CUDAGraphWrapper:
 
     The callable runs eagerly for ``warmup_iters`` calls (kernels JIT-load
     and the caching allocator stabilises), then the next call captures
-    the whole forward into a :class:`torch.cuda.CUDAGraph` against a
-    static input buffer; every subsequent same-shape call copies the
-    new input into that buffer and replays the graph, returning a
-    clone of the static output (the next replay would overwrite it).
+    the whole forward into a :class:`torch.cuda.CUDAGraph` against
+    static input buffers; every subsequent same-shape call copies the
+    new inputs into those buffers and replays the graph, returning
+    clones of the captured outputs (the next replay would overwrite
+    them).
 
-    The captured kernels reference the static input pointer, the
-    callable's parameters, the output buffer pointer, AND any internal
+    The captured kernels reference the static input pointers, the
+    callable's parameters, the output buffer pointers, AND any internal
     mutable buffers the callable touches in place (e.g. cache slots).
     Those internal buffers must be at stable storage addresses across
     calls -- typically by writing through an in-place ``copy_`` once a
     slot's shape stabilises during warmup.
 
-    A shape change drops the captured graph and restarts the cycle;
-    :meth:`reset` does the same explicitly (call when the external
-    state the callable depends on -- e.g. a fresh streaming cache --
-    is swapped out).
+    Input staging policy: only TOP-LEVEL tensor positional args and
+    tensor kwargs are copied into static buffers. Everything else (ints,
+    bools, ``None``, dataclasses, dicts, lists, tuples, custom objects)
+    passes through verbatim every call. This is intentional -- callers
+    routinely pass mutable state through containers (e.g. a streaming
+    cache as a ``dict[int, Tensor]`` whose tensors are in-place updated
+    by ``fn``); recursing into those containers would copy those
+    tensors into static buffers and break the in-place semantics. Pass
+    any tensor that varies per call as its own arg/kwarg so the wrapper
+    can stage it.
+
+    A change in the staged-tensor signature -- different set of
+    arg/kwarg names, or any staged tensor's ``shape``/``dtype``
+    changing -- drops the captured graph and restarts the warmup
+    cycle. :meth:`reset` does the same explicitly (call when the
+    external state ``fn`` depends on -- e.g. a fresh streaming cache
+    -- is swapped out).
+
+    Output handling: ``fn``'s return value is treated as a pytree;
+    every tensor leaf is captured into a static buffer and a clone is
+    returned to the caller (so the next replay can safely overwrite
+    the captured buffer). Non-tensor output leaves are passed through
+    by value from the capture call -- if those values vary call to
+    call (e.g. a returned Python int), the wrapper is the wrong tool.
 
     Compatibility with ``torch.compile``: ``fn`` may be a compiled
     callable, but Inductor + triton trigger lazy autotunes
@@ -43,70 +65,159 @@ class CUDAGraphWrapper:
         wrapper = CUDAGraphWrapper(model.forward, warmup_iters=2)
         # Rollout 1 -- variable shapes / Inductor autotune drain.
         for chunk in first_rollout_chunks:
-            y = wrapper.drain(chunk)        # eager, shared static buffer
+            y = wrapper.drain(chunk, timesteps=t, cache=cache)  # eager
         # Rollout 2+ -- steady shape, capture + replay.
         for chunk in steady_rollout_chunks:
-            y = wrapper(chunk)              # 2 warmups -> capture -> replays
+            y = wrapper(chunk, timesteps=t, cache=cache)        # captured
     """
 
-    def __init__(self, fn: Callable[..., torch.Tensor], warmup_iters: int = 2):
+    def __init__(self, fn: Callable[..., Any], warmup_iters: int = 2):
         self.fn = fn
         self.warmup_iters = warmup_iters
         self._graph: Optional[torch.cuda.CUDAGraph] = None
-        self._static_input: Optional[torch.Tensor] = None
-        self._static_output: Optional[torch.Tensor] = None
+        # Input staging state.
+        self._static_args: list[Any] = []  # one slot per positional arg
+        self._static_kwargs: dict[str, Any] = {}  # one slot per kwarg name
+        # Output staging state.
+        self._static_out_leaves: Optional[list[Any]] = None
+        self._out_spec: Any = None
         self._warmup_remaining = warmup_iters
 
     def reset(self) -> None:
         self._graph = None
-        self._static_input = None
-        self._static_output = None
+        self._static_args = []
+        self._static_kwargs = {}
+        self._static_out_leaves = None
+        self._out_spec = None
         self._warmup_remaining = self.warmup_iters
 
-    def _stage_input(self, x: torch.Tensor) -> torch.Tensor:
-        """Copy ``x`` into the (lazily-allocated, contiguous) static input
-        buffer and return that buffer. Used by every entry point so
-        ``self.fn`` always sees the same stride pattern."""
-        if self._static_input is None or self._static_input.shape != x.shape:
-            self.reset()
-            self._static_input = torch.empty_like(x).contiguous()
-        self._static_input.copy_(x)
-        return self._static_input
+    # ------------------------------------------------------------------
+    # Input staging
+    # ------------------------------------------------------------------
 
-    def drain(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
-        """Eager autotune drain through the shared static buffer.
+    @staticmethod
+    def _slot_compatible(slot: Any, fresh: Any) -> bool:
+        """Can ``slot`` (a static buffer or a non-tensor reference) absorb ``fresh``?
+
+        Tensor slot accepts a tensor of the same ``shape`` and
+        ``dtype``; non-tensor slot accepts any non-tensor value (we
+        forward the fresh value verbatim each call).
+        """
+        if isinstance(slot, torch.Tensor):
+            return (
+                isinstance(fresh, torch.Tensor)
+                and slot.shape == fresh.shape
+                and slot.dtype == fresh.dtype
+            )
+        return not isinstance(fresh, torch.Tensor)
+
+    def _slots_compatible_with(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> bool:
+        if len(self._static_args) != len(args):
+            return False
+        if set(self._static_kwargs) != set(kwargs):
+            return False
+        for slot, fresh in zip(self._static_args, args):
+            if not self._slot_compatible(slot, fresh):
+                return False
+        for name, slot in self._static_kwargs.items():
+            if not self._slot_compatible(slot, kwargs[name]):
+                return False
+        return True
+
+    @staticmethod
+    def _make_slot(value: Any) -> Any:
+        """Allocate a static buffer for a tensor, or return the value
+        verbatim for everything else (it'll be forwarded each call)."""
+        if isinstance(value, torch.Tensor):
+            return torch.empty_like(value).contiguous()
+        return value
+
+    def _stage(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        """Copy fresh top-level tensors into static buffers; forward
+        non-tensor args verbatim. Reallocate buffers (and drop the
+        captured graph) whenever the staged-tensor signature changes."""
+        if not self._slots_compatible_with(args, kwargs):
+            self.reset()
+            self._static_args = [self._make_slot(a) for a in args]
+            self._static_kwargs = {k: self._make_slot(v) for k, v in kwargs.items()}
+
+        staged_args: list[Any] = []
+        for slot, fresh in zip(self._static_args, args):
+            if isinstance(slot, torch.Tensor):
+                slot.copy_(fresh)
+                staged_args.append(slot)
+            else:
+                staged_args.append(fresh)
+
+        staged_kwargs: dict[str, Any] = {}
+        for name, fresh in kwargs.items():
+            slot = self._static_kwargs[name]
+            if isinstance(slot, torch.Tensor):
+                slot.copy_(fresh)
+                staged_kwargs[name] = slot
+            else:
+                staged_kwargs[name] = fresh
+
+        return tuple(staged_args), staged_kwargs
+
+    # ------------------------------------------------------------------
+    # Output handling
+    # ------------------------------------------------------------------
+
+    def _clone_output(self) -> Any:
+        assert self._static_out_leaves is not None and self._out_spec is not None
+        cloned = [
+            leaf.clone() if isinstance(leaf, torch.Tensor) else leaf
+            for leaf in self._static_out_leaves
+        ]
+        return tree_unflatten(cloned, self._out_spec)
+
+    # ------------------------------------------------------------------
+    # Public entry points
+    # ------------------------------------------------------------------
+
+    def drain(self, *args: Any, **kwargs: Any) -> Any:
+        """Eager autotune drain through the shared static buffers.
 
         Use during the very first rollout (variable-shape edges aside)
         so Inductor's lazy triton autotunes -- which call
         ``torch.cuda.synchronize`` and would crash a graph capture --
-        run on the eager path against the SAME buffer + stride that
+        run on the eager path against the SAME buffers + strides that
         :meth:`__call__` will later capture against. This prevents a
         second Inductor specialisation (and a second multi-second
-        autotune) when the wrapper takes over from rollout 2 onwards.
+        autotune) when the wrapper takes over from the next rollout
+        onwards.
 
         Doesn't consume ``warmup_iters`` and doesn't capture.
         """
-        return self.fn(self._stage_input(x), *args, **kwargs)
+        args, kwargs = self._stage(args, kwargs)
+        return self.fn(*args, **kwargs)
 
-    def __call__(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
-        static_input = self._stage_input(x)
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        args, kwargs = self._stage(args, kwargs)
 
         if self._graph is not None:
             self._graph.replay()
-            # Clone: replay-on-next-call would overwrite the buffer.
-            return self._static_output.clone()
+            # Clone: the next replay would overwrite the static output buffers.
+            return self._clone_output()
 
         if self._warmup_remaining > 0:
             self._warmup_remaining -= 1
-            return self.fn(static_input, *args, **kwargs)
+            return self.fn(*args, **kwargs)
 
         # Capture: trace one full forward against the static buffers.
         # `cudaStreamBeginCapture` only RECORDS the kernels -- it does
-        # not execute them -- so the static output / any in-place cache
+        # not execute them -- so the static outputs / any in-place cache
         # updates are no-ops at this point. Replay once immediately to
         # actually compute the output and advance the cache.
         self._graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(self._graph):
-            self._static_output = self.fn(static_input, *args, **kwargs)
+            out = self.fn(*args, **kwargs)
+        out_leaves, self._out_spec = tree_flatten(out)
+        self._static_out_leaves = out_leaves
         self._graph.replay()
-        return self._static_output.clone()
+        return self._clone_output()

--- a/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
@@ -47,6 +47,12 @@ from flashdreams.recipes.wan.autoencoder.vae import (
     WanVAEEncoder,
     WanVAEEncoderConfig,
 )
+from flashdreams.core.distributed.context_parallel import (
+    split_inputs_cp,
+    cat_outputs_cp,
+    split_inputs_cp_object_list,
+)
+
 
 AlpadreamsPipelineCache: TypeAlias = StreamInferencePipelineCache[
     EncoderAutoregressiveCache,  # EncCacheT
@@ -168,6 +174,15 @@ class AlpadreamsPipeline(
         )  # [B, V, L, D]
         image_embeddings = self.image_encoder(image)  # [B, V, 1, Cl, Hl, Wl]
 
+        # distribute multi-view
+        text_embeddings = split_inputs_cp(
+            text_embeddings, seq_dim=1, cp_group=self.V_group
+        )
+        image_embeddings = split_inputs_cp(
+            image_embeddings, seq_dim=1, cp_group=self.V_group
+        )
+        view_names = split_inputs_cp_object_list(view_names, cp_group=self.V_group)
+
         return super().initialize_cache(
             transformer_context={
                 "text_embeddings": text_embeddings,
@@ -196,11 +211,19 @@ class AlpadreamsPipeline(
             Decoded video chunk of shape ``[B, V, T, 3, H, W]`` in
             ``[-1, 1]``.
         """
-        return super().generate(
+        # distribute multi-view
+        hdmap = split_inputs_cp(hdmap, seq_dim=1, cp_group=self.V_group)
+
+        # generate
+        output = super().generate(
             autoregressive_index=autoregressive_index,
             cache=cache,
             input=hdmap,
         )
+
+        # gather multi-view
+        output = cat_outputs_cp(output, seq_dim=1, cp_group=self.V_group)
+        return output
 
     def get_num_frames(self, autoregressive_index: int) -> int:
         """Number of decoded video frames produced by AR step ``autoregressive_index``.

--- a/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
@@ -29,6 +29,11 @@ from typing import TypeAlias
 import torch
 from torch import Tensor
 
+from flashdreams.core.distributed.context_parallel import (
+    cat_outputs_cp,
+    split_inputs_cp,
+    split_inputs_cp_object_list,
+)
 from flashdreams.infra.decoder import DecoderAutoregressiveCache
 from flashdreams.infra.encoder import EncoderAutoregressiveCache
 from flashdreams.infra.encoder.text.cosmos_qwen import (
@@ -47,12 +52,6 @@ from flashdreams.recipes.wan.autoencoder.vae import (
     WanVAEEncoder,
     WanVAEEncoderConfig,
 )
-from flashdreams.core.distributed.context_parallel import (
-    split_inputs_cp,
-    cat_outputs_cp,
-    split_inputs_cp_object_list,
-)
-
 
 AlpadreamsPipelineCache: TypeAlias = StreamInferencePipelineCache[
     EncoderAutoregressiveCache,  # EncCacheT

--- a/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
@@ -127,6 +127,12 @@ class AlpadreamsPipeline(
         )
         self._decoder_temporal_compression: int = decoder.TEMPORAL_COMPRESSION_RATIO
 
+        # Take the view split outside of the transformer, so that VAE does not do duplicated job.
+        self.V_group = transformer.cp_groups.V_group
+        self.V_size = transformer.cp_groups.V_size
+        transformer.cp_groups.V_group = None
+        transformer.config.num_views //= self.V_size
+
     @property
     def device(self) -> torch.device:
         return self.diffusion_model.device

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -34,6 +34,7 @@ import torch.nn.functional as F
 from torch import Tensor
 
 from flashdreams.core.checkpoint.load import load_checkpoint
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
@@ -109,12 +110,18 @@ class CosmosTransformerCache(TransformerAutoregressiveCache):
     autoregressive_index: int = -1
 
     def start(self, autoregressive_index: int) -> None:
+        # Hoist the per-block KV pre-update hook out of the network
+        # forward (predict_flow runs the network with eager_mode=False)
+        # so capture-time / replay-time of the network never executes
+        # cache pointer-swap bookkeeping.
         self.autoregressive_index = autoregressive_index
+        self.network_cache.before_update(autoregressive_index)
 
     def finalize(self, autoregressive_index: int) -> None:
-        # Per-block KV update is fused inside the network forward
-        # (eager_mode=True), so finalize is a no-op here.
-        return
+        # Counterpart of start(): per-block KV post-update hook now
+        # lives at the AR-step boundary instead of inside the captured
+        # network forward.
+        self.network_cache.after_update(autoregressive_index)
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +187,18 @@ class CosmosTransformerConfig(TransformerConfig):
 
     # Speedup.
     compile_network: bool = True
+    use_cuda_graph: bool = True
+    """Wrap the (optionally compiled) network in :class:`CUDAGraphWrapper`
+    so steady-state ``predict_flow`` calls replay a captured graph
+    instead of re-launching kernels every denoising step. Caller is
+    responsible for keeping all non-staged inputs (timestep, rope_freqs,
+    masks, hdmap_condition, view_indices) at stable storage addresses
+    across calls -- the wrapper only stages the noisy latent."""
+    warmup_iters: int = 2
+    """Number of eager calls per rollout before the wrapper captures
+    (only consulted when :attr:`use_cuda_graph` is True). Two is the
+    minimum that drains Inductor autotune (call 1) AND gives a clean
+    no-sync stream (call 2) before ``cudaStreamBeginCapture``."""
 
     def __post_init__(self) -> None:
         # Wire HDMap conditioning channel-count.
@@ -203,6 +222,24 @@ class CosmosTransformerConfig(TransformerConfig):
         self._pT = self.len_t // kt
         self._pH = self.height // kh
         self._pW = self.width // kw
+
+        # First AR step at which the per-block KV cache's `cached_k()`
+        # reaches its steady (= window-full) shape. Before this step,
+        # the attention sequence length grows by `_pT` tokens per AR
+        # step (filling phase); from this step onwards every call sees
+        # the same `(sink_size + window_size)` tokens, so the network
+        # forward is shape-stable and safe for CUDA-graph capture.
+        # Counted in chunks (one chunk per AR step):
+        #   chunks_per_window = (sink_size_t + window_size_t) // _pT
+        # The last filling step (chunks_per_window - 1) ALREADY makes
+        # cached_k() return the full prefix, so it counts as steady.
+        chunks_total = self.sink_size_t + self.window_size_t
+        assert chunks_total % self._pT == 0, (
+            f"sink_size_t + window_size_t ({chunks_total}) must be "
+            f"divisible by _pT ({self._pT}) so the BlockKVCache can fit "
+            f"a whole number of AR chunks."
+        )
+        self._steady_ar_idx = chunks_total // self._pT - 1
 
 
 # ---------------------------------------------------------------------------
@@ -277,6 +314,22 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             self.network = torch.compile(  # type: ignore[assignment]
                 self.network, mode="max-autotune-no-cudagraphs"
             )
+
+        # Per-rollout dispatch (when use_cuda_graph=True):
+        # - AR step < cfg._steady_ar_idx (filling phase: cached_k()
+        #   length grows each step): wrapper.drain -- eager through
+        #   the wrapper's static input buffer. Each new shape drains
+        #   its own Inductor autotune so the same shape, when revisited
+        #   in a later rollout, no longer syncs during capture.
+        # - AR step >= cfg._steady_ar_idx (KV window first full and
+        #   stays full): wrapper.__call__ -- 2 warmups + 1 capture,
+        #   then pure replays for every same-shape predict_flow call.
+        self._use_cuda_graph = config.use_cuda_graph
+        self._network_call: Callable[..., Tensor] = (
+            CUDAGraphWrapper(self.network, warmup_iters=config.warmup_iters)
+            if config.use_cuda_graph
+            else self.network
+        )
 
     # ------------------------------------------------------------------
     # Patchify / CP plumbing
@@ -428,6 +481,13 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             mask_other_blocks, process_groups=self._process_groups, cp_dims=[1, 2, 3]
         )
 
+        # Drop any captured CUDA graph from the previous rollout: its
+        # kernels reference the old network_cache's slot pointers,
+        # which the freshly-initialised network_cache invalidates.
+        # Warmup + capture re-run on the next steady-state predict_flow.
+        if self._use_cuda_graph:
+            self._network_call.reset()  # type: ignore[union-attr]
+
         return CosmosTransformerCache(
             network_cache=network_cache,
             rope_adapter=rope_adapter,
@@ -483,8 +543,27 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         noisy_latent = self._maybe_inject_image(noisy_latent, cache)
         condition_video_input_mask = self._select_mask(cache)
 
-        return self.network(
-            x=noisy_latent,
+        # eager_mode=False: per-block KV before_update / after_update
+        # hooks are invoked at the AR-step boundary by
+        # CosmosTransformerCache.start() / .finalize(), not inside the
+        # network forward. This keeps the network forward graph-capture
+        # clean (no cache pointer-swap bookkeeping inside).
+        #
+        # AR step < _steady_ar_idx -> wrapper.drain (filling phase;
+        # cached_k() shape changes every step). AR step >=
+        # _steady_ar_idx -> wrapper.__call__ (window full, shape
+        # stable; warmup -> capture -> replay). See `__init__` for the
+        # per-rollout dispatch contract.
+        if self._use_cuda_graph:
+            network = (
+                self._network_call.drain  # type: ignore[union-attr]
+                if ar_idx < self.config._steady_ar_idx
+                else self._network_call
+            )
+        else:
+            network = self.network
+        return network(
+            noisy_latent,
             timesteps=timestep,
             rope_freqs=rope_freqs,
             cache=cache.network_cache,
@@ -492,7 +571,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             current_chunk_idx=ar_idx,
             hdmap_condition=input,
             view_indices=cache.view_indices,
-            eager_mode=True,
+            eager_mode=False,
         )
 
     def postprocess_clean_latent(

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -441,7 +441,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         )
 
         view_indices: Tensor | None = None
-        if cfg.num_views > 1:
+        if cfg.network.enable_cross_view_attn:
             assert view_names is not None and len(view_names) == cfg.num_views, (
                 f"view_names of length {cfg.num_views} required when "
                 f"num_views > 1 (got {view_names})"

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/context_parallel.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/context_parallel.py
@@ -29,23 +29,23 @@ class HierarchicalCPGroups:
 
     @property
     def HW_size(self) -> int:
-        return len(self.HW_ranks) or 1
+        return 1 if self.HW_group is None else self.HW_group.size()
 
     @property
     def T_size(self) -> int:
-        return len(self.T_ranks) or 1
+        return 1 if self.T_group is None else self.T_group.size()
 
     @property
     def THW_size(self) -> int:
-        return len(self.THW_ranks) or 1
+        return 1 if self.THW_group is None else self.THW_group.size()
 
     @property
     def V_size(self) -> int:
-        return len(self.V_ranks) or 1
+        return 1 if self.V_group is None else self.V_group.size()
 
     @property
     def VHW_size(self) -> int:
-        return len(self.VHW_ranks) or 1
+        return 1 if self.VHW_group is None else self.VHW_group.size()
 
 
 def create_hierarchical_cp_groups(

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/rope.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/rope.py
@@ -252,4 +252,6 @@ def apply_rope_freqs(x: Tensor, freqs: Tensor, interleaved: bool = False) -> Ten
     Returns:
         Output tensor of shape ``[B, S, H, D]``.
     """
-    return apply_rotary_pos_emb(x, freqs, interleaved)
+    return apply_rotary_pos_emb(
+        x, freqs, tensor_format="bshd", fused=True, interleaved=interleaved
+    )

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/rope.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/rope.py
@@ -252,6 +252,4 @@ def apply_rope_freqs(x: Tensor, freqs: Tensor, interleaved: bool = False) -> Ten
     Returns:
         Output tensor of shape ``[B, S, H, D]``.
     """
-    return apply_rotary_pos_emb(
-        x, freqs, tensor_format="bshd", fused=True, interleaved=interleaved
-    )
+    return apply_rotary_pos_emb(x, freqs, interleaved)


### PR DESCRIPTION
- Profiling fix: move postpone `.cpu()` so that the profiling for `finalize` is correct.
- CUDAGraph support for AlpaDreams.
- Multi-GPU VAE support for 4-View AlpaDreams
- Bug fix: AlpaDreams default resolution 720 -> 704
- add "openssh-client" in the docker file for working in a container.

Profiling now aligns with I4:

single-view:
<img width="2026" height="1054" alt="image" src="https://github.com/user-attachments/assets/c5016b0d-2d3d-4f55-a54b-8595bdf83ed2" />

4-view:
<img width="2060" height="972" alt="image" src="https://github.com/user-attachments/assets/196f229f-a836-4de5-ae0c-7485398282be" />

Only profiled up to 4 GPUs because requesting \> 4 is hard today. Will complete later on.

[port of sil/flashdreams!22]