### PR TITLE
Add ty static type checker with pre-commit enforcement and suppress errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,18 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
 
+      - name: Install dependencies
+        run: |
+          # ty needs third-party packages to resolve imports. Skip packages
+          # that cannot be installed on CPU-only runners:
+          # - transformer-engine-torch: source-only, requires CUDA to compile
+          # - ludus-renderer: unavailable in CI
+          uv sync --extra dev --group lint \
+            --no-install-package transformer-engine-torch \
+            --no-install-package ludus-renderer
+
       - name: Run linter checks
-        run: uv run --only-group lint pre-commit run -a
+        run: uv run --no-sync pre-commit run -a
 
   cpu:
     runs-on: linux-amd64-cpu8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,11 @@ repos:
         args: [--add-noqa]
         stages: [manual]
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty type check
+        entry: ty check
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Install all workspace packages (flashdreams core + every integration) into a venv:
 
 ```bash
-uv sync --extra dev
+uv sync --extra dev --group lint
 ```
 
 Then run commands with `uv run` (auto-activates the venv):
@@ -13,6 +13,56 @@ Then run commands with `uv run` (auto-activates the venv):
 ```bash
 uv run pytest flashdreams/tests
 uv run --package flashdreams --extra examples flashdreams/examples/run_alpadreams.py --help
+```
+
+## Development
+
+### Linting and type checking
+
+The project uses [ruff](https://docs.astral.sh/ruff/) for formatting/linting and
+[ty](https://docs.astral.sh/ty/) for static type checking, both enforced via
+pre-commit:
+
+```bash
+# Run all checks (ruff + ty)
+uv run pre-commit run -a
+
+# Run ty type checker directly
+uv run ty check
+```
+
+### IDE setup (VS Code)
+
+Install the [ty extension](https://marketplace.visualstudio.com/items?itemName=astral-sh.ty)
+for VS Code.
+
+To use ty as the primary language server (replaces Pylance):
+
+```jsonc
+// .vscode/settings.json
+{
+    "python.languageServer": "None"
+}
+```
+
+To use ty only for type checking alongside Pylance (completions, hover, etc.):
+
+```jsonc
+// .vscode/settings.json
+{
+    "python.languageServer": "Pylance",
+    "ty.disableLanguageServices": true
+}
+```
+
+### Tests
+
+```bash
+# CPU-safe tests (excludes GPU-dependent tests)
+uv run pytest -m "not manual"
+
+# Single test file
+uv run pytest flashdreams/tests/test_attention.py
 ```
 
 ## Instructions to run Alpadreams Inference

--- a/flashdreams/examples/run_alpadreams.py
+++ b/flashdreams/examples/run_alpadreams.py
@@ -199,9 +199,9 @@ def main() -> None:
     # all pixel-space inputs (first frame, HDMap video) to the matching
     # pixel-space resolution before feeding them to the pipeline.
     transformer_cfg = pipeline.diffusion_model.transformer.config
-    decoder_sp = pipeline.decoder.SPATIAL_COMPRESSION_RATIO
-    pixel_h = transformer_cfg.height * decoder_sp
-    pixel_w = transformer_cfg.width * decoder_sp
+    decoder_sp = pipeline.decoder.SPATIAL_COMPRESSION_RATIO  # ty:ignore[unresolved-attribute]
+    pixel_h = transformer_cfg.height * decoder_sp  # ty:ignore[unresolved-attribute]
+    pixel_w = transformer_cfg.width * decoder_sp  # ty:ignore[unresolved-attribute]
 
     first_frames: list[torch.Tensor] = []
     hdmap_videos: list[torch.Tensor] = []
@@ -238,7 +238,9 @@ def main() -> None:
     print("loaded hdmap_videos.shape:", hdmap_videos_t.shape)
 
     cache = pipeline.initialize_cache(
-        text=prompts_2d, image=first_frames_t, view_names=camera_names
+        text=prompts_2d,  # ty:ignore[unknown-argument]
+        image=first_frames_t,  # ty:ignore[unknown-argument]
+        view_names=camera_names,  # ty:ignore[unknown-argument]
     )
 
     torch.cuda.synchronize()
@@ -249,7 +251,7 @@ def main() -> None:
     stats_history: list[dict[str, float]] = []
     start = 0
     for i in range(args.total_blocks):
-        num_frames = pipeline.get_num_frames(i)
+        num_frames = pipeline.get_num_frames(i)  # ty:ignore[call-non-callable]
         end = start + num_frames
         if end > hdmap_num_frames:
             break
@@ -259,7 +261,7 @@ def main() -> None:
         video_chunk = pipeline.generate(
             autoregressive_index=i,
             cache=cache,
-            hdmap=hdmap_videos_t[:, :, start:end],
+            hdmap=hdmap_videos_t[:, :, start:end],  # ty:ignore[unknown-argument]
         )
         stats = pipeline.finalize(i, cache)
         if stats is not None:

--- a/flashdreams/examples/run_causal_wan21.py
+++ b/flashdreams/examples/run_causal_wan21.py
@@ -184,19 +184,19 @@ def main() -> None:
     image: torch.Tensor | None = None
     if is_i2v:
         transformer_cfg = pipeline.diffusion_model.transformer.config
-        decoder_sp = pipeline.decoder.spatial_compression_ratio
-        pixel_h = transformer_cfg.height * decoder_sp
-        pixel_w = transformer_cfg.width * decoder_sp
+        decoder_sp = pipeline.decoder.spatial_compression_ratio  # ty:ignore[unresolved-attribute]
+        pixel_h = transformer_cfg.height * decoder_sp  # ty:ignore[unresolved-attribute]
+        pixel_w = transformer_cfg.width * decoder_sp  # ty:ignore[unresolved-attribute]
         first_frame = media.read_image(args.image_path)[..., :3]  # drop alpha
         first_frame = cv2.resize(first_frame, (pixel_w, pixel_h))  # [H, W, 3]
         first_frame_t = (
-            torch.from_numpy(first_frame).to(device=device, dtype=transformer_cfg.dtype)
+            torch.from_numpy(first_frame).to(device=device, dtype=transformer_cfg.dtype)  # ty:ignore[unresolved-attribute]
             / 127.5
             - 1.0
         )  # [H, W, 3] in range [-1, 1]
         image = rearrange(first_frame_t, "h w c -> 1 1 c h w")  # [B=1, T=1, C=3, H, W]
 
-    cache = pipeline.initialize_cache(text=[prompt], image=image)
+    cache = pipeline.initialize_cache(text=[prompt], image=image)  # ty:ignore[unknown-argument]
 
     torch.cuda.synchronize()
     if torch.distributed.is_initialized():
@@ -206,7 +206,7 @@ def main() -> None:
     chunks: list[torch.Tensor] = []
     stats_history: list[dict[str, float]] = []
     for i in range(args.total_blocks):
-        num_frames = pipeline.get_num_output_frames(i)
+        num_frames = pipeline.get_num_output_frames(i)  # ty:ignore[call-non-callable]
         print(f"autoregressive_index: {i}, num_frames: {num_frames}")
         video_chunk = pipeline.generate(i, cache)
         stats = pipeline.finalize(i, cache)

--- a/flashdreams/examples/run_causal_wan22.py
+++ b/flashdreams/examples/run_causal_wan22.py
@@ -145,7 +145,7 @@ def main() -> None:
         .to(device=device)
     )
 
-    cache = pipeline.initialize_cache(text=[prompt], image=None)
+    cache = pipeline.initialize_cache(text=[prompt], image=None)  # ty:ignore[unknown-argument]
 
     torch.cuda.synchronize()
     if torch.distributed.is_initialized():
@@ -155,7 +155,7 @@ def main() -> None:
     chunks: list[torch.Tensor] = []
     stats_history: list[dict[str, float]] = []
     for i in range(args.total_blocks):
-        num_frames = pipeline.get_num_output_frames(i)
+        num_frames = pipeline.get_num_output_frames(i)  # ty:ignore[call-non-callable]
         print(f"autoregressive_index: {i}, num_frames: {num_frames}")
         video_chunk = pipeline.generate(i, cache)
         stats = pipeline.finalize(i, cache)

--- a/flashdreams/examples/run_lingbot_world.py
+++ b/flashdreams/examples/run_lingbot_world.py
@@ -175,7 +175,7 @@ def main() -> None:
 
         # Only needed for the world-scale normalizer; the actual Plücker
         # volume is rendered per-AR-step inside I2VCamCtrlEncoder.
-        _, trans_normalizer = compute_relative_poses(c2ws_t, framewise=True)
+        _, trans_normalizer = compute_relative_poses(c2ws_t, framewise=True)  # ty:ignore[invalid-assignment]
 
         with open(entry["text_prompt_path"], "r") as f:
             prompts.append(f.readlines()[0])
@@ -209,7 +209,7 @@ def main() -> None:
         .setup()
         .to(device=device)
     )
-    cache = pipeline.initialize_cache(text=prompts, image=first_frames_t)
+    cache = pipeline.initialize_cache(text=prompts, image=first_frames_t)  # ty:ignore[unknown-argument]
 
     torch.cuda.synchronize()
     if torch.distributed.is_initialized():
@@ -220,7 +220,7 @@ def main() -> None:
     stats_history: list[dict[str, float]] = []
     start = 0
     for i in range(args.total_blocks):
-        num_frames = pipeline.get_num_output_frames(i)
+        num_frames = pipeline.get_num_output_frames(i)  # ty:ignore[call-non-callable]
         end = start + num_frames
         if end > total_camera_frames:
             break

--- a/flashdreams/examples/run_wan21.py
+++ b/flashdreams/examples/run_wan21.py
@@ -155,7 +155,7 @@ def main() -> None:
             torch.from_numpy(first_frame).to(device=device, dtype=dtype) / 127.5 - 1.0
         )  # [H, W, 3] in range [-1, 1]
         image = rearrange(first_frame, "h w c -> 1 c h w")  # [T, 3, H, W]
