### PR TITLE
Lingbot World Perf Opt

### DIFF
--- a/flashdreams/examples/run_lingbot_world.py
+++ b/flashdreams/examples/run_lingbot_world.py
@@ -82,9 +82,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--config_name",
         type=str,
-        default="LingBot-World-Fast",
+        default="LingBot-World-Fast-Flash",
         choices=sorted(LINGBOT_WORLD_CONFIG_BUILDERS.keys()),
         help="Streaming checkpoint preset to load.",
+    )
+    parser.add_argument(
+        "--window_size_t",
+        type=int,
+        default=15,
+        help="Window size in latent frames.",
+    )
+    parser.add_argument(
+        "--sink_size_t",
+        type=int,
+        default=3,
+        help="Sink size in latent frames.",
     )
     parser.add_argument(
         "--total_blocks",
@@ -216,6 +228,8 @@ def main() -> None:
             compile_network=not args.no_compile,
             seed=42 + rank,
             enable_sync_and_profile=True,
+            window_size_t=args.window_size_t,
+            sink_size_t=args.sink_size_t,
         )
         .setup()
         .to(device=device)
@@ -267,7 +281,7 @@ def main() -> None:
         canvas = (canvas.float().numpy() + 1.0) / 2.0
         canvas = (canvas * 255).clip(0, 255).astype(np.uint8)
         save_path = (
-            f"{REPO_ROOT}/outputs/lingbot_{args.config_name}_{world_size}gpus.mp4"
+            f"{REPO_ROOT}/outputs/lingbot_{args.config_name}_{world_size}gpus_window{args.window_size_t}_sink{args.sink_size_t}.mp4"
         )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         media.write_video(save_path, canvas, fps=16)

