### PR TITLE
ci: trigger CI on main, dev branches, and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: linux-amd64-cpu8
     steps:
       - name: Get PR info
+        if: startsWith(github.ref_name, 'pull-request/')
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
 
@@ -37,6 +38,7 @@ jobs:
     runs-on: linux-amd64-gpu-rtxpro6000-latest-2
     steps:
       - name: Get PR info
+        if: startsWith(github.ref_name, 'pull-request/')
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
     branches:
+      - main
+      - "dev/**/*"
       - "pull-request/[0-9]+"
+    tags:
+      - '**'
 
 jobs:
   cpu:


### PR DESCRIPTION
## Summary

- Expand CI triggers beyond the copy-pr-bot pattern to also run on pushes to `main`, `dev/**/*` branches, and all tag pushes
- Matches the ncore CI trigger pattern while preserving the NVIDIA self-hosted runner security model (all push-based triggers)
- Enables CI feedback on dev branches before PRs are opened