### PR TITLE
Profiling against self-forcing public codebase carefully

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Self-Forcing
 
-Baselines: 
+Baselines:
 - [Official Repo Profiling](https://github.com/liruilong940607/Self-Forcing/pull/1#issue-4396013709)
 
 ### With flashdreams env:

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -3,7 +3,7 @@
 Baselines: 
 - [Official Repo Profiling](https://github.com/liruilong940607/Self-Forcing/pull/1#issue-4396013709)
 
-On A100, with flashdreams env:
+### With flashdreams env:
 
 ```bash
 uv run --package flashdreams --extra examples \
@@ -13,6 +13,7 @@ uv run --package flashdreams --extra examples \
     --total_blocks 7
 ```
 
+On A100
 > AR 0 encode 0.021 ms diffuse 16255.894 ms decode 143063.156 ms finalize 98.825 ms | total(w/o finalize) 159319.070 ms total 159417.895 ms | GPU mem alloc 19.162 GiB reserved 21.787 GiB peak 21.319 GiB
 > AR 1 encode 0.021 ms diffuse 1683.165 ms decode 56416.598 ms finalize 124.611 ms | total(w/o finalize) 58099.784 ms total 58224.396 ms | GPU mem alloc 19.163 GiB reserved 21.787 GiB peak 21.319 GiB
 > AR 2 encode 0.021 ms diffuse 642.681 ms decode 13.634 ms finalize 150.875 ms | total(w/o finalize) 656.336 ms total 807.210 ms | GPU mem alloc 19.162 GiB reserved 21.787 GiB peak 21.319 GiB
@@ -21,7 +22,16 @@ uv run --package flashdreams --extra examples \
 > AR 5 encode 0.022 ms diffuse 954.896 ms decode 13.474 ms finalize 228.108 ms | total(w/o finalize) 968.392 ms total 1196.499 ms | GPU mem alloc 19.189 GiB reserved 21.922 GiB peak 21.319 GiB
 > AR 6 encode 0.021 ms diffuse 1057.509 ms decode 13.473 ms finalize 254.318 ms | total(w/o finalize) 1071.003 ms total 1325.321 ms | GPU mem alloc 19.189 GiB reserved 21.922 GiB peak 21.319 GiB
 
-On A100, with self-forcing env:
+On GB200
+> AR 0 encode 0.022 ms diffuse 47020.234 ms decode 48014.711 ms finalize 43.231 ms | total(w/o finalize) 95034.968 ms total 95078.198 ms | GPU mem alloc 19.162 GiB reserved 22.135 GiB peak 21.407 GiB
+> AR 1 encode 0.026 ms diffuse 1607.381 ms decode 43041.988 ms finalize 38.407 ms | total(w/o finalize) 44649.396 ms total 44687.803 ms | GPU mem alloc 19.163 GiB reserved 22.135 GiB peak 21.407 GiB
+> AR 2 encode 0.022 ms diffuse 214.317 ms decode 4.320 ms finalize 35.907 ms | total(w/o finalize) 218.660 ms total 254.566 ms | GPU mem alloc 19.162 GiB reserved 22.135 GiB peak 21.407 GiB
+> AR 3 encode 0.022 ms diffuse 198.750 ms decode 89.716 ms finalize 40.423 ms | total(w/o finalize) 288.487 ms total 328.911 ms | GPU mem alloc 19.197 GiB reserved 21.533 GiB peak 21.407 GiB
+> AR 4 encode 0.023 ms diffuse 209.456 ms decode 3.531 ms finalize 36.530 ms | total(w/o finalize) 213.011 ms total 249.541 ms | GPU mem alloc 19.197 GiB reserved 21.537 GiB peak 21.407 GiB
+> AR 5 encode 0.021 ms diffuse 202.850 ms decode 3.532 ms finalize 37.491 ms | total(w/o finalize) 206.403 ms total 243.894 ms | GPU mem alloc 19.197 GiB reserved 21.537 GiB peak 21.407 GiB
+> AR 6 encode 0.023 ms diffuse 213.910 ms decode 3.537 ms finalize 40.247 ms | total(w/o finalize) 217.470 ms total 257.717 ms | GPU mem alloc 19.197 GiB reserved 21.537 GiB peak 21.407 GiB
+
+### With self-forcing env:
 
 ```bash
 conda activate self_forcing
@@ -32,6 +42,7 @@ PYTHONPATH=./flashdreams python -m torch.distributed.run --standalone --nnodes=1
   --total_blocks 7
 ```
 
+On A100
 > AR 0 encode 0.021 ms diffuse 9719.179 ms decode 4394.018 ms finalize 97.804 ms | total(w/o finalize) 14113.218 ms total 14211.022 ms | GPU mem alloc 19.078 GiB reserved 21.289 GiB peak 20.197 GiB
 > AR 1 encode 0.023 ms diffuse 14469.375 ms decode 11246.406 ms finalize 122.569 ms | total(w/o finalize) 25715.805 ms total 25838.374 ms | GPU mem alloc 19.079 GiB reserved 21.289 GiB peak 20.224 GiB
 > AR 2 encode 0.023 ms diffuse 636.438 ms decode 14.221 ms finalize 148.522 ms | total(w/o finalize) 650.681 ms total 799.204 ms | GPU mem alloc 19.078 GiB reserved 21.289 GiB peak 20.224 GiB

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,41 @@
+# Self-Forcing
+
+Baselines: 
+- [Official Repo Profiling](https://github.com/liruilong940607/Self-Forcing/pull/1#issue-4396013709)
+
+On A100, with flashdreams env:
+
+```bash
+uv run --package flashdreams --extra examples \
+  python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=1 \
+    flashdreams/examples/run_causal_wan21.py \
+    --config_name self_forcing_lighttae \
+    --total_blocks 7
+```
+
+> AR 0 encode 0.021 ms diffuse 16255.894 ms decode 143063.156 ms finalize 98.825 ms | total(w/o finalize) 159319.070 ms total 159417.895 ms | GPU mem alloc 19.162 GiB reserved 21.787 GiB peak 21.319 GiB
+> AR 1 encode 0.021 ms diffuse 1683.165 ms decode 56416.598 ms finalize 124.611 ms | total(w/o finalize) 58099.784 ms total 58224.396 ms | GPU mem alloc 19.163 GiB reserved 21.787 GiB peak 21.319 GiB
+> AR 2 encode 0.021 ms diffuse 642.681 ms decode 13.634 ms finalize 150.875 ms | total(w/o finalize) 656.336 ms total 807.210 ms | GPU mem alloc 19.162 GiB reserved 21.787 GiB peak 21.319 GiB
+> AR 3 encode 0.021 ms diffuse 748.495 ms decode 49.293 ms finalize 176.603 ms | total(w/o finalize) 797.809 ms total 974.412 ms | GPU mem alloc 19.189 GiB reserved 21.918 GiB peak 21.319 GiB
+> AR 4 encode 0.021 ms diffuse 851.870 ms decode 13.478 ms finalize 204.958 ms | total(w/o finalize) 865.368 ms total 1070.326 ms | GPU mem alloc 19.189 GiB reserved 21.922 GiB peak 21.319 GiB
+> AR 5 encode 0.022 ms diffuse 954.896 ms decode 13.474 ms finalize 228.108 ms | total(w/o finalize) 968.392 ms total 1196.499 ms | GPU mem alloc 19.189 GiB reserved 21.922 GiB peak 21.319 GiB
+> AR 6 encode 0.021 ms diffuse 1057.509 ms decode 13.473 ms finalize 254.318 ms | total(w/o finalize) 1071.003 ms total 1325.321 ms | GPU mem alloc 19.189 GiB reserved 21.922 GiB peak 21.319 GiB
+
+On A100, with self-forcing env:
+
+```bash
+conda activate self_forcing
+pip install mediapy pynvml loguru boto3 transformer-engine[pytorch,core-cu12]
+PYTHONPATH=./flashdreams python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=1 \
+  flashdreams/examples/run_causal_wan21.py \
+  --config_name self_forcing_lighttae \
+  --total_blocks 7
+```
+
+> AR 0 encode 0.021 ms diffuse 9719.179 ms decode 4394.018 ms finalize 97.804 ms | total(w/o finalize) 14113.218 ms total 14211.022 ms | GPU mem alloc 19.078 GiB reserved 21.289 GiB peak 20.197 GiB
+> AR 1 encode 0.023 ms diffuse 14469.375 ms decode 11246.406 ms finalize 122.569 ms | total(w/o finalize) 25715.805 ms total 25838.374 ms | GPU mem alloc 19.079 GiB reserved 21.289 GiB peak 20.224 GiB
+> AR 2 encode 0.023 ms diffuse 636.438 ms decode 14.221 ms finalize 148.522 ms | total(w/o finalize) 650.681 ms total 799.204 ms | GPU mem alloc 19.078 GiB reserved 21.289 GiB peak 20.224 GiB
+> AR 3 encode 0.022 ms diffuse 741.092 ms decode 469.722 ms finalize 175.246 ms | total(w/o finalize) 1210.837 ms total 1386.083 ms | GPU mem alloc 19.113 GiB reserved 21.402 GiB peak 20.232 GiB
+> AR 4 encode 0.022 ms diffuse 840.731 ms decode 14.098 ms finalize 201.189 ms | total(w/o finalize) 854.851 ms total 1056.040 ms | GPU mem alloc 19.113 GiB reserved 21.404 GiB peak 20.232 GiB
+>  AR 5 encode 0.021 ms diffuse 944.683 ms decode 14.080 ms finalize 226.367 ms | total(w/o finalize) 958.784 ms total 1185.151 ms | GPU mem alloc 19.113 GiB reserved 21.404 GiB peak 20.232 GiB
+> AR 6 encode 0.022 ms diffuse 1048.089 ms decode 14.090 ms finalize 253.412 ms | total(w/o finalize) 1062.201 ms total 1315.613 ms | GPU mem alloc 19.113 GiB reserved 21.404 GiB peak 20.232 GiB

--- a/flashdreams/examples/run_causal_wan21.py
+++ b/flashdreams/examples/run_causal_wan21.py
@@ -65,7 +65,7 @@ import torch
 from einops import rearrange
 
 from flashdreams.core.distributed import init as distributed_init
-from flashdreams.recipes.wan.autoencoder.vae import WanVAEDecoder
+from flashdreams.infra.decoder.base import StreamingVideoDecoder
 from flashdreams.recipes.wan.config.causal_wan21 import (
     CAUSAL_WAN21_CONFIG_BUILDERS,
     DEFAULT_VIDEO_HEIGHT,
@@ -75,7 +75,7 @@ from flashdreams.recipes.wan.config.causal_wan21 import (
 from flashdreams.recipes.wan.pipeline import WanInferencePipeline
 from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerConfig
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 DEFAULT_T2V_PROMPT = (
     "A stylish woman strolls down a bustling Tokyo street, the warm glow of "
@@ -190,7 +190,7 @@ def main() -> None:
     # I2V the pipeline derives them from the resized first-frame pixels.
     transformer_cfg = pipeline.diffusion_model.transformer.config
     assert isinstance(transformer_cfg, Wan21TransformerConfig)
-    assert isinstance(pipeline.decoder, WanVAEDecoder)
+    assert isinstance(pipeline.decoder, StreamingVideoDecoder)
     latent_h = DEFAULT_VIDEO_HEIGHT // WAN_VAE_SPATIAL_COMPRESSION
     latent_w = DEFAULT_VIDEO_WIDTH // WAN_VAE_SPATIAL_COMPRESSION
 

--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -16,10 +16,10 @@
 """Block KV cache for causal attention with a fixed-size local window."""
 
 from dataclasses import dataclass, field
-from typing import Self
 
 import torch
 from torch import Tensor
+from typing_extensions import Self
 
 
 @dataclass

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
@@ -212,7 +212,7 @@ class FlowMatchScheduler(Scheduler):
             timestep = timesteps[i].to(dtype=input_dtype)
             if i > 0:
                 assert clean is not None
-                noise = torch.randn_like(noisy, generator=rng)
+                noise = torch.empty_like(noisy).normal_(generator=rng)
                 noisy = ((1.0 - sigma) * clean + sigma * noise).to(input_dtype)
             flow = predict_flow(noisy, timestep)
             clean = noisy - sigma * flow
@@ -234,5 +234,5 @@ class FlowMatchScheduler(Scheduler):
         full_t = self._full_timesteps
         idx = torch.argmin((full_t - timestep.to(full_t.dtype)).abs()).reshape(1)
         sigma = self._full_sigmas.index_select(0, idx).reshape(())
-        noise = torch.randn_like(clean_input, generator=rng)
+        noise = torch.empty_like(clean_input).normal_(generator=rng)
         return ((1.0 - sigma) * clean_input + sigma * noise).to(clean_input.dtype)

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/fm_unipc.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/fm_unipc.py
@@ -405,5 +405,5 @@ class FlowMatchUniPCScheduler(Scheduler):
         ts = self.timesteps
         idx = torch.argmin((ts - timestep.to(ts.dtype)).abs()).reshape(1)
         sigma = self._sigmas_full.index_select(0, idx).reshape(())
-        noise = torch.randn_like(clean_input, generator=rng)
+        noise = torch.empty_like(clean_input).normal_(generator=rng)
         return ((1.0 - sigma) * clean_input + sigma * noise).to(clean_input.dtype)


### PR DESCRIPTION
TL;DR:
- **A100: ~ same speed**
- **B200: less than 2x speedup: 250ms v.s. 450ms e2e.**

See PERFORMANCE.md for details.

Also fixes a few line of codes to be compatible with older versions of python / torch.