### PR TITLE
chore: migrate container images from GitLab registry to GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ srun \
     --partition=gtc_demo \
     --time=24:00:00  \
     --pty \
-    --container-image=gitlab-master.nvidia.com:5005/sil/flashdreams:base-v0.3-20260424-55bd566 \
+    --container-image=ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566 \
     --container-mounts=/dev/nvidia-caps-imex-channels:/dev/nvidia-caps-imex-channels,/home:/home,/cm:/cm,/usr/share/glvnd/egl_vendor.d:/usr/share/glvnd/egl_vendor.d \
     --container-remap-root \
     --container-mount-home \

--- a/dev/slurm_interactive.sh
+++ b/dev/slurm_interactive.sh
@@ -30,7 +30,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO_ROOT="${FLASHDREAMS_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-IMAGE="${FLASHDREAMS_TEST_IMAGE:-gitlab-master.nvidia.com/sil/flashdreams:base-v0.3-20260424-55bd566}"
+IMAGE="${FLASHDREAMS_TEST_IMAGE:-ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566}"
 
 UV_CACHE_HOST="${FLASHDREAMS_UV_CACHE_DIR:-${HOME}/.cache/uv}"
 HF_CACHE_HOST="${FLASHDREAMS_HF_CACHE_DIR:-${HOME}/.cache/huggingface}"

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ Rebuild only when the Dockerfile or pinned dependencies change.
 | File | Purpose |
 |---|---|
 | `Dockerfile` | Image recipe. Based on `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`. |
-| `build_with_docker.sh` | Build + push a multi-arch (`linux/arm64` + `linux/amd64`) image to `gitlab-master.nvidia.com:5005/sil/flashdreams`. |
+| `build_with_docker.sh` | Build + push a multi-arch (`linux/arm64` + `linux/amd64`) image to `ghcr.io/nvidia/flashdreams`. |
 | `docker_farm_setup.sh` | One-time Buildx "farm" setup so arm64 builds run natively on `dgx-spark` instead of under QEMU emulation. |
 
 ---
@@ -21,7 +21,7 @@ Rebuild only when the Dockerfile or pinned dependencies change.
 ## Canonical image
 
 ```
-gitlab-master.nvidia.com:5005/sil/flashdreams:base-v0.3-20260424-55bd566
+ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566
 ```
 
 Multi-arch (linux/arm64 + linux/amd64) — the container runtime picks the
@@ -91,9 +91,9 @@ workstation, which is correct but noticeably slower.
 ### 2. Log in to the registry
 
 ```bash
-docker login gitlab-master.nvidia.com:5005
-# username: your NVIDIA handle
-# password: a GitLab personal access token with read_registry + write_registry
+docker login ghcr.io
+# username: your GitHub handle
+# password: a GitHub personal access token with read:packages + write:packages
 ```
 
 ### 3. Bump the tag (when the Dockerfile changes)

--- a/docker/build_with_docker.sh
+++ b/docker/build_with_docker.sh
@@ -6,11 +6,11 @@
 # WHAT THIS SCRIPT DOES
 # ---------------------
 # Builds `docker/Dockerfile` for both linux/arm64 and linux/amd64 in a single
-# buildx invocation and pushes the resulting manifest list to the NVIDIA
-# GitLab container registry.
+# buildx invocation and pushes the resulting manifest list to the GitHub
+# Container Registry (GHCR).
 #
 # Tag scheme:
-#     gitlab-master.nvidia.com:5005/sil/flashdreams:<TAG>-<YYYYMMDD>-<git-sha>
+#     ghcr.io/nvidia/flashdreams:<TAG>-<YYYYMMDD>-<git-sha>
 #
 # The date + short git SHA make every build uniquely addressable, while the
 # TAG prefix (e.g. "base-v0.3") tracks the Dockerfile's major revision.
@@ -26,9 +26,9 @@
 #      significantly slower.
 #      To request access to dgx-spark (SSH config, account), contact
 #      qiwu@nvidia.com.
-#   3. You are logged in to the NVIDIA GitLab registry:
-#          docker login gitlab-master.nvidia.com:5005
-#      (use a GitLab personal access token with `read_registry`+`write_registry`).
+#   3. You are logged in to the GitHub Container Registry:
+#          docker login ghcr.io
+#      (use a GitHub personal access token with `write:packages` scope).
 #   4. The working directory is the repo root (the build context is ".") and
 #      `docker/Dockerfile` is reachable. Invoke as:
 #          bash docker/build_with_docker.sh
@@ -76,5 +76,5 @@ docker buildx build \
     --allow network.host \
     --network host \
     --push \
