### PR TITLE
Speedup: add TAEHV compile and cudagraph support

### DIFF
--- a/flashdreams/flashdreams/recipes/alpadreams/config.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/config.py
@@ -55,7 +55,7 @@ AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS: dict[str, dict[str, str | dict[str, str]]
 # ---------------------------------------------------------------------------
 
 _DEFAULT_BATCH_SHAPE: tuple[int, ...] = (1,)
-_DEFAULT_VIDEO_HEIGHT = 720
+_DEFAULT_VIDEO_HEIGHT = 704
 _DEFAULT_VIDEO_WIDTH = 1280
 _WAN_VAE_SPATIAL_COMPRESSION = 8
 _DEFAULT_DENOISING_TIMESTEPS = [1000, 450]

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -1,7 +1,7 @@
-"""TAEHV video decoder, exposed as a infra :class:`Decoder`.
+"""TAEHV video decoder, exposed as an infra :class:`Decoder`.
 
-TAEHV is decode-only in our pipelines (encoding raises ``NotImplementedError``
-in the underlying impl), so this module ports just the decode side.
+TAEHV is decode-only in our pipelines, so this module ports just the
+decode side. See :mod:`.impl` for the streaming + CUDA-graph design.
 """
 
 from __future__ import annotations
@@ -25,9 +25,13 @@ class TeahvVAEDecoderConfig(DecoderConfig):
     _target: type["TeahvVAEDecoder"] = field(default_factory=lambda: TeahvVAEDecoder)
 
     checkpoint_path: str = AVAILABLE_TAEHV_CHECKPOINT_PATHS["lighttae"]
-    parallel: bool = True
-    """``True``: faster + higher memory; ``False``: lower memory."""
     dtype: torch.dtype = torch.bfloat16
+    use_cuda_graph: bool = True
+    """Wrap the decoder forward in a CUDA graph for steady-state replay."""
+    use_compile: bool = True
+    """Apply ``torch.compile(mode="max-autotune-no-cudagraphs")`` to the
+    decoder. Combine with ``use_cuda_graph=True`` for the rollout-aware
+    dispatch (drain Inductor autotune in rollout 1, capture in rollout 2)."""
 
 
 class TeahvVAEDecoder(Decoder[TAEHVCache]):
@@ -36,75 +40,60 @@ class TeahvVAEDecoder(Decoder[TAEHVCache]):
     Forward input is a latent tensor of shape ``[..., Tl, Cl, Hl, Wl]``;
     output is a video tensor of shape ``[..., T, C, H, W]`` with values in
     ``[-1, 1]``.
+
+    Note:
+        Set ``torch.backends.cudnn.benchmark = True`` once at process
+        start for ~5% extra on the eager seed/tail chunks.
     """
 
-    TEMPORAL_COMPRESSION_RATIO = 4
-    SPATIAL_COMPRESSION_RATIO = 8
+    TEMPORAL_COMPRESSION_RATIO = TAEHV.TEMPORAL_COMPRESSION_RATIO
+    SPATIAL_COMPRESSION_RATIO = TAEHV.SPATIAL_COMPRESSION_RATIO
 
     # Per-channel scaling for the lighttae checkpoint.
     _LIGHTTAE_MEAN: tuple[float, ...] = (
-        -0.7571,
-        -0.7089,
-        -0.9113,
-        0.1075,
-        -0.1745,
-        0.9653,
-        -0.1517,
-        1.5508,
-        0.4134,
-        -0.0715,
-        0.5517,
-        -0.3632,
-        -0.1922,
-        -0.9497,
-        0.2503,
-        -0.2921,
-    )
+        -0.7571, -0.7089, -0.9113, 0.1075,
+        -0.1745, 0.9653, -0.1517, 1.5508,
+        0.4134, -0.0715, 0.5517, -0.3632,
+        -0.1922, -0.9497, 0.2503, -0.2921,
+    )  # fmt: skip
     _LIGHTTAE_STD: tuple[float, ...] = (
-        2.8184,
-        1.4541,
-        2.3275,
-        2.6558,
-        1.2196,
-        1.7708,
-        2.6052,
-        2.0743,
-        3.2687,
-        2.1526,
-        2.8652,
-        1.5579,
-        1.6382,
-        1.1253,
-        2.8251,
-        1.9160,
-    )
+        2.8184, 1.4541, 2.3275, 2.6558,
+        1.2196, 1.7708, 2.6052, 2.0743,
+        3.2687, 2.1526, 2.8652, 1.5579,
+        1.6382, 1.1253, 2.8251, 1.9160,
+    )  # fmt: skip
 
     def __init__(self, config: TeahvVAEDecoderConfig) -> None:
         super().__init__(config)
         self.config: TeahvVAEDecoderConfig = config
 
-        self.parallel = config.parallel
         self.need_scaled = "lighttae" in config.checkpoint_path
