### PR TITLE
Implement CP for Wan2.1 (-> LingBot)

### DIFF
--- a/docs/source/examples/lingbot_world.rst
+++ b/docs/source/examples/lingbot_world.rst
@@ -9,7 +9,27 @@ Reference:
 
    export HF_TOKEN=<your-hf-token>
 
+Single GPU
+----------
+
+Currently, even single GPU inference requires `torchrun` to be used (in order to set the right env variables).
+
+.. code-block:: bash
+
    uv run --package flashdreams --extra examples \
-     python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=1 \
-       flashdreams/examples/run_lingbot_world.py \
+     torchrun --standalone --nnodes=1 --nproc_per_node=1 \
+       -m flashdreams.examples.run_lingbot_world \
+       --total_blocks 21
+
+Multi GPU
+---------
+
+Wan 2.1 context parallel assumes `cp_size == world_size`, so Lingbot World can be launched
+with `torchrun` across multiple GPUs:
+
+.. code-block:: bash
+
+   uv run --package flashdreams --extra examples \
+     torchrun --standalone --nnodes=1 --nproc_per_node=2 \
+       -m flashdreams.examples.run_lingbot_world \
        --total_blocks 21

--- a/flashdreams/flashdreams/recipes/lingbot_world/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/transformer/__init__.py
@@ -76,7 +76,7 @@ class LingbotWorldTransformer(Wan21Transformer):
         config: LingbotWorldTransformerConfig,
         device: torch.device | None = None,
     ) -> None:
-        super().__init__(config)
+        super().__init__(config, device=device)
 
     def predict_flow(
         self,

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
@@ -105,8 +105,8 @@ class Wan21TransformerConfig(TransformerConfig):
     Each instance is bound to one ``(batch_shape, height, width, len_t)``
     layout AND to one context-parallel size (``cp_size``). The per-rank
     token shape lives on :attr:`Wan21Transformer.latent_shape` (a property
-    derived from runtime CP groups), since it depends on the hierarchical
-    V→T→HW split chosen by :func:`create_hierarchical_cp_groups`.
+    derived from runtime CP groups), since Wan shards the flattened
+    ``(T*H*W)`` token axis with one THW context-parallel group.
     """
 
     _target: type["Wan21Transformer"] = field(default_factory=lambda: Wan21Transformer)
@@ -193,6 +193,9 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         self.config: Wan21TransformerConfig = config
 
         # Context-parallel groups -------------------------------------------------
+        #
+        # Same launcher contract as AlpaDreams (cp_size == world_size), but now wire
+        # Wan's THW CP group to WORLD so all existing CP-aware Wan plumbing works.
         self.cp_group = None
         self.cp_size = 1
         if torch.distributed.is_initialized():
@@ -202,15 +205,27 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
                 f"torch.distributed.get_world_size() ({world_size})"
             )
             if world_size > 1:
-                raise NotImplementedError(
-                    "Wan21Transformer does not support distributed inference"
-                )
+                self.cp_group = torch.distributed.group.WORLD
+                assert self.cp_group is not None, "WORLD group is not set"
+                self.cp_size = self.cp_group.size()
+        else:
+            assert config.cp_size == 1, (
+                f"WanTransformerConfig.cp_size must be 1 in non-distributed mode "
+                f"(got {config.cp_size})"
+            )
 
         # Token layout (pre-CP). Per-rank token count is on self.latent_shape[-2].
         kt, kh, kw = config.network.patch_size
         self._pT = config.len_t // kt
         self._pH = config.height // kh
         self._pW = config.width // kw
+        total_tokens = self._pT * self._pH * self._pW
+        assert total_tokens % self.cp_size == 0, (
+            f"Wan token length ({total_tokens} from len_t={config.len_t}, "
+            f"height={config.height}, width={config.width}, "
+            f"patch_size={config.network.patch_size}) must be divisible by "
+            f"cp_size={self.cp_size}"
+        )
 
         # Network ----------------------------------------------------------------
         self.network = config.network.setup()
@@ -274,7 +289,7 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         sizes, different image embedding, etc.) themselves and stitch them
         directly into a :class:`Wan21TransformerCache`.
         """
-        cp_size = self.config.cp_size
+        cp_size = self.cp_size
         chunk_size = self.latent_shape[-2]  # already CP-divided
         window_size = (self.config.window_size_t * self._pH * self._pW) // cp_size
         sink_size = (self.config.sink_size_t * self._pH * self._pW) // cp_size