-    -t gitlab-master.nvidia.com:5005/sil/flashdreams:$TAG-$(date +%Y%m%d)-$(git rev-parse --short HEAD) \
+    -t ghcr.io/nvidia/flashdreams:$TAG-$(date +%Y%m%d)-$(git rev-parse --short HEAD) \
     -f docker/Dockerfile .

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ is skipped.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `FLASHDREAMS_TEST_IMAGE` | `gitlab-master.nvidia.com:5005/sil/flashdreams:base-v0.3` | Container image used for the run. |
+| `FLASHDREAMS_TEST_IMAGE` | `ghcr.io/nvidia/flashdreams:base-v0.3` | Container image used for the run. |
 | `FLASHDREAMS_UV_CACHE_DIR` | `${HOME}/.cache/uv` | Host dir mounted to `/root/.cache/uv`. |
 | `FLASHDREAMS_HF_CACHE_DIR` | `${HOME}/.cache/huggingface` | Host dir mounted to `/root/.cache/huggingface`. |
 | `FLASHDREAMS_CACHE_DIR` | `${HOME}/.cache/flashdreams` | Host dir mounted to `/root/.cache/flashdreams`. |

--- a/tests/run_tests_docker.sh
+++ b/tests/run_tests_docker.sh
@@ -10,7 +10,7 @@
 #   ./tests/run_tests_docker.sh [TEST_TARGET...]
 #
 # Environment overrides:
-#   FLASHDREAMS_TEST_IMAGE         (default: gitlab-master.nvidia.com:5005/sil/flashdreams:base-v0.3-20260424-55bd566)
+#   FLASHDREAMS_TEST_IMAGE         (default: ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566)
 #   FLASHDREAMS_UV_CACHE_DIR       (default: ${HOME}/.cache/uv)
 #   FLASHDREAMS_HF_CACHE_DIR       (default: ${HOME}/.cache/huggingface)
 #   FLASHDREAMS_CACHE_DIR          (default: ${HOME}/.cache/flashdreams)
@@ -25,7 +25,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IMAGE="${FLASHDREAMS_TEST_IMAGE:-gitlab-master.nvidia.com:5005/sil/flashdreams:base-v0.3-20260424-55bd566}"
+IMAGE="${FLASHDREAMS_TEST_IMAGE:-ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566}"
 
 UV_CACHE_HOST="${FLASHDREAMS_UV_CACHE_DIR:-${HOME}/.cache/uv}"
 HF_CACHE_HOST="${FLASHDREAMS_HF_CACHE_DIR:-${HOME}/.cache/huggingface}"

--- a/tests/run_tests_slurm.sh
+++ b/tests/run_tests_slurm.sh
@@ -33,7 +33,7 @@
 #   --rebuild-image or `rm` the .sqsh file.
 #
 # Environment overrides:
-#   FLASHDREAMS_TEST_IMAGE        (default: gitlab-master.nvidia.com/sil/flashdreams:base-v0.3-20260424-55bd566)
+#   FLASHDREAMS_TEST_IMAGE        (default: ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566)
 #   FLASHDREAMS_UV_CACHE_DIR      (default: ${HOME}/.cache/uv)
 #   FLASHDREAMS_HF_CACHE_DIR      (default: ${HOME}/.cache/huggingface)
 #   FLASHDREAMS_CACHE_DIR         (default: ${HOME}/.cache/flashdreams)
@@ -51,7 +51,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IMAGE="${FLASHDREAMS_TEST_IMAGE:-gitlab-master.nvidia.com/sil/flashdreams:base-v0.3-20260424-55bd566}"
+IMAGE="${FLASHDREAMS_TEST_IMAGE:-ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566}"
 
 SLURM_PARTITION=""
 SLURM_ACCOUNT=""


### PR DESCRIPTION
## Summary

- Replace all `gitlab-master.nvidia.com[:5005]/sil/flashdreams` container image references with `ghcr.io/nvidia/flashdreams` across scripts and documentation
- Update `docker/build_with_docker.sh` to push to GHCR with updated login instructions (GitHub PAT with `write:packages` scope)
- Update `docker/README.md` with new registry login and canonical image references

## Images already pushed

Both tags were copied to GHCR via `crane copy` (preserving multi-arch manifests):

- `ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566`
- `ghcr.io/nvidia/flashdreams:base-v0.3`

## Files changed (7)

| File | Changes |
|---|---|
| `README.md` | Updated `--container-image=` reference |
| `tests/README.md` | Updated default image in env var table |
| `tests/run_tests_docker.sh` | Updated comment + `IMAGE` default |
| `tests/run_tests_slurm.sh` | Updated comment + `IMAGE` default |
| `dev/slurm_interactive.sh` | Updated `IMAGE` default |
| `docker/build_with_docker.sh` | Updated tag, login instructions, and push target |
| `docker/README.md` | Updated canonical image, push destination, and login instructions |

## Not modified (intentional)

- `integrations/alpadreams/pyproject.toml` — PyPI index URL for `ludus-renderer`, not a container image
- `uv.lock` — PyPI package URLs
- `.opencode/plans/*` — historical plan documents