### PR TITLE
Introduce two agent skills into repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,11 +121,12 @@ venv.bak/
 compile_commands.json
 *.dump
 
-.cursor/
-
 outputs/
 data_local/
 credentials/*.secret
 
 CLAUDE.md
+AGENTS.md
 .cursor/
+.claude/
+.agents/

--- a/agentic/skills/README.md
+++ b/agentic/skills/README.md
@@ -1,0 +1,38 @@
+# Agentic skills
+
+Project-authored [Agent Skills](https://docs.cursor.com/agent/skills) for this repository. These are **opt-in**: neither Cursor nor Claude Code loads skills from `agentic/skills/` automatically, so they won't collide with anything a developer already has under `~/.cursor/skills/` or `~/.claude/skills/`.
+
+Opt in by symlinking this directory into whichever tool you use. From the repo root:
+
+```bash
+# Cursor
+mkdir -p .cursor && ln -s ../agentic/skills .cursor/skills
+
+# Claude Code
+mkdir -p .claude && ln -s ../agentic/skills .claude/skills
+```
+
+`.cursor/` and `.claude/` are already gitignored (add entries if they aren't), so the symlinks stay local. If you want to be selective, symlink individual skill directories instead of the whole folder:
+
+```bash
+ln -s ../../agentic/skills/<skill-name> .cursor/skills/<skill-name>
+```
+
+## Layout
+
+Each skill is a directory containing a `SKILL.md` with YAML frontmatter:
+
+```
+agentic/skills/
+├── README.md
+└── <skill-name>/
+    ├── SKILL.md          # required: name, description, body
+    ├── reference.md      # optional: deeper docs, linked from SKILL.md
+    └── scripts/          # optional: executable helpers
+```
+
+The `SKILL.md` format is the same for Cursor and Claude Code: YAML frontmatter with `name` (lowercase-hyphenated, ≤64 chars) and `description` (specific, third person, includes both *what* and *when*), followed by markdown instructions. Keep the body under ~500 lines and push long-form reference into sibling files.
+
+## Authoring
+
+When adding a skill, prefer codifying conventions already visible in the codebase over re-deriving them. The goal is to reduce drift between human-written code and agent-written code, not to invent new style.

--- a/agentic/skills/README.md
+++ b/agentic/skills/README.md
@@ -1,6 +1,6 @@
 # Agentic skills
 
-Project-authored [Agent Skills](https://docs.cursor.com/agent/skills) for this repository. These are **opt-in**: neither Cursor nor Claude Code loads skills from `agentic/skills/` automatically, so they won't collide with anything a developer already has under `~/.cursor/skills/` or `~/.claude/skills/`.
+Project-authored [Agent Skills](https://docs.cursor.com/agent/skills). These are **opt-in**: neither agent (claude, cursor, ... ) loads skills from `agentic/skills/` automatically, so they won't collide with anything a developer already has under, e.g., `~/.cursor/skills/` or `~/.claude/skills/`.
 
 Opt in by symlinking this directory into whichever tool you use. From the repo root:
 
@@ -10,12 +10,15 @@ mkdir -p .cursor && ln -s ../agentic/skills .cursor/skills
 
 # Claude Code
 mkdir -p .claude && ln -s ../agentic/skills .claude/skills
+
+# Other / general agents
+mkdir -p .agents && ln -s ../agentic/skills .agents/skills
 ```
 
-`.cursor/` and `.claude/` are already gitignored (add entries if they aren't), so the symlinks stay local. If you want to be selective, symlink individual skill directories instead of the whole folder:
+`.cursor/` / `.claude/` / `.agents/` are already gitignored (add entries if they aren't), so the symlinks stay local. If you want to be selective, symlink individual skill directories instead of the whole folder:
 
 ```bash
-ln -s ../../agentic/skills/<skill-name> .cursor/skills/<skill-name>
+ln -s ../../agentic/skills/<skill-name> <.cursor|.claude|.agents>/skills/<skill-name>
 ```
 
 ## Layout
@@ -31,7 +34,7 @@ agentic/skills/
     └── scripts/          # optional: executable helpers
 ```
 
-The `SKILL.md` format is the same for Cursor and Claude Code: YAML frontmatter with `name` (lowercase-hyphenated, ≤64 chars) and `description` (specific, third person, includes both *what* and *when*), followed by markdown instructions. Keep the body under ~500 lines and push long-form reference into sibling files.
+The `SKILL.md` format follows the vendor-neutral specification [agentskills.io](https://agentskills.io/specification) and is compatible with claude, cursor, and other agents: YAML frontmatter with `name` (lowercase-hyphenated, ≤64 chars) and `description` (specific, third person, includes both *what* and *when*), followed by markdown instructions. Keep the body under ~500 lines and push long-form reference into sibling files.
 
 ## Authoring
 

--- a/agentic/skills/flashdreams-recipe-architecture/SKILL.md
+++ b/agentic/skills/flashdreams-recipe-architecture/SKILL.md
@@ -1,0 +1,465 @@
+---
+name: flashdreams-recipe-architecture
+description: Navigate the flashdreams package layout and recipe architecture — what belongs in core vs infra vs recipes, which abstract contracts a recipe must fulfil (Transformer, Encoder, Decoder, Pipeline, configs), how AR caches / CP / CFG / KV cache / CUDA-graph wrapping fit together, and where new tests live. Use when adding a new recipe under flashdreams/flashdreams/recipes/, when editing an existing recipe's configs or pipeline wiring, when porting a network into the flashdreams framework, or when the user asks where a piece of code should live. The `template` recipe is the source of truth for the reference design.
+---
+
+# flashdreams recipe architecture
+
+Read before adding a recipe under `flashdreams/flashdreams/recipes/` or making a structural change to an existing one. The goal: place code in the correct layer, fulfil the right contracts, and stay consistent with `recipes/template/` — the reference recipe that exercises every framework contract end-to-end.
+
+Keep docstrings consistent with the `python-docstring-style` skill.
+
+## 1. Three-layer mental model
+
+```
+flashdreams/
+├── core/        reusable primitives (no recipe-specific code)
+├── infra/       framework contracts + orchestration code (ABCs + base configs)
+└── recipes/     concrete model bindings that satisfy the infra contracts
+```
+
+**`core/`** — shared numerical building blocks. Never imports from `recipes/`. Includes `attention/` (`NativeAttention`, `RingAttention`, `BlockKVCache`), `checkpoint/load.py`, `distributed/` (`split_inputs_cp`, `cat_outputs_cp`, `*_object_list`), `io/`.
+
+**`infra/`** — the framework. ABCs, protocols, orchestration, pipeline wiring. Defines the contracts every recipe satisfies:
+
+- `infra.config` — `InstantiateConfig[T]`, `derive_config`, `PrintableConfig`.
+- `infra.pipeline` — `StreamInferencePipeline`, `StreamInferencePipelineConfig`, `StreamInferencePipelineCache`.
+- `infra.diffusion.{model, scheduler, transformer}` — `DiffusionModel`, `Scheduler` ABC (`FlowMatch*` implementations), `Transformer` ABC + `TransformerAutoregressiveCache`.
+- `infra.encoder`, `infra.decoder` — `Encoder`/`Decoder` ABCs and `NullEncoder` (identity; always-on plug-point stub).
+- `infra.compile` — `compile_module(..., mode="max-autotune-no-cudagraphs")`.
+- `infra.cuda_graph` — `CUDAGraphWrapper` with `warmup / drain / __call__ / reset`.
+- `infra.profiler` — `EventProfiler`.
+
+**`recipes/<name>/`** — concrete models. One model family per recipe. `recipes/template/` is the minimal reference; treat it as the design source of truth.
+
+### When in doubt about layer
+
+| Question | Layer |
+|---|---|
+| New attention variant or shared CUDA utility? | `core/` |
+| Reusable text/image encoder any recipe could use? | `infra/encoder/<kind>/` |
+| New ABC or generic orchestrator? | `infra/` |
+| Model-specific DiT, control encoder, or VAE? | `recipes/<name>/` |
+| CLI entry points, profiling scripts? | `run_*.py` under the recipe |
+
+Never add recipe-specific branching to `infra/` or `core/`; expose another slot or override instead.
+
+## 2. What a recipe owns vs what infra gives you
+
+Green = `core/` + `infra/` (inherit or compose). Red = recipe-authored. Solid = containment, dashed = subclass.
+
+```mermaid
+flowchart TB
+    classDef infra fill:#d6f5d6,stroke:#2e7d32,color:#1b5e20
+    classDef recipe fill:#fddede,stroke:#c62828,color:#b71c1c
+    classDef core fill:#e3e8ff,stroke:#3949ab,color:#1a237e
+
+    subgraph CORE["flashdreams.core (primitives)"]
+        direction LR
+        BKV["BlockKVCache"]:::core
+        ATT["NativeAttention<br/>RingAttention"]:::core
+        CP["split_inputs_cp<br/>cat_outputs_cp"]:::core
+        CKPT["load_checkpoint"]:::core
+    end
+
+    subgraph INFRA["flashdreams.infra (contracts)"]
+        direction TB
+        PIPE["StreamInferencePipeline<br/>+ Config + Cache"]:::infra
+        DM["DiffusionModel<br/>+ Config + FinalState"]:::infra
+        SCH["Scheduler (ABC)<br/>FlowMatch / UniPC"]:::infra
+        TF["Transformer (ABC)<br/>+ AR Cache (base)"]:::infra
+        ENC["Encoder (ABC)<br/>+ NullEncoder"]:::infra
+        DEC["Decoder (ABC)"]:::infra
+        CFG["InstantiateConfig<br/>derive_config"]:::infra
+        CG["CUDAGraphWrapper"]:::infra
+        CMP["compile_module"]:::infra
+    end
+
+    subgraph RECIPE["flashdreams.recipes.&lt;name&gt; (your code)"]
+        direction TB
+        RCFG["config.py<br/>build_&lt;variant&gt;(...) → PipelineConfig<br/>&lt;NAME&gt;_CONFIG_BUILDERS"]:::recipe
+        RT["transformer/__init__.py<br/>YourTransformer + Cache + Config<br/>(owns context_encoder slot)"]:::recipe
+        RN["transformer/network.py<br/>per-block network + NetworkCache"]:::recipe
+        RE["encoder.py (optional)<br/>per-AR-step control encoder"]:::recipe
+        RD["decoder.py (optional)<br/>latent → pixels"]:::recipe
+        RPIPE["pipeline.py (rare)<br/>StreamInferencePipeline subclass"]:::recipe
+    end
+
+    PIPE --> DM
+    PIPE --> ENC
+    PIPE --> DEC
+    DM --> TF
+    DM --> SCH
+    TF --> BKV
+    TF --> CP
+    TF --> CG
+    TF --> CMP
+    TF --> CKPT
+    TF --> ENC
+
+    RT -.->|subclass| TF
+    RT -.->|hosts| ENC
+    RE -.->|subclass| ENC
+    RD -.->|subclass| DEC
+    RPIPE -.->|subclass| PIPE
+    RCFG -.->|produces| PIPE
+
+    RT --> RN
+    RN --> ATT
+    RN --> BKV
+```
+
+**Minimum viable recipe** (matches `recipes/template/`):
+
+- `transformer/__init__.py` — `YourTransformer(Transformer[YourTransformerCache])`, `YourTransformerCache(TransformerAutoregressiveCache)`, `YourTransformerConfig(InstantiateConfig[YourTransformer])`.
+- `transformer/network.py` — the per-block network + its `NetworkCache` / `NetworkConfig`.
+- `config.py` — one `build_*(...) -> StreamInferencePipelineConfig`.
+
+`pipeline.py` is only required when you need a custom `initialize_cache` signature; `encoder.py` / `decoder.py` are only required when you own those stages. Text / CLIP-image encoders plug into `YourTransformerConfig.context_encoder` (see §5.2 and §6.3), not a new pipeline subclass.
+
+## 3. Recipe package layout
+
+The template layout is the minimum; richer recipes add more:
+
+```
+recipes/<name>/
+├── __init__.py              usually empty
+├── config.py                build_<variant>(...) → PipelineConfig; <NAME>_CONFIG_BUILDERS
+├── transformer/
+│   ├── __init__.py          Transformer subclass + Cache + Config
+│   └── network.py           per-block network + NetworkCache (or impl/ subpackage if split)
+├── encoder.py               per-AR-step control encoder (optional)
+├── decoder.py               VAE / projection decoder (optional)
+├── pipeline.py              StreamInferencePipeline subclass (optional, rare)
+└── constants.py             checkpoint URIs / prompts (optional)
+```
+
+Variants:
+
+- Many trained sizes → split `config.py` into a `config/` package (one file per variant).
+- Complex network → split `transformer/network.py` into `transformer/impl/` with `modules.py`, `network.py`, `rope.py`, etc.
+- Decoder-only recipe (e.g. standalone VAE) → export a `Decoder` subclass and config; skip `transformer/`, `pipeline.py`, `config.py`.
+
+## 4. Rollout call chain
+
+One rollout = `initialize_cache` → N × (`generate` + `finalize`). Bidirectional case is N = 1; streaming AR is N ≥ 2. One-shot context (text prompts, reference frames) is encoded inside the transformer's `initialize_autoregressive_cache` via `context_encoder`. The per-AR-step `encoder` runs once per AR step; the `decoder` runs once per AR step on the clean latent.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as user
+    participant P as StreamInferencePipeline
+    participant E as Encoder<br/>(per-AR-step, optional)
+    participant DM as DiffusionModel
+    participant T as YourTransformer
+    participant CE as context_encoder<br/>(one-shot)
+    participant S as Scheduler
+    participant C as YourCache (AR cache)
+    participant D as Decoder<br/>(optional)
+
+    Note over U,D: one-time setup
+    U->>P: initialize_cache(transformer_context,<br/>encoder_context, decoder_context)
+    P->>T: initialize_autoregressive_cache(**transformer_context)
+    T->>CE: forward(context) → context_embeddings
+    T->>CE: forward(negative_context)<br/>if guidance_scale > 1.0
+    T-->>C: allocate KV slots, project context,<br/>optional uncond cache,<br/>lazy CUDAGraphWrapper(s)
+    T->>P: YourCache
+    P-->>E: initialize_autoregressive_cache(**encoder_context)
+    P-->>D: initialize_autoregressive_cache(**decoder_context)
+    P->>U: PipelineCache
+
+    Note over U,D: per AR step (loop ar_idx = 0..N-1)
+    U->>P: generate(ar_idx, cache, input)
+    rect rgba(220, 235, 255, 0.5)
+        Note over P,E: AR Encode (optional)
+        P->>E: forward(control_input, ar_idx, cache.encoder_cache)
+        E-->>P: input_latent (before patchify and CP)
+    end
+    P->>DM: generate(ar_idx, cache.transformer_cache, input_latent)
+    rect rgba(220, 235, 255, 0.5)
+        Note over DM,T: Patchify and Split CP
+        DM->>T: patchify_and_maybe_split_cp(input_latent)
+        T-->>DM: input_latent (after patchify and CP)
+    end
+    rect rgba(255, 240, 220, 0.5)
+        Note over DM,C: pre-step hook
+        DM->>C: start(ar_idx)<br/>→ network_cache.before_update(ar_idx)
+    end
+    DM->>DM: noisy_latent_0 = randn(T.latent_shape)
+    rect rgba(230, 250, 230, 0.5)
+        Note over DM,S: Scheduler Sample — loop num_inference_steps
+        loop
+            DM->>S: step(noisy_i, t_i, predict_flow)
+            S->>T: predict_flow(noisy, t, cache, input)
+            Note right of T: CFG branch:<br/>flow = uncond + s*(cond - uncond)
+            T-->>S: flow
+            S-->>DM: noisy_{i+1}
+        end
+        DM->>DM: clean_latent := noisy_n
+    end
+    DM->>T: postprocess_clean_latent(clean, cache, input)
+    rect rgba(220, 235, 255, 0.5)
+        Note over DM,T: Unpatchify and Gather CP
+        DM->>T: unpatchify_and_maybe_gather_cp(clean)
+        T-->>DM: clean_latent (before patchify and CP)
+    end
+    DM-->>P: (clean_latent, FinalState)
+    rect rgba(220, 235, 255, 0.5)
+        Note over P,D: AR Decode (optional)
+        P->>D: forward(clean, ar_idx, cache.decoder_cache)
+        D-->>P: video_chunk
+    end
+    P-->>U: video_chunk
+
+    Note over U,D: advance the KV cache for the next AR step
+    U->>P: finalize(ar_idx, cache)
+    P->>DM: finalize(final_state)
+    alt context_noise > 0
+        DM->>S: add_noise(clean, timestep=context_noise)
+        S-->>DM: noisy_latent
+    else
+        DM->>DM: noisy_latent := clean
+    end
+    rect rgba(230, 250, 230, 0.5)
+        Note over DM,T: finalize_kv_cache (one extra predict for KV advance)
+        DM->>T: finalize_kv_cache(noisy, context_noise, cache, input)
+    end
+    rect rgba(255, 240, 220, 0.5)
+        Note over DM,C: post-step hook
+        DM->>C: finalize(ar_idx)<br/>→ network_cache.after_update(ar_idx)
+    end
+```
+
+### Shape boundaries
+
+Two disjoint shape regimes, separated by `patchify_and_maybe_split_cp`:
+
+- **Before patchify / gather**: everything the user, pipeline, encoder, and decoder see. Canonical layout `[B, C, T, H, W]` for video, `[B, N_ctx, D]` for context tokens.
+- **After patchify / split**: everything the network and scheduler touch. Canonical layout `[B, L/cp_size, C]` with `L = T*H*W`.
+
+The patchify hooks are the *only* place that boundary crosses. Never split or gather at a call site.
+
+## 5. The contracts a recipe must fulfil
+
+Scaffold in dependency order.
+
+### 5.1 Transformer (always required)
+
+Subclass `flashdreams.infra.diffusion.transformer.Transformer[YourCache]`. Must implement:
+
+- `latent_shape` (property): **per-rank** shape of the tensor `DiffusionModel.generate` will allocate noise at. Must already reflect CP sharding.
+- `predict_flow(noisy_latent, timestep, cache, input=None) -> Tensor`: one flow-match forward on the patchified latent, with CFG merge when `cache.network_cache_uncond` is populated.
+- `patchify_and_maybe_split_cp(x)` / `unpatchify_and_maybe_gather_cp(x)`: inverse pair mapping between the two shape regimes.
+- `initialize_autoregressive_cache(**transformer_context) -> YourCache`: build the per-rollout cache (encode context, allocate KV buffers, lazy-build `CUDAGraphWrapper`s).
+
+Optional overrides:
+
+- `postprocess_clean_latent(clean, cache, input)`: stamp known regions into predicted `x0` (e.g. I2V first-frame pinning). Default identity.
+- `finalize_kv_cache(...)`: default runs one extra `predict_flow`; override for dual-network DiTs or to honour `skip_finalize_kv_cache`.
+
+Your cache subclass hoists KV pre/post-updates out of the (potentially graph-captured) forward:
+
+```python
+@dataclass(kw_only=True)
+class YourTransformerCache(TransformerAutoregressiveCache):
+    network_cache: YourNetworkCache
+    network_cache_uncond: YourNetworkCache | None = None  # CFG off when None
+    autoregressive_index: int = -1
+
+    def start(self, autoregressive_index: int) -> None:
+        self.autoregressive_index = autoregressive_index
+        self.network_cache.before_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.before_update(autoregressive_index)
+
+    def finalize(self, autoregressive_index: int) -> None:
+        self.network_cache.after_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.after_update(autoregressive_index)
+```
+
+### 5.2 Transformer config (the context_encoder slot)
+
+Every transformer config owns two encoder-shaped knobs that are easy to confuse:
+
+- `context_encoder: InstantiateConfig[Encoder]` — **one-shot**, runs inside `initialize_autoregressive_cache`. Turns raw context (prompts, reference frames) into `context_embeddings`. Defaults to `NullEncoderConfig()` (identity) so pre-shaped tensors pass straight through; plug a text or CLIP image encoder here.
+- `network: YourNetworkConfig` — the underlying per-block network.
+
+Other knobs the template config standardises (all optional to inherit; keep names stable for tooling):
+
+- `dtype`, `checkpoint_path` (`None` → random init), `guidance_scale`, `len_t`, `window_size_t`, `sink_size_t`, `compile_network`, `use_cuda_graph`, `cuda_graph_warmup_iters`.
+- A property `requires_negative_context_embeddings` → `guidance_scale > 1.0`, for assertion at cache build time.
+
+### 5.3 Per-AR-step Encoder (optional)
+
+Subclass `flashdreams.infra.encoder.Encoder[YourEncoderCache]` when you need a *per-AR-step* control input (HDMap, camera control, first-frame VAE for I2V). Contract:
+
+- `forward(input, autoregressive_index=0, cache=None) -> Tensor` — output is in the pre-patchify regime.
+- `initialize_autoregressive_cache(**encoder_context) -> YourEncoderCache` — return a fresh cache even when stateless (`EncoderAutoregressiveCache()`).
+
+Set `encoder=None` in the pipeline config to disable; `pipeline.generate(input=None)` then round-trips.
+
+### 5.4 Decoder (optional)
+
+Subclass `flashdreams.infra.decoder.Decoder[YourDecoderCache]` for the final latent → pixel stage. Same shape as `Encoder`: input is a clean latent, output is pixels. `decoder=None` returns the unpatchified clean latent directly (training, latent eval).
+
+### 5.5 Pipeline (rare)
+
+The base `StreamInferencePipeline` is concrete and sufficient for the template and most recipes. Subclass only when you need a custom `initialize_cache` signature that wraps caller inputs (e.g. `text: list[list[str]]`, reference image) into the generic `transformer_context` / `encoder_context` / `decoder_context` dicts before forwarding.
+
+If none of that applies, use `StreamInferencePipelineConfig` directly and plug encoders into the slots provided (`pipeline.encoder`, `pipeline.decoder`, `transformer.context_encoder`).
+
+When subclassing, mirror the template:
+
+```python
+@dataclass(kw_only=True)
+class YourPipelineConfig(StreamInferencePipelineConfig):
+    _target: type["YourPipeline"] = field(default_factory=lambda: YourPipeline)
+
+YourPipelineCache: TypeAlias = StreamInferencePipelineCache[
+    YourEncoderCache, YourTransformerCache, YourDecoderCache,
+]
+```
+
+### 5.6 Configs and builders
+
+- Every config is `@dataclass(kw_only=True)` extending `InstantiateConfig[Target]` with `_target = field(default_factory=lambda: Target)`. Never use a bare instance as a default — always `field(default_factory=...)`.
+- Use `__post_init__` for cross-field validation and computing derived quantities.
+- Write `build_<variant>(...) -> StreamInferencePipelineConfig` (or your subclass) in `config.py`. Keyword-only, sensible defaults.
+- Register all builders in `<NAME>_CONFIG_BUILDERS: dict[str, Callable[..., ...]]` so downstream harnesses can enumerate them.
+- **Prefer `derive_config(base, **changes)` over duplicating a builder body.** It deep-copies and applies nested patches:
+  ```python
+  derive_config(
+      base,
+      diffusion_model=dict(
+          transformer=dict(guidance_scale=3.0),
+          scheduler=dict(num_inference_steps=8),
+      ),
+  )
+  ```
+- Publish reusable derive-patches as helpers alongside the builders. The template ships `with_compile_and_cuda_graph(base)` for the compile + CUDA-graph fast path.
+
+## 6. Cross-cutting conventions
+
+### 6.1 Latent shape and patchify
+
+Two common layouts:
+
+- **Flat `[*batch_shape, L, D]`** with `L = T*H*W`. Simpler; CP splits along `L`. The template uses this.
+- **Structured `[*batch_shape, V, T, HW, D]`** or similar. Needed for hierarchical CP groups (per-view × per-time × per-space).
+
+Rules:
+
+- `latent_shape` reports the **per-rank** shape — already CP-divided. It's populated by `initialize_autoregressive_cache` (spatial dims `H`, `W` are per-rollout args), so reading it before the cache is initialised must assert.
+- `patchify_and_maybe_split_cp` is the *only* place CP splitting happens.
+- When the encoder output is a struct (e.g. `ctrl_latent + mask`), patchify each field independently and return the same struct type — `DiffusionModel.generate` forwards opaquely.
+
+### 6.2 Context parallelism
+
+- **Auto-detect CP size** at transformer construction from `torch.distributed.get_world_size()`; fall back to `1` when not initialised. Don't duplicate `cp_size` on the recipe config — the launcher (`torchrun --nproc_per_node=N`) is the single source of truth.
+- Use `split_inputs_cp(x, seq_dim=..., cp_group=...)` / `cat_outputs_cp(...)`; pass `cp_group=None` as the single-GPU no-op.
+- For per-view lists (strings, view names), use the `_object_list` variants.
+- Prefer `flashdreams.core.attention.RingAttention` over manual all-gather + SDPA — it fuses the cross-rank KV gather with SDPA via a log-sum-exp merge.
+- Every divisibility assumption belongs at cache-build time or in `__post_init__`, with a readable message. Typical: `len_t * height * width % cp_size == 0`.
+
+### 6.3 One-shot context vs per-AR-step encoder
+
+| | one-shot `context_encoder` | per-AR-step `encoder` |
+|---|---|---|
+| **Slot** | `YourTransformerConfig.context_encoder` | `StreamInferencePipelineConfig.encoder` |
+| **Runs** | once, inside `initialize_autoregressive_cache` | every AR step, inside `pipeline.generate` |
+| **Input** | raw prompts / reference frames | per-step control (HDMap, camera, ...) |
+| **Output** | `context_embeddings` for the full rollout | per-step latent in pre-patchify regime |
+| **Disable** | `NullEncoderConfig()` (identity) | `encoder=None` |
+
+Getting this wrong is a common pitfall: putting a text encoder on the per-AR-step slot re-runs it for every AR step.
+
+### 6.4 Classifier-free guidance
+
+- Store an optional `network_cache_uncond` on the per-rollout cache. `None` means CFG off.
+- The `requires_negative_context_embeddings` property drives the assertion: CFG on implies a `negative_context` must be supplied at cache build time.
+- In `predict_flow`, short-circuit to the cond branch when `network_cache_uncond is None`; otherwise return `flow_uncond + s * (flow_cond - flow_uncond)`.
+- When wrapping the network in `CUDAGraphWrapper`, allocate **two independent wrapper instances** (one per branch) with identical `warmup_iters`. The residual stream diverges at the first context-bias addition so cond and uncond must not share static buffers.
+- Only encode `negative_context` when CFG is actually on:
+
+```python
+if cfg.requires_negative_context_embeddings:
+    assert negative_context is not None, "...guidance_scale > 1.0 requires negative_context."
+    negative_context_embeddings = self.context_encoder(input=negative_context)
+    network_cache_uncond = self.network.initialize_cache(..., context=negative_context_embeddings)
+```
+
+### 6.5 KV cache + CUDA graphs + `torch.compile`
+
+`BlockKVCache` has two code paths — *filling* (append + slice) and *steady-state* (roll-left + overwrite). Dynamo traces each branch as a separate subgraph; each autotunes separately the first time it runs.
+
+Contract for recipes that wrap the network in a `CUDAGraphWrapper`:
+
+1. Compile with `compile_module(network)` — pins `mode="max-autotune-no-cudagraphs"`, so `torch.compile` does **not** manage its own CUDA graphs.
+2. Wrap the compiled module in `CUDAGraphWrapper(network, warmup_iters=cfg.cuda_graph_warmup_iters)`. `warmup_iters >= 2` drains Inductor autotune on the eager path before capture.
+3. **Build the wrapper lazily inside `initialize_autoregressive_cache`.** The graph captures against the current KV-cache pointers, so a fresh rollout (new H/W, new cache) needs a fresh wrapper. CFG → two wrappers.
+4. Dispatch per AR step via a precomputed `_cuda_graph_capture_ar_idx` (named `_steady_ar_idx` in older recipes):
+   ```python
+   _cuda_graph_capture_ar_idx = (cfg.sink_size_t + cfg.window_size_t) // cfg.len_t
+   ```
+   AR steps `ar_idx < _cuda_graph_capture_ar_idx` go through `wrapper.drain` (eager — drains autotune AND exercises the cache's slice-returning filling path). AR steps `>= _cuda_graph_capture_ar_idx` go through `wrapper.__call__` (warmup → capture → replay).
+5. Any buffer the captured graph writes through in-place (KV slots, staged outputs) must have a stable storage address across replays. `CUDAGraphWrapper` only stages top-level tensor args.
+
+If you see `cudaErrorStreamCaptureUnsupported` or `operation not permitted when stream is capturing`, you're almost certainly autotune-firing inside capture — re-check the dispatch threshold and that `.drain` is used throughout the filling phase.
+
+Because these wrappers are expensive to build and hold GPU buffers, the template defaults `compile_network=False` and `use_cuda_graph=False` and exposes `with_compile_and_cuda_graph(base)` as the opt-in patch.
+
+### 6.6 Scheduler
+
+Pick from `FlowMatchSchedulerConfig` (self-forcing, 1–4 step) or a UniPC variant (full 35–50 step bidirectional). Both live under `infra.diffusion.scheduler`. The scheduler config is a field on `DiffusionModelConfig`, not on the recipe or pipeline config.
+
+### 6.7 Checkpoint loading
+
+Use `flashdreams.core.checkpoint.load.load_checkpoint(path)`. Standard shape:
+
+```python
+if config.checkpoint_path is not None:
+    state_dict = load_checkpoint(config.checkpoint_path)
+    self.network.load_state_dict(state_dict)
+```
+
+Supply a `state_dict_transform` on your transformer config when upstream training adds a prefix (e.g. `net.`, `generator_ema.model.`). `checkpoint_path=None` keeps the random init — the right default for unit tests.
+
+## 7. Testing conventions
+
+- Tests live in **`flashdreams/tests/test_<recipe>.py`** — top-level `tests/`, not inside the recipe.
+- `pytest`, plain helper functions; `@pytest.mark.parametrize` for seed / variant sweeps.
+- Unit tests default to `checkpoint_path=None`, `compile_network=False`, `use_cuda_graph=False`. Flip the fast-path knobs in a dedicated equivalence test comparing against the eager baseline.
+- CFG on/off is a `derive_config` patch on the base builder, not a separate builder.
+- CP equivalence is a **two-invocation test**:
+  1. Plain `pytest` (no distributed init) writes a reference tensor to `<tmpdir>/<recipe>/cp_reference.pt`.
+  2. A `torchrun --nproc_per_node=N` launch re-runs the same deterministic inputs and asserts the gathered output matches.
+  Run both in the same `srun` (or set a shared `*_CP_REF_PATH`) so they share `/tmp`.
+- Smoke shape: construct the config, `.setup().to("cuda").eval()`, build inputs with `cfg.dtype`, run `>= 2` AR steps (covers filling + the first steady step when `window_size_t == 2 * len_t`), assert output shape / device / finiteness.
+
+## 8. Scaffolding checklist
+
+When adding a new recipe `foo`:
+
+1. `recipes/foo/transformer/network.py` — per-block network + `FooNetworkCache` + `FooNetworkConfig`. Use `flashdreams.core.attention.RingAttention` for CP-aware attention.
+2. `recipes/foo/transformer/__init__.py` — `FooTransformerConfig` (with `context_encoder: InstantiateConfig[Any] = NullEncoderConfig`, `checkpoint_path: str | None = None`, `compile_network=False`, `use_cuda_graph=False`, `cuda_graph_warmup_iters=2`), `FooTransformerCache`, `FooTransformer(Transformer[FooTransformerCache])`. Implement all five abstract members; auto-detect CP size.
+3. (Optional) `recipes/foo/encoder.py` for per-AR-step control.
+4. (Optional) `recipes/foo/decoder.py` for the final stage.
+5. (Rare) `recipes/foo/pipeline.py` only if the base pipeline's `initialize_cache` signature doesn't fit.
+6. `recipes/foo/config.py` — at least one `build_foo_<variant>(...) -> StreamInferencePipelineConfig`, a second derived variant via `derive_config`, a `FOO_CONFIG_BUILDERS` dict, and a `with_compile_and_cuda_graph(base)` helper if you want the fast path.
+7. `flashdreams/tests/test_foo.py` — bidirectional + streaming smoke tests, CFG on/off via `derive_config`, no-control branch, compile + CUDA-graph equivalence, CP equivalence (two-invocation). Parametrise seed for determinism checks.
+
+## 9. Common pitfalls
+
+- **`latent_shape` returning the pre-CP (global) shape.** `DiffusionModel.generate` draws noise at this shape on this rank — must match the patchified latent after `split_inputs_cp`.
+- **Reading `latent_shape` before `initialize_autoregressive_cache`.** Per-rollout `(batch_size, H, W)` is populated lazily; reading earlier must assert, not silently return stale / `None`-laden values.
+- **Sharing one `CUDAGraphWrapper` across cond and uncond.** Capture fails or silently reuses stale activations. Allocate two.
+- **Building the `CUDAGraphWrapper` in `__init__` instead of `initialize_autoregressive_cache`.** The graph binds to the first cache's KV pointers; the second rollout then reads stale storage. Rebuild per rollout.
+- **`_cuda_graph_capture_ar_idx = chunks_total // len_t - 1`.** Off-by-one — that's the last filling step, not the first steady step.
+- **`compile_network=True` with `mode="max-autotune"`.** `torch.compile` then owns its own CUDA graphs and conflicts with `CUDAGraphWrapper`. Always go through `compile_module`.
+- **Bare instance as a `@dataclass` default.** Every pipeline config picks up the same mutable nested config; mutations leak between rollouts. Use `field(default_factory=...)`.
+- **Recipe-specific imports in `infra/` or `core/`.** Breaks the dependency direction.
+- **Plugging a text / CLIP-image encoder into the pipeline's per-AR-step `encoder` slot.** That slot runs every AR step. One-shot encoders go on `YourTransformerConfig.context_encoder` (see §6.3).
+- **Hard-coding `cp_size` on the recipe config.** Auto-detect from `torch.distributed.get_world_size()` instead; the launcher is the single source of truth.
+- **Unconditional `negative_context` encoding.** Only encode inside the `if cfg.requires_negative_context_embeddings:` branch so CFG-off rollouts don't pay for the extra pass.
+- **Asserting shape on a raw input with no shape hint in the error message.** Different recipes feed different rank layouts; add an `ndim` + `.shape` hint in `patchify_and_maybe_split_cp`'s assertion.

--- a/agentic/skills/python-docstring-style/SKILL.md
+++ b/agentic/skills/python-docstring-style/SKILL.md
@@ -12,7 +12,7 @@ House style distilled from `flashdreams/`. Match it when adding or editing Pytho
 Every `.py` file starts with the SPDX + Apache-2.0 block, then a blank line, then the module docstring, then a blank line, then imports.
 
 ```python
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) <YEAR> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,10 @@ Every `.py` file starts with the SPDX + Apache-2.0 block, then a blank line, the
 
 """Block KV cache for causal attention with a fixed-size local window."""
 ```
+
+**`<YEAR>` is the *current* calendar year, not a hardcoded literal.** Before stamping the header into a brand-new file, look up today's date (the agent host's clock, the system context, or `date +%Y` in a shell) and substitute it. The conversation's training-cutoff year is *not* the source of truth — emit e.g. `Copyright (c) 2027 …` if the file is being created in 2027.
+
+When **editing an existing file**, leave the existing year alone — the SPDX year reflects when the file was first authored, not when it was last touched. Only update the year if the file genuinely had no header before, or you're explicitly asked to refresh copyright years across the tree.
 
 ## Module docstring
 

--- a/agentic/skills/python-docstring-style/SKILL.md
+++ b/agentic/skills/python-docstring-style/SKILL.md
@@ -233,6 +233,78 @@ Practical rules:
 - **Custom section labels** like `Phases:`, `Per-step usage:`, `Typical usage example:` are **not** Napoleon-recognised. They render as plain paragraphs at best, and a stray blank-line can turn them into field-list warnings under `warningiserror`. Prefer `Note:` / `Example:` / `Examples:` (Napoleon-recognised) for anything callout-shaped. If a genuinely custom section is unavoidable, register it via `napoleon_custom_sections` in `conf.py` before using it in code.
 - **`Attributes:` section is legal**, but we document fields with PEP 257 attribute docstrings (see above) and let autodoc discover them — don't duplicate.
 
+## Developer voice — don't write a commit-log
+
+Docstrings and comments are read by the next developer opening the file, not by a reviewer scanning a diff. Describe the *interface* and any invariant a caller must not violate. Everything else — why the change was made, what it used to be, kernel / tolerance archaeology — belongs in a commit message or a review thread.
+
+Cut, on sight:
+
+- **Meta-narration.** `"Previously we..."`, `"As of this change..."`, `"now reads runtime state populated by..."`, `"no longer baked into the config"`. The diff tells that story.
+- **Decision logs that only restate the default.** `# Deliberately chosen so len_t != window_size_t / 2 != 1 — equal dims can mask off-by-one bugs.` The field's default is authoritative; if an invariant matters, state it once in one line, not as a paragraph.
+- **Retelling what a called function does.** Let the `:meth:` / `:func:` cross-reference carry it. `"Delegates to :meth:`X`."` is enough.
+- **"Callers who want Z patch on top via derive_config."** Obvious from the config module's contract — don't repeat in every builder.
+- **Example rollouts written as prose.** A `.. code-block:: bash` or the test file is cheaper to read.
+- **Tolerance archaeology.** One line for the floor (`"bf16 + TF32 ⇒ ~5e-2"`), not a bulleted breakdown per kernel.
+- **"Programming error" when an `assert` already says so.** The assert's message *is* the docstring for that case; a one-line summary plus the assert is enough.
+- **Restating the next 3 lines of code.** Rename a variable instead.
+
+Two before/after pairs:
+
+Bad (decision log + restated default):
+
+```python
+# Deliberately chosen so ``len_t != window_size_t / 2 != 1`` — equal
+# temporal dims can mask off-by-one bugs in the KV cache's
+# filling / steady bookkeeping. ``height`` and ``width`` are
+# supplied per rollout (see :meth:`…initialize_autoregressive_cache`).
+len_t: int = 2
+"""Pre-flatten latent frames per AR chunk."""
+```
+
+Good:
+
+```python
+len_t: int = 2
+"""Pre-flatten latent frames per AR chunk."""
+```
+
+Bad (inventory of what the function touches):
+
+```python
+"""Build a fully seeded cache for a new rollout.
+
+Routes raw ``context`` (and optional ``negative_context``) through
+:attr:`context_encoder` to produce the per-token context embeddings
+consumed by every block forward. Also stashes the per-rollout
+``(batch_size, height, width)`` and (when ``config.use_cuda_graph``
+is set) builds fresh :class:`CUDAGraphWrapper` instances sized to
+this rollout.
+"""
+```
+
+Good:
+
+```python
+"""Build a fully seeded cache for a new rollout.
+
+Runs ``context`` (and ``negative_context`` when CFG is on) through
+:attr:`context_encoder`, stashes the per-rollout
+``(batch_size, height, width)``, and — when ``config.use_cuda_graph``
+is set — builds fresh :class:`CUDAGraphWrapper` instances sized to
+this rollout.
+"""
+```
+
+### Polishing pass order
+
+When asked to tighten an existing file:
+
+1. Strip meta-narration and decision logs.
+2. Collapse any paragraph that restates adjacent field docstrings.
+3. Promote shape annotations out of prose into ``[B, L, C]`` tokens.
+4. Convert `"This method returns…"` → `"Return …"`; `"Will raise…"` → `"Raises…"`.
+5. Cut any `Args:` entry that only repeats the parameter name and type.
+
 ## Anti-patterns — don't adopt
 
 - reStructuredText `:param x:` / `:returns:` field lists — we use Google style. Napoleon tolerates mixing, but the rendered output is inconsistent.
@@ -241,3 +313,4 @@ Practical rules:
 - Single backticks in docstrings for non-references — Sphinx treats them as unresolved cross-references under the default role and warns.
 - Type info duplicated in `Args:` (`x (Tensor): …`) — the signature already has the type, and autodoc renders it.
 - Boilerplate "This function does X" opener — start with the verb directly.
+- Commit-log voice: `"Now uses…"`, `"Migrated from…"`, `"Originally…"`, `"Deliberately chosen so…"`. Describe the current contract, not the history.

--- a/agentic/skills/python-docstring-style/SKILL.md
+++ b/agentic/skills/python-docstring-style/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: python-docstring-style
+description: Write Python docstrings matching the flashdreams house style — SPDX header, one-line module docstring, Google-style function docstrings (Args/Returns/Raises), PEP 257 attribute docstrings on dataclass/class fields, double-backticks for code references, imperative first sentences. Use when authoring or editing any .py file under flashdreams/, when adding a new module/class/function/field, or when the user asks about docstring style.
+---
+
+# Python docstring style (flashdreams)
+
+House style distilled from `flashdreams/`. Match it when adding or editing Python code so agent output is indistinguishable from human-written code.
+
+## File header
+
+Every `.py` file starts with the SPDX + Apache-2.0 block, then a blank line, then the module docstring, then a blank line, then imports.
+
+```python
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Block KV cache for causal attention with a fixed-size local window."""
+```
+
+## Module docstring
+
+**One line**, noun phrase (not imperative), describes what the module provides — not how.
+
+- `"""Tensor and object splitting/gathering primitives for context parallelism."""`
+- `"""Reusable CUDA-graph capture wrapper for stateful inference callables."""`
+- `"""Multi-view, HDMap-conditioned Cosmos DiT for streaming alpadreams."""`
+
+If one line genuinely doesn't fit, use a one-line summary + blank line + wrapped prose, but prefer tightening the summary.
+
+## No stale inventories in headers (applies to every docstring)
+
+**Headers — module / class / function summaries — describe the *role*, not the current set of internals or supported variants.** Comma-separated or parenthetical inventories of sub-modules, sub-classes, supported backends, supported model versions, supported keyword arguments, etc. become wrong the moment something is added or removed and rarely get updated. Detail belongs in the body / `Args:` / attribute docstrings where autodoc surfaces it from the actual source.
+
+Module docstring:
+
+- Good: `"""Text encoders for diffusion conditioning."""`
+- Good: `"""Core building blocks shared across recipes."""`
+- Bad: `"""Text encoders (Cosmos Qwen, UMT5)."""` (lies when a third encoder is added)
+- Bad: `"""Core building blocks shared by all recipes (attention, checkpointing, distributed, I/O)."""`
+
+Class docstring:
+
+- Good: `"""Native attention module with configurable QKV layout and SDPA backend."""`
+- Bad: `"""Native attention (math / efficient / cudnn / flash) with bhsd|bshd layout."""` (the `Literal[...]` choices in the signature are the source of truth)
+
+Function docstring summary:
+
+- Good: `"""Configure attention format and backend."""`
+- Bad: `"""Configure attention format (bshd|bhsd) and backend (math, efficient, cudnn, flash)."""`
+
+Exception: a deliberate *feature-scope* line that names a fixed, externally-versioned surface (e.g. `"""Unified Wan inference pipeline (Wan 2.1 / Wan 2.2, T2V and I2V)."""`) is fine — those names are stable contracts, not the package's own evolving internals.
+
+## Function / method docstring
+
+Google style. Imperative first sentence. Blank line before the sections. `Args:`, `Returns:`, `Raises:` — include only what applies. Use double backticks for code references (``` ``x`` ```, ``` ``None`` ```, ``` ``x.shape[seq_dim] // cp_size`` ```).
+
+```python
+def split_inputs_cp(
+    x: Tensor, seq_dim: int, cp_group: ProcessGroup | None = None
+) -> Tensor:
+    """Slice a tensor along ``seq_dim`` to this rank's CP shard.
+
+    Args:
+        x: Input tensor.
+        seq_dim: Dimension to split along (negative indexing supported).
+        cp_group: CP process group; ``None`` returns ``x`` unchanged.
+
+    Returns:
+        Contiguous slice of length ``x.shape[seq_dim] // cp_size``.
+
+    Raises:
+        AssertionError: ``seq_dim`` is not divisible by the CP size.
+    """
+```
+
+Rules:
+
+- First sentence imperative (`"Slice …"`, `"Capture …"`, `"Return …"`), one line, ends with a period.
+- Don't repeat the type annotation in `Args:` — only the semantic meaning and any non-obvious constraints.
+- Describe `None` / default behavior inline: `"cp_group: CP process group; ``None`` returns ``x`` unchanged."`.
+- `Returns:` describes shape / semantics, not the type (type is in the signature).
+- Omit `Raises:` for purely internal asserts that callers shouldn't reason about; include it when a caller might want to catch / pattern-match.
+- Skip docstrings entirely for trivial private helpers (`_prefix`) whose body is self-explanatory. When in doubt, write one.
+
+## Class docstring
+
+Short one-liner on the `"""` line when the class is self-contained:
+
+```python
+@dataclass(kw_only=True)
+class CosmosTransformerCache(TransformerAutoregressiveCache):
+    """Long-lived AR cache for the Cosmos transformer."""
+```
+
+Multi-paragraph when the class has non-obvious structure, phases, or usage order. Use **custom section labels** (not Google's set) when they genuinely help — `Phases:`, `Per-step usage:`, `Note:`, `Typical usage example:`:
+
+```python
+class BlockKVCache:
+    """
+    KV cache for causal attention with a fixed-size local window and CUDA-graph support.
+
+    Keys and values can have arbitrary shape ``[..., total_size, ...]``; the sequence
+    (rolling) dimension is given by ``seq_dim`` (dimension index, can be negative).
+
+    Phases:
+        - Filling: cache not yet full; tokens are written contiguously;
+          ``cached_k()`` / ``cached_v()`` return only the valid prefix.
+        - Steady-state: cache full; each new chunk triggers a left-roll of the
+          local window and overwrites the rightmost positions;
+          ``cached_k()`` / ``cached_v()`` return the full buffer.
+
+    Per-step usage:
+        1. before_update(chunk_idx) — prepare (roll local window if steady-state).
+        2. update(k, v) — write the new chunk's keys/values into the cache.
+        3. cached_k() / cached_v() — get cached keys/values for attention.
+        4. after_update(chunk_idx) — update internal bookkeeping.
+    """
+```
+
+Do **not** use an `Attributes:` section in the class docstring — document attributes individually (see next section).
+
+## Dataclass / class field docstrings
+
+PEP 257 attribute docstrings: a triple-quoted string placed **on the line(s) after** each field declaration. Not `#` comments. Applies to both `@dataclass` fields and regular class attributes.
+
+```python
+@dataclass
+class BlockKVCache:
+    k_shape: tuple[int, ...]
+    """Shape of the keys. Must be the same as the values shape except for the last dimension."""
+
+    seq_dim: int
+    """Sequence dimension that will be rolled. Can be negative."""
+
+    sink_size: int = 0
+    """Number of sink tokens at the start of the cache that are never evicted. Defaults to 0."""
+
+    _prev_chunk_idx: int = -1
+    """Chunk index of the last written chunk; -1 when empty."""
+```
+
+Rules:
+
+- One sentence per attribute unless it has real nuance. Wrap at ~88 chars.
+- Include the default value's meaning when it's non-obvious (`"Defaults to 0."`, `"-1 when empty."`).
+- Document private (`_prefix`) fields too when their invariants matter.
+
+## Inline comments
+
+Comments explain *why* or a non-obvious invariant the code can't convey. Never narrate *what* the code does.
+
+Good:
+
+```python
+# Hoist per-block KV pre-update out of the (graph-captured) network
+# forward; predict_flow runs with eager_mode=False.
+self.autoregressive_index = autoregressive_index
+self.network_cache.before_update(autoregressive_index)
+```
+
+```python
+seq_dim = x.ndim + seq_dim  # bring it to positive dimension
+```
+
+Bad (obvious narration — omit):
+
+```python
+# Increment counter
+self._n_cached += self.chunk_size
+
+# Initialize k and v
+self._k = torch.empty(self.k_shape, device=self.device, dtype=self.dtype)
+```
+
+(The flashdreams code has occasional "initialize k and v" style comments — treat those as drift, not the standard; don't reproduce them in new code.)
+
+Other conventions:
+
+- TODO comments: `# TODO: short description` (no owner handle, no date).
+- Don't annotate a change you're making — code is read later without that context. Example of what **not** to write: `# Fixed bug where X happened` or `# Changed to use Y for performance`.
+
+## Section dividers within a file
+
+Use `##` double-hash comments as visual dividers between logical sections. Seen throughout the codebase:
+
+```python
+## Default camera names / view-index mapping
+
+DEFAULT_CAMERAS: tuple[str, ...] = (...)
+
+## Per-rollout cache
+
+@dataclass(kw_only=True)
+class CosmosTransformerCache(TransformerAutoregressiveCache):
+    ...
+```
+
+Place on its own line, one blank line before and after, short title. Don't use `# ---` rule lines or box-comments.
+
+## Formatting / voice
+
+- Line length: follow the file (most of the repo wraps around 88 chars; match what you see).
+- Backticks: double backticks `` ``x`` `` inside docstrings for code, not single or triple. Single backticks in docstrings try to resolve as cross-references and will emit warnings when they can't.
+- Shapes: annotate with double-backtick literals when it helps — `` ``[B, V, T, 1, H, W]`` ``. Use this liberally for tensor args.
+- Voice: third person descriptive for docstring summaries of classes/attributes ("Long-lived AR cache…"); imperative for functions/methods ("Slice…", "Capture…").
+- No emojis in docstrings or comments.
+
+## Sphinx / Napoleon compatibility
+
+Docs are built with `sphinx.ext.napoleon` (Google style) + `sphinx.ext.autodoc`, and `warningiserror = True` in `docs/source/conf.py` — **any malformed rST breaks CI**.
+
+Practical rules:
+
+- **Docstrings are reStructuredText, not Markdown.** Don't use `#` / `##` headings, `[text](url)` links, or triple-backtick code fences inside a docstring. For code blocks use `::` + an indented block, or the `Example:` / `Examples:` section (Napoleon renders it as a code block).
+- **Cross-references use rST roles**, not double backticks, when you want a hyperlink:
+  - `` :class:`CUDAGraphWrapper` ``, `` :meth:`BlockKVCache.update` ``, `` :func:`split_inputs_cp` ``, `` :attr:`BlockKVCache._k` ``, `` :mod:`flashdreams.infra.cuda_graph` ``, `` :obj:`None` ``.
+  - Plain double backticks are still correct for *non-linked* literal code (argument names, shapes, small expressions).
+- **Section labels Napoleon recognises** (and converts into rST admonitions / field lists):
+  `Args`, `Arguments`, `Attention`, `Attributes`, `Caution`, `Danger`, `Error`, `Example`, `Examples`, `Hint`, `Important`, `Keyword Args`, `Keyword Arguments`, `Methods`, `Note`, `Notes`, `Other Parameters`, `Parameters`, `Return`, `Returns`, `Raise`, `Raises`, `References`, `See Also`, `Tip`, `Todo`, `Warning`, `Warnings`, `Warn`, `Warns`, `Yield`, `Yields`.
+- **Custom section labels** like `Phases:`, `Per-step usage:`, `Typical usage example:` are **not** Napoleon-recognised. They render as plain paragraphs at best, and a stray blank-line can turn them into field-list warnings under `warningiserror`. Prefer `Note:` / `Example:` / `Examples:` (Napoleon-recognised) for anything callout-shaped. If a genuinely custom section is unavoidable, register it via `napoleon_custom_sections` in `conf.py` before using it in code.
+- **`Attributes:` section is legal**, but we document fields with PEP 257 attribute docstrings (see above) and let autodoc discover them — don't duplicate.
+
+## Anti-patterns — don't adopt
+
+- reStructuredText `:param x:` / `:returns:` field lists — we use Google style. Napoleon tolerates mixing, but the rendered output is inconsistent.
+- NumPy-style docstrings with `Parameters` / `----------` underlines — disabled via `napoleon_numpy_docstring = False`, renders wrong.
+- Markdown inside docstrings (headings, fenced code blocks, hyperlink syntax) — not rST, will not render and may warn.
+- Single backticks in docstrings for non-references — Sphinx treats them as unresolved cross-references under the default role and warns.
+- Type info duplicated in `Args:` (`x (Tensor): …`) — the signature already has the type, and autodoc renders it.
+- Boilerplate "This function does X" opener — start with the verb directly.

--- a/agentic/skills/python-docstring-style/SKILL.md
+++ b/agentic/skills/python-docstring-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-docstring-style
-description: Write Python docstrings matching the flashdreams house style — SPDX header, one-line module docstring, Google-style function docstrings (Args/Returns/Raises), PEP 257 attribute docstrings on dataclass/class fields, double-backticks for code references, imperative first sentences. Use when authoring or editing any .py file under flashdreams/, when adding a new module/class/function/field, or when the user asks about docstring style.
+description: Write Python docstrings and inline comments matching the flashdreams house style — SPDX header, one-line module docstring, Google-style function docstrings (Args/Returns/Raises), PEP 257 attribute docstrings on dataclass/class fields *and on module-level constants*, double-backticks for code references, imperative first sentences, and signpost-style inline block comments (kept, not stripped, on a tightening pass). Use when authoring or editing any .py file under flashdreams/, when adding a new module/class/function/field/constant, when polishing comments, or when the user asks about docstring or comment style.
 ---
 
 # Python docstring style (flashdreams)
@@ -40,28 +40,35 @@ Every `.py` file starts with the SPDX + Apache-2.0 block, then a blank line, the
 
 If one line genuinely doesn't fit, use a one-line summary + blank line + wrapped prose, but prefer tightening the summary.
 
-## No stale inventories in headers (applies to every docstring)
+## Inventories in headers — short, concrete, kept current
 
-**Headers — module / class / function summaries — describe the *role*, not the current set of internals or supported variants.** Comma-separated or parenthetical inventories of sub-modules, sub-classes, supported backends, supported model versions, supported keyword arguments, etc. become wrong the moment something is added or removed and rarely get updated. Detail belongs in the body / `Args:` / attribute docstrings where autodoc surfaces it from the actual source.
+A small inventory in a module / class header (the kind of "what's in here" line you'd want when you `cd` into the file for the first time) is *helpful*, not harmful, as long as it stays accurate. Agents are good at keeping these in sync, so the old "rarely get updated, drop them" rule is too strict for an agent-edited codebase.
 
-Module docstring:
+Keep an inventory when it's:
 
-- Good: `"""Text encoders for diffusion conditioning."""`
-- Good: `"""Core building blocks shared across recipes."""`
-- Bad: `"""Text encoders (Cosmos Qwen, UMT5)."""` (lies when a third encoder is added)
-- Bad: `"""Core building blocks shared by all recipes (attention, checkpointing, distributed, I/O)."""`
+- **Short and concrete** — one parenthetical or one comma-separated tail, not a paragraph.
+- **About a stable, named surface** — sub-modules, public helpers in this file, supported model versions, supported backends. Things that the next reader gains real orientation from.
+- **Easy to verify against the file** — if a reader can scan the file and check the line, it'll get fixed when something is added or removed.
 
-Class docstring:
+Examples that should stay:
 
+- `"""Camera-pose math: SE(3) helpers, relative poses, and Plücker rays."""`
+- `"""Unified Wan inference pipeline (Wan 2.1 / Wan 2.2, T2V and I2V)."""`
+- `"""Text encoders (Cosmos Qwen, UMT5)."""` — when this file genuinely defines exactly those two and adding a third is the kind of edit that touches this docstring anyway.
+
+Still avoid:
+
+- **Inventories of every kwarg / every option / every internal class.** Those belong in `Args:` / attribute docstrings / autodoc — the `Literal[...]` in the signature *is* the source of truth, so don't echo it in prose.
+- **Loose, sprawling inventories** that try to enumerate everything the module / class touches: `"""Core building blocks shared by all recipes (attention, checkpointing, distributed, I/O, configs, …)."""` — at this point the inventory is no longer load-bearing, just decoration.
+
+Class / function summary anti-examples:
+
+- Bad: `"""Native attention (math / efficient / cudnn / flash) with bhsd|bshd layout."""` — duplicates the `Literal[...]`.
 - Good: `"""Native attention module with configurable QKV layout and SDPA backend."""`
-- Bad: `"""Native attention (math / efficient / cudnn / flash) with bhsd|bshd layout."""` (the `Literal[...]` choices in the signature are the source of truth)
-
-Function docstring summary:
-
-- Good: `"""Configure attention format and backend."""`
 - Bad: `"""Configure attention format (bshd|bhsd) and backend (math, efficient, cudnn, flash)."""`
+- Good: `"""Configure attention format and backend."""`
 
-Exception: a deliberate *feature-scope* line that names a fixed, externally-versioned surface (e.g. `"""Unified Wan inference pipeline (Wan 2.1 / Wan 2.2, T2V and I2V)."""`) is fine — those names are stable contracts, not the package's own evolving internals.
+When in doubt: a one-line inventory that names *files / public symbols / model versions* is fine; an inline inventory of *every parameter value* belongs in the signature.
 
 ## Function / method docstring
 
@@ -91,6 +98,15 @@ Rules:
 - First sentence imperative (`"Slice …"`, `"Capture …"`, `"Return …"`), one line, ends with a period.
 - Don't repeat the type annotation in `Args:` — only the semantic meaning and any non-obvious constraints.
 - Describe `None` / default behavior inline: `"cp_group: CP process group; ``None`` returns ``x`` unchanged."`.
+- When a parameter is typed `T | None` for *signature reasons* (e.g. matching a base class) but is **required at runtime**, explain *why* the type is optional. A bare `"required (raises if None)"` is not enough — the next reader will ask "then why is it Optional?". Example:
+
+  ```text
+  cache: Per-rollout encoder cache. Typed ``Optional`` only to match
+      the :class:`Encoder` base signature (some encoders are stateless);
+      this encoder advances per-AR-step state in ``cache`` and asserts
+      when it is ``None``.
+  ```
+
 - `Returns:` describes shape / semantics, not the type (type is in the signature).
 - Omit `Raises:` for purely internal asserts that callers shouldn't reason about; include it when a caller might want to catch / pattern-match.
 - Skip docstrings entirely for trivial private helpers (`_prefix`) whose body is self-explanatory. When in doubt, write one.
@@ -158,11 +174,52 @@ Rules:
 - Include the default value's meaning when it's non-obvious (`"Defaults to 0."`, `"-1 when empty."`).
 - Document private (`_prefix`) fields too when their invariants matter.
 
+## Module-level constants
+
+Use the same PEP 257 attribute-docstring convention for module-level constants whenever the constant has a non-obvious value, a tuning rationale, or a cross-file invariant. This way the rationale shows up as a hover tooltip in editors and is reachable by autodoc — not just in a `#` comment that no tool can find.
+
+Good (rationale + tooltip-discoverable):
+
+```python
+_DEFAULT_MODEL_CHANNELS = 128
+"""``head_dim = model_channels // num_heads`` must be a size cuDNN's
+flash-attention supports; 64 is safe, 16/8 silently NaN."""
+
+_DEFAULT_DTYPE: torch.dtype = torch.bfloat16
+"""Encoder / decoder dtype — kept in lock-step with
+``TemplateTransformerConfig.dtype`` so ``input_proj`` doesn't see
+mismatched control + latent dtypes."""
+```
+
+Avoid the pure `#` form when there's a real reason for the value:
+
+```python
+# ``head_dim = model_channels // num_heads`` must be a size cuDNN's
+# flash-attention supports; 64 is safe, 16/8 silently NaN.
+_DEFAULT_MODEL_CHANNELS = 128
+```
+
+Skip the docstring entirely for self-evident constants — `_DEFAULT_NUM_HEADS = 2` doesn't need one.
+
+When converting `#`-comments-above-constant into PEP 257 docstrings, leave one blank line before the next constant so each name's docstring is unambiguously attached.
+
 ## Inline comments
 
-Comments explain *why* or a non-obvious invariant the code can't convey. Never narrate *what* the code does.
+Comments earn their place when they make the next read of this code faster. Three legitimate roles:
 
-Good:
+1. **Why / invariant** — non-obvious motivation or a constraint the code can't express.
+2. **Signpost a multi-line block** — a one-line lead-in that lets the reader skim past the next 3–10 lines instead of parsing them. This is *not* "narration"; it is structural orientation.
+3. **Local landmark on a tricky one-liner** — a few words next to a line whose intent isn't obvious from the names alone.
+
+When you're trimming or auditing a file, **be conservative about deleting existing comments**. The goal is "what helps the next reader", not "minimum comment count". A comment that would have helped you a moment ago when reading the block almost certainly helps the next person too — keep it.
+
+Good — signpost on a block:
+
+```python
+# Normalize seq_dim to a non-negative index so downstream
+# indexing math doesn't have to special-case negatives.
+self.seq_dim = self.seq_dim if self.seq_dim >= 0 else self.seq_dim + tensor_dim
+```
 
 ```python
 # Hoist per-block KV pre-update out of the (graph-captured) network
@@ -171,21 +228,38 @@ self.autoregressive_index = autoregressive_index
 self.network_cache.before_update(autoregressive_index)
 ```
 
+Good — local landmark:
+
 ```python
 seq_dim = x.ndim + seq_dim  # bring it to positive dimension
 ```
 
-Bad (obvious narration — omit):
+Bad — pure restatement of the very next line:
 
 ```python
 # Increment counter
 self._n_cached += self.chunk_size
 
-# Initialize k and v
+# Initialize k
 self._k = torch.empty(self.k_shape, device=self.device, dtype=self.dtype)
 ```
 
+Bad — restating an assertion's own message string immediately above / below it:
+
+```python
+# k and v must have the same shape except for the last dimension
+assert self.k_shape[:-1] == self.v_shape[:-1], (
+    "k and v must have the same shape except for the last dimension"
+)
+```
+
 (The flashdreams code has occasional "initialize k and v" style comments — treat those as drift, not the standard; don't reproduce them in new code.)
+
+Rule of thumb when deciding whether to keep an inline comment:
+
+- Does it summarize the next *block* (≥ 2–3 lines)? → keep.
+- Does it restate the line directly under it? → drop, or rename a variable instead.
+- Does it duplicate an `assert` message word-for-word? → drop, the message is the comment.
 
 Other conventions:
 
@@ -299,11 +373,14 @@ this rollout.
 
 When asked to tighten an existing file:
 
-1. Strip meta-narration and decision logs.
+1. Strip meta-narration and decision logs (commit-log voice, "previously…", "now reads…").
 2. Collapse any paragraph that restates adjacent field docstrings.
 3. Promote shape annotations out of prose into ``[B, L, C]`` tokens.
 4. Convert `"This method returns…"` → `"Return …"`; `"Will raise…"` → `"Raises…"`.
 5. Cut any `Args:` entry that only repeats the parameter name and type.
+6. Promote useful `#`-comment-on-a-constant lines into PEP 257 attribute docstrings on the constant.
+
+**Do not** sweep through and delete every inline comment in the name of "no narration". Inline comments that signpost a multi-line block (see [Inline comments](#inline-comments)) are part of the house style — a tightening pass should keep them, only deleting the ones that genuinely restate the next line or duplicate an `assert` message.
 
 ## Anti-patterns — don't adopt
 

--- a/flashdreams/flashdreams/__init__.py
+++ b/flashdreams/flashdreams/__init__.py
@@ -12,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Streaming inference recipes for video diffusion models."""

--- a/flashdreams/flashdreams/core/__init__.py
+++ b/flashdreams/flashdreams/core/__init__.py
@@ -12,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Core building blocks shared across recipes."""

--- a/flashdreams/flashdreams/core/attention/__init__.py
+++ b/flashdreams/flashdreams/core/attention/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Attention primitives: native SDPA, ring attention, and block KV cache."""
+"""Attention primitives and KV cache for streaming inference."""
 
 from flashdreams.core.attention.kvcache import BlockKVCache
 from flashdreams.core.attention.native import NativeAttention

--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -121,6 +121,8 @@ class BlockKVCache:
         assert -tensor_dim <= self.seq_dim < tensor_dim, (
             f"seq_dim must be in [-{tensor_dim}, {tensor_dim}), got {self.seq_dim}"
         )
+        # Normalize seq_dim to a non-negative index so downstream
+        # indexing math doesn't have to special-case negatives.
         self.seq_dim = self.seq_dim if self.seq_dim >= 0 else self.seq_dim + tensor_dim
 
         assert self.sink_size >= 0, "sink_size must be non-negative"

--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -34,7 +34,7 @@ class BlockKVCache:
     non-overlapping: each update adds one chunk of ``chunk_size`` tokens at the
     next logical position in the full sequence.
 
-    Note: Currently only support total_size (sink_size + window_size) divisible by chunk_size.
+    Note: Currently only supports ``total_size`` (``sink_size + window_size``) divisible by ``chunk_size``.
 
     Phases:
         - Filling: cache not yet full; tokens are written contiguously;
@@ -113,38 +113,32 @@ class BlockKVCache:
         return cache
 
     def __post_init__(self) -> None:
-        # k and v should have the same shape except for the last dimension
         assert self.k_shape[:-1] == self.v_shape[:-1], (
             "k and v must have the same shape except for the last dimension"
         )
 
-        # update seq_dim to be positive
         tensor_dim = len(self.k_shape)
         assert -tensor_dim <= self.seq_dim < tensor_dim, (
             f"seq_dim must be in [-{tensor_dim}, {tensor_dim}), got {self.seq_dim}"
         )
         self.seq_dim = self.seq_dim if self.seq_dim >= 0 else self.seq_dim + tensor_dim
 
-        # check non-negative sink size
         assert self.sink_size >= 0, "sink_size must be non-negative"
 
-        # buffer length at seq_dim must equal sink_size + window_size
         expected_length = self.sink_size + self.window_size
         assert self.k_shape[self.seq_dim] == expected_length, (
             f"k_shape[seq_dim] ({self.k_shape[self.seq_dim]}) must equal sink_size + window_size ({expected_length})"
         )
 
-        # check window_size + sink_size should be divisible by chunk_size
         assert (self.window_size + self.sink_size) % self.chunk_size == 0, (
             f"window_size + sink_size ({self.window_size + self.sink_size}) must be divisible by chunk_size ({self.chunk_size})"
         )
 
-        # initialize k and v
         self._k = torch.empty(self.k_shape, device=self.device, dtype=self.dtype)
         self._v = torch.empty(self.v_shape, device=self.device, dtype=self.dtype)
 
     def _seq_slice(self, start: int | None, end: int | None) -> tuple[slice | int, ...]:
-        """Return an index tuple that slices the sequence dimension to [start:end]; other dims are :."""
+        """Return an index tuple selecting ``[start:end]`` on ``seq_dim`` and all elements elsewhere."""
         idx: list[slice | int] = [slice(None)] * len(self.k_shape)
         idx[self.seq_dim] = slice(start, end)
         return tuple(idx)
@@ -319,7 +313,6 @@ class BlockKVCache:
                 f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
             )
 
-        # reset the current chunk index as the last step.
         self._curr_chunk_idx = None
 
     def cached_k(self) -> Tensor:

--- a/flashdreams/flashdreams/core/attention/native.py
+++ b/flashdreams/flashdreams/core/attention/native.py
@@ -36,8 +36,9 @@ class NativeAttention(torch.nn.Module):
         """Configure attention format and backend.
 
         Args:
-            qkv_format: "bshd" (B, S, H, D) or "bhsd" (B, H, S, D). Default is "bhsd".
-            backend: One of "math", "efficient", "cudnn", "flash" for ``sdpa_kernel``.
+            qkv_format: Layout of the QKV tensors; ``"bhsd"`` is ``(B, H, S, D)``,
+                ``"bshd"`` is ``(B, S, H, D)``.
+            backend: SDPA backend selected via ``sdpa_kernel``.
         """
         super().__init__()
         assert qkv_format in ["bhsd", "bshd"], f"Invalid qkv format: {qkv_format}"

--- a/flashdreams/flashdreams/core/attention/ring.py
+++ b/flashdreams/flashdreams/core/attention/ring.py
@@ -90,9 +90,11 @@ class RingAttention(NativeAttention):
         """Configure ring attention format and backend.
 
         Args:
-            qkv_format: "bshd" (B, S, H, D) or "bhsd" (B, H, S, D). Default is "bhsd".
-            backend: "cudnn" or "flash" for the manual ring SDPA ops.
-            convert_to_fp32: Use float32 for LSE merge across ring steps.
+            qkv_format: Layout of the QKV tensors; ``"bhsd"`` is ``(B, H, S, D)``,
+                ``"bshd"`` is ``(B, S, H, D)``.
+            backend: Local SDPA backend used inside the ring step.
+            convert_to_fp32: Promote partial outputs to ``float32`` for the
+                cross-rank log-sum-exp merge.
         """
         super().__init__()
         assert qkv_format in ["bhsd", "bshd"], f"Invalid qkv format: {qkv_format}"

--- a/flashdreams/flashdreams/core/checkpoint/load.py
+++ b/flashdreams/flashdreams/core/checkpoint/load.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unified checkpoint loaders for local, S3, and Hugging Face sources."""
+"""Unified checkpoint loader that dispatches by source URL."""
 
 import io
 import json
@@ -584,7 +584,7 @@ def load_checkpoint(
         ValueError: ``checkpoint_type='distributed'`` without a ``model``, or
             an invalid ``checkpoint_type``.
 
-    Typical usage example:
+    Examples:
 
       >>> state = load_checkpoint("s3://bucket/foo.safetensors")
       >>> model = load_checkpoint("s3://bucket/dcp_dir/", model=my_model)

--- a/flashdreams/flashdreams/core/checkpoint/remap.py
+++ b/flashdreams/flashdreams/core/checkpoint/remap.py
@@ -36,7 +36,7 @@ def remap_checkpoint_keys(
     Returns:
         New state dict with renamed keys; tensors are not copied.
 
-    Typical usage example:
+    Examples:
 
       >>> mapping = {r"^blocks\.(\d+)\.attn1\.to_q\.(.*)$": r"blocks.\1.to_q.\2"}
       >>> remapped = remap_checkpoint_keys(state_dict, mapping)

--- a/flashdreams/flashdreams/core/experimental/kvcache.py
+++ b/flashdreams/flashdreams/core/experimental/kvcache.py
@@ -104,6 +104,8 @@ class BlockKVCache:
         assert -tensor_dim <= self.seq_dim < tensor_dim, (
             f"seq_dim must be in [-{tensor_dim}, {tensor_dim}), got {self.seq_dim}"
         )
+        # Normalize seq_dim to a non-negative index so downstream
+        # indexing math doesn't have to special-case negatives.
         self.seq_dim = self.seq_dim if self.seq_dim >= 0 else self.seq_dim + tensor_dim
 
         assert self.sink_size >= 0, "sink_size must be non-negative"

--- a/flashdreams/flashdreams/core/experimental/kvcache.py
+++ b/flashdreams/flashdreams/core/experimental/kvcache.py
@@ -44,7 +44,7 @@ class BlockKVCache:
           local window and overwrites the rightmost positions;
           ``cached_k()`` / ``cached_v()`` return the full buffer.
 
-    Note: only supports continous chunks or overwriting the same cache positions.
+    Note: only supports continuous chunks or overwriting the same cache positions.
     The argument ``chunk_start`` and ``chunk_end`` are the start and end indices of
     the new chunk in the full sequence (not the indices into the cache). The new chunk
     should either be contiguous with the previous chunk (i.e. next chunk_start ==
@@ -96,52 +96,48 @@ class BlockKVCache:
     """Cached values. shape ``[..., total_size, ..., Dv]``, where the ``total_size`` is the length of the cache buffer at ``seq_dim`` dimension."""
 
     def __post_init__(self) -> None:
-        # k and v should have the same shape except for the last dimension
         assert self.k_shape[:-1] == self.v_shape[:-1], (
             "k and v must have the same shape except for the last dimension"
         )
 
-        # update seq_dim to be positive
         tensor_dim = len(self.k_shape)
         assert -tensor_dim <= self.seq_dim < tensor_dim, (
             f"seq_dim must be in [-{tensor_dim}, {tensor_dim}), got {self.seq_dim}"
         )
         self.seq_dim = self.seq_dim if self.seq_dim >= 0 else self.seq_dim + tensor_dim
 
-        # check non-negative sink size
         assert self.sink_size >= 0, "sink_size must be non-negative"
 
-        # buffer length at seq_dim must equal sink_size + window_size
         expected_length = self.sink_size + self.window_size
         assert self.k_shape[self.seq_dim] == expected_length, (
             f"k_shape[seq_dim] ({self.k_shape[self.seq_dim]}) must equal sink_size + window_size ({expected_length})"
         )
 
-        # initialize k and v
         self._k = torch.empty(self.k_shape, device=self.device, dtype=self.dtype)
         self._v = torch.empty(self.v_shape, device=self.device, dtype=self.dtype)
 
     def _seq_slice(self, start: int | None, end: int | None) -> tuple[slice | int, ...]:
-        """Return an index tuple that slices the sequence dimension to [start:end]; other dims are :."""
+        """Return an index tuple selecting ``[start:end]`` on ``seq_dim`` and all elements elsewhere."""
         idx: list[slice | int] = [slice(None)] * len(self.k_shape)
         idx[self.seq_dim] = slice(start, end)
         return tuple(idx)
 
     def _roll_local_window_left(self, evict_size: int) -> None:
-        """Shift the local window left by evict_size tokens.
+        """Shift the local window left by ``evict_size`` tokens.
 
-        Before the roll:
-        | -- sink tokens -- | -- (evicted tokens) -- retained window tokens -- |
+        Before the roll::
 
-        After the roll:
-        | -- sink tokens -- | -- retained window tokens -- |
+            | -- sink tokens -- | -- (evicted tokens) -- retained window tokens -- |
 
-        This function will write the "retained window tokens" to the left, if there are any.
+        After the roll::
+
+            | -- sink tokens -- | -- retained window tokens -- |
+
+        Retained window tokens (if any) are copied left over the evicted slots.
 
         Args:
             evict_size: Number of tokens to evict from the left of the local window.
         """
-        print(f"rolling local window left with evict_size {evict_size}")
         if evict_size <= 0:
             # No tokens to evict.
             return
@@ -175,11 +171,13 @@ class BlockKVCache:
     def _append_to_end(self, k: Tensor, v: Tensor) -> None:
         """Append the new chunk to the end of the cache.
 
-        Before the write:
-        | -- sink tokens -- | -- local window tokens -- |
+        Before the write::
 
-        After the write:
-        | -- sink tokens -- | -- local window tokens -- | -- new chunk -- |
+            | -- sink tokens -- | -- local window tokens -- |
+
+        After the write::
+
+            | -- sink tokens -- | -- local window tokens -- | -- new chunk -- |
         """
         total_size = self._k.shape[self.seq_dim]
         chunk_size = k.shape[self.seq_dim]
@@ -198,13 +196,14 @@ class BlockKVCache:
     def _write_to_rightmost(self, k: Tensor, v: Tensor, chunk_start: int) -> None:
         """Write the new chunk to the rightmost positions of the valid tokens.
 
-        Before the write:
-        | -- sink tokens -- | -- local window tokens -- (old tokens) -- |
+        Before the write::
 
-        After the write:
-        | -- sink tokens -- | -- local window tokens -- (new tokens) -- |
+            | -- sink tokens -- | -- local window tokens -- (old tokens) -- |
+
+        After the write::
+
+            | -- sink tokens -- | -- local window tokens -- (new tokens) -- |
         """
-        print(f"writing to rightmost: {k.shape}")
         chunk_size = k.shape[self.seq_dim]
 
         sink_capacity = max(self.sink_size - self._n_cached, 0)

--- a/flashdreams/flashdreams/core/io/s3_filesystem.py
+++ b/flashdreams/flashdreams/core/io/s3_filesystem.py
@@ -35,7 +35,7 @@ class S3FileSystem(FileSystemBase):
     can read and write to S3 transparently. Credentials are loaded from a
     JSON file passed at construction.
 
-    Typical usage example:
+    Examples:
 
       >>> fs = S3FileSystem(credential_path="credentials/s3_checkpoint.secret")
       >>> with fs.create_stream("s3://bucket/key.bin", "rb") as f:

--- a/flashdreams/flashdreams/core/io/s3_sync.py
+++ b/flashdreams/flashdreams/core/io/s3_sync.py
@@ -91,7 +91,7 @@ def sync_s3_dir_to_local(
             SHA256 of each downloaded file; one retry on mismatch.
         desc: Progress-bar label.
 
-    Typical usage example:
+    Examples:
 
       >>> sync_s3_dir_to_local(
       ...     s3_dir="s3://bucket/assets",

--- a/flashdreams/flashdreams/infra/config/base.py
+++ b/flashdreams/flashdreams/infra/config/base.py
@@ -57,7 +57,7 @@ def derive_config(
     dicts; leaf values overwrite directly. Raises ``KeyError`` on unknown
     paths.
 
-    Typical usage example:
+    Examples:
 
         new_config = derive_config(
             base_config,

--- a/flashdreams/flashdreams/infra/cuda_graph.py
+++ b/flashdreams/flashdreams/infra/cuda_graph.py
@@ -55,7 +55,7 @@ class CUDAGraphWrapper:
     (or an unwrapped call) before the wrapped path captures, otherwise
     capture fails with ``cudaErrorStreamCaptureUnsupported``.
 
-    Typical usage example:
+    Examples:
 
         wrapper = CUDAGraphWrapper(model.forward, warmup_iters=2)
 

--- a/flashdreams/flashdreams/infra/diffusion/model/base.py
+++ b/flashdreams/flashdreams/infra/diffusion/model/base.py
@@ -70,7 +70,7 @@ class DiffusionModel(nn.Module, Generic[TransformerCacheT]):
     Generic over the transformer's AR cache type so user-facing typing on
     ``cache`` is preserved end-to-end.
 
-    Typical usage example:
+    Examples:
 
         model = config.setup().to("cuda")
         cache = model.transformer.initialize_autoregressive_cache(...)

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/__init__.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Diffusion schedulers: base interface, flow-matching, and UniPC."""
+"""Diffusion schedulers for streaming inference."""
 
 from flashdreams.infra.diffusion.scheduler.base import (
     FlowPredictor,

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/base.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/base.py
@@ -51,7 +51,7 @@ class Scheduler(nn.Module, ABC):
     declare their own ``num_inference_steps`` / ``shift`` fields (the base
     holds no shared dataclass fields).
 
-    Typical usage example:
+    Examples:
 
         scheduler = config.setup()
         clean = scheduler.sample(initial_noise=noise, predict_flow=predictor)
@@ -95,7 +95,7 @@ class Scheduler(nn.Module, ABC):
         timestep: Tensor,
         rng: torch.Generator | None = None,
     ) -> Tensor:
-        """Forward corruption ``x_t = (1 - sigma(t)) * x_0 + sigma(t) * eps``.
+        """Apply the forward corruption ``x_t = (1 - sigma(t)) * x_0 + sigma(t) * eps``.
 
         Timestep value semantics are scheduler-specific: FlowMatch snaps to
         the nearest entry of its 1000-step training table; FlowUniPC

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
@@ -80,7 +80,7 @@ class FlowMatchScheduler(Scheduler):
             x_t = (1 - sigma(t)) * x0 + sigma(t) * eps
         return x0
 
-    Typical usage example:
+    Examples:
 
         scheduler = FlowMatchSchedulerConfig(
             num_inference_steps=4,
@@ -225,7 +225,7 @@ class FlowMatchScheduler(Scheduler):
         timestep: Tensor,
         rng: torch.Generator | None = None,
     ) -> Tensor:
-        """Forward corruption at an arbitrary timestep.
+        """Apply the forward corruption at an arbitrary timestep.
 
         Snaps ``timestep`` to the nearest entry of the warped training table
         and uses it as sigma in the standard lerp.

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/fm_unipc.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/fm_unipc.py
@@ -204,7 +204,7 @@ class FlowMatchUniPCScheduler(Scheduler):
     Schedule buffers (sigmas + per-step coefficients) stay fp32 regardless
     of ``module.to(dtype)``.
 
-    Typical usage example:
+    Examples:
 
         scheduler = FlowMatchUniPCSchedulerConfig(
             num_inference_steps=50, shift=5.0,
@@ -396,7 +396,7 @@ class FlowMatchUniPCScheduler(Scheduler):
         timestep: Tensor,
         rng: torch.Generator | None = None,
     ) -> Tensor:
-        """Forward corruption at an arbitrary timestep.
+        """Apply the forward corruption at an arbitrary timestep.
 
         Snaps ``timestep`` to the nearest entry of the inference schedule
         on-device (no Python sync) and uses the matching sigma in the lerp.

--- a/flashdreams/flashdreams/infra/diffusion/transformer/base.py
+++ b/flashdreams/flashdreams/infra/diffusion/transformer/base.py
@@ -37,7 +37,7 @@ class TransformerAutoregressiveCache:
     (default ``start`` / ``finalize`` are no-ops). Subclass and add fields
     plus AR bookkeeping for real per-rollout state.
 
-    Typical usage example:
+    Examples:
 
         cache.start(autoregressive_index)
         # one or more denoising steps...
@@ -73,7 +73,7 @@ class Transformer(nn.Module, ABC, Generic[TransformerCacheT]):
     transformers also subclass ``TransformerAutoregressiveCache`` and
     override ``initialize_autoregressive_cache``.
 
-    Typical usage example:
+    Examples:
 
         class MyTransformer(Transformer[MyCache]):
             def predict_flow(self, noisy_latent, timestep, cache, input=None):

--- a/flashdreams/flashdreams/infra/encoder/base.py
+++ b/flashdreams/flashdreams/infra/encoder/base.py
@@ -74,7 +74,7 @@ class NullEncoder(Encoder[EncoderAutoregressiveCache]):
     Wire as the pipeline's ``encoder`` slot to pass already-encoded tensors
     straight to the diffusion model.
 
-    Typical usage example:
+    Examples:
 
         config = StreamInferencePipelineConfig(
             encoder=NullEncoderConfig(),

--- a/flashdreams/flashdreams/infra/encoder/image/__init__.py
+++ b/flashdreams/flashdreams/infra/encoder/image/__init__.py
@@ -12,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Image encoders for diffusion conditioning."""

--- a/flashdreams/flashdreams/infra/encoder/image/clip.py
+++ b/flashdreams/flashdreams/infra/encoder/image/clip.py
@@ -52,7 +52,7 @@ class CLIPImageEncoder(Encoder):
 
     Stateless. Input images are ``[..., C, H, W]`` in ``[-1, 1]``.
 
-    Typical usage example:
+    Examples:
 
       >>> encoder = CLIPImageEncoderConfig().setup().to("cuda")
       >>> embeddings = encoder(image)  # [..., 257, 1280]

--- a/flashdreams/flashdreams/infra/encoder/text/__init__.py
+++ b/flashdreams/flashdreams/infra/encoder/text/__init__.py
@@ -12,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Text encoders for diffusion conditioning."""

--- a/flashdreams/flashdreams/infra/encoder/text/cosmos_qwen.py
+++ b/flashdreams/flashdreams/infra/encoder/text/cosmos_qwen.py
@@ -60,7 +60,7 @@ class CosmosReason1TextEncoder(Encoder):
     hidden layers into a 100,352-dim embedding (28 x 3584); the DiT
     projects this to 1024 via its ``crossattn_proj``.
 
-    Typical usage example:
+    Examples:
 
       >>> encoder = CosmosReason1TextEncoderConfig().setup().to("cuda")
       >>> embeddings = encoder(["a beautiful sunset"])

--- a/flashdreams/flashdreams/infra/encoder/text/umt5.py
+++ b/flashdreams/flashdreams/infra/encoder/text/umt5.py
@@ -61,7 +61,7 @@ class UMT5TextEncoder(Encoder):
 
     Stateless; called once before a rollout to encode prompts.
 
-    Typical usage example:
+    Examples:
 
       >>> encoder = UMT5TextEncoderConfig().setup().to("cuda")
       >>> embeddings = encoder(["a cat playing piano"])

--- a/flashdreams/flashdreams/infra/pipeline/base.py
+++ b/flashdreams/flashdreams/infra/pipeline/base.py
@@ -110,7 +110,7 @@ class StreamInferencePipeline(
     transformer's ``predict_flow`` / ``postprocess_clean_latent`` overrides
     own the typing on the ``input`` argument they receive.
 
-    Typical usage example:
+    Examples:
 
         cache = pipeline.initialize_cache(transformer_context={...})
         output = pipeline.generate(0, cache, input=...)

--- a/flashdreams/flashdreams/infra/profiler.py
+++ b/flashdreams/flashdreams/infra/profiler.py
@@ -23,7 +23,7 @@ import torch
 class EventProfiler:
     """Times stages between a start event and one ``record(stage)`` per stage.
 
-    Typical usage example:
+    Examples:
 
         profiler = EventProfiler()
         run_encoder()

--- a/flashdreams/flashdreams/recipes/alpadreams/encoder/pixel_shuffle.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/encoder/pixel_shuffle.py
@@ -39,6 +39,7 @@ class PixelShuffleVAEEncoderCache(EncoderAutoregressiveCache):
     """AR cache that tracks step index for frame selection."""
 
     autoregressive_index: int = -1
+    """AR step index for the chunk currently being processed; ``-1`` before the first call."""
 
 
 @dataclass(kw_only=True)
@@ -77,6 +78,18 @@ class PixelShuffleVAEEncoder(Encoder[PixelShuffleVAEEncoderCache]):
         autoregressive_index: int = 0,
         cache: PixelShuffleVAEEncoderCache | None = None,
     ) -> Tensor:
+        """Select frames for the current AR step and unshuffle into channels.
+
+        Args:
+            input: Video tensor of shape ``[..., T, C, H, W]`` in ``[-1, 1]``.
+            autoregressive_index: AR step index; AR step 0 keeps the first
+                frame in addition to the per-window selection.
+            cache: AR cache (created on the fly when ``None``); updated in place
+                with ``autoregressive_index``.
+
+        Returns:
+            Latent of shape ``[..., Tl, C * 64, H/8, W/8]``.
+        """
         if cache is None:
             cache = self.initialize_autoregressive_cache()
         cache.autoregressive_index = autoregressive_index

--- a/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/pipeline.py
@@ -95,7 +95,7 @@ class AlpadreamsPipeline(
 ):
     """Alpadreams streaming inference pipeline (Cosmos DiT + HDMap + I2V mask).
 
-    Typical usage example:
+    Examples:
 
         pipeline: AlpadreamsPipeline = ...
 

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -97,6 +97,7 @@ class CosmosTransformerCache(TransformerAutoregressiveCache):
     ``num_views == 1``."""
 
     autoregressive_index: int = -1
+    """AR step index for the chunk currently being processed; ``-1`` before the first ``start``."""
 
     def start(self, autoregressive_index: int) -> None:
         # Hoist per-block KV pre-update out of the (graph-captured) network
@@ -130,8 +131,13 @@ class CosmosTransformerConfig(InstantiateConfig["CosmosTransformer"]):
     )
 
     network: CosmosDiTNetworkConfig = field(default_factory=CosmosDiTNetworkConfig)
+    """Backbone Cosmos DiT network config."""
+
     dtype: torch.dtype = torch.bfloat16
+    """Network parameter / activation dtype."""
+
     checkpoint_path: str | None = None
+    """Optional path to a pretrained checkpoint; ``None`` keeps the random init."""
 
     state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None
     """Pre-load state-dict remap. Defaults to a ``net.`` prefix stripper."""

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Cosmos DiT building blocks (attention, AdaLN-LoRA, cross-view ops)."""
+"""Cosmos DiT building blocks."""
 
 import math
 from dataclasses import dataclass
@@ -119,7 +119,7 @@ class PatchEmbed(nn.Module):
     """Patch embedding module for video/image inputs.
 
     Note: The patchify operation (rearranging from spatial to patch tokens) is expected
-    to be performed externally. This module expects post-patchified flattend input of shape (..., D)
+    to be performed externally. This module expects post-patchified flattened input of shape (..., D)
     where D = in_channels * temporal_patch_size * spatial_patch_size^2.
     """
 

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Cosmos DiT network: multi-view, HDMap-conditioned, AdaLN-LoRA."""
+"""Cosmos DiT network for streaming alpadreams inference."""
 
 from dataclasses import dataclass, field
 
@@ -41,7 +41,10 @@ from .modules import (
 
 @dataclass
 class CosmosDiTNetworkCache:
+    """Cache container for all transformer blocks."""
+
     block_caches: list[BlockCache]
+    """Per-transformer-block self-attn KV + cross-attn KV cache, indexed by block position."""
 
     def __getitem__(self, index: int) -> BlockCache:
         return self.block_caches[index]
@@ -57,34 +60,70 @@ class CosmosDiTNetworkCache:
 
 @dataclass
 class CosmosDiTNetworkConfig(InstantiateConfig["CosmosDiTNetwork"]):
+    """Configuration for the Cosmos DiT network."""
+
     _target: type["CosmosDiTNetwork"] = field(default_factory=lambda: CosmosDiTNetwork)
 
     in_channels: int = 16
+    """Number of input latent channels before patch embedding."""
+
     out_channels: int = 16
+    """Output latent channels after the final layer."""
+
     patch_spatial: int = 2
+    """Spatial patch size (applied to both H and W)."""
+
     patch_temporal: int = 1
+    """Temporal patch size."""
+
     model_channels: int = 2048
+    """Transformer hidden size (width)."""
+
     num_blocks: int = 28
+    """Number of transformer blocks."""
+
     num_heads: int = 16
+    """Number of attention heads."""
+
     mlp_ratio: float = 4.0
+    """FFN inner-dim multiplier relative to ``model_channels``."""
+
     concat_padding_mask: bool = True
+    """If ``True``, expect a padding mask channel concatenated to the input at training."""
+
     use_adaln_lora: bool = True
+    """If ``True``, factorize AdaLN modulation through a low-rank LoRA path."""
+
     adaln_lora_dim: int = 256
+    """Rank of the AdaLN LoRA factorization when ``use_adaln_lora`` is ``True``."""
+
     use_crossattn_projection: bool = True
+    """If ``True``, project text embeddings through a linear before cross-attention."""
+
     crossattn_proj_in_channels: int = 100352
+    """Input dimension of the optional cross-attention projection."""
+
     crossattn_emb_channels: int = 1024
+    """Cross-attention key/value dimension."""
+
     timestep_scale: float = 0.001
-    # hdmap conditioning
+    """Multiplier applied to raw timestep values before sinusoidal embedding."""
+
     additional_concat_ch: int = 0
-    # multiview
+    """Extra channels concatenated for HDMap conditioning; ``0`` disables HDMap input."""
+
     enable_cross_view_attn: bool = False
+    """If ``True``, enable multi-view cross-view attention and AdaLN view modulation."""
+
     view_condition_dim: int = 16
+    """Embedding dim for the per-view conditioning vector."""
+
     n_cameras_emb: int = 7
+    """Number of distinct camera-view embeddings (size of the lookup table)."""
 
 
 class CosmosDiTNetwork(nn.Module):
-    """
-    DiT model for video generation with block-causal attention and KV-caching.
+    """DiT for video generation with block-causal attention and KV-caching.
 
     Combines the Cosmos DiT architecture with causal attention masking for
     autoregressive video generation.
@@ -187,30 +226,27 @@ class CosmosDiTNetwork(nn.Module):
             block.set_context_parallel_group(self_attn_group, cross_view_attn_group)
 
     def _fuse_shuffle_op_into_last_layer(self):
-        """
-        In the Cosmos model, the patchify operation is
-        "b c (t kt) (h kh) (w kw) -> b (t h w) (c kt kh kw)",
+        """Fuse the channel-shuffle that follows the last linear into its weights.
 
-        while the unpatchify operation is
-        "b (t h w) (kt kh kw c) -> b c (t kt) (h kh) (w kw)"
+        In the Cosmos model the patchify pattern is
+        ``b c (t kt) (h kh) (w kw) -> b (t h w) (c kt kh kw)`` while the
+        unpatchify pattern is
+        ``b (t h w) (kt kh kw c) -> b c (t kt) (h kh) (w kw)``. This mismatch
+        (likely a Cosmos bug) means the last dimension must be shuffled after
+        the network. Folding that shuffle into ``final_layer.linear`` removes
+        the explicit ``rearrange`` from the inference path.
 
-        This is likely a bug in the Cosmos model where the last dimension is shuffled after the network.
+        Calling this once is equivalent to running the following after the
+        last layer::
 
-        To fix this, we could fuse this shuffle op into the last linear layer,
-        so that we do not have to do this shuffle op explicitly before returning the result.
-
-        Calling this function to modify the last layer in place, is equivalent to the following code
-        after the last layer:
-        ```python
-        x = rearrange(
-            x,
-            "... (kt kh kw c) -> ... (c kt kh kw)",
-            kt=self.patch_temporal,
-            kh=self.patch_spatial,
-            kw=self.patch_spatial,
-            c=self.out_channels,
-        )
-        ```
+            x = rearrange(
+                x,
+                "... (kt kh kw c) -> ... (c kt kh kw)",
+                kt=self.patch_temporal,
+                kh=self.patch_spatial,
+                kw=self.patch_spatial,
+                c=self.out_channels,
+            )
         """
         if self._is_shuffle_op_fused:
             return
@@ -237,21 +273,18 @@ class CosmosDiTNetwork(nn.Module):
         return
 
     def _fuse_padding_mask_into_patch_embed(self) -> None:
-        """
-        Fuse the padding mask into the patch embedder in place.
+        """Fold the always-zero inference padding mask into ``x_embedder`` in place.
 
-        If `self.concat_padding_mask` is True, during training we are concatenating a
-        padding_mask with shape [B, 1, T, H, W] to the input x_B_C_T_H_W on the C dimension,
-        before passing it into the self.x_embedder. This is to work with data with different
-        spatial resolutions during training, where `1` indicates padded regions. During
-        inference, the padding_mask is always 0. So here we could simply remove the corresponding
-        channels in the x_embedder in place
+        When ``self.concat_padding_mask`` is ``True`` training concatenates a
+        ``[B, 1, T, H, W]`` padding mask to the input on the channel dimension
+        before ``x_embedder`` (``1`` marks padded regions for variable spatial
+        resolutions). At inference the mask is always zero, so the matching
+        input channels of ``x_embedder`` can simply be dropped.
 
-        Calling this function to modify the patch embedder in place, is equivalent to the following code
-        before passing the input into the patch embedder:
-        ```python
-        x_B_C_T_H_W = torch.cat([x_B_C_T_H_W, padding_mask], dim=1)
-        ```
+        Calling this once is equivalent to running the following before
+        ``x_embedder``::
+
+            x_B_C_T_H_W = torch.cat([x_B_C_T_H_W, padding_mask], dim=1)
         """
         if not self.config.concat_padding_mask:
             return
@@ -275,8 +308,7 @@ class CosmosDiTNetwork(nn.Module):
         return
 
     def update_parameters_after_loading_checkpoint(self) -> None:
-        # This function should be called after loading the checkpoint, to fuse some operations in the model
-        # weights to reduce computation during inference.
+        """Fuse load-time-known ops into weights; call once after loading the checkpoint."""
         if self._parameters_updated_after_loading_checkpoint:
             return
 
@@ -291,16 +323,14 @@ class CosmosDiTNetwork(nn.Module):
         cp_dims: list[int | None] | None = None,
         flatten_thw: bool = False,
     ) -> Tensor:
-        r"""
-        Patchify the input tensor and maybe split it along cp_dim if a process group is provided.
+        """Patchify and optionally CP-split the input video tensor.
 
-        If `flatten_thw` is False, the patchify pattern is:
-            "b v (t kt) c (h kh) (w kw) -> b v t (h w) (c kt kh kw)",
-        Otherwise, the patchify pattern is:
-            "b v (t kt) c (h kh) (w kw) -> b v (t h w) (c kt kh kw)"
+        If ``flatten_thw`` is ``False`` the patchify pattern is
+        ``b v (t kt) c (h kh) (w kw) -> b v t (h w) (c kt kh kw)``; otherwise
+        it is ``b v (t kt) c (h kh) (w kw) -> b v (t h w) (c kt kh kw)``.
 
         Returns:
-            Tensor: The patched tensor with shape [B, V, T, HW, D] or [B, V, L, D]
+            Patched tensor with shape ``[B, V, T, HW, D]`` or ``[B, V, L, D]``.
         """
         assert x.ndim == 6, f"x must be a 6D tensor, but got shape {x.shape}"
 
@@ -339,16 +369,14 @@ class CosmosDiTNetwork(nn.Module):
         cp_dims: list[int | None] | None = None,
         flatten_thw: bool = False,
     ) -> Tensor:
-        r"""
-        Unpatchify the input tensor and maybe gather it along cp_dim if a process group is provided.
+        """Unpatchify and optionally CP-gather the tensor back to video shape.
 
-        If `flatten_thw` is False, the unpatchify pattern is:
-            "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
-        Otherwise, the unpatchify pattern is:
-            "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)",
+        If ``flatten_thw`` is ``False`` the unpatchify pattern is
+        ``b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)``; otherwise
+        it is ``b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)``.
 
         Returns:
-            Tensor: The unpatched tensor with shape [B, V, T, C, H, W]
+            Unpatched tensor with shape ``[B, V, T, C, H, W]``.
         """
         if flatten_thw:
             pattern = "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
@@ -389,9 +417,7 @@ class CosmosDiTNetwork(nn.Module):
         # cross attn
         context: Tensor,
     ) -> CosmosDiTNetworkCache:
-        """
-        Initialize the cache for the DiT.
-        """
+        """Build a fresh autoregressive cache for the DiT given the chunk geometry."""
         if self.config.use_crossattn_projection:
             context = self.crossattn_proj(context)
 
@@ -415,19 +441,20 @@ class CosmosDiTNetwork(nn.Module):
         view_indices: Tensor | None = None,
         eager_mode: bool = True,
     ) -> Tensor:
-        """
-        Forward pass dispatching to training or inference mode.
+        """Run the DiT forward, dispatching to training or inference mode.
 
         Args:
-            x: Input video tensor [B, V, T, HW, D] or [B, V, L, D] after patchify
-            timesteps: Timesteps [1] or [B]
-            rope_freqs: RoPE cosine and sine embeddings [L, 1, 1, D]
-            cache: CosmosDiTCache
-            condition_video_input_mask: Condition video input mask [B, V, T, HW, D] or [B, V, L, D] after patchify
-            current_chunk_idx: Current chunk index in autoregressive inference
-            hdmap_condition: HDMap tensor [B, V, T, HW, D] or [B, V, L, D]
-            view_indices: View indices [B, V]
-            eager_mode: Whether to run in eager mode (True) or not (False)
+            x: Patchified video tokens of shape ``[B, V, T, HW, D]`` or ``[B, V, L, D]``.
+            timesteps: Scalar timestep ``[1]`` or per-sample ``[B]``.
+            rope_freqs: RoPE cosine/sine embeddings of shape ``[L, 1, 1, D]``.
+            cache: Per-block autoregressive cache produced by :meth:`initialize_cache`.
+            condition_video_input_mask: Patchified condition mask, same shape as ``x``.
+            current_chunk_idx: Current chunk index in autoregressive inference.
+            hdmap_condition: Optional HDMap tokens of shape ``[B, V, T, HW, D]`` or ``[B, V, L, D]``.
+            view_indices: Optional view indices of shape ``[B, V]``.
+            eager_mode: ``True`` runs cache pre/post-update inside the forward;
+                ``False`` expects the caller to drive ``before_update`` / ``after_update``
+                outside the (graph-captured) network.
         """
         assert self._parameters_updated_after_loading_checkpoint, (
             "We expect to have called update_parameters_after_loading_checkpoint() after loading the checkpoint"
@@ -472,7 +499,8 @@ class CosmosDiTNetwork(nn.Module):
         else:
             view_embedding_proj = None
 
-        # Note: If not in eager mode, we should call `before_update` and `after_update` MANUALLY outside the network.
+        # In non-eager mode the caller drives ``before_update``/``after_update``
+        # outside the (graph-captured) network forward.
         if eager_mode:
             cache.before_update(current_chunk_idx)
         for block_idx, block in enumerate(self.blocks):

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
@@ -142,7 +142,10 @@ class I2VCamCtrlEncoder(Encoder[I2VCamCtrlEncoderCache]):
         Args:
             input: Image chunk plus camera intrinsics/poses for this AR step.
             autoregressive_index: AR step index forwarded to both branches.
-            cache: Per-rollout encoder cache; required (raises if ``None``).
+            cache: Per-rollout encoder cache. Typed ``Optional`` only to
+                match the :class:`Encoder` base signature (some encoders
+                are stateless); this encoder advances per-AR-step state
+                in ``cache`` and asserts when it is ``None``.
 
         Returns:
             Composite I2V latent + Plücker embedding for the transformer to cross-attend to.

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
@@ -47,11 +47,16 @@ from .utils import (
 
 @dataclass(kw_only=True)
 class CamCtrlInput:
-    """Per-AR-step camera payload (intrinsics, poses, world scale)."""
+    """Per-AR-step camera payload."""
 
     intrinsics: Tensor
+    """Per-frame camera intrinsics of shape ``[..., T, 4]`` (fx, fy, cx, cy)."""
+
     poses: Tensor
+    """Per-frame camera-to-world poses of shape ``[..., T, 4, 4]``."""
+
     world_scale: float
+    """Scalar applied to translations when normalizing world coordinates."""
 
 
 @dataclass(kw_only=True)
@@ -59,7 +64,10 @@ class I2VCamCtrlInput:
     """Composite per-AR-step input: image chunk + camera payload."""
 
     i2v: Tensor | None = None
+    """Per-AR-step image chunk to encode through the I2V branch; ``None`` when omitted."""
+
     camctrl: CamCtrlInput
+    """Per-AR-step camera intrinsics, poses, and world scale."""
 
 
 @dataclass(kw_only=True)
@@ -67,9 +75,13 @@ class I2VCamCtrlEmbeddings:
     """Encoded I2V latent + Plücker volume the transformer cross-attends to."""
 
     i2v: I2VCtrl
+    """Output of the Wan-VAE I2V encoder branch."""
+
     plucker: Tensor
+    """Plücker pixel volume after the PixelShuffle encoder."""
 
     _is_patchified: bool = False
+    """``True`` once the consuming transformer has patchified this payload in place."""
 
 
 @dataclass(kw_only=True)
@@ -81,9 +93,12 @@ class I2VCamCtrlEncoderConfig(InstantiateConfig["I2VCamCtrlEncoder"]):
     )
 
     i2v: I2VCtrlEncoderConfig = field(default_factory=I2VCtrlEncoderConfig)
+    """Config for the Wan-VAE I2V encoder branch."""
+
     plucker: PixelShuffleVAEEncoderConfig = field(
         default_factory=PixelShuffleVAEEncoderConfig
     )
+    """Config for the PixelShuffle pseudo-VAE encoder applied to the Plücker volume."""
 
 
 @dataclass(kw_only=True)
@@ -91,7 +106,11 @@ class I2VCamCtrlEncoderCache(EncoderAutoregressiveCache):
     """Per-AR-step cache for the composite I2V + camera-control encoder."""
 
     i2v: I2VCtrlEncoderCache
+    """Per-rollout cache for the I2V encoder branch."""
+
     plucker: PixelShuffleVAEEncoderCache
+    """Per-rollout cache for the Plücker PixelShuffle encoder branch."""
+
     camera_last_pose: Tensor | None = None
     """Last-pose anchor used to make ``compute_relative_poses_causal``
     deterministic across AR steps; ``None`` at AR step 0."""
@@ -118,6 +137,16 @@ class I2VCamCtrlEncoder(Encoder[I2VCamCtrlEncoderCache]):
         autoregressive_index: int = 0,
         cache: I2VCamCtrlEncoderCache | None = None,
     ) -> I2VCamCtrlEmbeddings:
+        """Encode the per-AR-step image chunk and Plücker camera volume.
+
+        Args:
+            input: Image chunk plus camera intrinsics/poses for this AR step.
+            autoregressive_index: AR step index forwarded to both branches.
+            cache: Per-rollout encoder cache; required (raises if ``None``).
+
+        Returns:
+            Composite I2V latent + Plücker embedding for the transformer to cross-attend to.
+        """
         assert cache is not None, "I2VCamCtrlEncoder requires a per-rollout cache."
         assert input.i2v is not None, (
             "I2VCamCtrlEncoder.forward requires the per-AR-step image chunk."

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Camera-pose math helpers for the Lingbot World camera-control encoder."""
+"""Camera-pose math: SE(3) helpers, relative poses, and Plücker rays."""
 
 import torch
 from torch import Tensor

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Camera-pose math: SE(3) helpers, relative poses, and Plücker rays."""
+"""Camera-pose math helpers for the Lingbot World camera-control encoder."""
 
 import torch
 from torch import Tensor
 
 
 def SE3_inverse(T: Tensor) -> Tensor:
+    """Invert a batch of SE(3) transforms ``[..., 4, 4]`` analytically."""
     batch_shape = T.shape[:-2]
     Rot = T[..., :3, :3]
     trans = T[..., :3, 3:]
@@ -36,6 +37,19 @@ def compute_relative_poses(
     framewise: bool = False,
     normalize_trans: bool = True,
 ) -> tuple[Tensor, Tensor | float]:
+    """Compute relative camera poses against the first frame.
+
+    Args:
+        c2ws_mat: Camera-to-world poses of shape ``[T, 4, 4]``.
+        framewise: If ``True``, return frame-to-frame relative poses
+            instead of frame-to-first relative poses.
+        normalize_trans: If ``True``, scale all translations by the maximum
+            translation norm so the inputs sit roughly within unit norm.
+
+    Returns:
+        Tuple of relative poses ``[T, 4, 4]`` and the scalar normalizer
+        applied to translations (``1.0`` when ``normalize_trans`` is ``False``).
+    """
     ref_w2cs = SE3_inverse(c2ws_mat[0:1])
     relative_poses = torch.matmul(ref_w2cs, c2ws_mat)
     relative_poses[0] = torch.eye(4, device=c2ws_mat.device, dtype=c2ws_mat.dtype)
@@ -61,6 +75,19 @@ def compute_relative_poses_causal(
     trans_normalizer: Tensor | float = 1.0,
     ref_pose: Tensor | None = None,
 ) -> Tensor:
+    """Compute frame-to-frame relative poses anchored to ``ref_pose``.
+
+    Args:
+        c2ws_mat: Camera-to-world poses of shape ``[..., T, 4, 4]``.
+        trans_normalizer: Divisor applied to translations after the relative
+            transform; pre-computed by :func:`compute_relative_poses`.
+        ref_pose: Anchor pose of shape ``[..., 1, 4, 4]`` used to pad the
+            sequence on the left so the first relative pose is well-defined;
+            defaults to the first frame of ``c2ws_mat`` when ``None``.
+
+    Returns:
+        Relative poses of shape ``[..., T, 4, 4]``.
+    """
     if ref_pose is None:
         ref_pose = c2ws_mat[..., 0:1, :, :]
     assert ref_pose.shape[-3:] == (1, 4, 4)
@@ -80,6 +107,20 @@ def create_meshgrid(
     device: torch.device | str = "cuda",
     dtype: torch.dtype = torch.float32,
 ) -> Tensor:
+    """Build a flattened ``(x, y)`` pixel grid replicated across ``n_frames``.
+
+    Args:
+        n_frames: Number of frames to replicate the grid for.
+        height: Pixel-space height.
+        width: Pixel-space width.
+        bias: Sub-pixel offset added to integer pixel coordinates
+            (``0.5`` for pixel centers).
+        device: Output device.
+        dtype: Output dtype.
+
+    Returns:
+        Tensor of shape ``[n_frames, H * W, 2]`` with ``(x, y)`` per pixel.
+    """
     x_range = torch.arange(width, device=device, dtype=dtype)
     y_range = torch.arange(height, device=device, dtype=dtype)
     grid_y, grid_x = torch.meshgrid(y_range, x_range, indexing="ij")
@@ -95,6 +136,19 @@ def get_plucker_embeddings(
     width: int,
     only_rays_d: bool = False,
 ) -> Tensor:
+    """Compute per-pixel Plücker embeddings for a stack of camera frames.
+
+    Args:
+        c2ws_mat: Camera-to-world poses of shape ``[T, 4, 4]``.
+        Ks: Per-frame intrinsics ``[T, 4]`` (``fx, fy, cx, cy``).
+        height: Pixel-space height.
+        width: Pixel-space width.
+        only_rays_d: If ``True``, return ray directions only ``[T, H, W, 3]``;
+            otherwise stack ``[origins, directions]`` to ``[T, H, W, 6]``.
+
+    Returns:
+        Plücker tensor of shape ``[T, H, W, 3]`` or ``[T, H, W, 6]``.
+    """
     n_frames = c2ws_mat.shape[0]
     grid_xy = create_meshgrid(
         n_frames, height, width, device=c2ws_mat.device, dtype=c2ws_mat.dtype

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -39,7 +39,11 @@ class TeahvVAEDecoderConfig(InstantiateConfig["TeahvVAEDecoder"]):
     _target: type["TeahvVAEDecoder"] = field(default_factory=lambda: TeahvVAEDecoder)
 
     checkpoint_path: str = AVAILABLE_TAEHV_CHECKPOINT_PATHS["lighttae"]
+    """Path to a pretrained TAEHV checkpoint. Defaults to the ``lighttae`` weights."""
+
     dtype: torch.dtype = torch.bfloat16
+    """Network parameter / activation dtype."""
+
     use_cuda_graph: bool = True
     """Wrap the decoder forward in a CUDA graph for replay."""
 
@@ -60,23 +64,27 @@ class TeahvVAEDecoder(Decoder[TAEHVCache]):
     TEMPORAL_COMPRESSION_RATIO = TAEHV.TEMPORAL_COMPRESSION_RATIO
     SPATIAL_COMPRESSION_RATIO = TAEHV.SPATIAL_COMPRESSION_RATIO
 
-    # Lighttae per-channel scaling buffers (registered when need_scaled).
     mean: Tensor
-    std: Tensor
+    """Per-channel latent mean buffer; registered only when ``need_scaled``."""
 
-    # Per-channel scaling for the lighttae checkpoint.
+    std: Tensor
+    """Per-channel latent standard deviation buffer; registered only when ``need_scaled``."""
+
     _LIGHTTAE_MEAN: tuple[float, ...] = (
         -0.7571, -0.7089, -0.9113, 0.1075,
         -0.1745, 0.9653, -0.1517, 1.5508,
         0.4134, -0.0715, 0.5517, -0.3632,
         -0.1922, -0.9497, 0.2503, -0.2921,
     )  # fmt: skip
+    """Per-channel mean for the ``lighttae`` checkpoint's latent scaling."""
+
     _LIGHTTAE_STD: tuple[float, ...] = (
         2.8184, 1.4541, 2.3275, 2.6558,
         1.2196, 1.7708, 2.6052, 2.0743,
         3.2687, 2.1526, 2.8652, 1.5579,
         1.6382, 1.1253, 2.8251, 1.9160,
     )  # fmt: skip
+    """Per-channel standard deviation for the ``lighttae`` checkpoint's latent scaling."""
 
     def __init__(self, config: TeahvVAEDecoderConfig) -> None:
         super().__init__(config)
@@ -115,6 +123,17 @@ class TeahvVAEDecoder(Decoder[TAEHVCache]):
         autoregressive_index: int = 0,
         cache: TAEHVCache | None = None,
     ) -> Tensor:
+        """Decode a latent chunk to a video tensor in ``[-1, 1]``.
+
+        Args:
+            input: Latent of shape ``[..., Tl, Cl, Hl, Wl]``.
+            autoregressive_index: Unused by TAEHV; kept for the
+                :class:`~flashdreams.infra.decoder.Decoder` interface.
+            cache: Streaming decoder cache; created on the fly when ``None``.
+
+        Returns:
+            Video tensor of shape ``[..., T, C, H, W]`` in ``[-1, 1]``.
+        """
         if cache is None:
             cache = self.initialize_autoregressive_cache()
 

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -223,7 +223,7 @@ class TAEHV(nn.Module):
     latent_channels=48). The legacy ``"hy15"`` and ``"taecvx"`` variants are
     not ported.
 
-    Typical usage example:
+    Examples:
 
         taehv = TAEHV(checkpoint_path="...").to("cuda", torch.bfloat16)
         cache = taehv.prepare_cache()

--- a/flashdreams/flashdreams/recipes/template/README.md
+++ b/flashdreams/flashdreams/recipes/template/README.md
@@ -1,0 +1,61 @@
+# `template` recipe
+
+Minimal end-to-end recipe exercising every contract in
+`flashdreams.infra`. Use as a reference when scaffolding a new recipe.
+
+## What's exercised
+
+- **Offline rollout** — `build_cfg_offline`, one AR step over the full
+  temporal window.
+- **Autoregressive streaming** — `build_cfg_autoregressive`, multiple
+  AR steps over a sliding `BlockKVCache`.
+- **Classifier-free guidance** — opt-in by patching
+  `guidance_scale > 1.0` via `derive_config`. The uncond branch gets an
+  independent `network_cache_uncond`; `negative_context` is encoded
+  only when CFG is on.
+- **Context parallelism** along `L` — `cp_size` auto-detected from
+  `torch.distributed.get_world_size()`, so `torchrun --nproc_per_node=N`
+  is the single source of truth. Attention uses
+  `flashdreams.core.attention.RingAttention` (fuses the KV gather with
+  SDPA via an LSE merge).
+- **Per-AR-step control input** — `TemplateControlEncoder`. Setting
+  `encoder=None` exercises the no-control branch
+  (`test_template_no_control`).
+- **One-shot context encoder** — `TemplateTransformerConfig.context_encoder`
+  (defaults to `NullEncoderConfig`, identity). Plug in a text or CLIP
+  image encoder here.
+- **Output decoding** — `TemplateDecoder`.
+- **Config derivation** — `build_cfg_autoregressive` is a
+  `derive_config` patch on top of `build_cfg_offline`.
+- **`torch.compile` + `CUDAGraphWrapper`** — off by default; flip via
+  `with_compile_and_cuda_graph` (or `derive_config`). Covered by
+  `test_template_compile_and_cudagraph_equivalence`.
+- **Checkpoint loading** — `TemplateTransformerConfig.checkpoint_path`.
+  `None` keeps the random init.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `transformer/network.py` | 1-block DiT + `BlockKVCache` plumbing. |
+| `transformer/__init__.py` | `Transformer` subclass, AR cache, config. |
+| `encoder.py` | Control encoder (control channels → latent channels). |
+| `decoder.py` | Decoder (latent channels → output channels). |
+| `config.py` | Pipeline builders + `with_compile_and_cuda_graph`. |
+
+## Entry point
+
+```bash
+uv run --extra dev pytest flashdreams/tests/test_template.py -v
+# or as a script
+uv run --extra dev python flashdreams/tests/test_template.py
+# multi-GPU CP equivalence (after the single-GPU run has written the reference)
+uv run --extra dev torchrun --nproc_per_node=2 -m pytest \
+    flashdreams/tests/test_template.py::test_template_cp_equivalence -v
+```
+
+## Shape conventions
+
+- Pre-patchify: `[B, C, T, H, W]` for both noisy latent and control.
+- Post-patchify: `[B, L=T*H*W, C]`, CP-split to `[B, L/cp_size, C]`.
+- Decoded output: `[B, C_out, T, H, W]`.

--- a/flashdreams/flashdreams/recipes/template/config.py
+++ b/flashdreams/flashdreams/recipes/template/config.py
@@ -31,7 +31,6 @@ from flashdreams.recipes.template.encoder import TemplateControlEncoderConfig
 from flashdreams.recipes.template.transformer import TemplateTransformerConfig
 from flashdreams.recipes.template.transformer.network import TemplateDiTConfig
 
-
 _DEFAULT_IN_CHANNELS = 4
 _DEFAULT_CONTROL_CHANNELS = 8
 _DEFAULT_OUT_CHANNELS = 3

--- a/flashdreams/flashdreams/recipes/template/config.py
+++ b/flashdreams/flashdreams/recipes/template/config.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pipeline-config builders for the template recipe."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import torch
+
+from flashdreams.infra.config import derive_config
+from flashdreams.infra.diffusion.model import DiffusionModelConfig
+from flashdreams.infra.diffusion.scheduler.fm import FlowMatchSchedulerConfig
+from flashdreams.infra.pipeline import StreamInferencePipelineConfig
+from flashdreams.recipes.template.decoder import TemplateDecoderConfig
+from flashdreams.recipes.template.encoder import TemplateControlEncoderConfig
+from flashdreams.recipes.template.transformer import TemplateTransformerConfig
+from flashdreams.recipes.template.transformer.network import TemplateDiTConfig
+
+
+_DEFAULT_IN_CHANNELS = 4
+_DEFAULT_CONTROL_CHANNELS = 8
+_DEFAULT_OUT_CHANNELS = 3
+# ``head_dim = model_channels // num_heads`` must be a size cuDNN's
+# flash-attention supports; 64 is safe, 16/8 silently NaN.
+_DEFAULT_MODEL_CHANNELS = 128
+_DEFAULT_NUM_HEADS = 2
+# Keep the encoder / decoder dtypes in lock-step with
+# ``TemplateTransformerConfig.dtype`` so ``input_proj`` doesn't see
+# mismatched control + latent dtypes.
+_DEFAULT_DTYPE: torch.dtype = torch.bfloat16
+_DEFAULT_LEN_T_BIDIRECTIONAL = 8
+_DEFAULT_LEN_T_STREAMING = 2
+_DEFAULT_WINDOW_SIZE_T_STREAMING = 2 * _DEFAULT_LEN_T_STREAMING
+
+
+def build_cfg_offline(
+    *,
+    seed: int = 42,
+) -> StreamInferencePipelineConfig:
+    """Build the offline (bidirectional, one-shot) template pipeline.
+
+    Single AR step over the full temporal window
+    (``window_size_t == len_t``), CFG off, per-step control encoded
+    into the latent channel count, clean latent decoded to 3 channels.
+
+    Args:
+        seed: RNG seed for initial-noise draws.
+
+    Returns:
+        :class:`StreamInferencePipelineConfig` ready for ``.setup()``.
+    """
+    return StreamInferencePipelineConfig(
+        encoder=TemplateControlEncoderConfig(
+            control_channels=_DEFAULT_CONTROL_CHANNELS,
+            out_channels=_DEFAULT_IN_CHANNELS,
+            dtype=_DEFAULT_DTYPE,
+        ),
+        decoder=TemplateDecoderConfig(
+            in_channels=_DEFAULT_IN_CHANNELS,
+            out_channels=_DEFAULT_OUT_CHANNELS,
+            dtype=_DEFAULT_DTYPE,
+        ),
+        diffusion_model=DiffusionModelConfig(
+            seed=seed,
+            context_noise=0,
+            transformer=TemplateTransformerConfig(
+                network=TemplateDiTConfig(
+                    in_channels=_DEFAULT_IN_CHANNELS,
+                    context_channels=16,
+                    model_channels=_DEFAULT_MODEL_CHANNELS,
+                    num_heads=_DEFAULT_NUM_HEADS,
+                ),
+                len_t=_DEFAULT_LEN_T_BIDIRECTIONAL,
+                window_size_t=_DEFAULT_LEN_T_BIDIRECTIONAL,
+                sink_size_t=0,
+                guidance_scale=1.0,
+                dtype=_DEFAULT_DTYPE,
+            ),
+            scheduler=FlowMatchSchedulerConfig(
+                num_inference_steps=2,
+                denoising_timesteps=[1000, 500],
+                warp_denoising_step=True,
+                shift=5.0,
+                num_train_timesteps=1000,
+            ),
+        ),
+    )
+
+
+def build_cfg_autoregressive(
+    *,
+    seed: int = 42,
+) -> StreamInferencePipelineConfig:
+    """Build the streaming AR template pipeline from :func:`build_cfg_offline`.
+
+    Smaller per-chunk ``len_t`` and a larger ``window_size_t`` so the
+    KV cache fills over multiple AR steps before rolling. CFG off;
+    patch ``guidance_scale > 1.0`` on top via :func:`derive_config` to
+    enable it.
+
+    Args:
+        seed: RNG seed for initial-noise draws.
+
+    Returns:
+        :class:`StreamInferencePipelineConfig` ready for ``.setup()``.
+    """
+    base = build_cfg_offline(seed=seed)
+    # ``derive_config`` preserves the concrete subclass at runtime but
+    # widens to :class:`InstantiateConfig` at the type level.
+    return cast(
+        StreamInferencePipelineConfig,
+        derive_config(
+            base,
+            diffusion_model=dict(
+                transformer=dict(
+                    len_t=_DEFAULT_LEN_T_STREAMING,
+                    window_size_t=_DEFAULT_WINDOW_SIZE_T_STREAMING,
+                ),
+                scheduler=dict(
+                    num_inference_steps=1,
+                    denoising_timesteps=[500],
+                ),
+            ),
+        ),
+    )
+
+
+def with_compile_and_cuda_graph(
+    base: StreamInferencePipelineConfig,
+) -> StreamInferencePipelineConfig:
+    """Return ``base`` with ``compile_network`` and ``use_cuda_graph`` flipped on."""
+    return cast(
+        StreamInferencePipelineConfig,
+        derive_config(
+            base,
+            diffusion_model=dict(
+                transformer=dict(
+                    compile_network=True,
+                    use_cuda_graph=True,
+                ),
+            ),
+        ),
+    )
+
+
+TEMPLATE_CONFIG_BUILDERS: dict[str, Callable[..., StreamInferencePipelineConfig]] = {
+    "offline": build_cfg_offline,
+    "autoregressive": build_cfg_autoregressive,
+}

--- a/flashdreams/flashdreams/recipes/template/config.py
+++ b/flashdreams/flashdreams/recipes/template/config.py
@@ -34,14 +34,18 @@ from flashdreams.recipes.template.transformer.network import TemplateDiTConfig
 _DEFAULT_IN_CHANNELS = 4
 _DEFAULT_CONTROL_CHANNELS = 8
 _DEFAULT_OUT_CHANNELS = 3
-# ``head_dim = model_channels // num_heads`` must be a size cuDNN's
-# flash-attention supports; 64 is safe, 16/8 silently NaN.
+
 _DEFAULT_MODEL_CHANNELS = 128
+"""``head_dim = model_channels // num_heads`` must be a size cuDNN's
+flash-attention supports; 64 is safe, 16/8 silently NaN."""
+
 _DEFAULT_NUM_HEADS = 2
-# Keep the encoder / decoder dtypes in lock-step with
-# ``TemplateTransformerConfig.dtype`` so ``input_proj`` doesn't see
-# mismatched control + latent dtypes.
+
 _DEFAULT_DTYPE: torch.dtype = torch.bfloat16
+"""Encoder / decoder dtype — kept in lock-step with
+``TemplateTransformerConfig.dtype`` so ``input_proj`` doesn't see
+mismatched control + latent dtypes."""
+
 _DEFAULT_LEN_T_BIDIRECTIONAL = 8
 _DEFAULT_LEN_T_STREAMING = 2
 _DEFAULT_WINDOW_SIZE_T_STREAMING = 2 * _DEFAULT_LEN_T_STREAMING

--- a/flashdreams/flashdreams/recipes/template/decoder.py
+++ b/flashdreams/flashdreams/recipes/template/decoder.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tiny latent-to-pixel decoder for the template recipe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from flashdreams.infra.config import InstantiateConfig
+from flashdreams.infra.decoder import Decoder, DecoderAutoregressiveCache
+
+
+@dataclass(kw_only=True)
+class TemplateDecoderConfig(InstantiateConfig["TemplateDecoder"]):
+    """Config for the template decoder.
+
+    Point-wise ``Conv3d`` mapping latent channels to output channels.
+    Real recipes replace with a VAE / TAEHV / etc.
+    """
+
+    _target: type["TemplateDecoder"] = field(default_factory=lambda: TemplateDecoder)
+
+    in_channels: int = 4
+    """Channels of the clean latent produced by the transformer."""
+
+    out_channels: int = 3
+    """Channels emitted by the decoder (RGB-like)."""
+
+    dtype: torch.dtype = torch.bfloat16
+    """Parameter and activation dtype for the projection."""
+
+
+class TemplateDecoder(Decoder[DecoderAutoregressiveCache]):
+    """Stateless per-token latent-to-pixel decoder.
+
+    ``[B, C_latent, T, H, W] → [B, C_out, T, H, W]``. Stateless; the
+    cache exists only to satisfy the :class:`Decoder` contract.
+    """
+
+    def __init__(self, config: TemplateDecoderConfig) -> None:
+        super().__init__(config)
+        self.config: TemplateDecoderConfig = config
+        self.proj = nn.Conv3d(
+            config.in_channels, config.out_channels, kernel_size=1
+        ).to(dtype=config.dtype)
+        self.proj.eval()
+
+    def initialize_autoregressive_cache(
+        self, **_context: Any
+    ) -> DecoderAutoregressiveCache:
+        """Return an empty cache (stateless decoder)."""
+        return DecoderAutoregressiveCache()
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input: Tensor,
+        autoregressive_index: int = 0,
+        cache: DecoderAutoregressiveCache | None = None,
+    ) -> Tensor:
+        """Project ``[B, C_latent, T, H, W]`` latent to ``[B, C_out, T, H, W]``."""
+        assert input.ndim == 5, (
+            f"TemplateDecoder expects [B, C, T, H, W], got {tuple(input.shape)}."
+        )
+        _ = autoregressive_index, cache  # stateless
+        return self.proj(input.to(dtype=self.config.dtype))

--- a/flashdreams/flashdreams/recipes/template/encoder.py
+++ b/flashdreams/flashdreams/recipes/template/encoder.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tiny per-AR-step control encoder for the template recipe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from flashdreams.infra.config import InstantiateConfig
+from flashdreams.infra.encoder import Encoder, EncoderAutoregressiveCache
+
+
+@dataclass(kw_only=True)
+class TemplateControlEncoderConfig(InstantiateConfig["TemplateControlEncoder"]):
+    """Config for the template control encoder.
+
+    Point-wise ``Conv3d`` projecting a dummy control channel stack to
+    the transformer's ``in_channels``. Real recipes swap in an
+    HDMap / camera-control / depth encoder here.
+    """
+
+    _target: type["TemplateControlEncoder"] = field(
+        default_factory=lambda: TemplateControlEncoder
+    )
+
+    control_channels: int = 8
+    """Channels of the raw control tensor passed to :meth:`TemplateControlEncoder.forward`."""
+
+    out_channels: int = 4
+    """Channels emitted; must match the transformer's ``network.in_channels``."""
+
+    dtype: torch.dtype = torch.bfloat16
+    """Parameter and activation dtype for the projection."""
+
+
+class TemplateControlEncoder(Encoder[EncoderAutoregressiveCache]):
+    """Stateless per-token control encoder.
+
+    ``[B, C_ctrl, T, H, W] → [B, C_latent, T, H, W]`` — the
+    pre-patchify shape consumed by the transformer. Stateless; the
+    cache exists only to satisfy the :class:`Encoder` contract.
+    """
+
+    def __init__(self, config: TemplateControlEncoderConfig) -> None:
+        super().__init__(config)
+        self.config: TemplateControlEncoderConfig = config
+        self.proj = nn.Conv3d(
+            config.control_channels, config.out_channels, kernel_size=1
+        ).to(dtype=config.dtype)
+        self.proj.eval()
+
+    def initialize_autoregressive_cache(
+        self, **_context: Any
+    ) -> EncoderAutoregressiveCache:
+        """Return an empty cache (stateless encoder)."""
+        return EncoderAutoregressiveCache()
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input: Tensor,
+        autoregressive_index: int = 0,
+        cache: EncoderAutoregressiveCache | None = None,
+    ) -> Tensor:
+        """Project ``[B, C_ctrl, T, H, W]`` control to ``[B, C_latent, T, H, W]``."""
+        assert input.ndim == 5, (
+            f"TemplateControlEncoder expects [B, C, T, H, W], got {tuple(input.shape)}."
+        )
+        _ = autoregressive_index, cache  # stateless
+        return self.proj(input.to(dtype=self.config.dtype))

--- a/flashdreams/flashdreams/recipes/template/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/template/transformer/__init__.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reference :class:`Transformer` subclass for the template recipe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from flashdreams.core.checkpoint.load import load_checkpoint
+from flashdreams.infra.compile import compile_module
+from flashdreams.infra.config import InstantiateConfig
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper
+from flashdreams.infra.diffusion.transformer import (
+    Transformer,
+    TransformerAutoregressiveCache,
+)
+from flashdreams.infra.encoder import Encoder, NullEncoderConfig
+
+from .network import TemplateDiT, TemplateDiTCache, TemplateDiTConfig
+
+
+@dataclass(kw_only=True)
+class TemplateTransformerCache(TransformerAutoregressiveCache):
+    """Long-lived AR cache for :class:`TemplateTransformer`.
+
+    Cond and uncond branches own independent KV buffers: the residual
+    stream diverges at the first context-bias addition.
+    """
+
+    network_cache: TemplateDiTCache
+    """Conditional per-block KV cache and conditional context tokens."""
+
+    network_cache_uncond: TemplateDiTCache | None = None
+    """Unconditional cache. ``None`` disables CFG."""
+
+    autoregressive_index: int = -1
+    """AR step index for the chunk currently being processed; ``-1``
+    before the first :meth:`start` call."""
+
+    def start(self, autoregressive_index: int) -> None:
+        """Snapshot the AR index and run per-block pre-update hooks.
+
+        Hoisting ``before_update`` out of the network forward keeps the
+        captured region shape-stable across AR steps.
+        """
+        self.autoregressive_index = autoregressive_index
+        self.network_cache.before_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.before_update(autoregressive_index)
+
+    def finalize(self, autoregressive_index: int) -> None:
+        """Run per-block post-update hooks."""
+        self.network_cache.after_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.after_update(autoregressive_index)
+
+
+@dataclass(kw_only=True)
+class TemplateTransformerConfig(InstantiateConfig["TemplateTransformer"]):
+    """Config for the template transformer.
+
+    Bakes in the temporal layout (``len_t``, ``window_size_t``,
+    ``sink_size_t``) and the CFG / compile knobs. Per-rollout spatial
+    layout (``batch_size``, ``height``, ``width``) is supplied to
+    :meth:`TemplateTransformer.initialize_autoregressive_cache` so one
+    instance can serve multiple resolutions. CP size auto-detects from
+    ``torch.distributed.get_world_size()`` at construction.
+    """
+
+    _target: type["TemplateTransformer"] = field(
+        default_factory=lambda: TemplateTransformer
+    )
+
+    network: TemplateDiTConfig = field(default_factory=TemplateDiTConfig)
+    """Underlying DiT network config."""
+
+    context_encoder: InstantiateConfig[Any] = field(
+        default_factory=NullEncoderConfig
+    )
+    """One-shot encoder applied to raw ``context`` inside
+    :meth:`TemplateTransformer.initialize_autoregressive_cache`. The
+    default :class:`~flashdreams.infra.encoder.NullEncoder` is identity;
+    swap in a text or CLIP image encoder here."""
+
+    dtype: torch.dtype = torch.bfloat16
+    """Parameter and activation dtype."""
+
+    checkpoint_path: str | None = None
+    """Network checkpoint path for
+    :func:`flashdreams.core.checkpoint.load.load_checkpoint`. ``None``
+    keeps the random init."""
+
+    len_t: int = 2
+    """Pre-flatten latent frames per AR chunk."""
+
+    window_size_t: int = 4
+    """Pre-flatten sliding-window length, in temporal frames. The
+    default keeps ``window_size_t == 2 * len_t`` so the streaming KV
+    cache fills in exactly two AR steps before rolling; bidirectional
+    variants must override with ``window_size_t == len_t``."""
+
+    sink_size_t: int = 0
+    """Pre-flatten sink length, in temporal frames."""
+
+    guidance_scale: float = 1.0
+    """CFG scale. ``1.0`` disables CFG; ``> 1.0`` requires a
+    ``negative_context`` at cache build time."""
+
+    compile_network: bool = False
+    """Compile the network via :func:`flashdreams.infra.compile.compile_module`."""
+
+    use_cuda_graph: bool = False
+    """Wrap the network in :class:`CUDAGraphWrapper` for steady-state
+    replay. The wrapper is built lazily inside
+    :meth:`TemplateTransformer.initialize_autoregressive_cache` so each
+    rollout gets static buffers sized to its ``(height, width)``."""
+
+    cuda_graph_warmup_iters: int = 2
+    """Eager calls before CUDA-graph capture; see :class:`CUDAGraphWrapper`."""
+
+    @property
+    def requires_negative_context_embeddings(self) -> bool:
+        """``True`` when CFG is on (``guidance_scale > 1.0``)."""
+        return self.guidance_scale > 1.0
+
+
+class TemplateTransformer(Transformer[TemplateTransformerCache]):
+    """Reference :class:`Transformer` subclass used by the template recipe."""
+
+    config: TemplateTransformerConfig
+    network: TemplateDiT
+    context_encoder: Encoder
+
+    def __init__(self, config: TemplateTransformerConfig) -> None:
+        super().__init__(config)
+        self.config = config
+
+        if torch.distributed.is_initialized():
+            self._cp_size = torch.distributed.get_world_size()
+            self._cp_group = (
+                torch.distributed.group.WORLD if self._cp_size > 1 else None
+            )
+        else:
+            self._cp_size = 1
+            self._cp_group = None
+
+        self.network = TemplateDiT(config=config.network)
+        self.network = self.network.to(dtype=config.dtype)
+        self.network.eval()
+        self.network.set_context_parallel_group(cp_group=self._cp_group)
+
+        if config.checkpoint_path is not None:
+            state_dict = load_checkpoint(config.checkpoint_path)
+            self.network.load_state_dict(state_dict)
+
+        self.context_encoder = config.context_encoder.setup()
+
+        if config.compile_network:
+            self.network = compile_module(self.network)
+
+        self._batch_size: int | None = None
+        self._height: int | None = None
+        self._width: int | None = None
+
+        self._use_cuda_graph = config.use_cuda_graph
+        self._network_call: CUDAGraphWrapper | None = None
+        self._network_call_uncond: CUDAGraphWrapper | None = None
+
+    @property
+    def latent_shape(self) -> tuple[int, ...]:
+        """Per-rank latent shape ``[batch_size, L/cp_size, in_channels]``.
+
+        Populated by :meth:`initialize_autoregressive_cache`; reading
+        it earlier asserts.
+        """
+        assert (
+            self._batch_size is not None
+            and self._height is not None
+            and self._width is not None
+        ), (
+            "latent_shape requires an initialized rollout; call "
+            "initialize_autoregressive_cache(..., height=..., width=...) "
+            "first."
+        )
+        cfg = self.config
+        L = cfg.len_t * self._height * self._width
+        return (self._batch_size, L // self._cp_size, cfg.network.in_channels)
+
+    def patchify_and_maybe_split_cp(self, x: Tensor) -> Tensor:
+        """Delegate to :meth:`TemplateDiT.patchify_and_maybe_split_cp`."""
+        return self.network.patchify_and_maybe_split_cp(x)
+
+    def unpatchify_and_maybe_gather_cp(self, x: Tensor) -> Tensor:
+        """Delegate to :meth:`TemplateDiT.unpatchify_and_maybe_gather_cp`.
+
+        Reads the per-rollout ``(height, width)``; asserts if called
+        before :meth:`initialize_autoregressive_cache`.
+        """
+        assert self._height is not None and self._width is not None, (
+            "unpatchify_and_maybe_gather_cp requires an initialized "
+            "rollout; call initialize_autoregressive_cache(..., "
+            "height=..., width=...) first."
+        )
+        return self.network.unpatchify_and_maybe_gather_cp(
+            x, T=self.config.len_t, H=self._height, W=self._width
+        )
+
+    def initialize_autoregressive_cache(
+        self,
+        *,
+        height: int,
+        width: int,
+        context: Tensor,
+        negative_context: Tensor | None = None,
+    ) -> TemplateTransformerCache:
+        """Build a fully seeded cache for a new rollout.
+
+        Runs ``context`` (and ``negative_context`` when CFG is on)
+        through :attr:`context_encoder`, stashes the per-rollout
+        ``(batch_size, height, width)``, and — when
+        ``config.use_cuda_graph`` is set — builds fresh
+        :class:`CUDAGraphWrapper` instances sized to this rollout.
+
+        Args:
+            height: Pre-patchify latent height.
+            width: Pre-patchify latent width.
+            context: Raw conditional context passed through
+                :attr:`context_encoder`. The leading dim defines the
+                rollout's ``batch_size``.
+            negative_context: Raw unconditional context. Required iff
+                ``config.guidance_scale > 1.0``.
+
+        Returns:
+            Seeded :class:`TemplateTransformerCache`.
+        """
+        cfg = self.config
+        context_embeddings = self.context_encoder(input=context)
+        batch_size, _, _ = context_embeddings.shape
+
+        L_per_chunk = cfg.len_t * height * width
+        assert L_per_chunk % self._cp_size == 0, (
+            f"L = len_t*height*width ({L_per_chunk}) must be divisible by "
+            f"cp_size ({self._cp_size})."
+        )
+
+        HW = height * width
+        chunk_size = (cfg.len_t * HW) // self._cp_size
+        window_size = (cfg.window_size_t * HW) // self._cp_size
+        sink_size = (cfg.sink_size_t * HW) // self._cp_size
+
+        device = context_embeddings.device
+        dtype = cfg.dtype
+
+        network_cache = self.network.initialize_cache(
+            chunk_size=chunk_size,
+            window_size=window_size,
+            sink_size=sink_size,
+            context=context_embeddings,
+            batch_size=batch_size,
+            device=device,
+            dtype=dtype,
+        )
+
+        network_cache_uncond: TemplateDiTCache | None = None
+        if cfg.requires_negative_context_embeddings:
+            assert negative_context is not None, (
+                f"guidance_scale={cfg.guidance_scale} > 1.0 requires "
+                "negative_context_embeddings."
+            )
+            negative_context_embeddings = self.context_encoder(
+                input=negative_context
+            )
+            network_cache_uncond = self.network.initialize_cache(
+                chunk_size=chunk_size,
+                window_size=window_size,
+                sink_size=sink_size,
+                context=negative_context_embeddings,
+                batch_size=batch_size,
+                device=device,
+                dtype=dtype,
+            )
+
+        self._batch_size = batch_size
+        self._height = height
+        self._width = width
+
+        # One wrapper per rollout: static buffers and the captured
+        # graph are bound to this cache's KV pointers. The dispatch
+        # threshold matches the KV cache's filling → steady transition
+        # so the captured region only sees steady-state paths.
+        if self._use_cuda_graph:
+            self._cuda_graph_capture_ar_idx = (
+                cfg.sink_size_t + cfg.window_size_t
+            ) // cfg.len_t
+            self._network_call = CUDAGraphWrapper(
+                self.network, warmup_iters=cfg.cuda_graph_warmup_iters
+            )
+            self._network_call_uncond = CUDAGraphWrapper(
+                self.network, warmup_iters=cfg.cuda_graph_warmup_iters
+            )
+
+        return TemplateTransformerCache(
+            network_cache=network_cache,
+            network_cache_uncond=network_cache_uncond,
+        )
+
+    def _select_network(self, cache: TemplateTransformerCache, *, uncond: bool) -> Any:
+        # Filling phase: eager ``.drain`` (drains Inductor autotune and
+        # exercises the KV cache's slice-returning filling path).
+        # Steady phase: ``wrapper.__call__`` (warmup + capture + replay).
+        # Capturing in the filling phase would bake slice pointers into
+        # the graph and read stale storage after the cache rolls.
+        if not self._use_cuda_graph:
+            return self.network
+        network_call = self._network_call_uncond if uncond else self._network_call
+        assert isinstance(network_call, CUDAGraphWrapper), (
+            "predict_flow called before initialize_autoregressive_cache "
+            "while use_cuda_graph=True."
+        )
+        return (
+            network_call.drain
+            if cache.autoregressive_index < self._cuda_graph_capture_ar_idx
+            else network_call
+        )
+
+    def _predict_flow(
+        self,
+        noisy_latent: Tensor,
+        timestep: Tensor,
+        cache: TemplateTransformerCache,
+        network_cache: TemplateDiTCache,
+        control: Tensor | None,
+        *,
+        uncond: bool,
+    ) -> Tensor:
+        assert cache.autoregressive_index >= 0, (
+            "Cache.start(autoregressive_index) must be called before "
+            "predict_flow (DiffusionModel.generate handles this)."
+        )
+        return self._select_network(cache, uncond=uncond)(
+            noisy_latent,
+            timesteps=timestep,
+            cache=network_cache,
+            control=control,
+        )
+
+    def predict_flow(
+        self,
+        noisy_latent: Tensor,
+        timestep: Tensor,
+        cache: TemplateTransformerCache,
+        input: Tensor | None = None,
+    ) -> Tensor:
+        """Run the cond branch and merge in the uncond branch when CFG is on.
+
+        Args:
+            noisy_latent: ``[B, L/cp, in_channels]`` per-rank noisy latent.
+            timestep: Scalar timestep.
+            cache: Per-rollout cache; ``cache.autoregressive_index`` must
+                be set by a prior :meth:`TemplateTransformerCache.start`.
+            input: Encoded control latent, or ``None`` to skip the
+                per-token control bias.
+
+        Returns:
+            ``[B, L/cp, in_channels]`` flow prediction with CFG applied
+            when ``cache.network_cache_uncond`` is populated.
+        """
+        flow_cond = self._predict_flow(
+            noisy_latent=noisy_latent,
+            timestep=timestep,
+            cache=cache,
+            network_cache=cache.network_cache,
+            control=input,
+            uncond=False,
+        )
+        if cache.network_cache_uncond is None:
+            return flow_cond
+        else:
+            flow_uncond = self._predict_flow(
+                noisy_latent=noisy_latent,
+                timestep=timestep,
+                cache=cache,
+                network_cache=cache.network_cache_uncond,
+                control=input,
+                uncond=True,
+            )
+            return flow_uncond + self.config.guidance_scale * (flow_cond - flow_uncond)

--- a/flashdreams/flashdreams/recipes/template/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/template/transformer/__init__.py
@@ -91,9 +91,7 @@ class TemplateTransformerConfig(InstantiateConfig["TemplateTransformer"]):
     network: TemplateDiTConfig = field(default_factory=TemplateDiTConfig)
     """Underlying DiT network config."""
 
-    context_encoder: InstantiateConfig[Any] = field(
-        default_factory=NullEncoderConfig
-    )
+    context_encoder: InstantiateConfig[Any] = field(default_factory=NullEncoderConfig)
     """One-shot encoder applied to raw ``context`` inside
     :meth:`TemplateTransformer.initialize_autoregressive_cache`. The
     default :class:`~flashdreams.infra.encoder.NullEncoder` is identity;
@@ -284,9 +282,7 @@ class TemplateTransformer(Transformer[TemplateTransformerCache]):
                 f"guidance_scale={cfg.guidance_scale} > 1.0 requires "
                 "negative_context_embeddings."
             )
-            negative_context_embeddings = self.context_encoder(
-                input=negative_context
-            )
+            negative_context_embeddings = self.context_encoder(input=negative_context)
             network_cache_uncond = self.network.initialize_cache(
                 chunk_size=chunk_size,
                 window_size=window_size,

--- a/flashdreams/flashdreams/recipes/template/transformer/network.py
+++ b/flashdreams/flashdreams/recipes/template/transformer/network.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dummy single-block DiT network used by the template recipe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+from flashdreams.core.attention.kvcache import BlockKVCache
+from flashdreams.core.attention.ring import RingAttention
+from flashdreams.core.distributed.context_parallel import (
+    cat_outputs_cp,
+    split_inputs_cp,
+)
+from flashdreams.infra.config import InstantiateConfig
+
+
+@dataclass(kw_only=True)
+class TemplateDiTCache:
+    """Per-rollout network cache for :class:`TemplateDiT`.
+
+    Holds the block's KV cache plus the one-shot context embedding
+    injected as an additive bias every forward. Forwards the
+    ``before_update`` / ``after_update`` protocol to :class:`BlockKVCache`.
+    """
+
+    kv_cache: BlockKVCache
+    """Self-attention KV cache; shape ``[B, total_size, H, d_h]``."""
+
+    context: Tensor
+    """Per-rollout context tokens ``[B, N_ctx, D]``, injected as an
+    additive bias on every forward."""
+
+    def before_update(self, chunk_idx: int) -> None:
+        """Prepare the KV cache for writing chunk ``chunk_idx``."""
+        self.kv_cache.before_update(chunk_idx)
+
+    def after_update(self, chunk_idx: int) -> None:
+        """Commit bookkeeping after chunk ``chunk_idx`` has been written."""
+        self.kv_cache.after_update(chunk_idx)
+
+
+@dataclass(kw_only=True)
+class TemplateDiTConfig(InstantiateConfig["TemplateDiT"]):
+    """Config for the template recipe's dummy DiT."""
+
+    _target: type["TemplateDiT"] = field(default_factory=lambda: TemplateDiT)
+
+    in_channels: int = 4
+    """Latent channel count; matches the noise tensor's last dim after flattening."""
+
+    context_channels: int = 16
+    """Channel count of the pre-encoded context token tensor."""
+
+    model_channels: int = 64
+    """Hidden width used inside the block."""
+
+    num_heads: int = 4
+    """Attention head count. ``model_channels`` must be divisible by this."""
+
+    ffn_mult: float = 2.0
+    """Expansion factor applied to ``model_channels`` inside the FFN."""
+
+    def __post_init__(self) -> None:
+        assert self.model_channels % self.num_heads == 0, (
+            f"model_channels ({self.model_channels}) must be divisible by "
+            f"num_heads ({self.num_heads})."
+        )
+
+
+class TemplateDiT(nn.Module):
+    """Minimal single-block DiT used as a reference recipe.
+
+    Shape: per-token projection → time / context bias → self-attention
+    through a :class:`~flashdreams.core.attention.kvcache.BlockKVCache`
+    → FFN → output projection.
+
+    Per-step usage:
+        1. ``cache.before_update(chunk_idx)`` — hoisted to
+           :meth:`~flashdreams.recipes.template.transformer.TemplateTransformerCache.start`.
+        2. ``forward(noisy_latent, timesteps, cache, control)``.
+        3. ``cache.after_update(chunk_idx)`` — hoisted to
+           :meth:`~flashdreams.recipes.template.transformer.TemplateTransformerCache.finalize`.
+    """
+
+    def __init__(self, config: TemplateDiTConfig) -> None:
+        super().__init__()
+        self.config = config
+        D = config.model_channels
+        H = config.num_heads
+        self._head_dim = D // H
+        self._num_heads = H
+
+        self.input_proj = nn.Linear(config.in_channels, D)
+        self.context_proj = nn.Linear(config.context_channels, D)
+        # Scalar timestep lifted to ``[1, D]``. Real recipes use a
+        # sinusoidal embedding + MLP.
+        self.timestep_encoder = nn.Sequential(
+            nn.Linear(1, D),
+            nn.SiLU(),
+            nn.Linear(D, D),
+        )
+
+        self.norm1 = nn.LayerNorm(D)
+        self.q_proj = nn.Linear(D, D)
+        self.k_proj = nn.Linear(D, D)
+        self.v_proj = nn.Linear(D, D)
+        # ``bshd`` matches the native ``[B, S, H, d_h]`` layout;
+        # RingAttention handles the CP gather + LSE merge.
+        self.attn = RingAttention(qkv_format="bshd", backend="cudnn")
+        self.attn_out = nn.Linear(D, D)
+
+        self.norm2 = nn.LayerNorm(D)
+        ffn_hidden = int(D * config.ffn_mult)
+        self.ffn = nn.Sequential(
+            nn.Linear(D, ffn_hidden),
+            nn.GELU(),
+            nn.Linear(ffn_hidden, D),
+        )
+
+        self.output_proj = nn.Linear(D, config.in_channels)
+
+        self._cp_group: ProcessGroup | None = None
+
+    def set_context_parallel_group(self, cp_group: ProcessGroup | None) -> None:
+        """Wire the CP group used by attention and the patchify helpers.
+
+        Args:
+            cp_group: Context-parallel group; ``None`` disables CP and
+                makes the patchify helpers no-ops.
+        """
+        self._cp_group = cp_group
+        self.attn.set_context_parallel_group(cp_group)
+
+    def patchify_and_maybe_split_cp(self, x: Tensor) -> Tensor:
+        """Flatten ``[B, C, T, H, W]`` to ``[B, L=T*H*W, C]`` and CP-split along ``L``.
+
+        Args:
+            x: Pre-patchify latent ``[B, C, T, H, W]``.
+
+        Returns:
+            Per-rank ``[B, L/cp, C]`` latent (no split when
+            ``_cp_group`` is ``None``).
+        """
+        assert x.ndim == 5, f"Expected [B, C, T, H, W], got {tuple(x.shape)}."
+        B, C, T, H, W = x.shape
+        x = x.permute(0, 2, 3, 4, 1).reshape(B, T * H * W, C)
+        return split_inputs_cp(x, seq_dim=1, cp_group=self._cp_group)
+
+    def unpatchify_and_maybe_gather_cp(
+        self, x: Tensor, *, T: int, H: int, W: int
+    ) -> Tensor:
+        """Inverse of :meth:`patchify_and_maybe_split_cp`.
+
+        Args:
+            x: Per-rank latent ``[B, L/cp, C]``.
+            T: Pre-flatten temporal length.
+            H: Pre-flatten height.
+            W: Pre-flatten width.
+
+        Returns:
+            ``[B, C, T, H, W]`` with the CP shards concatenated along ``L``.
+        """
+        x = cat_outputs_cp(x, seq_dim=1, cp_group=self._cp_group)
+        B, L, C = x.shape
+        assert L == T * H * W, f"L mismatch: {L=} vs T*H*W={T * H * W}."
+        return x.reshape(B, T, H, W, C).permute(0, 4, 1, 2, 3).contiguous()
+
+    def initialize_cache(
+        self,
+        *,
+        chunk_size: int,
+        window_size: int,
+        sink_size: int,
+        context: Tensor,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> TemplateDiTCache:
+        """Allocate this block's KV cache and project the context tokens.
+
+        Args:
+            chunk_size: Per-rank tokens written per AR step.
+            window_size: Per-rank sliding-window size, excluding sinks.
+            sink_size: Per-rank sink-token count.
+            context: ``[B, N_ctx, context_channels]`` tokens; projected
+                to ``model_channels`` once here and reused every forward.
+            batch_size: Leading batch dim of the KV buffer.
+            device: Device for the KV buffer.
+            dtype: Dtype for the KV buffer and the projected context.
+        """
+        total = sink_size + window_size
+        k_shape = (batch_size, total, self._num_heads, self._head_dim)
+        v_shape = (batch_size, total, self._num_heads, self._head_dim)
+        kv_cache = BlockKVCache(
+            k_shape=k_shape,
+            v_shape=v_shape,
+            seq_dim=1,
+            chunk_size=chunk_size,
+            window_size=window_size,
+            sink_size=sink_size,
+            device=device,
+            dtype=dtype,
+        )
+        context = self.context_proj(context.to(dtype=dtype))
+        return TemplateDiTCache(kv_cache=kv_cache, context=context)
+
+    def forward(
+        self,
+        noisy_latent: Tensor,
+        *,
+        timesteps: Tensor,
+        cache: TemplateDiTCache,
+        control: Tensor | None = None,
+    ) -> Tensor:
+        """Predict flow for one per-rank AR chunk.
+
+        Args:
+            noisy_latent: ``[B, L/cp, in_channels]`` — already
+                patchified and CP-split by the transformer wrapper.
+            timesteps: Scalar timestep.
+            cache: Per-rollout cache. AR-step bookkeeping is hoisted
+                to :class:`TemplateTransformerCache`.
+            control: Per-AR-step control latent, same shape as
+                ``noisy_latent``; ``None`` skips the control bias.
+
+        Returns:
+            ``[B, L/cp, in_channels]`` flow prediction.
+        """
+        B, L_local, _ = noisy_latent.shape
+        D = self.config.model_channels
+
+        x = self.input_proj(noisy_latent)
+        if control is not None:
+            x = x + self.input_proj(control)
+
+        t_emb = self.timestep_encoder(timesteps.reshape(1, 1).to(x.dtype))
+        ctx_bias = cache.context.mean(dim=1)  # [B, D]
+        x = x + t_emb.view(1, 1, D) + ctx_bias.view(B, 1, D)
+
+        x = self._self_attn_block(x, kv_cache=cache.kv_cache)
+        return self.output_proj(x)
+
+    def _self_attn_block(self, x: Tensor, *, kv_cache: BlockKVCache) -> Tensor:
+        """Run one pre-norm self-attention + FFN residual block.
+
+        Q is this rank's current chunk; K/V come from ``kv_cache``
+        (filling or steady view). :class:`RingAttention` fuses the
+        cross-rank KV gather with the SDPA call.
+        """
+        B, L_local, D = x.shape
+
+        h = self.norm1(x)
+        q = self.q_proj(h).view(B, L_local, self._num_heads, self._head_dim)
+        k = self.k_proj(h).view(B, L_local, self._num_heads, self._head_dim)
+        v = self.v_proj(h).view(B, L_local, self._num_heads, self._head_dim)
+
+        kv_cache.update(k, v)
+        k_local = kv_cache.cached_k()  # [B, S_local, H, d_h]
+        v_local = kv_cache.cached_v()
+
+        attn = self.attn(q, k_local, v_local).reshape(B, L_local, D)
+        x = x + self.attn_out(attn)
+
+        x = x + self.ffn(self.norm2(x))
+        return x

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -440,7 +440,7 @@ class Decoder3d(nn.Module):
         upsamples: list[nn.Module] = []
         for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
             # Match legacy weight shapes: stages 1-3 halve their input dim
-            # because the preceding `Resample` already halved channels.
+            # because the preceding ``Resample`` already halved channels.
             if i in (1, 2, 3):
                 in_dim = in_dim // 2
             for _ in range(num_res_blocks + 1):
@@ -487,7 +487,7 @@ class WanVAE(nn.Module):
     direction is needed; the unused half's parameters and graph state are
     skipped, saving VRAM.
 
-    Typical usage example:
+    Examples:
 
         vae = WanVAE(vae_path="...", use_lightvae=True).to("cuda", torch.bfloat16)
         cache = vae.prepare_cache()
@@ -542,7 +542,7 @@ class WanVAE(nn.Module):
             "dropout": 0.0,
             "pruning_rate": pruning_rate,
         }
-        # Build on `meta` so only the checkpoint allocates real memory; skip
+        # Build on ``meta`` so only the checkpoint allocates real memory; skip
         # the disabled half so its params never materialise.
         with torch.device("meta"):
             if enable_encoder:

--- a/flashdreams/flashdreams/recipes/wan/pipeline.py
+++ b/flashdreams/flashdreams/recipes/wan/pipeline.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Protocol, cast, runtime_checkable
 
 import torch
 import torch.nn.functional as F
@@ -36,8 +37,8 @@ from flashdreams.infra.pipeline import (
     StreamInferencePipelineCache,
     StreamInferencePipelineConfig,
 )
-from flashdreams.recipes.wan.autoencoder.i2v import I2VCtrlEncoder, I2VCtrlEncoderCache
-from flashdreams.recipes.wan.autoencoder.vae import WanVAECache, WanVAEDecoder
+from flashdreams.recipes.wan.autoencoder.i2v import I2VCtrlEncoderCache
+from flashdreams.recipes.wan.autoencoder.vae import WanVAECache
 from flashdreams.recipes.wan.constants import NEGATIVE_PROMPT
 from flashdreams.recipes.wan.transformer.wan21 import (
     Wan21TransformerCache,
@@ -47,6 +48,21 @@ from flashdreams.recipes.wan.transformer.wan22 import (
     Wan22TransformerCache,
     Wan22TransformerConfig,
 )
+
+
+@runtime_checkable
+class _HasTemporalCompressionRatio(Protocol):
+    """Structural contract used by the I2V frame-count helpers.
+
+    ``get_num_input_frames`` and ``get_num_output_frames`` only need to know the encoder's
+    ``temporal_compression_ratio``; locking it to a concrete subclass
+    excludes downstream recipes (e.g. Lingbot World's
+    :class:`I2VCamCtrlEncoder`) that satisfy the same shape contract
+    without inheriting from :class:`I2VCtrlEncoder`.
+    """
+
+    @property
+    def temporal_compression_ratio(self) -> int: ...
 
 
 @dataclass(kw_only=True)
@@ -259,8 +275,11 @@ class WanInferencePipeline(
     def get_num_input_frames(self, autoregressive_index: int) -> int:
         """Number of input video frames the model expects at this AR step."""
         len_t = self._transformer_config.len_t
-        assert isinstance(self.encoder, I2VCtrlEncoder)
-        temporal_compression_ratio = self.encoder.temporal_compression_ratio
+        assert isinstance(self.encoder, _HasTemporalCompressionRatio), (
+            f"get_num_input_frames requires an I2V encoder exposing "
+            f"`temporal_compression_ratio`; got {type(self.encoder).__name__}."
+        )
+        temporal_compression_ratio = cast(int, self.encoder.temporal_compression_ratio)
         if autoregressive_index == 0:
             return 1 + (len_t - 1) * temporal_compression_ratio
         else:
@@ -269,8 +288,11 @@ class WanInferencePipeline(
     def get_num_output_frames(self, autoregressive_index: int) -> int:
         """Number of decoded video frames produced at this AR step."""
         len_t = self._transformer_config.len_t
-        assert isinstance(self.decoder, WanVAEDecoder)
-        temporal_compression_ratio = self.decoder.temporal_compression_ratio
+        assert isinstance(self.decoder, _HasTemporalCompressionRatio), (
+            f"get_num_output_frames requires a decoder exposing "
+            f"`temporal_compression_ratio`; got {type(self.decoder).__name__}."
+        )
+        temporal_compression_ratio = cast(int, self.decoder.temporal_compression_ratio)
         if autoregressive_index == 0:
             return 1 + (len_t - 1) * temporal_compression_ratio
         else:

--- a/flashdreams/flashdreams/recipes/wan/pipeline.py
+++ b/flashdreams/flashdreams/recipes/wan/pipeline.py
@@ -102,7 +102,7 @@ class WanInferencePipeline(
     pass an ``image`` to ``initialize_cache``. The pipeline config's
     ``encoder`` slot must agree (``None`` for T2V, an I2V config for I2V).
 
-    Typical usage example:
+    Examples:
 
         pipeline: WanInferencePipeline = ...
 

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
@@ -45,6 +45,7 @@ class WanDiTNetworkCache:
     """Cache container for all transformer blocks."""
 
     block_caches: list[BlockCache]
+    """Per-transformer-block KV cache, indexed by block position."""
 
     def __getitem__(self, index: int) -> BlockCache:
         """Get cache for a specific block."""
@@ -209,14 +210,14 @@ class WanDiTNetwork(nn.Module):
         process_groups: list[ProcessGroup | None] | None = None,
         cp_dims: list[int | None] | None = None,
     ) -> Tensor:
-        r"""
-        Patchify the input tensor and maybe split it along cp_dim if a process group is provided.
+        """Patchify and optionally CP-split the input video tensor.
 
-        The patchify pattern is:
-            "... (t kt) c (h kh) (w kw) -> ... (t h w) (c kt kh kw)",
+        The patchify pattern is
+        ``... (t kt) c (h kh) (w kw) -> ... (t h w) (c kt kh kw)``.
 
         Returns:
-            Tensor: The patched tensor with shape [..., L, D], where L = T * H * W / (kt * kh * kw)
+            Patched tensor with shape ``[..., L, D]`` where
+            ``L = T * H * W / (kt * kh * kw)``.
         """
         assert x.ndim >= 4, (
             f"x must have at least 4 trailing dims (T, C, H, W) "
@@ -252,14 +253,13 @@ class WanDiTNetwork(nn.Module):
         process_groups: list[ProcessGroup | None] | None = None,
         cp_dims: list[int | None] | None = None,
     ) -> Tensor:
-        r"""
-        Unpatchify the input tensor and maybe gather it along cp_dim if a process group is provided.
+        """Unpatchify and optionally CP-gather the tensor back to video shape.
 
-        The unpatchify pattern is:
-            "... (t h w) (c kt kh kw) -> ... (t kt) c (h kh) (w kw)",
+        The unpatchify pattern is
+        ``... (t h w) (c kt kh kw) -> ... (t kt) c (h kh) (w kw)``.
 
         Returns:
-            Tensor: The unpatched tensor with shape [..., T, C, H, W]
+            Unpatched tensor with shape ``[..., T, C, H, W]``.
         """
         assert x.ndim >= 2, f"x must be a 2D or higher tensor, but got shape {x.shape}"
 
@@ -327,8 +327,7 @@ class WanDiTNetwork(nn.Module):
         return WanDiTNetworkCache(block_caches=block_caches)
 
     def update_parameters_after_loading_checkpoint(self) -> None:
-        # This function should be called after loading the checkpoint, to fuse some operations in the model
-        # weights to reduce computation during inference.
+        """Fuse load-time-known ops into weights; call once after loading the checkpoint."""
         if self._parameters_updated_after_loading_checkpoint:
             return
 
@@ -341,31 +340,27 @@ class WanDiTNetwork(nn.Module):
         self._parameters_updated_after_loading_checkpoint = True
 
     def _fuse_shuffle_op_into_last_layer(self) -> None:
-        """
-        In the WAN model, the patchify operation is
-        "b c (t kt) (h kh) (w kw) -> b (t h w) (c kt kh kw)",
+        """Fuse the channel-shuffle that follows the last linear into its weights.
 
-        while the unpatchify operation is
-        "b (t h w) (kt kh kw c) -> b c (t kt) (h kh) (w kw)"
+        In the WAN model the patchify pattern is
+        ``b c (t kt) (h kh) (w kw) -> b (t h w) (c kt kh kw)`` while the
+        unpatchify pattern is
+        ``b (t h w) (kt kh kw c) -> b c (t kt) (h kh) (w kw)``. This mismatch
+        (likely a bug in the official implementation) means the last dimension
+        must be shuffled after the network. Folding that shuffle into
+        ``head.head`` removes the explicit ``rearrange`` from the inference path.
 
-        This is likely a bug in the official implementation where the last dimension is shuffled
-        after the network.
+        Calling this once is equivalent to running the following after the last
+        layer::
 
-        To fix this, we could fuse this shuffle op into the last linear layer,
-        so that we do not have to do this shuffle op explicitly before returning the result.
-
-        Calling this function to modify the last layer in place, is equivalent to the following code
-        after the last layer:
-        ```python
-        x = rearrange(
-            x,
-            "... (kt kh kw c) -> ... (c kt kh kw)",
-            kt=self.patch_size[0],
-            kh=self.patch_size[1],
-            kw=self.patch_size[2],
-            c=self.out_dim,
-        )
-        ```
+            x = rearrange(
+                x,
+                "... (kt kh kw c) -> ... (c kt kh kw)",
+                kt=self.patch_size[0],
+                kh=self.patch_size[1],
+                kw=self.patch_size[2],
+                c=self.out_dim,
+            )
         """
         if self._is_shuffle_op_fused:
             return

--- a/flashdreams/tests/test_template.py
+++ b/flashdreams/tests/test_template.py
@@ -149,9 +149,7 @@ def _run_rollout(
         "width": width,
     }
     if use_cfg:
-        transformer_context["negative_context"] = inputs[
-            "negative_context_embeddings"
-        ]
+        transformer_context["negative_context"] = inputs["negative_context_embeddings"]
 
     cache = pipeline.initialize_cache(transformer_context=transformer_context)
     assert isinstance(cache.transformer_cache, TemplateTransformerCache)
@@ -235,9 +233,7 @@ def test_template_no_control() -> None:
     from typing import cast
 
     base = build_cfg_offline(seed=0)
-    config = cast(
-        StreamInferencePipelineConfig, derive_config(base, encoder=None)
-    )
+    config = cast(StreamInferencePipelineConfig, derive_config(base, encoder=None))
     pipeline = config.setup()
     assert isinstance(pipeline, StreamInferencePipeline)
     assert pipeline.encoder is None
@@ -419,9 +415,7 @@ def test_template_compile_and_cudagraph_equivalence() -> None:
     device = torch.device("cuda")
     seed = 0
 
-    base = _with_cfg(
-        build_cfg_autoregressive(seed=seed), guidance_scale=2.0
-    )
+    base = _with_cfg(build_cfg_autoregressive(seed=seed), guidance_scale=2.0)
     fast = with_compile_and_cuda_graph(base)
 
     torch.manual_seed(seed)
@@ -447,7 +441,10 @@ def test_template_compile_and_cudagraph_equivalence() -> None:
     ):
         assert name_e == name_f, (name_e, name_f)
         torch.testing.assert_close(
-            p_e.detach(), p_f.detach(), rtol=0, atol=0,
+            p_e.detach(),
+            p_f.detach(),
+            rtol=0,
+            atol=0,
             msg=f"seeded init diverged on parameter {name_e}",
         )
 
@@ -525,9 +522,7 @@ def _cp_one_predict_flow(
     """
     from flashdreams.core.distributed.context_parallel import split_inputs_cp
 
-    base = _with_cfg(
-        build_cfg_autoregressive(seed=seed), guidance_scale=2.0
-    )
+    base = _with_cfg(build_cfg_autoregressive(seed=seed), guidance_scale=2.0)
     torch.manual_seed(seed)
     pipeline = base.setup().to(device).eval()
     transformer = pipeline.diffusion_model.transformer
@@ -585,9 +580,7 @@ def _cp_one_predict_flow(
     )
     transformer_cache.finalize(ar_idx)
 
-    return cat_outputs_cp(
-        flow_local, seq_dim=1, cp_group=transformer._cp_group
-    )
+    return cat_outputs_cp(flow_local, seq_dim=1, cp_group=transformer._cp_group)
 
 
 def test_template_cp_equivalence() -> None:

--- a/flashdreams/tests/test_template.py
+++ b/flashdreams/tests/test_template.py
@@ -1,0 +1,678 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end smoke tests + manual driver for the ``template`` recipe.
+
+``test_template_cp_equivalence`` is a two-invocation test: the
+single-GPU branch writes a reference tensor to
+``$TEMPLATE_CP_REF_PATH`` (default ``<tmpdir>/flashdreams/cp_reference.pt``),
+then a torchrun launch reads it and asserts equivalence.
+
+.. code-block:: bash
+
+    uv run --extra dev pytest \
+        flashdreams/tests/test_template.py::test_template_cp_equivalence -v
+    uv run --extra dev torchrun --nproc_per_node=2 -m pytest \
+        flashdreams/tests/test_template.py::test_template_cp_equivalence -v
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from flashdreams.core.distributed.context_parallel import cat_outputs_cp
+from flashdreams.infra.config import derive_config
+from flashdreams.infra.pipeline import (
+    StreamInferencePipeline,
+    StreamInferencePipelineConfig,
+)
+from flashdreams.recipes.template.config import (
+    build_cfg_autoregressive,
+    build_cfg_offline,
+    with_compile_and_cuda_graph,
+)
+from flashdreams.recipes.template.transformer import (
+    TemplateTransformer,
+    TemplateTransformerCache,
+    TemplateTransformerConfig,
+)
+
+# Asymmetric ``H != W != len_t`` to catch transpose / reshape bugs a
+# square shape would hide.
+TEMPLATE_DEFAULT_BATCH_SIZE = 1
+TEMPLATE_DEFAULT_HEIGHT = 3
+TEMPLATE_DEFAULT_WIDTH = 4
+
+_CP_REFERENCE_PATH = Path(
+    os.environ.get(
+        "TEMPLATE_CP_REF_PATH",
+        str(Path(tempfile.gettempdir()) / "flashdreams" / "cp_reference.pt"),
+    )
+)
+"""Shared reference tensor for :func:`test_template_cp_equivalence`.
+
+Set ``TEMPLATE_CP_REF_PATH`` to a shared-FS path when the two
+invocations don't share ``/tmp``."""
+
+
+## Shared helpers
+
+
+def _make_inputs(
+    cfg: TemplateTransformerConfig,
+    *,
+    batch_size: int,
+    height: int,
+    width: int,
+    control_channels: int,
+    context_channels: int,
+    n_context_tokens: int,
+    device: torch.device,
+    seed: int,
+) -> dict[str, torch.Tensor]:
+    """Build deterministic per-rollout inputs for one rank.
+
+    Uses a seeded :class:`torch.Generator` so repeated calls with the
+    same ``seed`` are bit-identical — required for the eager-vs-compiled
+    and CP-equivalence checks.
+    """
+    gen = torch.Generator(device=device).manual_seed(seed)
+    dtype = cfg.dtype
+    return dict(
+        context_embeddings=torch.randn(
+            batch_size,
+            n_context_tokens,
+            context_channels,
+            device=device,
+            generator=gen,
+            dtype=dtype,
+        ),
+        negative_context_embeddings=torch.randn(
+            batch_size,
+            n_context_tokens,
+            context_channels,
+            device=device,
+            generator=gen,
+            dtype=dtype,
+        ),
+        control_pre_patchify=torch.randn(
+            batch_size,
+            control_channels,
+            cfg.len_t,
+            height,
+            width,
+            device=device,
+            generator=gen,
+            dtype=dtype,
+        ),
+    )
+
+
+def _run_rollout(
+    *,
+    pipeline: StreamInferencePipeline,
+    num_ar_steps: int,
+    use_cfg: bool,
+    inputs: dict[str, torch.Tensor],
+    height: int,
+    width: int,
+    use_control: bool = True,
+) -> list[torch.Tensor]:
+    """Initialize the cache, run ``num_ar_steps``, and return per-step outputs.
+
+    Args:
+        use_control: When ``False``, forwards ``input=None`` to
+            ``pipeline.generate``. The pipeline must be built with
+            ``encoder=None`` or ``generate`` asserts.
+    """
+    transformer_context: dict[str, object] = {
+        "context": inputs["context_embeddings"],
+        "height": height,
+        "width": width,
+    }
+    if use_cfg:
+        transformer_context["negative_context"] = inputs[
+            "negative_context_embeddings"
+        ]
+
+    cache = pipeline.initialize_cache(transformer_context=transformer_context)
+    assert isinstance(cache.transformer_cache, TemplateTransformerCache)
+    if use_cfg:
+        assert cache.transformer_cache.network_cache_uncond is not None
+    else:
+        assert cache.transformer_cache.network_cache_uncond is None
+
+    control = inputs["control_pre_patchify"] if use_control else None
+    outputs: list[torch.Tensor] = []
+    for ar_idx in range(num_ar_steps):
+        out = pipeline.generate(ar_idx, cache, input=control)
+        outputs.append(out)
+        # Skip ``finalize`` on the last step — the canonical "hot loop,
+        # optional last finalize" pattern.
+        if ar_idx < num_ar_steps - 1:
+            pipeline.finalize(ar_idx, cache)
+    return outputs
+
+
+## Basic smoke tests
+
+# ``RingAttention`` dispatches to CUDA-only SDPA backends.
+_CUDA_REQUIRED = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="template recipe uses RingAttention which requires CUDA.",
+)
+
+
+@_CUDA_REQUIRED
+@pytest.mark.parametrize("seed", [0, 42])
+def test_template_bidirectional(seed: int) -> None:
+    """``build_cfg_offline`` runs a single AR step end-to-end."""
+    config = build_cfg_offline(seed=seed)
+    pipeline = config.setup()
+    assert isinstance(pipeline, StreamInferencePipeline)
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, TemplateTransformer)
+    cfg = transformer.config
+
+    device = torch.device("cuda")
+    pipeline.to(device).eval()
+
+    H, W = TEMPLATE_DEFAULT_HEIGHT, TEMPLATE_DEFAULT_WIDTH
+    B = TEMPLATE_DEFAULT_BATCH_SIZE
+    inputs = _make_inputs(
+        cfg,
+        batch_size=B,
+        height=H,
+        width=W,
+        control_channels=8,
+        context_channels=16,
+        n_context_tokens=4,
+        device=device,
+        seed=seed,
+    )
+    outputs = _run_rollout(
+        pipeline=pipeline,
+        num_ar_steps=1,
+        use_cfg=False,
+        inputs=inputs,
+        height=H,
+        width=W,
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0].shape == (B, 3, cfg.len_t, H, W)
+    assert outputs[0].device.type == device.type
+    assert torch.isfinite(outputs[0]).all()
+
+
+@_CUDA_REQUIRED
+def test_template_no_control() -> None:
+    """Rollout with no encoder + ``input=None`` skips the control bias.
+
+    Covers the ``TemplateDiT.forward`` branch that skips
+    ``self.input_proj(control)`` when no control tensor is supplied,
+    and asserts the no-control output disagrees with the matching
+    control-on rollout.
+    """
+    from typing import cast
+
+    base = build_cfg_offline(seed=0)
+    config = cast(
+        StreamInferencePipelineConfig, derive_config(base, encoder=None)
+    )
+    pipeline = config.setup()
+    assert isinstance(pipeline, StreamInferencePipeline)
+    assert pipeline.encoder is None
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, TemplateTransformer)
+    cfg = transformer.config
+
+    device = torch.device("cuda")
+    pipeline.to(device).eval()
+
+    H, W = TEMPLATE_DEFAULT_HEIGHT, TEMPLATE_DEFAULT_WIDTH
+    B = TEMPLATE_DEFAULT_BATCH_SIZE
+    inputs = _make_inputs(
+        cfg,
+        batch_size=B,
+        height=H,
+        width=W,
+        control_channels=8,
+        context_channels=16,
+        n_context_tokens=4,
+        device=device,
+        seed=0,
+    )
+    outputs_no_ctrl = _run_rollout(
+        pipeline=pipeline,
+        num_ar_steps=1,
+        use_cfg=False,
+        inputs=inputs,
+        height=H,
+        width=W,
+        use_control=False,
+    )
+    assert len(outputs_no_ctrl) == 1
+    assert outputs_no_ctrl[0].shape == (B, 3, cfg.len_t, H, W)
+    assert torch.isfinite(outputs_no_ctrl[0]).all()
+
+    # A matching control-on rollout (same seed, same inputs) must
+    # differ — otherwise the control bias is silently dropped.
+    torch.manual_seed(0)
+    with_ctrl_pipeline = build_cfg_offline(seed=0).setup().to(device).eval()
+    outputs_with_ctrl = _run_rollout(
+        pipeline=with_ctrl_pipeline,
+        num_ar_steps=1,
+        use_cfg=False,
+        inputs=inputs,
+        height=H,
+        width=W,
+        use_control=True,
+    )
+    assert not torch.allclose(
+        outputs_no_ctrl[0], outputs_with_ctrl[0], rtol=1e-2, atol=1e-2
+    ), "control-off and control-on rollouts produced identical outputs"
+
+
+@_CUDA_REQUIRED
+def test_template_streaming_cfg() -> None:
+    """``build_cfg_autoregressive`` runs multi-step AR with CFG on."""
+    config = _with_cfg(build_cfg_autoregressive(seed=0), guidance_scale=2.0)
+    pipeline = config.setup()
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, TemplateTransformer)
+    cfg = transformer.config
+    # Exercise both the filling and steady-state KV-cache phases.
+    num_ar_steps = (cfg.sink_size_t + cfg.window_size_t) // cfg.len_t + 2
+    device = torch.device("cuda")
+    pipeline.to(device).eval()
+
+    H, W = TEMPLATE_DEFAULT_HEIGHT, TEMPLATE_DEFAULT_WIDTH
+    B = TEMPLATE_DEFAULT_BATCH_SIZE
+    inputs = _make_inputs(
+        cfg,
+        batch_size=B,
+        height=H,
+        width=W,
+        control_channels=8,
+        context_channels=16,
+        n_context_tokens=4,
+        device=device,
+        seed=0,
+    )
+    outputs = _run_rollout(
+        pipeline=pipeline,
+        num_ar_steps=num_ar_steps,
+        use_cfg=True,
+        inputs=inputs,
+        height=H,
+        width=W,
+    )
+
+    assert len(outputs) == num_ar_steps
+    for out in outputs:
+        assert out.shape == (B, 3, cfg.len_t, H, W)
+        assert torch.isfinite(out).all()
+    assert not torch.allclose(outputs[0], outputs[1])
+
+
+@_CUDA_REQUIRED
+def test_template_cfg_rejects_missing_negative_context() -> None:
+    """CFG on without negative context must fail at cache build time."""
+    config = _with_cfg(build_cfg_autoregressive(seed=0), guidance_scale=2.0)
+    pipeline = config.setup()
+    pipeline.to("cuda").eval()
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, TemplateTransformer)
+
+    B = TEMPLATE_DEFAULT_BATCH_SIZE
+    dtype = transformer.config.dtype
+    context = torch.randn(B, 4, 16, device="cuda", dtype=dtype)
+    with pytest.raises(AssertionError, match="negative_context_embeddings"):
+        pipeline.initialize_cache(
+            transformer_context={
+                "context": context,
+                "height": TEMPLATE_DEFAULT_HEIGHT,
+                "width": TEMPLATE_DEFAULT_WIDTH,
+            }
+        )
+
+
+@_CUDA_REQUIRED
+def test_template_latent_shape_respects_cp_size() -> None:
+    """``latent_shape`` reflects the per-rollout, per-rank ``L`` partition.
+
+    Populated lazily by
+    :meth:`TemplateTransformer.initialize_autoregressive_cache`;
+    reading it earlier asserts.
+    """
+    device = torch.device("cuda")
+    pipeline = build_cfg_offline().setup().to(device).eval()
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, TemplateTransformer)
+    cfg = transformer.config
+    assert isinstance(cfg, TemplateTransformerConfig)
+
+    with pytest.raises(AssertionError, match="initialize_autoregressive_cache"):
+        _ = transformer.latent_shape
+
+    H, W = TEMPLATE_DEFAULT_HEIGHT, TEMPLATE_DEFAULT_WIDTH
+    B = TEMPLATE_DEFAULT_BATCH_SIZE
+    context = torch.randn(B, 4, 16, device=device, dtype=cfg.dtype)
+    pipeline.initialize_cache(
+        transformer_context={"context": context, "height": H, "width": W}
+    )
+    # cp_size == 1 here; torch.distributed isn't initialised.
+    L = cfg.len_t * H * W
+    expected = (B, L // transformer._cp_size, cfg.network.in_channels)
+    assert transformer.latent_shape == expected
+
+
+## torch.compile + CUDAGraphWrapper equivalence
+
+
+def _with_cfg(
+    base: StreamInferencePipelineConfig, *, guidance_scale: float
+) -> StreamInferencePipelineConfig:
+    """Return ``base`` with ``guidance_scale`` patched onto the transformer."""
+    from typing import cast
+
+    return cast(
+        StreamInferencePipelineConfig,
+        derive_config(
+            base,
+            diffusion_model=dict(
+                transformer=dict(guidance_scale=guidance_scale),
+            ),
+        ),
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="torch.compile + CUDAGraphWrapper equivalence requires CUDA.",
+)
+def test_template_compile_and_cudagraph_equivalence() -> None:
+    """Eager vs ``torch.compile`` + ``CUDAGraphWrapper`` agree numerically.
+
+    Uses streaming + CFG and runs past ``_cuda_graph_capture_ar_idx``
+    so both the ``drain`` (filling) and captured (steady) paths fire.
+    """
+    device = torch.device("cuda")
+    seed = 0
+
+    base = _with_cfg(
+        build_cfg_autoregressive(seed=seed), guidance_scale=2.0
+    )
+    fast = with_compile_and_cuda_graph(base)
+
+    torch.manual_seed(seed)
+    eager_pipeline = base.setup().to(device).eval()
+
+    torch.manual_seed(seed)
+    fast_pipeline = fast.setup().to(device).eval()
+
+    # The fast pipeline's state_dict keys differ (compile wraps into
+    # ``OptimizedModule``, CUDAGraphWrapper adds submodules), but both
+    # rollouts use the same raw network constructed under the same
+    # ``manual_seed``, so underlying weights match bit-for-bit. Assert
+    # that here so any regression is caught early.
+    eager_raw = eager_pipeline.diffusion_model.transformer.network
+    fast_raw = fast_pipeline.diffusion_model.transformer.network
+    fast_raw_inner = getattr(fast_raw, "_orig_mod", fast_raw)
+    assert isinstance(eager_raw, torch.nn.Module)
+    assert isinstance(fast_raw_inner, torch.nn.Module)
+    for (name_e, p_e), (name_f, p_f) in zip(
+        eager_raw.named_parameters(),
+        fast_raw_inner.named_parameters(),
+        strict=True,
+    ):
+        assert name_e == name_f, (name_e, name_f)
+        torch.testing.assert_close(
+            p_e.detach(), p_f.detach(), rtol=0, atol=0,
+            msg=f"seeded init diverged on parameter {name_e}",
+        )
+
+    cfg = eager_pipeline.diffusion_model.transformer.config
+    assert isinstance(cfg, TemplateTransformerConfig)
+    # Cross the filling → steady boundary with at least one steady
+    # step so both ``drain`` and captured ``__call__`` fire.
+    num_ar_steps = (cfg.sink_size_t + cfg.window_size_t) // cfg.len_t + 2
+
+    H, W = TEMPLATE_DEFAULT_HEIGHT, TEMPLATE_DEFAULT_WIDTH
+    B = TEMPLATE_DEFAULT_BATCH_SIZE
+    inputs = _make_inputs(
+        cfg,
+        batch_size=B,
+        height=H,
+        width=W,
+        control_channels=8,
+        context_channels=16,
+        n_context_tokens=4,
+        device=device,
+        seed=seed,
+    )
+
+    eager_outputs = _run_rollout(
+        pipeline=eager_pipeline,
+        num_ar_steps=num_ar_steps,
+        use_cfg=True,
+        inputs=inputs,
+        height=H,
+        width=W,
+    )
+    fast_outputs = _run_rollout(
+        pipeline=fast_pipeline,
+        num_ar_steps=num_ar_steps,
+        use_cfg=True,
+        inputs=inputs,
+        height=H,
+        width=W,
+    )
+
+    assert len(eager_outputs) == len(fast_outputs) == num_ar_steps
+    # bfloat16 (~3 decimal digits) plus TF32 drift between Inductor's
+    # Triton matmul (``ALLOW_TF32=True``) and eager ``F.linear`` sets a
+    # natural floor around 5e-2 for end-to-end AR outputs.
+    for ar_idx, (eager, fast_out) in enumerate(zip(eager_outputs, fast_outputs)):
+        assert fast_out.shape == eager.shape
+        assert torch.isfinite(fast_out).all(), f"NaN at AR step {ar_idx} (fast)"
+        assert torch.isfinite(eager).all(), f"NaN at AR step {ar_idx} (eager)"
+        torch.testing.assert_close(
+            fast_out,
+            eager,
+            rtol=5e-2,
+            atol=5e-2,
+            msg=f"mismatch at AR step {ar_idx}",
+        )
+
+
+## CP equivalence (two-invocation; see module docstring)
+
+
+def _cp_one_predict_flow(
+    *,
+    device: torch.device,
+    seed: int,
+    ar_idx: int,
+    timestep_value: float,
+) -> torch.Tensor:
+    """Build a transformer + gather one ``predict_flow`` pass.
+
+    Rank-agnostic: the transformer auto-detects ``cp_size`` from the
+    active process group. All tensors that must match across ranks are
+    drawn globally from a fixed seed, then CP-split inside the helper.
+    Returns the gathered flow tensor ``[B, L, C]`` — pre-unpatchify,
+    post-attention; the boundary where CP equivalence is meaningful.
+    """
+    from flashdreams.core.distributed.context_parallel import split_inputs_cp
+
+    base = _with_cfg(
+        build_cfg_autoregressive(seed=seed), guidance_scale=2.0
+    )
+    torch.manual_seed(seed)
+    pipeline = base.setup().to(device).eval()
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, TemplateTransformer)
+    cfg = transformer.config
+
+    gen = torch.Generator(device=device).manual_seed(seed + 17)
+    B = TEMPLATE_DEFAULT_BATCH_SIZE
+    H, W = TEMPLATE_DEFAULT_HEIGHT, TEMPLATE_DEFAULT_WIDTH
+    in_ch = cfg.network.in_channels
+    dtype = cfg.dtype
+    context = torch.randn(B, 4, 16, device=device, generator=gen, dtype=dtype)
+    neg_context = torch.randn(B, 4, 16, device=device, generator=gen, dtype=dtype)
+    control_global = torch.randn(
+        B,
+        in_ch,
+        cfg.len_t,
+        H,
+        W,
+        device=device,
+        generator=gen,
+        dtype=dtype,
+    )
+    noisy_global = torch.randn(
+        B,
+        cfg.len_t * H * W,
+        in_ch,
+        device=device,
+        generator=gen,
+        dtype=dtype,
+    )
+
+    cache = pipeline.initialize_cache(
+        transformer_context={
+            "context": context,
+            "negative_context": neg_context,
+            "height": H,
+            "width": W,
+        }
+    )
+    transformer_cache = cache.transformer_cache
+    assert isinstance(transformer_cache, TemplateTransformerCache)
+
+    control_local = transformer.patchify_and_maybe_split_cp(control_global)
+    noisy_local = split_inputs_cp(
+        noisy_global, seq_dim=1, cp_group=transformer._cp_group
+    )
+
+    transformer_cache.start(ar_idx)
+    flow_local = transformer.predict_flow(
+        noisy_latent=noisy_local,
+        timestep=torch.tensor(timestep_value, device=device),
+        cache=transformer_cache,
+        input=control_local,
+    )
+    transformer_cache.finalize(ar_idx)
+
+    return cat_outputs_cp(
+        flow_local, seq_dim=1, cp_group=transformer._cp_group
+    )
+
+
+def test_template_cp_equivalence() -> None:
+    """Non-distributed vs ``cp_size=world_size`` produce the same global output.
+
+    Two-invocation protocol (see module docstring):
+
+    - ``WORLD_SIZE == 1``: write the global flow tensor to
+      :data:`_CP_REFERENCE_PATH`.
+    - ``WORLD_SIZE >= 2`` (under ``torchrun``): compare rank 0's
+      gathered tensor to the reference.
+    """
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    rank = int(os.environ.get("RANK", "0"))
+
+    if not torch.cuda.is_available():
+        pytest.skip("CP equivalence requires CUDA.")
+
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+
+    if world_size > 1:
+        assert dist.is_nccl_available()
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                init_method="env://",
+                world_size=world_size,
+                rank=rank,
+            )
+
+    flow_global = _cp_one_predict_flow(
+        device=device,
+        seed=0,
+        ar_idx=0,
+        timestep_value=500.0,
+    )
+
+    if world_size == 1:
+        _CP_REFERENCE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {"flow_global": flow_global.detach().cpu()},
+            _CP_REFERENCE_PATH,
+        )
+        assert torch.isfinite(flow_global).all()
+        return
+
+    if not _CP_REFERENCE_PATH.exists():
+        pytest.skip(
+            f"CP reference {_CP_REFERENCE_PATH} not found — run the "
+            f"single-GPU branch (plain pytest, no torchrun) first."
+        )
+
+    if rank == 0:
+        reference = torch.load(_CP_REFERENCE_PATH, weights_only=True)["flow_global"]
+        # bf16 + ring-attention fp32 LSE merge gives ~2-3 decimal
+        # digits at the gathered flow; 2e-2 catches real shard bugs
+        # without flaking on merge drift.
+        torch.testing.assert_close(
+            flow_global.detach().cpu(),
+            reference,
+            rtol=2e-2,
+            atol=2e-2,
+        )
+
+    if world_size > 1 and dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    # Lightweight manual driver. Every test here requires CUDA.
+    if torch.cuda.is_available():
+        torch.manual_seed(0)
+        test_template_latent_shape_respects_cp_size()
+        print("[OK] latent_shape CP-aware")
+        test_template_bidirectional(seed=0)
+        print("[OK] bidirectional")
+        test_template_no_control()
+        print("[OK] no-control rollout")
+        test_template_streaming_cfg()
+        print("[OK] streaming + CFG")
+        test_template_cfg_rejects_missing_negative_context()
+        print("[OK] CFG uncond-context assertion")
+        test_template_compile_and_cudagraph_equivalence()
+        print("[OK] compile + CUDAGraphWrapper equivalence")
+    else:
+        print("[SKIP] CUDA-only tests (no CUDA device available)")

--- a/flashdreams/tests/test_template.py
+++ b/flashdreams/tests/test_template.py
@@ -234,6 +234,11 @@ def test_template_no_control() -> None:
 
     base = build_cfg_offline(seed=0)
     config = cast(StreamInferencePipelineConfig, derive_config(base, encoder=None))
+    # Seed before each ``setup()`` so the no-control and with-control
+    # pipelines initialise identical weights — the assertion below only
+    # isolates the control branch when the underlying networks match
+    # bit-for-bit.
+    torch.manual_seed(0)
     pipeline = config.setup()
     assert isinstance(pipeline, StreamInferencePipeline)
     assert pipeline.encoder is None
@@ -602,24 +607,13 @@ def test_template_cp_equivalence() -> None:
     torch.cuda.set_device(rank)
     device = torch.device(f"cuda:{rank}")
 
-    if world_size > 1:
-        assert dist.is_nccl_available()
-        if not dist.is_initialized():
-            dist.init_process_group(
-                backend="nccl",
-                init_method="env://",
-                world_size=world_size,
-                rank=rank,
-            )
-
-    flow_global = _cp_one_predict_flow(
-        device=device,
-        seed=0,
-        ar_idx=0,
-        timestep_value=500.0,
-    )
-
     if world_size == 1:
+        flow_global = _cp_one_predict_flow(
+            device=device,
+            seed=0,
+            ar_idx=0,
+            timestep_value=500.0,
+        )
         _CP_REFERENCE_PATH.parent.mkdir(parents=True, exist_ok=True)
         torch.save(
             {"flow_global": flow_global.detach().cpu()},
@@ -628,27 +622,50 @@ def test_template_cp_equivalence() -> None:
         assert torch.isfinite(flow_global).all()
         return
 
+    # Check the reference file *before* initialising NCCL so a missing
+    # reference doesn't leak the process group via ``pytest.skip``.
     if not _CP_REFERENCE_PATH.exists():
         pytest.skip(
             f"CP reference {_CP_REFERENCE_PATH} not found — run the "
             f"single-GPU branch (plain pytest, no torchrun) first."
         )
 
-    if rank == 0:
-        reference = torch.load(_CP_REFERENCE_PATH, weights_only=True)["flow_global"]
-        # bf16 + ring-attention fp32 LSE merge gives ~2-3 decimal
-        # digits at the gathered flow; 2e-2 catches real shard bugs
-        # without flaking on merge drift.
-        torch.testing.assert_close(
-            flow_global.detach().cpu(),
-            reference,
-            rtol=2e-2,
-            atol=2e-2,
+    assert dist.is_nccl_available()
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend="nccl",
+            init_method="env://",
+            world_size=world_size,
+            rank=rank,
         )
 
-    if world_size > 1 and dist.is_initialized():
-        dist.barrier()
-        dist.destroy_process_group()
+    # Anything that can raise after ``init_process_group`` must run in a
+    # ``try``/``finally`` — otherwise an assertion failure (or any other
+    # exception) would leak the process group into the next test in the
+    # same torchrun worker.
+    try:
+        flow_global = _cp_one_predict_flow(
+            device=device,
+            seed=0,
+            ar_idx=0,
+            timestep_value=500.0,
+        )
+
+        if rank == 0:
+            reference = torch.load(_CP_REFERENCE_PATH, weights_only=True)["flow_global"]
+            # bf16 + ring-attention fp32 LSE merge gives ~2-3 decimal
+            # digits at the gathered flow; 2e-2 catches real shard bugs
+            # without flaking on merge drift.
+            torch.testing.assert_close(
+                flow_global.detach().cpu(),
+                reference,
+                rtol=2e-2,
+                atol=2e-2,
+            )
+    finally:
+        if dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## MR Summary: `dev/ruilongl/agentic` vs `main`

**4 commits, 49 files, +2914 / -185**

### Motivation

Introduce two agent skills to drive consistency in the `flashdreams` codebase:

1. **[python-docstring-style](agentic/skills/python-docstring-style/SKILL.md)** — codifies the house docstring style (SPDX header, one-line module docstrings, Google-style `Args/Returns/Raises`, PEP-257 attribute docstrings on dataclass fields, double-backtick code refs, imperative first sentences). Used as the rule for a sweeping pass that brings existing modules in line.

2. **[flashdreams-recipe-architecture](agentic/skills/flashdreams-recipe-architecture/SKILL.md)** — captures what belongs in `core` vs `infra` vs `recipes`, the contracts a recipe must fulfil, and how AR cache / CP / CFG / KV cache / CUDA-graph wiring fit together. Goal: automate adding new model recipes and converge existing recipes onto one consistent design (cleanup deferred to a follow-up MR).


### Using the skills

Skills are **opt-in** per developer. Symlink them into Cursor or Claude Code first:

```bash
# Cursor
mkdir -p .cursor && ln -s ../agentic/skills .cursor/skills

# Claude Code
mkdir -p .claude && ln -s ../agentic/skills .claude/skills
```

Once symlinked, the agent loads each skill's `name` + `description` at chat start and reads the body when the conversation matches. Two ways to trigger:

- **Implicit** — describe the task naturally; the agent picks the skill whose description matches:
  - `python-docstring-style` → "add docstrings to this module", "what's our docstring convention?", any edit to a `.py` file under `flashdreams/`.
  - `flashdreams-recipe-architecture` → "add a new recipe for `<model>`", "where should this code live?", "port `<network>` into flashdreams", "wire up CFG / KV cache / CP / CUDA graph for `<recipe>`".
- **Explicit** — name the skill directly when you want certainty: *"Use the `python-docstring-style` skill to clean up `foo.py`."* or *"Follow `flashdreams-recipe-architecture` and scaffold a new recipe called `bar`."*

Verify it fired by looking for an early `Read` of `agentic/skills/<skill>/SKILL.md` in the agent's tool calls. Full instructions live in [agentic/skills/README.md](agentic/skills/README.md).


### Changes in this MR

- **New agent skills** under [agentic/skills/](agentic/skills/) plus a skills [README](agentic/skills/README.md).
- **New `template` recipe** as the source of truth referenced by the architecture skill: [config.py](flashdreams/flashdreams/recipes/template/config.py), [encoder.py](flashdreams/flashdreams/recipes/template/encoder.py), [decoder.py](flashdreams/flashdreams/recipes/template/decoder.py), [transformer/](flashdreams/flashdreams/recipes/template/transformer/), [README.md](flashdreams/flashdreams/recipes/template/README.md), and tests [test_template.py](flashdreams/tests/test_template.py).
- **Codebase-wide docstring polish** applying the docstring skill across `core/`, `infra/`, and `recipes/{alpadreams,lingbot_world,taehv,wan}` — mostly mechanical (one-line module docstrings, attribute docstrings on dataclass fields, removing narrative comments, fixing `continous`→`continuous`, dropping a stray `print` in [core/experimental/kvcache.py](flashdreams/flashdreams/core/experimental/kvcache.py)). No behavior change.

### Follow-up

A subsequent MR will use the recipe-architecture skill to migrate the existing recipes (`alpadreams`, `wan`, `lingbot_world`, ...) onto the `template` design.