### PR TITLE
Add an argument to create noise in unpatchified shape.

### DIFF
--- a/flashdreams/flashdreams/infra/diffusion/model/base.py
+++ b/flashdreams/flashdreams/infra/diffusion/model/base.py
@@ -63,6 +63,10 @@ class DiffusionModelConfig(InstantiateConfig["DiffusionModel"]):
     """Timestep used by ``finalize`` for the AR cache-update forward.
     ``0`` skips ``add_noise``."""
 
+    _noise_in_unpatchified_shape: bool = False
+    """Debug only: Create the noise in the unpatchified shape (to align with the open-source codebases).
+    Note this will hurt performance so only use it for debugging."""
+
 
 class DiffusionModel(nn.Module, Generic[TransformerCacheT]):
     """Autoregressive diffusion model (scheduler + transformer).
@@ -162,26 +166,59 @@ class DiffusionModel(nn.Module, Generic[TransformerCacheT]):
             input = self.transformer.patchify_and_maybe_split_cp(input)
         cache.start(autoregressive_index)
 
-        initial_noise = torch.randn(
-            self.latent_shape,
-            device=self.device,
-            dtype=self.dtype,
-            generator=self.rng,
-        )
+        if self.config._noise_in_unpatchified_shape:
+            # The `self.latent_shape` is for patchified latent. To align with the OSS codebases
+            # we here want to create the noise with the *unpatchified* shape, then patchify it back.
+            dummy_latent = torch.empty(
+                self.latent_shape, device=self.device, dtype=self.dtype
+            )
+            dummy_latent = self.transformer.unpatchify_and_maybe_gather_cp(dummy_latent)
+            initial_noise = torch.randn(
+                dummy_latent.shape,
+                device=self.device,
+                dtype=self.dtype,
+                generator=self.rng,
+            )  # shape of an unpatchified latent
+
+        else:
+            initial_noise = torch.randn(
+                self.latent_shape,
+                device=self.device,
+                dtype=self.dtype,
+                generator=self.rng,
+            )  # shape of a patchified latent
 
         def predict_flow(noisy_latent: Tensor, timestep: Tensor) -> Tensor:
-            return self.transformer.predict_flow(
+            if self.config._noise_in_unpatchified_shape:
+                # If the noise is in the unpatchified shape, we need to patchify it first
+                # because the transformer expects a patchified latent.
+                noisy_latent = self.transformer.patchify_and_maybe_split_cp(
+                    noisy_latent
+                )
+
+            output = self.transformer.predict_flow(
                 noisy_latent=noisy_latent,
                 timestep=timestep,
                 cache=cache,
                 input=input,
-            )
+            )  # patchified output
+
+            if self.config._noise_in_unpatchified_shape:
+                # The we need to unpatchify it again, to make sure scheduler operates
+                # on the unpatchified latent.
+                output = self.transformer.unpatchify_and_maybe_gather_cp(output)
+            return output
 
         clean_latent = self.scheduler.sample(
             initial_noise=initial_noise,
             predict_flow=predict_flow,
             rng=self.rng,
         )
+
+        if self.config._noise_in_unpatchified_shape:
+            # If this option is enabled, the scheduler operates on the unpatchified latent.
+            # So the clean latent it outputs is in the unpatchified shape. Here we patchify it.
+            clean_latent = self.transformer.patchify_and_maybe_split_cp(clean_latent)
 
         clean_latent = self.transformer.postprocess_clean_latent(
             clean_latent=clean_latent,
@@ -219,11 +256,23 @@ class DiffusionModel(nn.Module, Generic[TransformerCacheT]):
         context_noise = self.config.context_noise
         timestep = torch.tensor(context_noise, device=self.device, dtype=self.dtype)
         if context_noise > 0.0:
+            clean_latent = final_state.clean_latent
+            if self.config._noise_in_unpatchified_shape:
+                # If this option is enabled, we want the scheduler to operate on the unpatchified latent.
+                clean_latent = self.transformer.unpatchify_and_maybe_gather_cp(
+                    final_state.clean_latent
+                )
             noisy_latent = self.scheduler.add_noise(
-                clean_input=final_state.clean_latent,
+                clean_input=clean_latent,
                 timestep=timestep,
                 rng=self.rng,
             )
+            if self.config._noise_in_unpatchified_shape:
+                # If this option is enabled, then the scheduler outputs an unpatchified latent so we
+                # need to patchify it.
+                noisy_latent = self.transformer.patchify_and_maybe_split_cp(
+                    noisy_latent
+                )
         else:
             noisy_latent = final_state.clean_latent
         self.transformer.finalize_kv_cache(

--- a/flashdreams/flashdreams/recipes/wan/config/causal_wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/config/causal_wan21.py
@@ -112,14 +112,14 @@ def _taehv_vae_decoder_config() -> TeahvVAEDecoderConfig:
     return TeahvVAEDecoderConfig()
 
 
-def _scheduler_config(num_inference_steps: int = 4) -> FlowMatchSchedulerConfig:
+def _scheduler_config(num_inference_steps: int = 4, shift: float = 5.0) -> FlowMatchSchedulerConfig:
     """Self-Forcing flow-match scheduler defaults."""
     timesteps = _DEFAULT_DENOISING_TIMESTEPS[:num_inference_steps]
     return FlowMatchSchedulerConfig(
         num_inference_steps=num_inference_steps,
         denoising_timesteps=timesteps,
         warp_denoising_step=True,
-        shift=5.0,
+        shift=shift,
         sigma_min=0.0,
         extra_one_step=True,
         num_train_timesteps=_DEFAULT_NUM_TRAIN_TIMESTEPS,
@@ -182,7 +182,7 @@ def build_self_forcing(
                 checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS["self_forcing"],
                 compile_network=compile_network,
             ),
-            scheduler=_scheduler_config(num_inference_steps=4),
+            scheduler=_scheduler_config(num_inference_steps=4, shift=8.0),
         ),
     )
 
@@ -205,7 +205,7 @@ def build_self_forcing_lighttae(
                 checkpoint_path=AVAILABLE_CAUSAL_WAN21_CHECKPOINT_PATHS["self_forcing"],
                 compile_network=compile_network,
             ),
-            scheduler=_scheduler_config(num_inference_steps=4),
+            scheduler=_scheduler_config(num_inference_steps=4, shift=8.0),
         ),
     )
 

--- a/flashdreams/flashdreams/recipes/wan/config/causal_wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/config/causal_wan21.py
@@ -112,7 +112,9 @@ def _taehv_vae_decoder_config() -> TeahvVAEDecoderConfig:
     return TeahvVAEDecoderConfig()
 
 
-def _scheduler_config(num_inference_steps: int = 4, shift: float = 5.0) -> FlowMatchSchedulerConfig:
+def _scheduler_config(
+    num_inference_steps: int = 4, shift: float = 5.0
+) -> FlowMatchSchedulerConfig:
     """Self-Forcing flow-match scheduler defaults."""
     timesteps = _DEFAULT_DENOISING_TIMESTEPS[:num_inference_steps]
     return FlowMatchSchedulerConfig(


### PR DESCRIPTION
To numerically compare with open-source codebases, we need to create noises in the same way -- in unpatchified shape -- so that we can make sure the results are the same with seed control.

Introducing `_noise_in_unpatchified_shape` in `DiffusionModelConfig`. Setting it along with the seed, allows to create (almost) same results with public self-forcing code with the same seed [[link]](https://github.com/liruilong940607/Self-Forcing/pull/1#issuecomment-4395201931):

Self-forcing official code [seed 42] (use my MR in the above link):

https://github.com/user-attachments/assets/1e2cbc21-de0c-4cd0-b2c4-3761fe087e1e

Our codebase [seed 42]:


https://github.com/user-attachments/assets/79199f5e-0498-4f6d-99f0-02357006476e