--- a/flashdreams/examples/run_lingbot_world.py
+++ b/flashdreams/examples/run_lingbot_world.py
@@ -64,6 +64,9 @@ from flashdreams.recipes.lingbot_world.config import (
 from flashdreams.recipes.lingbot_world.encoder.camctrl import CamCtrlInput
 from flashdreams.recipes.lingbot_world.encoder.utils import compute_relative_poses
 from flashdreams.recipes.lingbot_world.pipeline import LingbotWorldInferencePipeline
+from flashdreams.recipes.lingbot_world.transformer import (
+    LingbotWorldTransformerConfig,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_DATA_DIR_S3 = "s3://flashdreams/assets/example_data/lingbot_world"
@@ -89,14 +92,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--window_size_t",
         type=int,
-        default=15,
-        help="Window size in latent frames.",
+        default=None,
+        help=(
+            "Override the streaming window size (latent frames). "
+            "Defaults to the value baked into the selected --config_name."
+        ),
     )
     parser.add_argument(
         "--sink_size_t",
         type=int,
-        default=3,
-        help="Sink size in latent frames.",
+        default=None,
+        help=(
+            "Override the streaming sink size (latent frames). "
+            "Defaults to the value baked into the selected --config_name."
+        ),
     )
     parser.add_argument(
         "--total_blocks",
@@ -222,14 +231,21 @@ def main() -> None:
 
     # --------------------------------------------------------- pipeline init
     builder = LINGBOT_WORLD_CONFIG_BUILDERS[args.config_name]
+    # Only forward window/sink overrides when the user explicitly set them, so
+    # the per-preset defaults baked into each builder (e.g. 60/0 for Fast,
+    # 15/3 for Fast-Flash) survive when the CLI flags are omitted.
+    builder_overrides: dict[str, int] = {}
+    if args.window_size_t is not None:
+        builder_overrides["window_size_t"] = args.window_size_t
+    if args.sink_size_t is not None:
+        builder_overrides["sink_size_t"] = args.sink_size_t
     pipeline = (
         builder(
             cp_size=world_size,
             compile_network=not args.no_compile,
             seed=42 + rank,
             enable_sync_and_profile=True,
-            window_size_t=args.window_size_t,
-            sink_size_t=args.sink_size_t,
+            **builder_overrides,
         )
         .setup()
         .to(device=device)
@@ -280,7 +296,26 @@ def main() -> None:
         canvas = rearrange(video, "1 v t c h w -> t h (v w) c")
         canvas = (canvas.float().numpy() + 1.0) / 2.0
         canvas = (canvas * 255).clip(0, 255).astype(np.uint8)
-        save_path = f"{REPO_ROOT}/outputs/lingbot_{args.config_name}_{world_size}gpus_window{args.window_size_t}_sink{args.sink_size_t}.mp4"
+        # Resolve the effective window/sink for the filename: CLI overrides
+        # win, otherwise read what the transformer config actually used.
+        transformer_cfg = pipeline.diffusion_model.transformer.config
+        assert isinstance(transformer_cfg, LingbotWorldTransformerConfig), (
+            f"Expected LingbotWorldTransformerConfig, got {type(transformer_cfg).__name__}"
+        )
+        effective_window = (
+            args.window_size_t
+            if args.window_size_t is not None
+            else transformer_cfg.window_size_t
+        )
+        effective_sink = (
+            args.sink_size_t
+            if args.sink_size_t is not None
+            else transformer_cfg.sink_size_t
+        )
+        save_path = (
+            f"{REPO_ROOT}/outputs/lingbot_{args.config_name}_{world_size}gpus"
+            f"_window{effective_window}_sink{effective_sink}.mp4"
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         media.write_video(save_path, canvas, fps=16)
         print(f"saved generated video to {save_path}")

--- a/flashdreams/examples/run_lingbot_world.py
+++ b/flashdreams/examples/run_lingbot_world.py
@@ -280,9 +280,7 @@ def main() -> None:
         canvas = rearrange(video, "1 v t c h w -> t h (v w) c")
         canvas = (canvas.float().numpy() + 1.0) / 2.0
         canvas = (canvas * 255).clip(0, 255).astype(np.uint8)
-        save_path = (
-            f"{REPO_ROOT}/outputs/lingbot_{args.config_name}_{world_size}gpus_window{args.window_size_t}_sink{args.sink_size_t}.mp4"
-        )
+        save_path = f"{REPO_ROOT}/outputs/lingbot_{args.config_name}_{world_size}gpus_window{args.window_size_t}_sink{args.sink_size_t}.mp4"
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         media.write_video(save_path, canvas, fps=16)
         print(f"saved generated video to {save_path}")

--- a/flashdreams/flashdreams/recipes/lingbot_world/config.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/config.py
@@ -62,7 +62,6 @@ AVAILABLE_LINGBOT_WORLD_CHECKPOINT_PATHS: dict[str, str] = {
 # Upstream Fast 4-step schedule and its independently distilled Flash 2-step
 # variant (the Flash list is not a prefix of the Fast list).
 _DEFAULT_DENOISING_TIMESTEPS = [999, 978, 947, 825]
-_FLASH_DENOISING_TIMESTEPS = [999, 947]
 _DEFAULT_NUM_TRAIN_TIMESTEPS = 1000
 
 _DEFAULT_BATCH_SHAPE: tuple[int, ...] = (1, 1)  # [B=1, V=1]
@@ -106,6 +105,8 @@ def _transformer_config(
     checkpoint_path: str,
     cp_size: int,
     compile_network: bool,
+    window_size_t: int = 60,
+    sink_size_t: int = 0,
 ) -> LingbotWorldTransformerConfig:
     """Lingbot World 14B transformer defaults for streaming inference."""
     return LingbotWorldTransformerConfig(
@@ -122,8 +123,8 @@ def _transformer_config(
         # CFG off by default to match the upstream Lingbot checkpoint.
         guidance_scale=1.0,
         # Streaming defaults.
-        window_size_t=60,
-        sink_size_t=0,
+        window_size_t=window_size_t,
+        sink_size_t=sink_size_t,
         # I2V channel-concat (mask + first-frame latent), not stamping.
         stamp_image_latent=False,
         concat_image_mask_to_latent=True,
@@ -180,8 +181,10 @@ def build_lingbot_world_fast_flash(
     compile_network: bool = True,
     seed: int = 42,
     enable_sync_and_profile: bool = False,
+    window_size_t: int = 15,
+    sink_size_t: int = 3,
 ) -> LingbotWorldInferencePipelineConfig:
-    """LingBot-World-Fast checkpoint, TAEHV decoder, 2-step distilled schedule."""
+    """LingBot-World-Fast checkpoint, TAEHV decoder."""
     return LingbotWorldInferencePipelineConfig(
         enable_sync_and_profile=enable_sync_and_profile,
         encoder=_pipeline_encoder_config(),
@@ -194,8 +197,10 @@ def build_lingbot_world_fast_flash(
                 ],
                 cp_size=cp_size,
                 compile_network=compile_network,
+                window_size_t=window_size_t,
+                sink_size_t=sink_size_t,
             ),
-            scheduler=_scheduler_config(_FLASH_DENOISING_TIMESTEPS),
+            scheduler=_scheduler_config(_DEFAULT_DENOISING_TIMESTEPS),
         ),
     )
 

--- a/flashdreams/flashdreams/recipes/lingbot_world/config.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/config.py
@@ -59,8 +59,7 @@ AVAILABLE_LINGBOT_WORLD_CHECKPOINT_PATHS: dict[str, str] = {
 
 ## Canonical Lingbot World streaming defaults
 
-# Upstream Fast 4-step schedule and its independently distilled Flash 2-step
-# variant (the Flash list is not a prefix of the Fast list).
+# Upstream Fast 4-step distilled schedule.
 _DEFAULT_DENOISING_TIMESTEPS = [999, 978, 947, 825]
 _DEFAULT_NUM_TRAIN_TIMESTEPS = 1000
 
@@ -86,8 +85,10 @@ def _scheduler_config(
 ) -> FlowMatchSchedulerConfig:
     """Lingbot World flow-match scheduler.
 
-    Parameterized by the full timestep list because the Fast and Flash
-    variants ship independently distilled schedules.
+    Takes the timestep list as a parameter so future variants that ship a
+    different distilled schedule can plug it in without touching the rest
+    of the builder. Both currently-shipped Lingbot World presets pass
+    ``_DEFAULT_DENOISING_TIMESTEPS``.
     """
     return FlowMatchSchedulerConfig(
         num_inference_steps=len(denoising_timesteps),

--- a/flashdreams/flashdreams/recipes/lingbot_world/config.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/config.py
@@ -155,6 +155,8 @@ def build_lingbot_world_fast(
     compile_network: bool = True,
     seed: int = 42,
     enable_sync_and_profile: bool = False,
+    window_size_t: int = 60,
+    sink_size_t: int = 0,
 ) -> LingbotWorldInferencePipelineConfig:
     """LingBot-World-Fast checkpoint, Wan VAE decoder, 4-step distilled schedule."""
     return LingbotWorldInferencePipelineConfig(
@@ -169,6 +171,8 @@ def build_lingbot_world_fast(
                 ],
                 cp_size=cp_size,
                 compile_network=compile_network,
+                window_size_t=window_size_t,
+                sink_size_t=sink_size_t,
             ),
             scheduler=_scheduler_config(_DEFAULT_DENOISING_TIMESTEPS),
         ),

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/i2v.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/i2v.py
@@ -84,6 +84,8 @@ class I2VCtrlEncoder(Encoder[I2VCtrlEncoderCache]):
         self.config: I2VCtrlEncoderConfig = config
         self.encoder = config.encoder.setup()
 
+        self._last_latent: Tensor | None = None
+
     def initialize_autoregressive_cache(self) -> I2VCtrlEncoderCache:
         return self.encoder.initialize_autoregressive_cache()
 
@@ -94,13 +96,18 @@ class I2VCtrlEncoder(Encoder[I2VCtrlEncoderCache]):
         autoregressive_index: int = 0,
         cache: I2VCtrlEncoderCache | None = None,
     ) -> I2VCtrl:
-        # TODO: the Wan VAE encoder is identity after chunk 3, so for I2V we
-        # could cache and skip the VAE call past that point.
-        latent = self.encoder(
-            input,
-            autoregressive_index=autoregressive_index,
-            cache=cache,
-        )
+        # TODO: the Wan VAE encoder is identity after chunk 5, so for I2V we
+        # could cache and skip the VAE call past that point. Hardcoded for now
+        # to be fixed later.
+        if autoregressive_index < 5:
+            self._last_latent = latent = self.encoder(
+                input,
+                autoregressive_index=autoregressive_index,
+                cache=cache,
+            )
+        else:
+            assert self._last_latent is not None
+            latent = self._last_latent
         # Mask shape matches latent so they patchify identically and the
         # downstream blend is a plain elementwise multiply.
         mask = torch.zeros_like(latent)

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/i2v.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/i2v.py
@@ -87,6 +87,9 @@ class I2VCtrlEncoder(Encoder[I2VCtrlEncoderCache]):
         self._last_latent: Tensor | None = None
 
     def initialize_autoregressive_cache(self) -> I2VCtrlEncoderCache:
+        # New rollout: the previous rollout's first-frame latent must not
+        # leak into AR steps >= 5 of this one.
+        self._last_latent = None
         return self.encoder.initialize_autoregressive_cache()
 
     @torch.no_grad()
@@ -96,6 +99,10 @@ class I2VCtrlEncoder(Encoder[I2VCtrlEncoderCache]):
         autoregressive_index: int = 0,
         cache: I2VCtrlEncoderCache | None = None,
     ) -> I2VCtrl:
+        # Defensive reset: covers callers that drive the encoder directly
+        # without going through ``initialize_autoregressive_cache``.
+        if autoregressive_index == 0:
+            self._last_latent = None
         # TODO: the Wan VAE encoder is identity after chunk 5, so for I2V we
         # could cache and skip the VAE call past that point. Hardcoded for now
         # to be fixed later.
@@ -106,7 +113,12 @@ class I2VCtrlEncoder(Encoder[I2VCtrlEncoderCache]):
                 cache=cache,
             )
         else:
-            assert self._last_latent is not None
+            assert self._last_latent is not None, (
+                "I2VCtrlEncoder has no cached latent at "
+                f"autoregressive_index={autoregressive_index}; "
+                "the rollout must have started at autoregressive_index=0 "
+                "and run contiguously through index 4."
+            )
             latent = self._last_latent
         # Mask shape matches latent so they patchify identically and the
         # downstream blend is a plain elementwise multiply.

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
@@ -27,6 +27,7 @@ from torch import Tensor
 from flashdreams.core.checkpoint.load import load_checkpoint
 from flashdreams.infra.compile import compile_module
 from flashdreams.infra.config import InstantiateConfig
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
@@ -75,13 +76,18 @@ class Wan21TransformerCache(TransformerAutoregressiveCache):
     """Current AR step index, set by ``start``."""
 
     def start(self, autoregressive_index: int) -> None:
+        # Hoist per-block KV pre-update out of the (graph-captured) network
+        # forward; predict_flow runs with eager_mode=False so the network
+        # itself does not call before_update.
         self.autoregressive_index = autoregressive_index
+        self.network_cache_cond.before_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.before_update(autoregressive_index)
 
     def finalize(self, autoregressive_index: int) -> None:
-        # The per-block KV update happens inside the network forward in
-        # eager_mode=True. DiffusionModel.finalize has already re-keyed both
-        # branches with the clean representation, so nothing to do here.
-        return
+        self.network_cache_cond.after_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.after_update(autoregressive_index)
 
 
 ## Transformer
@@ -152,6 +158,15 @@ class Wan21TransformerConfig(InstantiateConfig["Wan21Transformer"]):
     compile_network: bool = False
     """``torch.compile`` the network on init."""
 
+    use_cuda_graph: bool = True
+    """Wrap the network in ``CUDAGraphWrapper`` for steady-state replay.
+    Caller must keep non-staged inputs at stable storage addresses across
+    calls. ``predict_flow`` dispatches to ``wrapper.drain`` while the KV
+    cache is still filling and to ``wrapper`` once it reaches steady state."""
+
+    warmup_iters: int = 2
+    """Eager calls before capture (>= 2 to drain Inductor autotune)."""
+
     stamp_image_latent: bool = False
     """See class docstring (mask-inject I2V recipe)."""
 
@@ -165,6 +180,33 @@ class Wan21TransformerConfig(InstantiateConfig["Wan21Transformer"]):
 
         if self.concat_image_mask_to_latent:
             self.network.in_dim += 4 + 16
+
+        kt, kh, kw = self.network.patch_size
+        assert (
+            self.len_t % kt == 0
+            and self.height % kh == 0
+            and self.width % kw == 0
+        ), (
+            f"({self.len_t}, {self.height}, {self.width}) must be divisible by "
+            f"patch_size ({kt}, {kh}, {kw})"
+        )
+        self._pT = self.len_t // kt
+        self._pH = self.height // kh
+        self._pW = self.width // kw
+
+        # First AR step whose forward runs on the KV cache's steady-state
+        # code path. The cache fills at AR step ``chunks_total // _pT - 1``;
+        # the *next* step is the first one whose ``before_update`` sees
+        # ``is_steady_state() == True`` and whose forward takes the steady branches.
+        # Drain must cover that first steady call so Inductor autotunes those
+        # branches on the eager path before capture.
+        chunks_total = self.sink_size_t + self.window_size_t
+        assert chunks_total % self._pT == 0, (
+            f"sink_size_t + window_size_t ({chunks_total}) must be "
+            f"divisible by _pT ({self._pT}) so the BlockKVCache can fit "
+            f"a whole number of AR chunks."
+        )
+        self._steady_ar_idx = chunks_total // self._pT
 
 
 class Wan21Transformer(Transformer[Wan21TransformerCache]):
@@ -200,10 +242,10 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
             )
 
         # Token layout (pre-CP). Per-rank token count is on self.latent_shape[-2].
-        kt, kh, kw = config.network.patch_size
-        self._pT = config.len_t // kt
-        self._pH = config.height // kh
-        self._pW = config.width // kw
+        # _pT / _pH / _pW are computed in config.__post_init__.
+        self._pT = config._pT
+        self._pH = config._pH
+        self._pW = config._pW
         total_tokens = self._pT * self._pH * self._pW
         assert total_tokens % self.cp_size == 0, (
             f"Wan token length ({total_tokens} from len_t={config.len_t}, "
@@ -229,6 +271,23 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
 
         if config.compile_network:
             self.network = compile_module(self.network)
+
+        # Per-rollout dispatch when use_cuda_graph=True:
+        # filling phase -> wrapper.drain (eager, drains Inductor autotune);
+        # steady-state -> wrapper.__call__ (warmup + capture + replay).
+        # Cond and CFG-uncond branches each get their own wrapper since each
+        # mutates an independent rolling KV cache.
+        self._use_cuda_graph = config.use_cuda_graph
+        self._network_call_cond: CUDAGraphWrapper | WanDiTNetwork = (
+            CUDAGraphWrapper(self.network, warmup_iters=config.warmup_iters)
+            if config.use_cuda_graph
+            else self.network
+        )
+        self._network_call_uncond: CUDAGraphWrapper | WanDiTNetwork = (
+            CUDAGraphWrapper(self.network, warmup_iters=config.warmup_iters)
+            if config.use_cuda_graph
+            else self.network
+        )
 
     @property
     def latent_shape(self) -> tuple[int, ...]:
@@ -327,6 +386,14 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         )
         rope_adapter.set_context_parallel_group(cp_group=self.cp_group)
 
+        # Reset any prior CUDA graph: it refers to slot pointers from the
+        # previous cache, which the new cache invalidates.
+        if self._use_cuda_graph:
+            assert isinstance(self._network_call_cond, CUDAGraphWrapper)
+            self._network_call_cond.reset()
+            assert isinstance(self._network_call_uncond, CUDAGraphWrapper)
+            self._network_call_uncond.reset()
+
         return Wan21TransformerCache(
             network_cache_cond=network_cache_cond,
             network_cache_uncond=network_cache_uncond,
@@ -347,6 +414,24 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         is a plain per-token blend ``(1 - m) * latent + m * control.latent``.
         """
         return latent * (1.0 - control.mask) + control.latent * control.mask
+
+    def _select_network(
+        self, cache: Wan21TransformerCache, *, uncond: bool
+    ) -> Any:
+        if not self._use_cuda_graph:
+            return self.network
+
+        network_call = (
+            self._network_call_uncond if uncond else self._network_call_cond
+        )
+        assert isinstance(network_call, CUDAGraphWrapper)
+        # Cond and CFG-uncond branches both mutate their rolling KV cache, so
+        # neither branch can be graph-captured until the cache is steady.
+        return (
+            network_call.drain
+            if cache.autoregressive_index < self.config._steady_ar_idx
+            else network_call
+        )
 
     def predict_flow(
         self,
@@ -383,25 +468,25 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
             mask = input.mask[..., :16]
             network_input = torch.cat([network_input, mask, input.latent], dim=-1)
 
-        flow_cond = self.network(
+        flow_cond = self._select_network(cache, uncond=False)(
             x=network_input,
             timesteps=timestep,
             cache=cache.network_cache_cond,
             rope_freqs=rope_freqs,
             current_chunk_idx=ar_idx,
-            eager_mode=True,
+            eager_mode=False,
             **network_extra_kwargs,
         )
         if cache.network_cache_uncond is None:
             return flow_cond
 
-        flow_uncond = self.network(
+        flow_uncond = self._select_network(cache, uncond=True)(
             x=network_input,
             timesteps=timestep,
             cache=cache.network_cache_uncond,
             rope_freqs=rope_freqs,
             current_chunk_idx=ar_idx,
-            eager_mode=True,
+            eager_mode=False,
             **network_extra_kwargs,
         )
         return flow_uncond + self.config.guidance_scale * (flow_cond - flow_uncond)

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
@@ -183,9 +183,7 @@ class Wan21TransformerConfig(InstantiateConfig["Wan21Transformer"]):
 
         kt, kh, kw = self.network.patch_size
         assert (
-            self.len_t % kt == 0
-            and self.height % kh == 0
-            and self.width % kw == 0
+            self.len_t % kt == 0 and self.height % kh == 0 and self.width % kw == 0
         ), (
             f"({self.len_t}, {self.height}, {self.width}) must be divisible by "
             f"patch_size ({kt}, {kh}, {kw})"
@@ -415,15 +413,11 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         """
         return latent * (1.0 - control.mask) + control.latent * control.mask
 
-    def _select_network(
-        self, cache: Wan21TransformerCache, *, uncond: bool
-    ) -> Any:
+    def _select_network(self, cache: Wan21TransformerCache, *, uncond: bool) -> Any:
         if not self._use_cuda_graph:
             return self.network
 
-        network_call = (
-            self._network_call_uncond if uncond else self._network_call_cond
-        )
+        network_call = self._network_call_uncond if uncond else self._network_call_cond
         assert isinstance(network_call, CUDAGraphWrapper)
         # Cond and CFG-uncond branches both mutate their rolling KV cache, so
         # neither branch can be graph-captured until the cache is steady.


### PR DESCRIPTION
Perf optimization for lingbot world example. Changes are:
- [Lossy] Update `LingBot-World-Fast-Flash` config and change default from `LingBot-World-Fast` to `LingBot-World-Fast-Flash` config. The main difference in `LingBot-World-Fast-Flash` is the use of local window (15) and sink (3), along with using TAEHV for decoding.
- [Lossless] Add CUDAGraph for Wan DiT. This doesn't bring in much perf improvement (a few ms) but doesn't hurt to have.
- [Lossless] Update `I2VCtrlEncoder` to skip encoding after some number of rollouts (we can do this because WAN I2V is attaching zeros to image condition and after a few rollouts the encoded input would become steady).


```bash
# 4x GB300s
uv run --package flashdreams --extra examples   \
  python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=4    \
  flashdreams/examples/run_lingbot_world.py    --total_blocks 21 
```

before [config `LingBot-World-Fast`]: 12 frames / 1400ms = 8 fps
> AR 18 encode 91.386 ms diffuse 968.096 ms decode 125.967 ms finalize 215.342 ms | total(w/o finalize) 1185.450 ms total 1400.792 ms | GPU mem alloc 65.881 GiB reserved 94.676 GiB peak 71.282 GiB

after [config `LingBot-World-Fast-Flash`]: 12 frames / 523 ms = 23 fps
> AR 18 encode 1.419 ms diffuse 415.617 ms decode 2.992 ms finalize 103.447 ms | total(w/o finalize) 420.028 ms total 523.474 ms | GPU mem alloc 52.137 GiB reserved 57.844 GiB peak 54.067 GiB

Visuals:

https://github.com/user-attachments/assets/628658f1-155d-430f-a51d-29f433873a60



Appendix: Ablation on local window + sink size

https://github.com/user-attachments/assets/c71c9639-ac6b-4314-b1e0-518ec15028ab

https://github.com/user-attachments/assets/ad380e6d-0095-4bb2-9e9b-eb8e61be7258


