### PR TITLE
[Do not merge] Experiment on block sparse attn

### DIFF
--- a/flashdreams/flashdreams/core/attention/__init__.py
+++ b/flashdreams/flashdreams/core/attention/__init__.py
@@ -15,8 +15,20 @@
 
 """Attention primitives and KV cache for streaming inference."""
 
+from flashdreams.core.attention.bsa import (
+    BlockSparseAttention,
+    build_local_spatial_block_mask,
+    build_topk_block_mask,
+)
 from flashdreams.core.attention.kvcache import BlockKVCache
 from flashdreams.core.attention.native import NativeAttention
 from flashdreams.core.attention.ring import RingAttention
 
-__all__ = ["NativeAttention", "RingAttention", "BlockKVCache"]
+__all__ = [
+    "BlockKVCache",
+    "BlockSparseAttention",
+    "NativeAttention",
+    "RingAttention",
+    "build_local_spatial_block_mask",
+    "build_topk_block_mask",
+]

--- a/flashdreams/flashdreams/core/attention/_flashvsr_reference.py
+++ b/flashdreams/flashdreams/core/attention/_flashvsr_reference.py
@@ -1,0 +1,262 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import math
+from typing import Tuple, Optional
+from einops import rearrange
+
+from block_sparse_attn import block_sparse_attn_func
+
+from projects.cosmos.sil.causal_wan.fast_infer.v2.tests.templated_benchmark import torch_cudnn_attention
+
+try:
+    from transformer_engine.pytorch.attention.rope import apply_rotary_pos_emb
+except ImportError:
+    from transformer_engine.pytorch.attention import apply_rotary_pos_emb
+
+from projects.cosmos.sil.causal_wan.fast_infer.v2.network_cosmos2 import SinsoidalRotaryFrequency
+
+@torch.no_grad()
+def build_local_block_mask_shifted_vec_normal_slide(block_h: int,
+                                                   block_w: int,
+                                                   win_h: int = 6,
+                                                   win_w: int = 6,
+                                                   include_self: bool = True,
+                                                   device=None) -> torch.Tensor:
+    device = device or torch.device("cpu")
+    H, W = block_h, block_w
+    r = torch.arange(H, device=device)
+    c = torch.arange(W, device=device)
+    YY, XX = torch.meshgrid(r, c, indexing="ij")
+    r_all = YY.reshape(-1)
+    c_all = XX.reshape(-1)
+    r_half = win_h // 2
+    c_half = win_w // 2
+    start_r = r_all - r_half
+    end_r   = start_r + win_h - 1
+    start_c = c_all - c_half
+    end_c   = start_c + win_w - 1
+    in_row = (r_all[None, :] >= start_r[:, None]) & (r_all[None, :] <= end_r[:, None])
+    in_col = (c_all[None, :] >= start_c[:, None]) & (c_all[None, :] <= end_c[:, None])
+    mask = in_row & in_col
+    if not include_self:
+        mask.fill_diagonal_(False)
+    return mask
+
+
+class WindowPartition3D:
+    """Partition / reverse-partition helpers for 5-D tensors (B,F,H,W,C)."""
+    @staticmethod
+    def partition(x: torch.Tensor, win: Tuple[int, int, int]):
+        B, F, H, W, C = x.shape
+        wf, wh, ww = win
+        assert F % wf == 0 and H % wh == 0 and W % ww == 0, "Dims must divide by window size."
+        x = x.view(B, F // wf, wf, H // wh, wh, W // ww, ww, C)
+        x = x.permute(0, 1, 3, 5, 2, 4, 6, 7).contiguous()
+        return x.view(-1, wf * wh * ww, C)
+
+    @staticmethod
+    def reverse(windows: torch.Tensor, win: Tuple[int, int, int], orig: Tuple[int, int, int]):
+        F, H, W = orig
+        wf, wh, ww = win
+        nf, nh, nw = F // wf, H // wh, W // ww
+        B = windows.size(0) // (nf * nh * nw)
+        x = windows.view(B, nf, nh, nw, wf, wh, ww, -1)
+        x = x.permute(0, 1, 4, 2, 5, 3, 6, 7).contiguous()
+        return x.view(B, F, H, W, -1)
+
+
+@torch.no_grad()
+def generate_draft_block_mask(batch_size, nheads, seqlen,
+                              q_w, k_w, topk=10, local_attn_mask=None):
+    assert batch_size == 1, "Only batch_size=1 supported for now"
+    assert local_attn_mask is not None, "local_attn_mask must be provided"
+    avgpool_q = torch.mean(q_w, dim=1) 
+    avgpool_k = torch.mean(k_w, dim=1)
+    avgpool_q = rearrange(avgpool_q, 's (h d) -> s h d', h=nheads)
+    avgpool_k = rearrange(avgpool_k, 's (h d) -> s h d', h=nheads)
+    q_heads = avgpool_q.permute(1, 0, 2)
+    k_heads = avgpool_k.permute(1, 0, 2)
+    D = avgpool_q.shape[-1]
+    scores = torch.einsum("hld,hmd->hlm", q_heads, k_heads) / math.sqrt(D)
+
+    repeat_head = scores.shape[0]
+    repeat_len = scores.shape[1] // local_attn_mask.shape[0]
+    repeat_num = scores.shape[2] // local_attn_mask.shape[1]
+    local_attn_mask = local_attn_mask.unsqueeze(1).unsqueeze(0).repeat(repeat_len, 1, repeat_num, 1)
+    local_attn_mask = rearrange(local_attn_mask, 'x a y b -> (x a) (y b)')
+    local_attn_mask = local_attn_mask.unsqueeze(0).repeat(repeat_head, 1, 1)
+    local_attn_mask = local_attn_mask.to(torch.float32)
+    local_attn_mask = local_attn_mask.masked_fill(local_attn_mask == False, -float('inf'))
+    local_attn_mask = local_attn_mask.masked_fill(local_attn_mask == True, 0)
+    scores = scores + local_attn_mask
+
+    attn_map = torch.softmax(scores, dim=-1)
+    attn_map = rearrange(attn_map, 'h (it s1) s2 -> (h it) s1 s2', it=seqlen)
+    loop_num, s1, s2 = attn_map.shape
+    flat = attn_map.reshape(loop_num, -1)
+    n = flat.shape[1]
+    apply_topk = min(flat.shape[1]-1, topk)
+    thresholds = torch.topk(flat, k=apply_topk + 1, dim=1, largest=True).values[:, -1]
+    thresholds = thresholds.unsqueeze(1)
+    mask_new = (flat > thresholds).reshape(loop_num, s1, s2)
+    mask_new = rearrange(mask_new, '(h it) s1 s2 -> h (it s1) s2', it=seqlen)  # keep shape note
+    # 修正：上行变量名统一
+    # mask_new = rearrange(attn_map, 'h (it s1) s2 -> h (it s1) s2', it=seqlen) * 0 + mask_new
+    mask = mask_new.unsqueeze(0).repeat(batch_size, 1, 1, 1)
+    return mask
+
+
+
+# ----------------------------
+# Attention kernels
+# ----------------------------
+def flash_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, num_heads: int, attention_mask=None):
+    if attention_mask is not None:
+        # print(f"Using block sparse attention")
+        seqlen = q.shape[1]
+        seqlen_kv = k.shape[1]
+        q = rearrange(q, "b s (n d) -> (b s) n d", n=num_heads)
+        k = rearrange(k, "b s (n d) -> (b s) n d", n=num_heads)
+        v = rearrange(v, "b s (n d) -> (b s) n d", n=num_heads)
+        cu_seqlens_q = torch.tensor([0, seqlen], device=q.device, dtype=torch.int32)
+        cu_seqlens_k = torch.tensor([0, seqlen_kv], device=q.device, dtype=torch.int32)
+        head_mask_type = torch.tensor([1]*num_heads, device=q.device, dtype=torch.int32)
+        streaming_info = None
+        base_blockmask = attention_mask
+        max_seqlen_q_ = seqlen
+        max_seqlen_k_ = seqlen_kv
+        p_dropout = 0.0
+        x = block_sparse_attn_func(
+            q, k, v,
+            cu_seqlens_q, cu_seqlens_k,
+            head_mask_type,
+            streaming_info,
+            base_blockmask,
+            max_seqlen_q_, max_seqlen_k_,
+            p_dropout,
+            deterministic=False,
+            softmax_scale=None,
+            is_causal=False,
+            exact_streaming=False,
+            return_attn_probs=False,
+        ).unsqueeze(0)
+        x = rearrange(x, "b s n d -> b s (n d)", n=num_heads)
+    else:
+        # print(f"Using cudnn attention")
+        q = rearrange(q, "b s (n d) -> b n s d", n=num_heads)
+        k = rearrange(k, "b s (n d) -> b n s d", n=num_heads)
+        v = rearrange(v, "b s (n d) -> b n s d", n=num_heads)
+        x = torch_cudnn_attention(q, k, v, return_lse=False)
+        x = rearrange(x, "b n s d -> b s (n d)", n=num_heads)
+    return x
+
+
+def modulate(x: torch.Tensor, shift: torch.Tensor, scale: torch.Tensor):
+    return (x * (1 + scale) + shift)
+
+
+def sinusoidal_embedding_1d(dim, position):
+    sinusoid = torch.outer(position.type(torch.float64), torch.pow(
+        10000, -torch.arange(dim//2, dtype=torch.float64, device=position.device).div(dim//2)))
+    x = torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
+    return x.to(position.dtype)
+
+
+def rope_apply(x, freqs, num_heads):
+    assert x.ndim == 3 and freqs.ndim == 4
+    b, s, D = x.shape
+    x = x.reshape(b, s, num_heads, D // num_heads)
+    x_out = apply_rotary_pos_emb(x, freqs, tensor_format="bshd", fused=True, interleaved=True)
+    return x_out.reshape(b, s, D)
+
+
+class AttentionModule(nn.Module):
+    def __init__(self, num_heads):
+        super().__init__()
+        self.num_heads = num_heads
+        
+    def forward(self, q, k, v, attention_mask=None):
+        x = flash_attention(q=q, k=k, v=v, num_heads=self.num_heads, attention_mask=attention_mask)
+        return x
+
+
+class SelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, eps: float = 1e-6):
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+
+        self.q = nn.Linear(dim, dim)
+        self.k = nn.Linear(dim, dim)
+        self.v = nn.Linear(dim, dim)
+        self.o = nn.Linear(dim, dim)
+        self.norm_q = torch.nn.RMSNorm(dim, eps=eps)
+        self.norm_k = torch.nn.RMSNorm(dim, eps=eps)
+        
+        self.attn = AttentionModule(self.num_heads)
+        self.local_attn_mask = None
+
+    def forward(self, x, freqs, f=None, h=None, w=None, topk=None,
+                kv_len=None,
+                is_stream=False, pre_cache_k=None, pre_cache_v=None, local_range = 9):
+
+        B, L, D = x.shape
+        assert L == f * h * w, "Sequence length mismatch with provided (f,h,w)."
+
+        q = self.norm_q(self.q(x))
+        k = self.norm_k(self.k(x))
+        v = self.v(x)
+        q = rope_apply(q, freqs, self.num_heads)
+        k = rope_apply(k, freqs, self.num_heads)
+
+        win = (2, 8, 8)
+        q = q.view(B, f, h, w, D)
+        k = k.view(B, f, h, w, D)
+        v = v.view(B, f, h, w, D)
+
+        q_w = WindowPartition3D.partition(q, win)
+        k_w = WindowPartition3D.partition(k, win)
+        v_w = WindowPartition3D.partition(v, win)
+
+        seqlen = f//win[0]
+        one_len = k_w.shape[0] // B // seqlen
+        if pre_cache_k is not None and pre_cache_v is not None:
+            k_w = torch.cat([pre_cache_k, k_w], dim=0)
+            v_w = torch.cat([pre_cache_v, v_w], dim=0)
+
+        block_n = q_w.shape[0] // B
+        block_s = q_w.shape[1]
+        block_n_kv = k_w.shape[0] // B
+
+        reorder_q = rearrange(q_w, '(b block_n) (block_s) d -> b (block_n block_s) d', block_n=block_n, block_s=block_s)
+        reorder_k = rearrange(k_w, '(b block_n) (block_s) d -> b (block_n block_s) d', block_n=block_n_kv, block_s=block_s)
+        reorder_v = rearrange(v_w, '(b block_n) (block_s) d -> b (block_n block_s) d', block_n=block_n_kv, block_s=block_s)
+
+        if self.local_attn_mask is None or self.local_attn_mask_h!=h//8 or self.local_attn_mask_w!=w//8 or self.local_range!=local_range:
+            self.local_attn_mask = build_local_block_mask_shifted_vec_normal_slide(h//8, w//8, local_range, local_range, include_self=True, device=k_w.device)
+            self.local_attn_mask_h = h//8
+            self.local_attn_mask_w = w//8
+            self.local_range = local_range
+        attention_mask = generate_draft_block_mask(B, self.num_heads, seqlen, q_w, k_w, topk=topk, local_attn_mask=self.local_attn_mask)
+
+        x = self.attn(reorder_q, reorder_k, reorder_v, attention_mask)
+
+        cur_block_n, cur_block_s, _ = k_w.shape
+        cache_num = cur_block_n // one_len
+        if cache_num > kv_len:
+            cache_k = k_w[one_len:, :, :]
+            cache_v = v_w[one_len:, :, :]
+        else:
+            cache_k = k_w
+            cache_v = v_w
+
+        x = rearrange(x, 'b (block_n block_s) d -> (b block_n) (block_s) d', block_n=block_n, block_s=block_s)
+        x = WindowPartition3D.reverse(x, win, (f, h, w))
+        x = x.view(B, f*h*w, D)
+
+        if is_stream:
+            return self.o(x), cache_k, cache_v
+        return self.o(x)
+

--- a/flashdreams/flashdreams/core/attention/bsa.py
+++ b/flashdreams/flashdreams/core/attention/bsa.py
@@ -1,0 +1,571 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Block-sparse attention backed by ``block_sparse_attn``.
+
+Single-GPU only. Mirrors :class:`NativeAttention`'s constructor /
+forward signature so it can be dropped in as a sparse alternative; CP
+is intentionally omitted (raises if requested).
+
+Also provides :func:`build_local_spatial_block_mask` and
+:func:`build_topk_block_mask` for constructing the per-head 0/1
+``base_blockmask`` consumed by :meth:`BlockSparseAttention.forward` —
+ported from the FlashVSR reference (a local-spatial neighbourhood
+gate combined with a per-head, per-temporal-q-window top-K selection
+on averaged window descriptors).
+"""
+
+import math
+from typing import Literal
+
+import torch
+from einops import rearrange
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+import block_sparse_attn.block_sparse_attn_interface as _bsa_interface
+from block_sparse_attn import block_sparse_attn_func
+
+
+def _replace_ones_with_count_capture_safe(
+    tensor: Tensor,
+) -> tuple[Tensor, int]:
+    """Capture-safe replacement for ``block_sparse_attn``'s helper.
+
+    Two changes vs. the library original, both required for the call to
+    work under ``torch.cuda.graph(...)`` capture:
+
+    1. Replace ``count[ones_mask]`` + ``masked_scatter`` with a pure
+       ``torch.where`` so the rewrite has no value-dependent shapes.
+       The original couldn't determine the gathered-source size without
+       a host sync — illegal during stream capture
+       (``cudaErrorStreamCaptureUnsupported``).
+    2. Return ``ones_num`` as a Python ``int`` (taken from the input's
+       static shape). Downstream the library does
+       ``assert base_blockmask.shape[1] == ones_num``; if ``ones_num``
+       is a 0-d GPU tensor (the natural ``ones_mask.sum()`` return),
+       ``==`` yields a tensor and ``assert`` triggers a ``bool()``
+       host sync — same capture failure, just one line later.
+
+    Item (2) is exact in our use: :class:`BlockSparseAttention` is the
+    only call site and always passes a 1-D ``head_mask_type`` made of
+    all ones (every head is block-sparse), so the count of ones equals
+    ``tensor.shape[-1]``. The library only consumes ``ones_num`` for
+    the assertion above, never inside its kernel, so a static int is a
+    drop-in replacement for the original tensor return.
+    """
+    ones_mask = tensor == 1
+    count = torch.cumsum(ones_mask, dim=-1).to(tensor.dtype)
+    rewritten = torch.where(ones_mask, count, tensor)
+    return rewritten, int(tensor.shape[-1])
+
+
+# Monkey-patch on import so every call site in this venv (only
+# :func:`block_sparse_attn_func` for now) routes through the capture-safe
+# variant. Cheap and reversible: we hold the original under a private
+# attribute in case a future caller wants the lib's untouched behaviour.
+_bsa_interface._replace_ones_with_count_original = (
+    _bsa_interface.replace_ones_with_count
+)
+_bsa_interface.replace_ones_with_count = _replace_ones_with_count_capture_safe
+
+# block_sparse_attn's CUDA kernel hard-codes a 128-token block edge; the
+# block-mask resolution and any downstream padding follow from this.
+_BSA_BLOCK_SIZE: int = 128
+
+
+class BlockSparseAttention(torch.nn.Module):
+    """Block-sparse attention with the same surface as :class:`NativeAttention`.
+
+    Wraps ``block_sparse_attn.block_sparse_attn_func``: every head is
+    treated as block-sparse (``head_mask_type == 1``) and gated by a
+    per-(batch, head) ``blockmask`` at 128-token granularity. Passing an
+    all-ones ``blockmask`` (or ``None``) recovers dense attention.
+
+    Forward synthesizes the blockmask on the fly from a 3D ``q_thw``
+    ``(T_q, H, W)`` describing the query token-grid, with an optional
+    ``kv_thw`` ``(T_k, H, W)`` for the K/V grid (defaults to ``q_thw``
+    for self-attention). It pools per-block descriptors, builds /
+    re-uses a cached local-spatial mask, and applies a per-head top-K
+    selection where ``K = max(1, round(topk_ratio * slab_size))``.
+    ``topk_ratio = 1.0`` short-circuits to an all-ones mask, recovering
+    dense attention. Callers must hand in q/k/v that are already in
+    ``128``-token block-major order (i.e. each contiguous 128-token
+    span along the sequence axis is one window).
+
+    For escape hatches, ``forward`` also accepts an explicit
+    ``blockmask`` that overrides the synthesis path entirely; this is
+    primarily for tests / fully bespoke masking.
+    """
+
+    def __init__(
+        self,
+        qkv_format: Literal["bhsd", "bshd"] = "bhsd",
+        *,
+        topk_ratio: float = 0.5,
+        local_range: int = 9,
+        window: tuple[int, int, int] = (2, 8, 8),
+    ) -> None:
+        """Configure attention layout and auto-mask params.
+
+        Args:
+            qkv_format: Layout of the QKV tensors; ``"bhsd"`` is
+                ``(B, H, S, D)``, ``"bshd"`` is ``(B, S, H, D)``.
+            topk_ratio: Fraction of entries kept per
+                ``(head, temporal_q_block)`` slab. Each slab has
+                ``Hb * Wb * (Tb * Hb * Wb)`` entries (with
+                ``Tb, Hb, Wb`` the block-grid derived from ``layout``
+                and ``window``); the per-slab integer top-K is
+                ``max(1, round(topk_ratio * slab_size))``. Must be in
+                ``[0.0, 1.0]``. ``1.0`` short-circuits to a full-ones
+                mask (dense attention).
+            local_range: Side length (in blocks) of the square local
+                spatial neighbourhood used by the auto-mask path.
+                Recommended: ``9`` or ``11``. ``9`` → sharper details;
+                ``11`` → more stable results.
+            window: ``(wf, wh, ww)`` 3D window mapping the token grid
+                ``(T, H, W)`` to the BSA block grid
+                ``(T//wf, H//wh, W//ww)``. The product must equal the
+                BSA block size (128). Default ``(2, 8, 8)`` matches
+                FlashVSR.
+        """
+        super().__init__()
+        assert qkv_format in ("bhsd", "bshd"), f"Invalid qkv format: {qkv_format}"
+        assert 0.0 <= topk_ratio <= 1.0, (
+            f"topk_ratio must be in [0, 1]; got {topk_ratio}."
+        )
+        wf, wh, ww = window
+        assert wf * wh * ww == _BSA_BLOCK_SIZE, (
+            f"window product must equal the BSA block size "
+            f"({_BSA_BLOCK_SIZE}); got {wf}*{wh}*{ww}={wf * wh * ww}."
+        )
+        self.qkv_format = qkv_format
+        self.topk_ratio = topk_ratio
+        self.local_range = local_range
+        self.window = window
+
+        # Lazy local-spatial mask, rebuilt only when (spatial_h,
+        # spatial_w) changes. ``local_range`` is fixed at init so it
+        # never invalidates the cache.
+        self._local_attn_mask: Tensor | None = None
+        self._local_attn_mask_key: tuple[int, int] = (-1, -1)
+
+    def set_context_parallel_group(self, cp_group: ProcessGroup | None) -> None:
+        """Reject CP — :class:`BlockSparseAttention` is single-GPU only."""
+        if cp_group is not None:
+            raise NotImplementedError(
+                "BlockSparseAttention does not support context parallel; "
+                "use NativeAttention or RingAttention instead."
+            )
+
+    def is_context_parallel_enabled(self) -> bool:
+        """Always ``False``."""
+        return False
+
+    def context_parallel_size(self) -> int:
+        """Always ``1``."""
+        return 1
+
+    def _get_local_attn_mask(
+        self, spatial_h: int, spatial_w: int, device: torch.device
+    ) -> Tensor:
+        """Lazily build / reuse the cached local-spatial block mask."""
+        key = (spatial_h, spatial_w)
+        if self._local_attn_mask is None or self._local_attn_mask_key != key:
+            self._local_attn_mask = build_local_spatial_block_mask(
+                spatial_h,
+                spatial_w,
+                self.local_range,
+                self.local_range,
+                include_self=True,
+                device=device,
+            )
+            self._local_attn_mask_key = key
+        return self._local_attn_mask
+
+    # Treat the whole forward as opaque to ``torch.compile`` / Dynamo:
+    # the body builds shape-dependent control tensors (cu_seqlens via
+    # ``torch.arange``, ``base_blockmask`` via ``torch.ones``, the cached
+    # local-spatial mask whose grid is derived from ``q_thw``) whose
+    # sizes Inductor cannot prove divisibility for once ``kv_thw[0]``
+    # is symbolic (streaming KV cache: ``T_k`` flips ``2 → 4``). Inductor
+    # gives up with ``CantSplit: 880 not divisible by 48400*((s//7040))
+    # + 48400``. Disabling the tracer here lets the surrounding compiled
+    # network treat BSA as a single opaque call and run it eagerly,
+    # which is the right behaviour anyway — ``block_sparse_attn_func``
+    # is already a custom op with its own kernels, nothing to fuse.
+    @torch.compiler.disable(recursive=True)
+    @torch.no_grad()
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        *,
+        q_thw: tuple[int, int, int] | None = None,
+        kv_thw: tuple[int, int, int] | None = None,
+        blockmask: Tensor | None = None,
+    ) -> Tensor:
+        """Run block-sparse attention.
+
+        Mask selection:
+
+        - Default: synthesize from ``q_thw`` (+ optional ``kv_thw``)
+          and ``self.topk_ratio``. ``topk_ratio == 1.0``
+          short-circuits to a full-ones mask (dense attention).
+        - ``blockmask`` provided: used as-is, overriding the
+          synthesis path entirely.
+
+        Args:
+            query: Query tensor in ``self.qkv_format``. The sequence
+                axis must be in ``128``-token block-major order.
+            key: Key tensor in ``self.qkv_format``.
+            value: Value tensor in ``self.qkv_format``.
+            q_thw: ``(T_q, H, W)`` token-grid dims for the query
+                with ``Sq = T_q * H * W``. Each entry must be
+                divisible by the matching ``self.window`` entry.
+                Required unless ``blockmask`` is provided.
+            kv_thw: ``(T_k, H, W)`` token-grid dims for the key /
+                value sequence. ``H`` and ``W`` must match
+                ``q_thw``'s spatial entries (the local mask is
+                spatial-only and shared across q/k); ``T_k`` may
+                differ from ``T_q`` (e.g. streaming KV caches longer
+                than the query chunk). Defaults to ``q_thw`` —
+                self-attention with ``Sq == Sk``.
+            blockmask: Optional override 0/1 mask of shape
+                ``(B, H, ceil(Sq/128), ceil(Sk/128))`` selecting which
+                ``128 x 128`` ``(q_block, k_block)`` tiles each head
+                attends to.
+
+        Returns:
+            Attention output in the same layout as inputs.
+        """
+        # block_sparse_attn_func consumes a packed varlen layout
+        # (total, H, D); collapse the batch into the token axis once
+        # here and undo it on the output.
+        if self.qkv_format == "bhsd":
+            query = query.transpose(1, 2)
+            key = key.transpose(1, 2)
+            value = value.transpose(1, 2)
+
+        B, Sq, H, D = query.shape
+        Sk = key.shape[1]
+        assert key.shape[2] == H and value.shape[2] == H, (
+            "BlockSparseAttention requires query/key/value to share num_heads."
+        )
+        assert key.shape[0] == B and value.shape[0] == B, (
+            "BlockSparseAttention requires query/key/value to share batch size."
+        )
+
+        device = query.device
+
+        q_packed = query.reshape(B * Sq, H, D)
+        k_packed = key.reshape(B * Sk, H, D)
+        v_packed = value.reshape(B * Sk, H, D)
+
+        cu_seqlens_q = torch.arange(
+            0, (B + 1) * Sq, Sq, device=device, dtype=torch.int32
+        )
+        cu_seqlens_k = torch.arange(
+            0, (B + 1) * Sk, Sk, device=device, dtype=torch.int32
+        )
+
+        # head_mask_type[h] == 1 marks head h as block-sparse; the
+        # kernel reindexes ones via replace_ones_with_count, so the
+        # blockmask's head axis must enumerate every head we pass in.
+        head_mask_type = torch.ones(H, device=device, dtype=torch.int32)
+
+        n_q_blocks = (Sq + _BSA_BLOCK_SIZE - 1) // _BSA_BLOCK_SIZE
+        n_k_blocks = (Sk + _BSA_BLOCK_SIZE - 1) // _BSA_BLOCK_SIZE
+
+        if blockmask is not None:
+            assert blockmask.shape == (B, H, n_q_blocks, n_k_blocks), (
+                f"blockmask shape must be (B={B}, H={H}, "
+                f"n_q_blocks={n_q_blocks}, n_k_blocks={n_k_blocks}); "
+                f"got {tuple(blockmask.shape)}."
+            )
+            # Kernel expects a low-bit-width tensor on cuda; convert is
+            # safe for both bool and int dtypes.
+            base_blockmask = blockmask.to(device=device, dtype=torch.uint8)
+        else:
+            assert q_thw is not None, (
+                "BlockSparseAttention.forward requires either ``q_thw`` "
+                "(auto-mask path) or an explicit ``blockmask`` override."
+            )
+            T_q, H_tok, W_tok = q_thw
+            T_k, H_k, W_k = (T_q, H_tok, W_tok) if kv_thw is None else kv_thw
+            assert (H_k, W_k) == (H_tok, W_tok), (
+                f"kv_thw spatial dims (H={H_k}, W={W_k}) must match "
+                f"q_thw's (H={H_tok}, W={W_tok}); the local-spatial "
+                f"mask is shared across q and k."
+            )
+            wf, wh, ww = self.window
+            assert (
+                T_q % wf == 0
+                and T_k % wf == 0
+                and H_tok % wh == 0
+                and W_tok % ww == 0
+            ), (
+                f"q_thw=(T_q={T_q}, H={H_tok}, W={W_tok}) and T_k={T_k} "
+                f"must each be divisible by window={self.window}."
+            )
+            L_q = T_q * H_tok * W_tok
+            L_k = T_k * H_tok * W_tok
+            assert Sq == L_q, f"Sq={Sq} must equal T_q*H*W={L_q} (q_thw={q_thw})."
+            assert Sk == L_k, (
+                f"Sk={Sk} must equal T_k*H*W={L_k} "
+                f"(kv_thw={kv_thw if kv_thw is not None else q_thw})."
+            )
+            Tb_q = T_q // wf
+            Tb_k = T_k // wf
+            Hb = H_tok // wh
+            Wb = W_tok // ww
+            n_blocks_q = Tb_q * Hb * Wb
+            n_blocks_k = Tb_k * Hb * Wb
+            spatial_q_blocks = Hb * Wb
+            slab_size = spatial_q_blocks * n_blocks_k
+            topk_int = max(1, int(round(self.topk_ratio * slab_size)))
+
+            if topk_int >= slab_size:
+                # ``topk_ratio == 1.0`` (or ratios that round up to the
+                # full slab): every q-block sees every k-block, so we
+                # skip the descriptor-pool / softmax / topk path
+                # entirely and synthesize an all-ones mask in one go.
+                base_blockmask = torch.ones(
+                    (B, H, n_blocks_q, n_blocks_k),
+                    device=device,
+                    dtype=torch.uint8,
+                )
+            else:
+                # Mean-pool within each 128-token window to get a
+                # single descriptor per (block, head); the spatial-only
+                # local mask is broadcast over the temporal axis
+                # inside build_topk_block_mask.
+                q_desc = query.reshape(
+                    B, n_blocks_q, _BSA_BLOCK_SIZE, H, D
+                ).mean(dim=2)
+                k_desc = key.reshape(
+                    B, n_blocks_k, _BSA_BLOCK_SIZE, H, D
+                ).mean(dim=2)
+                local_mask = self._get_local_attn_mask(Hb, Wb, device)
+                base_blockmask = build_topk_block_mask(
+                    q_desc,
+                    k_desc,
+                    num_temporal_q_blocks=Tb_q,
+                    num_temporal_k_blocks=Tb_k,
+                    topk=topk_int,
+                    local_spatial_block_mask=local_mask,
+                )
+
+        out_packed = block_sparse_attn_func(
+            q_packed,
+            k_packed,
+            v_packed,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            head_mask_type,
+            None,
+            base_blockmask,
+            Sq,
+            Sk,
+            0.0,
+            deterministic=False,
+            softmax_scale=None,
+            is_causal=False,
+            exact_streaming=False,
+            return_attn_probs=False,
+        )
+
+        out = out_packed.reshape(B, Sq, H, D)
+        if self.qkv_format == "bhsd":
+            out = out.transpose(1, 2)
+        return out
+
+
+@torch.no_grad()
+def build_local_spatial_block_mask(
+    spatial_h: int,
+    spatial_w: int,
+    win_h: int,
+    win_w: int,
+    *,
+    include_self: bool = True,
+    device: torch.device | str | None = None,
+) -> Tensor:
+    """Build a 2D local-neighbourhood mask over a spatial block grid.
+
+    For every block at row-major position ``(r, c)`` in a
+    ``spatial_h x spatial_w`` grid, mark every other ``(r', c')`` whose
+    row offset lies in ``[r - win_h//2, r - win_h//2 + win_h - 1]`` and
+    column offset in the matching window. The window is shifted (not
+    centred): the left/top half is ``win_*//2`` cells, so even window
+    sizes are biased one cell to the upper-left, matching the FlashVSR
+    reference.
+
+    Args:
+        spatial_h: Number of block rows.
+        spatial_w: Number of block columns.
+        win_h: Window height (in blocks).
+        win_w: Window width (in blocks).
+        include_self: Keep ``(r, c) -> (r, c)`` self-edges.
+        device: Output device.
+
+    Returns:
+        ``[spatial_h * spatial_w, spatial_h * spatial_w]`` ``bool``
+        mask in row-major order over the spatial grid.
+    """
+    device = torch.device(device) if device is not None else torch.device("cpu")
+    rows = torch.arange(spatial_h, device=device)
+    cols = torch.arange(spatial_w, device=device)
+    yy, xx = torch.meshgrid(rows, cols, indexing="ij")
+    r_all = yy.reshape(-1)
+    c_all = xx.reshape(-1)
+
+    r_half = win_h // 2
+    c_half = win_w // 2
+    start_r = r_all - r_half
+    end_r = start_r + win_h - 1
+    start_c = c_all - c_half
+    end_c = start_c + win_w - 1
+
+    in_row = (r_all[None, :] >= start_r[:, None]) & (r_all[None, :] <= end_r[:, None])
+    in_col = (c_all[None, :] >= start_c[:, None]) & (c_all[None, :] <= end_c[:, None])
+    mask = in_row & in_col
+    if not include_self:
+        mask.fill_diagonal_(False)
+    return mask
+
+
+@torch.no_grad()
+def build_topk_block_mask(
+    q_block_descriptor: Tensor,
+    k_block_descriptor: Tensor,
+    *,
+    num_temporal_q_blocks: int,
+    num_temporal_k_blocks: int,
+    topk: int,
+    local_spatial_block_mask: Tensor,
+) -> Tensor:
+    """Build a per-head top-K block mask for :class:`BlockSparseAttention`.
+
+    Mirrors the FlashVSR ``generate_draft_block_mask`` flow:
+
+    1. Score each ``(q_block, k_block)`` pair per head as
+       ``q_block_descriptor @ k_block_descriptor / sqrt(d_head)``.
+    2. Add ``-inf`` outside the spatial-only local mask, broadcast over
+       the temporal axis (every temporal pair is allowed by the local
+       mask).
+    3. Softmax over keys.
+    4. For each ``(head, temporal_q_block)`` slab of shape
+       ``(spatial_q, N_k)``, flatten and keep entries strictly greater
+       than the ``(topk + 1)``-th largest value — i.e. at most ``topk``
+       entries (modulo ties).
+
+    Args:
+        q_block_descriptor: Per-block query summary,
+            ``[B, N_q, num_heads, head_dim]``. The reference obtains it
+            by 3D-window-partitioning the latent and averaging within
+            each window. ``N_q`` must equal
+            ``num_temporal_q_blocks * spatial_q`` where ``spatial_q``
+            is the leading edge of ``local_spatial_block_mask``.
+        k_block_descriptor: Per-block key summary,
+            ``[B, N_k, num_heads, head_dim]``.
+        num_temporal_q_blocks: Number of temporal blocks in ``N_q``.
+        num_temporal_k_blocks: Number of temporal blocks in ``N_k``.
+        topk: Top-K count per ``(head, temporal_q_block)`` slab. Must
+            be at least ``1``; clamped to ``spatial_q * N_k - 1`` if
+            larger so the threshold lookup is valid.
+        local_spatial_block_mask: ``[spatial_q, spatial_k]`` ``bool``
+            mask gating allowed spatial pairs. Build via
+            :func:`build_local_spatial_block_mask`.
+
+    Returns:
+        ``[B, num_heads, N_q, N_k]`` ``uint8`` mask suitable for
+        :meth:`BlockSparseAttention.forward`'s ``blockmask`` argument.
+    """
+    assert q_block_descriptor.ndim == 4 and k_block_descriptor.ndim == 4, (
+        "q/k_block_descriptor must be [B, N, H, D]; got "
+        f"{tuple(q_block_descriptor.shape)} and {tuple(k_block_descriptor.shape)}."
+    )
+    B, N_q, H, dh = q_block_descriptor.shape
+    Bk, N_k, Hk, dhk = k_block_descriptor.shape
+    assert (B, H, dh) == (Bk, Hk, dhk), (
+        "q/k descriptors must share batch, num_heads and head_dim; got "
+        f"{(B, H, dh)} vs {(Bk, Hk, dhk)}."
+    )
+    assert local_spatial_block_mask.ndim == 2, (
+        f"local_spatial_block_mask must be 2D; got {tuple(local_spatial_block_mask.shape)}."
+    )
+    spatial_q, spatial_k = local_spatial_block_mask.shape
+    assert N_q == num_temporal_q_blocks * spatial_q, (
+        f"N_q={N_q} must equal num_temporal_q_blocks={num_temporal_q_blocks} "
+        f"* spatial_q={spatial_q}."
+    )
+    assert N_k == num_temporal_k_blocks * spatial_k, (
+        f"N_k={N_k} must equal num_temporal_k_blocks={num_temporal_k_blocks} "
+        f"* spatial_k={spatial_k}."
+    )
+    assert topk >= 1, f"topk must be >= 1; got {topk}."
+
+    device = q_block_descriptor.device
+
+    # Compute scores in the descriptor dtype (matching the FlashVSR
+    # reference, which scores in bf16 and only promotes to fp32 once
+    # the local mask is added). Softmax / topk run in fp32.
+    scores = torch.einsum(
+        "bnhd,bmhd->bhnm", q_block_descriptor, k_block_descriptor
+    ) / math.sqrt(dh)
+
+    # Broadcast the spatial-only mask over the temporal axes:
+    #   (spatial_q, spatial_k)
+    # → (num_temporal_q_blocks * spatial_q, num_temporal_k_blocks * spatial_k)
+    # Every temporal pair (tq, tk) sees the same spatial gate, matching
+    # the reference.
+    full_mask = local_spatial_block_mask.to(device=device, dtype=torch.bool)
+    full_mask = full_mask[None, :, None, :].expand(
+        num_temporal_q_blocks, spatial_q, num_temporal_k_blocks, spatial_k
+    )
+    full_mask = rearrange(
+        full_mask, "tq sq tk sk -> (tq sq) (tk sk)"
+    ).contiguous()
+
+    # bhnm + nm; broadcast over (B, H). Cast to fp32 here so the
+    # masked_fill / softmax / topk path matches the reference's
+    # implicit bf16+fp32 → fp32 promotion.
+    scores = scores.to(torch.float32).masked_fill(~full_mask, float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+
+    # Per-(B, H, tq) top-K over (spatial_q × N_k):
+    #   (B, H, N_q, N_k) → (B, H, tq, spatial_q, N_k)
+    #                   → (B, H, tq, spatial_q * N_k)
+    slab = rearrange(
+        attn, "b h (tq sq) nk -> b h tq (sq nk)", tq=num_temporal_q_blocks
+    )
+    n_entries = slab.shape[-1]
+    apply_topk = min(n_entries - 1, topk)
+    # values[..., -1] is the (apply_topk+1)-th largest; strict ">"
+    # selects at most ``apply_topk`` entries, matching the reference.
+    thresholds = torch.topk(
+        slab, k=apply_topk + 1, dim=-1, largest=True
+    ).values[..., -1:]
+    keep = slab > thresholds
+
+    keep = rearrange(
+        keep,
+        "b h tq (sq nk) -> b h (tq sq) nk",
+        sq=spatial_q,
+        nk=N_k,
+    )
+    return keep.to(dtype=torch.uint8).contiguous()

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/__init__.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
+from einops import rearrange
 from torch import Tensor
 
 from flashdreams.core.checkpoint.load import load_checkpoint
@@ -42,11 +43,42 @@ from .impl.context_parallel import (
     HierarchicalCPGroups,
     create_hierarchical_cp_groups,
 )
+from .impl.modules import _ALPADREAMS_BSA_WINDOW
 from .impl.network import (
     CosmosDiTNetwork,
     CosmosDiTNetworkCache,
     CosmosDiTNetworkConfig,
 )
+
+
+def _reorder_rope_freqs_to_block_major(
+    rope_freqs: Tensor,
+    thw: tuple[int, int, int],
+    window: tuple[int, int, int],
+) -> Tensor:
+    """Reorder ``[L, 1, 1, d]`` rope freqs from row-major to BSA block-major.
+
+    The rope adapter builds ``freqs_*`` with einops ``(t h w)``
+    (row-major) ordering, but the alpadreams patchify emits the
+    network input in 128-token block-major order. Reorder once here
+    so ``apply_rope_freqs`` lines each token up with its own ``(t,
+    h, w)`` rope; without this every q/k token gets the wrong rope
+    after patchify and attention quality collapses.
+    """
+    T, H, W = thw
+    wf, wh, ww = window
+    L = rope_freqs.shape[0]
+    assert L == T * H * W, (
+        f"rope_freqs length {L} must equal T*H*W={T * H * W} "
+        f"(thw={thw}); CP-split rope is not handled here."
+    )
+    return rearrange(
+        rope_freqs.reshape(T, H, W, *rope_freqs.shape[1:]),
+        "(nf wf) (nh wh) (nw ww) ... -> (nf nh nw wf wh ww) ...",
+        wf=wf,
+        wh=wh,
+        ww=ww,
+    )
 
 ## Default camera names / view-index mapping
 
@@ -575,6 +607,12 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             "predict_flow (DiffusionModel.generate handles this)."
         )
         rope_freqs = cache.rope_adapter.shift_t(offset=ar_idx * self.config._pT)
+        if self.flatten_thw:
+            rope_freqs = _reorder_rope_freqs_to_block_major(
+                rope_freqs,
+                thw=(self.config._pT, self.config._pH, self.config._pW),
+                window=_ALPADREAMS_BSA_WINDOW,
+            )
         noisy_latent = self._maybe_inject_image(noisy_latent, cache)
         return self._select_network(cache, uncond=uncond)(
             noisy_latent,

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/modules.py
@@ -24,8 +24,30 @@ from einops import rearrange, repeat
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from flashdreams.core.attention import BlockKVCache, RingAttention
+from flashdreams.core.attention import (
+    BlockKVCache,
+    BlockSparseAttention,
+    RingAttention,
+)
 from flashdreams.recipes.wan.transformer.impl.rope import apply_rope_freqs
+
+# Hardcoded BSA self-attention layout for the alpadreams 720p config:
+# post-patchify token grid is (T_q=2, H=88//2=44, W=160//2=80); BSA's
+# 128-token block constraint factors cleanly with window=(2, 4, 16),
+# giving a (1, 11, 5) block grid per chunk (55 blocks of 128 tokens =
+# 7040). The KV cache temporal dim grows over rollout (T_k in
+# ``{2, 4, ...}``) so ``T_k`` is derived dynamically inside ``apply_kv``
+# from the cached K's sequence length.
+_ALPADREAMS_BSA_T_Q: int = 2
+_ALPADREAMS_BSA_HW: tuple[int, int] = (44, 80)
+_ALPADREAMS_BSA_WINDOW: tuple[int, int, int] = (2, 4, 16)
+# By the time q/k/v reach :class:`SelfAttention.apply_kv` they're
+# already in 128-token block-major order: the alpadreams patchify
+# (:meth:`CosmosDiTNetwork.patchify_and_maybe_split_cp` with
+# ``flatten_thw=True``) bakes a FlashVSR-style 3-D window-partition
+# into its einops pattern, and ``rope_freqs`` is reordered to match
+# at the alpadreams transformer wrapper. So this module never has to
+# permute q/k/v again per layer.
 
 
 class GPT2FeedForward(nn.Module):
@@ -392,7 +414,82 @@ class MultiHeadAttention(nn.Module):
 
 
 class SelfAttention(MultiHeadAttention):
-    """Self-attention: queries and K/V are derived from the same ``x`` each step."""
+    """Self-attention: queries and K/V are derived from the same ``x`` each step.
+
+    Overrides the parent's :class:`RingAttention` with
+    :class:`BlockSparseAttention` so the self-attention path can run
+    block-sparse over the post-patchify ``(T, H, W)`` token grid. Cross-
+    and cross-view-attention keep using :class:`RingAttention` because
+    their K/V come from non-3D-structured context.
+    """
+
+    def __init__(
+        self,
+        query_dim: int,
+        context_dim: int | None = None,
+        n_heads: int = 8,
+        head_dim: int = 64,
+    ) -> None:
+        super().__init__(
+            query_dim=query_dim,
+            context_dim=context_dim,
+            n_heads=n_heads,
+            head_dim=head_dim,
+        )
+        # Swap the parent's RingAttention with BSA. ``topk_ratio``
+        # defaults to ``1.0`` (dense, matches RingAttention numerics)
+        # so this is a drop-in until we tune a sparser ratio.
+        self.attn_op = BlockSparseAttention(
+            qkv_format="bshd",
+            window=_ALPADREAMS_BSA_WINDOW,
+        )
+
+    def apply_kv(
+        self,
+        x: Tensor,
+        kv_cache: BlockKVCache,
+        rope_freqs: Tensor | None = None,
+    ) -> Tensor:
+        """Run BSA self-attention against the cached K/V.
+
+        ``q_thw`` is fixed at ``(_ALPADREAMS_BSA_T_Q, *_ALPADREAMS_BSA_HW)``
+        because each AR chunk feeds exactly ``T_q`` post-patchify
+        frames into the query. ``kv_thw`` derives ``T_k`` from the
+        cached K's sequence length so the BSA call tracks the
+        streaming KV cache as it grows past one chunk
+        (e.g. ``T_k = 2 → 4`` once the second window is committed).
+        """
+        batch_shape = x.shape[:-2]
+        batch_size = math.prod(batch_shape)
+        L, D = x.shape[-2:]
+        n, d = self.n_heads, self.head_dim
+        assert n * d == D, "n * d must be equal to D"
+
+        q = self.q_norm(self.q_proj(x).reshape(batch_size, L, n, d))
+        if rope_freqs is not None:
+            q = apply_rope_freqs(q, rope_freqs)
+
+        cached_k = kv_cache.cached_k()
+        cached_v = kv_cache.cached_v()
+
+        H_tok, W_tok = _ALPADREAMS_BSA_HW
+        Sk = cached_k.shape[1]
+        spatial = H_tok * W_tok
+        assert Sk % spatial == 0, (
+            f"Cached K seq length {Sk} must be a multiple of H*W={spatial} "
+            f"so T_k is integral."
+        )
+        T_k = Sk // spatial
+        q_thw = (_ALPADREAMS_BSA_T_Q, H_tok, W_tok)
+        kv_thw = (T_k, H_tok, W_tok)
+
+        # q/cached_k/v are already in 128-token block-major order
+        # (see the module docstring): patchify fused the 3-D window-
+        # partition into its einops pattern and the KV cache appends
+        # in that same order, so we hand them to BSA as-is.
+        out = self.attn_op(q, cached_k, cached_v, q_thw=q_thw, kv_thw=kv_thw)
+        out = out.reshape(batch_shape + (L, n * d))
+        return self.output_proj(out)
 
     def initialize_cache(
         self,

--- a/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/transformer/impl/network.py
@@ -30,6 +30,7 @@ from flashdreams.core.distributed.context_parallel import (
 from flashdreams.infra.config import InstantiateConfig
 
 from .modules import (
+    _ALPADREAMS_BSA_WINDOW,
     Block,
     BlockCache,
     FinalLayer,
@@ -325,27 +326,56 @@ class CosmosDiTNetwork(nn.Module):
     ) -> Tensor:
         """Patchify and optionally CP-split the input video tensor.
 
-        If ``flatten_thw`` is ``False`` the patchify pattern is
-        ``b v (t kt) c (h kh) (w kw) -> b v t (h w) (c kt kh kw)``; otherwise
-        it is ``b v (t kt) c (h kh) (w kw) -> b v (t h w) (c kt kh kw)``.
+        ``flatten_thw=False`` uses the multi-view pattern
+        ``b v (t kt) c (h kh) (w kw) -> b v t (h w) (c kt kh kw)``.
+
+        ``flatten_thw=True`` (single-view, ``BlockSparseAttention``
+        path) fuses patchify with FlashVSR's 3-D window-partition so
+        the seq axis comes out in **128-token block-major order**
+        already: each contiguous ``wf*wh*ww`` span along ``L`` is one
+        ``(wf, wh, ww)`` 3-D window over the post-patch ``(T, H, W)``
+        token grid. Doing it here means the partition is paid once
+        per AR step instead of N-blocks × per-layer; it's the cheap-
+        est place to put it because the patchify rearrange is already
+        a permute + contiguous. The single-view assumption keeps the
+        seq axis from interleaving with the view axis (cross-view
+        attention's ``b v (t hw) d -> b t v hw d`` rearrange would
+        miscount otherwise).
 
         Returns:
-            Patched tensor with shape ``[B, V, T, HW, D]`` or ``[B, V, L, D]``.
+            Patched tensor with shape ``[B, V, T, HW, D]`` or
+            ``[B, V, L, D]``.
         """
         assert x.ndim == 6, f"x must be a 6D tensor, but got shape {x.shape}"
 
         if flatten_thw:
-            pattern = "... v (t kt) c (h kh) (w kw) -> ... v (t h w) (c kt kh kw)"
+            assert x.shape[-5] == 1, (
+                f"flatten_thw=True is single-view only; got V={x.shape[-5]}."
+            )
+            wf, wh, ww = _ALPADREAMS_BSA_WINDOW
+            pattern = (
+                "... v (nf wf kt) c (nh wh kh) (nw ww kw) "
+                "-> ... v (nf nh nw wf wh ww) (c kt kh kw)"
+            )
+            x = rearrange(
+                x,
+                pattern,
+                kt=self.config.patch_temporal,
+                kh=self.config.patch_spatial,
+                kw=self.config.patch_spatial,
+                wf=wf,
+                wh=wh,
+                ww=ww,
+            )
         else:
             pattern = "... v (t kt) c (h kh) (w kw) -> ... v t (h w) (c kt kh kw)"
-
-        x = rearrange(
-            x,
-            pattern,
-            kt=self.config.patch_temporal,
-            kh=self.config.patch_spatial,
-            kw=self.config.patch_spatial,
-        )
+            x = rearrange(
+                x,
+                pattern,
+                kt=self.config.patch_temporal,
+                kh=self.config.patch_spatial,
+                kw=self.config.patch_spatial,
+            )
 
         if process_groups is not None:
             assert cp_dims is not None and len(cp_dims) == len(process_groups), (
@@ -371,18 +401,19 @@ class CosmosDiTNetwork(nn.Module):
     ) -> Tensor:
         """Unpatchify and optionally CP-gather the tensor back to video shape.
 
-        If ``flatten_thw`` is ``False`` the unpatchify pattern is
-        ``b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)``; otherwise
-        it is ``b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)``.
+        Inverse of :meth:`patchify_and_maybe_split_cp`. The
+        ``flatten_thw=True`` branch undoes the fused
+        patchify + window-partition in a single rearrange.
 
         Returns:
             Unpatched tensor with shape ``[B, V, T, C, H, W]``.
         """
         if flatten_thw:
-            pattern = "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
             assert x.ndim == 4, f"x must be a 4D tensor, but got shape {x.shape}"
+            assert x.shape[-3] == 1, (
+                f"flatten_thw=True is single-view only; got V={x.shape[-3]}."
+            )
         else:
-            pattern = "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
             assert x.ndim == 5, f"x must be a 5D tensor, but got shape {x.shape}"
 
         if process_groups is not None:
@@ -397,15 +428,35 @@ class CosmosDiTNetwork(nn.Module):
                     )
                     x = cat_outputs_cp(x, seq_dim=cp_dim, cp_group=process_group)
 
-        x = rearrange(
-            x,
-            pattern,
-            h=pH,
-            w=pW,
-            kt=self.config.patch_temporal,
-            kh=self.config.patch_spatial,
-            kw=self.config.patch_spatial,
-        )
+        if flatten_thw:
+            wf, wh, ww = _ALPADREAMS_BSA_WINDOW
+            pattern = (
+                "b v (nf nh nw wf wh ww) (c kt kh kw) "
+                "-> b v (nf wf kt) c (nh wh kh) (nw ww kw)"
+            )
+            x = rearrange(
+                x,
+                pattern,
+                nh=pH // wh,
+                nw=pW // ww,
+                wf=wf,
+                wh=wh,
+                ww=ww,
+                kt=self.config.patch_temporal,
+                kh=self.config.patch_spatial,
+                kw=self.config.patch_spatial,
+            )
+        else:
+            pattern = "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
+            x = rearrange(
+                x,
+                pattern,
+                h=pH,
+                w=pW,
+                kt=self.config.patch_temporal,
+                kh=self.config.patch_spatial,
+                kw=self.config.patch_spatial,
+            )
         return x  # [B, V, T, C, H, W]
 
     def initialize_cache(

--- a/flashdreams/tests/test_bsa.py
+++ b/flashdreams/tests/test_bsa.py
@@ -1,0 +1,778 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :class:`BlockSparseAttention`.
+
+Run on a single GPU::
+
+    PYTHONPATH=. pytest tests/test_bsa.py -v
+"""
+
+import math
+
+import pytest
+import torch
+from einops import rearrange
+
+pytest.importorskip("block_sparse_attn")
+
+from flashdreams.core.attention import (
+    BlockSparseAttention,
+    NativeAttention,
+    build_local_spatial_block_mask,
+    build_topk_block_mask,
+)
+
+
+def _make_qkv(
+    *,
+    batch: int,
+    heads: int,
+    seq: int,
+    dim: int,
+    qkv_format: str,
+    dtype: torch.dtype,
+    device: str,
+    seed: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    g = torch.Generator(device=device).manual_seed(seed)
+    if qkv_format == "bhsd":
+        shape = (batch, heads, seq, dim)
+    else:
+        shape = (batch, seq, heads, dim)
+    q = torch.randn(shape, generator=g, dtype=dtype, device=device)
+    k = torch.randn(shape, generator=g, dtype=dtype, device=device)
+    v = torch.randn(shape, generator=g, dtype=dtype, device=device)
+    return q, k, v
+
+
+@pytest.mark.parametrize("qkv_format", ["bhsd", "bshd"])
+@pytest.mark.parametrize("blockmask_mode", ["auto_dense", "explicit_ones"])
+def test_full_blockmask_matches_sdpa(qkv_format: str, blockmask_mode: str) -> None:
+    """Both the auto-mask path with ``topk_ratio=1.0`` and an explicit
+    all-ones override must reproduce dense SDPA."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    batch, heads, seq, dim = 2, 4, 256, 128
+
+    q, k, v = _make_qkv(
+        batch=batch,
+        heads=heads,
+        seq=seq,
+        dim=dim,
+        qkv_format=qkv_format,
+        dtype=dtype,
+        device=device,
+    )
+
+    sdpa = NativeAttention(qkv_format=qkv_format, backend="cudnn").to(device)
+    # topk_ratio defaults to 1.0; with seq=256, q_thw=(4, 8, 8) gives
+    # L = 256 tokens and a (2, 1, 1) block grid.
+    bsa = BlockSparseAttention(qkv_format=qkv_format).to(device)
+
+    q_thw = (4, 8, 8)
+    if blockmask_mode == "auto_dense":
+        kwargs = {"q_thw": q_thw}
+    else:
+        # Block size is 128 in BSA; seq=256 → 2 q-blocks and 2 k-blocks.
+        n_blocks = seq // 128
+        blockmask = torch.ones(
+            (batch, heads, n_blocks, n_blocks), dtype=torch.uint8, device=device
+        )
+        kwargs = {"blockmask": blockmask}
+
+    with torch.no_grad():
+        out_sdpa = sdpa(q, k, v)
+        out_bsa = bsa(q, k, v, **kwargs)
+
+    assert out_sdpa.shape == out_bsa.shape
+    torch.testing.assert_close(out_bsa, out_sdpa, atol=5e-3, rtol=5e-3)
+
+
+def test_partial_blockmask_differs_from_sdpa() -> None:
+    """A partial blockmask should change the output (sanity check)."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    batch, heads, seq, dim = 1, 4, 256, 64
+
+    q, k, v = _make_qkv(
+        batch=batch,
+        heads=heads,
+        seq=seq,
+        dim=dim,
+        qkv_format="bshd",
+        dtype=dtype,
+        device=device,
+    )
+
+    sdpa = NativeAttention(qkv_format="bshd", backend="cudnn").to(device)
+    bsa = BlockSparseAttention(qkv_format="bshd").to(device)
+
+    # Drop the (q_block=0, k_block=1) tile so block 0 of Q sees only
+    # block 0 of K — clearly different from dense attention.
+    n_blocks = seq // 128
+    blockmask = torch.ones(
+        (batch, heads, n_blocks, n_blocks), dtype=torch.uint8, device=device
+    )
+    blockmask[:, :, 0, 1] = 0
+
+    with torch.no_grad():
+        out_sdpa = sdpa(q, k, v)
+        out_bsa = bsa(q, k, v, blockmask=blockmask)
+
+    diff = (out_bsa.float() - out_sdpa.float()).abs().max().item()
+    assert diff > 1e-2, (
+        f"Partial blockmask should diverge from SDPA, but max abs diff "
+        f"was only {diff:.2e}."
+    )
+
+
+def test_diagonal_blockmask_matches_blockwise_sdpa() -> None:
+    """Diagonal-only blockmask matches running SDPA per (q_block, k_block)
+    aligned tile (each q-block only attends to its own k-block)."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    batch, heads, seq, dim = 1, 2, 256, 64
+    block = 128
+    n_blocks = seq // block
+
+    q, k, v = _make_qkv(
+        batch=batch,
+        heads=heads,
+        seq=seq,
+        dim=dim,
+        qkv_format="bshd",
+        dtype=dtype,
+        device=device,
+    )
+
+    bsa = BlockSparseAttention(qkv_format="bshd").to(device)
+    blockmask = torch.eye(n_blocks, dtype=torch.uint8, device=device)
+    blockmask = blockmask.expand(batch, heads, n_blocks, n_blocks).contiguous()
+
+    with torch.no_grad():
+        out_bsa = bsa(q, k, v, blockmask=blockmask)
+
+    # Reference: independent SDPA per diagonal tile, concatenated.
+    ref = torch.zeros_like(out_bsa)
+    for i in range(n_blocks):
+        s = i * block
+        e = s + block
+        # SDPA in bhsd; reshape then transpose to call F.scaled_dot_product_attention.
+        q_t = q[:, s:e].transpose(1, 2)
+        k_t = k[:, s:e].transpose(1, 2)
+        v_t = v[:, s:e].transpose(1, 2)
+        with torch.nn.attention.sdpa_kernel(
+            torch.nn.attention.SDPBackend.CUDNN_ATTENTION
+        ):
+            out = torch.nn.functional.scaled_dot_product_attention(q_t, k_t, v_t)
+        ref[:, s:e] = out.transpose(1, 2)
+
+    torch.testing.assert_close(out_bsa, ref, atol=5e-3, rtol=5e-3)
+
+
+# ---------------------------------------------------------------------------
+# Mask helpers — verified against verbatim ports of the FlashVSR reference.
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def _ref_local_mask(
+    block_h: int,
+    block_w: int,
+    win_h: int,
+    win_w: int,
+    *,
+    include_self: bool,
+    device: torch.device,
+) -> torch.Tensor:
+    """Verbatim port of build_local_block_mask_shifted_vec_normal_slide."""
+    H, W = block_h, block_w
+    r = torch.arange(H, device=device)
+    c = torch.arange(W, device=device)
+    YY, XX = torch.meshgrid(r, c, indexing="ij")
+    r_all = YY.reshape(-1)
+    c_all = XX.reshape(-1)
+    r_half = win_h // 2
+    c_half = win_w // 2
+    start_r = r_all - r_half
+    end_r = start_r + win_h - 1
+    start_c = c_all - c_half
+    end_c = start_c + win_w - 1
+    in_row = (r_all[None, :] >= start_r[:, None]) & (r_all[None, :] <= end_r[:, None])
+    in_col = (c_all[None, :] >= start_c[:, None]) & (c_all[None, :] <= end_c[:, None])
+    mask = in_row & in_col
+    if not include_self:
+        mask.fill_diagonal_(False)
+    return mask
+
+
+@torch.no_grad()
+def _ref_topk_mask(
+    batch_size: int,
+    nheads: int,
+    seqlen: int,
+    q_w: torch.Tensor,
+    k_w: torch.Tensor,
+    *,
+    topk: int,
+    local_attn_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Verbatim port of generate_draft_block_mask (B=1 path)."""
+    assert batch_size == 1
+    avgpool_q = torch.mean(q_w, dim=1)
+    avgpool_k = torch.mean(k_w, dim=1)
+    avgpool_q = rearrange(avgpool_q, "s (h d) -> s h d", h=nheads)
+    avgpool_k = rearrange(avgpool_k, "s (h d) -> s h d", h=nheads)
+    q_heads = avgpool_q.permute(1, 0, 2)
+    k_heads = avgpool_k.permute(1, 0, 2)
+    D = avgpool_q.shape[-1]
+    scores = torch.einsum("hld,hmd->hlm", q_heads, k_heads) / math.sqrt(D)
+
+    repeat_head = scores.shape[0]
+    repeat_len = scores.shape[1] // local_attn_mask.shape[0]
+    repeat_num = scores.shape[2] // local_attn_mask.shape[1]
+    lm = local_attn_mask.unsqueeze(1).unsqueeze(0).repeat(
+        repeat_len, 1, repeat_num, 1
+    )
+    lm = rearrange(lm, "x a y b -> (x a) (y b)")
+    lm = lm.unsqueeze(0).repeat(repeat_head, 1, 1)
+    lm = lm.to(torch.float32)
+    lm = lm.masked_fill(lm == False, -float("inf"))  # noqa: E712
+    lm = lm.masked_fill(lm == True, 0)  # noqa: E712
+    scores = scores + lm
+    attn_map = torch.softmax(scores, dim=-1)
+    attn_map = rearrange(attn_map, "h (it s1) s2 -> (h it) s1 s2", it=seqlen)
+    loop_num, s1, s2 = attn_map.shape
+    flat = attn_map.reshape(loop_num, -1)
+    apply_topk = min(flat.shape[1] - 1, topk)
+    thresholds = torch.topk(flat, k=apply_topk + 1, dim=1, largest=True).values[:, -1]
+    thresholds = thresholds.unsqueeze(1)
+    mask_new = (flat > thresholds).reshape(loop_num, s1, s2)
+    mask_new = rearrange(mask_new, "(h it) s1 s2 -> h (it s1) s2", it=seqlen)
+    return mask_new.unsqueeze(0).repeat(batch_size, 1, 1, 1)
+
+
+def test_build_local_spatial_block_mask_matches_reference() -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    for spatial_h, spatial_w, win_h, win_w, include_self in [
+        (8, 8, 6, 6, True),
+        (4, 6, 3, 5, False),
+        (5, 5, 1, 1, True),
+    ]:
+        ours = build_local_spatial_block_mask(
+            spatial_h, spatial_w, win_h, win_w, include_self=include_self, device=device
+        )
+        ref = _ref_local_mask(
+            spatial_h, spatial_w, win_h, win_w, include_self=include_self, device=device
+        )
+        assert torch.equal(ours, ref), (
+            f"local mask mismatch for "
+            f"({spatial_h}, {spatial_w}, {win_h}, {win_w}, {include_self})"
+        )
+
+
+def test_build_topk_block_mask_matches_reference() -> None:
+    assert torch.cuda.is_available()
+    device = "cuda"
+    dtype = torch.float32
+
+    nheads = 4
+    head_dim = 32
+    win_size = 128
+
+    spatial_h, spatial_w = 4, 4
+    spatial_q = spatial_h * spatial_w
+    spatial_k = spatial_q
+    nf_q = 3
+    nf_k = 5
+    N_q = nf_q * spatial_q
+    N_k = nf_k * spatial_k
+
+    g = torch.Generator(device=device).manual_seed(7)
+    q_w = torch.randn(
+        (N_q, win_size, nheads * head_dim), generator=g, dtype=dtype, device=device
+    )
+    k_w = torch.randn(
+        (N_k, win_size, nheads * head_dim), generator=g, dtype=dtype, device=device
+    )
+
+    local_mask = build_local_spatial_block_mask(
+        spatial_h, spatial_w, 3, 3, include_self=True, device=device
+    )
+
+    for topk in [1, 5, 32, 1000]:
+        ref_mask = _ref_topk_mask(
+            batch_size=1,
+            nheads=nheads,
+            seqlen=nf_q,
+            q_w=q_w,
+            k_w=k_w,
+            topk=topk,
+            local_attn_mask=local_mask,
+        )
+
+        # Convert (N_q, win, H*D) → (1, N_q, H, D) by averaging over win.
+        q_desc = rearrange(
+            q_w.mean(dim=1), "s (h d) -> 1 s h d", h=nheads
+        ).contiguous()
+        k_desc = rearrange(
+            k_w.mean(dim=1), "s (h d) -> 1 s h d", h=nheads
+        ).contiguous()
+
+        ours = build_topk_block_mask(
+            q_desc,
+            k_desc,
+            num_temporal_q_blocks=nf_q,
+            num_temporal_k_blocks=nf_k,
+            topk=topk,
+            local_spatial_block_mask=local_mask,
+        )
+
+        assert ours.shape == (1, nheads, N_q, N_k)
+        assert ours.dtype == torch.uint8
+        assert torch.equal(ours.bool(), ref_mask), f"topk mask mismatch at topk={topk}"
+
+
+def test_topk_mask_with_huge_topk_keeps_local_mask() -> None:
+    """When ``topk`` exceeds the in-window count, the kept entries
+    should be exactly the local mask broadcast over the temporal axes."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+
+    nheads = 2
+    head_dim = 16
+    spatial_h, spatial_w = 4, 4
+    spatial_q = spatial_h * spatial_w
+    nf_q, nf_k = 2, 2
+    N_q = nf_q * spatial_q
+    N_k = nf_k * spatial_q
+
+    g = torch.Generator(device=device).manual_seed(0)
+    q_desc = torch.randn(
+        (1, N_q, nheads, head_dim), generator=g, dtype=torch.float32, device=device
+    )
+    k_desc = torch.randn(
+        (1, N_k, nheads, head_dim), generator=g, dtype=torch.float32, device=device
+    )
+
+    local_mask = build_local_spatial_block_mask(
+        spatial_h, spatial_w, 3, 3, include_self=True, device=device
+    )
+
+    # Within each (head, temporal_q) slab there are
+    # spatial_q * (nf_k * spatial_q) entries; only spatial_q * (nf_k * in_window_count)
+    # of them are non-zero after softmax. With topk = (entries - 1), the
+    # threshold sits at the smallest positive entry → kept ≈ local mask.
+    apply_topk = spatial_q * N_k - 1
+    mask = build_topk_block_mask(
+        q_desc,
+        k_desc,
+        num_temporal_q_blocks=nf_q,
+        num_temporal_k_blocks=nf_k,
+        topk=apply_topk,
+        local_spatial_block_mask=local_mask,
+    )
+
+    # Expand local mask to (1, 1, N_q, N_k) and compare.
+    expected = local_mask[None, :, None, :].expand(nf_q, spatial_q, nf_k, spatial_q)
+    expected = rearrange(expected, "tq sq tk sk -> (tq sq) (tk sk)").contiguous()
+    expected = expected[None, None, :, :].expand(1, nheads, N_q, N_k)
+    assert torch.equal(mask.bool(), expected)
+
+
+def test_bsa_with_topk_mask_end_to_end() -> None:
+    """End-to-end: build a topk mask, run BSA, sanity-check shape and
+    that it differs from dense SDPA (mask is doing real work)."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+
+    nheads = 4
+    head_dim = 32
+    spatial_h, spatial_w = 4, 4
+    spatial_q = spatial_h * spatial_w
+    win_size = 128  # must equal BSA block size
+    nf_q = nf_k = 2
+    N_q = nf_q * spatial_q
+    seq_q = N_q * win_size
+    seq_k = N_q * win_size
+
+    g = torch.Generator(device=device).manual_seed(1)
+    q = torch.randn(
+        (1, seq_q, nheads, head_dim), generator=g, dtype=torch.bfloat16, device=device
+    )
+    k = torch.randn(
+        (1, seq_k, nheads, head_dim), generator=g, dtype=torch.bfloat16, device=device
+    )
+    v = torch.randn(
+        (1, seq_k, nheads, head_dim), generator=g, dtype=torch.bfloat16, device=device
+    )
+
+    # Slab size = spatial_q * (Tb * spatial_q) = 16 * 32 = 512;
+    # ratio = 4/512 = 0.0078125 → topk_int = round(0.0078125 * 512) = 4.
+    bsa = BlockSparseAttention(
+        qkv_format="bshd", topk_ratio=4 / 512, local_range=3
+    ).to(device)
+    sdpa = NativeAttention(qkv_format="bshd", backend="cudnn").to(device)
+    # Token-grid: (Tb*wf, Hb*wh, Wb*ww) = (2*2, 4*8, 4*8) = (4, 32, 32);
+    # L = 4*32*32 = 4096 = seq_q ✓.
+    q_thw = (nf_q * 2, spatial_h * 8, spatial_w * 8)
+    with torch.no_grad():
+        out_bsa = bsa(q, k, v, q_thw=q_thw)
+        out_sdpa = sdpa(q, k, v)
+
+    assert out_bsa.shape == (1, seq_q, nheads, head_dim)
+    assert torch.isfinite(out_bsa).all()
+    diff = (out_bsa.float() - out_sdpa.float()).abs().max().item()
+    assert diff > 1e-2, (
+        f"topk-derived mask should sparsify attention; got max abs diff {diff:.2e}"
+    )
+
+
+def test_bsa_local_attn_mask_is_cached_and_invalidates_on_layout_change() -> None:
+    """The lazily-built local mask should be reused across forward
+    calls with the same (spatial_h, spatial_w) and rebuilt otherwise."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+
+    nheads, head_dim = 2, 16
+    win_size = 128
+    spatial_h, spatial_w = 4, 4
+    spatial_q = spatial_h * spatial_w
+    nf_q = nf_k = 2
+    seq = nf_q * spatial_q * win_size
+
+    g = torch.Generator(device=device).manual_seed(2)
+    q = torch.randn(
+        (1, seq, nheads, head_dim), generator=g, dtype=torch.bfloat16, device=device
+    )
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    bsa = BlockSparseAttention(
+        qkv_format="bshd", topk_ratio=0.05, local_range=3
+    ).to(device)
+
+    # First spatial: (Hb=4, Wb=4) → token (H=32, W=32); T=nf_q*wf=4.
+    q_thw_1 = (nf_q * 2, spatial_h * 8, spatial_w * 8)
+
+    assert bsa._local_attn_mask is None
+    with torch.no_grad():
+        bsa(q, k, v, q_thw=q_thw_1)
+    first_mask = bsa._local_attn_mask
+    assert first_mask is not None
+
+    with torch.no_grad():
+        bsa(q, k, v, q_thw=q_thw_1)
+    assert bsa._local_attn_mask is first_mask, "Cached mask should be reused."
+
+    # Different spatial block grid (2, 8) → token (H=16, W=64); seq
+    # length matches because Hb*Wb stays at 16.
+    spatial_h2, spatial_w2 = 2, 8
+    q_thw_2 = (nf_q * 2, spatial_h2 * 8, spatial_w2 * 8)
+    seq2 = nf_q * (spatial_h2 * spatial_w2) * win_size
+    q2 = torch.randn(
+        (1, seq2, nheads, head_dim), generator=g, dtype=torch.bfloat16, device=device
+    )
+    k2 = torch.randn_like(q2)
+    v2 = torch.randn_like(q2)
+    with torch.no_grad():
+        bsa(q2, k2, v2, q_thw=q_thw_2)
+    assert bsa._local_attn_mask is not first_mask, (
+        "Mask should be rebuilt when the block grid changes."
+    )
+    assert bsa._local_attn_mask_key == (spatial_h2, spatial_w2)
+
+
+def _flashvsr_partition_3d(
+    x: torch.Tensor, win: tuple[int, int, int]
+) -> torch.Tensor:
+    """Verbatim port of WindowPartition3D.partition (5-D in, 3-D out)."""
+    B, F, H, W, C = x.shape
+    wf, wh, ww = win
+    assert F % wf == 0 and H % wh == 0 and W % ww == 0
+    x = x.view(B, F // wf, wf, H // wh, wh, W // ww, ww, C)
+    x = x.permute(0, 1, 3, 5, 2, 4, 6, 7).contiguous()
+    return x.view(-1, wf * wh * ww, C)
+
+
+def test_bsa_module_matches_flashvsr_full_flow() -> None:
+    """Compare ``BlockSparseAttention(topk_ratio=R, local_range=L)``
+    end-to-end against the FlashVSR reference: same window-partitioned
+    q/k/v, same pooled descriptors, same mask (verbatim ports), same
+    BSA call. Outputs must match bit-exactly."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+
+    B = 1
+    nheads = 4
+    head_dim = 32
+    D_total = nheads * head_dim
+
+    F_dim, H_dim, W_dim = 4, 32, 32
+    win = (2, 8, 8)
+    wf, wh, ww = win
+    win_size = wf * wh * ww
+    assert win_size == 128, "FlashVSR uses 2x8x8=128 to match the BSA block size."
+
+    nf_q = F_dim // wf
+    sp_h = H_dim // wh
+    sp_w = W_dim // ww
+    spatial_q = sp_h * sp_w
+
+    g = torch.Generator(device=device).manual_seed(3)
+    x_q = torch.randn(
+        (B, F_dim, H_dim, W_dim, D_total),
+        generator=g,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    x_k = torch.randn(
+        (B, F_dim, H_dim, W_dim, D_total),
+        generator=g,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    x_v = torch.randn(
+        (B, F_dim, H_dim, W_dim, D_total),
+        generator=g,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    # FlashVSR window-partition + reorder to (B, S, D_total) flat-block-major.
+    q_w = _flashvsr_partition_3d(x_q, win)
+    k_w = _flashvsr_partition_3d(x_k, win)
+    v_w = _flashvsr_partition_3d(x_v, win)
+    block_n = q_w.shape[0] // B
+    block_n_kv = k_w.shape[0] // B
+    block_s = q_w.shape[1]
+    reorder_q = rearrange(
+        q_w,
+        "(b block_n) (block_s) d -> b (block_n block_s) d",
+        block_n=block_n,
+        block_s=block_s,
+    )
+    reorder_k = rearrange(
+        k_w,
+        "(b block_n) (block_s) d -> b (block_n block_s) d",
+        block_n=block_n_kv,
+        block_s=block_s,
+    )
+    reorder_v = rearrange(
+        v_w,
+        "(b block_n) (block_s) d -> b (block_n block_s) d",
+        block_n=block_n_kv,
+        block_s=block_s,
+    )
+
+    q_bshd = rearrange(reorder_q, "b s (h d) -> b s h d", h=nheads)
+    k_bshd = rearrange(reorder_k, "b s (h d) -> b s h d", h=nheads)
+    v_bshd = rearrange(reorder_v, "b s (h d) -> b s h d", h=nheads)
+
+    topk = 8
+    local_range = 3
+
+    # Reference path: build the local mask + topk mask via the
+    # verbatim FlashVSR ports and pass that as an explicit blockmask.
+    ref_local = _ref_local_mask(
+        sp_h, sp_w, local_range, local_range, include_self=True, device=device
+    )
+    ref_blockmask = _ref_topk_mask(
+        batch_size=B,
+        nheads=nheads,
+        seqlen=nf_q,
+        q_w=q_w,
+        k_w=k_w,
+        topk=topk,
+        local_attn_mask=ref_local,
+    )
+    ref_blockmask_u8 = ref_blockmask.to(torch.uint8)
+
+    # Module-under-test path: same q/k/v, same (topk, local_range),
+    # but the mask is synthesized inside forward via the auto path.
+    # Convert the integer top-K used by the reference into the ratio
+    # the module accepts: slab_size = spatial_q * (n_temp_k * spatial_q),
+    # and the module recomputes int(round(ratio * slab_size)) which
+    # must round back to ``topk``.
+    slab_size = spatial_q * (nf_q * spatial_q)
+    topk_ratio = topk / slab_size
+    bsa_auto = BlockSparseAttention(
+        qkv_format="bshd", topk_ratio=topk_ratio, local_range=local_range
+    ).to(device)
+    bsa_explicit = BlockSparseAttention(qkv_format="bshd").to(device)
+
+    with torch.no_grad():
+        out_auto = bsa_auto(
+            q_bshd, k_bshd, v_bshd, q_thw=(F_dim, H_dim, W_dim)
+        )
+        out_explicit = bsa_explicit(
+            q_bshd, k_bshd, v_bshd, blockmask=ref_blockmask_u8
+        )
+
+    # Both runs use the same BSA kernel on the same q/k/v; if the mask
+    # synthesis is correct the outputs are bit-identical.
+    torch.testing.assert_close(out_auto, out_explicit, atol=0.0, rtol=0.0)
+
+    # Also check the cached local mask matches the reference.
+    assert torch.equal(bsa_auto._local_attn_mask, ref_local)
+    assert bsa_auto._local_attn_mask_key == (sp_h, sp_w)
+
+    # And that the auto path uses some sparsity (otherwise the test
+    # wouldn't be exercising the topk logic).
+    n_q_blocks = nf_q * spatial_q
+    n_k_blocks = nf_q * spatial_q
+    assert ref_blockmask_u8.shape == (B, nheads, n_q_blocks, n_k_blocks)
+    sparsity = 1.0 - ref_blockmask_u8.float().mean().item()
+    assert sparsity > 0.5, (
+        f"Expected at least 50% sparsity, got {sparsity:.2%}."
+    )
+
+
+def test_topk_ratio_one_matches_sdpa() -> None:
+    """``topk_ratio = 1.0`` must short-circuit to a full-ones mask
+    (regardless of ``local_range``) and reproduce dense SDPA.
+
+    Uses a layout whose local mask would otherwise gate out most
+    pairs (``local_range = 3`` on a 4×4 block grid), so the test
+    fails if the short-circuit is missing and the kept set falls back
+    to the local mask."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # Token-grid (T=4, H=32, W=32) with default window (2, 8, 8) →
+    # block grid (2, 4, 4); seq = T*H*W = 4096.
+    T_tok, H_tok, W_tok = 4, 32, 32
+    seq = T_tok * H_tok * W_tok
+
+    nheads = 4
+    head_dim = 64
+
+    g = torch.Generator(device=device).manual_seed(11)
+    q = torch.randn(
+        (1, seq, nheads, head_dim), generator=g, dtype=dtype, device=device
+    )
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    bsa = BlockSparseAttention(
+        qkv_format="bshd", topk_ratio=1.0, local_range=3
+    ).to(device)
+    sdpa = NativeAttention(qkv_format="bshd", backend="cudnn").to(device)
+
+    with torch.no_grad():
+        out_bsa = bsa(q, k, v, q_thw=(T_tok, H_tok, W_tok))
+        out_sdpa = sdpa(q, k, v)
+
+    assert out_bsa.shape == out_sdpa.shape
+    torch.testing.assert_close(out_bsa, out_sdpa, atol=5e-3, rtol=5e-3)
+
+
+def test_forward_requires_q_thw_or_blockmask() -> None:
+    """Calling forward without either ``q_thw`` or ``blockmask`` must
+    raise — the dense fallback was intentionally removed."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+
+    bsa = BlockSparseAttention(qkv_format="bshd").to(device)
+    q = torch.randn(1, 256, 2, 32, dtype=torch.bfloat16, device=device)
+    with pytest.raises(AssertionError, match="q_thw"):
+        bsa(q, q, q)
+
+
+def test_init_rejects_invalid_window() -> None:
+    """``window`` product must equal the BSA block size (128)."""
+    with pytest.raises(AssertionError, match="window product"):
+        BlockSparseAttention(window=(2, 8, 4))  # 2 * 8 * 4 = 64, not 128
+
+
+def test_asymmetric_q_thw_kv_thw_matches_sdpa() -> None:
+    """``T_q != T_k`` (streaming KV cache) with ``topk_ratio=1.0`` must
+    still reproduce dense SDPA over the full asymmetric K/V tensor.
+
+    Mirrors the alpadreams call site: query is one chunk's worth
+    (``T_q = 2``) and the cached K/V already covers two chunks
+    (``T_k = 4``)."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # window=(2, 4, 16) → 128-token blocks; spatial block grid (11, 5)
+    # is too large for this unit test, so use a smaller grid that
+    # still factors into 128 per window: window=(2, 8, 8), token grid
+    # (T_q=2, H=16, W=16) → spatial=(2, 2) blocks, slab manageable.
+    wf, wh, ww = 2, 8, 8
+    H_tok = 16
+    W_tok = 16
+    T_q = 2
+    T_k = 4
+
+    nheads = 4
+    head_dim = 64
+    Sq = T_q * H_tok * W_tok
+    Sk = T_k * H_tok * W_tok
+
+    g = torch.Generator(device=device).manual_seed(13)
+    q = torch.randn(
+        (1, Sq, nheads, head_dim), generator=g, dtype=dtype, device=device
+    )
+    k = torch.randn(
+        (1, Sk, nheads, head_dim), generator=g, dtype=dtype, device=device
+    )
+    v = torch.randn(
+        (1, Sk, nheads, head_dim), generator=g, dtype=dtype, device=device
+    )
+
+    bsa = BlockSparseAttention(
+        qkv_format="bshd", topk_ratio=1.0, window=(wf, wh, ww), local_range=3
+    ).to(device)
+    sdpa = NativeAttention(qkv_format="bshd", backend="cudnn").to(device)
+
+    with torch.no_grad():
+        out_bsa = bsa(
+            q,
+            k,
+            v,
+            q_thw=(T_q, H_tok, W_tok),
+            kv_thw=(T_k, H_tok, W_tok),
+        )
+        out_sdpa = sdpa(q, k, v)
+
+    assert out_bsa.shape == out_sdpa.shape == (1, Sq, nheads, head_dim)
+    torch.testing.assert_close(out_bsa, out_sdpa, atol=5e-3, rtol=5e-3)
+
+
+def test_kv_thw_must_match_q_thw_spatial() -> None:
+    """The local-spatial mask is shared, so spatial dims must agree."""
+    assert torch.cuda.is_available()
+    device = "cuda"
+
+    bsa = BlockSparseAttention(qkv_format="bshd").to(device)
+    # Token grids differ in H: (2, 16, 16) vs (2, 8, 32). Same Sk total
+    # but spatial grid differs → must raise.
+    Sq = 2 * 16 * 16
+    Sk = 2 * 8 * 32
+    q = torch.randn(1, Sq, 2, 64, dtype=torch.bfloat16, device=device)
+    k = torch.randn(1, Sk, 2, 64, dtype=torch.bfloat16, device=device)
+    v = torch.randn_like(k)
+    with pytest.raises(AssertionError, match="spatial dims"):
+        bsa(q, k, v, q_thw=(2, 16, 16), kv_thw=(2, 8, 32))


### PR DESCRIPTION
Bring in block sparse attn (https://github.com/mit-han-lab/Block-Sparse-Attention) backend. With 50% pruning rate it still doesn't show benefits (introduce large overhead:

```bash
uv run --package flashdreams --extra examples   python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=1     flashdreams/examples/run_alpadreams.py     --n_cameras 1 --total_blocks 20
```


- baseline: 87ms
- block sparse attn 50% prunning: DiT 156ms on GB300

Visuals: right is baseline; left is block sparse attn.

https://github.com/user-attachments/assets/9d62931d-0930-4632-9027-b96ec79da11c

