### PR TITLE
Fix CP for AlpaDreams model when T=3

### DIFF
--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -291,6 +291,12 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             else self.network
         )
 
+        # In the case of single view, we always flatten the latent tensor into
+        # 4D [B, V, L, D]. This makes CP easier: just directly apply on L dimension.
+        # For multi-view, we keep the original 5D [B, V, T, HW, D] shape so we can apply
+        # dedicated hierarchical CP groups.
+        self.flatten_thw = config.num_views == 1
+
     ## Patchify / CP plumbing
 
     @property
@@ -300,44 +306,73 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         kt = cfg.network.patch_temporal
         kh = kw = cfg.network.patch_spatial
         D = cfg.network.in_channels * kt * kh * kw
-        return (
-            *cfg.batch_shape,
-            cfg.num_views // self.cp_groups.V_size,
-            self.config._pT // self.cp_groups.T_size,
-            (self.config._pH * self.config._pW) // self.cp_groups.HW_size,
-            D,
-        )
+        if self.flatten_thw:
+            return (
+                *cfg.batch_shape,
+                cfg.num_views // self.cp_groups.V_size,
+                (self.config._pT * self.config._pH * self.config._pW)
+                // self.cp_groups.THW_size,
+                D,
+            )
+        else:
+            return (
+                *cfg.batch_shape,
+                cfg.num_views // self.cp_groups.V_size,
+                self.config._pT // self.cp_groups.T_size,
+                (self.config._pH * self.config._pW) // self.cp_groups.HW_size,
+                D,
+            )
 
-    @property
-    def _process_groups(self) -> list[Any]:
-        return [self.cp_groups.V_group, self.cp_groups.T_group, self.cp_groups.HW_group]
+    def patchify_and_maybe_split_cp(self, x: Tensor) -> Tensor:
+        # x expected to be [B, V, T, C, H, W]
+        assert x.ndim == 6, f"x must be a 6D tensor, but got shape {x.shape}"
 
-    @property
-    def _cp_dims(self) -> list[int]:
-        return [-5, -4, -3]  # V, T, HW
-
-    def patchify_and_maybe_split_cp(self, x: Any) -> Any:
-        # Cosmos network expects 6D [B, V, T, C, H, W]; pass cp_dims as
-        # positive [1, 2, 3] for that layout.
-        if isinstance(x, Tensor):
+        if self.flatten_thw:
             return self.network.patchify_and_maybe_split_cp(
                 x,
-                process_groups=self._process_groups,
-                cp_dims=[1, 2, 3],
-            )
-        raise TypeError(
-            f"CosmosTransformer.patchify_and_maybe_split_cp got unsupported "
-            f"input type {type(x).__name__}; expected Tensor."
-        )
+                process_groups=[self.cp_groups.V_group, self.cp_groups.THW_group],
+                cp_dims=[-3, -2],
+                flatten_thw=True,
+            )  # [B, V, L, D]
+        else:
+            return self.network.patchify_and_maybe_split_cp(
+                x,
+                process_groups=[
+                    self.cp_groups.V_group,
+                    self.cp_groups.T_group,
+                    self.cp_groups.HW_group,
+                ],
+                cp_dims=[-4, -3, -2],
+                flatten_thw=False,
+            )  # [B, V, T, HW, D]
 
     def unpatchify_and_maybe_gather_cp(self, x: Tensor) -> Tensor:
-        return self.network.unpatchify_and_maybe_gather_cp(
-            pH=self.config._pH,
-            pW=self.config._pW,
-            x=x,
-            process_groups=self._process_groups,
-            cp_dims=[1, 2, 3],
-        )
+        if self.flatten_thw:
+            # x expected to be [B, V, L, D]
+            assert x.ndim == 4, f"x must be a 4D tensor, but got shape {x.shape}"
+            return self.network.unpatchify_and_maybe_gather_cp(
+                pH=self.config._pH,
+                pW=self.config._pW,
+                x=x,
+                process_groups=[self.cp_groups.V_group, self.cp_groups.THW_group],
+                cp_dims=[-3, -2],
+                flatten_thw=True,
+            )  # [B, V, T, C, H, W]
+        else:
+            # x expected to be [B, V, T, HW, D]
+            assert x.ndim == 5, f"x must be a 5D tensor, but got shape {x.shape}"
+            return self.network.unpatchify_and_maybe_gather_cp(
+                pH=self.config._pH,
+                pW=self.config._pW,
+                x=x,
+                process_groups=[
+                    self.cp_groups.V_group,
+                    self.cp_groups.T_group,
+                    self.cp_groups.HW_group,
+                ],
+                cp_dims=[-4, -3, -2],
+                flatten_thw=False,
+            )  # [B, V, T, C, H, W]
 
     ## Condition / cache plumbing
 
