### PR TITLE
docs: Use no-project flag when building docs to prevent failure in main

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -54,8 +54,11 @@ jobs:
           echo "DOCS_SUBDIR=main" >> $GITHUB_ENV
 
       - name: Sphinx build
+        # --no-project: the "Override version" step above rewrites the version
+        # field to "main" which is not PEP 440 compliant. Without --no-project
+        # uv would try to parse the workspace pyproject.toml and fail.
         run: |
-          uv run --no-sync sphinx-build -b html docs/source _build
+          uv run --no-project sphinx-build -b html docs/source _build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
This pull request makes a minor update to the documentation build workflow to ensure compatibility with the version override logic. The change ensures that Sphinx can build the documentation even when the version field is set to a non-standard value.

- Documentation build process:
  * Updated the Sphinx build step in `.github/workflows/doc.yml` to add the `--no-project` flag to the `uv run` command, preventing errors when the version is set to a non-PEP 440 compliant value.