### PR TITLE
build: Require minimum version of uv 0.11.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ members = ["flashdreams", "integrations/*"]
 # compiled against cuBLAS 13.4.x, while torch 2.11 pins nvidia-cublas 13.1.0.3.
 # cuBLAS 13.4 is backwards compatible with 13.1.
 [tool.uv]
+required-version = ">=0.11.8"
 override-dependencies = ["nvidia-cublas>=13.4"]
 
 # `transformer-engine-torch` has no prebuilt wheel and must be built against


### PR DESCRIPTION
Old `uv` versions can run into build-isolation issues building, e.g. TE