### PR TITLE
Remove explicit handling of device ID in gRPC server

### DIFF
--- a/integrations/alpadreams/alpadreams/conditioning/conditioning_wrapper.py
+++ b/integrations/alpadreams/alpadreams/conditioning/conditioning_wrapper.py
@@ -66,16 +66,6 @@ AV_POSITIVE_PROMPT = (
 )
 
 
-def get_av_text_prompts(
-    batch_size: int = 1,
-    device: torch.device | str = "cuda",
-    text_prompt: str = AV_POSITIVE_PROMPT,
-) -> list[TextPrompt]:
-    """Get autonomous driving text prompts."""
-    del device
-    return [TextPrompt(positive=text_prompt)] * batch_size
-
-
 @dataclass
 class AlpadreamsConditioningState:
     """State for generation, including renderer and pipeline state."""

--- a/integrations/alpadreams/alpadreams/conditioning/world_scenario/ftheta.py
+++ b/integrations/alpadreams/alpadreams/conditioning/world_scenario/ftheta.py
@@ -324,7 +324,7 @@ class FThetaCamera(CameraBase):
             poly (np.ndarray): the polynomial of the FTheta model. Usually 5 coefficients.
             linear_cde (np.ndarray): the linear constrain matrix of the FTheta model. Usually 3 coefficients.
                 A = [[c, d], [e, 1]]. A is used in forward (ray2pixel) mapping
