### PR TITLE
Add KV-drop experiment report and implement KV-drop functionality in alpadreams pipeline

### DIFF
--- a/KV_DROP_EXPERIMENT.md
+++ b/KV_DROP_EXPERIMENT.md
@@ -311,21 +311,3 @@ The 4-view config is also supported:
 - Concrete numbers used in this report come from the chunk4 recipe
   (`len_t = 4`, `pH * pW = 45 * 80`, `window_size_t = 8`,
   `temporal_compression = 4`, `patch_temporal = 1`).
-
-## Command to run the experiment
-
-Experiment command:
-```bash
-torchrun --nproc_per_node=1 examples/run_alpadreams.py \
-    --n_cameras 1 --total_blocks 60 \
-    --overwrite_config_name sv_2steps_chunk4_loc8_pshuffle_lighttae \
-    --no_compile --kv_drop_t 1
-```
-
-Baseline command:
-```bash
-torchrun --nproc_per_node=1 examples/run_alpadreams.py \
-    --n_cameras 1 --total_blocks 60 \
-    --overwrite_config_name sv_2steps_chunk4_loc8_pshuffle_lighttae \
-    --no_compile --kv_drop_t 0
-```

--- a/KV_DROP_EXPERIMENT.md
+++ b/KV_DROP_EXPERIMENT.md
@@ -1,0 +1,331 @@
+# Alpadreams KV-Drop Experiment Report
+
+This document describes the design and implementation of the
+**KV-drop** inference-time experiment for the alpadreams autoregressive
+rollout. The goal is to test whether the same trained checkpoint can be
+inferenced with a *sliding-window overlap* between consecutive AR steps,
+where the trailing `kv_drop_t` latent frames per step are discarded
+from the persistent KV cache and re-rolled / re-denoised at the head of
+the next step's query window. Implementation is gated by a new
+`kv_drop_t` field on `CosmosTransformerConfig`; setting it to `0`
+exactly reproduces the existing rollout.
+
+## Motivation
+
+In the existing alpadreams rollout each AR step:
+
+- denoises `len_t` latent frames per step (`len_t = 4` in the chunk4
+  recipes),
+- commits all `len_t` K/V tokens to the persistent KV cache,
+- emits `len_t * temporal_compression` decoded frames per step,
+- advances the AR pointer by `len_t * temporal_compression` decoded
+  frames.
+
+The KV-drop scheme tests an inference-only modification:
+
+- still denoise `len_t` latent frames per step,
+- but commit only `len_t - kv_drop_t` of them to the persistent KV
+  cache and to the streaming decoder,
+- emit `(len_t - kv_drop_t) * temporal_compression` decoded frames per
+  step,
+- advance the AR pointer by `(len_t - kv_drop_t) * temporal_compression`
+  decoded frames; the next step's query window therefore *overlaps* the
+  current step's tail by `kv_drop_t` latent frames.
+
+The empirical question is whether the dropped tail being re-denoised
+with one extra step of future context — at the head of the next AR
+step's window — improves visual quality, costs quality, or stays
+roughly neutral, given that the trained checkpoint never saw this
+inference pattern.
+
+## Scheme
+
+For chunk4 (`len_t = 4`) with `kv_drop_t = 1`:
+
+```text
+latent t →   0  1  2  3  4  5  6  7  8  9 10 11
+step 0      [▓  ▓  ▓  ░]
+                      └─↻ re-denoised in step 1
+step 1               [▓  ▓  ▓  ░]
+                              └─↻ re-denoised in step 2
+step 2                        [▓  ▓  ▓  ░]
+                                       └─↻ re-denoised in step 3
+step 3                                 [▓  ▓  ▓  ░]
+```
+
+`▓` = committed (KV cache + decoder + output), `░` = denoised then
+discarded, `↻` = re-rolled with fresh noise as the head of the next
+step's window.
+
+Per step:
+
+- DiT denoises `len_t = 4` latent positions (no compute change).
+- KV cache writes `(len_t - kv_drop_t) * pH * pW = 3 * pH * pW` tokens.
+- Streaming decoder consumes 3 latent frames, producing `3 * 4 = 12`
+  RGB frames (or `1 + (3 - 1) * 4 = 9` at AR step 0 due to the
+  first-decode trim).
+- AR pointer advances by 9 (step 0) / 12 (steady-state) decoded frames.
+- Consecutive HDMap input windows overlap by `kv_drop_t * 4 = 4`
+  decoded frames.
+
+## Key invariants
+
+1. **Persistent cache window stays at `window_size_t` latent frames**
+   (chunk4 = 8). The new path does NOT change the persistent locality
+   budget; the trained checkpoint still sees at most 8 frames of
+   committed history.
+2. **Attention-visible window stays at `window_size_t + sink_size_t`
+   latent positions per self-attention call**. Within a step the
+   committed prefix attends to history + the transient X tail, but the
+   *visible* sequence is capped by temporarily hiding the oldest
+   `excess` cached tokens FROM THE ATTENTION VIEW ONLY. The persistent
+   buffer is never modified by this hiding.
+3. **`kv_drop_t = 0` is the legacy path bit-for-bit.** All new control
+   flow degenerates: the commit prefix equals the full denoising
+   window, no transient tail, no eviction-from-view, decoder receives
+   the full clean latent.
+4. **Within-step self-attention is preserved.** The X tail K/V is
+   computed locally for the current `predict_flow` call and concatenated
+   into the attention K/V (after capping). All `len_t` queries in the
+   current step see history + full `len_t` current K/V, just as during
+   training.
+5. **Multiple `predict_flow` calls within one AR step (denoising loop +
+   finalize-pass at `context_noise = 128`) overwrite the same commit
+   slice.** The persistent cache state at the end of an AR step is the
+   finalize-pass committed prefix; the transient tail from any pass is
+   never persisted.
+6. **RoPE positions remain consistent across overlap.** Step `t`'s
+   queries land at absolute RoPE positions
+   `[t * _pT_commit, t * _pT_commit + _pT)`, where
+   `_pT_commit = (len_t - kv_drop_t) // patch_temporal`. Overlap
+   positions get the same absolute RoPE index in both AR steps that
+   touch them.
+
+## Files modified
+
+### Core attention and KV cache
+
+- [`flashdreams/core/attention/kvcache.py`](flashdreams/flashdreams/core/attention/kvcache.py)
+  - Refactored `BlockKVCache` from split filling/steady-state
+    chunk-aligned writes into a unified roll-and-append path for the
+    `sink_size == 0` case. The path supports non-divisible windows
+    (`window_size` no longer needs to be a multiple of `chunk_size`):
+    each new chunk evicts exactly
+    `max(0, _n_cached + chunk_size - window_size)` of the oldest
+    rolling tokens, then appends the chunk at the right edge. Repeated
+    same-`chunk_idx` updates overwrite a tracked
+    `_last_write_start / _last_write_end` slice instead of appending
+    again.
+  - The `sink_size > 0` path is preserved unchanged (still asserts
+    `(window_size + sink_size) % chunk_size == 0`); a `FIXME` notes that
+    extending the non-divisible roll-and-append path to non-zero sink is
+    out of scope for this experiment.
+  - `cached_k()` / `cached_v()` now use `min(_n_cached + chunk_size,
+    total_size)` to compute the visible end, which collapses to the old
+    formula when divisible.
+
+### Self-attention
+
+- [`flashdreams/recipes/alpadreams/transformer/impl/modules.py`](flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py)
+  - Rewrote `SelfAttention.forward`: project the full `len_t` K/V
+    locally (with RoPE), write only the leading `kv_cache.chunk_size`
+    tokens to the persistent cache, then build the attention-visible
+    K/V as `cat(cached_k_visible, k_trans)` where
+    `cached_k_visible = cached_k()[..., excess:, :, :]` and
+    `excess = max(0, cached_len + trans_len - (window_size + sink_size))`.
+    The base `MultiHeadAttention.forward` and the `CrossAttention`
+    path are untouched, so cross-attention (which projects K/V from a
+    different feature dimension) keeps its original signature and
+    behavior.
+
+### Transformer + recipes
+
+- [`flashdreams/recipes/alpadreams/transformer/__init__.py`](flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py)
+  - Added `kv_drop_t: int = 1` to `CosmosTransformerConfig` with
+    assertions (`0 <= kv_drop_t < len_t` and
+    `(len_t - kv_drop_t) % patch_temporal == 0`) and derived helpers
+    `_len_t_commit = len_t - kv_drop_t` (pre-patchify) and
+    `_pT_commit = _len_t_commit // patch_temporal` (post-patchify).
+  - `CosmosTransformer.__init__` now raises `NotImplementedError` when
+    `kv_drop_t > 0` is combined with T-axis context parallelism
+    (`cp_groups.T_size > 1`) or `compile_network=True`, because both
+    cases need design work that is out of scope for the first cut.
+  - `CosmosTransformer.initialize_autoregressive_cache` now passes
+    `chunk_size = num_tokens_per_view_per_step * cfg._pT_commit`
+    (instead of `* cfg._pT`) to `network.initialize_cache`. The
+    persistent cache therefore advances by the committed temporal
+    stride.
+  - `CosmosTransformer.predict_flow` shifts RoPE by
+    `ar_idx * cfg._pT_commit` (instead of `ar_idx * cfg._pT`).
+
+- [`flashdreams/recipes/alpadreams/config.py`](flashdreams/flashdreams/recipes/alpadreams/config.py)
+  - `_transformer_config(...)` accepts a `kv_drop_t: int = 1` kwarg and
+    forwards it to `CosmosTransformerConfig`.
+  - chunk4 builders
+    (`build_sv_2steps_chunk4_loc8_pshuffle_lighttae`,
+    `build_mv_2steps_chunk4_loc8_pshuffle_lighttae`) default
+    `kv_drop_t=1` (the experiment).
+  - chunk2 / chunk3 builders default `kv_drop_t=0` because they use a
+    stateful Wan VAE HDMap encoder that is not yet supported with
+    overlap (see "First-cut limitations" below). Existing tests against
+    these recipes therefore continue to exercise the legacy path.
+
+### Pipeline
+
+- [`flashdreams/infra/pipeline/base.py`](flashdreams/flashdreams/infra/pipeline/base.py)
+  - Added `_pre_decode_hook(clean_latent, autoregressive_index)` to
+    `StreamInferencePipeline.generate`, called between the diffusion
+    model and the decoder. Default returns `clean_latent` unchanged.
+    The `FinalState` stashed on the pipeline cache holds the unsliced
+    clean latent, so subclasses can return a sliced view without
+    affecting the AR cache or the finalize path.
+
+- [`flashdreams/recipes/alpadreams/pipeline.py`](flashdreams/flashdreams/recipes/alpadreams/pipeline.py)
+  - Caches `_len_t_latent`, `_len_t_commit`, and `_kv_drop_t` from the
+    transformer config.
+  - Raises `NotImplementedError` in `__init__` when `kv_drop_t > 0` is
+    combined with a stateful `WanVAEEncoder` HDMap encoder.
+  - Splits the per-step frame-count API into:
+    - `get_num_input_frames(i)` (HDMap input window, sized by `len_t`):
+      - step 0: `1 + (len_t - 1) * temporal_compression`
+      - steady: `len_t * temporal_compression`
+    - `get_num_output_frames(i)` (decoded frames + AR pointer advance,
+      sized by `_len_t_commit`):
+      - step 0: `1 + (_len_t_commit - 1) * temporal_compression`
+      - steady: `_len_t_commit * temporal_compression`
+    - `get_num_frames(i)` is kept as a back-compat alias for
+      `get_num_output_frames(i)`.
+  - Overrides `_pre_decode_hook` to slice
+    `clean_latent[:, :, : self._len_t_commit]` before passing to the
+    streaming decoder, so the decoder cache (TAEHV / Wan VAE) advances
+    by the committed prefix only. Skipped when
+    `_len_t_commit == _len_t_latent`.
+
+### Example runner
+
+- [`flashdreams/examples/run_alpadreams.py`](flashdreams/examples/run_alpadreams.py)
+  - Added `--kv_drop_t` CLI flag. When set, it is passed straight to
+    the recipe builder (rather than mutating the config after build),
+    so other knobs that depend on `kv_drop_t` are picked up
+    consistently.
+  - The AR loop now uses `get_num_input_frames(i)` to slice the HDMap
+    input window and `get_num_output_frames(i)` to advance the AR
+    pointer, so consecutive HDMap windows overlap by
+    `kv_drop_t * temporal_compression` decoded frames when
+    `kv_drop_t > 0`.
+
+### gRPC server (production)
+
+- [`integrations/alpadreams/.../video_model_flashdreams_pipeline.py`](integrations/alpadreams/alpadreams/conditioning/video_model_flashdreams_pipeline.py)
+  - Builds `CosmosTransformerConfig` directly. Pinned `kv_drop_t=0`
+    explicitly so the production server keeps the legacy
+    non-overlapping rollout regardless of the new field's default; this
+    avoids quietly turning on the experiment for production traffic.
+
+## First-cut limitations
+
+When `kv_drop_t > 0`, the implementation explicitly raises
+`NotImplementedError` in any of the following situations:
+
+1. **Wan VAE HDMap encoder.** The chunk2 / chunk3 recipes use the
+   `WanVAEEncoder`, whose `WanVAECache` advances by however many input
+   pixel frames it sees. Overlapping HDMap input windows would push the
+   encoder state past where the AR pointer actually is. PixelShuffle
+   (chunk4) is stateless w.r.t. temporal context (`last_frame` mode
+   re-indexes from each local input window) and is safe.
+2. **T-axis context parallelism.** With `cp_groups.T_size > 1`, each
+   rank's local prefix slice does not equal the global temporal
+   prefix; ranks owning the dropped tail would mis-commit their tokens.
+   HW-only CP is also gated for now until tested.
+3. **`torch.compile`.** Non-divisible rolling windows, transient tails,
+   and dynamic `excess` values introduce dynamic shapes that have not
+   been validated under `torch.compile`. Run with `--no_compile`.
+
+The plan calls these out as `FIXME`s in the relevant code paths.
+Lifting them is future work and is independent of the
+`kv_drop_t = 1` experiment itself.
+
+## How to run
+
+Two runs on the same prompt / HDMap / seed make the comparison clean:
+
+Baseline (legacy non-overlapping rollout):
+
+```bash
+torchrun --nproc_per_node=1 flashdreams/examples/run_alpadreams.py \
+    --n_cameras 1 --total_blocks 60 \
+    --overwrite_config_name sv_2steps_chunk4_loc8_pshuffle_lighttae \
+    --no_compile --kv_drop_t 0
+```
+
+Experiment (`kv_drop_t = 1` overlap):
+
+```bash
+torchrun --nproc_per_node=1 flashdreams/examples/run_alpadreams.py \
+    --n_cameras 1 --total_blocks 60 \
+    --overwrite_config_name sv_2steps_chunk4_loc8_pshuffle_lighttae \
+    --no_compile --kv_drop_t 1
+```
+
+The 4-view config is also supported:
+`mv_2steps_chunk4_loc8_pshuffle_lighttae`.
+
+## Expected behavior to verify
+
+- **Bit-for-bit baseline at `--kv_drop_t 0`.** With everything else
+  held constant, the experiment knob `0` should produce the same
+  rollout as `HEAD` (chunk size, RoPE offsets, encoder window, decoder
+  window, output frame count all unchanged).
+- **Frame counts at `--kv_drop_t 1` (chunk4).** Step 0 emits 9 RGB
+  frames (vs 13 in the baseline), steady-state steps emit 12 RGB
+  frames (vs 16). Total emitted frames per `total_blocks` is therefore
+  smaller under `kv_drop_t = 1`.
+- **Persistent KV cache cap.** After steady state, each view's
+  persistent KV cache holds at most `window_size_t = 8` committed
+  latent frames worth of K/V (same as baseline).
+- **Attention-visible K/V cap.** Each self-attention call sees at most
+  `window_size_t + sink_size_t = 8` latent positions, by temporarily
+  hiding the oldest cached tokens when adding the transient tail. The
+  persistent cache itself is not modified by the hiding.
+- **Transient tail does not persist.** After an AR step finishes, the
+  cache reflects only the finalize-pass's committed prefix; the X
+  tokens at the tail are absent from `cache.cached_k()`.
+- **Quality (open empirical question).** The trained checkpoint never
+  saw this inference pattern. Three plausible outcomes:
+  1. Mostly fine, with a small quality dip;
+  2. A noticeable seam at the step-0 / step-1 boundary because step 1
+     re-denoises latent index 3 (= source frame 12) from fresh noise
+     against a length-3 cache rather than the length-4 cache that
+     training expected;
+  3. Degradation that snowballs as the AR step count grows.
+- **Run-time cost.** DiT compute is unchanged (still denoises `len_t`
+  positions per step), but extra encoder / decoder work is wasted on
+  the dropped tail, so wall-time is roughly the same. The benefit is
+  purely on the conditioning pattern at commit time, not on throughput.
+
+## Pointers
+
+- Plan / design notes: `.cursor/plans/visualize-ar-overlap-scheme_*.plan.md`
+  (kept for the design discussion; not required to use the
+  implementation).
+- Concrete numbers used in this report come from the chunk4 recipe
+  (`len_t = 4`, `pH * pW = 45 * 80`, `window_size_t = 8`,
+  `temporal_compression = 4`, `patch_temporal = 1`).
+
+## Command to run the experiment
+
+Experiment command:
+```bash
+torchrun --nproc_per_node=1 examples/run_alpadreams.py \
+    --n_cameras 1 --total_blocks 60 \
+    --overwrite_config_name sv_2steps_chunk4_loc8_pshuffle_lighttae \
+    --no_compile --kv_drop_t 1
+```
+
+Baseline command:
+```bash
+torchrun --nproc_per_node=1 examples/run_alpadreams.py \
+    --n_cameras 1 --total_blocks 60 \
+    --overwrite_config_name sv_2steps_chunk4_loc8_pshuffle_lighttae \
+    --no_compile --kv_drop_t 0
+```