@@ -419,15 +454,9 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         image = F.pad(image_embeddings, (0, 0, 0, 0, 0, 0, 0, cfg.len_t - 1))
 
         # Patchify image and masks once at rollout start.
-        image_patched = self.network.patchify_and_maybe_split_cp(
-            image, process_groups=self._process_groups, cp_dims=[1, 2, 3]
-        )
-        mask_first_patched = self.network.patchify_and_maybe_split_cp(
-            mask_first_block, process_groups=self._process_groups, cp_dims=[1, 2, 3]
-        )
-        mask_other_patched = self.network.patchify_and_maybe_split_cp(
-            mask_other_blocks, process_groups=self._process_groups, cp_dims=[1, 2, 3]
-        )
+        image_patched = self.patchify_and_maybe_split_cp(image)
+        mask_first_patched = self.patchify_and_maybe_split_cp(mask_first_block)
+        mask_other_patched = self.patchify_and_maybe_split_cp(mask_other_blocks)
 
         # Reset any prior CUDA graph: it refers to slot pointers from the
         # previous cache, which the new cache invalidates.

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
@@ -746,4 +746,8 @@ class Block(nn.Module):
         mlp_out = self.mlp(normed_x)
         x = x + gate_mlp * mlp_out
 
+        # reshape back to 5D if needed
+        if T is not None and HW is not None:
+            x = x.reshape(B, V, T, HW, D)  # [B, V, T, HW, D]
+
         return x

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
@@ -607,17 +607,17 @@ class Block(nn.Module):
 
     def forward(
         self,
-        x: Tensor,  # [B, V, T, HW, D]
+        x: Tensor,
         emb: Tensor,
         cache: BlockCache,
-        rope_freqs: Tensor,  # [L, 1, 1, D]
+        rope_freqs: Tensor,
         adaln_lora: Tensor | None = None,
         view_embedding_proj: Tensor | None = None,
     ) -> Tensor:
         """Run the full block update for one denoising step.
 
         Args:
-            x: Input tensor with shape [B, V, T, HW, D].
+            x: Input tensor with shape [B, V, T, HW, D] or [B, V, L, D].
             emb: Timestep embedding with shape [B, D].
             cache: KV cache container for this block.
             rope_freqs: RoPE frequencies with shape [L, 1, 1, D].
@@ -627,17 +627,25 @@ class Block(nn.Module):
         Returns:
             Updated hidden states with the same shape as ``x``.
         """
-        B, V, T, HW, D = x.shape
+        if x.ndim == 5:
+            B, V, T, HW, D = x.shape
+            L = T * HW
+            x = x.reshape(B, V, L, D)
+        else:
+            assert x.ndim == 4, "x must be a 4D tensor"
+            B, V, L, D = x.shape
+            # If x passes in as a 4D tensor, we don't know T and HW.
+            T = HW = None
 
         # Reshape embeddings to be broadcastable with x.
-        emb = emb.reshape(B, 1, 1, 1, D)
+        emb = emb.reshape(B, 1, 1, D)
 
         # Compute AdaLN modulation
         if self.use_adaln_lora:
             assert adaln_lora is not None, (
                 "adaln_lora is required when use_adaln_lora is True"
             )
-            adaln_lora = adaln_lora.reshape(B, 1, 1, 1, 3 * D)
+            adaln_lora = adaln_lora.reshape(B, 1, 1, 3 * D)
             shift_self, scale_self, gate_self = (
                 self.adaln_modulation_self_attn(emb) + adaln_lora
             ).chunk(3, dim=-1)
