### PR TITLE
ci: only run on pull-request pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "dev/**/*"
       - "pull-request/[0-9]+"
     tags:
       - '**'


### PR DESCRIPTION
The NV copy-pr-bot automatically creates `pull-request/N` branches for CI runs, so skip running duplicate versions in dev-branches