--- a/flashdreams/examples/run_alpadreams.py
+++ b/flashdreams/examples/run_alpadreams.py
@@ -117,6 +117,22 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Disable torch.compile of the DiT network.",
     )
+    parser.add_argument(
+        "--kv_drop_t",
+        type=int,
+        default=None,
+        help=(
+            "Override `CosmosTransformerConfig.kv_drop_t` (number of "
+            "trailing latent frames per AR step that are NOT committed to "
+            "the persistent KV cache and decoder; the X tail still "
+            "participates in the current step's self-attention as a "
+            "transient, then is re-rolled and re-denoised next step). "
+            "Defaults to the builder's value (1). Pass 0 for the legacy "
+            "non-overlapping rollout. Currently requires --no_compile, no "
+            "T-axis context parallelism, and a PixelShuffle HDMap encoder "
+            "config (chunk4)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -172,11 +188,17 @@ def main() -> None:
         print("HF_TOKEN detected; using env-var auth for huggingface_hub")
 
     builder = ALPADREAMS_CONFIG_BUILDERS[config_name]
-    pipeline_config = builder(
+    builder_kwargs: dict[str, int | bool] = dict(
         cp_size=world_size,
         compile_network=not args.no_compile,
         seed=42 + rank,
     )
+    # Pass the CLI override straight to the builder rather than mutating
+    # the config after construction, so the recipe's other knobs (e.g.
+    # ``window_size_t``) can react to ``kv_drop_t`` consistently.
+    if args.kv_drop_t is not None:
+        builder_kwargs["kv_drop_t"] = args.kv_drop_t
+    pipeline_config = builder(**builder_kwargs)
     pipeline = pipeline_config.setup()
     pipeline.to(device=device)
 
@@ -234,12 +256,21 @@ def main() -> None:
     stats_history: list[dict[str, float]] = []
     start = 0
     for i in range(args.total_blocks):
-        num_frames = pipeline.get_num_frames(i)
-        end = start + num_frames
+        # The DiT still consumes a full ``len_t``-sized HDMap window per
+        # AR step (so it can denoise N latent positions, including the
+        # trailing ``kv_drop_t`` transient tail). The AR pointer only
+        # advances by the COMMITTED frame count -- with ``kv_drop_t > 0``
+        # consecutive input windows therefore overlap by
+        # ``kv_drop_t * temporal_compression`` frames.
+        input_frames = pipeline.get_num_input_frames(i)
+        output_frames = pipeline.get_num_output_frames(i)
+        end = start + input_frames
         if end > hdmap_num_frames:
             break
         print(
-            f"autoregressive_index: {i}, num_frames: {num_frames}, start: {start}, end: {end}"
+            f"autoregressive_index: {i}, "
+            f"input_frames: {input_frames}, output_frames: {output_frames}, "
+            f"start: {start}, end: {end}"
         )
         generated_video.append(
             pipeline.generate(
@@ -248,7 +279,7 @@ def main() -> None:
                 hdmap=hdmap_videos_t[:, :, start:end],
             ).cpu()
         )
-        start = end
+        start += output_frames
         stats = pipeline.finalize(i, cache)
         if stats is not None:
             stats_history.append({"autoregressive_index": i, **stats})

--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -13,17 +13,28 @@ class BlockKVCache:
     Keys and values can have arbitrary shape ``[..., total_size, ...]``; the sequence
     (rolling) dimension is given by ``seq_dim`` (dimension index, can be negative).
     Layout along that dimension: [sink tokens | local window tokens]. Sink tokens are
-    never evicted; the local window rolls left as new chunks are added if full. Chunks are
-    non-overlapping: each update adds one chunk of ``chunk_size`` tokens at the
-    next logical position in the full sequence.
+    never evicted; the local window rolls left as new chunks are added if full.
 
-    Note: Currently only support total_size (sink_size + window_size) divisible by chunk_size.
+    There are two write paths internally:
 
-    Phases:
+    - **Sink-aware chunk-aligned** (when ``sink_size > 0``): preserves the
+      original behavior where each update writes exactly ``chunk_size``
+      tokens, the rolling window is rolled left by ``chunk_size`` whenever
+      the buffer is full, and ``(window_size + sink_size)`` must be a
+      multiple of ``chunk_size``. New chunks that would overlap the sink
+      region drop their leading tokens.
+    - **Roll-and-append** (when ``sink_size == 0``): unifies filling and
+      steady-state writes. Before each new chunk, evict exactly
+      ``max(0, n_cached + chunk_size - window_size)`` of the oldest
+      rolling tokens, then append the new chunk at the right edge.
+      ``window_size`` is no longer required to be a multiple of
+      ``chunk_size``; ``chunk_size <= window_size`` is required.
+
+    Phases (descriptive only; not enforced as a state machine):
         - Filling: cache not yet full; tokens are written contiguously;
           ``cached_k()`` / ``cached_v()`` return only the valid prefix.
-        - Steady-state: cache full; each new chunk triggers a left-roll of the
-          local window and overwrites the rightmost positions;
+        - Steady-state: cache full; each new chunk triggers a left-roll of
+          the local window and overwrites the rightmost positions;
           ``cached_k()`` / ``cached_v()`` return the full buffer.
 
     The argument ``chunk_idx`` (0, 1, 2, ...) is the index of the new chunk in the full
@@ -78,6 +89,13 @@ class BlockKVCache:
     _v: Tensor = field(init=False)
     """Cached values. shape ``[..., total_size, ..., Dv]``, where the ``total_size`` is the length of the cache buffer at ``seq_dim`` dimension."""
 
+    _last_write_start: int = 0
+    """Start index of the most recent successful write along ``seq_dim``.
+    Re-used by same-``chunk_idx`` overwrites in the roll-and-append path."""
+
+    _last_write_end: int = 0
+    """End index of the most recent successful write along ``seq_dim``."""
+
     @classmethod
     def from_tensor(cls, k: Tensor, v: Tensor, seq_dim: int) -> Self:
         cache = cls(
@@ -117,10 +135,35 @@ class BlockKVCache:
             f"k_shape[seq_dim] ({self.k_shape[self.seq_dim]}) must equal sink_size + window_size ({expected_length})"
         )
 
-        # check window_size + sink_size should be divisible by chunk_size
-        assert (self.window_size + self.sink_size) % self.chunk_size == 0, (
-            f"window_size + sink_size ({self.window_size + self.sink_size}) must be divisible by chunk_size ({self.chunk_size})"
-        )
+        if self.sink_size > 0:
+            # Sink-aware chunk-aligned path: keep the original divisibility
+            # requirement so the rolling window stays chunk-aligned and
+            # incoming chunks that overlap the sink region can drop their
+            # leading tokens deterministically.
+            #
+            # FIXME: extend the roll-and-append path to support a non-zero
+            # sink (e.g. by always preserving slots [0:sink_size] and
+            # rolling only the [sink_size:] subrange). Not needed for the
+            # alpadreams ``kv_drop_t`` experiment because alpadreams sets
+            # ``sink_size_t == 0``.
+            assert (
+                self.window_size + self.sink_size
+            ) % self.chunk_size == 0, (
+                f"window_size + sink_size ({self.window_size + self.sink_size}) "
+                f"must be divisible by chunk_size ({self.chunk_size}) when "
+                f"sink_size > 0; non-divisible rolling windows with non-zero "
+                f"sink are not implemented yet."
+            )
+        else:
+            # Roll-and-append path: ``window_size`` does not need to be a
+            # multiple of ``chunk_size``, but each chunk must fit inside
+            # the rolling window so we never have to drop leading tokens
+            # from the incoming chunk itself.
+            assert self.chunk_size <= self.window_size, (
+                f"chunk_size ({self.chunk_size}) must be <= window_size "
+                f"({self.window_size}) in the roll-and-append path "
+                f"(sink_size == 0)."
+            )
 
         # initialize k and v
         self._k = torch.empty(self.k_shape, device=self.device, dtype=self.dtype)
@@ -199,6 +242,50 @@ class BlockKVCache:
         self._k[sl] = k
         self._v[sl] = v
 
+    def _roll_and_append(self, k: Tensor, v: Tensor) -> None:
+        """Unified roll-and-append for ``sink_size == 0`` (handles non-divisible windows).
+
+        Evicts exactly ``max(0, _n_cached + chunk_size - window_size)`` of the
+        oldest rolling tokens, shifts the remaining valid prefix left to cover
+        the eviction, and writes the incoming chunk at the right edge of the
+        valid region. ``_n_cached`` itself is bumped in :meth:`after_update`.
+        """
+        chunk_size = self.chunk_size
+        window = self.window_size
+
+        excess = self._n_cached + chunk_size - window
+        if excess > 0:
+            # Shift the (n_cached - excess) trailing rolling tokens to the
+            # front, freeing space at the right edge for the new chunk.
+            keep = self._n_cached - excess
+            if keep > 0:
+                src = self._seq_slice(excess, self._n_cached)
+                dst = self._seq_slice(0, keep)
+                self._k[dst] = self._k[src].clone()
+                self._v[dst] = self._v[src].clone()
+            write_start = keep
+        else:
+            write_start = self._n_cached
+
+        write_end = write_start + chunk_size
+        sl = self._seq_slice(write_start, write_end)
+        self._k[sl] = k
+        self._v[sl] = v
+
+        self._last_write_start = write_start
+        self._last_write_end = write_end
+
+    def _overwrite_last_write(self, k: Tensor, v: Tensor) -> None:
+        """Re-write the slice of the most recent successful write.
+
+        Used by same-``chunk_idx`` updates in the roll-and-append path,
+        which can be triggered by repeated ``predict_flow`` calls inside
+        one AR step (denoising loop iterations + the finalize pass).
+        """
+        sl = self._seq_slice(self._last_write_start, self._last_write_end)
+        self._k[sl] = k
+        self._v[sl] = v
+
     def is_steady_state(self) -> bool:
         """Return True if the cache is full (steady-state phase)."""
         assert self._curr_chunk_idx is not None, (
@@ -237,7 +324,12 @@ class BlockKVCache:
             "Expected the new chunk_idx to be +1 from the previous chunk_idx, "
             f"got {chunk_idx} != {self._prev_chunk_idx} + 1"
         )
-        if self.is_steady_state():
+        # The roll-and-append path (sink_size == 0) folds the eviction into
+        # ``update`` itself so the eviction count can depend on the actual
+        # incoming chunk size and the buffer can be non-divisible. The
+        # sink-aware chunk-aligned path keeps the original split of
+        # before_update-rolls / update-writes.
+        if self.sink_size > 0 and self.is_steady_state():
             self._roll_local_window_left()
 
     def update(self, k: Tensor, v: Tensor) -> None:
@@ -264,11 +356,31 @@ class BlockKVCache:
             f"Expected input v to have chunk_size ({chunk_size_v}) at seq_dim ({self.seq_dim}), "
             f"got {chunk_size_v} != {self.chunk_size}"
         )
-        if self.is_steady_state():
+        if self.sink_size == 0:
+            # Roll-and-append path: support non-divisible windows.
+            if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+                self._roll_and_append(k, v)
+            elif self._curr_chunk_idx == self._prev_chunk_idx:
+                # Repeated predict_flow within the same AR step (denoising
+                # loop iterations + finalize pass) write to the same slice.
+                self._overwrite_last_write(k, v)
+            else:
+                raise ValueError(
+                    f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+                )
+        elif self.is_steady_state():
             self._overwrite_rightmost_steady(k, v)
+            # Track the slice we just overwrote so external observers can
+            # introspect it; same-chunk_idx overwrites take the same path
+            # and produce the same result either way.
+            total = self._k.shape[self.seq_dim]
+            self._last_write_end = total
+            self._last_write_start = max(self.sink_size, total - self.chunk_size)
         else:
             if self._curr_chunk_idx == self._prev_chunk_idx + 1:
                 self._append_to_end(k, v)
+                self._last_write_start = self._n_cached
+                self._last_write_end = self._n_cached + self.chunk_size
             elif self._curr_chunk_idx == self._prev_chunk_idx:
                 self._overwrite_rightmost_filling(k, v)
             else:
@@ -290,10 +402,12 @@ class BlockKVCache:
         )
 
         if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            if self.is_steady_state():
-                pass
-            else:
-                self._n_cached += self.chunk_size
+            total = self._k.shape[self.seq_dim]
+            # ``_n_cached`` is the post-update count of valid tokens.
+            # For both write paths, the right edge of the last write is
+            # exactly the right edge of the valid region (and is bounded
+            # by the buffer size).
+            self._n_cached = min(self._n_cached + self.chunk_size, total)
             self._prev_chunk_idx += 1
         elif self._curr_chunk_idx == self._prev_chunk_idx:
             pass
@@ -311,8 +425,10 @@ class BlockKVCache:
         """
         if self.is_steady_state():
             return self._k
+        total = self._k.shape[self.seq_dim]
         if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._k[self._seq_slice(0, self._n_cached + self.chunk_size)]
+            end = min(self._n_cached + self.chunk_size, total)
+            return self._k[self._seq_slice(0, end)]
         elif self._curr_chunk_idx == self._prev_chunk_idx:
             return self._k[self._seq_slice(0, self._n_cached)]
         else:
@@ -326,8 +442,10 @@ class BlockKVCache:
         """
         if self.is_steady_state():
             return self._v
+        total = self._v.shape[self.seq_dim]
         if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._v[self._seq_slice(0, self._n_cached + self.chunk_size)]
+            end = min(self._n_cached + self.chunk_size, total)
+            return self._v[self._seq_slice(0, end)]
         elif self._curr_chunk_idx == self._prev_chunk_idx:
             return self._v[self._seq_slice(0, self._n_cached)]
         else:
@@ -339,3 +457,5 @@ class BlockKVCache:
         """Reset the cache to its initial empty state."""
         self._prev_chunk_idx = -1
         self._n_cached = 0
+        self._last_write_start = 0
+        self._last_write_end = 0

--- a/flashdreams/flashdreams/infra/pipeline/base.py
+++ b/flashdreams/flashdreams/infra/pipeline/base.py
@@ -234,20 +234,47 @@ class StreamInferencePipeline(
         if events is not None:
             events.record("diffuse")
 
+        # Optional subclass hook between the diffusion model and the decoder.
+        # Default is identity. The :class:`FinalState` stashed on the cache
+        # already holds the unsliced clean_latent, so subclasses are free
+        # to return a sliced view here without affecting the AR cache or
+        # the finalize path.
+        decoder_input = self._pre_decode_hook(
+            clean_latent=clean_latent,
+            autoregressive_index=autoregressive_index,
+        )
+
         if self.decoder is not None:
             assert cache.decoder_cache is not None  # invariant: paired with decoder
             output = self.decoder(
-                input=clean_latent,
+                input=decoder_input,
                 autoregressive_index=autoregressive_index,
                 cache=cache.decoder_cache,
             )
         else:
-            output = clean_latent
+            output = decoder_input
 
         if events is not None:
             events.record("decode")
 
         return output
+
+    def _pre_decode_hook(
+        self,
+        clean_latent: Tensor,
+        autoregressive_index: int,
+    ) -> Tensor:
+        """Optional transform applied to ``clean_latent`` before the decoder.
+
+        Default returns ``clean_latent`` unchanged. Subclasses can override
+        to slice / re-shape the latent without touching
+        :attr:`StreamInferencePipelineCache.final_state`. Used by
+        :class:`AlpadreamsPipeline` to drop the trailing ``kv_drop_t``
+        latent frames from the streaming decoder's input so that the
+        stateful decoder cache advances by the committed prefix only.
+        """
+        del autoregressive_index  # unused in the default identity hook
+        return clean_latent
 
     @torch.no_grad()
     def finalize(

--- a/flashdreams/flashdreams/recipes/alpadreams/config.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/config.py
@@ -96,6 +96,7 @@ def _transformer_config(
     len_t_latent: int,
     window_size_t: int,
     encode_with_pixel_shuffle: bool,
+    kv_drop_t: int = 1,
 ) -> CosmosTransformerConfig:
     return CosmosTransformerConfig(
         network=CosmosDiTNetworkConfig(),
@@ -112,6 +113,7 @@ def _transformer_config(
         w_extrapolation_ratio=3.0,
         window_size_t=window_size_t,
         sink_size_t=0,
+        kv_drop_t=kv_drop_t,
         compile_network=compile_network,
     )
 
@@ -132,6 +134,13 @@ def build_sv_2steps_chunk2_loc6_lightvae_lighttae(
     cp_size: int = 1,
     compile_network: bool = True,
     seed: int = 42,
+    # FIXME: this recipe uses a stateful Wan VAE HDMap encoder, which the
+    # ``kv_drop_t > 0`` first-cut does not support (see
+    # ``AlpadreamsPipeline.__init__`` for the gate). Default to the
+    # legacy non-overlapping rollout here so this recipe keeps working;
+    # ``kv_drop_t > 0`` only defaults to 1 on the PixelShuffle chunk4
+    # recipes where it is safe.
+    kv_drop_t: int = 0,
 ) -> AlpadreamsPipelineConfig:
     """Single-view, chunk2, light Wan VAE HDMap encoder + LightTAE decoder."""
     return AlpadreamsPipelineConfig(
@@ -153,6 +162,7 @@ def build_sv_2steps_chunk2_loc6_lightvae_lighttae(
                 len_t_latent=2,
                 window_size_t=6,
                 encode_with_pixel_shuffle=False,
+                kv_drop_t=kv_drop_t,
             ),
             scheduler=_scheduler_config(),
         ),
@@ -164,6 +174,10 @@ def build_sv_2steps_chunk2_loc6_vae_vae(
     cp_size: int = 1,
     compile_network: bool = True,
     seed: int = 42,
+    # See note in ``build_sv_2steps_chunk2_loc6_lightvae_lighttae``: this
+    # recipe also uses a stateful Wan VAE HDMap encoder, so the
+    # ``kv_drop_t > 0`` path is gated and we default to legacy rollout.
+    kv_drop_t: int = 0,
 ) -> AlpadreamsPipelineConfig:
     """Single-view, chunk2, full Wan VAE for both HDMap encoding and decoding."""
     return AlpadreamsPipelineConfig(
@@ -185,6 +199,7 @@ def build_sv_2steps_chunk2_loc6_vae_vae(
                 len_t_latent=2,
                 window_size_t=6,
                 encode_with_pixel_shuffle=False,
+                kv_drop_t=kv_drop_t,
             ),
             scheduler=_scheduler_config(),
         ),
@@ -196,6 +211,10 @@ def build_sv_2steps_chunk3_loc6_vae_vae(
     cp_size: int = 1,
     compile_network: bool = True,
     seed: int = 42,
+    # See note in ``build_sv_2steps_chunk2_loc6_lightvae_lighttae``: this
+    # recipe also uses a stateful Wan VAE HDMap encoder, so the
+    # ``kv_drop_t > 0`` path is gated and we default to legacy rollout.
+    kv_drop_t: int = 0,
 ) -> AlpadreamsPipelineConfig:
     """Single-view, chunk3, full Wan VAE for both HDMap encoding and decoding."""
     return AlpadreamsPipelineConfig(
@@ -217,6 +236,7 @@ def build_sv_2steps_chunk3_loc6_vae_vae(
                 len_t_latent=3,
                 window_size_t=6,
                 encode_with_pixel_shuffle=False,
+                kv_drop_t=kv_drop_t,
             ),
             scheduler=_scheduler_config(),
         ),
@@ -228,6 +248,7 @@ def build_sv_2steps_chunk4_loc8_pshuffle_lighttae(
     cp_size: int = 1,
     compile_network: bool = True,
     seed: int = 42,
+    kv_drop_t: int = 1,
 ) -> AlpadreamsPipelineConfig:
     """Single-view, chunk4, PixelShuffle HDMap encoder + LightTAE decoder."""
     return AlpadreamsPipelineConfig(
@@ -249,6 +270,7 @@ def build_sv_2steps_chunk4_loc8_pshuffle_lighttae(
                 len_t_latent=4,
                 window_size_t=8,
                 encode_with_pixel_shuffle=True,
+                kv_drop_t=kv_drop_t,
             ),
             scheduler=_scheduler_config(),
         ),
@@ -260,6 +282,7 @@ def build_mv_2steps_chunk4_loc8_pshuffle_lighttae(
     cp_size: int = 1,
     compile_network: bool = True,
     seed: int = 42,
+    kv_drop_t: int = 1,
 ) -> AlpadreamsPipelineConfig:
     """4-view, chunk4, PixelShuffle HDMap encoder + LightTAE decoder."""
     return AlpadreamsPipelineConfig(
@@ -281,6 +304,7 @@ def build_mv_2steps_chunk4_loc8_pshuffle_lighttae(
                 len_t_latent=4,
                 window_size_t=8,
                 encode_with_pixel_shuffle=True,
+                kv_drop_t=kv_drop_t,
             ),
             scheduler=_scheduler_config(),
         ),

--- a/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
@@ -121,6 +121,29 @@ class AlpadreamsPipeline(
 
         transformer = self.diffusion_model.transformer
         self._len_t_latent: int = transformer.config.len_t
+        # Pre-patchify number of latent frames committed per AR step, i.e.
+        # ``len_t - kv_drop_t``. Used downstream to split the decoder input
+        # window from the DiT query window when ``kv_drop_t > 0``.
+        self._len_t_commit: int = transformer.config._len_t_commit
+        self._kv_drop_t: int = transformer.config.kv_drop_t
+
+        # FIXME: stateful HDMap encoders (Wan VAE) advance their conv
+        # state by the number of pixel-frames they see per call. With
+        # ``kv_drop_t > 0`` consecutive HDMap input windows OVERLAP by
+        # ``kv_drop_t * temporal_compression`` frames (see ``get_num_input_frames``
+        # vs ``get_num_output_frames``), and the encoder cache would
+        # double-process the overlapping region, corrupting the
+        # conditioning. PixelShuffle is stateless w.r.t. temporal context
+        # and is safe. Until a proper fix lands (cache reset / reuse),
+        # gate ``kv_drop_t > 0`` to PixelShuffle-encoder configs only.
+        if self._kv_drop_t > 0 and isinstance(self.encoder, WanVAEEncoder):
+            raise NotImplementedError(
+                "kv_drop_t > 0 is not yet supported with a stateful Wan VAE "
+                "HDMap encoder. Use a PixelShuffle encoder recipe (e.g. "
+                "build_sv_2steps_chunk4_loc8_pshuffle_lighttae) or set "
+                "kv_drop_t=0."
+            )
+
         decoder = self.decoder
         assert decoder is not None and hasattr(decoder, "TEMPORAL_COMPRESSION_RATIO"), (
             f"Decoder {type(decoder).__name__} must expose "
@@ -197,13 +220,75 @@ class AlpadreamsPipeline(
             input=hdmap,
         )
 
-    def get_num_frames(self, autoregressive_index: int) -> int:
-        """Number of decoded video frames produced by AR step ``autoregressive_index``.
+    def get_num_input_frames(self, autoregressive_index: int) -> int:
+        """Number of HDMap pixel frames the pipeline expects as input per AR step.
 
-        AR step 0 emits the streaming-VAE anchor frame plus
-        ``(len_t - 1) * temporal_compression`` decoded frames; subsequent
-        steps emit ``len_t * temporal_compression`` frames each.
+        The DiT always consumes ``len_t`` latent frames per AR step
+        regardless of ``kv_drop_t`` (the trailing ``kv_drop_t`` latents
+        are denoised and used as a transient self-attention tail before
+        being discarded). So the per-AR-step HDMap input window is
+        always sized by ``len_t``:
+
+        - AR step 0: ``1 + (len_t - 1) * temporal_compression`` frames
+          (anchor frame + denoised tail).
+        - Steady-state: ``len_t * temporal_compression`` frames.
+
+        Consecutive input windows overlap by
+        ``kv_drop_t * temporal_compression`` frames when ``kv_drop_t > 0``;
+        callers should advance their AR pointer using
+        :meth:`get_num_output_frames` instead.
         """
         if autoregressive_index == 0:
             return 1 + (self._len_t_latent - 1) * self._decoder_temporal_compression
         return self._len_t_latent * self._decoder_temporal_compression
+
+    def get_num_output_frames(self, autoregressive_index: int) -> int:
+        """Number of decoded video frames emitted per AR step (= AR pointer advance).
+
+        Sized by ``_len_t_commit = len_t - kv_drop_t`` because only the
+        committed prefix of each AR step's clean latent reaches the
+        streaming decoder:
+
+        - AR step 0: ``1 + (_len_t_commit - 1) * temporal_compression``
+          frames (anchor frame + committed tail).
+        - Steady-state: ``_len_t_commit * temporal_compression`` frames.
+
+        Equals :meth:`get_num_input_frames` when ``kv_drop_t == 0``.
+        """
+        if autoregressive_index == 0:
+            return 1 + (self._len_t_commit - 1) * self._decoder_temporal_compression
+        return self._len_t_commit * self._decoder_temporal_compression
+
+    # Back-compat alias: most callers want the output count (it doubles
+    # as the AR pointer advance). Pre-``kv_drop_t`` callers wrote loops
+    # like ``end = start + get_num_frames(i); ...; start = end`` which
+    # only stays correct when ``kv_drop_t == 0``; with the experiment
+    # turned on, callers should split into
+    # ``get_num_input_frames`` / ``get_num_output_frames`` (see
+    # ``examples/run_alpadreams.py``).
+    def get_num_frames(self, autoregressive_index: int) -> int:
+        return self.get_num_output_frames(autoregressive_index)
+
+    def _pre_decode_hook(
+        self,
+        clean_latent: Tensor,
+        autoregressive_index: int,
+    ) -> Tensor:
+        """Slice the clean latent to the committed prefix before the decoder.
+
+        ``DiffusionModel.generate`` returns the unpatchified clean latent
+        for all ``len_t`` denoised positions, but with ``kv_drop_t > 0``
+        only the first ``_len_t_commit`` are committed to the decoder.
+        Streaming decoders (TAEHV, Wan VAE) advance their conv-state cache
+        by however many latent frames they see per call, so we must drop
+        the trailing ``kv_drop_t`` frames here -- otherwise the decoder
+        time index would race past the AR pointer by ``kv_drop_t`` per
+        step.
+
+        For ``kv_drop_t == 0`` this is a no-op (slice covers the full T).
+        """
+        del autoregressive_index  # decoder slicing is uniform across steps
+        if self._len_t_commit == self._len_t_latent:
+            return clean_latent
+        # Latent layout from ``unpatchify_and_maybe_gather_cp``: [B, V, T, C, H, W].
+        return clean_latent[:, :, : self._len_t_commit]

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -179,6 +179,24 @@ class CosmosTransformerConfig(TransformerConfig):
     window_size_t: int = 8
     sink_size_t: int = 0
 
+    # KV drop overlap (in pre-patchify T frames). Trailing ``kv_drop_t``
+    # latent frames per AR step are NOT committed to the persistent KV
+    # cache; they participate as a transient tail in the current step's
+    # self-attention only and are re-rolled / re-denoised as the head of
+    # the next AR step's query window. ``0`` reproduces the legacy
+    # non-overlapping AR rollout.
+    #
+    # Constraints (asserted in ``__post_init__``):
+    #   * ``0 <= kv_drop_t < len_t``
+    #   * ``(len_t - kv_drop_t) % patch_temporal == 0``
+    #
+    # First-cut limitations (enforced in ``CosmosTransformer.__init__``):
+    #   * No T-axis context parallelism when ``kv_drop_t > 0``.
+    #   * No ``torch.compile`` when ``kv_drop_t > 0``.
+    #   * The per-AR-step HDMap encoder must be stateless (PixelShuffle);
+    #     stateful Wan VAE encoders are gated at the pipeline layer.
+    kv_drop_t: int = 1
+
     # Speedup.
     compile_network: bool = True
 
@@ -204,6 +222,19 @@ class CosmosTransformerConfig(TransformerConfig):
         self._pT = self.len_t // kt
         self._pH = self.height // kh
         self._pW = self.width // kw
+
+        assert 0 <= self.kv_drop_t < self.len_t, (
+            f"kv_drop_t ({self.kv_drop_t}) must be in [0, len_t={self.len_t})"
+        )
+        commit_t = self.len_t - self.kv_drop_t
+        assert commit_t % kt == 0, (
+            f"(len_t - kv_drop_t) ({commit_t}) must be divisible by "
+            f"patch_temporal ({kt})"
+        )
+        self._len_t_commit = commit_t
+        """Pre-patchify number of latent frames committed per AR step."""
+        self._pT_commit = commit_t // kt
+        """Post-patchify temporal stride per AR step (== ``_pT - kv_drop_t // kt``)."""
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +287,27 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
                 f"mode (got {config.cp_size})"
             )
             self.cp_groups = HierarchicalCPGroups(rank=0)
+
+        # FIXME: First-cut `kv_drop_t > 0` does not handle T-axis context
+        # parallelism: each rank's local temporal prefix slice no longer
+        # corresponds to the global temporal prefix, so commit/drop
+        # decisions would be wrong on ranks that own dropped tail frames.
+        if config.kv_drop_t > 0 and self.cp_groups.T_size > 1:
+            raise NotImplementedError(
+                f"kv_drop_t > 0 is not yet supported with T-axis context "
+                f"parallelism (cp_groups.T_size={self.cp_groups.T_size}). "
+                f"HW-axis CP is also gated for now until tested."
+            )
+
+        # FIXME: First-cut `kv_drop_t > 0` introduces non-divisible
+        # rolling KV windows, transient attention tails, and dynamic
+        # attention-visible lengths, none of which have been validated
+        # under torch.compile. Use ``--no_compile`` for the experiment.
+        if config.kv_drop_t > 0 and config.compile_network:
+            raise NotImplementedError(
+                "kv_drop_t > 0 with torch.compile is not validated yet; "
+                "pass compile_network=False (e.g. --no_compile)."
+            )
 
         self.network = CosmosDiTNetwork(config=config.network)
         if device is not None:
@@ -381,8 +433,14 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         num_tokens_per_view_per_step = cfg._pH * cfg._pW
         if self.cp_groups.THW_group is not None:
             num_tokens_per_view_per_step //= self.cp_groups.THW_group.size()
+        # ``chunk_size`` is the per-AR-step COMMIT size (post-patchify
+        # ``_pT_commit`` temporal frames), not the full denoising window
+        # (``_pT``). With ``kv_drop_t > 0`` the trailing ``kv_drop_t``
+        # latent frames are excluded from the persistent cache; they
+        # participate in the current step's self-attention as a transient
+        # tail (see ``SelfAttention.forward``) and are then discarded.
         network_cache = self.network.initialize_cache(
-            chunk_size=num_tokens_per_view_per_step * cfg._pT,
+            chunk_size=num_tokens_per_view_per_step * cfg._pT_commit,
             window_size=num_tokens_per_view_per_step * cfg.window_size_t,
             sink_size=num_tokens_per_view_per_step * cfg.sink_size_t,
             context=text_embeddings,
@@ -478,7 +536,15 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             "CosmosTransformerCache.start(autoregressive_index) must be called "
             "before predict_flow (DiffusionModel.generate handles this)."
         )
-        rope_freqs = cache.rope_adapter.shift_t(offset=ar_idx * self.config._pT)
+        # The AR pointer advances by ``_pT_commit`` (post-patchify temporal
+        # stride per committed step), not by ``_pT``: with ``kv_drop_t > 0``
+        # the next step's query window overlaps the current step's tail by
+        # ``kv_drop_t`` latent frames, so its RoPE positions start at
+        # ``ar_idx * _pT_commit``. Equal to the legacy ``ar_idx * _pT``
+        # when ``kv_drop_t == 0``.
+        rope_freqs = cache.rope_adapter.shift_t(
+            offset=ar_idx * self.config._pT_commit
+        )
 
         # AR step 0: inject the encoded first-frame latent into the noisy input.
         noisy_latent = self._maybe_inject_image(noisy_latent, cache)

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
@@ -374,7 +374,23 @@ class MultiHeadAttention(nn.Module):
 
 
 class SelfAttention(MultiHeadAttention):
-    """Self-attention: queries and K/V are derived from the same ``x`` each step."""
+    """Self-attention: queries and K/V are derived from the same ``x`` each step.
+
+    Supports the alpadreams ``kv_drop_t`` experiment: the persistent
+    ``kv_cache`` only stores the leading ``kv_cache.chunk_size`` K/V tokens
+    of the current step (the "commit prefix"), but during this forward the
+    trailing ``L - chunk_size`` tokens (the "transient X tail") still
+    participate in self-attention so the trained chunk-internal attention
+    pattern is preserved. The attention-visible K/V is capped at
+    ``kv_cache.window_size + kv_cache.sink_size`` (the buffer's full
+    locality budget) by temporarily hiding the oldest cached tokens from
+    this attention view -- the persistent buffer is never modified by the
+    hiding.
+
+    When ``chunk_size == L`` (i.e. ``kv_drop_t == 0`` for alpadreams) this
+    collapses to the legacy behavior bit-for-bit: the entire current K/V
+    is committed, no transient tail, no eviction-from-view.
+    """
 
     def initialize_cache(
         self,
@@ -416,8 +432,75 @@ class SelfAttention(MultiHeadAttention):
         kv_cache: BlockKVCache,
         rope_freqs: Tensor,
     ) -> Tensor:
-        """Same as base ``forward`` with ``update_kv_cache=True``."""
-        return super().forward(x, kv_cache, rope_freqs=rope_freqs, update_kv_cache=True)
+        """Self-attention with KV-drop-aware commit prefix and transient tail.
+
+        See the class docstring for the contract. ``kv_cache.chunk_size`` is
+        treated as the commit prefix length; the remaining ``L - chunk_size``
+        tokens of the current step's K/V are the transient tail.
+
+        Note: this overrides the base ``MultiHeadAttention.forward`` instead
+        of calling ``super().forward(...)`` because the base path always
+        writes the full K/V into the cache. Putting the commit-prefix logic
+        in :class:`SelfAttention` keeps :class:`CrossAttention` -- which
+        runs with ``update_kv_cache=False`` and a one-shot text K/V cache
+        of a different feature dimension -- on the original code path.
+        """
+        batch_shape = x.shape[:-2]
+        batch_size = math.prod(batch_shape)
+        L, D = x.shape[-2:]
+        n, d = self.n_heads, self.head_dim
+        assert n * d == D, "n * d must be equal to D"
+
+        # Project full-N current K/V (with RoPE).
+        k_full = self.k_norm(self.k_proj(x).reshape(batch_size, L, n, d))
+        v_full = self.v_proj(x).reshape(batch_size, L, n, d)
+        if rope_freqs is not None:
+            k_full = apply_rope_freqs(k_full, rope_freqs)
+
+        # Persistent cache only stores the leading ``commit_len`` tokens.
+        commit_len = kv_cache.chunk_size
+        assert commit_len <= L, (
+            f"kv_cache.chunk_size ({commit_len}) must be <= L ({L}) for "
+            "the SelfAttention KV-drop path."
+        )
+        kv_cache.update(
+            k_full[..., :commit_len, :, :],
+            v_full[..., :commit_len, :, :],
+        )
+
+        cached_k = kv_cache.cached_k()
+        cached_v = kv_cache.cached_v()
+
+        if commit_len < L:
+            # X-tail transient: present in attention this forward only,
+            # never persisted.
+            k_trans = k_full[..., commit_len:, :, :]
+            v_trans = v_full[..., commit_len:, :, :]
+            # Cap attention-visible K/V to the buffer's locality budget
+            # (sink + rolling window) by temporarily slicing off the
+            # oldest cached tokens FROM THE ATTENTION VIEW ONLY. The
+            # persistent buffer behind ``cached_k``/``cached_v`` is
+            # untouched.
+            cap = kv_cache.window_size + kv_cache.sink_size
+            cached_len = cached_k.shape[-3]
+            trans_len = k_trans.shape[-3]
+            excess = cached_len + trans_len - cap
+            if excess > 0:
+                cached_k = cached_k[..., excess:, :, :]
+                cached_v = cached_v[..., excess:, :, :]
+            full_k = torch.cat([cached_k, k_trans], dim=-3)
+            full_v = torch.cat([cached_v, v_trans], dim=-3)
+        else:
+            full_k = cached_k
+            full_v = cached_v
+
+        # Compute Q + attention (same projection / RoPE as the base path).
+        q = self.q_norm(self.q_proj(x).reshape(batch_size, L, n, d))
+        if rope_freqs is not None:
+            q = apply_rope_freqs(q, rope_freqs)
+        out = self.attn_op(q, full_k, full_v)
+        out = out.reshape(batch_shape + (L, n * d))
+        return self.output_proj(out)
 
 
 class CrossAttention(MultiHeadAttention):

--- a/integrations/alpadreams/alpadreams/conditioning/video_model_flashdreams_pipeline.py
+++ b/integrations/alpadreams/alpadreams/conditioning/video_model_flashdreams_pipeline.py
@@ -242,6 +242,11 @@ class FlashDreamsPipelineVideoModelAPI(VideoModelAPI[FlashDreamsPipelineLatentCa
             len_t=len_t,
             checkpoint_path=checkpoint_path,
             compile_network=compile_net,
+            # Server pins legacy non-overlapping rollout: the production
+            # checkpoints were trained without ``kv_drop_t > 0``, and the
+            # gRPC server has not been adapted to the kv_drop_t experiment
+            # yet (e.g. encoder caveats, frame-count split, decoder slice).
+            kv_drop_t=0,
         )
 
         scheduler_config = FlowMatchSchedulerConfig(


### PR DESCRIPTION
This commit introduces a new document detailing the KV-drop experiment for the alpadreams autoregressive rollout, which tests the impact of discarding trailing latent frames during inference. Key changes include:

* Implementation of the `kv_drop_t` parameter in `CosmosTransformerConfig` to control the number of trailing frames not committed to the KV cache.
* Modifications to the attention mechanism to support the new KV-drop behavior, ensuring that the transient tail participates in self-attention.
* Updates to the pipeline to handle input and output frame calculations based on the new KV-drop logic.
* Added command-line argument support for overriding `kv_drop_t` in the example runner.

This experiment aims to evaluate the visual quality of the generated outputs with overlapping input windows during autoregressive steps.

[port of sil/flashdreams!24]