--- a/flashdreams/tests/test_wan_lingbot_context_parallel.py
+++ b/flashdreams/tests/test_wan_lingbot_context_parallel.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import types
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from flashdreams.recipes.lingbot_world.encoder.camctrl import I2VCamCtrlEmbeddings
+from flashdreams.recipes.lingbot_world.transformer import (
+    LingbotWorldTransformer,
+    LingbotWorldTransformerConfig,
+)
+from flashdreams.recipes.lingbot_world.transformer.impl.network import (
+    LingbotWorldDiTNetworkConfig,
+)
+from flashdreams.recipes.wan.autoencoder.i2v import I2VCtrl
+from flashdreams.recipes.wan.transformer.impl.network import WanDiTNetworkConfig
+from flashdreams.recipes.wan.transformer.wan21 import (
+    Wan21Transformer,
+    Wan21TransformerConfig,
+)
+
+
+class _FakeProcessGroup:
+    def __init__(self, world_size: int, rank: int) -> None:
+        self._world_size = world_size
+        self._rank = rank
+
+    def size(self) -> int:
+        return self._world_size
+
+    def rank(self) -> int:
+        return self._rank
+
+
+class _DummyNetwork(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cp_group = None
+        self.parameters_updated = False
+
+    def set_context_parallel_group(self, cp_group=None) -> None:
+        self.cp_group = cp_group
+
+    def update_parameters_after_loading_checkpoint(self) -> None:
+        self.parameters_updated = True
+
+
+@dataclass
+class _DummyNetworkConfig:
+    patch_size: tuple[int, int, int] = (1, 2, 2)
+    in_dim: int = 16
+
+    def setup(self) -> _DummyNetwork:
+        return _DummyNetwork()
+
+
+def _mock_distributed(
+    monkeypatch, world_size: int = 2, rank: int = 0
+) -> _FakeProcessGroup:
+    fake_group = _FakeProcessGroup(world_size=world_size, rank=rank)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: world_size)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: rank)
+    monkeypatch.setattr(
+        torch.distributed,
+        "group",
+        types.SimpleNamespace(WORLD=fake_group),
+        raising=False,
+    )
+    return fake_group
+
+
+def test_wan21_uses_world_cp_group_when_distributed(monkeypatch) -> None:
+    fake_group = _mock_distributed(monkeypatch, world_size=2, rank=0)
+    transformer = Wan21Transformer(
+        Wan21TransformerConfig(
+            network=_DummyNetworkConfig(),  # ty:ignore[invalid-argument-type]
+            batch_shape=(1,),
+            len_t=2,
+            height=4,
+            width=4,
+            cp_size=2,
+            window_size_t=2,
+            sink_size_t=0,
+        )
+    )
+
+    assert transformer.cp_group is fake_group
+    assert transformer.cp_size == 2
+    assert isinstance(transformer.network, _DummyNetwork)
+    assert transformer.network.cp_group is fake_group
+    assert transformer.network.parameters_updated
+
+
+def test_wan21_requires_cp_size_one_without_distributed(monkeypatch) -> None:
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    with pytest.raises(
+        AssertionError, match="cp_size must be 1 in non-distributed mode"
+    ):
+        Wan21Transformer(
+            Wan21TransformerConfig(
+                network=_DummyNetworkConfig(),  # ty:ignore[invalid-argument-type]
+                batch_shape=(1,),
+                len_t=2,
+                height=4,
+                width=4,
+                cp_size=2,
+            )
+        )
+
+
+def test_wan21_requires_tokens_divisible_by_cp_size(monkeypatch) -> None:
+    _mock_distributed(monkeypatch, world_size=2, rank=0)
+    with pytest.raises(AssertionError, match="must be divisible by cp_size=2"):
+        Wan21Transformer(
+            Wan21TransformerConfig(
+                network=_DummyNetworkConfig(),  # ty:ignore[invalid-argument-type]
+                batch_shape=(1,),
+                len_t=1,
+                height=2,
+                width=2,
+                cp_size=2,
+                window_size_t=1,
+                sink_size_t=0,
+            )
+        )
+
+
+def test_wan_patchify_unpatchify_round_trip_without_cp() -> None:
+    network = WanDiTNetworkConfig(
+        dim=64,
+        ffn_dim=128,
+        num_heads=4,
+        num_layers=1,
+        patch_embedding_type="linear",
+    ).setup()
+    latent = torch.randn(1, 2, 16, 4, 4)
+
+    patched = network.patchify_and_maybe_split_cp(
+        latent,
+        process_groups=[None],
+        cp_dims=[-2],
+    )
+    restored = network.unpatchify_and_maybe_gather_cp(
+        pH=2,
+        pW=2,
+        x=patched,
+        process_groups=[None],
+        cp_dims=[-2],
+    )
+
+    assert patched.shape == (1, 8, 64)
+    torch.testing.assert_close(restored, latent)
+
+
+def test_lingbot_patchify_marks_i2v_and_plucker_as_patchified() -> None:
+    transformer = LingbotWorldTransformer(
+        LingbotWorldTransformerConfig(
+            network=LingbotWorldDiTNetworkConfig(
+                dim=64,
+                ffn_dim=128,
+                num_heads=4,
+                num_layers=1,
+                patch_embedding_type="linear",
+                control_type="cam",
+            ),
+            batch_shape=(1, 1),
+            len_t=2,
+            height=4,
+            width=4,
+            cp_size=1,
+            window_size_t=2,
+            sink_size_t=0,
+            compile_network=False,
+        )
+    )
+
+    camctrl_embeddings = I2VCamCtrlEmbeddings(
+        i2v=I2VCtrl(
+            latent=torch.randn(1, 1, 2, 16, 4, 4),
+            mask=torch.randn(1, 1, 2, 16, 4, 4),
+        ),
+        plucker=torch.randn(1, 1, 2, 6 * 64, 4, 4),
+    )
+
+    patched = transformer.patchify_and_maybe_split_cp(camctrl_embeddings)
+    assert isinstance(patched, I2VCamCtrlEmbeddings)
+    assert patched._is_patchified
+    assert patched.i2v._is_patchified
+    assert patched.i2v.latent.shape == (1, 1, 8, 64)
+    assert patched.i2v.mask.shape == (1, 1, 8, 64)
+    assert patched.plucker.shape == (1, 1, 8, 1536)
+
+    # Idempotent once marked patchified.
+    assert transformer.patchify_and_maybe_split_cp(patched) is patched


### PR DESCRIPTION
Adds mGPU support for LingBot world. It's not very efficient (about 1.25x speedup 1->4 GPUs) but always a starting point that will let me develop an mGPU inference server.