### PR TITLE
Fix CUDA graph capture crash at the first steady-state AR step

### DIFF
--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -197,9 +197,9 @@ class CosmosTransformerConfig(InstantiateConfig["CosmosTransformer"]):
         self._pW = self.width // kw
 
         # First AR step whose forward runs on the KV cache's steady-state
-        # code path. The cache fills at AR step ``chunks_total // _pT - 1``; 
-        # the *next* step is the first one whose ``before_update`` sees 
-        # ``is_steady_state() == True`` and whose forward takes the steady branches. 
+        # code path. The cache fills at AR step ``chunks_total // _pT - 1``;
+        # the *next* step is the first one whose ``before_update`` sees
+        # ``is_steady_state() == True`` and whose forward takes the steady branches.
         # Drain must cover that first steady call so Dynamo traces / Inductor autotunes
         # those branches on the eager path.
         chunks_total = self.sink_size_t + self.window_size_t

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -196,16 +196,19 @@ class CosmosTransformerConfig(InstantiateConfig["CosmosTransformer"]):
         self._pH = self.height // kh
         self._pW = self.width // kw
 
-        # First AR step at which the per-block KV cache reaches its full
-        # (sink + window) shape. From here on the network forward is
-        # shape-stable and safe for CUDA-graph capture.
+        # First AR step whose forward runs on the KV cache's steady-state
+        # code path. The cache fills at AR step ``chunks_total // _pT - 1``; 
+        # the *next* step is the first one whose ``before_update`` sees 
+        # ``is_steady_state() == True`` and whose forward takes the steady branches. 
+        # Drain must cover that first steady call so Dynamo traces / Inductor autotunes
+        # those branches on the eager path.
         chunks_total = self.sink_size_t + self.window_size_t
         assert chunks_total % self._pT == 0, (
             f"sink_size_t + window_size_t ({chunks_total}) must be "
             f"divisible by _pT ({self._pT}) so the BlockKVCache can fit "
             f"a whole number of AR chunks."
         )
-        self._steady_ar_idx = chunks_total // self._pT - 1
+        self._steady_ar_idx = chunks_total // self._pT
 
 
 ## Default state-dict transform


### PR DESCRIPTION
**Problem.** `alpadreams` rollouts crashed on the first AR step whose KV cache was already full at forward time (AR 3 in the repro run):

```
triton_poi_fused_copy_slice_0 ...
  -> benchmark_gpu ... torch.cuda.synchronize()
torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
  (cudaErrorStreamCaptureUnsupported)
```

**Root cause.** `BlockKVCache` has two distinct code paths:

- *filling*: `_append_to_end` + sliced `cached_k` / `cached_v`
- *steady*: `_roll_local_window_left` + `_overwrite_rightmost_steady` + full-buffer `cached_k` / `cached_v`

`torch.compile` traces these lazily, per branch. The dispatch between the `CUDAGraphWrapper.drain` path (eager, drains Inductor autotune) and the `__call__` path (warmup + capture + replay) is gated by `_steady_ar_idx`, which was set to the AR step where the cache *fills*:

```python
self._steady_ar_idx = chunks_total // self._pT - 1
```

But the steady branches don't run until the *next* step — the first one whose `before_update` sees `is_steady_state() == True`. So drain covered only the filling branches; the first steady call happened inside `__call__`, and if it landed on the capture iteration, Inductor's triton autotune called `torch.cuda.synchronize()` inside `torch.cuda.graph(...)` → crash.

**Fix.** Drop the `- 1`:

```python
self._steady_ar_idx = chunks_total // self._pT
```

Now drain covers up to and including the first AR step that executes the steady-state branches, so `CUDAGraphWrapper.warmup_iters` gets to compile them eagerly before capture opens. Mirrors the reference implementation's `can_use_graph(current_start) == (current_start >= sink + local)` gate.

**Cost.** One extra eager AR step per rollout (trades a few hundred ms of startup for correctness). No model or numerics changes.

**Test.** `run_alpadreams` rollout that previously died at AR 3 now completes end-to-end.