### PR TITLE
build: Move ludus-renderer from internal GitLab to public Artifactory PyPi index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,29 +8,13 @@ on:
     tags:
       - '**'
 
+# Authenticate uv against the Artifactory PyPI index.
+# The secret is a read-only Artifactory access token for the
+# svc-oss-flashdreams-pypi-local-cicd service account.
+env:
+  UV_HTTP_BASIC_FLASHDREAMS_PYPI: "svc-oss-flashdreams-pypi-local-cicd:${{ secrets.ARTIFACTORY_FLASHDREAMS_PYPI_TOKEN }}"
+
 jobs:
-  lint:
-    runs-on: linux-amd64-cpu8
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Install dependencies
-        run: |
-          # ty needs third-party packages to resolve imports. Skip packages
-          # that cannot be installed on CPU-only runners:
-          # - transformer-engine-torch: source-only, requires CUDA to compile
-          # - ludus-renderer: unavailable in CI
-          uv sync --extra dev --group lint \
-            --no-install-package transformer-engine-torch \
-            --no-install-package ludus-renderer
-
-      - name: Run linter checks
-        run: uv run --no-sync pre-commit run -a
-
   cpu:
     runs-on: linux-amd64-cpu8
     steps:
@@ -44,6 +28,20 @@ jobs:
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        run: |
+          # ty needs third-party packages to resolve imports. Skip packages
+          # that cannot be installed on CPU-only runners:
+          # - transformer-engine-torch: source-only, requires CUDA to compile
+          uv sync --extra dev --group lint \
+            --no-install-package transformer-engine-torch
+
+      - name: Run linter checks
+        run: uv run --no-sync pre-commit run -a
 
       - name: Run wheel build
         run: |

--- a/docs/source/examples/alpadreams.rst
+++ b/docs/source/examples/alpadreams.rst
@@ -43,6 +43,28 @@ across the world.
 Credentials
 -----------
 
+Artifactory
+~~~~~~~~~~~
+
+Alpadreams depends on the the ``ludus-renderer`` package. This
+is _currently_ hosted in a Artifactory PyPI repository.
+``uv`` authenticates via ``~/.netrc``. Add the following
+entry with your personal Artifactory identity token:
+
+.. code-block:: text
+
+   machine artifactory.nvidia.com
+     login <your-nvidia-username>
+     password <your-artifactory-identity-token>
+
+To generate a token, go to
+`Artifactory → User Profile → Identity Tokens <https://artifactory.nvidia.com/ui/admin/artifactory/user_profile>`_
+and create one scoped to the ``oss-flashdreams-pypi-local`` repository
+(or use a broader scope if you have one).
+
+S3 checkpoints
+~~~~~~~~~~~~~~
+
 Checkpoints are pulled from the team S3 bucket. Drop a JSON file at
 ``credentials/s3_checkpoint.secret`` with ``aws_access_key_id``,
 ``aws_secret_access_key``, ``endpoint_url``, ``region_name`` and the

--- a/integrations/alpadreams/pyproject.toml
+++ b/integrations/alpadreams/pyproject.toml
@@ -20,11 +20,11 @@ dependencies = [
 
 [tool.uv.sources]
 flashdreams = { workspace = true }
-ludus-renderer = { index = "ludus_renderer_gitlab" }
+ludus-renderer = { index = "flashdreams_pypi" }
 
 [[tool.uv.index]]
-name = "ludus_renderer_gitlab"
-url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple"
+name = "flashdreams_pypi"
+url = "https://artifactory.nvidia.com/artifactory/api/pypi/oss-flashdreams-pypi-local/simple"
 explicit = true
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -574,7 +574,7 @@ requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
-    { name = "ludus-renderer", specifier = "==0.5.0+cuda", index = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple" },
+    { name = "ludus-renderer", specifier = "==0.5.0+cuda", index = "https://artifactory.nvidia.com/artifactory/api/pypi/oss-flashdreams-pypi-local/simple" },
     { name = "mediapy", specifier = ">=1.1" },
     { name = "opencv-python-headless" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1004,7 +1004,7 @@ wheels = [
 [[package]]
 name = "ludus-renderer"
 version = "0.5.0+cuda"
-source = { registry = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple" }
+source = { registry = "https://artifactory.nvidia.com/artifactory/api/pypi/oss-flashdreams-pypi-local/simple" }
 dependencies = [
     { name = "ffmpeg" },
     { name = "imageio" },
@@ -1019,9 +1019,9 @@ dependencies = [
     { name = "setuptools" },
     { name = "torch" },
 ]
-sdist = { url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/files/99403b745029880c011c287903b744ab3dde5400eaf7305af7df8c79f85f97da/ludus_renderer-0.5.0+cuda.tar.gz", hash = "sha256:99403b745029880c011c287903b744ab3dde5400eaf7305af7df8c79f85f97da" }
+sdist = { url = "https://artifactory.nvidia.com/artifactory/api/pypi/oss-flashdreams-pypi-local/ludus-renderer/0.5.0+cuda/ludus_renderer-0.5.0+cuda.tar.gz", hash = "sha256:99403b745029880c011c287903b744ab3dde5400eaf7305af7df8c79f85f97da" }
 wheels = [
-    { url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/files/0f1f32f34ac4d7472bb8b447ed36ec19c8a30e50f7c5568cd1b7fc4bccc2c926/ludus_renderer-0.5.0+cuda-py3-none-any.whl", hash = "sha256:0f1f32f34ac4d7472bb8b447ed36ec19c8a30e50f7c5568cd1b7fc4bccc2c926" },
+    { url = "https://artifactory.nvidia.com/artifactory/api/pypi/oss-flashdreams-pypi-local/ludus-renderer/0.5.0+cuda/ludus_renderer-0.5.0+cuda-py3-none-any.whl", hash = "sha256:0f1f32f34ac4d7472bb8b447ed36ec19c8a30e50f7c5568cd1b7fc4bccc2c926" },
 ]
 
 [[package]]


### PR DESCRIPTION
Gitlab-internal package registry is not accessible publicy, move to artifactory.nvidia.com. Currently still requires authentication, will be opened with OSS.

Registered a CI read-only token with the secret ARTIFACTORY_FLASHDREAMS_PYPI_TOKEN.

Developers should setup personal access tokens in `.netrc` for `artifactory.nvidia.com` as documented.