-        self.taehv = TAEHV(checkpoint_path=config.checkpoint_path).to(
-            dtype=config.dtype
-        )
+        self.taehv = TAEHV(
+            checkpoint_path=config.checkpoint_path,
+            use_cuda_graph=config.use_cuda_graph,
+            use_compile=config.use_compile,
+        ).to(dtype=config.dtype)
 
         if self.need_scaled:
             self.register_buffer(
                 "mean",
-                torch.tensor(self._LIGHTTAE_MEAN, dtype=config.dtype),
+                torch.tensor(self._LIGHTTAE_MEAN, dtype=config.dtype).view(
+                    1, 1, -1, 1, 1
+                ),
                 persistent=False,
             )
             self.register_buffer(
                 "std",
-                torch.tensor(self._LIGHTTAE_STD, dtype=config.dtype),
+                torch.tensor(self._LIGHTTAE_STD, dtype=config.dtype).view(
+                    1, 1, -1, 1, 1
+                ),
                 persistent=False,
             )
 
     def initialize_autoregressive_cache(self) -> TAEHVCache:
         return self.taehv.prepare_cache()
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(
         self,
         input: Tensor,
@@ -121,14 +110,10 @@ class TeahvVAEDecoder(Decoder[TAEHVCache]):
         z = input.reshape(batch_size, T, C, H, W)
 
         if self.need_scaled:
-            z = z * self.std.view(1, 1, -1, 1, 1)
-            z = z + self.mean.view(1, 1, -1, 1, 1)
+            z = z * self.std
+            z = z + self.mean
 
-        x = (
-            self.taehv.decode_video(z, parallel=self.parallel, cache=cache)
-            .mul_(2)
-            .sub_(1)
-        )
+        x = self.taehv.decode(z, cache=cache).mul_(2).sub_(1)
         return x.reshape(*batch_shape, *x.shape[1:])
 
     @property

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -103,7 +103,10 @@ class TeahvVAEDecoder(Decoder[TAEHVCache]):
         if cache is None:
             cache = self.initialize_autoregressive_cache()
 
-        assert input.ndim >= 4, "Expected input to have shape [..., T, C, H, W]"
+        assert input.ndim >= 4, (
+            f"Expected input to have shape [..., T, C, H, W] (ndim>=4), "
+            f"got ndim={input.ndim}"
+        )
 
         *batch_shape, T, C, H, W = input.shape
         batch_size = math.prod(batch_shape)

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -1,374 +1,379 @@
-#!/usr/bin/env python3
-"""
-Tiny AutoEncoder for Hunyuan Video
-(DNN for encoding / decoding videos to Hunyuan Video's latent space)
+"""Tiny AutoEncoder for Hunyuan Video (TAEHV) -- streaming causal decode.
+
+Decode-only slim port: the TAEHV encoder side is unused in our pipelines and
+not included here. Encoder weights present in the checkpoint are dropped via
+``strict=False`` at load time.
+
+Per-rollout dispatch (when ``use_cuda_graph=True``):
+    - Rollout 1 (cache empty): bare module / wrapper.drain -- runs the
+      decoder eagerly through the wrapper's static buffer so any
+      Inductor / triton autotunes happen on the eager path (illegal
+      during graph capture).
+    - Rollout 2+ (cache populated): wrapper.__call__ -- ``warmup_iters``
+      eager warmups, then capture, then pure replay for every
+      same-shape body chunk.
+
+Example::
+
+    decoder = TAEHV(checkpoint_path="...").to(device, torch.bfloat16)
+    cache = decoder.prepare_cache()
+    x_first = decoder.decode(z_first, cache=cache)   # 5 frames (trimmed)
+    x_body  = decoder.decode(z_body,  cache=cache)   # 8 frames
 """
 
-from collections import namedtuple
-from dataclasses import dataclass
-from typing import List, Optional
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from tqdm.auto import tqdm
 
 from flashdreams.core.checkpoint.load import load_checkpoint
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.infra.decoder import DecoderAutoregressiveCache
 
-DecoderResult = namedtuple("DecoderResult", ("frame", "memory"))
-TWorkItem = namedtuple("TWorkItem", ("input_tensor", "block_index"))
+
+@dataclass
+class TAEHVCache(DecoderAutoregressiveCache):
+    """Streaming decoder cache; one slot per ``MemBlock`` keyed by ``id(module)``.
+
+    Slots hold a single ``[B, 1, C, H, W]`` frame -- the last input frame
+    of the previous chunk -- which becomes the rolled-in left context
+    for the next chunk's MemBlock. Slots have stable storage addresses
+    after the first chunk so CUDA-graph replay can write through them
+    in place.
+    """
+
+    dec_state: Dict[int, torch.Tensor] = field(default_factory=dict)
 
 
-def conv(n_in, n_out, **kwargs):
+def _set_or_copy(
+    state: Dict[int, torch.Tensor], key: int, new_value: torch.Tensor
+) -> None:
+    """Write ``new_value`` into ``state[key]``: in-place ``copy_`` once the
+    slot exists at the matching shape, else allocate a fresh clone.
+
+    Pointer stability is required for CUDA-graph capture (kernels
+    reference the slot's storage address).
+    """
+    cur = state.get(key)
+    if cur is not None and cur.shape == new_value.shape:
+        cur.copy_(new_value)
+    else:
+        state[key] = new_value.clone()
+
+
+def _conv(n_in: int, n_out: int, **kwargs) -> nn.Conv2d:
     return nn.Conv2d(n_in, n_out, 3, padding=1, **kwargs)
 
 
 class Clamp(nn.Module):
-    def forward(self, x):
+    """Soft saturating clamp -- ``tanh(x/3) * 3`` (used at decoder input)."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.tanh(x / 3) * 3
 
 
 class MemBlock(nn.Module):
-    def __init__(self, n_in, n_out, act_func):
+    """Residual block with a 1-frame temporal-left memory slot.
+
+    The forward concatenates ``x`` with a 1-step time-shifted copy
+    (``past``) along channels, runs a 3-conv stack, and adds the ``skip``
+    projection. :meth:`cache_step` advances the per-instance slot:
+    snapshot the last input frame -> next call uses it as ``past``.
+    """
+
+    def __init__(self, n_in: int, n_out: int, act_func: nn.Module):
         super().__init__()
         self.conv = nn.Sequential(
-            conv(n_in * 2, n_out),
+            _conv(n_in * 2, n_out),
             act_func,
-            conv(n_out, n_out),
+            _conv(n_out, n_out),
             act_func,
-            conv(n_out, n_out),
+            _conv(n_out, n_out),
         )
         self.skip = (
             nn.Conv2d(n_in, n_out, 1, bias=False) if n_in != n_out else nn.Identity()
         )
         self.act = act_func
 
-    def forward(self, x, past):
+    def forward(self, x: torch.Tensor, past: torch.Tensor) -> torch.Tensor:
         return self.act(self.conv(torch.cat([x, past], 1)) + self.skip(x))
 
+    def cache_step(
+        self, x: torch.Tensor, state: Dict[int, torch.Tensor], batch: int
+    ) -> torch.Tensor:
+        """Apply with streaming left-context drawn from ``state``.
 
-class TPool(nn.Module):
-    def __init__(self, n_f, stride):
-        super().__init__()
-        self.stride = stride
-        self.conv = nn.Conv2d(n_f * stride, n_f, 1, bias=False)
-
-    def forward(self, x):
-        _NT, C, H, W = x.shape
-        return self.conv(x.reshape(-1, self.stride * C, H, W))
+        Builds ``past`` by rolling ``x`` right one step, padded with the
+        previous chunk's last frame (or zeros on the first chunk). On
+        steady-state calls only the cached single-frame slot is read,
+        matching the legacy ``cache_mem[i] = _x; ... prev_mem[:, -1:]``
+        access pattern bit-for-bit.
+        """
+        key = id(self)
+        bt, c, h, w = x.shape
+        t = bt // batch
+        x5 = x.view(batch, t, c, h, w)
+        prev = state.get(key)
+        if prev is None:
+            past = F.pad(x5, (0, 0, 0, 0, 0, 0, 1, 0))[:, :t]
+        else:
+            past = torch.cat([prev, x5[:, :-1]], dim=1)
+        out = self.forward(x, past.reshape(bt, c, h, w))
+        _set_or_copy(state, key, x5[:, -1:])
+        return out
 
 
 class TGrow(nn.Module):
-    def __init__(self, n_f, stride):
+    """Temporal upsample by ``stride``: 1x1 conv expands channels, then
+    reshape splits the new channel chunks into consecutive timesteps.
+
+    Stateless across streaming chunks (each chunk's frames are upsampled
+    independently)."""
+
+    def __init__(self, n_f: int, stride: int):
         super().__init__()
         self.stride = stride
         self.conv = nn.Conv2d(n_f, n_f * stride, 1, bias=False)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         _NT, C, H, W = x.shape
-        x = self.conv(x)
-        return x.reshape(-1, C, H, W)
+        return self.conv(x).reshape(-1, C, H, W)
 
 
-def apply_model_with_memblocks(
-    model, x, parallel, show_progress_bar, cache_mem: List | None = None
-):
+class Decoder(nn.Module):
+    """TAEHV decoder body, owned by :class:`TAEHV`.
+
+    Input: ``[B, T, C_z, H, W]`` latent (T == ``z`` time dim).
+    Output: ``[B, T_out, C_img * patch**2, H_out, W_out]`` raw frames
+    (no clamp / pixel-shuffle / trim -- those happen in
+    :meth:`TAEHV.decode`).
     """
-    Apply a sequential model with memblocks to the given input.
-    Args:
-    - model: nn.Sequential of blocks to apply
-    - x: input data, of dimensions NTCHW
-    - parallel: if True, parallelize over timesteps (fast but uses O(T) memory)
-        if False, each timestep will be processed sequentially (slow but uses O(1) memory)
-    - show_progress_bar: if True, enables tqdm progressbar display
 
-    Returns NTCHW tensor of output data.
-    """
-    assert x.ndim == 5, f"TAEHV operates on NTCHW tensors, but got {x.ndim}-dim tensor"
-    N, T, C, H, W = x.shape
-    if parallel:
-        x = x.reshape(N * T, C, H, W)
-        # parallel over input timesteps, iterate over blocks
-        for idx, b in enumerate(model):
-            if isinstance(b, MemBlock):
-                prev_mem = cache_mem[idx]
-                NT, C, H, W = x.shape
-                T = NT // N
-                _x = x.reshape(N, T, C, H, W)
-                if prev_mem is None:
-                    # roll to the right and left pad with zeros
-                    curr_mem = F.pad(_x, (0, 0, 0, 0, 0, 0, 1, 0), value=0)[:, :T]
-                else:
-                    # roll to the right and left pad with the last frame in previous mem
-                    curr_mem = torch.cat([prev_mem[:, -1:], _x[:, :-1]], dim=1)
-                x = b(x, curr_mem.reshape(x.shape))
-                cache_mem[idx] = _x
-            else:
-                x = b(x)
-        NT, C, H, W = x.shape
-        T = NT // N
-        x = x.view(N, T, C, H, W)
-    else:
-        # TODO(oboerbohan): at least on macos this still gradually uses more memory during decode...
-        # need to fix :(
-        out = []
-        # iterate over input timesteps and also iterate over blocks.
-        # because of the cursed TPool/TGrow blocks, this is not a nested loop,
-        # it's actually a ***graph traversal*** problem! so let's make a queue
-        work_queue = [
-            TWorkItem(xt, 0)
-            for t, xt in enumerate(x.reshape(N, T * C, H, W).chunk(T, dim=1))
-        ]
-        # in addition to manually managing our queue, we also need to manually manage our progressbar.
-        # we'll update it for every source node that we consume.
-        progress_bar = tqdm(range(T), disable=not show_progress_bar)
-        # we'll also need a separate addressable memory per node as well
-        mem = [None] * len(model) if cache_mem is None else cache_mem
-        while work_queue:
-            xt, i = work_queue.pop(0)
-            if i == 0:
-                # new source node consumed
-                progress_bar.update(1)
-            if i == len(model):
-                # reached end of the graph, append result to output list
-                out.append(xt)
-            else:
-                # fetch the block to process
-                b = model[i]
-                if isinstance(b, MemBlock):
-                    # mem blocks are simple since we're visiting the graph in causal order
-                    if mem[i] is None:
-                        xt_new = b(xt, xt * 0)
-                        mem[i] = xt
-                    else:
-                        xt_new = b(xt, mem[i])
-                        mem[i].copy_(xt)
-                        # ^ inplace might reduce mysterious pytorch memory allocations? doesn't help though
-                    # add successor to work queue
-                    work_queue.insert(0, TWorkItem(xt_new, i + 1))
-                elif isinstance(b, TPool):
-                    # pool blocks are miserable
-                    if mem[i] is None:
-                        mem[i] = []  # pool memory is itself a queue of inputs to pool
-                    mem[i].append(xt)
-                    if len(mem[i]) > b.stride:
-                        # pool mem is in invalid state, we should have pooled before this
-                        raise ValueError("???")
-                    elif len(mem[i]) < b.stride:
-                        # pool mem is not yet full, go back to processing the work queue
-                        pass
-                    else:
-                        # pool mem is ready, run the pool block
-                        N, C, H, W = xt.shape
-                        xt = b(torch.cat(mem[i], 1).view(N * b.stride, C, H, W))
-                        # reset the pool mem
-                        mem[i] = []
-                        # add successor to work queue
-                        work_queue.insert(0, TWorkItem(xt, i + 1))
-                elif isinstance(b, TGrow):
-                    xt = b(xt)
-                    NT, C, H, W = xt.shape
-                    # each tgrow has multiple successor nodes
-                    for xt_next in reversed(
-                        xt.view(N, b.stride * C, H, W).chunk(b.stride, 1)
-                    ):
-                        # add successor to work queue
-                        work_queue.insert(0, TWorkItem(xt_next, i + 1))
-                else:
-                    # normal block with no funny business
-                    xt = b(xt)
-                    # add successor to work queue
-                    work_queue.insert(0, TWorkItem(xt, i + 1))
-        progress_bar.close()
-        x = torch.stack(out, 1)
-    return x
-
-
-@dataclass
-class TAEHVCache(DecoderAutoregressiveCache):
-    enc_conv_idx: List[int]
-    enc_feat_map: List[Optional[torch.Tensor]]
-    dec_conv_idx: List[int]
-    dec_feat_map: List[Optional[torch.Tensor]]
-
-
-class TAEHV(nn.Module):
     def __init__(
         self,
-        checkpoint_path="taew2_1.pth",
-        decoder_time_upscale=(True, True),
-        decoder_space_upscale=(True, True, True),
-        patch_size=1,
-        latent_channels=16,
-        model_type="wan21",
+        n_f: tuple[int, int, int, int],
+        latent_channels: int,
+        image_channels: int,
+        patch_size: int,
+        decoder_time_upscale: tuple[bool, bool],
+        decoder_space_upscale: tuple[bool, bool, bool],
+        act_func: nn.Module,
     ):
-        """Initialize pretrained TAEHV from the given checkpoint.
-
-        Arg:
-            checkpoint_path: path to weight file to load. taehv.pth for Hunyuan, taew2_1.pth for Wan 2.1.
-            decoder_time_upscale: whether temporal upsampling is enabled for each block. upsampling can be disabled for a cheaper preview.
-            decoder_space_upscale: whether spatial upsampling is enabled for each block. upsampling can be disabled for a cheaper preview.
-            patch_size: input/output pixelshuffle patch-size for this model.
-            latent_channels: number of latent channels (z dim) for this model.
-        """
         super().__init__()
-        self.patch_size = patch_size
-        self.latent_channels = latent_channels
-        self.image_channels = 3
-        self.is_cogvideox = checkpoint_path is not None and "taecvx" in checkpoint_path
-        # if checkpoint_path is not None and "taew2_2" in checkpoint_path:
-        #     self.patch_size, self.latent_channels = 2, 48
-        self.model_type = model_type
-        if model_type == "wan22":
-            self.patch_size, self.latent_channels = 2, 48
-        if model_type == "hy15":
-            act_func = nn.LeakyReLU(0.2, inplace=True)
-        else:
-            act_func = nn.ReLU(inplace=True)
-
-        self.encoder = nn.Sequential(
-            conv(self.image_channels * self.patch_size**2, 64),
-            act_func,
-            TPool(64, 2),
-            conv(64, 64, stride=2, bias=False),
-            MemBlock(64, 64, act_func),
-            MemBlock(64, 64, act_func),
-            MemBlock(64, 64, act_func),
-            TPool(64, 2),
-            conv(64, 64, stride=2, bias=False),
-            MemBlock(64, 64, act_func),
-            MemBlock(64, 64, act_func),
-            MemBlock(64, 64, act_func),
-            TPool(64, 1),
-            conv(64, 64, stride=2, bias=False),
-            MemBlock(64, 64, act_func),
-            MemBlock(64, 64, act_func),
-            MemBlock(64, 64, act_func),
-            conv(64, self.latent_channels),
-        )
-        n_f = [256, 128, 64, 64]
-        self.frames_to_trim = 2 ** sum(decoder_time_upscale) - 1
-        self.decoder = nn.Sequential(
+        # Layer indices match the legacy ``self.decoder = nn.Sequential(...)``
+        # so checkpoint keys (``decoder.<idx>.<param>``) load unchanged.
+        self.blocks = nn.Sequential(
             Clamp(),
-            conv(self.latent_channels, n_f[0]),
+            _conv(latent_channels, n_f[0]),
             act_func,
             MemBlock(n_f[0], n_f[0], act_func),
             MemBlock(n_f[0], n_f[0], act_func),
             MemBlock(n_f[0], n_f[0], act_func),
             nn.Upsample(scale_factor=2 if decoder_space_upscale[0] else 1),
             TGrow(n_f[0], 1),
-            conv(n_f[0], n_f[1], bias=False),
+            _conv(n_f[0], n_f[1], bias=False),
             MemBlock(n_f[1], n_f[1], act_func),
             MemBlock(n_f[1], n_f[1], act_func),
             MemBlock(n_f[1], n_f[1], act_func),
             nn.Upsample(scale_factor=2 if decoder_space_upscale[1] else 1),
             TGrow(n_f[1], 2 if decoder_time_upscale[0] else 1),
-            conv(n_f[1], n_f[2], bias=False),
+            _conv(n_f[1], n_f[2], bias=False),
             MemBlock(n_f[2], n_f[2], act_func),
             MemBlock(n_f[2], n_f[2], act_func),
             MemBlock(n_f[2], n_f[2], act_func),
             nn.Upsample(scale_factor=2 if decoder_space_upscale[2] else 1),
             TGrow(n_f[2], 2 if decoder_time_upscale[1] else 1),
-            conv(n_f[2], n_f[3], bias=False),
+            _conv(n_f[2], n_f[3], bias=False),
             act_func,
-            conv(n_f[3], self.image_channels * self.patch_size**2),
+            _conv(n_f[3], image_channels * patch_size**2),
         )
-        if checkpoint_path is not None:
-            state_dict = load_checkpoint(checkpoint_path)
-            self.load_state_dict(self.patch_tgrow_layers(state_dict))
 
-    def patch_tgrow_layers(self, sd):
-        """Patch TGrow layers to use a smaller kernel if needed.
+    def forward(
+        self, z: torch.Tensor, state: Dict[int, torch.Tensor], batch: int
+    ) -> torch.Tensor:
+        b, t, c, h, w = z.shape
+        x = z.reshape(b * t, c, h, w)
+        for blk in self.blocks:
+            if isinstance(blk, MemBlock):
+                x = blk.cache_step(x, state, batch)
+            else:
+                x = blk(x)
+        bt, c_out, h_out, w_out = x.shape
+        return x.reshape(b, bt // b, c_out, h_out, w_out)
 
-        Args:
-            sd: state dict to patch
-        """
-        new_sd = self.state_dict()
-        for i, layer in enumerate(self.decoder):
-            if isinstance(layer, TGrow):
-                key = f"decoder.{i}.conv.weight"
-                if sd[key].shape[0] > new_sd[key].shape[0]:
-                    # take the last-timestep output channels
-                    sd[key] = sd[key][-new_sd[key].shape[0] :]
-        return sd
 
-    def encode_video(
+def _patch_tgrow_state_dict(
+    sd: Dict[str, torch.Tensor], decoder_blocks: nn.Sequential
+) -> Dict[str, torch.Tensor]:
+    """Truncate over-sized TGrow ``conv.weight`` rows in ``sd`` to the
+    model's expected output channels.
+
+    Some shipped checkpoints store TGrow weights for ``stride=2`` even
+    when the model is configured with ``stride=1``; keep only the
+    last-timestep slice (matches legacy ``patch_tgrow_layers``).
+    """
+    sd = dict(sd)
+    for i, layer in enumerate(decoder_blocks):
+        if isinstance(layer, TGrow):
+            key = f"decoder.blocks.{i}.conv.weight"
+            if key in sd:
+                expected = layer.conv.weight.shape[0]
+                if sd[key].shape[0] > expected:
+                    sd[key] = sd[key][-expected:]
+    return sd
+
+
+class TAEHV(nn.Module):
+    """Tiny AutoEncoder for Hunyuan Video / Wan -- streaming decode-only.
+
+    Loads a TAEHV checkpoint (encoder weights in the file are silently
+    dropped). ``decode`` accepts an ``[N, T, C_z, H, W]`` latent and
+    returns an ``[N, T_out, C_img, H*patch*scale, W*patch*scale]``
+    image tensor in ``[0, 1]``. Each rollout uses a fresh
+    :class:`TAEHVCache`.
+
+    Per-rollout dispatch when ``use_cuda_graph=True``:
+        - Rollout 1: bare decoder / wrapper.drain -- drains Inductor
+          autotune on the eager path against the wrapper's static
+          buffer.
+        - Rollout 2+: wrapper.__call__ -- 2 warmups + 1 capture, then
+          pure replays for every same-shape body chunk.
+
+    Example::
+
+        taehv = TAEHV(checkpoint_path="...").to("cuda", torch.bfloat16)
+        cache = taehv.prepare_cache()
+        x = taehv.decode(z, cache=cache)
+
+    Note:
+        Set ``torch.backends.cudnn.benchmark = True`` once at process
+        start for ~5% extra on the eager seed/tail chunks.
+    """
+
+    TEMPORAL_COMPRESSION_RATIO = 4
+    SPATIAL_COMPRESSION_RATIO = 8
+
+    def __init__(
         self,
-        x,
-        parallel=True,
-        show_progress_bar=False,
-        cache: Optional[TAEHVCache] = None,
+        checkpoint_path: str = "taew2_1.pth",
+        decoder_time_upscale: tuple[bool, bool] = (True, True),
+        decoder_space_upscale: tuple[bool, bool, bool] = (True, True, True),
+        patch_size: int = 1,
+        latent_channels: int = 16,
+        model_type: str = "wan21",
+        use_cuda_graph: bool = True,
+        use_compile: bool = True,
+        warmup_iters: int = 2,
     ):
-        """Encode a sequence of frames.
+        super().__init__()
+        # ``wan22`` uses a different patch-size / latent-channel config; the
+        # other supported model types share the defaults above.
+        if model_type == "wan22":
+            patch_size, latent_channels = 2, 48
+        act_func = nn.ReLU(inplace=True)
 
-        Args:
-            x: input NTCHW RGB (C=3) tensor with values in [0, 1].
-            parallel: if True, all frames will be processed at once.
-              (this is faster but may require more memory).
-              if False, frames will be processed sequentially.
-        Returns NTCHW latent tensor with ~Gaussian values.
-        """
-        if self.patch_size > 1:
-            x = F.pixel_unshuffle(x, self.patch_size)
-        if x.shape[1] % 4 != 0:
-            # pad at end to multiple of 4
-            n_pad = 4 - x.shape[1] % 4
-            padding = x[:, -1:].repeat_interleave(n_pad, dim=1)
-            x = torch.cat([x, padding], 1)
-        return apply_model_with_memblocks(
-            self.encoder,
-            x,
-            parallel,
-            show_progress_bar,
-            cache_mem=cache.enc_feat_map if cache is not None else None,
+        self.patch_size = patch_size
+        self.latent_channels = latent_channels
+        self.image_channels = 3
+        self.model_type = model_type
+        # Frames the decoder must drop from the front of its FIRST chunk
+        # output. ``2 ** sum(time_upscale) - 1`` matches legacy.
+        self.frames_to_trim = 2 ** sum(decoder_time_upscale) - 1
+
+        n_f = (256, 128, 64, 64)
+        # Build on `meta` -- only the checkpoint allocates real memory.
+        with torch.device("meta"):
+            self.decoder = Decoder(
+                n_f=n_f,
+                latent_channels=latent_channels,
+                image_channels=self.image_channels,
+                patch_size=patch_size,
+                decoder_time_upscale=decoder_time_upscale,
+                decoder_space_upscale=decoder_space_upscale,
+                act_func=act_func,
+            )
+
+        sd = load_checkpoint(checkpoint_path)
+        # Re-key from legacy ``decoder.<i>.*`` to ``decoder.blocks.<i>.*``
+        # (the new ``Decoder`` wraps the Sequential in an attribute).
+        sd = {
+            (
+                k.replace("decoder.", "decoder.blocks.", 1)
+                if k.startswith("decoder.") and not k.startswith("decoder.blocks.")
+                else k
+            ): v
+            for k, v in sd.items()
+        }
+        sd = _patch_tgrow_state_dict(sd, self.decoder.blocks)
+        # ``assign=True``: meta params become the checkpoint tensors as-is;
+        # ``strict=False``: silently drop encoder-only weights.
+        self.load_state_dict(sd, strict=False, assign=True)
+
+        self.eval().requires_grad_(False)
+
+        self._use_cuda_graph = use_cuda_graph
+
+        if use_compile:
+            self.decoder = torch.compile(  # type: ignore[assignment]
+                self.decoder, mode="max-autotune-no-cudagraphs"
+            )
+        self._decoder_call: Callable[..., torch.Tensor] = (
+            CUDAGraphWrapper(self.decoder, warmup_iters=warmup_iters)
+            if use_cuda_graph
+            else self.decoder
         )
-
-    def decode_video(
-        self,
-        x,
-        parallel=True,
-        show_progress_bar=False,
-        cache: Optional[TAEHVCache] = None,
-    ):
-        """Decode a sequence of frames.
-
-        Args:
-            x: input NTCHW latent (C=12) tensor with ~Gaussian values.
-            parallel: if True, all frames will be processed at once.
-              (this is faster but may require more memory).
-              if False, frames will be processed sequentially.
-        Returns NTCHW RGB tensor with ~[0, 1] values.
-        """
-        # NOTE(qi): We only trim the first decoded chunk. Index 3 corresponds to the first MemBlock in the decoder.
-        #           We can also use other ways to determine if it's the first decode.
-        first_decode = True if cache is None else (cache.dec_feat_map[3] is None)
-        # Combine with the original logic to determine if we should skip trimming.
-        skip_trim = (self.is_cogvideox and x.shape[1] % 2 == 0) or (not first_decode)
-        x = apply_model_with_memblocks(
-            self.decoder,
-            x,
-            parallel,
-            show_progress_bar,
-            cache_mem=cache.dec_feat_map if cache is not None else None,
-        )
-        if self.model_type == "hy15":
-            x = x.clamp_(-1, 1)
-        else:
-            x = x.clamp_(0, 1)
-        if self.patch_size > 1:
-            x = F.pixel_shuffle(x, self.patch_size)
-        if skip_trim:
-            # skip trimming for cogvideox to make frame counts match.
-            # this still doesn't have correct temporal alignment for certain frame counts
-            # (cogvideox seems to pad at the start?), but for multiple-of-4 it's fine.
-            return x
-        return x[:, self.frames_to_trim :]
 
     def prepare_cache(self) -> TAEHVCache:
-        return TAEHVCache(
-            enc_conv_idx=[],
-            enc_feat_map=[None] * len(self.encoder),
-            dec_conv_idx=[],
-            dec_feat_map=[None] * len(self.decoder),
-        )
+        """Return a fresh empty cache and drop any captured CUDA graph.
+
+        Captured kernels reference the previous cache's slot pointers,
+        which a new cache invalidates -- warmup + capture re-run on the
+        next decode of each shape.
+        """
+        if self._use_cuda_graph:
+            self._decoder_call.reset()  # type: ignore[union-attr]
+        return TAEHVCache()
+
+    @torch.inference_mode()
+    def decode(
+        self, z: torch.Tensor, cache: Optional[TAEHVCache] = None
+    ) -> torch.Tensor:
+        """Streaming decode of ``z`` (``[N, T, C_z, H, W]`` latent).
+
+        First call (``cache.dec_state`` empty): runs the decoder eagerly
+        and trims the leading ``frames_to_trim`` frames; subsequent
+        same-shape calls go through the captured graph.
+        """
+        if cache is None:
+            cache = self.prepare_cache()
+        state = cache.dec_state
+        first_decode = not state
+        # Bind decoder before the first call so steady-state calls go through
+        # the wrapper while the autotune-during-capture shape is the eager
+        # path.
+        if self._use_cuda_graph:
+            decoder = (
+                self._decoder_call.drain  # type: ignore[union-attr]
+                if first_decode
+                else self._decoder_call
+            )
+        else:
+            decoder = self.decoder
+
+        b = z.shape[0]
+        x = decoder(z, state, b)
+        # Clamp / pixel-shuffle / trim happen outside the captured region;
+        # the wrapper returns ``static_output.clone()`` so ``clamp_`` is
+        # safe in-place.
+        x = x.clamp_(0, 1)
+        if self.patch_size > 1:
+            n, t, c, h, w = x.shape
+            x = F.pixel_shuffle(x.reshape(n * t, c, h, w), self.patch_size)
+            x = x.reshape(n, t, x.shape[1], x.shape[2], x.shape[3])
+        if first_decode:
+            x = x[:, self.frames_to_trim :]
+        return x

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -236,6 +236,13 @@ class TAEHV(nn.Module):
     image tensor in ``[0, 1]``. Each rollout uses a fresh
     :class:`TAEHVCache`.
 
+    Supported ``model_type`` values: ``"wan21"`` (default; ReLU,
+    ``patch_size=1``, ``latent_channels=16``) and ``"wan22"`` (ReLU,
+    ``patch_size=2``, ``latent_channels=48``). The legacy ``"hy15"``
+    (LeakyReLU + ``[-1, 1]`` clamp) and ``"taecvx"`` (cogvideox even-T
+    skip-trim) variants are NOT supported here -- pass them and the
+    constructor raises.
+
     Per-rollout dispatch when ``use_cuda_graph=True``:
         - Rollout 1: bare decoder / wrapper.drain -- drains Inductor
           autotune on the eager path against the wrapper's static
@@ -257,6 +264,8 @@ class TAEHV(nn.Module):
     TEMPORAL_COMPRESSION_RATIO = 4
     SPATIAL_COMPRESSION_RATIO = 8
 
+    SUPPORTED_MODEL_TYPES = ("wan21", "wan22")
+
     def __init__(
         self,
         checkpoint_path: str = "taew2_1.pth",
@@ -266,10 +275,24 @@ class TAEHV(nn.Module):
         latent_channels: int = 16,
         model_type: str = "wan21",
         use_cuda_graph: bool = True,
-        use_compile: bool = True,
+        use_compile: bool = False,
         warmup_iters: int = 2,
     ):
         super().__init__()
+        if model_type not in self.SUPPORTED_MODEL_TYPES:
+            raise ValueError(
+                f"TAEHV: model_type={model_type!r} is not supported by this slim "
+                f"impl (supported: {self.SUPPORTED_MODEL_TYPES}). The legacy "
+                f"'hy15' / 'taecvx' branches (different activation, clamp range, "
+                f"or trim semantics) were dropped in the decode-only refactor."
+            )
+        if checkpoint_path is not None and "taecvx" in checkpoint_path:
+            # CogVideoX checkpoints relied on a legacy ``skip_trim`` branch
+            # (``is_cogvideox and x.shape[1] % 2 == 0``) that is not ported.
+            raise ValueError(
+                f"TAEHV: cogvideox checkpoint {checkpoint_path!r} is not "
+                f"supported by this slim impl."
+            )
         # ``wan22`` uses a different patch-size / latent-channel config; the
         # other supported model types share the defaults above.
         if model_type == "wan22":

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -483,7 +483,7 @@ class WanVAE(nn.Module):
         vae_path: str,
         use_lightvae: bool = False,
         use_cuda_graph: bool = True,
-        use_compile: bool = False,
+        use_compile: bool = True,
         warmup_iters: int = 2,
         enable_encoder: bool = True,
         enable_decoder: bool = True,

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/rope.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/rope.py
@@ -15,7 +15,9 @@ except (ImportError, OSError):
     except (ImportError, OSError):
         from loguru import logger
 
-        logger.info("transformer_engine is unavailable; using pure PyTorch RoPE fallback.")
+        logger.info(
+            "transformer_engine is unavailable; using pure PyTorch RoPE fallback."
+        )
 
         def _rotate_half(x: Tensor, interleaved: bool = False) -> Tensor:
             if interleaved:
@@ -58,6 +60,7 @@ except (ImportError, OSError):
             cos = torch.cos(rope).to(dtype=t.dtype)
             sin = torch.sin(rope).to(dtype=t.dtype)
             return t * cos + _rotate_half(t, interleaved) * sin
+
 
 T = TypeVar("T")
 

--- a/flashdreams/tests/taehv/_profile_taehv.py
+++ b/flashdreams/tests/taehv/_profile_taehv.py
@@ -1,0 +1,248 @@
+"""Compare 2nd-rollout latency: reference vs slim TAEHV decode.
+
+Run on a GPU (typically inside an interactive srun)::
+
+    PYTHONPATH=./flashdreams python flashdreams/tests/taehv/_profile_taehv.py
+    PYTHONPATH=./flashdreams python flashdreams/tests/taehv/_profile_taehv.py --quick
+
+The first chunk of every decode populates the streaming cache and
+allocates workspaces; we measure the *second* chunk (and only the
+second) to get a stable, cache-warm number that mirrors steady-state
+rollout.
+
+Notes on first-run cost: with ``use_compile=True`` (the default),
+Inductor autotunes ``max-autotune-no-cudagraphs`` for each unique input
+shape. TAEHV is much smaller than Wan VAE so first run is typically
+~1-3 min. Subsequent runs hit the on-disk Inductor + triton caches.
+Pass ``--quick`` to skip compilation entirely (CUDA-graph capture only).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+# Park Inductor + triton caches on local disk before torch is imported, so
+# repeat runs of this script reuse autotune decisions.
+_CACHE_ROOT = f"/tmp/{os.environ.get('USER', 'flashdreams')}/taehv_profile"
+os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", f"{_CACHE_ROOT}/inductor")
+os.environ.setdefault("TRITON_CACHE_DIR", f"{_CACHE_ROOT}/triton")
+
+import torch  # noqa: E402
+
+from flashdreams.core.checkpoint.load import load_checkpoint  # noqa: E402
+from flashdreams.recipes.taehv import (  # noqa: E402
+    AVAILABLE_TAEHV_CHECKPOINT_PATHS,
+)
+from flashdreams.recipes.taehv.impl import TAEHV as TAEHVNew  # noqa: E402
+
+# Sibling module: when run as a script (not via pytest), `conftest.py` is
+# not loaded, so add this directory to `sys.path` ourselves.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from impl_reference import TAEHV as TAEHVLegacy  # noqa: E402
+
+
+def _build_pair(
+    checkpoint_path: str,
+    dtype: torch.dtype,
+    device: torch.device,
+    *,
+    use_compile: bool,
+) -> tuple[TAEHVLegacy, TAEHVNew]:
+    weights = load_checkpoint(checkpoint_path)
+    weights = {k: v.to(dtype) for k, v in weights.items()}
+
+    def _cached(_path):
+        return weights
+
+    targets = (
+        "impl_reference.load_checkpoint",
+        "flashdreams.recipes.taehv.impl.load_checkpoint",
+    )
+    with patch(targets[0], _cached), patch(targets[1], _cached):
+        legacy = TAEHVLegacy(checkpoint_path=checkpoint_path).to(
+            device=device, dtype=dtype
+        )
+        new = TAEHVNew(
+            checkpoint_path=checkpoint_path, use_compile=use_compile
+        ).to(device=device, dtype=dtype)
+    return legacy, new
+
+
+def _log(msg: str, t0: float | None = None) -> float:
+    t = time.perf_counter()
+    prefix = f"[{t - t0:6.1f}s] " if t0 is not None else ""
+    print(f"  {prefix}{msg}", flush=True)
+    return t
+
+
+@torch.no_grad()
+def _time_second_decode_legacy(
+    model: TAEHVLegacy, latents: torch.Tensor, *, chunk_t: int, n_repeat: int
+) -> float:
+    """Warm the cache, then time ``n_repeat`` chunk-B decodes (legacy)."""
+    z_a = latents[:, :chunk_t]
+    z_b = latents[:, chunk_t : 2 * chunk_t]
+
+    cache = model.prepare_cache()
+    model.decode_video(z_a, parallel=True, cache=cache)
+    # Legacy has no CUDA graph; one warm chunk is enough.
+    model.decode_video(z_b, parallel=True, cache=cache)
+    torch.cuda.synchronize()
+
+    times_ms: list[float] = []
+    for _ in range(n_repeat):
+        start, end = (
+            torch.cuda.Event(enable_timing=True),
+            torch.cuda.Event(enable_timing=True),
+        )
+        start.record()
+        model.decode_video(z_b, parallel=True, cache=cache)
+        end.record()
+        torch.cuda.synchronize()
+        times_ms.append(start.elapsed_time(end))
+
+    times_ms.sort()
+    return sum(times_ms[:-1]) / (len(times_ms) - 1)
+
+
+@torch.no_grad()
+def _time_second_decode_new(
+    model: TAEHVNew, latents: torch.Tensor, *, chunk_t: int, n_repeat: int
+) -> float:
+    """Warm the cache + capture the CUDA graph, then time ``n_repeat`` decodes."""
+    z_a = latents[:, :chunk_t]
+    z_b = latents[:, chunk_t : 2 * chunk_t]
+
+    cache = model.prepare_cache()
+    model.decode(z_a, cache=cache)
+    # 2 wrapper warmups + 1 capture pass = wrapped graph ready before timing.
+    for _ in range(3):
+        model.decode(z_b, cache=cache)
+    torch.cuda.synchronize()
+
+    times_ms: list[float] = []
+    for _ in range(n_repeat):
+        start, end = (
+            torch.cuda.Event(enable_timing=True),
+            torch.cuda.Event(enable_timing=True),
+        )
+        start.record()
+        model.decode(z_b, cache=cache)
+        end.record()
+        torch.cuda.synchronize()
+        times_ms.append(start.elapsed_time(end))
+
+    times_ms.sort()
+    return sum(times_ms[:-1]) / (len(times_ms) - 1)
+
+
+def _peak_mem_mib(fn, *args, **kwargs) -> tuple[float, float]:
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    out = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated() / (1024**2)
+    return out, peak
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--ckpts",
+        nargs="+",
+        choices=sorted(AVAILABLE_TAEHV_CHECKPOINT_PATHS),
+        default=["lighttae"],
+    )
+    p.add_argument("--quick", action="store_true", help="Disable torch.compile.")
+    p.add_argument("--n-repeat", type=int, default=10)
+    p.add_argument("--height", type=int, default=720)
+    p.add_argument("--width", type=int, default=1280)
+    p.add_argument(
+        "--chunk-t", type=int, default=2, help="Latent timesteps per AR chunk."
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    dtype = torch.bfloat16
+    device = torch.device("cuda")
+    h, w = args.height, args.width
+
+    use_compile = not args.quick
+    print("=" * 78)
+    print(
+        f"TAEHV 2nd-rollout decode latency: legacy vs slim "
+        f"(bf16, {device}, H={h}, W={w}, use_compile={use_compile})"
+    )
+    print(
+        f"  decode chunk A=B={args.chunk_t} latents (warm + timed x{args.n_repeat})"
+    )
+    print(f"  ckpts={args.ckpts}")
+    print(f"  inductor cache: {os.environ['TORCHINDUCTOR_CACHE_DIR']}")
+    print(f"  triton cache:   {os.environ['TRITON_CACHE_DIR']}")
+    print("=" * 78, "\n", flush=True)
+
+    rows: list[tuple[str, float, float, float, float]] = []
+    for ckpt_key in args.ckpts:
+        ckpt_path = AVAILABLE_TAEHV_CHECKPOINT_PATHS[ckpt_key]
+        t_ckpt = time.perf_counter()
+        print(f"[{ckpt_key}] building models...", flush=True)
+        legacy, new = _build_pair(ckpt_path, dtype, device, use_compile=use_compile)
+        _log("models built", t_ckpt)
+
+        torch.manual_seed(0)
+        latents = torch.empty(
+            1, 2 * args.chunk_t, 16, h // 8, w // 8, dtype=dtype, device=device
+        ).uniform_(-1, 1)
+
+        t = time.perf_counter()
+        leg_dec, leg_dec_mem = _peak_mem_mib(
+            _time_second_decode_legacy,
+            legacy,
+            latents,
+            chunk_t=args.chunk_t,
+            n_repeat=args.n_repeat,
+        )
+        _log(f"legacy decode timed: {leg_dec:.3f} ms", t)
+
+        t = time.perf_counter()
+        new_dec, new_dec_mem = _peak_mem_mib(
+            _time_second_decode_new,
+            new,
+            latents,
+            chunk_t=args.chunk_t,
+            n_repeat=args.n_repeat,
+        )
+        _log(f"new decode timed:    {new_dec:.3f} ms", t)
+
+        _log(f"[{ckpt_key}] total elapsed", t_ckpt)
+        print()
+
+        rows.append((ckpt_key, leg_dec, new_dec, leg_dec_mem, new_dec_mem))
+
+        del legacy, new, latents
+        torch.cuda.empty_cache()
+
+    hdr = (
+        f"{'ckpt':<12} {'legacy ms':>10} {'new ms':>10} "
+        f"{'speedup':>9} {'legacy MiB':>11} {'new MiB':>10} {'mem dlt':>10}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for ckpt, lt, nt, lm, nm in rows:
+        speedup = lt / nt if nt > 0 else float("inf")
+        mem_dlt = nm - lm
+        print(
+            f"{ckpt:<12} {lt:>10.3f} {nt:>10.3f} "
+            f"{speedup:>8.2f}x {lm:>11.1f} {nm:>10.1f} {mem_dlt:>+10.1f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/flashdreams/tests/taehv/_profile_taehv.py
+++ b/flashdreams/tests/taehv/_profile_taehv.py
@@ -53,11 +53,16 @@ def _build_pair(
     *,
     use_compile: bool,
 ) -> tuple[TAEHVLegacy, TAEHVNew]:
+    import copy
+
     weights = load_checkpoint(checkpoint_path)
     weights = {k: v.to(dtype) for k, v in weights.items()}
 
+    # Return a fresh shallow copy each call: the legacy ``patch_tgrow_layers``
+    # mutates the dict in place, which would otherwise feed the new impl
+    # already-truncated TGrow weights when the legacy ctor ran first.
     def _cached(_path):
-        return weights
+        return copy.copy(weights)
 
     targets = (
         "impl_reference.load_checkpoint",
@@ -67,9 +72,9 @@ def _build_pair(
         legacy = TAEHVLegacy(checkpoint_path=checkpoint_path).to(
             device=device, dtype=dtype
         )
-        new = TAEHVNew(
-            checkpoint_path=checkpoint_path, use_compile=use_compile
-        ).to(device=device, dtype=dtype)
+        new = TAEHVNew(checkpoint_path=checkpoint_path, use_compile=use_compile).to(
+            device=device, dtype=dtype
+        )
     return legacy, new
 
 
@@ -180,9 +185,7 @@ def main() -> None:
         f"TAEHV 2nd-rollout decode latency: legacy vs slim "
         f"(bf16, {device}, H={h}, W={w}, use_compile={use_compile})"
     )
-    print(
-        f"  decode chunk A=B={args.chunk_t} latents (warm + timed x{args.n_repeat})"
-    )
+    print(f"  decode chunk A=B={args.chunk_t} latents (warm + timed x{args.n_repeat})")
     print(f"  ckpts={args.ckpts}")
     print(f"  inductor cache: {os.environ['TORCHINDUCTOR_CACHE_DIR']}")
     print(f"  triton cache:   {os.environ['TRITON_CACHE_DIR']}")

--- a/flashdreams/tests/taehv/conftest.py
+++ b/flashdreams/tests/taehv/conftest.py
@@ -1,0 +1,18 @@
+"""Make ``impl_reference`` importable as a sibling from this directory.
+
+``pyproject.toml`` runs pytest with ``--import-mode=importlib``, which
+does not add a test file's directory to ``sys.path`` and does not build
+a parent package even when ``__init__.py`` is present, so neither
+``from .impl_reference import ...`` nor a bare ``from impl_reference
+import ...`` works out of the box. Inject this folder into ``sys.path``
+so the bare absolute form resolves.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = str(Path(__file__).resolve().parent)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)

--- a/flashdreams/tests/taehv/impl_reference.py
+++ b/flashdreams/tests/taehv/impl_reference.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+Tiny AutoEncoder for Hunyuan Video
+(DNN for encoding / decoding videos to Hunyuan Video's latent space)
+"""
+
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from tqdm.auto import tqdm
+
+from flashdreams.core.checkpoint.load import load_checkpoint
+from flashdreams.infra.decoder import DecoderAutoregressiveCache
+
+DecoderResult = namedtuple("DecoderResult", ("frame", "memory"))
+TWorkItem = namedtuple("TWorkItem", ("input_tensor", "block_index"))
+
+
+def conv(n_in, n_out, **kwargs):
+    return nn.Conv2d(n_in, n_out, 3, padding=1, **kwargs)
+
+
+class Clamp(nn.Module):
+    def forward(self, x):
+        return torch.tanh(x / 3) * 3
+
+
+class MemBlock(nn.Module):
+    def __init__(self, n_in, n_out, act_func):
+        super().__init__()
+        self.conv = nn.Sequential(
+            conv(n_in * 2, n_out),
+            act_func,
+            conv(n_out, n_out),
+            act_func,
+            conv(n_out, n_out),
+        )
+        self.skip = (
+            nn.Conv2d(n_in, n_out, 1, bias=False) if n_in != n_out else nn.Identity()
+        )
+        self.act = act_func
+
+    def forward(self, x, past):
+        return self.act(self.conv(torch.cat([x, past], 1)) + self.skip(x))
+
+
+class TPool(nn.Module):
+    def __init__(self, n_f, stride):
+        super().__init__()
+        self.stride = stride
+        self.conv = nn.Conv2d(n_f * stride, n_f, 1, bias=False)
+
+    def forward(self, x):
+        _NT, C, H, W = x.shape
+        return self.conv(x.reshape(-1, self.stride * C, H, W))
+
+
+class TGrow(nn.Module):
+    def __init__(self, n_f, stride):
+        super().__init__()
+        self.stride = stride
+        self.conv = nn.Conv2d(n_f, n_f * stride, 1, bias=False)
+
+    def forward(self, x):
+        _NT, C, H, W = x.shape
+        x = self.conv(x)
+        return x.reshape(-1, C, H, W)
+
+
+def apply_model_with_memblocks(
+    model, x, parallel, show_progress_bar, cache_mem: List | None = None
+):
+    """
+    Apply a sequential model with memblocks to the given input.
+    Args:
+    - model: nn.Sequential of blocks to apply
+    - x: input data, of dimensions NTCHW
+    - parallel: if True, parallelize over timesteps (fast but uses O(T) memory)
+        if False, each timestep will be processed sequentially (slow but uses O(1) memory)
+    - show_progress_bar: if True, enables tqdm progressbar display
+
+    Returns NTCHW tensor of output data.
+    """
+    assert x.ndim == 5, f"TAEHV operates on NTCHW tensors, but got {x.ndim}-dim tensor"
+    N, T, C, H, W = x.shape
+    if parallel:
+        x = x.reshape(N * T, C, H, W)
+        # parallel over input timesteps, iterate over blocks
+        for idx, b in enumerate(model):
+            if isinstance(b, MemBlock):
+                prev_mem = cache_mem[idx]
+                NT, C, H, W = x.shape
+                T = NT // N
+                _x = x.reshape(N, T, C, H, W)
+                if prev_mem is None:
+                    # roll to the right and left pad with zeros
+                    curr_mem = F.pad(_x, (0, 0, 0, 0, 0, 0, 1, 0), value=0)[:, :T]
+                else:
+                    # roll to the right and left pad with the last frame in previous mem
+                    curr_mem = torch.cat([prev_mem[:, -1:], _x[:, :-1]], dim=1)
+                x = b(x, curr_mem.reshape(x.shape))
+                cache_mem[idx] = _x
+            else:
+                x = b(x)
+        NT, C, H, W = x.shape
+        T = NT // N
+        x = x.view(N, T, C, H, W)
+    else:
+        # TODO(oboerbohan): at least on macos this still gradually uses more memory during decode...
+        # need to fix :(
+        out = []
+        # iterate over input timesteps and also iterate over blocks.
+        # because of the cursed TPool/TGrow blocks, this is not a nested loop,
+        # it's actually a ***graph traversal*** problem! so let's make a queue
+        work_queue = [
+            TWorkItem(xt, 0)
+            for t, xt in enumerate(x.reshape(N, T * C, H, W).chunk(T, dim=1))
+        ]
+        # in addition to manually managing our queue, we also need to manually manage our progressbar.
+        # we'll update it for every source node that we consume.
+        progress_bar = tqdm(range(T), disable=not show_progress_bar)
+        # we'll also need a separate addressable memory per node as well
+        mem = [None] * len(model) if cache_mem is None else cache_mem
+        while work_queue:
+            xt, i = work_queue.pop(0)
+            if i == 0:
+                # new source node consumed
+                progress_bar.update(1)
+            if i == len(model):
+                # reached end of the graph, append result to output list
+                out.append(xt)
+            else:
+                # fetch the block to process
+                b = model[i]
+                if isinstance(b, MemBlock):
+                    # mem blocks are simple since we're visiting the graph in causal order
+                    if mem[i] is None:
+                        xt_new = b(xt, xt * 0)
+                        mem[i] = xt
+                    else:
+                        xt_new = b(xt, mem[i])
+                        mem[i].copy_(xt)
+                        # ^ inplace might reduce mysterious pytorch memory allocations? doesn't help though
+                    # add successor to work queue
+                    work_queue.insert(0, TWorkItem(xt_new, i + 1))
+                elif isinstance(b, TPool):
+                    # pool blocks are miserable
+                    if mem[i] is None:
+                        mem[i] = []  # pool memory is itself a queue of inputs to pool
+                    mem[i].append(xt)
+                    if len(mem[i]) > b.stride:
+                        # pool mem is in invalid state, we should have pooled before this
+                        raise ValueError("???")
+                    elif len(mem[i]) < b.stride:
+                        # pool mem is not yet full, go back to processing the work queue
+                        pass
+                    else:
+                        # pool mem is ready, run the pool block
+                        N, C, H, W = xt.shape
+                        xt = b(torch.cat(mem[i], 1).view(N * b.stride, C, H, W))
+                        # reset the pool mem
+                        mem[i] = []
+                        # add successor to work queue
+                        work_queue.insert(0, TWorkItem(xt, i + 1))
+                elif isinstance(b, TGrow):
+                    xt = b(xt)
+                    NT, C, H, W = xt.shape
+                    # each tgrow has multiple successor nodes
+                    for xt_next in reversed(
+                        xt.view(N, b.stride * C, H, W).chunk(b.stride, 1)
+                    ):
+                        # add successor to work queue
+                        work_queue.insert(0, TWorkItem(xt_next, i + 1))
+                else:
+                    # normal block with no funny business
+                    xt = b(xt)
+                    # add successor to work queue
+                    work_queue.insert(0, TWorkItem(xt, i + 1))
+        progress_bar.close()
+        x = torch.stack(out, 1)
+    return x
+
+
+@dataclass
+class TAEHVCache(DecoderAutoregressiveCache):
+    enc_conv_idx: List[int]
+    enc_feat_map: List[Optional[torch.Tensor]]
+    dec_conv_idx: List[int]
+    dec_feat_map: List[Optional[torch.Tensor]]
+
+
+class TAEHV(nn.Module):
+    def __init__(
+        self,
+        checkpoint_path="taew2_1.pth",
+        decoder_time_upscale=(True, True),
+        decoder_space_upscale=(True, True, True),
+        patch_size=1,
+        latent_channels=16,
+        model_type="wan21",
+    ):
+        """Initialize pretrained TAEHV from the given checkpoint.
+
+        Arg:
+            checkpoint_path: path to weight file to load. taehv.pth for Hunyuan, taew2_1.pth for Wan 2.1.
+            decoder_time_upscale: whether temporal upsampling is enabled for each block. upsampling can be disabled for a cheaper preview.
+            decoder_space_upscale: whether spatial upsampling is enabled for each block. upsampling can be disabled for a cheaper preview.
+            patch_size: input/output pixelshuffle patch-size for this model.
+            latent_channels: number of latent channels (z dim) for this model.
+        """
+        super().__init__()
+        self.patch_size = patch_size
+        self.latent_channels = latent_channels
+        self.image_channels = 3
+        self.is_cogvideox = checkpoint_path is not None and "taecvx" in checkpoint_path
+        # if checkpoint_path is not None and "taew2_2" in checkpoint_path:
+        #     self.patch_size, self.latent_channels = 2, 48
+        self.model_type = model_type
+        if model_type == "wan22":
+            self.patch_size, self.latent_channels = 2, 48
+        if model_type == "hy15":
+            act_func = nn.LeakyReLU(0.2, inplace=True)
+        else:
+            act_func = nn.ReLU(inplace=True)
+
+        self.encoder = nn.Sequential(
+            conv(self.image_channels * self.patch_size**2, 64),
+            act_func,
+            TPool(64, 2),
+            conv(64, 64, stride=2, bias=False),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            TPool(64, 2),
+            conv(64, 64, stride=2, bias=False),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            TPool(64, 1),
+            conv(64, 64, stride=2, bias=False),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            conv(64, self.latent_channels),
+        )
+        n_f = [256, 128, 64, 64]
+        self.frames_to_trim = 2 ** sum(decoder_time_upscale) - 1
+        self.decoder = nn.Sequential(
+            Clamp(),
+            conv(self.latent_channels, n_f[0]),
+            act_func,
+            MemBlock(n_f[0], n_f[0], act_func),
+            MemBlock(n_f[0], n_f[0], act_func),
+            MemBlock(n_f[0], n_f[0], act_func),
+            nn.Upsample(scale_factor=2 if decoder_space_upscale[0] else 1),
+            TGrow(n_f[0], 1),
+            conv(n_f[0], n_f[1], bias=False),
+            MemBlock(n_f[1], n_f[1], act_func),
+            MemBlock(n_f[1], n_f[1], act_func),
+            MemBlock(n_f[1], n_f[1], act_func),
+            nn.Upsample(scale_factor=2 if decoder_space_upscale[1] else 1),
+            TGrow(n_f[1], 2 if decoder_time_upscale[0] else 1),
+            conv(n_f[1], n_f[2], bias=False),
+            MemBlock(n_f[2], n_f[2], act_func),
+            MemBlock(n_f[2], n_f[2], act_func),
+            MemBlock(n_f[2], n_f[2], act_func),
+            nn.Upsample(scale_factor=2 if decoder_space_upscale[2] else 1),
+            TGrow(n_f[2], 2 if decoder_time_upscale[1] else 1),
+            conv(n_f[2], n_f[3], bias=False),
+            act_func,
+            conv(n_f[3], self.image_channels * self.patch_size**2),
+        )
+        if checkpoint_path is not None:
+            state_dict = load_checkpoint(checkpoint_path)
+            self.load_state_dict(self.patch_tgrow_layers(state_dict))
+
+    def patch_tgrow_layers(self, sd):
+        """Patch TGrow layers to use a smaller kernel if needed.
+
+        Args:
+            sd: state dict to patch
+        """
+        new_sd = self.state_dict()
+        for i, layer in enumerate(self.decoder):
+            if isinstance(layer, TGrow):
+                key = f"decoder.{i}.conv.weight"
+                if sd[key].shape[0] > new_sd[key].shape[0]:
+                    # take the last-timestep output channels
+                    sd[key] = sd[key][-new_sd[key].shape[0] :]
+        return sd
+
+    def encode_video(
+        self,
+        x,
+        parallel=True,
+        show_progress_bar=False,
+        cache: Optional[TAEHVCache] = None,
+    ):
+        """Encode a sequence of frames.
+
+        Args:
+            x: input NTCHW RGB (C=3) tensor with values in [0, 1].
+            parallel: if True, all frames will be processed at once.
+              (this is faster but may require more memory).
+              if False, frames will be processed sequentially.
+        Returns NTCHW latent tensor with ~Gaussian values.
+        """
+        if self.patch_size > 1:
+            x = F.pixel_unshuffle(x, self.patch_size)
+        if x.shape[1] % 4 != 0:
+            # pad at end to multiple of 4
+            n_pad = 4 - x.shape[1] % 4
+            padding = x[:, -1:].repeat_interleave(n_pad, dim=1)
+            x = torch.cat([x, padding], 1)
+        return apply_model_with_memblocks(
+            self.encoder,
+            x,
+            parallel,
+            show_progress_bar,
+            cache_mem=cache.enc_feat_map if cache is not None else None,
+        )
+
+    def decode_video(
+        self,
+        x,
+        parallel=True,
+        show_progress_bar=False,
+        cache: Optional[TAEHVCache] = None,
+    ):
+        """Decode a sequence of frames.
+
+        Args:
+            x: input NTCHW latent (C=12) tensor with ~Gaussian values.
+            parallel: if True, all frames will be processed at once.
+              (this is faster but may require more memory).
+              if False, frames will be processed sequentially.
+        Returns NTCHW RGB tensor with ~[0, 1] values.
+        """
+        # NOTE(qi): We only trim the first decoded chunk. Index 3 corresponds to the first MemBlock in the decoder.
+        #           We can also use other ways to determine if it's the first decode.
+        first_decode = True if cache is None else (cache.dec_feat_map[3] is None)
+        # Combine with the original logic to determine if we should skip trimming.
+        skip_trim = (self.is_cogvideox and x.shape[1] % 2 == 0) or (not first_decode)
+        x = apply_model_with_memblocks(
+            self.decoder,
+            x,
+            parallel,
+            show_progress_bar,
+            cache_mem=cache.dec_feat_map if cache is not None else None,
+        )
+        if self.model_type == "hy15":
+            x = x.clamp_(-1, 1)
+        else:
+            x = x.clamp_(0, 1)
+        if self.patch_size > 1:
+            x = F.pixel_shuffle(x, self.patch_size)
+        if skip_trim:
+            # skip trimming for cogvideox to make frame counts match.
+            # this still doesn't have correct temporal alignment for certain frame counts
+            # (cogvideox seems to pad at the start?), but for multiple-of-4 it's fine.
+            return x
+        return x[:, self.frames_to_trim :]
+
+    def prepare_cache(self) -> TAEHVCache:
+        return TAEHVCache(
+            enc_conv_idx=[],
+            enc_feat_map=[None] * len(self.encoder),
+            dec_conv_idx=[],
+            dec_feat_map=[None] * len(self.decoder),
+        )

--- a/flashdreams/tests/taehv/test_taehv_equivalence.py
+++ b/flashdreams/tests/taehv/test_taehv_equivalence.py
@@ -1,0 +1,146 @@
+"""Numerical equivalence between reference and slim TAEHV decode.
+
+Requires GPU. Compares the upstream reference :class:`TAEHV` in
+:mod:`impl_reference` (sibling module in this folder) against the
+rewrite in :mod:`flashdreams.recipes.taehv.impl` on a streaming causal
+decode (5 same-shape body chunks -- enough to exercise the
+warmup -> capture -> replay path of the CUDA-graph wrapper).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from flashdreams.core.checkpoint.load import load_checkpoint
+from flashdreams.recipes.taehv import AVAILABLE_TAEHV_CHECKPOINT_PATHS
+from flashdreams.recipes.taehv import impl as _impl_new
+from flashdreams.recipes.taehv.impl import TAEHV as TAEHVNew
+
+# Sibling module; ``conftest.py`` adds this directory to ``sys.path``.
+import impl_reference as _impl_reference  # noqa: E402
+
+TAEHVLegacy = _impl_reference.TAEHV
+
+
+def _build_pair(
+    checkpoint_path: str,
+    dtype: torch.dtype,
+    device: torch.device,
+    *,
+    use_compile: bool,
+    use_cuda_graph: bool,
+) -> tuple[TAEHVLegacy, TAEHVNew]:
+    """Construct legacy and slim TAEHV from a single shared checkpoint.
+
+    The checkpoint is loaded once, cast to ``dtype``, and re-served via
+    a patch on each impl module's ``load_checkpoint`` so both models
+    see identical weights without a second S3 round-trip.
+    """
+    weights = load_checkpoint(checkpoint_path)
+    weights = {k: v.to(dtype) for k, v in weights.items()}
+
+    def _cached(_path):
+        return weights
+
+    with (
+        patch.object(_impl_reference, "load_checkpoint", _cached),
+        patch.object(_impl_new, "load_checkpoint", _cached),
+    ):
+        legacy = TAEHVLegacy(checkpoint_path=checkpoint_path).to(
+            device=device, dtype=dtype
+        )
+        new = TAEHVNew(
+            checkpoint_path=checkpoint_path,
+            use_cuda_graph=use_cuda_graph,
+            use_compile=use_compile,
+        ).to(device=device, dtype=dtype)
+    return legacy, new
+
+
+# (mode_id, dtype, use_compile, use_cuda_graph, atol, rtol)
+#
+# - "eager" runs in fp32 with strict bit-exact tolerances: this isolates
+#   the impl-vs-legacy logic. Any diff is a real impl bug.
+_MODES: list[tuple[str, torch.dtype, bool, bool, float, float]] = [
+    ("eager", torch.float32, False, False, 1e-5, 1.3e-6),
+]
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="TAEHV equivalence test requires GPU"
+)
+@torch.no_grad()
+@pytest.mark.parametrize("checkpoint_key", ["lighttae"])
+@pytest.mark.parametrize(
+    ("mode_id", "dtype", "use_compile", "use_cuda_graph", "atol", "rtol"),
+    _MODES,
+    ids=[m[0] for m in _MODES],
+)
+def test_taehv_streaming_equivalence(
+    checkpoint_key: str,
+    mode_id: str,
+    dtype: torch.dtype,
+    use_compile: bool,
+    use_cuda_graph: bool,
+    atol: float,
+    rtol: float,
+) -> None:
+    """Legacy and slim TAEHV must match on streaming decode.
+
+    Streaming schedule:
+      - Decode rollout 1 (chunk A): T=2 latents -> 5 frames (after
+        ``frames_to_trim=3``). Bare / drain path.
+      - Decode rollouts 2-5 (chunks B0..B3): T=2 latents -> 8 frames
+        each. With ``compile_cg`` the wrapper does 2 warmup + 1 capture
+        + 1 replay over these 4 calls.
+    """
+    device = torch.device("cuda")
+    checkpoint_path = AVAILABLE_TAEHV_CHECKPOINT_PATHS[checkpoint_key]
+
+    legacy, new = _build_pair(
+        checkpoint_path,
+        dtype,
+        device,
+        use_compile=use_compile,
+        use_cuda_graph=use_cuda_graph,
+    )
+
+    torch.manual_seed(0)
+    # 5 chunks of T=2 latents (10 total) at a small spatial size.
+    latents = torch.empty(1, 10, 16, 32, 32, dtype=dtype, device=device).uniform_(
+        -1, 1
+    )
+
+    cache_legacy = legacy.prepare_cache()
+    cache_new = new.prepare_cache()
+
+    def _close(actual: torch.Tensor, expected: torch.Tensor, label: str) -> None:
+        torch.testing.assert_close(
+            actual,
+            expected,
+            atol=atol,
+            rtol=rtol,
+            msg=lambda m: f"{mode_id} / {checkpoint_key} / {label}: {m}",
+        )
+
+    # First chunk: 2 latents -> 5 frames (8 - frames_to_trim=3).
+    z_a = latents[:, :2]
+    out_legacy_a = legacy.decode_video(z_a, parallel=True, cache=cache_legacy)
+    out_new_a = new.decode(z_a, cache=cache_new)
+    assert out_legacy_a.shape[1] == 5, (
+        f"Expected 5 frames after first decode, got {out_legacy_a.shape[1]}"
+    )
+    _close(out_new_a, out_legacy_a, "decode A")
+
+    # Steady-state body chunks: 4 calls of T=2 latents -> 8 frames each.
+    for k in range(4):
+        z_chunk = latents[:, 2 + 2 * k : 2 + 2 * (k + 1)]
+        out_legacy_k = legacy.decode_video(z_chunk, parallel=True, cache=cache_legacy)
+        out_new_k = new.decode(z_chunk, cache=cache_new)
+        assert out_legacy_k.shape[1] == 8, (
+            f"Expected 8 frames in chunk B[{k}], got {out_legacy_k.shape[1]}"
+        )
+        _close(out_new_k, out_legacy_k, f"decode B[{k}]")

--- a/flashdreams/tests/taehv/test_taehv_equivalence.py
+++ b/flashdreams/tests/taehv/test_taehv_equivalence.py
@@ -1,14 +1,21 @@
 """Numerical equivalence between reference and slim TAEHV decode.
 
-Requires GPU. Compares the upstream reference :class:`TAEHV` in
-:mod:`impl_reference` (sibling module in this folder) against the
+Requires GPU + network (downloads the lighttae checkpoint from S3) and
+is therefore marked ``@pytest.mark.manual`` -- opt in via
+``pytest -m manual ...``. Compares the upstream reference :class:`TAEHV`
+in :mod:`impl_reference` (sibling module in this folder) against the
 rewrite in :mod:`flashdreams.recipes.taehv.impl` on a streaming causal
-decode (5 same-shape body chunks -- enough to exercise the
-warmup -> capture -> replay path of the CUDA-graph wrapper).
+decode (5 same-shape body chunks).
+
+The default ``_MODES`` table only exercises ``eager`` (no compile, no
+CUDA graph). Add a ``compile_cg`` row to also smoke-test the
+warmup -> capture -> replay path of :class:`CUDAGraphWrapper` (use loose
+bf16 tolerances).
 """
 
 from __future__ import annotations
 
+import copy
 from unittest.mock import patch
 
 import pytest
@@ -37,13 +44,17 @@ def _build_pair(
 
     The checkpoint is loaded once, cast to ``dtype``, and re-served via
     a patch on each impl module's ``load_checkpoint`` so both models
-    see identical weights without a second S3 round-trip.
+    see identical weights without a second S3 round-trip. Each call
+    returns a *fresh shallow copy* of the dict, because the legacy
+    ``patch_tgrow_layers`` mutates entries in place -- otherwise the
+    new impl would see the already-truncated TGrow weights when the
+    legacy constructor runs first.
     """
     weights = load_checkpoint(checkpoint_path)
     weights = {k: v.to(dtype) for k, v in weights.items()}
 
     def _cached(_path):
-        return weights
+        return copy.copy(weights)
 
     with (
         patch.object(_impl_reference, "load_checkpoint", _cached),
@@ -62,13 +73,18 @@ def _build_pair(
 
 # (mode_id, dtype, use_compile, use_cuda_graph, atol, rtol)
 #
-# - "eager" runs in fp32 with strict bit-exact tolerances: this isolates
-#   the impl-vs-legacy logic. Any diff is a real impl bug.
+# - "eager" runs in fp32 with tight (but not bit-exact) tolerances:
+#   isolates the impl-vs-legacy logic. The new impl uses different
+#   reduction orders for some reshapes (e.g. ``view`` instead of
+#   ``reshape`` paths) so float accumulations can drift by a few ULPs;
+#   ``1e-5 / 1.3e-6`` keeps real divergences (>= ~5 ULPs of bf16) easy
+#   to spot while tolerating the noise.
 _MODES: list[tuple[str, torch.dtype, bool, bool, float, float]] = [
     ("eager", torch.float32, False, False, 1e-5, 1.3e-6),
 ]
 
 
+@pytest.mark.manual
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="TAEHV equivalence test requires GPU"
 )
@@ -94,8 +110,9 @@ def test_taehv_streaming_equivalence(
       - Decode rollout 1 (chunk A): T=2 latents -> 5 frames (after
         ``frames_to_trim=3``). Bare / drain path.
       - Decode rollouts 2-5 (chunks B0..B3): T=2 latents -> 8 frames
-        each. With ``compile_cg`` the wrapper does 2 warmup + 1 capture
-        + 1 replay over these 4 calls.
+        each. With a ``compile_cg`` row (not in the default ``_MODES``)
+        the wrapper would do 2 warmup + 1 capture + 1 replay over these
+        4 calls.
     """
     device = torch.device("cuda")
     checkpoint_path = AVAILABLE_TAEHV_CHECKPOINT_PATHS[checkpoint_key]
@@ -110,9 +127,7 @@ def test_taehv_streaming_equivalence(
 
     torch.manual_seed(0)
     # 5 chunks of T=2 latents (10 total) at a small spatial size.
-    latents = torch.empty(1, 10, 16, 32, 32, dtype=dtype, device=device).uniform_(
-        -1, 1
-    )
+    latents = torch.empty(1, 10, 16, 32, 32, dtype=dtype, device=device).uniform_(-1, 1)
 
     cache_legacy = legacy.prepare_cache()
     cache_new = new.prepare_cache()


### PR DESCRIPTION
Speedup: 13.3ms -> 4.68ms

<img width="708" height="62" alt="Screenshot 2026-04-29 at 7 08 29 AM" src="https://github.com/user-attachments/assets/06b162b5-c89e-4e0f-88d2-f5e84590f222" />


The AlpaDreams inference script also verifies the speedup: `decode 5.485 ms`

> 2026-04-29 07:17:25.765 | INFO     | flashdreams.infra.pipeline.base:finalize:324 - AR 19 encode 52.382 ms diffuse 111.632 ms decode 5.485 ms finalize 56.193 ms | total(w/o finalize) 169.499 ms total 225.692 ms | GPU mem alloc 31.146 GiB reserved 36.357 GiB peak 34.486 GiB


Profiling entrance:
```bash
PYTHONPATH=./flashdreams python flashdreams/tests/taehv/_profile_taehv.py
```

Parity test:
```bash
PYTHONPATH=./flashdreams pytest flashdreams/tests/taehv/test_taehv_equivalence.py -v
```