-            device (str): the device to use. if None, use cuda if available, otherwise cpu.
+            device (str): the device to use. If None, defaults to "cuda".
         """
         if linear_cde is None:
             linear_cde = np.array([1, 0, 0], dtype=np.float32)
@@ -337,13 +337,7 @@ class FThetaCamera(CameraBase):
         self._center = np.asarray([cx, cy], dtype=np.float32)
         self._width = int(width)
         self._height = int(height)
-        self.device = (
-            device
-            if device is not None
-            else "cuda"
-            if torch.cuda.is_available()
-            else "cpu"
-        )
+        self.device = device if device is not None else "cuda"
         self.dtype = dtype
         self.reference_poly = "bw" if is_bw_poly else "fw"
 
@@ -679,13 +673,7 @@ class FThetaCamera(CameraBase):
         u, v = torch.meshgrid(u, v, indexing="xy")  # must pass indexing='xy'
         uv_coords = torch.stack([u, v], dim=-1).reshape(-1, 2)  # shape (H*W, 2)
 
-        # Use GPU version directly if on GPU
-        if self.device == "cuda":
-            rays, _ = self.pixel2ray_torch(uv_coords)
-        else:
-            # CPU path
-            rays = self.pixel2ray(uv_coords.cpu().numpy())[0]
-            rays = torch.tensor(rays, device=self.device, dtype=self.dtype)
+        rays, _ = self.pixel2ray_torch(uv_coords)
 
         rays = rays.reshape(self.height, self.width, 3)
         return rays

--- a/integrations/alpadreams/alpadreams/conditioning/world_scenario/pinhole.py
+++ b/integrations/alpadreams/alpadreams/conditioning/world_scenario/pinhole.py
@@ -60,7 +60,7 @@ class PinholeCamera(CameraBase):
         self.dtype = dtype
 
         if device is None:
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.device = "cuda"
         else:
             self.device = device
         self._intrinsics = np.array([fx, fy, cx, cy, w, h], dtype=np.float32)

--- a/integrations/alpadreams/alpadreams/grpc/server.py
+++ b/integrations/alpadreams/alpadreams/grpc/server.py
@@ -14,18 +14,20 @@ import gc
 import os
 import threading
 import time
+import traceback
 import uuid
 import warnings
 from concurrent import futures
 from enum import IntEnum
 from pathlib import Path
-from typing import Any, Callable, Literal
+from typing import Any, Callable
 
 import grpc
 import numpy as np
 import torch
 import torch.distributed as dist
 from alpadreams.conditioning.conditioning_wrapper import (
+    AV_POSITIVE_PROMPT,
     AlpadreamsConditioningState,
     AlpadreamsConditioningWrapper,
     TextPrompt,
@@ -186,9 +188,8 @@ def capture_exceptions(func: Callable) -> Callable:
             return func(*args, **kwargs)
         except Exception as e:
             logger.error(f"Error in {func.__name__}: {e}")
-            # print stack trace
-            import traceback
 
+            # print stack trace
             traceback.print_exc()
             raise
 
@@ -250,7 +251,7 @@ def build_alpadreams_conditioning_wrapper(
 class WorldModelEngine:
     def __init__(
         self,
-        device: str = "cuda",
+        device: torch.device | str = torch.device("cuda:0"),
         # image encoding related
         output_format: str = "png",
         jpeg_quality: int = 90,
@@ -293,6 +294,10 @@ class WorldModelEngine:
 
         # Save configurations
         self.device = torch.device(device)
+        if self.device.type != "cuda":
+            raise ValueError(f"CUDA device is required, got {self.device}")
+        if self.device.index is None:
+            self.device = torch.device("cuda:0")
         self.n_cameras = n_cameras
         self.seed_for_every_rollout_default = seed_for_every_rollout
 
@@ -486,7 +491,6 @@ class WorldModelEngine:
                 hdmap_parquets,
                 camera_names=camera_names,
                 target_resolution_hw=(res_H, res_W),
-                device=self.device,
             )
         logger.info(
             f"[Rank {self.rank}] Loaded scene: {scene_data.scene_id}, num_frames: {scene_data.num_frames}"
@@ -857,7 +861,7 @@ class WorldModelService(
 
     def __init__(
         self,
-        device: str = "cuda",
+        device: torch.device | str = torch.device("cuda:0"),
         output_format: str = "png",
         jpeg_quality: int = 90,
         recording_dir: Path | str | None = None,
@@ -881,7 +885,7 @@ class WorldModelService(
         Initialize the World Model gRPC service.
 
         Args:
-            device: Device to run inference on ("cuda" or "cpu").
+            device: CUDA device used for inference.
             output_format: Output image format ("png" or "jpeg").
             jpeg_quality: JPEG quality (1-100) if using JPEG format.
             recording_dir: Directory to save session recordings (None to disable).
@@ -1045,7 +1049,7 @@ class WorldModelService(
             ]
             logger.info(f"Using client prompt: {request.text_prompt.positive[:50]}...")
         else:
-            text_prompts = get_av_text_prompts(batch_size=1, device=self.device)
+            text_prompts = [TextPrompt(positive=AV_POSITIVE_PROMPT)]
             logger.info("Using default AV prompt")
 
         # 3. Parse debug options
@@ -1363,7 +1367,10 @@ class SessionState:
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description="gRPC server for bbox-conditioned video generation"
+        description=(
+            "gRPC server for bbox-conditioned video generation. "
+            "CUDA is required and context parallel size is derived from world size."
+        )
     )
     parser.add_argument(
         "--host",
@@ -1376,12 +1383,6 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=50051,
         help="Port to bind the server to (default: 50051)",
-    )
-    parser.add_argument(
-        "--device",
-        type=str,
-        default="cuda",
-        help="Device to run inference on (default: cuda)",
     )
     parser.add_argument(
         "--max_workers",
@@ -1441,12 +1442,6 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Sink size in latent frames. Default: 3 for multi-view, 0 for single-view."
         ),
-    )
-    parser.add_argument(
-        "--context_parallel_size",
-        type=int,
-        default=1,
-        help="Context parallel world size. Should be multiple of or divisor of n_cameras.",
     )
     parser.add_argument(
         "--seed_for_every_rollout",
@@ -1517,53 +1512,48 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def initialize_distributed(
-    context_parallel_size: int, n_cameras: int, device: Literal["cuda", "cpu"]
-) -> tuple[torch.device, int, int]:
-    # Sanity check context parallel size
-    if context_parallel_size > 1:
-        if "RANK" not in os.environ:
-            raise RuntimeError(
-                "Context parallel requires torch.distributed.run --nproc_per_node=N"
-            )
-        if (
-            context_parallel_size % n_cameras != 0
-            and n_cameras % context_parallel_size != 0
-        ):
-            raise ValueError(
-                f"CP size {context_parallel_size} must divide n_cameras {n_cameras} or vice versa"
-            )
+def initialize_distributed(n_cameras: int) -> tuple[torch.device, int, int]:
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "CUDA is required for inference in the Alpadreams gRPC server."
+        )
 
-    # Initialize distributed
-    if context_parallel_size > 1:
+    has_rank = "RANK" in os.environ
+    has_world_size = "WORLD_SIZE" in os.environ
+    if has_rank != has_world_size:
+        raise RuntimeError(
+            "Distributed launch expects both RANK and WORLD_SIZE to be set."
+        )
+
+    distributed_launch = has_rank and has_world_size
+    if distributed_launch:
         distributed_init()
         world_rank = dist.get_rank()
         world_size = dist.get_world_size()
     else:
         world_rank = 0
         world_size = 1
-    assert context_parallel_size == world_size, (
-        f"Error: context_parallel_size ({context_parallel_size}) must match world_size ({world_size})"
-    )
+
+    context_parallel_size = world_size
+    if (
+        context_parallel_size % n_cameras != 0
+        and n_cameras % context_parallel_size != 0
+    ):
+        raise ValueError(
+            f"CP size {context_parallel_size} must divide n_cameras {n_cameras} or vice versa"
+        )
+
+    device_count = torch.cuda.device_count()
+    if device_count < 1:
+        raise RuntimeError("CUDA device count must be >= 1 for inference.")
+    local_rank = world_rank % device_count
+    torch_device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(torch_device)
 
     logger.info(
         f"Rank {world_rank} initialized distributed with context_parallel_size {context_parallel_size}"
     )
-
-    # Initialize device properly, accounting for context parallel
-    if device == "cuda":
-        if context_parallel_size > 1:
-            local_rank = dist.get_rank() % torch.cuda.device_count()
-            torch_device = torch.device(f"cuda:{local_rank}")
-            torch.cuda.set_device(torch_device)
-        else:
-            torch_device = torch.device("cuda:0")
-    elif device == "cpu":
-        torch_device = torch.device(device)
-    else:
-        raise ValueError(f"Invalid device: {device}")
-
-    return torch_device, world_rank, world_size
+    return torch_device, world_rank, context_parallel_size
 
 
 def main() -> None:
@@ -1576,9 +1566,7 @@ def main() -> None:
     # Parse denoising steps from comma-separated string
     denoising_step_list = [int(x.strip()) for x in args.denoising_steps.split(",")]
 
-    device, world_rank, world_size = initialize_distributed(
-        args.context_parallel_size, args.n_cameras, args.device
-    )
+    device, world_rank, context_parallel_size = initialize_distributed(args.n_cameras)
     logger.info(
         "Using flashdreams pipeline backend; checkpoints are loaded lazily via flashdreams checkpoint loader."
     )
@@ -1598,14 +1586,14 @@ def main() -> None:
         atexit.register(save_profiling_data)
 
     # Common model kwargs shared between WorldModelService (rank 0) and WorldModelEngine (other ranks)
-    model_kwargs = dict(
+    model_kwargs: dict[str, Any] = dict(
         device=device,
         output_format=args.output_format,
         jpeg_quality=args.jpeg_quality,
         n_cameras=args.n_cameras,
         local_attn_size=args.local_attn_size,
         sink_size=args.sink_size,
-        context_parallel_size=args.context_parallel_size,
+        context_parallel_size=context_parallel_size,
         resolution=args.resolution,
         encode_with_pixel_shuffle=args.encode_with_pixel_shuffle,
         denoising_step_list=denoising_step_list,
@@ -1618,6 +1606,8 @@ def main() -> None:
         no_tae=args.no_tae,
     )
 
+    server: grpc.Server | None = None
+    service: WorldModelService | None = None
     if world_rank == 0:  # Only rank 0 runs the HTTP server
         logger.info("=" * 80)
         logger.info("Starting gRPC World Model Service")
@@ -1670,7 +1660,7 @@ def main() -> None:
             logger.error(f"Error in server.wait_for_termination(): {e}")
             raise e
 
-        send_signal(ControlSignal.EXIT, torch.device(f"cuda:{world_rank}"))
+        send_signal(ControlSignal.EXIT, device)
 
     else:  # non-rank 0 processes
         engine = WorldModelEngine(
@@ -1682,7 +1672,7 @@ def main() -> None:
             logger.critical(f"Shutting down engine on rank {world_rank}...")
 
     # Release CUDA graphs before destroying process group (otherwise may pin NCCL communicator memory)
-    if world_rank == 0:
+    if world_rank == 0 and server is not None and service is not None:
         del server
         del service
     else:
@@ -1693,7 +1683,7 @@ def main() -> None:
     torch.cuda.synchronize()
 
     # Wait for rank 0 to finish saving before destroying process group
-    if args.context_parallel_size > 1:
+    if dist.is_initialized():
         dist.barrier()
         logger.info(
             f"[Rank {world_rank}] All ranks synchronized, destroying process group..."

--- a/integrations/alpadreams/alpadreams/grpc/utils.py
+++ b/integrations/alpadreams/alpadreams/grpc/utils.py
@@ -133,7 +133,6 @@ def load_static_world_from_zip_bytes(
     hdmap_zip_bytes: bytes,
     camera_names: list[str],
     target_resolution_hw: tuple[int, int],
-    device: torch.device = torch.device("cuda:0"),
     perform_mirror_augment: bool = False,
 ) -> SceneData:
     """