-        cache = pipeline.initialize_cache(text=[prompt], image=image)
+        cache = pipeline.initialize_cache(text=[prompt], image=image)  # ty:ignore[unknown-argument]
     else:
         pipeline = (
             build_wan21_t2v_1pt3b_480p(
@@ -167,7 +167,7 @@ def main() -> None:
             .to(device=device)
         )
 
-        cache = pipeline.initialize_cache(text=[prompt])
+        cache = pipeline.initialize_cache(text=[prompt])  # ty:ignore[unknown-argument]
 
     generated_video = pipeline.generate(autoregressive_index=0, cache=cache)
     # Single-AR-step rollouts don't need finalize; run it for API

--- a/flashdreams/flashdreams/core/attention/native.py
+++ b/flashdreams/flashdreams/core/attention/native.py
@@ -122,7 +122,7 @@ class NativeAttention(torch.nn.Module):
                 # Pass a dummy buffer to satisfy context_parallel's buffers[0].device
                 # check (required in PyTorch 2.9+ where buffers cannot be empty).
                 _dummy = torch.empty(self.device_mesh.size(), device=query.device)
-                with torch.distributed.tensor.experimental.context_parallel(
+                with torch.distributed.tensor.experimental.context_parallel(  # ty:ignore[possibly-missing-submodule]
                     self.device_mesh,
                     buffers=[
                         _dummy,

--- a/flashdreams/flashdreams/core/attention/ring.py
+++ b/flashdreams/flashdreams/core/attention/ring.py
@@ -39,11 +39,11 @@ def torch_sdpa_cudnn(
         Attention output, or ``(output, lse)`` when ``return_lse=True``.
     """
     out, lse, *_ = torch.ops.aten._scaled_dot_product_cudnn_attention(
-        query=query,
-        key=key,
-        value=value,
-        attn_bias=None,
-        compute_log_sumexp=True,
+        query=query,  # ty:ignore[invalid-argument-type]
+        key=key,  # ty:ignore[invalid-argument-type]
+        value=value,  # ty:ignore[invalid-argument-type]
+        attn_bias=None,  # ty:ignore[invalid-argument-type]
+        compute_log_sumexp=True,  # ty:ignore[invalid-argument-type]
     )
     return out, (lse if return_lse else None)
 
@@ -63,9 +63,9 @@ def torch_sdpa_flash(
         Attention output, or ``(output, lse)`` when ``return_lse=True``.
     """
     out, lse, *_ = torch.ops.aten._scaled_dot_product_flash_attention(
-        query=query,
-        key=key,
-        value=value,
+        query=query,  # ty:ignore[invalid-argument-type]
+        key=key,  # ty:ignore[invalid-argument-type]
+        value=value,  # ty:ignore[invalid-argument-type]
     )
     return out, (lse if return_lse else None)
 

--- a/flashdreams/flashdreams/core/checkpoint/load.py
+++ b/flashdreams/flashdreams/core/checkpoint/load.py
@@ -363,7 +363,7 @@ def load_distributed_checkpoint(
         checkpoint_path, credential_path=credential_path
     )
     state_dict = model.state_dict()
-    torch.distributed.checkpoint.load(
+    torch.distributed.checkpoint.load(  # ty:ignore[possibly-missing-submodule]
         state_dict,
         storage_reader=storage_reader,
         planner=DefaultLoadPlanner(allow_partial_load=True),

--- a/flashdreams/flashdreams/core/experimental/kvcache.py
+++ b/flashdreams/flashdreams/core/experimental/kvcache.py
@@ -166,8 +166,8 @@ class BlockKVCache:
             # write the tokens to new positions.
             dst_slice = self._seq_slice(dst_start, dst_end)
             src_slice = self._seq_slice(src_start, src_end)
-            self._k[dst_slice] = self._k[src_slice].clone()
-            self._v[dst_slice] = self._v[src_slice].clone()
+            self._k[dst_slice] = self._k[src_slice].clone()  # ty:ignore[invalid-assignment, not-subscriptable]
+            self._v[dst_slice] = self._v[src_slice].clone()  # ty:ignore[invalid-assignment, not-subscriptable]
             self._n_cached -= evict_size
 
     def _append_to_end(self, k: Tensor, v: Tensor) -> None:
@@ -179,7 +179,7 @@ class BlockKVCache:
         After the write:
         | -- sink tokens -- | -- local window tokens -- | -- new chunk -- |
         """
-        total_size = self._k.shape[self.seq_dim]
+        total_size = self._k.shape[self.seq_dim]  # ty:ignore[unresolved-attribute]
         chunk_size = k.shape[self.seq_dim]
 
         write_start = self._n_cached
@@ -189,8 +189,8 @@ class BlockKVCache:
         read_end = chunk_size
         read_start = chunk_size - (write_end - write_start)
         sl_read = self._seq_slice(read_start, read_end)
-        self._k[sl_write] = k[sl_read]
-        self._v[sl_write] = v[sl_read]
+        self._k[sl_write] = k[sl_read]  # ty:ignore[invalid-assignment]
+        self._v[sl_write] = v[sl_read]  # ty:ignore[invalid-assignment]
         self._n_cached += read_end - read_start
 
     def _write_to_rightmost(self, k: Tensor, v: Tensor, chunk_start: int) -> None:
@@ -222,13 +222,13 @@ class BlockKVCache:
                 read_end = read_start + sink_capacity
                 sl_read = self._seq_slice(read_start, read_end)
                 sl_write = self._seq_slice(write_start, write_end)
-                self._k[sl_write] = k[sl_read]
-                self._v[sl_write] = v[sl_read]
+                self._k[sl_write] = k[sl_read]  # ty:ignore[invalid-assignment]
+                self._v[sl_write] = v[sl_read]  # ty:ignore[invalid-assignment]
                 self._n_cached += sink_capacity
                 # 2. the rest of the tokens should be written to the
                 # rightmost positions of the valid tokens.
                 sl_read = self._seq_slice(read_end, chunk_size)
-                self._write_to_rightmost(k[sl_read], v[sl_read])
+                self._write_to_rightmost(k[sl_read], v[sl_read])  # ty:ignore[missing-argument]
 
         else:
             # If the sink is full.
@@ -238,8 +238,8 @@ class BlockKVCache:
                 # The input token does not overlap with the sink tokens. Simply write to the
                 # rightmost positions of the valid tokens.
                 sl = self._seq_slice(write_start, write_end)
-                self._k[sl] = k
-                self._v[sl] = v
+                self._k[sl] = k  # ty:ignore[invalid-assignment]
+                self._v[sl] = v  # ty:ignore[invalid-assignment]
             else:
                 # The input token overlaps with the sink tokens, so we only keep partial of it.
                 # Here we can safely assume the sink tokens have already been filled up because
@@ -249,16 +249,16 @@ class BlockKVCache:
                 read_start = read_end - (write_end - write_start)
                 sl_read = self._seq_slice(read_start, read_end)
                 sl_write = self._seq_slice(write_start, write_end)
-                self._k[sl_write] = k[sl_read]
-                self._v[sl_write] = v[sl_read]
+                self._k[sl_write] = k[sl_read]  # ty:ignore[invalid-assignment]
+                self._v[sl_write] = v[sl_read]  # ty:ignore[invalid-assignment]
 
                 # We might also need to update the sink tokens.
                 if chunk_start < self.sink_size:
                     sl_read = sl_write = self._seq_slice(chunk_start, self.sink_size)
-                    self._k[sl_write] = k[sl_read]
-                    self._v[sl_write] = v[sl_read]
+                    self._k[sl_write] = k[sl_read]  # ty:ignore[invalid-assignment]
+                    self._v[sl_write] = v[sl_read]  # ty:ignore[invalid-assignment]
 
-    def is_steady_state(self, chunk_start: int) -> bool:
+    def is_steady_state(self, chunk_start: int) -> bool:  # ty:ignore[invalid-return-type]
         """If this update will write to the same positions as the rest of the updates."""
         is_overlapping_with_sink = chunk_start < self.sink_size
         if is_overlapping_with_sink:
@@ -276,7 +276,7 @@ class BlockKVCache:
             chunk_size = k.shape[self.seq_dim]
             chunk_end = chunk_start + chunk_size
 
-            total_size = self._k.shape[self.seq_dim]
+            total_size = self._k.shape[self.seq_dim]  # ty:ignore[unresolved-attribute]
             evict_size = self._n_cached + chunk_size - total_size
             self._roll_local_window_left(evict_size)
             self._append_to_end(k, v)
@@ -285,15 +285,15 @@ class BlockKVCache:
             self._prev_chunk_end = chunk_end
 
     def cached_v(self) -> Tensor:
-        total_size = self._k.shape[self.seq_dim]
+        total_size = self._k.shape[self.seq_dim]  # ty:ignore[unresolved-attribute]
         if self._n_cached == total_size:
-            return self._v
+            return self._v  # ty:ignore[invalid-return-type]
         else:
-            return self._v[self._seq_slice(0, self._n_cached)]
+            return self._v[self._seq_slice(0, self._n_cached)]  # ty:ignore[not-subscriptable]
 
     def cached_k(self) -> Tensor:
-        total_size = self._k.shape[self.seq_dim]
+        total_size = self._k.shape[self.seq_dim]  # ty:ignore[unresolved-attribute]
         if self._n_cached == total_size:
-            return self._k
+            return self._k  # ty:ignore[invalid-return-type]
         else:
-            return self._k[self._seq_slice(0, self._n_cached)]
+            return self._k[self._seq_slice(0, self._n_cached)]  # ty:ignore[not-subscriptable]

--- a/flashdreams/flashdreams/core/experimental/test_block_kvcache.py
+++ b/flashdreams/flashdreams/core/experimental/test_block_kvcache.py
@@ -38,7 +38,7 @@ class _NaiveKVCache:
             self._total_v = v
         else:
             self._total_k = torch.cat([self._total_k, k], dim=1)
-            self._total_v = torch.cat([self._total_v, v], dim=1)
+            self._total_v = torch.cat([self._total_v, v], dim=1)  # ty:ignore[no-matching-overload]
 
     def ovewrite_rightmost(self, k: torch.Tensor, v: torch.Tensor) -> None:
         assert self._total_k is not None

--- a/flashdreams/flashdreams/core/io/s3_sync.py
+++ b/flashdreams/flashdreams/core/io/s3_sync.py
@@ -71,7 +71,7 @@ def sync_s3_dir_to_local(
     show_progress: bool = True,
     verify_checksum: bool = True,
     desc: str = "Syncing from S3",
-) -> str:
+) -> str:  # ty:ignore[invalid-return-type]
     """Download an S3 directory to local cache (rank 0 only) and optionally verify checksums."""
     if not s3_dir.startswith("s3://"):
         assert os.path.exists(s3_dir), f"{s3_dir} is not a S3 path or a local path."

--- a/flashdreams/flashdreams/infra/decoder/base.py
+++ b/flashdreams/flashdreams/infra/decoder/base.py
@@ -76,4 +76,4 @@ class Decoder(ABC, nn.Module, Generic[DecCacheT]):
         Returns:
             A fresh :class:`DecoderAutoregressiveCache` (or subclass).
         """
-        return DecoderAutoregressiveCache()  # type: ignore[return-value]
+        return DecoderAutoregressiveCache()  # type: ignore[return-value]  # ty:ignore[invalid-return-type]

--- a/flashdreams/flashdreams/infra/diffusion/model/base.py
+++ b/flashdreams/flashdreams/infra/diffusion/model/base.py
@@ -70,7 +70,7 @@ class DiffusionModel(nn.Module, Generic[TransformerCacheT]):
     """
 
     @dataclass(kw_only=True)
-    class FinalState(Generic[TransformerCacheT]):
+    class FinalState(Generic[TransformerCacheT]):  # ty:ignore[shadowed-type-variable]
         """State passed from :meth:`generate` to :meth:`finalize`."""
 
         clean_latent: Tensor
@@ -91,7 +91,7 @@ class DiffusionModel(nn.Module, Generic[TransformerCacheT]):
     def __init__(self, config: DiffusionModelConfig) -> None:
         super().__init__()
         self.config = config
-        self.transformer = self.config.transformer.setup()
+        self.transformer = self.config.transformer.setup()  # ty:ignore[invalid-assignment]
         self.scheduler = self.config.scheduler.setup()
         self._rng: torch.Generator | None = None
 
@@ -189,7 +189,7 @@ class DiffusionModel(nn.Module, Generic[TransformerCacheT]):
         )
 
         clean_latent = self.transformer.unpatchify_and_maybe_gather_cp(clean_latent)
-        return clean_latent, final_state
+        return clean_latent, final_state  # ty:ignore[invalid-return-type]
 
     def finalize(
         self,

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
@@ -219,16 +219,16 @@ class FlowMatchScheduler(Scheduler):
 
         noisy = initial_noise
         clean: Tensor | None = None
-        for i in range(timesteps.shape[0]):
-            sigma = sigmas[i]
+        for i in range(timesteps.shape[0]):  # ty:ignore[not-subscriptable]
+            sigma = sigmas[i]  # ty:ignore[not-subscriptable]
             # Schedule buffers are pinned to fp32 (to preserve integer
             # timestep values under a stray `module.to(bf16)`), but the
             # network expects timesteps in the input dtype so that
             # downstream modulation / Linear layers stay consistent.
-            timestep = timesteps[i].to(dtype=input_dtype)
+            timestep = timesteps[i].to(dtype=input_dtype)  # ty:ignore[not-subscriptable]
             if i > 0:
                 noise = torch.randn_like(noisy, generator=rng)
-                noisy = ((1.0 - sigma) * clean + sigma * noise).to(input_dtype)  # type: ignore[operator]
+                noisy = ((1.0 - sigma) * clean + sigma * noise).to(input_dtype)  # type: ignore[operator]  # ty:ignore[unsupported-operator]
             flow = predict_flow(noisy, timestep)
             clean = noisy - sigma * flow
         assert clean is not None, "denoising_step_list is empty"
@@ -258,7 +258,7 @@ class FlowMatchScheduler(Scheduler):
         """
         assert timestep.shape == (), f"expected scalar timestep, got {timestep.shape}"
         full_t = self._full_timesteps
-        idx = torch.argmin((full_t - timestep.to(full_t.dtype)).abs()).reshape(1)
-        sigma = self._full_sigmas.index_select(0, idx).reshape(())
+        idx = torch.argmin((full_t - timestep.to(full_t.dtype)).abs()).reshape(1)  # ty:ignore[no-matching-overload]
+        sigma = self._full_sigmas.index_select(0, idx).reshape(())  # ty:ignore[call-non-callable]
         noise = torch.randn_like(clean_input, generator=rng)
         return ((1.0 - sigma) * clean_input + sigma * noise).to(clean_input.dtype)

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/fm_unipc.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/fm_unipc.py
@@ -330,7 +330,7 @@ class FlowMatchUniPCScheduler(Scheduler):
             result is cast back to ``initial_noise.dtype``.
         """
         input_dtype = initial_noise.dtype
-        N = self.timesteps.shape[0]
+        N = self.timesteps.shape[0]  # ty:ignore[not-subscriptable]
 
         sample = initial_noise
         m_prev: Tensor | None = None
@@ -338,7 +338,7 @@ class FlowMatchUniPCScheduler(Scheduler):
         last_sample: Tensor | None = None
 
         for i in range(N):
-            timestep = self.timesteps[i]
+            timestep = self.timesteps[i]  # ty:ignore[not-subscriptable]
             # Network forward (heavy compute -- everything else here is
             # ~free relative to this).
             flow = predict_flow(sample, timestep)
@@ -348,7 +348,7 @@ class FlowMatchUniPCScheduler(Scheduler):
             # Promote to fp32 to match upstream's
             # ``model_output = model_output.to(dtype=torch.float32)``
             # before convert_model_output.
-            m_curr = sample.to(torch.float32) - self.sigmas[i] * flow.to(torch.float32)
+            m_curr = sample.to(torch.float32) - self.sigmas[i] * flow.to(torch.float32)  # ty:ignore[not-subscriptable]
 
             # Corrector (skip on first step).
             #
@@ -363,10 +363,10 @@ class FlowMatchUniPCScheduler(Scheduler):
                 assert last_sample is not None and m_prev is not None
                 m_pp = m_prev_prev if m_prev_prev is not None else m_prev
                 corrected = (
-                    self.a_corr[i] * last_sample.to(torch.float32)
-                    + self.b_corr_m0[i] * m_prev
-                    + self.b_corr_dprev[i] * (m_pp - m_prev)
-                    + self.b_corr_dt[i] * (m_curr - m_prev)
+                    self.a_corr[i] * last_sample.to(torch.float32)  # ty:ignore[not-subscriptable]
+                    + self.b_corr_m0[i] * m_prev  # ty:ignore[not-subscriptable]
+                    + self.b_corr_dprev[i] * (m_pp - m_prev)  # ty:ignore[not-subscriptable]
+                    + self.b_corr_dt[i] * (m_curr - m_prev)  # ty:ignore[not-subscriptable]
                 )
                 sample = corrected.to(input_dtype)
 
@@ -383,9 +383,9 @@ class FlowMatchUniPCScheduler(Scheduler):
             # the warmup step to skip a zero-tensor allocation.
             m_p = m_prev if m_prev is not None else m_curr
             predicted = (
-                self.a_pred[i] * sample.to(torch.float32)
-                + self.b_pred_m0[i] * m_curr
-                + self.b_pred_dprev[i] * (m_p - m_curr)
+                self.a_pred[i] * sample.to(torch.float32)  # ty:ignore[not-subscriptable]
+                + self.b_pred_m0[i] * m_curr  # ty:ignore[not-subscriptable]
+                + self.b_pred_dprev[i] * (m_p - m_curr)  # ty:ignore[not-subscriptable]
             )
             sample = predicted.to(input_dtype)
 
@@ -419,7 +419,7 @@ class FlowMatchUniPCScheduler(Scheduler):
         """
         assert timestep.shape == (), f"expected scalar timestep, got {timestep.shape}"
         ts = self.timesteps
-        idx = torch.argmin((ts - timestep.to(ts.dtype)).abs()).reshape(1)
-        sigma = self._sigmas_full.index_select(0, idx).reshape(())
+        idx = torch.argmin((ts - timestep.to(ts.dtype)).abs()).reshape(1)  # ty:ignore[no-matching-overload]
+        sigma = self._sigmas_full.index_select(0, idx).reshape(())  # ty:ignore[call-non-callable]
         noise = torch.randn_like(clean_input, generator=rng)
         return ((1.0 - sigma) * clean_input + sigma * noise).to(clean_input.dtype)

--- a/flashdreams/flashdreams/infra/diffusion/transformer/base.py
+++ b/flashdreams/flashdreams/infra/diffusion/transformer/base.py
@@ -183,7 +183,7 @@ class Transformer(nn.Module, ABC, Generic[TransformerCacheT]):
         Returns:
             A fresh :class:`TransformerAutoregressiveCache` (or subclass).
         """
-        return TransformerAutoregressiveCache()  # type: ignore[return-value]
+        return TransformerAutoregressiveCache()  # type: ignore[return-value]  # ty:ignore[invalid-return-type]
 
     def postprocess_clean_latent(
         self,

--- a/flashdreams/flashdreams/infra/encoder/base.py
+++ b/flashdreams/flashdreams/infra/encoder/base.py
@@ -74,7 +74,7 @@ class Encoder(ABC, nn.Module, Generic[EncCacheT]):
         Returns:
             A fresh :class:`EncoderAutoregressiveCache` (or subclass).
         """
-        return EncoderAutoregressiveCache()  # type: ignore[return-value]
+        return EncoderAutoregressiveCache()  # type: ignore[return-value]  # ty:ignore[invalid-return-type]
 
 
 @dataclass(kw_only=True)

--- a/flashdreams/flashdreams/infra/encoder/image/clip.py
+++ b/flashdreams/flashdreams/infra/encoder/image/clip.py
@@ -91,7 +91,8 @@ class CLIPImageEncoder(Encoder):
             ),
         ).to(device, dtype=self.image_encoder.dtype)
         image_embeds: BaseModelOutputWithPooling = self.image_encoder(
-            **images, output_hidden_states=True
+            **images,  # ty: ignore[invalid-argument-type]
+            output_hidden_states=True,
         )
 
         assert image_embeds.hidden_states is not None

--- a/flashdreams/flashdreams/infra/pipeline/base.py
+++ b/flashdreams/flashdreams/infra/pipeline/base.py
@@ -132,9 +132,9 @@ class StreamInferencePipeline(
     def __init__(self, config: StreamInferencePipelineConfig) -> None:
         super().__init__()
         self.config = config
-        self.encoder = config.encoder.setup() if config.encoder is not None else None
-        self.decoder = config.decoder.setup() if config.decoder is not None else None
-        self.diffusion_model = config.diffusion_model.setup()
+        self.encoder = config.encoder.setup() if config.encoder is not None else None  # ty:ignore[invalid-assignment]
+        self.decoder = config.decoder.setup() if config.decoder is not None else None  # ty:ignore[invalid-assignment]
+        self.diffusion_model = config.diffusion_model.setup()  # ty:ignore[invalid-assignment]
 
     @property
     def device(self) -> torch.device:

--- a/flashdreams/flashdreams/recipes/alpadreams/config.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/config.py
@@ -175,7 +175,7 @@ def build_sv_2steps_chunk2_loc6_lightvae_lighttae(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["single_view"][
                     "vae_encoding"
-                ]["chunk2"],  # type: ignore[index]
+                ]["chunk2"],  # type: ignore[index]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
                 num_views=1,
@@ -212,7 +212,7 @@ def build_sv_2steps_chunk2_loc6_lightvae_lighttae_perf(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["single_view"][
                     "vae_encoding"
-                ]["chunk2"],  # type: ignore[index]
+                ]["chunk2"],  # type: ignore[index]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
                 num_views=1,
@@ -244,7 +244,7 @@ def build_sv_2steps_chunk2_loc6_vae_vae(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["single_view"][
                     "vae_encoding"
-                ]["chunk2"],  # type: ignore[index]
+                ]["chunk2"],  # type: ignore[index]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
                 num_views=1,
@@ -276,7 +276,7 @@ def build_sv_2steps_chunk3_loc6_vae_vae(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["single_view"][
                     "vae_encoding"
-                ]["chunk3"],  # type: ignore[index]
+                ]["chunk3"],  # type: ignore[index]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
                 num_views=1,
@@ -308,7 +308,7 @@ def build_sv_2steps_chunk4_loc8_pshuffle_lighttae(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["single_view"][
                     "pixel_shuffle"
-                ],  # type: ignore[index]
+                ],  # type: ignore[index]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
                 num_views=1,
@@ -340,7 +340,7 @@ def build_mv_2steps_chunk4_loc8_pshuffle_lighttae(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["4views"][
                     "pixel_shuffle"
-                ],  # type: ignore[arg-type]
+                ],  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
                 num_views=4,

--- a/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
@@ -88,7 +88,7 @@ class AlpadreamsPipelineConfig(StreamInferencePipelineConfig):
 
     _target: type["StreamInferencePipeline"] = field(
         default_factory=lambda: AlpadreamsPipeline
-    )
+    )  # ty:ignore[invalid-assignment]
 
     text_encoder: CosmosReason1TextEncoderConfig = field(
         default_factory=CosmosReason1TextEncoderConfig
@@ -130,8 +130,8 @@ class AlpadreamsPipeline(
 
     def __init__(self, config: AlpadreamsPipelineConfig) -> None:
         super().__init__(config)
-        self.text_encoder = config.text_encoder.setup()
-        self.image_encoder = config.image_encoder.setup()
+        self.text_encoder = config.text_encoder.setup()  # ty:ignore[invalid-assignment]
+        self.image_encoder = config.image_encoder.setup()  # ty:ignore[invalid-assignment]
 
         assert self.encoder is not None, (
             "AlpadreamsPipeline requires a per-AR-step HDMap encoder; "
@@ -139,19 +139,19 @@ class AlpadreamsPipeline(
         )
 
         transformer = self.diffusion_model.transformer
-        self._len_t_latent: int = transformer.config.len_t
+        self._len_t_latent: int = transformer.config.len_t  # ty:ignore[unresolved-attribute]
         decoder = self.decoder
         assert decoder is not None and hasattr(decoder, "TEMPORAL_COMPRESSION_RATIO"), (
             f"Decoder {type(decoder).__name__} must expose "
             "TEMPORAL_COMPRESSION_RATIO (e.g. WanVAEDecoder, TeahvVAEDecoder)."
         )
-        self._decoder_temporal_compression: int = decoder.TEMPORAL_COMPRESSION_RATIO
+        self._decoder_temporal_compression: int = decoder.TEMPORAL_COMPRESSION_RATIO  # ty:ignore[invalid-assignment]
 
         # Take the view split outside of the transformer, so that VAE does not do duplicated job.
-        self.V_group = transformer.cp_groups.V_group
-        self.V_size = transformer.cp_groups.V_size
-        transformer.cp_groups.V_group = None
-        transformer.config.num_views //= self.V_size
+        self.V_group = transformer.cp_groups.V_group  # ty:ignore[unresolved-attribute]
+        self.V_size = transformer.cp_groups.V_size  # ty:ignore[unresolved-attribute]
+        transformer.cp_groups.V_group = None  # ty:ignore[invalid-assignment]
+        transformer.config.num_views //= self.V_size  # ty:ignore[unresolved-attribute]
 
     @property
     def device(self) -> torch.device:
@@ -190,12 +190,16 @@ class AlpadreamsPipeline(
 
         # distribute multi-view
         text_embeddings = split_inputs_cp(
-            text_embeddings, seq_dim=1, cp_group=self.V_group
+            text_embeddings,
+            seq_dim=1,
+            cp_group=self.V_group,  # ty:ignore[invalid-argument-type]
         )
         image_embeddings = split_inputs_cp(
-            image_embeddings, seq_dim=1, cp_group=self.V_group
+            image_embeddings,
+            seq_dim=1,
+            cp_group=self.V_group,  # ty:ignore[invalid-argument-type]
         )
-        view_names = split_inputs_cp_object_list(view_names, cp_group=self.V_group)
+        view_names = split_inputs_cp_object_list(view_names, cp_group=self.V_group)  # ty:ignore[invalid-argument-type]
 
         return super().initialize_cache(
             transformer_context={
@@ -226,7 +230,7 @@ class AlpadreamsPipeline(
             ``[-1, 1]``.
         """
         # distribute multi-view
-        hdmap = split_inputs_cp(hdmap, seq_dim=1, cp_group=self.V_group)
+        hdmap = split_inputs_cp(hdmap, seq_dim=1, cp_group=self.V_group)  # ty:ignore[invalid-argument-type]
 
         # generate
         output = super().generate(
@@ -236,7 +240,7 @@ class AlpadreamsPipeline(
         )
 
         # gather multi-view
-        output = cat_outputs_cp(output, seq_dim=1, cp_group=self.V_group)
+        output = cat_outputs_cp(output, seq_dim=1, cp_group=self.V_group)  # ty:ignore[invalid-argument-type]
         return output
 
     def get_num_frames(self, autoregressive_index: int) -> int:

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -321,12 +321,12 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         if config.checkpoint_path is not None:
             transform = config.state_dict_transform or _strip_net_prefix
             state_dict = load_checkpoint(config.checkpoint_path)
-            state_dict = transform(state_dict)
+            state_dict = transform(state_dict)  # ty:ignore[invalid-argument-type]
             self.network.load_state_dict(state_dict)
         self.network.update_parameters_after_loading_checkpoint()
 
         if config.compile_network:
-            self.network = torch.compile(  # type: ignore[assignment]
+            self.network = torch.compile(  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
                 self.network, mode="max-autotune-no-cudagraphs"
             )
 
@@ -501,7 +501,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         # which the freshly-initialised network_cache invalidates.
         # Warmup + capture re-run on the next steady-state predict_flow.
         if self._use_cuda_graph:
-            self._network_call.reset()  # type: ignore[union-attr]
+            self._network_call.reset()  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
 
         return CosmosTransformerCache(
             network_cache=network_cache,
@@ -571,7 +571,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         # per-rollout dispatch contract.
         if self._use_cuda_graph:
             network = (
-                self._network_call.drain  # type: ignore[union-attr]
+                self._network_call.drain  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
                 if ar_idx < self.config._steady_ar_idx
                 else self._network_call
             )

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
@@ -73,7 +73,7 @@ class Timesteps(nn.Module):
         Returns:
             Embedded tensor of shape (..., num_channels).
         """
-        emb = timesteps.unsqueeze(-1) * self.emb
+        emb = timesteps.unsqueeze(-1) * self.emb  # ty:ignore[unsupported-operator]
         emb = torch.cat([torch.cos(emb), torch.sin(emb)], dim=-1)
         return emb
 

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
@@ -182,7 +182,7 @@ class CosmosDiTNetwork(nn.Module):
         cross_view_attn_group: ProcessGroup | None = None,
     ) -> None:
         for block in self.blocks:
-            block.set_context_parallel_group(self_attn_group, cross_view_attn_group)
+            block.set_context_parallel_group(self_attn_group, cross_view_attn_group)  # ty:ignore[call-non-callable]
 
     def _fuse_shuffle_op_into_last_layer(self):
         """
@@ -260,11 +260,11 @@ class CosmosDiTNetwork(nn.Module):
         self.x_embedder.in_channels -= 1
         in_channels_to_keep = self.x_embedder.get_linear_in_channels()
         self.x_embedder.proj[1].weight.data = (
-            self.x_embedder.proj[1].weight.data[:, :in_channels_to_keep].contiguous()
+            self.x_embedder.proj[1].weight.data[:, :in_channels_to_keep].contiguous()  # ty:ignore[not-subscriptable]
         )
         if self.x_embedder.proj[1].bias is not None:
             self.x_embedder.proj[1].bias.data = (
-                self.x_embedder.proj[1].bias.data[:in_channels_to_keep].contiguous()
+                self.x_embedder.proj[1].bias.data[:in_channels_to_keep].contiguous()  # ty:ignore[not-subscriptable]
             )
 
         self._is_padding_mask_fused = True
@@ -377,7 +377,7 @@ class CosmosDiTNetwork(nn.Module):
 
         return CosmosDiTNetworkCache(
             block_caches=[
-                block.initialize_cache(chunk_size, window_size, sink_size, context)
+                block.initialize_cache(chunk_size, window_size, sink_size, context)  # ty:ignore[call-non-callable]
                 for block in self.blocks
             ],
         )

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
@@ -94,7 +94,7 @@ class I2VCamCtrlEncoderCache:
     camera_last_pose: Tensor
 
 
-class I2VCamCtrlEncoder(Encoder[I2VCamCtrlEncoderCache]):
+class I2VCamCtrlEncoder(Encoder[I2VCamCtrlEncoderCache]):  # ty:ignore[invalid-type-arguments]
     """Per-AR-step I2V control encoder with camera control."""
 
     def __init__(self, config: I2VCamCtrlEncoderConfig) -> None:
@@ -104,9 +104,9 @@ class I2VCamCtrlEncoder(Encoder[I2VCamCtrlEncoderCache]):
 
     def initialize_autoregressive_cache(self) -> I2VCamCtrlEncoderCache:
         return I2VCamCtrlEncoderCache(
-            i2v=self.i2v_encoder.initialize_autoregressive_cache(),
-            plucker=self.plucker_encoder.initialize_autoregressive_cache(),
-            camera_last_pose=None,
+            i2v=self.i2v_encoder.initialize_autoregressive_cache(),  # ty:ignore[invalid-argument-type]
+            plucker=self.plucker_encoder.initialize_autoregressive_cache(),  # ty:ignore[invalid-argument-type]
+            camera_last_pose=None,  # ty:ignore[invalid-argument-type]
         )
 
     @torch.no_grad()
@@ -116,11 +116,11 @@ class I2VCamCtrlEncoder(Encoder[I2VCamCtrlEncoderCache]):
         autoregressive_index: int = 0,
         cache: I2VCtrlEncoderCache | None = None,
     ) -> I2VCamCtrlEmbeddings:
-        height, width = input.i2v.shape[-2:]
+        height, width = input.i2v.shape[-2:]  # ty:ignore[unresolved-attribute]
         i2v = self.i2v_encoder(
             input=input.i2v,
             autoregressive_index=autoregressive_index,
-            cache=cache.i2v,
+            cache=cache.i2v,  # ty:ignore[unresolved-attribute]
         )
         plucker = self._render_plucker(
             height=height,
@@ -128,22 +128,22 @@ class I2VCamCtrlEncoder(Encoder[I2VCamCtrlEncoderCache]):
             intrinsics=input.camctrl.intrinsics,
             poses=input.camctrl.poses,
             world_scale=input.camctrl.world_scale,
-            cache=cache,
+            cache=cache,  # ty:ignore[invalid-argument-type]
         )
         plucker = self.plucker_encoder(
             input=plucker,
             autoregressive_index=autoregressive_index,
-            cache=cache.plucker,
+            cache=cache.plucker,  # ty:ignore[unresolved-attribute]
         )
         return I2VCamCtrlEmbeddings(i2v=i2v, plucker=plucker)
 
     @property
     def temporal_compression_ratio(self) -> int:
-        return self.i2v_encoder.temporal_compression_ratio
+        return self.i2v_encoder.temporal_compression_ratio  # ty:ignore[invalid-return-type]
 
     @property
     def spatial_compression_ratio(self) -> int:
-        return self.i2v_encoder.spatial_compression_ratio
+        return self.i2v_encoder.spatial_compression_ratio  # ty:ignore[invalid-return-type]
 
     @torch.no_grad()
     def _render_plucker(

--- a/flashdreams/flashdreams/recipes/lingbot_world/pipeline.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/pipeline.py
@@ -95,6 +95,6 @@ class LingbotWorldInferencePipeline(WanInferencePipeline):
         return StreamInferencePipeline.generate(
             self,
             autoregressive_index=autoregressive_index,
-            cache=cache,
+            cache=cache,  # ty:ignore[invalid-argument-type]
             input=camctrl_input,
         )

--- a/flashdreams/flashdreams/recipes/lingbot_world/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/transformer/__init__.py
@@ -102,9 +102,9 @@ class LingbotWorldTransformer(Wan21Transformer):
                 return x
             else:
                 return I2VCamCtrlEmbeddings(
-                    i2v=super().patchify_and_maybe_split_cp(x.i2v),
-                    plucker=super().patchify_and_maybe_split_cp(x.plucker),
+                    i2v=super().patchify_and_maybe_split_cp(x.i2v),  # ty:ignore[invalid-argument-type]
+                    plucker=super().patchify_and_maybe_split_cp(x.plucker),  # ty:ignore[invalid-argument-type]
                     _is_patchified=True,
                 )
         else:
-            return super().patchify_and_maybe_split_cp(x)
+            return super().patchify_and_maybe_split_cp(x)  # ty:ignore[invalid-return-type]

--- a/flashdreams/flashdreams/recipes/lingbot_world/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/transformer/impl/modules.py
@@ -73,7 +73,7 @@ class CamCtrlBlock(Block):
         Returns:
             Updated hidden states with shape ``[..., L, D]``.
         """
-        e = (self.modulation + e).chunk(6, dim=-2)
+        e = (self.modulation + e).chunk(6, dim=-2)  # ty:ignore[invalid-assignment]
 
         y = self.norm1(x) * (1 + e[1]) + e[0]
         y = self.self_attn(

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -129,7 +129,7 @@ class TeahvVAEDecoder(Decoder[TAEHVCache]):
         z = input.reshape(batch_size, T, C, H, W)
 
         if self.need_scaled:
-            z = z * self.std
+            z = z * self.std  # ty:ignore[unsupported-operator]
             z = z + self.mean
 
         x = self.taehv.decode(z, cache=cache).mul_(2).sub_(1)

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -344,7 +344,7 @@ class TAEHV(nn.Module):
                 if k.startswith("decoder.") and not k.startswith("decoder.blocks.")
                 else k
             ): v
-            for k, v in sd.items()
+            for k, v in sd.items()  # ty:ignore[call-non-callable]
         }
         sd = _patch_tgrow_state_dict(sd, self.decoder.blocks)
         # ``assign=True``: meta params become the checkpoint tensors as-is;
@@ -373,7 +373,7 @@ class TAEHV(nn.Module):
         next decode of each shape.
         """
         if self._use_cuda_graph:
-            self._decoder_call.reset()  # type: ignore[union-attr]
+            self._decoder_call.reset()  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         return TAEHVCache()
 
     @torch.inference_mode()
@@ -395,7 +395,7 @@ class TAEHV(nn.Module):
         # path.
         if self._use_cuda_graph:
             decoder = (
-                self._decoder_call.drain  # type: ignore[union-attr]
+                self._decoder_call.drain  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
                 if first_decode
                 else self._decoder_call
             )

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/i2v.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/i2v.py
@@ -96,10 +96,10 @@ class I2VCtrlEncoder(Encoder[I2VCtrlEncoderCache]):
     def __init__(self, config: I2VCtrlEncoderConfig) -> None:
         super().__init__(config)
         self.config: I2VCtrlEncoderConfig = config
-        self.encoder = config.encoder.setup()
+        self.encoder = config.encoder.setup()  # ty:ignore[invalid-assignment]
 
     def initialize_autoregressive_cache(self) -> I2VCtrlEncoderCache:
-        return self.encoder.initialize_autoregressive_cache()
+        return self.encoder.initialize_autoregressive_cache()  # ty:ignore[invalid-return-type]
 
     @torch.no_grad()
     def forward(

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -117,7 +117,7 @@ class CausalConv3d(nn.Conv3d):
         super().__init__(*args, **kwargs)
         ph, pw = self.padding[1], self.padding[2]
         self._spatial_pad = (pw, pw, ph, ph)
-        self._has_spatial_pad = ph > 0 or pw > 0
+        self._has_spatial_pad = ph > 0 or pw > 0  # ty:ignore[unsupported-operator]
         self._time_pad = 2 * self.padding[0]
         self.padding = (0, 0, 0)
 
@@ -125,11 +125,11 @@ class CausalConv3d(nn.Conv3d):
         self, x: torch.Tensor, prev: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         time_pad = self._time_pad
-        if prev is not None and time_pad > 0:
+        if prev is not None and time_pad > 0:  # ty:ignore[unsupported-operator]
             x = torch.cat([prev, x], dim=2)
-            time_pad = max(0, time_pad - prev.shape[2])
+            time_pad = max(0, time_pad - prev.shape[2])  # ty:ignore[unsupported-operator]
         if time_pad or self._has_spatial_pad:
-            x = F.pad(x, (*self._spatial_pad, time_pad, 0))
+            x = F.pad(x, (*self._spatial_pad, time_pad, 0))  # ty:ignore[invalid-argument-type]
         return super().forward(x)
 
     def cache_step(
@@ -395,7 +395,7 @@ class Encoder3d(nn.Module):
         for layer in self.middle:
             x = layer(x, state)
         norm, act, conv = self.head
-        return conv.cache_step(act(norm(x)), state)
+        return conv.cache_step(act(norm(x)), state)  # ty:ignore[call-non-callable]
 
 
 class Decoder3d(nn.Module):
@@ -454,7 +454,7 @@ class Decoder3d(nn.Module):
         for layer in self.upsamples:
             x = layer(x, state)
         norm, act, conv = self.head
-        return conv.cache_step(act(norm(x)), state)
+        return conv.cache_step(act(norm(x)), state)  # ty:ignore[call-non-callable]
 
 
 class WanVAE(nn.Module):
@@ -524,21 +524,21 @@ class WanVAE(nn.Module):
                 self.encoder = Encoder3d(
                     z_dim=self.Z_DIM * 2,
                     temperal_downsample=(False, True, True),
-                    **common,
+                    **common,  # ty:ignore[invalid-argument-type]
                 )
                 self.conv1 = CausalConv3d(self.Z_DIM * 2, self.Z_DIM * 2, 1)
             if enable_decoder:
                 self.decoder = Decoder3d(
                     z_dim=self.Z_DIM,
                     temperal_upsample=(True, True, False),
-                    **common,
+                    **common,  # ty:ignore[invalid-argument-type]
                 )
                 self.conv2 = CausalConv3d(self.Z_DIM, self.Z_DIM, 1)
 
         # `assign=True`: meta params become the checkpoint tensors as-is;
         # caller does `.to(device, dtype)` afterward. `strict=False`
         # tolerates the missing half (encoder-only or decoder-only).
-        self.load_state_dict(load_checkpoint(vae_path), strict=False, assign=True)
+        self.load_state_dict(load_checkpoint(vae_path), strict=False, assign=True)  # ty:ignore[invalid-argument-type]
 
         self.register_buffer(
             "mean",
@@ -587,9 +587,9 @@ class WanVAE(nn.Module):
         """
         if self._use_cuda_graph:
             if self._enable_encoder:
-                self._encoder_call.reset()  # type: ignore[union-attr]
+                self._encoder_call.reset()  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
             if self._enable_decoder:
-                self._decoder_call.reset()  # type: ignore[union-attr]
+                self._decoder_call.reset()  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
         return WanVAECache()
 
     @torch.inference_mode()
@@ -614,7 +614,7 @@ class WanVAE(nn.Module):
         # before the seed call populates `state`.
         if self._use_cuda_graph:
             encoder_body = (
-                self._encoder_call.drain  # type: ignore[union-attr]
+                self._encoder_call.drain  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
                 if not state
                 else self._encoder_call
             )
@@ -650,11 +650,11 @@ class WanVAE(nn.Module):
             "WanVAE.decode called but the model was constructed with "
             "enable_decoder=False"
         )
-        z = z / self.inv_std + self.mean
+        z = z / self.inv_std + self.mean  # ty:ignore[unsupported-operator]
         # See `encode` for rollout 1 vs 2+ dispatch rationale.
         if self._use_cuda_graph:
             decoder = (
-                self._decoder_call.drain  # type: ignore[union-attr]
+                self._decoder_call.drain  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
                 if not cache.dec_state
                 else self._decoder_call
             )

--- a/flashdreams/flashdreams/recipes/wan/config/causal_wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/config/causal_wan21.py
@@ -80,9 +80,9 @@ def _remap_self_or_causal_forcing_state_dict(
     matches the keys ``WanDiTNetwork.state_dict()`` exposes.
     """
     if "generator_ema" in state_dict:
-        state_dict = state_dict["generator_ema"]  # type: ignore[assignment]
+        state_dict = state_dict["generator_ema"]  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
     elif "generator" in state_dict:
-        state_dict = state_dict["generator"]  # type: ignore[assignment]
+        state_dict = state_dict["generator"]  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
 
     out: dict[str, Tensor] = {}
     for k, v in state_dict.items():
@@ -224,7 +224,7 @@ def build_self_forcing(
         diffusion_model=DiffusionModelConfig(
             seed=seed,
             transformer=_transformer_config(
-                checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS["self_forcing"],  # type: ignore[arg-type]
+                checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS["self_forcing"],  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
             ),
@@ -252,7 +252,7 @@ def build_self_forcing_lighttae(
         diffusion_model=DiffusionModelConfig(
             seed=seed,
             transformer=_transformer_config(
-                checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS["self_forcing"],  # type: ignore[arg-type]
+                checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS["self_forcing"],  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
             ),
@@ -282,7 +282,7 @@ def build_causal_forcing_chunkwise(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS[
                     "causal_forcing"
-                ]["chunkwise"],  # type: ignore[index]
+                ]["chunkwise"],  # type: ignore[index]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
             ),
@@ -312,7 +312,7 @@ def build_causal_forcing_framewise(
             transformer=_transformer_config(
                 checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS[
                     "causal_forcing"
-                ]["framewise"],  # type: ignore[index]
+                ]["framewise"],  # type: ignore[index]  # ty:ignore[invalid-argument-type]
                 cp_size=cp_size,
                 compile_network=compile_network,
                 # framewise: one latent frame per chunk.

--- a/flashdreams/flashdreams/recipes/wan/pipeline.py
+++ b/flashdreams/flashdreams/recipes/wan/pipeline.py
@@ -46,7 +46,7 @@ from flashdreams.recipes.wan.transformer.wan22 import Wan22TransformerCache
 @dataclass(kw_only=True)
 class WanInferencePipelineCache(
     StreamInferencePipelineCache[
-        I2VCtrlEncoderCache | None,  # EncCacheT
+        I2VCtrlEncoderCache | None,  # EncCacheT  # ty:ignore[invalid-type-arguments]
         Wan21TransformerCache | Wan22TransformerCache,  # TransformerCacheT
         WanVAECache,  # DecCacheT
     ]
@@ -109,7 +109,7 @@ class WanInferencePipelineConfig(StreamInferencePipelineConfig):
 
 class WanInferencePipeline(
     StreamInferencePipeline[
-        I2VCtrlEncoderCache | None,  # EncCacheT
+        I2VCtrlEncoderCache | None,  # EncCacheT  # ty:ignore[invalid-type-arguments]
         Wan21TransformerCache | Wan22TransformerCache,  # TransformerCacheT
         WanVAECache,  # DecCacheT
     ]
@@ -146,8 +146,8 @@ class WanInferencePipeline(
 
     def __init__(self, config: WanInferencePipelineConfig) -> None:
         super().__init__(config)
-        self.text_encoder = config.text_encoder.setup()
-        self.image_encoder = (
+        self.text_encoder = config.text_encoder.setup()  # ty:ignore[invalid-assignment]
+        self.image_encoder = (  # ty:ignore[invalid-assignment]
             config.image_encoder.setup() if config.image_encoder is not None else None
         )
 
@@ -182,7 +182,7 @@ class WanInferencePipeline(
 
         text_embeddings = self.text_encoder(text)  # [B, L, D]
 
-        guidance_scale = self.diffusion_model.transformer.config.guidance_scale
+        guidance_scale = self.diffusion_model.transformer.config.guidance_scale  # ty:ignore[unresolved-attribute]
         if guidance_scale > 1.0:
             negative_text_embeddings = self.text_encoder([NEGATIVE_PROMPT] * n)
         else:
@@ -296,8 +296,8 @@ class WanInferencePipeline(
 
     def get_num_input_frames(self, autoregressive_index: int) -> int:
         """Number of input video frames accepted by the model."""
-        len_t = self.diffusion_model.transformer.config.len_t
-        temporal_compression_ratio = self.encoder.temporal_compression_ratio
+        len_t = self.diffusion_model.transformer.config.len_t  # ty:ignore[unresolved-attribute]
+        temporal_compression_ratio = self.encoder.temporal_compression_ratio  # ty:ignore[unresolved-attribute]
         if autoregressive_index == 0:
             return 1 + (len_t - 1) * temporal_compression_ratio
         else:
@@ -305,8 +305,8 @@ class WanInferencePipeline(
 
     def get_num_output_frames(self, autoregressive_index: int) -> int:
         """Number of output video frames produced by the model."""
-        len_t = self.diffusion_model.transformer.config.len_t
-        temporal_compression_ratio = self.decoder.temporal_compression_ratio
+        len_t = self.diffusion_model.transformer.config.len_t  # ty:ignore[unresolved-attribute]
+        temporal_compression_ratio = self.decoder.temporal_compression_ratio  # ty:ignore[unresolved-attribute]
         if autoregressive_index == 0:
             return 1 + (len_t - 1) * temporal_compression_ratio
         else:

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
@@ -120,7 +120,9 @@ class Head(nn.Module):
             "before running the forward pass"
         )
         assert x.ndim == e.ndim, "x and e must have the same number of dimensions"
-        e = (self.modulation + e).chunk(2, dim=-2)  # [..., 1, D] each
+        e = (self.modulation + e).chunk(
+            2, dim=-2
+        )  # [..., 1, D] each  # ty:ignore[invalid-assignment]
         x = self.norm(x) * (1 + e[1]) + e[0]  # [..., L, D]
         x = self.head(x)
         return x
@@ -386,7 +388,7 @@ class CrossAttention(MultiHeadAttention):
         """
         text_cache = self.compute_kv(context_text)
         if self.i2v:
-            img_cache = self.compute_kv_image(context_img)
+            img_cache = self.compute_kv_image(context_img)  # ty:ignore[invalid-argument-type]
         else:
             img_cache = None
         return CrossAttnCache(text=text_cache, img=img_cache)
@@ -555,7 +557,9 @@ class Block(nn.Module):
             "We expect to have called update_parameters_after_loading_checkpoint() "
             "before running the forward pass"
         )
-        e = (self.modulation + e).chunk(6, dim=-2)  # [..., 1, D] each
+        e = (self.modulation + e).chunk(
+            6, dim=-2
+        )  # [..., 1, D] each  # ty:ignore[invalid-assignment]
 
         y = self.norm1(x) * (1 + e[1]) + e[0]  # [..., L, D]
         y = self.self_attn(

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
@@ -202,7 +202,7 @@ class WanDiTNetwork(nn.Module):
         This must be called before ``initialize_cache`` when CP is used.
         """
         for block in self.blocks:
-            block.set_context_parallel_group(cp_group)
+            block.set_context_parallel_group(cp_group)  # ty:ignore[call-non-callable]
 
     def patchify_and_maybe_split_cp(
         self,
@@ -321,7 +321,7 @@ class WanDiTNetwork(nn.Module):
             block_caches=[
                 block.initialize_cache(
                     chunk_size, window_size, sink_size, context_text, context_img
-                )
+                )  # ty:ignore[call-non-callable]
                 for block in self.blocks
             ],
         )
@@ -334,7 +334,7 @@ class WanDiTNetwork(nn.Module):
 
         self._fuse_shuffle_op_into_last_layer()
         for block in self.blocks:
-            block.update_parameters_after_loading_checkpoint()
+            block.update_parameters_after_loading_checkpoint()  # ty:ignore[call-non-callable]
         self.head.update_parameters_after_loading_checkpoint()
 
         self._parameters_updated_after_loading_checkpoint = True
@@ -471,7 +471,7 @@ if __name__ == "__main__":
     t2v_state_dict = load_checkpoint(
         "https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B/blob/main/diffusion_pytorch_model.safetensors"
     )
-    t2v_network.load_state_dict(t2v_state_dict)
+    t2v_network.load_state_dict(t2v_state_dict)  # ty:ignore[invalid-argument-type]
     print("Test T2V network loading done")
 
     i2v_network_config = WanDiTNetwork14BConfig(
@@ -481,5 +481,5 @@ if __name__ == "__main__":
     i2v_state_dict = load_checkpoint(
         "https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P/blob/main/diffusion_pytorch_model.safetensors.index.json"
     )
-    i2v_network.load_state_dict(i2v_state_dict)
+    i2v_network.load_state_dict(i2v_state_dict)  # ty:ignore[invalid-argument-type]
     print("Test I2V network loading done")

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
@@ -223,8 +223,8 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         if config.checkpoint_path is not None:
             state_dict = load_checkpoint(config.checkpoint_path)
             if config.state_dict_transform is not None:
-                state_dict = config.state_dict_transform(state_dict)
-            self.network.load_state_dict(state_dict)
+                state_dict = config.state_dict_transform(state_dict)  # ty:ignore[invalid-argument-type]
+            self.network.load_state_dict(state_dict)  # ty:ignore[invalid-argument-type]
         self.network.update_parameters_after_loading_checkpoint()
 
         if config.compile_network:
@@ -278,7 +278,7 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         chunk_size = self.latent_shape[-2]  # already CP-divided
         window_size = (self.config.window_size_t * self._pH * self._pW) // cp_size
         sink_size = (self.config.sink_size_t * self._pH * self._pW) // cp_size
-        return self.network.initialize_cache(
+        return self.network.initialize_cache(  # ty:ignore[unresolved-attribute]
             chunk_size=chunk_size,
             window_size=window_size,
             sink_size=sink_size,
@@ -499,18 +499,18 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
                 return x
             else:
                 return I2VCtrl(
-                    latent=self.patchify_and_maybe_split_cp(x.latent),
-                    mask=self.patchify_and_maybe_split_cp(x.mask),
+                    latent=self.patchify_and_maybe_split_cp(x.latent),  # ty:ignore[invalid-argument-type]
+                    mask=self.patchify_and_maybe_split_cp(x.mask),  # ty:ignore[invalid-argument-type]
                     _is_patchified=True,
                 )
-        return self.network.patchify_and_maybe_split_cp(
+        return self.network.patchify_and_maybe_split_cp(  # ty:ignore[unresolved-attribute]
             x,
             process_groups=[self.cp_group],
             cp_dims=[-2],
         )
 
     def unpatchify_and_maybe_gather_cp(self, x: Tensor) -> Tensor:
-        return self.network.unpatchify_and_maybe_gather_cp(
+        return self.network.unpatchify_and_maybe_gather_cp(  # ty:ignore[unresolved-attribute]
             pH=self._pH,
             pW=self._pW,
             x=x,

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan22.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan22.py
@@ -361,7 +361,7 @@ class Wan22Transformer(Transformer[Wan22TransformerCache]):
         )
 
     def patchify_and_maybe_split_cp(self, x: Tensor) -> Tensor:
-        return self.transformer_high_noise.patchify_and_maybe_split_cp(x)
+        return self.transformer_high_noise.patchify_and_maybe_split_cp(x)  # ty:ignore[invalid-return-type]
 
     def unpatchify_and_maybe_gather_cp(self, x: Tensor) -> Tensor:
         return self.transformer_high_noise.unpatchify_and_maybe_gather_cp(x)

--- a/flashdreams/tests/scheduler/_bench_lookup.py
+++ b/flashdreams/tests/scheduler/_bench_lookup.py
@@ -141,7 +141,7 @@ def main() -> None:
     b_desc = full_t_desc.shape[0] - 1 - b
     print(
         f"  (sanity: argmin={a}, search_asc={b} -> desc={b_desc}; "
-        f"vals={full_t_desc[a].item():.2f} vs {full_t_desc[b_desc].item():.2f})"
+        f"vals={full_t_desc[a].item():.2f} vs {full_t_desc[b_desc].item():.2f})"  # ty:ignore[invalid-argument-type]
     )
 
 

--- a/flashdreams/tests/scheduler/_check_no_sync.py
+++ b/flashdreams/tests/scheduler/_check_no_sync.py
@@ -62,11 +62,11 @@ def main() -> None:
     # one-shot scalar construction in the test driver).
     fm_t = torch.empty((), dtype=torch.int64, device=device)
     fm_t.fill_(128)
-    unipc_t = unipc.timesteps[0]
+    unipc_t = unipc.timesteps[0]  # ty:ignore[not-subscriptable]
 
     # warm-up (allocators, autograd state, etc.) without sync mode on
-    fm.sample(noise, _stub)
-    unipc.sample(noise, _stub)
+    fm.sample(noise, _stub)  # ty:ignore[invalid-argument-type]
+    unipc.sample(noise, _stub)  # ty:ignore[invalid-argument-type]
     fm.add_noise(clean, fm_t)
     unipc.add_noise(clean, unipc_t)
     torch.cuda.synchronize()
@@ -74,9 +74,9 @@ def main() -> None:
     # Now turn sync detection on. ``"error"`` raises on any sync op.
     torch.cuda.set_sync_debug_mode("error")
     try:
-        out = fm.sample(noise, _stub)
+        out = fm.sample(noise, _stub)  # ty:ignore[invalid-argument-type]
         print(f"  FlowMatch.sample      -> ok ({tuple(out.shape)} {out.dtype})")
-        out = unipc.sample(noise, _stub)
+        out = unipc.sample(noise, _stub)  # ty:ignore[invalid-argument-type]
         print(f"  FlowUniPC.sample      -> ok ({tuple(out.shape)} {out.dtype})")
         out = fm.add_noise(clean, fm_t)
         print(f"  FlowMatch.add_noise   -> ok ({tuple(out.shape)} {out.dtype})")

--- a/flashdreams/tests/scheduler/_flow_unipc_inner.py
+++ b/flashdreams/tests/scheduler/_flow_unipc_inner.py
@@ -122,7 +122,7 @@ class FlowUniPCMultistepScheduler:
             num_train_timesteps=num_train_timesteps,
             solver_order=solver_order,
             prediction_type=prediction_type,
-            shift=shift,
+            shift=shift,  # ty:ignore[invalid-argument-type]
             use_dynamic_shifting=use_dynamic_shifting,
             thresholding=thresholding,
             dynamic_thresholding_ratio=dynamic_thresholding_ratio,
@@ -147,7 +147,7 @@ class FlowUniPCMultistepScheduler:
 
         if not use_dynamic_shifting:
             # when use_dynamic_shifting is True, we apply the timestep shifting on the fly based on the image resolution
-            sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
+            sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # ty:ignore[unsupported-operator]
 
         self.sigmas = sigmas
         self.timesteps = sigmas * num_train_timesteps
@@ -195,15 +195,17 @@ class FlowUniPCMultistepScheduler:
 
         if sigmas is None:
             sigmas = np.linspace(
-                self.sigma_max, self.sigma_min, num_inference_steps + 1
+                self.sigma_max,
+                self.sigma_min,
+                num_inference_steps + 1,  # ty:ignore[unsupported-operator]
             ).copy()[:-1]  # pyright: ignore
 
         if self.config.use_dynamic_shifting:
-            sigmas = self.time_shift(mu, 1.0, sigmas)  # pyright: ignore
+            sigmas = self.time_shift(mu, 1.0, sigmas)  # pyright: ignore  # ty:ignore[invalid-argument-type]
         else:
             if shift is None:
                 shift = self.config.shift
-            sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # pyright: ignore
+            sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # pyright: ignore  # ty:ignore[unsupported-operator]
 
         if self.config.final_sigmas_type == "sigma_min":
             # NOTE: upstream references ``self.alphas_cumprod`` here which
@@ -221,7 +223,7 @@ class FlowUniPCMultistepScheduler:
             )
 
         timesteps = sigmas * self.config.num_train_timesteps
-        sigmas = np.concatenate([sigmas, [sigma_last]]).astype(np.float32)  # pyright: ignore
+        sigmas = np.concatenate([sigmas, [sigma_last]]).astype(np.float32)  # pyright: ignore  # ty:ignore[invalid-assignment]
 
         self.sigmas = torch.from_numpy(sigmas)
         self.timesteps = torch.from_numpy(timesteps).to(
@@ -255,7 +257,7 @@ class FlowUniPCMultistepScheduler:
                 sample.float()
             )  # upcast for quantile calculation, and clamp not implemented for cpu half
 
-        sample = sample.reshape(batch_size, channels * np.prod(remaining_dims))
+        sample = sample.reshape(batch_size, channels * np.prod(remaining_dims))  # ty:ignore[invalid-argument-type]
 
         abs_sample = sample.abs()  # "a certain percentile absolute pixel value"
 
@@ -364,7 +366,7 @@ class FlowUniPCMultistepScheduler:
             lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
             rk = (lambda_si - lambda_s0) / h
             rks.append(rk)
-            D1s.append((mi - m0) / rk)  # pyright: ignore
+            D1s.append((mi - m0) / rk)  # pyright: ignore  # ty:ignore[unsupported-operator]
 
         rks.append(1.0)
         rks = torch.tensor(rks, device=device)
@@ -460,7 +462,7 @@ class FlowUniPCMultistepScheduler:
             lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
             rk = (lambda_si - lambda_s0) / h
             rks.append(rk)
-            D1s.append((mi - m0) / rk)  # pyright: ignore
+            D1s.append((mi - m0) / rk)  # pyright: ignore  # ty:ignore[unsupported-operator]
 
         rks.append(1.0)
         rks = torch.tensor(rks, device=device)
@@ -507,7 +509,7 @@ class FlowUniPCMultistepScheduler:
                 corr_res = torch.einsum("k,bkc...->bc...", rhos_c[:-1], D1s)
             else:
                 corr_res = 0
-            D1_t = model_t - m0
+            D1_t = model_t - m0  # ty:ignore[unsupported-operator]
             x_t = x_t_ - alpha_t * B_h * (corr_res + rhos_c[-1] * D1_t)
         else:
             x_t_ = alpha_t / alpha_s0 * x - sigma_t * h_phi_1 * m0
@@ -515,7 +517,7 @@ class FlowUniPCMultistepScheduler:
                 corr_res = torch.einsum("k,bkc...->bc...", rhos_c[:-1], D1s)
             else:
                 corr_res = 0
-            D1_t = model_t - m0
+            D1_t = model_t - m0  # ty:ignore[unsupported-operator]
             x_t = x_t_ - sigma_t * B_h * (corr_res + rhos_c[-1] * D1_t)
         x_t = x_t.to(x.dtype)
         return x_t
@@ -608,7 +610,7 @@ class FlowUniPCMultistepScheduler:
             self.lower_order_nums += 1
 
         # upon completion increase step index by one
-        self._step_index += 1  # pyright: ignore
+        self._step_index += 1  # pyright: ignore  # ty:ignore[unsupported-operator]
 
         if not return_dict:
             return (prev_sample,)
@@ -634,10 +636,10 @@ class FlowUniPCMultistepScheduler:
             schedule_timesteps = self.timesteps.to(
                 original_samples.device, dtype=torch.float32
             )
-            timesteps = timesteps.to(original_samples.device, dtype=torch.float32)
+            timesteps = timesteps.to(original_samples.device, dtype=torch.float32)  # ty:ignore[invalid-assignment]
         else:
             schedule_timesteps = self.timesteps.to(original_samples.device)
-            timesteps = timesteps.to(original_samples.device)
+            timesteps = timesteps.to(original_samples.device)  # ty:ignore[invalid-assignment]
 
         step_indices = [
             self.index_for_timestep(t, schedule_timesteps) for t in timesteps

--- a/flashdreams/tests/scheduler/_profile_scheduler.py
+++ b/flashdreams/tests/scheduler/_profile_scheduler.py
@@ -88,7 +88,7 @@ def _build_fm_pair() -> tuple[FlowMatchSchedulerReference, FlowMatchScheduler]:
         shift=_FM_SHIFT,
         denoising_timesteps=list(_FM_DENOISING),
     ).setup()
-    return ref, new
+    return ref, new  # ty:ignore[invalid-return-type]
 
 
 def _build_unipc_pair() -> tuple[FlowUniPCSchedulerReference, FlowMatchUniPCScheduler]:
@@ -104,7 +104,7 @@ def _build_unipc_pair() -> tuple[FlowUniPCSchedulerReference, FlowMatchUniPCSche
         shift=_UNIPC_SHIFT,
         solver_order=_UNIPC_ORDER,
     ).setup()
-    return ref, new
+    return ref, new  # ty:ignore[invalid-return-type]
 
 
 def _make_stub_predict_flow():
@@ -127,7 +127,7 @@ def _time_sample(
     predict_flow = _make_stub_predict_flow()
 
     for _ in range(n_warmup):
-        scheduler.sample(noise, predict_flow)
+        scheduler.sample(noise, predict_flow)  # ty:ignore[call-non-callable]
     torch.cuda.synchronize()
 
     times_ms = []
@@ -137,7 +137,7 @@ def _time_sample(
             torch.cuda.Event(enable_timing=True),
         )
         start.record()
-        scheduler.sample(noise, predict_flow)
+        scheduler.sample(noise, predict_flow)  # ty:ignore[call-non-callable]
         end.record()
         torch.cuda.synchronize()
         times_ms.append(start.elapsed_time(end))

--- a/flashdreams/tests/scheduler/impl_reference_flow_match.py
+++ b/flashdreams/tests/scheduler/impl_reference_flow_match.py
@@ -166,8 +166,8 @@ class FlowMatchSchedulerReference(nn.Module):
     ) -> Tensor:
         noisy = initial_noise
         clean: Tensor | None = None
-        for i, t_cpu in enumerate(self.denoising_step_list):
-            timestep = t_cpu.to(device=initial_noise.device, dtype=initial_noise.dtype)
+        for i, t_cpu in enumerate(self.denoising_step_list):  # ty:ignore[invalid-argument-type]
+            timestep = t_cpu.to(device=initial_noise.device, dtype=initial_noise.dtype)  # ty:ignore[unresolved-attribute]
             sigma = self._timestep_to_sigma(timestep, like=noisy)
             if i > 0:
                 assert clean is not None

--- a/flashdreams/tests/scheduler/impl_reference_flow_unipc.py
+++ b/flashdreams/tests/scheduler/impl_reference_flow_unipc.py
@@ -65,7 +65,7 @@ class FlowUniPCSchedulerReference(nn.Module):
                 model_output=flow,
                 timestep=timestep,
                 sample=x,
-            ).prev_sample
+            ).prev_sample  # ty:ignore[unresolved-attribute]
         return x
 
     def add_noise(
@@ -80,5 +80,5 @@ class FlowUniPCSchedulerReference(nn.Module):
             noise=noise,
             timesteps=timestep.reshape(1).to(
                 device=clean_input.device, dtype=torch.int64
-            ),
+            ),  # ty:ignore[invalid-argument-type]
         )

--- a/flashdreams/tests/scheduler/test_scheduler_equivalence.py
+++ b/flashdreams/tests/scheduler/test_scheduler_equivalence.py
@@ -87,7 +87,7 @@ def _build_fm_pair() -> tuple[_ref_fm.FlowMatchSchedulerReference, FlowMatchSche
         shift=_FM_SHIFT,
         denoising_timesteps=list(_FM_DENOISING),
     )
-    return _ref_fm.FlowMatchSchedulerReference(ref_cfg), new_cfg.setup()
+    return _ref_fm.FlowMatchSchedulerReference(ref_cfg), new_cfg.setup()  # ty:ignore[invalid-return-type]
 
 
 @pytest.mark.parametrize("device", _devices(), ids=lambda d: d.type)
@@ -122,7 +122,7 @@ def test_flow_match_sample_parity(
     rng_ref = torch.Generator(device=device).manual_seed(123)
     rng_new = torch.Generator(device=device).manual_seed(123)
     out_ref = ref.sample(noise, predict_flow, rng=rng_ref)
-    out_new = new.sample(noise, predict_flow, rng=rng_new)
+    out_new = new.sample(noise, predict_flow, rng=rng_new)  # ty:ignore[invalid-argument-type]
     torch.testing.assert_close(out_new, out_ref, atol=atol, rtol=rtol)
 
 
@@ -188,7 +188,7 @@ def _build_unipc_pair() -> tuple[
         shift=_UNIPC_SHIFT,
         solver_order=_UNIPC_ORDER,
     )
-    return _ref_unipc.FlowUniPCSchedulerReference(ref_cfg), new_cfg.setup()
+    return _ref_unipc.FlowUniPCSchedulerReference(ref_cfg), new_cfg.setup()  # ty:ignore[invalid-return-type]
 
 
 @pytest.mark.parametrize("device", _devices(), ids=lambda d: d.type)
@@ -219,7 +219,7 @@ def test_flow_unipc_sample_parity(
     predict_flow = _stub_predict_flow_factory(0.7, 0.1)
 
     out_ref = ref.sample(noise, predict_flow)
-    out_new = new.sample(noise, predict_flow)
+    out_new = new.sample(noise, predict_flow)  # ty:ignore[invalid-argument-type]
     torch.testing.assert_close(out_new, out_ref, atol=atol, rtol=rtol)
 
 
@@ -251,7 +251,7 @@ def test_flow_unipc_add_noise_parity(
     # rewrite compare on the same schedule shape.
     dummy = torch.zeros(1, 1, 1, 1, 1, dtype=dtype, device=device)
     ref.sample(dummy, _stub_predict_flow_factory(0.0, 0.0))
-    new.sample(dummy, _stub_predict_flow_factory(0.0, 0.0))
+    new.sample(dummy, _stub_predict_flow_factory(0.0, 0.0))  # ty:ignore[invalid-argument-type]
 
     torch.manual_seed(1)
     clean = torch.empty(2, 4, 8, 16, 16, dtype=dtype, device=device).uniform_(-1, 1)

--- a/flashdreams/tests/taehv/_profile_taehv.py
+++ b/flashdreams/tests/taehv/_profile_taehv.py
@@ -75,7 +75,7 @@ def _build_pair(
     import copy
 
     weights = load_checkpoint(checkpoint_path)
-    weights = {k: v.to(dtype) for k, v in weights.items()}
+    weights = {k: v.to(dtype) for k, v in weights.items()}  # ty:ignore[call-non-callable]
 
     # Return a fresh shallow copy each call: the legacy ``patch_tgrow_layers``
     # mutates the dict in place, which would otherwise feed the new impl

--- a/flashdreams/tests/taehv/_profile_taehv.py
+++ b/flashdreams/tests/taehv/_profile_taehv.py
@@ -60,7 +60,7 @@ from flashdreams.recipes.taehv.impl import TAEHV as TAEHVNew  # noqa: E402
 # relative import used by `test_taehv_equivalence.py` doesn't apply here
 # because `__name__ == "__main__"` and there is no parent package.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import impl_reference as _impl_reference  # noqa: E402
+import impl_reference as _impl_reference  # noqa: E402  # ty:ignore[unresolved-import]
 
 TAEHVLegacy = _impl_reference.TAEHV
 

--- a/flashdreams/tests/taehv/impl_reference.py
+++ b/flashdreams/tests/taehv/impl_reference.py
@@ -71,7 +71,11 @@ class TGrow(nn.Module):
 
 
 def apply_model_with_memblocks(
-    model, x, parallel, show_progress_bar, cache_mem: List | None = None
+    model,
+    x,
+    parallel,
+    show_progress_bar,
+    cache_mem: List | None = None,  # ty:ignore[unsupported-operator]
 ):
     """
     Apply a sequential model with memblocks to the given input.
@@ -91,7 +95,7 @@ def apply_model_with_memblocks(
         # parallel over input timesteps, iterate over blocks
         for idx, b in enumerate(model):
             if isinstance(b, MemBlock):
-                prev_mem = cache_mem[idx]
+                prev_mem = cache_mem[idx]  # ty:ignore[not-subscriptable]
                 NT, C, H, W = x.shape
                 T = NT // N
                 _x = x.reshape(N, T, C, H, W)
@@ -102,7 +106,7 @@ def apply_model_with_memblocks(
                     # roll to the right and left pad with the last frame in previous mem
                     curr_mem = torch.cat([prev_mem[:, -1:], _x[:, :-1]], dim=1)
                 x = b(x, curr_mem.reshape(x.shape))
-                cache_mem[idx] = _x
+                cache_mem[idx] = _x  # ty:ignore[invalid-assignment]
             else:
                 x = b(x)
         NT, C, H, W = x.shape

--- a/flashdreams/tests/taehv/test_taehv_equivalence.py
+++ b/flashdreams/tests/taehv/test_taehv_equivalence.py
@@ -50,7 +50,7 @@ def _build_pair(
     legacy constructor runs first.
     """
     weights = load_checkpoint(checkpoint_path)
-    weights = {k: v.to(dtype) for k, v in weights.items()}
+    weights = {k: v.to(dtype) for k, v in weights.items()}  # ty:ignore[call-non-callable]
 
     def _cached(_path):
         return copy.copy(weights)

--- a/flashdreams/tests/test_alpadreams.py
+++ b/flashdreams/tests/test_alpadreams.py
@@ -34,23 +34,23 @@ def test_alpadreams_streaming_inference():
 
     config = build_sv_2steps_chunk2_loc6_lightvae_lighttae()
     pipeline = config.setup().to(device)
-    cache = pipeline.initialize_cache(text=text, image=image)
+    cache = pipeline.initialize_cache(text=text, image=image)  # ty:ignore[unknown-argument]
 
     autoregressive_index = 0
-    num_frames = pipeline.get_num_frames(autoregressive_index)
+    num_frames = pipeline.get_num_frames(autoregressive_index)  # ty:ignore[call-non-callable]
     hdmap = torch.randn(
         1, num_views, num_frames, 3, height, width, device=device, dtype=dtype
     )
-    decoded_video = pipeline.generate(autoregressive_index, hdmap=hdmap, cache=cache)
+    decoded_video = pipeline.generate(autoregressive_index, hdmap=hdmap, cache=cache)  # ty:ignore[unknown-argument]
     pipeline.finalize(autoregressive_index, cache=cache)
     assert decoded_video.shape == hdmap.shape
 
     autoregressive_index = 1
-    num_frames = pipeline.get_num_frames(autoregressive_index)
+    num_frames = pipeline.get_num_frames(autoregressive_index)  # ty:ignore[call-non-callable]
     hdmap = torch.randn(
         1, num_views, num_frames, 3, height, width, device=device, dtype=dtype
     )
-    decoded_video = pipeline.generate(autoregressive_index, hdmap=hdmap, cache=cache)
+    decoded_video = pipeline.generate(autoregressive_index, hdmap=hdmap, cache=cache)  # ty:ignore[unknown-argument]
     pipeline.finalize(autoregressive_index, cache=cache)
     assert decoded_video.shape == hdmap.shape
 

--- a/flashdreams/tests/test_checkpoint.py
+++ b/flashdreams/tests/test_checkpoint.py
@@ -39,5 +39,5 @@ def test_load_checkpoint_from_s3() -> None:
         assert os.path.getsize(local_path) > 0
 
         state_dict_from_local = torch.load(local_path)
-        for k, v in state_dict.items():
+        for k, v in state_dict.items():  # ty:ignore[call-non-callable]
             assert (v == state_dict_from_local[k]).all()

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -38,7 +38,7 @@ class _NaiveKVCache:
             self._total_v = v
         else:
             self._total_k = torch.cat([self._total_k, k], dim=1)
-            self._total_v = torch.cat([self._total_v, v], dim=1)
+            self._total_v = torch.cat([self._total_v, v], dim=1)  # ty:ignore[no-matching-overload]
 
     def ovewrite_rightmost(self, k: torch.Tensor, v: torch.Tensor) -> None:
         assert self._total_k is not None

--- a/flashdreams/tests/test_lingbot_camera_utils.py
+++ b/flashdreams/tests/test_lingbot_camera_utils.py
@@ -54,14 +54,14 @@ def test_compute_relative_poses_causal():
     poses = random_SE3((10,))
 
     relative_poses1, trans_normalizer = compute_relative_poses(poses, framewise=True)
-    relative_poses2 = compute_relative_poses_causal(poses, trans_normalizer)
+    relative_poses2 = compute_relative_poses_causal(poses, trans_normalizer)  # ty:ignore[invalid-argument-type]
     torch.testing.assert_close(relative_poses1, relative_poses2, atol=1e-4, rtol=1e-4)
 
     last_pose = None
     relative_poses3 = []
     for pose in poses:
         pose = pose.unsqueeze(0)
-        relative_pose = compute_relative_poses_causal(pose, trans_normalizer, last_pose)
+        relative_pose = compute_relative_poses_causal(pose, trans_normalizer, last_pose)  # ty:ignore[invalid-argument-type]
         relative_poses3.append(relative_pose)
         last_pose = pose
     relative_poses3 = torch.cat(relative_poses3, dim=0)

--- a/flashdreams/tests/test_model_instantiation.py
+++ b/flashdreams/tests/test_model_instantiation.py
@@ -144,7 +144,7 @@ class TestDiTNetwork:
         state_dict = load_checkpoint(
             "https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B/blob/main/diffusion_pytorch_model.safetensors"
         )
-        network.load_state_dict(state_dict)
+        network.load_state_dict(state_dict)  # ty:ignore[invalid-argument-type]
 
         assert network is not None
 
@@ -164,6 +164,6 @@ class TestDiTNetwork:
         state_dict = load_checkpoint(
             "https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-720P/blob/main/diffusion_pytorch_model.safetensors.index.json"
         )
-        network.load_state_dict(state_dict)
+        network.load_state_dict(state_dict)  # ty:ignore[invalid-argument-type]
 
         assert network is not None

--- a/flashdreams/tests/test_vae.py
+++ b/flashdreams/tests/test_vae.py
@@ -120,4 +120,4 @@ def test_tokenizer(
 if __name__ == "__main__":
     for tokenizer_choice in ["lightvae", "vae"]:
         for detokenizer_choice in ["lighttae", "lightvae", "vae"]:
-            test_tokenizer(tokenizer_choice, detokenizer_choice)
+            test_tokenizer(tokenizer_choice, detokenizer_choice)  # ty:ignore[invalid-argument-type]

--- a/flashdreams/tests/test_video_vae_tyro_cli.py
+++ b/flashdreams/tests/test_video_vae_tyro_cli.py
@@ -38,7 +38,7 @@ from flashdreams.recipes.wan.autoencoder.vae import WanVAEEncoder, WanVAEEncoder
 def test_video_vae_config_cli_defaults(config_cls: type, target_cls: type) -> None:
     config = tyro.cli(config_cls, args=[])
     assert isinstance(config, config_cls)
-    assert config._target is target_cls
+    assert config._target is target_cls  # ty:ignore[unresolved-attribute]
 
 
 def test_pixelshuffle_cli_accepts_frame_selection_override() -> None:

--- a/flashdreams/tests/wanvae/_profile_wan_vae.py
+++ b/flashdreams/tests/wanvae/_profile_wan_vae.py
@@ -65,7 +65,7 @@ from flashdreams.recipes.wan.autoencoder.vae import (
 # relative import used by `test_wan_vae_equivalence.py` doesn't apply
 # here because `__name__ == "__main__"` and there is no parent package.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import impl_reference as _impl_reference  # noqa: E402
+import impl_reference as _impl_reference  # noqa: E402  # ty:ignore[unresolved-import]
 
 WanVAELegacy = _impl_reference.WanVAE
 

--- a/flashdreams/tests/wanvae/_profile_wan_vae.py
+++ b/flashdreams/tests/wanvae/_profile_wan_vae.py
@@ -79,7 +79,7 @@ def _build_pair(
 ) -> tuple[WanVAELegacy, WanVAENew]:
     use_lightvae = "lightvae" in checkpoint_path
     weights = load_checkpoint(checkpoint_path)
-    weights = {k: v.to(dtype) for k, v in weights.items()}
+    weights = {k: v.to(dtype) for k, v in weights.items()}  # ty:ignore[call-non-callable]
 
     def _cached(_path):
         return weights

--- a/flashdreams/tests/wanvae/impl_reference.py
+++ b/flashdreams/tests/wanvae/impl_reference.py
@@ -45,11 +45,11 @@ class CausalConv3d(nn.Conv3d):
 
     def forward(self, x, cache_x=None):
         padding = list(self._padding)
-        if cache_x is not None and self._padding[4] > 0:
+        if cache_x is not None and self._padding[4] > 0:  # ty:ignore[unsupported-operator]
             cache_x = cache_x.to(x.device)
             x = torch.cat([cache_x, x], dim=2)
             padding[4] -= cache_x.shape[2]
-        x = F.pad(x, padding)
+        x = F.pad(x, padding)  # ty:ignore[invalid-argument-type]
 
         return super().forward(x)
 
@@ -922,7 +922,9 @@ class WanVAE_(nn.Module):
         return mu
 
     def encode(self, x, scale, return_mu=False, cache: Optional[WanVAECache] = None):
-        if cache.enc_feat_map[0] is not None:  # not the first chunk
+        if (
+            cache.enc_feat_map[0] is not None  # ty: ignore[unresolved-attribute]
+        ):  # not the first chunk
             t = x.shape[2]
             iter_ = t // 4
             results = []
@@ -1204,10 +1206,10 @@ def _video_vae(
     # load checkpoint
     if pretrained_path is not None:
         weights_dict = load_checkpoint(pretrained_path)
-        for k in weights_dict.keys():
-            if weights_dict[k].dtype != dtype:
-                weights_dict[k] = weights_dict[k].to(dtype)
-        model.load_state_dict(weights_dict, assign=True)
+        for k in weights_dict.keys():  # ty:ignore[call-non-callable]
+            if weights_dict[k].dtype != dtype:  # ty:ignore[not-subscriptable]
+                weights_dict[k] = weights_dict[k].to(dtype)  # ty:ignore[invalid-assignment, not-subscriptable]
+        model.load_state_dict(weights_dict, assign=True)  # ty:ignore[invalid-argument-type]
 
     return model
 

--- a/flashdreams/tests/wanvae/test_wan_vae_equivalence.py
+++ b/flashdreams/tests/wanvae/test_wan_vae_equivalence.py
@@ -61,7 +61,7 @@ def _build_pair(
     """
     use_lightvae = "lightvae" in checkpoint_path
     weights = load_checkpoint(checkpoint_path)
-    weights = {k: v.to(dtype) for k, v in weights.items()}
+    weights = {k: v.to(dtype) for k, v in weights.items()}  # ty:ignore[call-non-callable]
 
     def _cached(_path):
         return weights

--- a/integrations/alpadreams/alpadreams/conditioning/conditioning_wrapper.py
+++ b/integrations/alpadreams/alpadreams/conditioning/conditioning_wrapper.py
@@ -219,7 +219,7 @@ class AlpadreamsConditioningWrapper(nn.Module):
                     )
                 checkpoint_path = AVAILABLE_ALPADREAMS_CHECKPOINT_PATHS["single_view"][
                     "vae_encoding"
-                ][f"chunk{len_t}"]
+                ][f"chunk{len_t}"]  # ty:ignore[invalid-argument-type]
                 tokenizer_key = "vae" if no_tae else "lightvae"
                 hdmap_encoder_config = WanVAEEncoderConfig(
                     checkpoint_path=AVAILABLE_WAN_VAE_CHECKPOINT_PATHS[tokenizer_key],
@@ -267,7 +267,7 @@ class AlpadreamsConditioningWrapper(nn.Module):
             window_size_t=local_attn_size,
             sink_size_t=sink_size,
             len_t=len_t,
-            checkpoint_path=checkpoint_path,
+            checkpoint_path=checkpoint_path,  # ty:ignore[invalid-argument-type]
             compile_network=compile_net,
         )
 

--- a/integrations/alpadreams/alpadreams/conditioning/renderer.py
+++ b/integrations/alpadreams/alpadreams/conditioning/renderer.py
@@ -207,7 +207,7 @@ class LudusRenderer:
             timestamps_batch,
             camera_type_id_batch,
             camera_poses_batch,
-            resolution=(H, W),
+            resolution=(H, W),  # ty:ignore[invalid-argument-type]
         )
 
         rgb = images[:, :, :, :3]
@@ -217,7 +217,7 @@ class LudusRenderer:
             rgb.squeeze(0)
             .permute(0, 3, 1, 2)
             .contiguous()
-            .view(n_cameras, n_frames, 3, H, W)
+            .view(n_cameras, n_frames, 3, H, W)  # ty:ignore[invalid-argument-type]
         )
 
     def cleanup(self) -> None:

--- a/integrations/alpadreams/alpadreams/conditioning/renderer.py
+++ b/integrations/alpadreams/alpadreams/conditioning/renderer.py
@@ -207,7 +207,7 @@ class LudusRenderer:
             timestamps_batch,
             camera_type_id_batch,
             camera_poses_batch,
-            resolution=(H, W),  # ty:ignore[invalid-argument-type]
+            resolution=(H, W),
         )
 
         rgb = images[:, :, :, :3]
@@ -217,7 +217,7 @@ class LudusRenderer:
             rgb.squeeze(0)
             .permute(0, 3, 1, 2)
             .contiguous()
-            .view(n_cameras, n_frames, 3, H, W)  # ty:ignore[invalid-argument-type]
+            .view(n_cameras, n_frames, 3, H, W)
         )
 
     def cleanup(self) -> None:

--- a/integrations/alpadreams/alpadreams/conditioning/world_scenario/camera_base.py
+++ b/integrations/alpadreams/alpadreams/conditioning/world_scenario/camera_base.py
@@ -491,8 +491,8 @@ class CameraBase:
 
                     _, pixel1, pixel2 = cv2.clipLine(
                         (0, 0, W, H),
-                        pixel1.astype(np.int32),  # pyright: ignore[reportArgumentType]
-                        pixel2.astype(np.int32),  # pyright: ignore[reportArgumentType]
+                        pixel1.astype(np.int32),  # pyright: ignore[reportArgumentType]  # ty:ignore[invalid-argument-type]
+                        pixel2.astype(np.int32),  # pyright: ignore[reportArgumentType]  # ty:ignore[invalid-argument-type]
                     )
 
                     depth_mean = (depth[i] + depth[i + 1]) / 2

--- a/integrations/alpadreams/alpadreams/conditioning/world_scenario/ftheta.py
+++ b/integrations/alpadreams/alpadreams/conditioning/world_scenario/ftheta.py
@@ -473,7 +473,7 @@ class FThetaCamera(CameraBase):
 
         elif self.reference_poly == "fw":
             fw_poly_coef = self._fw_poly.coef.copy()
-            fw_poly_coef /= 1 / avg_ratio
+            fw_poly_coef /= 1 / avg_ratio  # ty:ignore[unsupported-operator]
 
             self._intrinsics = np.array(
                 [
@@ -599,7 +599,7 @@ class FThetaCamera(CameraBase):
     def _update_calibrated_camera(self) -> None:
         """Updates the internals of this object after calulating various properties."""
         self._compute_fov()
-        self._max_ray_angle = self._max_angle.copy()
+        self._max_ray_angle = self._max_angle.copy()  # ty:ignore[unresolved-attribute]
         is_fw_poly_slope_negative_in_domain = False
         ray_angle = self._max_ray_angle.copy()
         assert ray_angle is not None

--- a/integrations/alpadreams/alpadreams/grpc/profiling_server.py
+++ b/integrations/alpadreams/alpadreams/grpc/profiling_server.py
@@ -33,7 +33,7 @@ try:
 
     _CUDA_AVAILABLE = torch.cuda.is_available()
 except Exception:
-    torch = None  # type: ignore[assignment]
+    torch = None  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
     _CUDA_AVAILABLE = False
 
 # Thread-local storage for passing profiling context through nested calls

--- a/integrations/alpadreams/alpadreams/grpc/server.py
+++ b/integrations/alpadreams/alpadreams/grpc/server.py
@@ -187,7 +187,7 @@ def capture_exceptions(func: Callable) -> Callable:
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            logger.error(f"Error in {func.__name__}: {e}")
+            logger.error(f"Error in {func.__name__}: {e}")  # ty:ignore[unresolved-attribute]
 
             # print stack trace
             traceback.print_exc()
@@ -418,20 +418,20 @@ class WorldModelEngine:
         return_hdmap_frames = kwargs.get("return_hdmap_frames")
         effective_seed = kwargs.get("effective_seed")
         # -------------------------------------------------------------------
-        assert len(text_prompts) == 1, (
-            f"[rank {self.rank}] Expected 1 text prompt, got {len(text_prompts)}"
+        assert len(text_prompts) == 1, (  # ty:ignore[invalid-argument-type]
+            f"[rank {self.rank}] Expected 1 text prompt, got {len(text_prompts)}"  # ty:ignore[invalid-argument-type]
         )
-        assert self.n_cameras == len(camera_names), (
-            f"[rank {self.rank}] Expected {self.n_cameras} camera names, got {len(camera_names)}"
+        assert self.n_cameras == len(camera_names), (  # ty:ignore[invalid-argument-type]
+            f"[rank {self.rank}] Expected {self.n_cameras} camera names, got {len(camera_names)}"  # ty:ignore[invalid-argument-type]
         )
-        assert self.n_cameras == len(camera_models_from_client), (
-            f"[rank {self.rank}] Expected {self.n_cameras} camera models, got {len(camera_models_from_client)}"
+        assert self.n_cameras == len(camera_models_from_client), (  # ty:ignore[invalid-argument-type]
+            f"[rank {self.rank}] Expected {self.n_cameras} camera models, got {len(camera_models_from_client)}"  # ty:ignore[invalid-argument-type]
         )
-        assert self.n_cameras == len(rig_to_camera_transforms), (
-            f"[rank {self.rank}] Expected {self.n_cameras} rig_to_camera transforms, got {len(rig_to_camera_transforms)}"
+        assert self.n_cameras == len(rig_to_camera_transforms), (  # ty:ignore[invalid-argument-type]
+            f"[rank {self.rank}] Expected {self.n_cameras} rig_to_camera transforms, got {len(rig_to_camera_transforms)}"  # ty:ignore[invalid-argument-type]
         )
-        assert len(hdmap_parquets) > 0, (
-            f"[rank {self.rank}] Expected non-empty HD map parquets, got {len(hdmap_parquets)}"
+        assert len(hdmap_parquets) > 0, (  # ty:ignore[invalid-argument-type]
+            f"[rank {self.rank}] Expected non-empty HD map parquets, got {len(hdmap_parquets)}"  # ty:ignore[invalid-argument-type]
         )
 
         def short_text(text: str) -> str:
@@ -463,18 +463,20 @@ class WorldModelEngine:
 
         # Retrieve profiler and start time
         profiler = get_profiler()
-        chunk_idx = profiler.get_chunk_idx(session_id)
+        chunk_idx = profiler.get_chunk_idx(session_id)  # ty:ignore[invalid-argument-type]
 
         # 1. Convert to RGB tensor
         res_W, res_H = self.api.video_resolution_wh
         decoded_frames: list[torch.Tensor] = []
         with profiler.measure(
-            "decode_initial_frames", session_id=session_id, chunk_idx=chunk_idx
+            "decode_initial_frames",
+            session_id=session_id,  # ty: ignore[invalid-argument-type]
+            chunk_idx=chunk_idx,
         ):
-            for i, img_msg in enumerate(initial_frames_list):
+            for i, img_msg in enumerate(initial_frames_list):  # ty:ignore[invalid-argument-type]
                 frame_tensor = decode_image(
-                    img_msg.data,
-                    video_model_pb2.ImageFormat.Name(img_msg.format),
+                    img_msg.data,  # ty:ignore[unresolved-attribute]
+                    video_model_pb2.ImageFormat.Name(img_msg.format),  # ty:ignore[unresolved-attribute]
                     target_resolution_hw=(res_H, res_W),
                 )  # [3, H, W]
                 decoded_frames.append(frame_tensor)
@@ -485,11 +487,13 @@ class WorldModelEngine:
 
         # 2. Load static world map from zip bytes
         with profiler.measure(
-            "load_static_world_map", session_id=session_id, chunk_idx=chunk_idx
+            "load_static_world_map",
+            session_id=session_id,  # ty: ignore[invalid-argument-type]
+            chunk_idx=chunk_idx,
         ):
             scene_data = load_static_world_from_zip_bytes(
-                hdmap_parquets,
-                camera_names=camera_names,
+                hdmap_parquets,  # ty:ignore[invalid-argument-type]
+                camera_names=camera_names,  # ty:ignore[invalid-argument-type]
                 target_resolution_hw=(res_H, res_W),
             )
         logger.info(
@@ -497,30 +501,30 @@ class WorldModelEngine:
         )
 
         # Store client-provided intrinsics on scene_data so create_renderer can find them
-        for cam_name, cam_model in camera_models_from_client.items():
+        for cam_name, cam_model in camera_models_from_client.items():  # ty:ignore[unresolved-attribute]
             scene_data.camera_models[cam_name] = cam_model
 
         # 3. Create multi-camera renderer
-        renderer = self.api.create_renderer(scene_data, camera_names)
+        renderer = self.api.create_renderer(scene_data, camera_names)  # ty:ignore[invalid-argument-type]
 
         # 4. Store session state (generation deferred to first render_video_chunk)
-        for cam_name, rig_to_cam in rig_to_camera_transforms.items():
-            rig_to_camera_transforms[cam_name] = torch.tensor(
+        for cam_name, rig_to_cam in rig_to_camera_transforms.items():  # ty:ignore[unresolved-attribute]
+            rig_to_camera_transforms[cam_name] = torch.tensor(  # ty:ignore[invalid-assignment]
                 rig_to_cam, device=self.device
             )
         session_state = SessionState(
-            session_id=session_id,
-            camera_names=camera_names,
-            rig_to_camera_transforms=rig_to_camera_transforms,
+            session_id=session_id,  # ty:ignore[invalid-argument-type]
+            camera_names=camera_names,  # ty:ignore[invalid-argument-type]
+            rig_to_camera_transforms=rig_to_camera_transforms,  # ty:ignore[invalid-argument-type]
             scene_data=scene_data,
             renderer=renderer,
             initial_rgb_frames=initial_rgb_frames,
-            text_prompts=text_prompts,
-            skip_video_generation=skip_video_generation,
-            return_hdmap_frames=return_hdmap_frames,
+            text_prompts=text_prompts,  # ty:ignore[invalid-argument-type]
+            skip_video_generation=skip_video_generation,  # ty:ignore[invalid-argument-type]
+            return_hdmap_frames=return_hdmap_frames,  # ty:ignore[invalid-argument-type]
             effective_seed=effective_seed,
         )
-        self.sessions[session_id] = session_state
+        self.sessions[session_id] = session_state  # ty:ignore[invalid-assignment]
         logger.info(
             f"[Rank {self.rank}] Session initialized, generation deferred to first render_video_chunk call"
         )
@@ -556,10 +560,10 @@ class WorldModelEngine:
 
         # Retrieve profiler and start time
         profiler = get_profiler()
-        chunk_idx = profiler.get_chunk_idx(session_id)
+        chunk_idx = profiler.get_chunk_idx(session_id)  # ty:ignore[invalid-argument-type]
 
         # Get session state
-        session_state = self.sessions[session_id]
+        session_state = self.sessions[session_id]  # ty:ignore[invalid-argument-type]
         skip_video_generation = session_state.skip_video_generation
 
         # multiGPU: split views to all ranks.
@@ -573,7 +577,9 @@ class WorldModelEngine:
 
         # 3. Parse rig trajectory (FLU) and derive per-camera poses
         with profiler.measure(
-            "parse_trajectory_continuation", session_id=session_id, chunk_idx=chunk_idx
+            "parse_trajectory_continuation",
+            session_id=session_id,  # ty: ignore[invalid-argument-type]
+            chunk_idx=chunk_idx,
         ):
             # Compute per-camera trajectories:  camera_to_world[t] = rig_to_world[t] @ rig_to_camera
             camera_poses_per_view: dict[str, torch.Tensor] = {}
@@ -581,7 +587,7 @@ class WorldModelEngine:
                 rig_to_cam = session_state.rig_to_camera_transforms[cam_name]
                 camera_poses_per_view[cam_name] = compute_camera_poses_from_rig(
                     rig_poses_flu, rig_to_cam
-                )
+                )  # ty:ignore[invalid-assignment]
 
         # Do a sanity check on the camera poses
         for cam_name, camera_pose in camera_poses_per_view.items():
@@ -589,8 +595,8 @@ class WorldModelEngine:
             assert camera_pose.device == self.device, (
                 f"Camera pose for {cam_name} is on device {camera_pose.device}, expected {self.device}"
             )
-            assert camera_pose.shape == (len(frame_timestamps_us), 4, 4), (
-                f"Camera pose for {cam_name} has shape {camera_pose.shape}, expected ({len(frame_timestamps_us), 4, 4})"
+            assert camera_pose.shape == (len(frame_timestamps_us), 4, 4), (  # ty:ignore[invalid-argument-type]
+                f"Camera pose for {cam_name} has shape {camera_pose.shape}, expected ({len(frame_timestamps_us), 4, 4})"  # ty:ignore[invalid-argument-type]
             )
         assert len(camera_poses_per_view) == len(camera_names), (
             f"[Rank {self.rank}] Expected {len(camera_names)} camera poses, got {len(camera_poses_per_view)}"
@@ -600,19 +606,19 @@ class WorldModelEngine:
         is_first_chunk = not session_state.generation_started
         if is_first_chunk:
             logger.info(
-                f"[Rank {self.rank}] Starting generation with {len(frame_timestamps_us)} frames (skip_video={skip_video_generation})..."
+                f"[Rank {self.rank}] Starting generation with {len(frame_timestamps_us)} frames (skip_video={skip_video_generation})..."  # ty:ignore[invalid-argument-type]
             )
             self._set_rollout_seed_for_next_generation(session_state.effective_seed)
             logger.info(
                 f"[Rank {self.rank}] Using session random seed: {session_state.effective_seed} "
                 "(None means no explicit per-rollout seed)"
             )
-            with profiling_context(session_id, chunk_idx):
+            with profiling_context(session_id, chunk_idx):  # ty:ignore[invalid-argument-type]
                 with profiler.measure(
                     "start_generation_total",
-                    session_id=session_id,
+                    session_id=session_id,  # ty:ignore[invalid-argument-type]
                     chunk_idx=chunk_idx,
-                    num_frames=len(frame_timestamps_us),
+                    num_frames=len(frame_timestamps_us),  # ty:ignore[invalid-argument-type]
                 ):
                     output = self.api.start_generation(
                         text_prompts=session_state.text_prompts,
@@ -620,7 +626,7 @@ class WorldModelEngine:
                         renderer=session_state.renderer,
                         camera_names=camera_names,
                         camera_poses_per_view=camera_poses_per_view,
-                        frame_timestamps_us=frame_timestamps_us,
+                        frame_timestamps_us=frame_timestamps_us,  # ty:ignore[invalid-argument-type]
                         skip_video_generation=skip_video_generation,
                     )
             session_state.bbox_state = output.state
@@ -631,20 +637,20 @@ class WorldModelEngine:
             )
 
             logger.info(
-                f"[Rank {self.rank}] Continuing generation with {len(frame_timestamps_us)} frames (skip_video={skip_video_generation})..."
+                f"[Rank {self.rank}] Continuing generation with {len(frame_timestamps_us)} frames (skip_video={skip_video_generation})..."  # ty:ignore[invalid-argument-type]
             )
-            with profiling_context(session_id, chunk_idx):
+            with profiling_context(session_id, chunk_idx):  # ty:ignore[invalid-argument-type]
                 with profiler.measure(
                     "continue_generation_total",
-                    session_id=session_id,
+                    session_id=session_id,  # ty:ignore[invalid-argument-type]
                     chunk_idx=chunk_idx,
-                    num_frames=len(frame_timestamps_us),
+                    num_frames=len(frame_timestamps_us),  # ty:ignore[invalid-argument-type]
                 ):
                     output = self.api.continue_generation(
                         state=session_state.bbox_state,
                         camera_names=camera_names,
                         camera_poses_per_view=camera_poses_per_view,
-                        frame_timestamps_us=frame_timestamps_us,
+                        frame_timestamps_us=frame_timestamps_us,  # ty:ignore[invalid-argument-type]
                         object_info_per_frame=object_info_per_frame,
                         skip_video_generation=skip_video_generation,
                     )
@@ -661,7 +667,9 @@ class WorldModelEngine:
         # output.rgb_frames: [B, V, T, 3, H, W], output.condition_frames: [B, V, T, 3, H, W]
         camera_outputs = []
         with profiler.measure(
-            "encode_output_frames", session_id=session_id, chunk_idx=chunk_idx
+            "encode_output_frames",
+            session_id=session_id,  # ty: ignore[invalid-argument-type]
+            chunk_idx=chunk_idx,
         ):
             for v_idx, cam_name in enumerate(camera_names):
                 cam_output = {
@@ -794,7 +802,7 @@ class WorldModelEngine:
 
         # Clean up session resources (just session state)
         logger.info(f"[Rank {self.rank}] Closing session {session_id} on all ranks")
-        self._cleanup_session(session_id)
+        self._cleanup_session(session_id)  # ty:ignore[invalid-argument-type]
         logger.info(
             f"[Rank {self.rank}] Session {session_id} closed and removed from storage"
         )

--- a/integrations/alpadreams/alpadreams/grpc/utils.py
+++ b/integrations/alpadreams/alpadreams/grpc/utils.py
@@ -565,5 +565,5 @@ def proto_to_dict(proto_msg) -> dict:
         return MessageToDict(
             proto_msg,
             preserving_proto_field_name=True,
-            including_default_value_fields=True,
+            including_default_value_fields=True,  # ty:ignore[unknown-argument]
         )

--- a/integrations/alpadreams/tests/test_conditioning_wrapper.py
+++ b/integrations/alpadreams/tests/test_conditioning_wrapper.py
@@ -44,7 +44,7 @@ class _FakePipeline:
     ) -> torch.Tensor:
         # Mirror StreamInferencePipeline behavior: generate() records the latest AR
         # index on the cache so callers can derive the next step.
-        cache.autoregressive_index = autoregressive_index
+        cache.autoregressive_index = autoregressive_index  # ty:ignore[unresolved-attribute]
         # Return model-range tensor in [-1, 1] so wrapper conversion can be validated.
         return torch.linspace(
             -1.0,
@@ -121,7 +121,7 @@ def test_start_continue_and_finalize_flow() -> None:
     start_output = wrapper.start_generation(
         text_prompts=text_prompts,
         initial_rgb_frames=torch.zeros((1, 1, 3, 6, 8), dtype=torch.uint8),
-        renderer=renderer,
+        renderer=renderer,  # ty:ignore[invalid-argument-type]
         camera_names=camera_names,
         camera_poses_per_view=_make_camera_poses(camera_names, num_frames=1),
         frame_timestamps_us=[1_000_000],
@@ -167,7 +167,7 @@ def test_skip_generation_and_cleanup() -> None:
     output = wrapper.start_generation(
         text_prompts=[TextPrompt(positive="drive")],
         initial_rgb_frames=torch.zeros((1, 1, 3, 6, 8), dtype=torch.uint8),
-        renderer=renderer,
+        renderer=renderer,  # ty:ignore[invalid-argument-type]
         camera_names=camera_names,
         camera_poses_per_view=_make_camera_poses(camera_names, num_frames=1),
         frame_timestamps_us=[1_000_000],
@@ -198,7 +198,7 @@ def test_start_generation_rejects_mismatched_timestamp_length() -> None:
         wrapper.start_generation(
             text_prompts=[TextPrompt(positive="drive")],
             initial_rgb_frames=torch.zeros((1, 1, 3, 6, 8), dtype=torch.uint8),
-            renderer=renderer,
+            renderer=renderer,  # ty:ignore[invalid-argument-type]
             camera_names=camera_names,
             camera_poses_per_view=_make_camera_poses(camera_names, num_frames=2),
             frame_timestamps_us=[1, 2],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,24 @@ extra-paths = ["flashdreams", "integrations/alpadreams"]
 [tool.ty.src]
 # Auto-generated protobuf stubs — not maintained, no type annotations
 # Pre-existing shim with dynamic patterns that confuse type checkers
+# gRPC server code is tightly coupled to proto-generated types (excluded above);
+# type errors cascade from unresolved protobuf message fields.
 exclude = [
     "**/protos/",
-    "docker/model_specific/cfg_parallel_state.py",
+    "integrations/alpadreams/alpadreams/grpc/",
 ]
+
+[tool.ty.rules]
+# Intentional pattern: recipe subclasses override base methods with more specific
+# signatures (violates Liskov but is the established design in this codebase).
+invalid-method-override = "ignore"
 
 [tool.ty.analysis]
 # transformer-engine has no type stubs; treat all imports as Any
 replace-imports-with-any = ["transformer_engine.**"]
+
+# Test profiling scripts use sys.path manipulation for sibling imports
+allowed-unresolved-imports = ["impl_reference"]
 
 [dependency-groups]
 lint = ["pre-commit>=4.3.0", "ty>=0.0.33"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,10 @@ python-version = "3.12"
 extra-paths = ["flashdreams", "integrations/alpadreams"]
 
 [tool.ty.src]
-# Auto-generated protobuf .pyi stubs trigger `conflicting-metaclass` errors due to
-# protobuf's EnumTypeWrapper pattern (known ty limitation). The stubs are still used
-# for import resolution — this only skips checking the files themselves.
-# Pre-existing shim with dynamic patterns that confuse type checkers.
+# Auto-generated protobuf stubs trigger `conflicting-metaclass` errors due to
+# protobuf's EnumTypeWrapper pattern (known ty limitation).
 exclude = [
-    "**/protos/",
-    "docker/model_specific/cfg_parallel_state.py",
+    "**/protos/*pb2*",
 ]
 
 [tool.ty.rules]
@@ -42,9 +39,6 @@ invalid-method-override = "ignore"
 [tool.ty.analysis]
 # These packages have no type stubs or are unavailable in CI; treat imports as Any
 replace-imports-with-any = ["transformer_engine.**", "ludus_renderer.**"]
-
-# Test profiling scripts use sys.path manipulation for sibling imports
-allowed-unresolved-imports = ["impl_reference"]
 
 [dependency-groups]
 lint = ["pre-commit>=4.3.0", "ty>=0.0.33"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ python-version = "3.12"
 extra-paths = ["flashdreams", "integrations/alpadreams"]
 
 [tool.ty.src]
-# Auto-generated protobuf stubs — not maintained, no type annotations
-# Pre-existing shim with dynamic patterns that confuse type checkers
-# gRPC server code is tightly coupled to proto-generated types (excluded above);
-# type errors cascade from unresolved protobuf message fields.
+# Auto-generated protobuf .pyi stubs trigger `conflicting-metaclass` errors due to
+# protobuf's EnumTypeWrapper pattern (known ty limitation). The stubs are still used
+# for import resolution — this only skips checking the files themselves.
+# Pre-existing shim with dynamic patterns that confuse type checkers.
 exclude = [
     "**/protos/",
-    "integrations/alpadreams/alpadreams/grpc/",
+    "docker/model_specific/cfg_parallel_state.py",
 ]
 
 [tool.ty.rules]
@@ -40,8 +40,8 @@ exclude = [
 invalid-method-override = "ignore"
 
 [tool.ty.analysis]
-# transformer-engine has no type stubs; treat all imports as Any
-replace-imports-with-any = ["transformer_engine.**"]
+# These packages have no type stubs or are unavailable in CI; treat imports as Any
+replace-imports-with-any = ["transformer_engine.**", "ludus_renderer.**"]
 
 # Test profiling scripts use sys.path manipulation for sibling imports
 allowed-unresolved-imports = ["impl_reference"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,24 @@ no-build-isolation-package = ["transformer-engine-torch"]
 [tool.pyright]
 extraPaths = ["flashdreams", "integrations/alpadreams"]
 
+[tool.ty.environment]
+python-version = "3.12"
+extra-paths = ["flashdreams", "integrations/alpadreams"]
+
+[tool.ty.src]
+# Auto-generated protobuf stubs — not maintained, no type annotations
+# Pre-existing shim with dynamic patterns that confuse type checkers
+exclude = [
+    "**/protos/",
+    "docker/model_specific/cfg_parallel_state.py",
+]
+
+[tool.ty.analysis]
+# transformer-engine has no type stubs; treat all imports as Any
+replace-imports-with-any = ["transformer_engine.**"]
+
 [dependency-groups]
-lint = ["pre-commit>=4.3.0"]
+lint = ["pre-commit>=4.3.0", "ty>=0.0.33"]
 
 # Sphinx toolchain for building docs locally (`uv run --group docs sphinx-build ...`).
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,10 @@ docs-ci = [
     { name = "tqdm", specifier = ">=4.60" },
     { name = "transformers", specifier = "==4.57.6" },
 ]
-lint = [{ name = "pre-commit", specifier = ">=4.3.0" }]
+lint = [
+    { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "ty", specifier = ">=0.0.33" },
+]
 
 [[package]]
 name = "accessible-pygments"
@@ -2034,6 +2037,30 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.33"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
+    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
+    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
+    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request primarily adds `ty:ignore` comments throughout the codebase to suppress type-checking errors from the `ty` static type checker, enabling its integration into the project's CI and pre-commit workflows. This allows the code to pass type checks despite unresolved attributes, invalid assignments, or other type issues, facilitating incremental adoption of static typing. Additionally, the CI workflow and pre-commit configuration are updated to install and run `ty` checks.

Key changes include:

**CI/CD and Pre-commit Integration:**

* Updated `.github/workflows/ci.yml` to install all dependencies needed for `ty` type checking, skipping packages incompatible with CPU-only CI runners, and to run the linter without re-syncing dependencies.
* Modified `.pre-commit-config.yaml` to add a new local pre-commit hook for running `ty check` on Python files.

**Type Ignore Annotations in Example Scripts:**

* Added `# ty:ignore[...]` comments to suppress type errors in example scripts such as `run_alpadreams.py`, `run_causal_wan21.py`, `run_causal_wan22.py`, `run_lingbot_world.py`, and `run_wan21.py`. These address unresolved attributes, unknown arguments, and callability issues on pipeline objects and methods. [[1]](diffhunk://#diff-e2d6b86f4acd1c81401d36d9ffba55f12705cdce4bf7c8654233f168b59b12b6L202-R204) [[2]](diffhunk://#diff-e2d6b86f4acd1c81401d36d9ffba55f12705cdce4bf7c8654233f168b59b12b6L241-R243) [[3]](diffhunk://#diff-e2d6b86f4acd1c81401d36d9ffba55f12705cdce4bf7c8654233f168b59b12b6L252-R254) [[4]](diffhunk://#diff-e2d6b86f4acd1c81401d36d9ffba55f12705cdce4bf7c8654233f168b59b12b6L262-R264) [[5]](diffhunk://#diff-d02d67f45160e7a48e78ab88a0a8dd5ae035fac126b64e984056bc1316c3fe77L187-R199) [[6]](diffhunk://#diff-d02d67f45160e7a48e78ab88a0a8dd5ae035fac126b64e984056bc1316c3fe77L209-R209) [[7]](diffhunk://#diff-ca7489abd9c5a938247a5fad49bcbb526bbf784de6cd3026463ced171aa4e917L148-R148) [[8]](diffhunk://#diff-ca7489abd9c5a938247a5fad49bcbb526bbf784de6cd3026463ced171aa4e917L158-R158) [[9]](diffhunk://#diff-044cba0b8292f488a6dea7c6032db4384ec7fa0a52a7cb35a1dcd50db613d534L178-R178) [[10]](diffhunk://#diff-044cba0b8292f488a6dea7c6032db4384ec7fa0a52a7cb35a1dcd50db613d534L212-R212) [[11]](diffhunk://#diff-044cba0b8292f488a6dea7c6032db4384ec7fa0a52a7cb35a1dcd50db613d534L223-R223) [[12]](diffhunk://#diff-44d5ad83cbd4b0ecf8b60904c41eac4fa7b97456b79b393ab1c9e8723392cc1dL158-R158) [[13]](diffhunk://#diff-44d5ad83cbd4b0ecf8b60904c41eac4fa7b97456b79b393ab1c9e8723392cc1dL170-R170)

**Type Ignore Annotations in Core Modules:**

* Added `# ty:ignore[...]` comments in core modules such as `native.py`, `ring.py`, `load.py`, and especially throughout `experimental/kvcache.py` to suppress errors related to missing submodules, invalid assignments, unresolved attributes, and argument types. [[1]](diffhunk://#diff-2beb0af3a24fdbbad0fc834fcc27e40063e059cdde1e9cfd9aceaf2f52198c2eL125-R125) [[2]](diffhunk://#diff-c45e5033e6f59e6a15390565cd019b426c082513b7381ebc58e1aac755136471L42-R46) [[3]](diffhunk://#diff-c45e5033e6f59e6a15390565cd019b426c082513b7381ebc58e1aac755136471L66-R68) [[4]](diffhunk://#diff-08cb00a029a9281dbdba1ad0931412fe9ba9f8bc44361658853c99a8cf81cbd6L366-R366) [[5]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L169-R170) [[6]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L182-R182) [[7]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L192-R193) [[8]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L225-R231) [[9]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L241-R242) [[10]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L252-R261) [[11]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L279-R279) [[12]](diffhunk://#diff-ef52481bcfeb0e98113315f576dbf8f8ee582b5debd57daaf7db97dc75565ea6L288-R299)

These changes collectively enable type checking with `ty` in CI and pre-commit hooks, while suppressing current type errors to prevent workflow failures and allow for gradual type improvements.