@@ -673,7 +681,7 @@ class Block(nn.Module):
             ) = view_embedding_proj.chunk(9, dim=-1)
 
             def expand_view_mod(v_mod: Tensor) -> Tensor:
-                return v_mod.reshape(B, V, 1, 1, D)
+                return v_mod.reshape(B, V, 1, D)
 
             shift_self = shift_self + expand_view_mod(view_shift_self)
             scale_self = scale_self + expand_view_mod(view_scale_self)
@@ -690,7 +698,7 @@ class Block(nn.Module):
         # Self-attention (API aligned with Attention.forward)
         normed_x = self.layer_norm_self_attn(x) * (1 + scale_self) + shift_self
         attn_out = self.self_attn(
-            normed_x.reshape(B, V, -1, D),
+            normed_x,
             rope_freqs=rope_freqs,
             kv_cache=cache.self_attn,
         ).reshape_as(normed_x)
@@ -698,8 +706,11 @@ class Block(nn.Module):
 
         # Cross-view attention: dense
         if self.enable_cross_view_attn:
+            assert T is not None and HW is not None, (
+                "T and HW must be available (x should be a 5D tensor) when cross-view attention is enabled"
+            )
             normed_x_cv = self.layer_norm_cross_view_attn(x)
-            x_cv = rearrange(normed_x_cv, "b v t hw d -> b t v hw d")
+            x_cv = rearrange(normed_x_cv, "b v (t hw) d -> b t v hw d", t=T, hw=HW)
             if self.cross_view_attn.is_context_parallel_enabled():
                 # When cross-view attention is CP-enabled, assume views are split
                 # across GPUs in rank order. For 4 views on 2 GPUs, that is
@@ -719,13 +730,13 @@ class Block(nn.Module):
                 x_context = repeat(x_cv, "b t v hw d -> b t v2 (v hw) d", v2=V)
             cross_view_attn_kv_cache = self.cross_view_attn.compute_kv(x_context)
             cv_out = self.cross_view_attn(x_cv, kv_cache=cross_view_attn_kv_cache)
-            cv_out = rearrange(cv_out, "b t v hw d -> b v t hw d")
+            cv_out = rearrange(cv_out, "b t v hw d -> b v (t hw) d")
             x = x + cv_out
 
         # Cross-attention
         normed_x = self.layer_norm_cross_attn(x) * (1 + scale_cross) + shift_cross
         cross_out = self.cross_attn(
-            normed_x.reshape(B, V, -1, D),
+            normed_x,
             kv_cache=cache.cross_attn,
         ).reshape_as(normed_x)
         x = x + gate_cross * cross_out

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
@@ -343,9 +343,9 @@ class CosmosDiTNetwork(nn.Module):
         Unpatchify the input tensor and maybe gather it along cp_dim if a process group is provided.
 
         If `flatten_thw` is False, the unpatchify pattern is:
-            "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
-        Otherwise, the unpatchify pattern is:
             "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
+        Otherwise, the unpatchify pattern is:
+            "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
 
         Returns:
             Tensor: The unpatched tensor with shape [B, V, T, C, H, W]

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
@@ -289,21 +289,29 @@ class CosmosDiTNetwork(nn.Module):
         x: Tensor,  # [B, V, T, C, H, W]
         process_groups: list[ProcessGroup | None] | None = None,
         cp_dims: list[int | None] | None = None,
+        flatten_thw: bool = False,
     ) -> Tensor:
         r"""
         Patchify the input tensor and maybe split it along cp_dim if a process group is provided.
 
-        The patchify pattern is:
+        If `flatten_thw` is False, the patchify pattern is:
             "b v (t kt) c (h kh) (w kw) -> b v t (h w) (c kt kh kw)",
+        Otherwise, the patchify pattern is:
+            "b v (t kt) c (h kh) (w kw) -> b v (t h w) (c kt kh kw)"
 
         Returns:
-            Tensor: The patched tensor with shape [B, V, T, HW, D]
+            Tensor: The patched tensor with shape [B, V, T, HW, D] or [B, V, L, D]
         """
         assert x.ndim == 6, f"x must be a 6D tensor, but got shape {x.shape}"
 
