### PR TITLE
add alpadreams perf config: sv_2steps_chunk2_loc6_lightvae_lighttae_perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export FLASHDREAMS_CACHE_DIR=~/.cache/flashdreams # default
 
 # 4. Run inference script. Checkpoints and example data are auto-downloaded at first run.
 # - single view on single GPU
+# - add (--overwrite_config_name sv_2steps_chunk2_loc6_lightvae_lighttae_perf) for best perf.
 uv run --package flashdreams --extra examples \
   python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=1 \
     flashdreams/examples/run_alpadreams.py \

--- a/flashdreams/flashdreams/recipes/alpadreams/config.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/config.py
@@ -76,15 +76,23 @@ _DEFAULT_DENOISING_TIMESTEPS = [1000, 450]
 _DEFAULT_NUM_TRAIN_TIMESTEPS = 1000
 
 
-def _wan_vae_decoder_config() -> WanVAEDecoderConfig:
+def _wan_vae_decoder_config(
+    *, use_compile: bool = False, use_cuda_graph: bool = True
+) -> WanVAEDecoderConfig:
     return WanVAEDecoderConfig(
         checkpoint_path=AVAILABLE_WAN_VAE_CHECKPOINT_PATHS["vae"],
+        use_compile=use_compile,
+        use_cuda_graph=use_cuda_graph,
     )
 
 
-def _teahv_vae_decoder_config() -> TeahvVAEDecoderConfig:
+def _teahv_vae_decoder_config(
+    *, use_compile: bool = False, use_cuda_graph: bool = True
+) -> TeahvVAEDecoderConfig:
     return TeahvVAEDecoderConfig(
         checkpoint_path=AVAILABLE_TAEHV_CHECKPOINT_PATHS["lighttae"],
+        use_compile=use_compile,
+        use_cuda_graph=use_cuda_graph,
     )
 
 
@@ -130,9 +138,16 @@ def _transformer_config(
     )
 
 
-def _wan_vae_encoder(*, checkpoint_name: str = "vae") -> WanVAEEncoderConfig:
+def _wan_vae_encoder(
+    *,
+    checkpoint_name: str = "vae",
+    use_compile: bool = False,
+    use_cuda_graph: bool = True,
+) -> WanVAEEncoderConfig:
     return WanVAEEncoderConfig(
         checkpoint_path=AVAILABLE_WAN_VAE_CHECKPOINT_PATHS[checkpoint_name],
+        use_compile=use_compile,
+        use_cuda_graph=use_cuda_graph,
     )
 
 
@@ -154,6 +169,43 @@ def build_sv_2steps_chunk2_loc6_lightvae_lighttae(
         enable_sync_and_profile=True,
         encoder=_wan_vae_encoder(checkpoint_name="lightvae"),
         decoder=_teahv_vae_decoder_config(),
+        diffusion_model=DiffusionModelConfig(
+            seed=seed,
+            context_noise=128,
+            transformer=_transformer_config(
+                checkpoint_path=AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["single_view"][
+                    "vae_encoding"
+                ]["chunk2"],  # type: ignore[index]
+                cp_size=cp_size,
+                compile_network=compile_network,
+                num_views=1,
+                len_t_latent=2,
+                window_size_t=6,
+                encode_with_pixel_shuffle=False,
+            ),
+            scheduler=_scheduler_config(),
+        ),
+    )
+
+
+# Performance optimized version of the above config
+def build_sv_2steps_chunk2_loc6_lightvae_lighttae_perf(
+    *,
+    cp_size: int = 1,
+    compile_network: bool = True,
+    seed: int = 42,
+) -> AlpadreamsPipelineConfig:
+    """Single-view, chunk2, light Wan VAE HDMap encoder + LightTAE decoder."""
+    return AlpadreamsPipelineConfig(
+        text_encoder=CosmosReason1TextEncoderConfig(),
+        image_encoder=_wan_vae_encoder(
+            checkpoint_name="lightvae", use_compile=True, use_cuda_graph=True
+        ),
+        enable_sync_and_profile=True,
+        encoder=_wan_vae_encoder(
+            checkpoint_name="lightvae", use_compile=True, use_cuda_graph=True
+        ),
+        decoder=_teahv_vae_decoder_config(use_compile=True, use_cuda_graph=True),
         diffusion_model=DiffusionModelConfig(
             seed=seed,
             context_noise=128,
@@ -303,6 +355,7 @@ def build_mv_2steps_chunk4_loc8_pshuffle_lighttae(
 
 ALPADREAMS_CONFIG_BUILDERS: dict[str, Callable[..., AlpadreamsPipelineConfig]] = {
     "sv_2steps_chunk2_loc6_lightvae_lighttae": build_sv_2steps_chunk2_loc6_lightvae_lighttae,
+    "sv_2steps_chunk2_loc6_lightvae_lighttae_perf": build_sv_2steps_chunk2_loc6_lightvae_lighttae_perf,
     "sv_2steps_chunk2_loc6_vae_vae": build_sv_2steps_chunk2_loc6_vae_vae,
     "sv_2steps_chunk3_loc6_vae_vae": build_sv_2steps_chunk3_loc6_vae_vae,
     "sv_2steps_chunk4_loc8_pshuffle_lighttae": build_sv_2steps_chunk4_loc8_pshuffle_lighttae,


### PR DESCRIPTION
config: `sv_2steps_chunk2_loc6_lightvae_lighttae`

> AR 19 encode 52.571 ms diffuse 101.054 ms decode 13.238 ms finalize 49.144 ms | total(w/o finalize) 166.864 ms total 216.008 ms | GPU mem alloc 30.832 GiB reserved 38.219 GiB peak 34.232 GiB

config: `sv_2steps_chunk2_loc6_lightvae_lighttae_perf`

> AR 19 encode 30.766 ms diffuse 101.648 ms decode 5.024 ms finalize 52.461 ms | total(w/o finalize) 137.438 ms total 189.898 ms | GPU mem alloc 30.938 GiB reserved 36.797 GiB peak 34.166 GiB


The only change is enabling torch compile and cudagraph for VAE encoder and decoder. Visually checked to be identical:

https://github.com/user-attachments/assets/cab689e7-4320-4ae3-ac03-31b77a67616f

https://github.com/user-attachments/assets/806edcb3-c374-4929-b787-aee8be7cb5a2