--- a/integrations/alpadreams/tests/test_grpc_server_initialize_distributed.py
+++ b/integrations/alpadreams/tests/test_grpc_server_initialize_distributed.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from alpadreams.grpc import server
+
+
+def test_initialize_distributed_single_process_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+
+    set_device_calls: list[torch.device] = []
+    monkeypatch.setattr(server.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(server.torch.cuda, "device_count", lambda: 4)
+    monkeypatch.setattr(
+        server.torch.cuda, "set_device", lambda device: set_device_calls.append(device)
+    )
+
+    device, world_rank, context_parallel_size = server.initialize_distributed(
+        n_cameras=1
+    )
+
+    assert device == torch.device("cuda:0")
+    assert world_rank == 0
+    assert context_parallel_size == 1
+    assert set_device_calls == [torch.device("cuda:0")]
+
+
+def test_initialize_distributed_derives_cp_from_world_size(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "4")
+
+    init_calls = 0
+
+    def _fake_distributed_init() -> None:
+        nonlocal init_calls
+        init_calls += 1
+
+    set_device_calls: list[torch.device] = []
+    monkeypatch.setattr(server, "distributed_init", _fake_distributed_init)
+    monkeypatch.setattr(server.dist, "get_rank", lambda: 1)
+    monkeypatch.setattr(server.dist, "get_world_size", lambda: 4)
+    monkeypatch.setattr(server.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(server.torch.cuda, "device_count", lambda: 8)
+    monkeypatch.setattr(
+        server.torch.cuda, "set_device", lambda device: set_device_calls.append(device)
+    )
+
+    device, world_rank, context_parallel_size = server.initialize_distributed(
+        n_cameras=2
+    )
+
+    assert init_calls == 1
+    assert device == torch.device("cuda:1")
+    assert world_rank == 1
+    assert context_parallel_size == 4
+    assert set_device_calls == [torch.device("cuda:1")]
+
+
+def test_initialize_distributed_validates_camera_divisibility(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "4")
+
+    monkeypatch.setattr(server, "distributed_init", lambda: None)
+    monkeypatch.setattr(server.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(server.dist, "get_world_size", lambda: 4)
+    monkeypatch.setattr(server.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(server.torch.cuda, "device_count", lambda: 8)
+    monkeypatch.setattr(server.torch.cuda, "set_device", lambda device: None)
+
+    with pytest.raises(ValueError, match="must divide n_cameras"):
+        server.initialize_distributed(n_cameras=3)
+
+
+def test_initialize_distributed_requires_cuda(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.setattr(server.torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="CUDA is required"):
+        server.initialize_distributed(n_cameras=1)
+
+
+def test_initialize_distributed_requires_rank_and_world_size_pair(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.setattr(server.torch.cuda, "is_available", lambda: True)
+
+    with pytest.raises(RuntimeError, match="both RANK and WORLD_SIZE"):
+        server.initialize_distributed(n_cameras=1)

--- a/integrations/alpadreams/tests/test_grpc_server_integration.py
+++ b/integrations/alpadreams/tests/test_grpc_server_integration.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import grpc
 import numpy as np
-import pytest
-import torch
 from alpadreams.grpc.protos import (
     camera_pb2,
     common_pb2,
@@ -151,8 +149,6 @@ def test_grpc_server_start_render_close_roundtrip(
         "127.0.0.1",
         "--port",
         str(port),
-        "--device",
-        "cuda",
         "--output_format",
         "jpeg",
         "--n_cameras",


### PR DESCRIPTION
* Make `alpadreams.grpc.server` automatically infer the context parallel size from worldsize (`torchrun` parameters)
* Remove `cpu` codepaths in distributed world setup (we aren't going to be using that anyway)
* Inline some util functions
* Add a unit test for `AlpadreamsConditioningWrapper`

To launch inference after the change, use
```
uv run torchrun --nnodes 1 --nproc_per_node 4 -m alpadreams.grpc.server --local_attn_size 8 --output_format jpeg --n_cameras 4 --host 0.0.0.0
```

(no more `--context_parallel_size` needed)