+        if flatten_thw:
+            pattern = "... v (t kt) c (h kh) (w kw) -> ... v (t h w) (c kt kh kw)"
+        else:
+            pattern = "... v (t kt) c (h kh) (w kw) -> ... v t (h w) (c kt kh kw)"
+
         x = rearrange(
             x,
-            "... v (t kt) c (h kh) (w kw) -> ... v t (h w) (c kt kh kw)",
+            pattern,
             kt=self.config.patch_temporal,
             kh=self.config.patch_spatial,
             kw=self.config.patch_spatial,
@@ -326,20 +334,28 @@ class CosmosDiTNetwork(nn.Module):
         self,
         pH: int,
         pW: int,
-        x: Tensor,  # [B, V, T, HW, D]
+        x: Tensor,  # [B, V, T, HW, D] or [B, V, L, D]
         process_groups: list[ProcessGroup | None] | None = None,
         cp_dims: list[int | None] | None = None,
+        flatten_thw: bool = False,
     ) -> Tensor:
         r"""
         Unpatchify the input tensor and maybe gather it along cp_dim if a process group is provided.
 
-        The unpatchify pattern is:
+        If `flatten_thw` is False, the unpatchify pattern is:
+            "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
+        Otherwise, the unpatchify pattern is:
             "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
 
         Returns:
             Tensor: The unpatched tensor with shape [B, V, T, C, H, W]
         """
-        assert x.ndim == 5, f"x must be a 5D tensor, but got shape {x.shape}"
+        if flatten_thw:
+            pattern = "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
+            assert x.ndim == 4, f"x must be a 4D tensor, but got shape {x.shape}"
+        else:
+            pattern = "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
+            assert x.ndim == 5, f"x must be a 5D tensor, but got shape {x.shape}"
 
         if process_groups is not None:
             assert cp_dims is not None and len(cp_dims) == len(process_groups), (
@@ -355,7 +371,7 @@ class CosmosDiTNetwork(nn.Module):
 
         x = rearrange(
             x,
-            "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
+            pattern,
             h=pH,
             w=pW,
             kt=self.config.patch_temporal,
@@ -403,13 +419,13 @@ class CosmosDiTNetwork(nn.Module):
         Forward pass dispatching to training or inference mode.
 
         Args:
-            x: Input video tensor [B, V, T, HW, D] after patchify
+            x: Input video tensor [B, V, T, HW, D] or [B, V, L, D] after patchify
             timesteps: Timesteps [1] or [B]
-            rope_freqs: RoPE cosine and sine embeddings [T*HW, 1, 1, D]
+            rope_freqs: RoPE cosine and sine embeddings [L, 1, 1, D]
             cache: CosmosDiTCache
-            condition_video_input_mask: Condition video input mask [B, V, T, HW, D] after patchify
+            condition_video_input_mask: Condition video input mask [B, V, T, HW, D] or [B, V, L, D] after patchify
             current_chunk_idx: Current chunk index in autoregressive inference
-            hdmap_condition: HDMap tensor [B, V, T, HW, D]
+            hdmap_condition: HDMap tensor [B, V, T, HW, D] or [B, V, L, D]
             view_indices: View indices [B, V]
             eager_mode: Whether to run in eager mode (True) or not (False)
         """


### PR DESCRIPTION
Fix the same bug as in https://github.com/NVIDIA/flashdreams/pull/35 but with a different approach.

Reason: Input CP is first T then HW. RoPE + attn CP is on L = THW. When T=3 for GPU=4, T is not splittable. So input will be split on HW dimension, while RoPE and attn is split on L, thus causes issue.

Fix: for single view, always flatten input to L=T*H*W, then for input + rope + attn, all split on L dimension. 

Test:
```bash
uv run --package flashdreams --extra examples   python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=4     flashdreams/examples/run_alpadreams.py     --n_cameras 1 --total_blocks 20  --overwrite_config_name sv_2steps_chunk3_loc6_vae_vae
```

Before:

https://github.com/user-attachments/assets/d6eaf2fc-d3f7-4870-951d-6d22f8aaa9f5

After:

https://github.com/user-attachments/assets/b31c2623-0c4b-40cf-8e9a-1cd607e45e25

