### PR TITLE
Chore: add pyright configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ override-dependencies = ["nvidia-cublas>=13.4"]
 # https://github.com/NVIDIA/TransformerEngine/issues/1323 — disable isolation
 # so TE builds against the resolved torch from the project venv.
 no-build-isolation-package = ["transformer-engine-torch"]
+
+[tool.pyright]
+extraPaths = ["flashdreams", "integrations/alpadreams"]


### PR DESCRIPTION
Because of our "monorepo" design, `pyright` was not discovering `flashdreams` correctly (trying to load the repo root instead of the python package). This MR fixes this with an explicit configuration block.