### PR TITLE
alpadreams: replace ludus-renderer with SlangPy rasterizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,8 @@ jobs:
           # ty needs third-party packages to resolve imports. Skip packages
           # that cannot be installed on CPU-only runners:
           # - transformer-engine-torch: source-only, requires CUDA to compile
-          # - ludus-renderer: unavailable in CI
           uv sync --extra dev --group lint \
-            --no-install-package transformer-engine-torch \
-            --no-install-package ludus-renderer
+            --no-install-package transformer-engine-torch
 
       - name: Run linter checks
         run: uv run --no-sync pre-commit run -a

--- a/integrations/alpadreams/alpadreams/conditioning/renderer.py
+++ b/integrations/alpadreams/alpadreams/conditioning/renderer.py
@@ -13,78 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Ludus-based HD map renderer.
+"""SlangPy-based HD-map renderer.
 
-This module provides the LudusRenderer class, which wraps the ludus_renderer
-library to render HD map scenes for conditioning video generation.
+This module provides the :class:`LudusRenderer` class, which renders HD-map
+conditioning frames for the Alpadreams video model. The class name is
+preserved for backwards compatibility, but the implementation no longer
+depends on the closed-source ``ludus-renderer`` wheel: it now uses a SlangPy
+software rasterizer (see :mod:`alpadreams.conditioning.slang_renderer`) that
+runs custom Slang compute kernels under PyTorch's CUDA context.
+
+Public API surface (``__init__``, :meth:`render_all_frames_and_cameras`,
+:meth:`cleanup`, :func:`load_and_attach_ludus_scene`) is unchanged so callers
+in :mod:`alpadreams.grpc` work without modification.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
-import ludus_renderer
 import torch
+from alpadreams.conditioning.slang_renderer import (
+    RasterConfig,
+    SceneBundle,
+    SlangConditionRasterizer,
+    mirror_augment_bundle,
+    scene_data_to_bundle,
+)
+from alpadreams.conditioning.slang_renderer.camera import FThetaCameraModel
+from alpadreams.conditioning.world_scenario.data_loaders import load_scene
 from alpadreams.conditioning.world_scenario.data_types import SceneData
 from alpadreams.conditioning.world_scenario.ftheta import FThetaCamera
 from alpadreams.conditioning.world_scenario.pinhole import PinholeCamera
-from ludus_renderer import (
-    load_clipgt_scene,
-    mirror_augment_scene,
-)
-from ludus_renderer.render_utils import (
-    SceneAdapter,
-)
-from ludus_renderer.torch import (
-    LudusCudaTimestampedContext,
-)
-from ludus_renderer.torch.ops import (
-    CAMERA_TYPE_REGULAR,
-)
+
+SCENE_BUNDLE_KEY = "ludus_scene"
 
 
 class LudusRenderer:
-    @staticmethod
-    def to_ludus_camera(
-        camera: PinholeCamera | FThetaCamera,
-    ) -> ludus_renderer.FThetaCamera:
-        """
-        Convert an Imaginaire camera to a Ludus camera.
-        """
+    """Render HD-map conditioning frames for one or more cameras.
 
-        if isinstance(camera, PinholeCamera):
-            raise NotImplementedError("Pinhole camera not supported yet")
-
-        elif isinstance(camera, FThetaCamera):
-            return ludus_renderer.FThetaCamera(
-                principal_point=camera._center_torch,
-                image_size=torch.tensor(
-                    [camera._width, camera._height], device=camera.device
-                ),
-                fw_poly=camera._fw_poly_torch,
-                max_ray_angle=float(camera._max_ray_angle_torch),
-                # linear_distortion=camera._A_torch,  # TODO: Is it _A_torch or _inv_A_torch?
-                depth_max=200.0,  # TODO: How to get it from camera data?
-            )
-
-        else:
-            raise ValueError(f"Unsupported camera type: {type(camera)}")
-
-    def to_ludus_camera_pose(self, camera_poses: torch.Tensor) -> torch.Tensor:
-        """
-        Convert an Imaginaire camera pose to a Ludus camera pose.
-        Args:
-            camera_poses: Camera poses [num_frames, 4, 4].
-        Returns:
-            Ludus camera poses [num_frames, 4, 4].
-        """
-        return torch.linalg.inv(camera_poses)
+    The class wraps :class:`SlangConditionRasterizer` with the multi-camera
+    batching contract that :class:`AlpadreamsConditioningWrapper` expects:
+    ``render_all_frames_and_cameras`` returns a ``[V, T, 3, H, W]`` uint8
+    tensor on GPU.
+    """
 
     def __init__(
         self,
         scene_data: SceneData,
-        camera_models: dict,
+        camera_models: dict[str, FThetaCamera | PinholeCamera],
         hdmap_color_version: str = "v3",
         bbox_color_version: str = "v3",
         traffic_light_color_version: str = "v2",
@@ -92,11 +69,22 @@ class LudusRenderer:
         device: torch.device = torch.device("cuda"),
         coordinate_system: Literal["FLU", "RDF"] = "FLU",
     ):
-        """Render a full sequence for one or more cameras.
+        """Construct a renderer for a fixed set of cameras.
 
         Args:
-            args: Command line arguments
-            all_cameras: If True, render all available cameras. Otherwise uses args.camera.
+            scene_data: World scenario data; must already have a SceneBundle
+                attached under ``metadata[SCENE_BUNDLE_KEY]`` (see
+                :func:`load_and_attach_ludus_scene`).
+            camera_models: ``{camera_name: FThetaCamera}`` dictionary. Pinhole
+                cameras are not supported.
+            hdmap_color_version: Must be ``"v3"`` (other palettes are not
+                ported from ludus).
+            bbox_color_version: Must be ``"v3"``.
+            traffic_light_color_version: Must be ``"v2"``.
+            windowless: Unused; kept for API parity.
+            device: CUDA device on which the rasterizer runs.
+            coordinate_system: Must be ``"FLU"``; the rasterizer converts to
+                RDF internally.
         """
         assert hdmap_color_version == "v3", (
             "Only v3 color version is supported for LudusRenderer"
@@ -107,38 +95,56 @@ class LudusRenderer:
         assert traffic_light_color_version == "v2", (
             "Only v2 color version is supported for LudusRenderer"
         )
-
-        assert len(camera_models) > 0, "Must provide at least one camera model"
-        self.scene_data = scene_data
-        self.camera_models = camera_models
-        self.device = device
         assert coordinate_system == "FLU", (
             "FLU coordinate system is expected for LudusRenderer"
         )
+        assert len(camera_models) > 0, "Must provide at least one camera model"
+        del windowless  # accepted for API compatibility, never used
 
-        # Create context
-        self.ctx = LudusCudaTimestampedContext(device=self.device)
-        self.ctx.set_depth_scaling(True)
-        self.ctx.set_msaa_samples(4)
-        self.ctx.set_max_tessellation_levels(cube=0)
+        self.scene_data = scene_data
+        self.camera_models = camera_models
+        self.device = device
 
-        # Create and upload cameras
-        all_camera_map = {}
-        all_cameras = []
+        bundle = scene_data.metadata.get(SCENE_BUNDLE_KEY)
+        if not isinstance(bundle, SceneBundle):
+            raise ValueError(
+                f"scene_data.metadata['{SCENE_BUNDLE_KEY}'] must be a SceneBundle. "
+                "Did you forget to call load_and_attach_ludus_scene()?"
+            )
+
+        widths: set[int] = set()
+        heights: set[int] = set()
         for camera_name, camera_model in camera_models.items():
-            cam = self.to_ludus_camera(camera_model)
-            all_cameras.append(cam)
-            all_camera_map[camera_name] = len(all_cameras) - 1
-        self.all_cameras = all_cameras
-        self.all_camera_map = all_camera_map
-        self.ctx.upload_cameras(all_cameras)
+            if isinstance(camera_model, PinholeCamera):
+                raise NotImplementedError(
+                    f"Pinhole camera not supported by SlangPy rasterizer (camera '{camera_name}')."
+                )
+            if not isinstance(camera_model, FThetaCamera):
+                raise TypeError(
+                    f"Unsupported camera type for '{camera_name}': {type(camera_model)}"
+                )
+            widths.add(int(camera_model.width))
+            heights.add(int(camera_model.height))
 
-        # Upload scene
-        assert "ludus_scene" in self.scene_data.metadata, (
-            "Ludus scene not found in scene data"
+        if len(widths) != 1 or len(heights) != 1:
+            raise ValueError(
+                f"All cameras must share resolution; got widths={widths}, heights={heights}"
+            )
+        width = widths.pop()
+        height = heights.pop()
+
+        raster_config = RasterConfig(width=width, height=height, compute_device="cuda")
+        slang_camera_models: dict[str, FThetaCameraModel] = {
+            name: FThetaCameraModel(model, output_width=width, output_height=height)
+            for name, model in camera_models.items()
+        }
+
+        self._rasterizer = SlangConditionRasterizer(
+            camera_models=slang_camera_models,
+            raster=raster_config,
+            device=self.device,
         )
-        scene = self.scene_data.metadata["ludus_scene"]
-        self.scene_id = self.ctx.upload_scene(scene.timestamped_scene)
+        self._rasterizer.load_scene(bundle)
 
     def render_all_frames_and_cameras(
         self,
@@ -147,98 +153,53 @@ class LudusRenderer:
         frame_timestamps_us: list[int],
         object_infos: list[dict | None] | None = None,
     ) -> torch.Tensor:
-        """Render a batch of frames and cameras.
+        """Render a batch of frames for the given cameras.
 
         Args:
-            camera_names: List of camera names to render.
-            camera_poses_per_camera: Dictionary of camera poses per camera.
-            frame_timestamps_us: List of frame timestamps in microseconds.
-            object_infos: List of object infos.
+            camera_names: Ordered list of camera names (defines the V axis).
+            camera_poses_per_camera: ``{camera_name: [T, 4, 4]}`` camera-to-world
+                poses in the same world frame as the loaded SceneBundle. The
+                CLIPGT loader converts everything to OpenCV RDF
+                (``scene_data.metadata["coordinate_frame"] == "opencv_rdf"``),
+                so ego poses can be passed straight through. On the renderer's
+                CUDA device.
+            frame_timestamps_us: Frame timestamps in microseconds (unused; the
+                Slang rasterizer treats the scene as static, but we accept the
+                argument for API parity with the previous ludus path).
+            object_infos: Per-frame dynamic-object info dicts (unused; bbox
+                tracks are not yet ported to the SlangPy backend).
+
+        Returns:
+            ``[V, T, 3, H, W]`` uint8 tensor on the renderer's CUDA device.
         """
+        del object_infos  # bbox tracks are not yet ported
 
         n_cameras = len(camera_names)
-        assert n_cameras > 0, "Number of cameras must be greater than 0"
-
+        if n_cameras == 0:
+            raise ValueError("camera_names must be non-empty")
         n_frames = len(frame_timestamps_us)
-        assert n_frames > 0, "Number of frames must be greater than 0"
+        if n_frames == 0:
+            raise ValueError("frame_timestamps_us must be non-empty")
 
-        # Create batch tensors
-        scene_id_batch = torch.full(
-            (n_frames * n_cameras,),
-            self.scene_id,
-            dtype=torch.int32,
-            device=self.device,
-        )
-        camera_type_id_batch = torch.full(
-            (n_frames * n_cameras,),
-            CAMERA_TYPE_REGULAR,
-            dtype=torch.int32,
-            device=self.device,
-        )
-        timestamps_batch = torch.tensor(
-            frame_timestamps_us, dtype=torch.int64, device=self.device
-        ).repeat(n_cameras)
-
-        H, W = None, None
-
-        camera_id_batch = []
-        camera_poses_batch = []
-
+        per_view: list[torch.Tensor] = []
         for camera_name in camera_names:
-            # Get camera ID, model and check resolution
-            c = self.all_camera_map[camera_name]
-            m = self.all_cameras[c]
-            if H is None or W is None:
-                H, W = m.image_size[1], m.image_size[0]
-            assert H == m.image_size[1] and W == m.image_size[0], (
-                "All cameras must have the same resolution"
-            )
-
-            # Append camera ID
-            camera_id_batch.append(c)
-
-            # Get camera poses and check shape
+            if camera_name not in self.camera_models:
+                raise KeyError(f"Unknown camera name: {camera_name}")
             poses = camera_poses_per_camera[camera_name]
-            assert len(poses) == n_frames, (
-                "Camera poses must have the same length as frame timestamps"
-            )
-            assert poses.ndim == 3, "Camera poses must be a 3D array"
-            assert poses.shape == (n_frames, 4, 4), (
-                "Camera poses must have the same length as frame timestamps"
-            )
-            camera_poses_batch.append(self.to_ludus_camera_pose(poses))
+            if poses.shape != (n_frames, 4, 4):
+                raise ValueError(
+                    f"camera_poses for '{camera_name}' must be [{n_frames}, 4, 4], got {tuple(poses.shape)}"
+                )
+            poses_cuda = poses.to(device=self.device, dtype=torch.float32)
+            frames = self._rasterizer.render_camera(camera_name, poses_cuda)
+            per_view.append(frames)
 
-        camera_id_batch = (
-            torch.tensor(camera_id_batch, dtype=torch.int32, device=self.device)
-            .unsqueeze(1)
-            .repeat(1, n_frames)
-            .flatten()
-        )
-        camera_poses_batch = torch.stack(camera_poses_batch, dim=0).reshape(-1, 4, 4)
-
-        images = self.ctx.render(
-            scene_id_batch,
-            camera_id_batch,
-            timestamps_batch,
-            camera_type_id_batch,
-            camera_poses_batch,
-            resolution=(H, W),
-        )
-
-        rgb = images[:, :, :, :3]
-        if self.ctx.needs_vflip:
-            rgb = rgb.flip(1)
-        return (
-            rgb.squeeze(0)
-            .permute(0, 3, 1, 2)
-            .contiguous()
-            .view(n_cameras, n_frames, 3, H, W)
-        )
+        return torch.stack(per_view, dim=0).contiguous()
 
     def cleanup(self) -> None:
-        """Cleanup the renderer."""
-        # LudusCudaTimestampedContext handles cleanup in its destructor
-        pass
+        """Release rasterizer resources (no-op for now)."""
+        # SlangPy device cleanup is handled by garbage collection.
+        return None
 
 
 def load_and_attach_ludus_scene(
@@ -252,19 +213,60 @@ def load_and_attach_ludus_scene(
     n_mirrors: int = 2,
     lookahead_m: float = 50.0,
 ) -> SceneData:
-    """Load HDMap scene from path and attach it to scene data."""
-    ludus_scene = load_clipgt_scene(
-        scene_data_path,
-        device=torch.device(device),
-        include_ego_trajectory=include_ego_trajectory,
-        include_ego_obstacle=include_ego_obstacle,
-        simplify_dual_lane_lines=simplify_dual_lane_lines,
-    )
+    """Build a SceneBundle from ``scene_data`` and attach it to its metadata.
+
+    The function name is preserved for backwards compatibility with
+    ``alpadreams.grpc.utils.load_static_world_from_zip_bytes``; the SceneBundle
+    is stored under ``scene_data.metadata[SCENE_BUNDLE_KEY]`` for the
+    LudusRenderer constructor to consume.
+
+    Args:
+        scene_data_path: Unused; kept for API parity (the previous
+            implementation reloaded the scene from disk via ludus, but
+            flashdreams' :class:`SceneData` already carries everything we need).
+        scene_data: World scenario data populated by :func:`load_scene`.
+        device: Unused; the SceneBundle is held on the host (numpy arrays) and
+            uploaded to GPU at render time.
+        include_ego_trajectory: Reserved for future ego-trajectory rendering;
+            currently a no-op (matches the default flashdreams config).
+        include_ego_obstacle: Reserved for future ego-obstacle rendering;
+            currently a no-op.
+        simplify_dual_lane_lines: Reserved; the new pattern engine already
+            applies the standard lane-line simplifications.
+        perform_mirror_augment: If True, mirror-stitches the scene
+            ``n_mirrors`` times.
+        n_mirrors: Number of mirror copies to add.
+        lookahead_m: Distance past the last ego pose to place the first mirror plane.
+
+    Returns:
+        ``scene_data`` with ``metadata[SCENE_BUNDLE_KEY]`` set to the new bundle.
+    """
+    del scene_data_path  # not needed: SceneData is already populated
+    del device
+    del include_ego_trajectory
+    del include_ego_obstacle
+    del simplify_dual_lane_lines
+
+    raster_config = RasterConfig()
+    bundle = scene_data_to_bundle(scene_data, raster_config)
     if perform_mirror_augment:
-        augmented_scene = mirror_augment_scene(
-            ludus_scene, n_mirrors=n_mirrors, lookahead_m=lookahead_m
+        bundle = mirror_augment_bundle(
+            bundle,
+            scene_data.ego_poses,
+            n_mirrors=n_mirrors,
+            lookahead_m=lookahead_m,
         )
-    else:
-        augmented_scene = ludus_scene
-    scene_data.metadata["ludus_scene"] = SceneAdapter(augmented_scene)
+    scene_data.metadata[SCENE_BUNDLE_KEY] = bundle
     return scene_data
+
+
+__all__ = [
+    "LudusRenderer",
+    "SCENE_BUNDLE_KEY",
+    "load_and_attach_ludus_scene",
+]
+
+
+# Re-exports kept here so existing code that references these names through
+# alpadreams.conditioning.renderer keeps working.
+_ = (Any, load_scene)

--- a/integrations/alpadreams/alpadreams/conditioning/renderer.py
+++ b/integrations/alpadreams/alpadreams/conditioning/renderer.py
@@ -158,11 +158,12 @@ class LudusRenderer:
         Args:
             camera_names: Ordered list of camera names (defines the V axis).
             camera_poses_per_camera: ``{camera_name: [T, 4, 4]}`` camera-to-world
-                poses in the same world frame as the loaded SceneBundle. The
-                CLIPGT loader converts everything to OpenCV RDF
-                (``scene_data.metadata["coordinate_frame"] == "opencv_rdf"``),
-                so ego poses can be passed straight through. On the renderer's
-                CUDA device.
+                poses in OpenCV RDF (matching ``scene_data.metadata["coordinate_frame"]``,
+                which is always ``opencv_rdf`` for CLIPGT-loaded scenes). The
+                gRPC server converts client-supplied FLU poses to RDF inside
+                :func:`alpadreams.grpc.utils.compute_camera_poses_from_rig`,
+                so callers there get this for free; if you build poses from
+                some other source make sure they're already in RDF.
             frame_timestamps_us: Frame timestamps in microseconds (unused; the
                 Slang rasterizer treats the scene as static, but we accept the
                 argument for API parity with the previous ludus path).

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/__init__.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/__init__.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SlangPy-based HD-map rasterizer that replaces the ludus-renderer CUDA path.
+
+The Slang shader code, scene-bundle representation, and per-pass orchestration
+in this subpackage are adapted from the roaddreams sample
+(``references/omni-dreams-slangpy/samples/roaddreams``). The public surface
+exposed here is what :mod:`alpadreams.conditioning.renderer` consumes; nothing
+else in flashdreams should depend on this subpackage directly.
+"""
+
+from alpadreams.conditioning.slang_renderer.config import RasterConfig
+from alpadreams.conditioning.slang_renderer.mirror_augment import mirror_augment_bundle
+from alpadreams.conditioning.slang_renderer.rasterizer import SlangConditionRasterizer
+from alpadreams.conditioning.slang_renderer.scene_loader import scene_data_to_bundle
+from alpadreams.conditioning.slang_renderer.types import (
+    SceneBundle,
+    WorldLineSegments,
+    WorldPolygonList,
+    WorldTriangleList,
+)
+
+__all__ = [
+    "RasterConfig",
+    "SceneBundle",
+    "SlangConditionRasterizer",
+    "WorldLineSegments",
+    "WorldPolygonList",
+    "WorldTriangleList",
+    "mirror_augment_bundle",
+    "scene_data_to_bundle",
+]

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/camera.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/camera.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""F-theta camera model adapter for the SlangPy rasterizer.
+
+Adapts a flashdreams :class:`FThetaCamera` (which already carries forward and
+backward polynomials in :class:`numpy.polynomial.Polynomial` form) into the
+LUT + linear-matrix representation that the Slang shader consumes.
+
+The adapter is conceptually equivalent to ``roaddreams.camera.FThetaCameraModel``
+but builds its LUTs from the flashdreams polynomial directly so we don't have
+to re-fit an inverse on the CPU.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import numpy.typing as npt
+
+from alpadreams.conditioning.world_scenario.ftheta import FThetaCamera
+
+
+@dataclass
+class FThetaCameraModel:
+    """Per-camera projection state needed by the Slang rasterizer.
+
+    Constructed from a flashdreams :class:`FThetaCamera`. ``output_width`` /
+    ``output_height`` are the framebuffer dimensions (post-resize); the
+    polynomial coefficients are interpreted in the camera's native pixel
+    coordinates and an explicit ``uv_scale`` accounts for any downsample.
+    """
+
+    source: FThetaCamera
+    output_width: int
+    output_height: int
+    cx: float = field(init=False)
+    cy: float = field(init=False)
+    width: int = field(init=False)
+    height: int = field(init=False)
+    linear_cde: npt.NDArray[np.float32] = field(init=False)
+    fw_poly_coef: npt.NDArray[np.float32] = field(init=False)
+    bw_poly_coef: npt.NDArray[np.float32] = field(init=False)
+    radius_lut: npt.NDArray[np.float32] = field(init=False)
+    theta_lut: npt.NDArray[np.float32] = field(init=False)
+    max_angle_rad: float = field(init=False)
+    max_radius_px: float = field(init=False)
+    angle_to_radius_tail_slope: float = field(init=False)
+    radius_to_angle_tail_slope: float = field(init=False)
+    linear_matrix: npt.NDArray[np.float32] = field(init=False)
+    uv_scale: npt.NDArray[np.float32] = field(init=False)
+
+    def __post_init__(self) -> None:
+        center = np.asarray(self.source.center, dtype=np.float32)
+        self.cx = float(center[0])
+        self.cy = float(center[1])
+        self.width = int(self.source.width)
+        self.height = int(self.source.height)
+        self.linear_cde = np.asarray(self.source.linear_cde, dtype=np.float32)
+
+        self.fw_poly_coef = np.asarray(self.source._fw_poly.coef, dtype=np.float32)
+        self.bw_poly_coef = np.asarray(self.source._bw_poly.coef, dtype=np.float32)
+        is_backward = self.source.reference_poly == "bw"
+
+        max_radius = float(
+            np.hypot(
+                max(self.cx, self.width - self.cx),
+                max(self.cy, self.height - self.cy),
+            )
+        )
+        sample_count = 4096
+        if is_backward:
+            # ``pixeldistance-to-angle``: sample radii uniformly and evaluate
+            # the polynomial directly to get angles.
+            self.radius_lut = np.linspace(
+                0.0, max_radius * 1.10, sample_count, dtype=np.float32
+            )
+            self.theta_lut = _eval_poly(self.bw_poly_coef, self.radius_lut)
+        else:
+            # ``angle-to-pixeldistance``: sample angles uniformly and evaluate
+            # the *forward* polynomial to get pixel distances. We must NOT
+            # re-evaluate the inverted bw_poly here because for synthetic /
+            # low-degree forward polynomials the inverse fit can be unstable
+            # (~1e18 outputs) and break ``angle_to_radius`` downstream.
+            # See https://gitlab-master.nvidia.com/sil/omni-dreams/-/commit/92091220
+            # for the original report on clipgt-065dcac9-...
+            max_angle_guess = 1.6  # ~92deg half-FOV is plenty for any FTheta cam
+            angles = np.linspace(0.0, max_angle_guess, sample_count, dtype=np.float32)
+            radii = _eval_poly(self.fw_poly_coef, angles)
+            # Monotonise before clipping so the inverse interpolation
+            # (radius -> angle) stays well defined.
+            radii_monotonic = np.maximum.accumulate(radii)
+            within_range = radii_monotonic <= max_radius * 1.10
+            if within_range.all():
+                cutoff = sample_count
+            else:
+                cutoff = int(np.argmin(within_range))
+                cutoff = max(cutoff, 2)
+            self.theta_lut = angles[:cutoff].astype(np.float32)
+            self.radius_lut = radii_monotonic[:cutoff].astype(np.float32)
+
+        self.theta_lut = np.maximum.accumulate(self.theta_lut).astype(np.float32)
+        self.max_angle_rad = float(self.theta_lut[-1])
+        self.max_radius_px = float(self.radius_lut[-1])
+        theta_step = float(self.theta_lut[-1] - self.theta_lut[-2])
+        radius_step = float(self.radius_lut[-1] - self.radius_lut[-2])
+        self.angle_to_radius_tail_slope = radius_step / max(theta_step, 1e-6)
+        self.radius_to_angle_tail_slope = theta_step / max(radius_step, 1e-6)
+
+        c, d, e = self.linear_cde.tolist()
+        self.linear_matrix = np.array([[c, d], [e, 1.0]], dtype=np.float32)
+        target_width = float(self.output_width)
+        target_height = float(self.output_height)
+        self.uv_scale = np.array(
+            [target_width / float(self.width), target_height / float(self.height)],
+            dtype=np.float32,
+        )
+
+    def angle_to_radius(self, angle_rad: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+        """Convert ray angle (rad) to pixel radius via the camera polynomial."""
+        angles = np.asarray(angle_rad, dtype=np.float32)
+        flat_angles = angles.reshape(-1)
+        clipped = np.clip(flat_angles, self.theta_lut[0], self.theta_lut[-1])
+        radii = np.interp(clipped, self.theta_lut, self.radius_lut).astype(np.float32)
+        high_mask = flat_angles > self.max_angle_rad
+        if np.any(high_mask):
+            radii[high_mask] = (
+                self.max_radius_px
+                + (flat_angles[high_mask] - self.max_angle_rad) * self.angle_to_radius_tail_slope
+            )
+        return radii.reshape(angles.shape).astype(np.float32)
+
+    def build_angle_to_radius_lut(self, sample_count: int = 4096) -> tuple[npt.NDArray[np.float32], int, float, float, float]:
+        """Build the angle→radius LUT in the framebuffer's pixel coordinates."""
+        max_angle = float(self.max_angle_rad)
+        angles = np.linspace(0.0, max_angle, sample_count, dtype=np.float32)
+        radii_native = self.angle_to_radius(angles).astype(np.float32)
+        scale = 0.5 * (float(self.uv_scale[0]) + float(self.uv_scale[1]))
+        radii = (radii_native * scale).astype(np.float32)
+        max_radius = float(radii[-1])
+        if sample_count >= 2:
+            tail_slope = float(radii[-1] - radii[-2]) / max(float(max_angle / (sample_count - 1)), 1e-6)
+        else:
+            tail_slope = float(self.angle_to_radius_tail_slope) * scale
+        return radii, sample_count, max_angle, max_radius, tail_slope
+
+    def build_radius_to_angle_lut(self) -> tuple[npt.NDArray[np.float32], int, float, float]:
+        """Build the radius→angle LUT in the framebuffer's pixel coordinates."""
+        scale = 0.5 * (float(self.uv_scale[0]) + float(self.uv_scale[1]))
+        radii_scaled = (np.asarray(self.radius_lut, dtype=np.float32) * scale).astype(np.float32)
+        angles = np.asarray(self.theta_lut, dtype=np.float32)
+        max_radius = float(radii_scaled[-1])
+        if len(radii_scaled) >= 2:
+            tail_slope = float(angles[-1] - angles[-2]) / max(float(radii_scaled[-1] - radii_scaled[-2]), 1e-6)
+        else:
+            tail_slope = float(self.radius_to_angle_tail_slope) / max(scale, 1e-6)
+        return angles, int(len(angles)), max_radius, tail_slope
+
+    def scaled_linear_rows(self) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float32]]:
+        """Return ``linear_row0/1`` and their inverse, in framebuffer pixels."""
+        scale_x, scale_y = float(self.uv_scale[0]), float(self.uv_scale[1])
+        row0 = np.array(
+            [self.linear_matrix[0, 0] * scale_x, self.linear_matrix[0, 1] * scale_x],
+            dtype=np.float32,
+        )
+        row1 = np.array(
+            [self.linear_matrix[1, 0] * scale_y, self.linear_matrix[1, 1] * scale_y],
+            dtype=np.float32,
+        )
+        linear = np.stack([row0, row1], axis=0).astype(np.float32)
+        inverse = np.linalg.inv(linear).astype(np.float32)
+        return row0, row1, inverse[0], inverse[1]
+
+    def principal_px_scaled(self) -> npt.NDArray[np.float32]:
+        return np.array(
+            [self.cx * float(self.uv_scale[0]), self.cy * float(self.uv_scale[1])],
+            dtype=np.float32,
+        )
+
+
+def _eval_poly(coeffs: npt.NDArray[np.float32], xs: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+    """Horner evaluation of a polynomial with float32 coefficients."""
+    result = np.zeros_like(xs, dtype=np.float32)
+    for coeff in reversed(coeffs.tolist()):
+        result = result * xs + np.float32(coeff)
+    return result.astype(np.float32)

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/colors.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/colors.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HD-map v3 color tables and lane-line style descriptors.
+
+Lifted from ``roaddreams.colors`` so flashdreams' Slang rasterizer paints HD
+map elements with the same palette ludus-renderer used.
+"""
+
+from __future__ import annotations
+
+LANE_LINE_STYLE_CONFIG: dict[str, dict[str, object]] = {
+    "WHITE SOLID_SINGLE": {"color": (1.0, 1.0, 1.0, 1.0), "pattern": "solid", "width_scale": 1.0},
+    "WHITE LONG_DASHED_SINGLE": {
+        "color": (1.0, 1.0, 1.0, 1.0),
+        "pattern": "long_dashed",
+        "width_scale": 1.0,
+    },
+    "WHITE SHORT_DASHED_SINGLE": {
+        "color": (1.0, 1.0, 1.0, 1.0),
+        "pattern": "short_dashed",
+        "width_scale": 1.0,
+    },
+    "WHITE DOT_DASHED_SINGLE": {
+        "color": (1.0, 1.0, 1.0, 1.0),
+        "pattern": "dot_dashed",
+        "width_scale": 1.0,
+    },
+    "WHITE SOLID_GROUP": {
+        "color": (1.0, 1.0, 1.0, 1.0),
+        "pattern": "dual",
+        "dual_pattern": ("solid", "solid"),
+        "width_scale": 1.0,
+    },
+    "YELLOW SOLID_SINGLE": {
+        "color": (1.0, 1.0, 0.0, 1.0),
+        "pattern": "solid",
+        "width_scale": 1.0,
+    },
+    "YELLOW LONG_DASHED_SINGLE": {
+        "color": (1.0, 1.0, 0.0, 1.0),
+        "pattern": "long_dashed",
+        "width_scale": 1.0,
+    },
+    "YELLOW DASHED_SOLID": {
+        "color": (1.0, 1.0, 0.0, 1.0),
+        "pattern": "dual",
+        "dual_pattern": ("solid", "long_dashed"),
+        "width_scale": 1.0,
+    },
+    "YELLOW SOLID_DASHED": {
+        "color": (1.0, 1.0, 0.0, 1.0),
+        "pattern": "dual",
+        "dual_pattern": ("long_dashed", "solid"),
+        "width_scale": 1.0,
+    },
+    "YELLOW DOT_SOLID_SINGLE": {
+        "color": (1.0, 1.0, 0.0, 1.0),
+        "pattern": "dotted_1_9",
+        "width_scale": 1.0,
+    },
+    "YELLOW SOLID_GROUP": {
+        "color": (1.0, 1.0, 0.0, 1.0),
+        "pattern": "dual",
+        "dual_pattern": ("solid", "solid"),
+        "width_scale": 1.0,
+    },
+    "OTHER": {"color": (181.0 / 255.0, 164.0 / 255.0, 71.0 / 255.0, 1.0), "pattern": "solid", "width_scale": 1.0},
+}
+
+HDMAP_V3_COLORS: dict[str, tuple[float, float, float, float]] = {
+    "lanelines": (98.0 / 255.0, 183.0 / 255.0, 249.0 / 255.0, 1.0),
+    "road_boundaries": (253.0 / 255.0, 1.0 / 255.0, 232.0 / 255.0, 1.0),
+    "wait_lines": (108.0 / 255.0, 179.0 / 255.0, 59.0 / 255.0, 1.0),
+    "crosswalks": (139.0 / 255.0, 93.0 / 255.0, 1.0, 1.0),
+    "road_markings": (20.0 / 255.0, 254.0 / 255.0, 185.0 / 255.0, 1.0),
+    "poles": (183.0 / 255.0, 69.0 / 255.0, 177.0 / 255.0, 1.0),
+    "traffic_signs": (8.0 / 255.0, 2.0 / 255.0, 1.0, 1.0),
+    "traffic_lights": (100.0 / 255.0, 100.0 / 255.0, 100.0 / 255.0, 1.0),
+    "intersection_areas": (87.0 / 255.0, 110.0 / 255.0, 1.0, 0.95),
+    "road_islands": (1.0, 155.0 / 255.0, 37.0 / 255.0, 0.95),
+}

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/config.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/config.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tunable knobs for the SlangPy HD-map rasterizer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ComputeDeviceName = Literal["automatic", "cuda", "vulkan"]
+
+
+@dataclass(frozen=True)
+class RasterConfig:
+    """Per-camera rasterizer configuration.
+
+    The defaults are the same as the ``RasterConfig`` in roaddreams: tuned for
+    HD-map conditioning frames at 1280x704. ``width``/``height`` are filled in
+    by :class:`alpadreams.conditioning.renderer.LudusRenderer` from the camera
+    resolution at construction time.
+    """
+
+    width: int = 1280
+    height: int = 704
+    compute_device: ComputeDeviceName = "cuda"
+    sync_gpu_timing: bool = False
+    near_plane_m: float = 0.1
+    far_plane_m: float = 200.0
+    fog_start_m: float = 40.0
+    fog_end_m: float = 140.0
+    fog_power: float = 1.5
+    triangle_raytrace_distance_m: float = 25.0
+    lane_segment_interval_m: float = 0.05
+    polyline_segment_interval_m: float = 0.8
+    line_width_px: float = 12.0
+    pole_width_px: float = 5.0
+    dual_line_offset_m: float = 0.10
+    depth_clear_m: float = 1.0e6

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/math3d.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/math3d.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""3D transform helpers used by the slang rasterizer.
+
+Lifted from ``roaddreams.math3d``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import numpy.typing as npt
+
+
+def quaternion_to_matrix_xyzw(
+    quat: list[float] | tuple[float, float, float, float],
+) -> npt.NDArray[np.float32]:
+    """Convert an ``(x, y, z, w)`` quaternion to a 3x3 rotation matrix."""
+    x, y, z, w = quat
+    xx = x * x
+    yy = y * y
+    zz = z * z
+    xy = x * y
+    xz = x * z
+    yz = y * z
+    wx = w * x
+    wy = w * y
+    wz = w * z
+    return np.array(
+        [
+            [1.0 - 2.0 * (yy + zz), 2.0 * (xy - wz), 2.0 * (xz + wy)],
+            [2.0 * (xy + wz), 1.0 - 2.0 * (xx + zz), 2.0 * (yz - wx)],
+            [2.0 * (xz - wy), 2.0 * (yz + wx), 1.0 - 2.0 * (xx + yy)],
+        ],
+        dtype=np.float32,
+    )
+
+
+def transform_from_rt(
+    rotation: npt.NDArray[np.float32],
+    translation_xyz: list[float] | tuple[float, float, float],
+) -> npt.NDArray[np.float32]:
+    result = np.eye(4, dtype=np.float32)
+    result[:3, :3] = rotation
+    result[:3, 3] = np.asarray(translation_xyz, dtype=np.float32)
+    return result
+
+
+def invert_transform(matrix: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    inv = np.eye(4, dtype=np.float32)
+    inv[:3, :3] = rotation.T
+    inv[:3, 3] = -(rotation.T @ translation)
+    return inv
+
+
+def transform_points(
+    matrix: npt.NDArray[np.float32], points_xyz: npt.NDArray[np.float32]
+) -> npt.NDArray[np.float32]:
+    ones = np.ones((points_xyz.shape[0], 1), dtype=np.float32)
+    points_h = np.concatenate([points_xyz, ones], axis=1)
+    return (points_h @ matrix.T)[:, :3].astype(np.float32)
+
+
+def yaw_from_matrix(matrix: npt.NDArray[np.float32]) -> float:
+    return float(math.atan2(matrix[1, 0], matrix[0, 0]))

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/mirror_augment.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/mirror_augment.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mirror-stitch augmentation for static :class:`SceneBundle` instances.
+
+This is a simplified port of ``ludus_renderer.augmentation.mirror_augment_scene``.
+The original handled time-stamped polyline / polygon / cube pools and rebuilt
+ego-trajectory and ego-obstacle pools across each segment. The flashdreams
+gRPC server only ever exercises the static HD-map path
+(``include_ego_trajectory=False``, ``include_ego_obstacle=False``), so the
+relevant behaviour reduces to:
+
+1. Pick a mirror plane near the end of the ego trajectory (``lookahead_m``
+   metres beyond the last ego position along its forward heading).
+2. Reflect every line segment, triangle vertex, and polygon vertex of the
+   source scene across that plane.
+3. Concatenate the reflected geometry with the original layers.
+
+We repeat steps 2-3 for ``n_mirrors`` iterations, alternating which plane each
+new copy is reflected across (so the result is `[orig | mirror | orig | ...]`
+just like ludus). For ``n_mirrors == 0`` or no ego pose data, the bundle is
+returned unchanged.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+import numpy as np
+import numpy.typing as npt
+from loguru import logger
+from scipy.spatial.transform import Rotation
+
+from alpadreams.conditioning.slang_renderer.types import (
+    SceneBundle,
+    WorldLineSegments,
+    WorldPolygonList,
+    WorldTriangleList,
+)
+from alpadreams.conditioning.world_scenario.data_types import EgoPose
+
+
+def mirror_augment_bundle(
+    bundle: SceneBundle,
+    ego_poses: list[EgoPose],
+    *,
+    n_mirrors: int = 1,
+    lookahead_m: float = 50.0,
+) -> SceneBundle:
+    """Extend ``bundle`` by mirror-stitching it ``n_mirrors`` times.
+
+    Args:
+        bundle: The static SceneBundle to augment.
+        ego_poses: Ego trajectory used to derive the first mirror plane. Must
+            contain at least two poses.
+        n_mirrors: Number of mirror copies to add (total tiles = ``n_mirrors + 1``).
+        lookahead_m: Distance past the last ego pose to place the first mirror plane.
+
+    Returns:
+        A new SceneBundle containing the original layers plus reflected copies.
+        If ``n_mirrors <= 0`` or insufficient ego data is available the original
+        bundle is returned.
+    """
+    if n_mirrors <= 0:
+        return bundle
+    if len(ego_poses) < 2:
+        logger.warning(
+            "mirror_augment_bundle: at least 2 ego poses are required to compute a mirror plane; "
+            "returning the original bundle unchanged."
+        )
+        return bundle
+
+    last_position = np.asarray(ego_poses[-1].position, dtype=np.float32)
+    forward = _ego_forward_direction(ego_poses)
+    if forward is None:
+        logger.warning(
+            "mirror_augment_bundle: could not determine ego forward direction; "
+            "returning the original bundle unchanged."
+        )
+        return bundle
+
+    line_layers = list(bundle.line_layers)
+    triangle_layers = list(bundle.triangle_layers)
+    polygon_layers = list(bundle.polygon_layers)
+
+    plane_point = (last_position + forward * float(lookahead_m)).astype(np.float32)
+    plane_normal = forward.astype(np.float32)
+
+    for tile_index in range(1, n_mirrors + 1):
+        plane_point_iter = (last_position + forward * float(lookahead_m * tile_index)).astype(np.float32)
+        line_layers.extend(_reflect_lines(bundle.line_layers, plane_point_iter, plane_normal))
+        triangle_layers.extend(_reflect_triangles(bundle.triangle_layers, plane_point_iter, plane_normal))
+        polygon_layers.extend(_reflect_polygons(bundle.polygon_layers, plane_point_iter, plane_normal))
+
+    _ = plane_point  # tile_index=1 already covers the initial plane
+
+    return SceneBundle(
+        line_layers=tuple(line_layers),
+        triangle_layers=tuple(triangle_layers),
+        polygon_layers=tuple(polygon_layers),
+    )
+
+
+def _ego_forward_direction(ego_poses: list[EgoPose]) -> npt.NDArray[np.float32] | None:
+    last_position = np.asarray(ego_poses[-1].position, dtype=np.float32)
+    look_back = min(10, len(ego_poses) - 1)
+    if look_back >= 1:
+        ref_position = np.asarray(ego_poses[-1 - look_back].position, dtype=np.float32)
+        delta = last_position - ref_position
+        norm = float(np.linalg.norm(delta))
+        if norm > 1e-1:
+            return (delta / norm).astype(np.float32)
+
+    quat = np.asarray(ego_poses[-1].orientation, dtype=np.float32)
+    if quat.shape != (4,):
+        return None
+    rotation = Rotation.from_quat(quat).as_matrix().astype(np.float32)
+    forward = rotation[:, 0].astype(np.float32)
+    norm = float(np.linalg.norm(forward))
+    if not math.isfinite(norm) or norm < 1e-6:
+        return None
+    return (forward / norm).astype(np.float32)
+
+
+def _reflect_points(
+    points_xyz: npt.NDArray[np.float32],
+    plane_point: npt.NDArray[np.float32],
+    plane_normal: npt.NDArray[np.float32],
+) -> npt.NDArray[np.float32]:
+    if points_xyz.size == 0:
+        return points_xyz
+    diffs = points_xyz - plane_point
+    distances = np.einsum("...i,i->...", diffs, plane_normal).astype(np.float32)
+    return (points_xyz - 2.0 * distances[..., None] * plane_normal[None, :]).astype(np.float32)
+
+
+def _reflect_lines(
+    layers: Iterable[WorldLineSegments],
+    plane_point: npt.NDArray[np.float32],
+    plane_normal: npt.NDArray[np.float32],
+) -> list[WorldLineSegments]:
+    reflected: list[WorldLineSegments] = []
+    for layer in layers:
+        segments = np.asarray(layer.segments_world, dtype=np.float32)
+        if len(segments) == 0:
+            continue
+        flat = segments.reshape(-1, 3)
+        flat = _reflect_points(flat, plane_point, plane_normal)
+        reflected.append(
+            WorldLineSegments(
+                segments_world=flat.reshape(segments.shape).astype(np.float32),
+                color_rgba=layer.color_rgba,
+                width_px=layer.width_px,
+                layer_name=f"{layer.layer_name}_mirror",
+            )
+        )
+    return reflected
+
+
+def _reflect_triangles(
+    layers: Iterable[WorldTriangleList],
+    plane_point: npt.NDArray[np.float32],
+    plane_normal: npt.NDArray[np.float32],
+) -> list[WorldTriangleList]:
+    reflected: list[WorldTriangleList] = []
+    for layer in layers:
+        triangles = np.asarray(layer.triangles_world, dtype=np.float32)
+        if len(triangles) == 0:
+            continue
+        flat = triangles.reshape(-1, 3)
+        flat = _reflect_points(flat, plane_point, plane_normal)
+        # Reverse winding so the reflection's triangle normals stay correct.
+        new_triangles = flat.reshape(triangles.shape)[:, ::-1, :].copy().astype(np.float32)
+        reflected.append(
+            WorldTriangleList(
+                triangles_world=new_triangles,
+                color_rgba=layer.color_rgba,
+                layer_name=f"{layer.layer_name}_mirror",
+            )
+        )
+    return reflected
+
+
+def _reflect_polygons(
+    layers: Iterable[WorldPolygonList],
+    plane_point: npt.NDArray[np.float32],
+    plane_normal: npt.NDArray[np.float32],
+) -> list[WorldPolygonList]:
+    reflected: list[WorldPolygonList] = []
+    for layer in layers:
+        new_polygons: list[npt.NDArray[np.float32]] = []
+        for polygon in layer.polygons_world:
+            polygon_arr = np.asarray(polygon, dtype=np.float32)
+            if polygon_arr.shape[0] < 3:
+                continue
+            mirrored = _reflect_points(polygon_arr, plane_point, plane_normal)
+            new_polygons.append(mirrored[::-1].copy().astype(np.float32))
+        if not new_polygons:
+            continue
+        reflected.append(
+            WorldPolygonList(
+                polygons_world=tuple(new_polygons),
+                color_rgba=layer.color_rgba,
+                layer_name=f"{layer.layer_name}_mirror",
+            )
+        )
+    return reflected

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/patterns.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/patterns.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Polyline / polygon utilities used while building a SceneBundle.
+
+Lifted from ``roaddreams.patterns``.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import numpy.typing as npt
+
+
+def subdivide_polyline(points_xyz: npt.NDArray[np.float32], interval_m: float) -> npt.NDArray[np.float32]:
+    if len(points_xyz) <= 1:
+        return points_xyz.astype(np.float32)
+
+    samples: list[npt.NDArray[np.float32]] = [points_xyz[0].astype(np.float32)]
+    for p0, p1 in zip(points_xyz[:-1], points_xyz[1:], strict=False):
+        direction = p1 - p0
+        length = float(np.linalg.norm(direction))
+        if length < 1e-6:
+            continue
+        steps = max(1, int(np.ceil(length / interval_m)))
+        for i in range(1, steps + 1):
+            t = i / steps
+            samples.append((p0 + direction * t).astype(np.float32))
+    return np.stack(samples, axis=0).astype(np.float32)
+
+
+def segments_from_polyline(points_xyz: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+    if len(points_xyz) < 2:
+        return np.empty((0, 2, 3), dtype=np.float32)
+    return np.stack([points_xyz[:-1], points_xyz[1:]], axis=1).astype(np.float32)
+
+
+def resample_polyline(points_xyz: npt.NDArray[np.float32], interval_m: float) -> npt.NDArray[np.float32]:
+    if len(points_xyz) <= 1:
+        return points_xyz.astype(np.float32)
+    if interval_m <= 1e-6:
+        return points_xyz.astype(np.float32)
+
+    deltas = points_xyz[1:] - points_xyz[:-1]
+    lengths = np.linalg.norm(deltas, axis=1).astype(np.float32)
+    cumulative = np.concatenate([np.zeros((1,), dtype=np.float32), np.cumsum(lengths, dtype=np.float32)])
+    total_length = float(cumulative[-1])
+    if total_length <= interval_m:
+        return np.stack([points_xyz[0], points_xyz[-1]], axis=0).astype(np.float32)
+
+    sample_distances = np.arange(0.0, total_length, interval_m, dtype=np.float32)
+    if total_length - float(sample_distances[-1]) > 1e-4:
+        sample_distances = np.concatenate([sample_distances, np.array([total_length], dtype=np.float32)])
+
+    sampled: list[npt.NDArray[np.float32]] = []
+    segment_index = 0
+    for distance in sample_distances:
+        while segment_index < len(lengths) - 1 and distance > cumulative[segment_index + 1]:
+            segment_index += 1
+
+        segment_length = float(lengths[segment_index])
+        if segment_length <= 1e-6:
+            sampled.append(points_xyz[segment_index].astype(np.float32))
+            continue
+
+        local_t = float((distance - cumulative[segment_index]) / segment_length)
+        local_t = float(np.clip(local_t, 0.0, 1.0))
+        point = points_xyz[segment_index] * (1.0 - local_t) + points_xyz[segment_index + 1] * local_t
+        sampled.append(point.astype(np.float32))
+
+    if np.linalg.norm(sampled[-1] - points_xyz[-1]) > 1e-4:
+        sampled.append(points_xyz[-1].astype(np.float32))
+    return np.stack(sampled, axis=0).astype(np.float32)
+
+
+def _segment_lengths(line_segments: npt.NDArray[np.float32]) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], float]:
+    lengths = np.linalg.norm(line_segments[:, 1] - line_segments[:, 0], axis=1).astype(np.float32)
+    cumulative = np.concatenate([np.zeros((1,), dtype=np.float32), np.cumsum(lengths, dtype=np.float32)])
+    return lengths, cumulative, float(cumulative[-1])
+
+
+def _clip_pattern(line_segments: npt.NDArray[np.float32], on_length_m: float, off_length_m: float) -> npt.NDArray[np.float32]:
+    if len(line_segments) == 0:
+        return line_segments
+
+    lengths, cumulative, total_length = _segment_lengths(line_segments)
+    result: list[npt.NDArray[np.float32]] = []
+    start = 0.0
+    while start < total_length:
+        end = min(start + on_length_m, total_length)
+        for index, segment in enumerate(line_segments):
+            seg_start = float(cumulative[index])
+            seg_end = float(cumulative[index + 1])
+            if seg_end <= start or seg_start >= end or lengths[index] <= 1e-6:
+                continue
+
+            clip_start = max(start, seg_start)
+            clip_end = min(end, seg_end)
+            t0 = (clip_start - seg_start) / float(lengths[index])
+            t1 = (clip_end - seg_start) / float(lengths[index])
+            p0 = segment[0] + (segment[1] - segment[0]) * t0
+            p1 = segment[0] + (segment[1] - segment[0]) * t1
+            result.append(np.stack([p0, p1], axis=0).astype(np.float32))
+        start += on_length_m + off_length_m
+
+    if not result:
+        return np.empty((0, 2, 3), dtype=np.float32)
+    return np.stack(result, axis=0).astype(np.float32)
+
+
+def offset_segments(
+    line_segments: npt.NDArray[np.float32],
+    offset_distance_m: float,
+) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
+    if len(line_segments) == 0:
+        empty = np.empty((0, 2, 3), dtype=np.float32)
+        return empty, empty
+
+    left: list[npt.NDArray[np.float32]] = []
+    right: list[npt.NDArray[np.float32]] = []
+    for segment in line_segments:
+        direction = segment[1] - segment[0]
+        direction_xy = direction[:2]
+        norm = float(np.linalg.norm(direction_xy))
+        if norm < 1e-6:
+            continue
+        tangent_xy = direction_xy / norm
+        normal = np.array([-tangent_xy[1], tangent_xy[0], 0.0], dtype=np.float32)
+        offset = normal * offset_distance_m
+        left.append((segment + offset).astype(np.float32))
+        right.append((segment - offset).astype(np.float32))
+
+    if not left:
+        empty = np.empty((0, 2, 3), dtype=np.float32)
+        return empty, empty
+    return np.stack(left, axis=0).astype(np.float32), np.stack(right, axis=0).astype(np.float32)
+
+
+def apply_pattern(
+    line_segments: npt.NDArray[np.float32],
+    pattern: str,
+    dual_pattern: tuple[str, str] | None = None,
+    dual_offset_m: float = 0.10,
+) -> list[npt.NDArray[np.float32]]:
+    if pattern == "solid":
+        return [line_segments]
+    if pattern == "long_dashed":
+        return [_clip_pattern(line_segments, on_length_m=3.0, off_length_m=9.0)]
+    if pattern == "short_dashed":
+        return [_clip_pattern(line_segments, on_length_m=1.5, off_length_m=1.5)]
+    if pattern == "dot_dashed":
+        base = _clip_pattern(line_segments, on_length_m=0.91, off_length_m=2.74)
+        return [base[::3] if len(base) > 0 else base]
+    if pattern == "dotted_1_9":
+        return [line_segments[::10]]
+    if pattern == "dual":
+        left, right = offset_segments(line_segments, dual_offset_m)
+        left_pattern, right_pattern = dual_pattern or ("solid", "solid")
+        result: list[npt.NDArray[np.float32]] = []
+        result.extend(apply_pattern(left, left_pattern, dual_offset_m=dual_offset_m))
+        result.extend(apply_pattern(right, right_pattern, dual_offset_m=dual_offset_m))
+        return result
+    return [line_segments]
+
+
+def triangulate_polygon_fan(points_xyz: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+    unique_points: list[npt.NDArray[np.float32]] = []
+    for point in points_xyz:
+        if unique_points and np.linalg.norm(unique_points[-1] - point) < 1e-4:
+            continue
+        unique_points.append(point.astype(np.float32))
+    if len(unique_points) >= 2 and np.linalg.norm(unique_points[0] - unique_points[-1]) < 1e-4:
+        unique_points = unique_points[:-1]
+    if len(unique_points) < 3:
+        return np.empty((0, 3, 3), dtype=np.float32)
+
+    base = unique_points[0]
+    triangles = [
+        np.stack([base, unique_points[i], unique_points[i + 1]], axis=0).astype(np.float32)
+        for i in range(1, len(unique_points) - 1)
+    ]
+    return np.stack(triangles, axis=0).astype(np.float32)
+
+
+def triangulate_polygon_xy(points_xyz: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+    points = np.asarray(points_xyz, dtype=np.float32)
+    unique_points: list[npt.NDArray[np.float32]] = []
+    for point in points:
+        if unique_points and np.linalg.norm(unique_points[-1] - point) < 1e-4:
+            continue
+        unique_points.append(point.astype(np.float32))
+    if len(unique_points) >= 2 and np.linalg.norm(unique_points[0] - unique_points[-1]) < 1e-4:
+        unique_points = unique_points[:-1]
+    if len(unique_points) < 3:
+        return np.empty((0, 3, 3), dtype=np.float32)
+
+    polygon = np.stack(unique_points, axis=0).astype(np.float32)
+    # Auto-detect the dominant plane: project to whichever pair of axes
+    # has the most variance. Roaddreams' FLU scenes are flat in XY
+    # (ground polygons have z=0), but flashdreams' RDF scenes are flat
+    # in XZ (ground polygons have y=0). Picking the wrong pair collapses
+    # the polygon to a line and forces a `triangulate_polygon_fan`
+    # fallback whose triangles all share vertex 0 -- which projects to
+    # the same screen pixel and produces fan-shaped wedge artifacts.
+    spread = polygon.max(axis=0) - polygon.min(axis=0)
+    drop_axis = int(np.argmin(spread))
+    keep_axes = [a for a in (0, 1, 2) if a != drop_axis]
+    polygon_xy = polygon[:, keep_axes]
+
+    signed_area = 0.5 * float(np.sum(polygon_xy[:, 0] * np.roll(polygon_xy[:, 1], -1) - np.roll(polygon_xy[:, 0], -1) * polygon_xy[:, 1]))
+    if abs(signed_area) < 1e-6:
+        return triangulate_polygon_fan(polygon)
+    if signed_area < 0.0:
+        polygon = polygon[::-1].copy()
+        polygon_xy = polygon_xy[::-1].copy()
+
+    def cross2d(a: npt.NDArray[np.float32], b: npt.NDArray[np.float32], c: npt.NDArray[np.float32]) -> float:
+        ab = b - a
+        ac = c - a
+        return float(ab[0] * ac[1] - ab[1] * ac[0])
+
+    def point_in_triangle(point: npt.NDArray[np.float32], a: npt.NDArray[np.float32], b: npt.NDArray[np.float32], c: npt.NDArray[np.float32]) -> bool:
+        ab = cross2d(a, b, point)
+        bc = cross2d(b, c, point)
+        ca = cross2d(c, a, point)
+        eps = 1e-6
+        return ab >= -eps and bc >= -eps and ca >= -eps
+
+    indices = list(range(len(polygon)))
+    triangles: list[npt.NDArray[np.float32]] = []
+    safety_counter = 0
+    max_iterations = len(indices) * len(indices)
+    while len(indices) > 3 and safety_counter < max_iterations:
+        ear_found = False
+        for offset, current_idx in enumerate(indices):
+            prev_idx = indices[(offset - 1) % len(indices)]
+            next_idx = indices[(offset + 1) % len(indices)]
+            a = polygon_xy[prev_idx]
+            b = polygon_xy[current_idx]
+            c = polygon_xy[next_idx]
+            if cross2d(a, b, c) <= 1e-6:
+                continue
+
+            contains_other = False
+            for test_idx in indices:
+                if test_idx in (prev_idx, current_idx, next_idx):
+                    continue
+                if point_in_triangle(polygon_xy[test_idx], a, b, c):
+                    contains_other = True
+                    break
+            if contains_other:
+                continue
+
+            triangles.append(np.stack([polygon[prev_idx], polygon[current_idx], polygon[next_idx]], axis=0).astype(np.float32))
+            del indices[offset]
+            ear_found = True
+            break
+        if not ear_found:
+            return triangulate_polygon_fan(polygon)
+        safety_counter += 1
+
+    if len(indices) == 3:
+        triangles.append(np.stack([polygon[indices[0]], polygon[indices[1]], polygon[indices[2]]], axis=0).astype(np.float32))
+
+    if not triangles:
+        return np.empty((0, 3, 3), dtype=np.float32)
+    return np.stack(triangles, axis=0).astype(np.float32)
+
+
+def split_segment_runs(line_segments: npt.NDArray[np.float32], atol: float = 1e-4) -> list[npt.NDArray[np.float32]]:
+    if len(line_segments) == 0:
+        return []
+
+    runs: list[list[npt.NDArray[np.float32]]] = [[line_segments[0, 0].astype(np.float32), line_segments[0, 1].astype(np.float32)]]
+    for segment in line_segments[1:]:
+        current_run = runs[-1]
+        if np.linalg.norm(current_run[-1] - segment[0]) <= atol:
+            current_run.append(segment[1].astype(np.float32))
+        else:
+            runs.append([segment[0].astype(np.float32), segment[1].astype(np.float32)])
+    return [np.stack(run, axis=0).astype(np.float32) for run in runs if len(run) >= 2]
+
+
+def concatenate_segments(segment_groups: Iterable[npt.NDArray[np.float32]]) -> npt.NDArray[np.float32]:
+    non_empty = [group.astype(np.float32) for group in segment_groups if len(group) > 0]
+    if not non_empty:
+        return np.empty((0, 2, 3), dtype=np.float32)
+    return np.concatenate(non_empty, axis=0).astype(np.float32)

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/rasterizer.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/rasterizer.py
@@ -1,0 +1,648 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SlangPy-backed HD-map rasterizer with PyTorch tensor I/O.
+
+This module is a flashdreams-tailored adaptation of
+``roaddreams.rasterizer.SlangConditionRasterizer``. It differs from the
+upstream sample in three substantive ways:
+
+1. **Torch tensors at the boundary.** Camera poses come in as torch CUDA
+   tensors and rendered RGB frames are returned as torch CUDA tensors. The
+   SlangPy device shares PyTorch's CUDA context via
+   :func:`slangpy.create_torch_device` so the inter-op cost is a single
+   device-local copy per pass rather than a host round-trip.
+
+2. **Multi-camera batching.** :meth:`SlangConditionRasterizer.render_camera`
+   loops over the per-camera frame batch internally, returning ``[N, 3, H, W]``
+   on GPU. The per-camera projection state (LUTs, linear matrix, principal
+   point) is rebuilt once at construction and reused across frames.
+
+3. **Static SceneBundle input.** The Slang kernels treat the scene as static;
+   ``timestamps_us`` is accepted to match the LudusRenderer signature but is
+   currently unused (flashdreams loads HD-map-only conditioning scenes).
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+import importlib.resources
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import torch
+
+from alpadreams.conditioning.slang_renderer.camera import FThetaCameraModel
+from alpadreams.conditioning.slang_renderer.config import RasterConfig
+from alpadreams.conditioning.slang_renderer.patterns import triangulate_polygon_xy
+from alpadreams.conditioning.slang_renderer.types import SceneBundle
+
+
+class SlangConditionRasterizer:
+    """Renders HD-map conditioning frames from a static SceneBundle.
+
+    One instance owns the SlangPy device, the compiled module, scene buffers,
+    and per-camera projection state. Construct it once per ``LudusRenderer``,
+    upload a scene with :meth:`load_scene`, then render with
+    :meth:`render_camera` for each camera in your batch.
+    """
+
+    def __init__(
+        self,
+        camera_models: dict[str, FThetaCameraModel],
+        raster: RasterConfig,
+        device: torch.device,
+    ) -> None:
+        if device.type != "cuda":
+            raise ValueError(f"SlangConditionRasterizer requires a CUDA device, got {device}")
+        if not camera_models:
+            raise ValueError("camera_models must contain at least one entry")
+
+        try:
+            import slangpy as spy
+            from slangpy import Module
+        except ImportError as exc:  # pragma: no cover - environment misconfig
+            raise RuntimeError(
+                "SlangPy is required for the conditioning renderer. "
+                "Install with `uv sync` so `slangpy` is resolved."
+            ) from exc
+
+        self._spy = spy
+        self._raster = raster
+        self._torch_device = device
+        self._camera_models = dict(camera_models)
+
+        for name, model in self._camera_models.items():
+            if model.output_width != raster.width or model.output_height != raster.height:
+                raise ValueError(
+                    f"Camera '{name}' resolution ({model.output_width}x{model.output_height}) "
+                    f"does not match RasterConfig ({raster.width}x{raster.height})"
+                )
+
+        shader_dir = importlib.resources.files(
+            "alpadreams.conditioning.slang_renderer"
+        ).joinpath("slang")
+        # slangpy.create_torch_device automatically prepends slangpy's own shader
+        # path; we only need to add our own kernel directory.
+        self._device = spy.create_torch_device(
+            type=spy.DeviceType.cuda,
+            torch_device=device,
+            include_paths=[str(shader_dir)],
+        )
+        self._module = Module(self._device.load_module("rasterizer.slang"))
+
+        self._dummy_u32_buffer = self._device.create_buffer(
+            usage=(
+                spy.BufferUsage.shader_resource
+                | spy.BufferUsage.unordered_access
+                | spy.BufferUsage.copy_source
+                | spy.BufferUsage.copy_destination
+            ),
+            label="dummy_u32",
+            data=np.zeros((1,), dtype=np.uint32),
+        )
+
+        self._rgb_tensor = spy.Tensor.empty(
+            self._device, dtype=self._module.float4, shape=(raster.height, raster.width)
+        )
+        self._depth_tensor = spy.Tensor.empty(
+            self._device, dtype=self._module.float, shape=(raster.height, raster.width)
+        )
+        self._depth_bits_tensor = spy.Tensor.empty(
+            self._device, dtype=self._module.uint, shape=(raster.height, raster.width)
+        )
+        self._rgb_rgba8_tensor = spy.Tensor.empty(
+            self._device, dtype=self._module.uint, shape=(raster.height, raster.width)
+        )
+
+        self._scene: SceneBundle | None = None
+        self._line_buffer: Any | None = None
+        self._line_count: int = 0
+        self._scene_triangle_buffer: Any | None = None
+        self._scene_triangle_count: int = 0
+        self._polygon_triangle_buffer: Any | None = None
+        self._polygon_triangle_count: int = 0
+        self._near_triangle_mask_buffer: Any | None = None
+        self._near_triangle_index_buffer: Any | None = None
+        self._near_triangle_counter_buffer: Any | None = None
+
+        self._camera_state: dict[str, _CameraState] = {}
+        for name, model in self._camera_models.items():
+            self._camera_state[name] = self._build_camera_state(model)
+
+    def load_scene(self, scene: SceneBundle) -> None:
+        """Upload a SceneBundle's geometry into GPU buffers."""
+        with self._device_context():
+            self._scene = scene
+            self._line_buffer, self._line_count = self._upload_line_primitives(scene)
+            (
+                self._scene_triangle_buffer,
+                self._scene_triangle_count,
+                self._polygon_triangle_buffer,
+                self._polygon_triangle_count,
+            ) = self._upload_triangle_primitives(scene)
+
+            capacity = self._polygon_triangle_count
+            if capacity > 0:
+                self._near_triangle_mask_buffer = self._create_u32_buffer(
+                    element_count=capacity, label="near_triangle_mask"
+                )
+                self._near_triangle_index_buffer = self._create_u32_buffer(
+                    element_count=capacity, label="near_triangle_indices"
+                )
+                self._near_triangle_counter_buffer = self._create_u32_buffer(
+                    element_count=4, label="near_triangle_counter"
+                )
+            else:
+                self._near_triangle_mask_buffer = None
+                self._near_triangle_index_buffer = None
+                self._near_triangle_counter_buffer = None
+
+    def render_camera(
+        self,
+        camera_name: str,
+        camera_to_world: torch.Tensor,
+    ) -> torch.Tensor:
+        """Render a sequence of frames for a single camera.
+
+        Args:
+            camera_name: Name registered in ``camera_models`` at construction.
+            camera_to_world: ``[N, 4, 4]`` camera-to-world poses in the same
+                world frame as the loaded SceneBundle (flashdreams' CLIPGT
+                loader emits OpenCV RDF; pass ego poses straight through).
+                On the same CUDA device as this rasterizer.
+
+        Returns:
+            ``[N, 3, H, W]`` uint8 RGB tensor on the rasterizer's CUDA device.
+        """
+        if self._scene is None:
+            raise RuntimeError("load_scene() must be called before render_camera()")
+        if camera_name not in self._camera_state:
+            raise KeyError(f"Camera '{camera_name}' was not registered at construction time")
+        if camera_to_world.ndim != 3 or camera_to_world.shape[-2:] != (4, 4):
+            raise ValueError(
+                f"camera_to_world must be [N, 4, 4], got shape {tuple(camera_to_world.shape)}"
+            )
+
+        n_frames = int(camera_to_world.shape[0])
+        H = self._raster.height
+        W = self._raster.width
+        out = torch.empty((n_frames, 3, H, W), dtype=torch.uint8, device=self._torch_device)
+        if n_frames == 0:
+            return out
+
+        camera_state = self._camera_state[camera_name]
+        poses_np = camera_to_world.detach().to(torch.float32).cpu().numpy()
+        for frame_idx in range(n_frames):
+            world_to_camera = np.linalg.inv(poses_np[frame_idx]).astype(np.float32)
+            self._render_single_frame(camera_state, world_to_camera, out[frame_idx])
+        return out
+
+    def _render_single_frame(
+        self,
+        camera: "_CameraState",
+        world_to_camera_rdf: npt.NDArray[np.float32],
+        out_chw: torch.Tensor,
+    ) -> None:
+        with self._device_context():
+            spy = self._spy
+            width = self._raster.width
+            height = self._raster.height
+
+            world_to_camera_uniform = spy.float4x4(world_to_camera_rdf.reshape(-1).tolist())
+            principal_uniform = spy.float2(float(camera.principal_px[0]), float(camera.principal_px[1]))
+            linear_row0_uniform = spy.float2(float(camera.linear_row0[0]), float(camera.linear_row0[1]))
+            linear_row1_uniform = spy.float2(float(camera.linear_row1[0]), float(camera.linear_row1[1]))
+            inv_linear_row0_uniform = spy.float2(
+                float(camera.inv_linear_row0[0]), float(camera.inv_linear_row0[1])
+            )
+            inv_linear_row1_uniform = spy.float2(
+                float(camera.inv_linear_row1[0]), float(camera.inv_linear_row1[1])
+            )
+
+            near_triangle_count = 0
+            if (
+                self._polygon_triangle_count > 0
+                and self._polygon_triangle_buffer is not None
+                and self._near_triangle_mask_buffer is not None
+                and self._near_triangle_index_buffer is not None
+                and self._near_triangle_counter_buffer is not None
+            ):
+                classify_encoder = self._device.create_command_encoder()
+                classify_encoder.clear_buffer(self._near_triangle_mask_buffer)
+                classify_encoder.clear_buffer(self._near_triangle_counter_buffer)
+                self._module.classify_near_triangles_world.dispatch(
+                    spy.uint3(self._polygon_triangle_count, 1, 1),
+                    triangles=self._polygon_triangle_buffer,
+                    near_triangle_mask=self._near_triangle_mask_buffer,
+                    near_triangle_indices=self._near_triangle_index_buffer,
+                    counters=self._near_triangle_counter_buffer,
+                    world_to_camera_rdf=world_to_camera_uniform,
+                    triangle_raytrace_distance_m=float(self._raster.triangle_raytrace_distance_m),
+                    command_encoder=classify_encoder,
+                )
+                self._device.submit_command_buffer(classify_encoder.finish())
+                near_triangle_count = int(self._read_u32_buffer(self._near_triangle_counter_buffer, count=1)[0])
+
+            clear_encoder = self._device.create_command_encoder()
+            self._module.clear_targets.dispatch(
+                spy.uint3(width, height, 1),
+                rgb=self._rgb_tensor,
+                depth=self._depth_tensor,
+                depth_bits=self._depth_bits_tensor,
+                image_width=width,
+                image_height=height,
+                clear_depth=float(self._raster.depth_clear_m),
+                command_encoder=clear_encoder,
+            )
+            self._device.submit_command_buffer(clear_encoder.finish())
+
+            if self._line_count > 0 and self._line_buffer is not None:
+                lines_encoder = self._device.create_command_encoder()
+                self._module.rasterize_lines_world.dispatch(
+                    spy.uint3(self._line_count, 1, 1),
+                    lines=self._line_buffer,
+                    angle_to_radius_lut=camera.angle_to_radius_lut,
+                    rgb=self._rgb_tensor,
+                    depth=self._depth_tensor,
+                    depth_bits=self._depth_bits_tensor,
+                    image_width=width,
+                    image_height=height,
+                    world_to_camera_rdf=world_to_camera_uniform,
+                    principal_px=principal_uniform,
+                    linear_row0=linear_row0_uniform,
+                    linear_row1=linear_row1_uniform,
+                    near_plane_m=float(self._raster.near_plane_m),
+                    lut_count=camera.angle_lut_count,
+                    lut_max_angle=float(camera.angle_lut_max_angle),
+                    lut_max_radius=float(camera.angle_lut_max_radius),
+                    lut_tail_slope=float(camera.angle_lut_tail_slope),
+                    fog_start_m=float(self._raster.fog_start_m),
+                    fog_end_m=float(self._raster.fog_end_m),
+                    fog_power=float(self._raster.fog_power),
+                    command_encoder=lines_encoder,
+                )
+                self._device.submit_command_buffer(lines_encoder.finish())
+
+            if self._scene_triangle_count > 0 and self._scene_triangle_buffer is not None:
+                scene_tri_encoder = self._device.create_command_encoder()
+                self._module.rasterize_triangles_world.dispatch(
+                    spy.uint3(self._scene_triangle_count, 1, 1),
+                    triangles=self._scene_triangle_buffer,
+                    near_triangle_mask=self._near_triangle_mask_buffer or self._dummy_u32_buffer,
+                    angle_to_radius_lut=camera.angle_to_radius_lut,
+                    rgb=self._rgb_tensor,
+                    depth=self._depth_tensor,
+                    depth_bits=self._depth_bits_tensor,
+                    image_width=width,
+                    image_height=height,
+                    world_to_camera_rdf=world_to_camera_uniform,
+                    principal_px=principal_uniform,
+                    linear_row0=linear_row0_uniform,
+                    linear_row1=linear_row1_uniform,
+                    near_plane_m=float(self._raster.near_plane_m),
+                    lut_count=camera.angle_lut_count,
+                    lut_max_angle=float(camera.angle_lut_max_angle),
+                    lut_max_radius=float(camera.angle_lut_max_radius),
+                    lut_tail_slope=float(camera.angle_lut_tail_slope),
+                    skip_masked=0,
+                    fog_start_m=float(self._raster.fog_start_m),
+                    fog_end_m=float(self._raster.fog_end_m),
+                    fog_power=float(self._raster.fog_power),
+                    command_encoder=scene_tri_encoder,
+                )
+                self._device.submit_command_buffer(scene_tri_encoder.finish())
+
+            if (
+                self._polygon_triangle_count > 0
+                and self._polygon_triangle_buffer is not None
+                and self._near_triangle_mask_buffer is not None
+            ):
+                polygon_encoder = self._device.create_command_encoder()
+                self._module.rasterize_triangles_world.dispatch(
+                    spy.uint3(self._polygon_triangle_count, 1, 1),
+                    triangles=self._polygon_triangle_buffer,
+                    near_triangle_mask=self._near_triangle_mask_buffer,
+                    angle_to_radius_lut=camera.angle_to_radius_lut,
+                    rgb=self._rgb_tensor,
+                    depth=self._depth_tensor,
+                    depth_bits=self._depth_bits_tensor,
+                    image_width=width,
+                    image_height=height,
+                    world_to_camera_rdf=world_to_camera_uniform,
+                    principal_px=principal_uniform,
+                    linear_row0=linear_row0_uniform,
+                    linear_row1=linear_row1_uniform,
+                    near_plane_m=float(self._raster.near_plane_m),
+                    lut_count=camera.angle_lut_count,
+                    lut_max_angle=float(camera.angle_lut_max_angle),
+                    lut_max_radius=float(camera.angle_lut_max_radius),
+                    lut_tail_slope=float(camera.angle_lut_tail_slope),
+                    skip_masked=1,
+                    fog_start_m=float(self._raster.fog_start_m),
+                    fog_end_m=float(self._raster.fog_end_m),
+                    fog_power=float(self._raster.fog_power),
+                    command_encoder=polygon_encoder,
+                )
+                self._device.submit_command_buffer(polygon_encoder.finish())
+
+            if (
+                near_triangle_count > 0
+                and self._polygon_triangle_buffer is not None
+                and self._near_triangle_index_buffer is not None
+            ):
+                raytrace_encoder = self._device.create_command_encoder()
+                self._module.raytrace_triangles_world.dispatch(
+                    spy.uint3(width, height, 1),
+                    near_triangle_indices=self._near_triangle_index_buffer,
+                    triangles=self._polygon_triangle_buffer,
+                    radius_to_angle_lut=camera.radius_to_angle_lut,
+                    rgb=self._rgb_tensor,
+                    depth=self._depth_tensor,
+                    depth_bits=self._depth_bits_tensor,
+                    image_width=width,
+                    image_height=height,
+                    world_to_camera_rdf=world_to_camera_uniform,
+                    principal_px=principal_uniform,
+                    inv_linear_row0=inv_linear_row0_uniform,
+                    inv_linear_row1=inv_linear_row1_uniform,
+                    near_plane_m=float(self._raster.near_plane_m),
+                    radius_lut_count=camera.radius_lut_count,
+                    radius_lut_max_radius=float(camera.radius_lut_max_radius),
+                    radius_lut_tail_slope=float(camera.radius_lut_tail_slope),
+                    near_triangle_count=near_triangle_count,
+                    fog_start_m=float(self._raster.fog_start_m),
+                    fog_end_m=float(self._raster.fog_end_m),
+                    fog_power=float(self._raster.fog_power),
+                    command_encoder=raytrace_encoder,
+                )
+                self._device.submit_command_buffer(raytrace_encoder.finish())
+
+            convert_encoder = self._device.create_command_encoder()
+            self._module.pack_rgb_to_rgba8.dispatch(
+                spy.uint3(width, height, 1),
+                rgb=self._rgb_tensor,
+                rgba8=self._rgb_rgba8_tensor,
+                image_width=width,
+                image_height=height,
+                command_encoder=convert_encoder,
+            )
+            self._device.submit_command_buffer(convert_encoder.finish())
+
+            # The RGBA8 tensor lives on the same CUDA context as PyTorch (we
+            # built the SlangPy device via create_torch_device above), so
+            # to_torch() returns a zero-copy view of the GPU-resident buffer.
+            rgba_packed = self._rgb_rgba8_tensor.to_torch()
+            rgba_uint8 = rgba_packed.view(torch.uint8).reshape(height, width, 4)
+            rgb_chw = rgba_uint8[..., :3].permute(2, 0, 1)
+            out_chw.copy_(rgb_chw)
+
+    def _build_camera_state(self, model: FThetaCameraModel) -> "_CameraState":
+        radii, angle_count, max_angle, max_radius, angle_tail_slope = model.build_angle_to_radius_lut()
+        angles, radius_count, radius_max_radius, radius_tail_slope = model.build_radius_to_angle_lut()
+        spy = self._spy
+        angle_buffer = self._device.create_buffer(
+            usage=spy.BufferUsage.shader_resource,
+            label="angle_to_radius_lut",
+            data=np.ascontiguousarray(radii, dtype=np.float32),
+        )
+        radius_buffer = self._device.create_buffer(
+            usage=spy.BufferUsage.shader_resource,
+            label="radius_to_angle_lut",
+            data=np.ascontiguousarray(angles, dtype=np.float32),
+        )
+        row0, row1, inv_row0, inv_row1 = model.scaled_linear_rows()
+        return _CameraState(
+            angle_to_radius_lut=angle_buffer,
+            angle_lut_count=angle_count,
+            angle_lut_max_angle=max_angle,
+            angle_lut_max_radius=max_radius,
+            angle_lut_tail_slope=angle_tail_slope,
+            radius_to_angle_lut=radius_buffer,
+            radius_lut_count=radius_count,
+            radius_lut_max_radius=radius_max_radius,
+            radius_lut_tail_slope=radius_tail_slope,
+            principal_px=model.principal_px_scaled(),
+            linear_row0=row0,
+            linear_row1=row1,
+            inv_linear_row0=inv_row0,
+            inv_linear_row1=inv_row1,
+        )
+
+    def _upload_line_primitives(self, scene: SceneBundle) -> tuple[Any | None, int]:
+        line_batches: list[np.ndarray] = []
+        for layer in scene.line_layers:
+            if len(layer.segments_world) == 0:
+                continue
+            segments = np.asarray(layer.segments_world, dtype=np.float32)
+            if not bool(np.all(np.isfinite(segments))):
+                # Last-line-of-defence guard. A single NaN endpoint here
+                # poisons the GPU line raster pass: the shader's
+                # ``distance_to_line > half_width`` check evaluates to
+                # ``false`` for NaN inputs, so every pixel inside the
+                # bounding box gets painted, producing the giant blob /
+                # speckle pattern. See
+                # https://gitlab-master.nvidia.com/sil/omni-dreams/-/commit/92091220
+                bad = int(np.sum(~np.all(np.isfinite(segments.reshape(-1, 6)), axis=1)))
+                print(
+                    f"[rasterizer] WARNING: dropping line layer "
+                    f"'{layer.layer_name}' — {bad} of {segments.shape[0]} "
+                    "segment(s) contain NaN/Inf. Fix the scene loader.",
+                    flush=True,
+                )
+                continue
+            batch = np.zeros((segments.shape[0], 16), dtype=np.float32)
+            batch[:, 0:3] = segments[:, 0, :]
+            batch[:, 3] = 1.0
+            batch[:, 4:7] = segments[:, 1, :]
+            batch[:, 7] = 1.0
+            batch[:, 8:12] = np.asarray(layer.color_rgba, dtype=np.float32)
+            batch[:, 12] = np.float32(layer.width_px)
+            line_batches.append(batch)
+
+        if not line_batches:
+            return None, 0
+
+        data = np.ascontiguousarray(np.concatenate(line_batches, axis=0), dtype=np.float32)
+        return (
+            self._device.create_buffer(
+                usage=self._spy.BufferUsage.shader_resource,
+                label="line_primitives",
+                data=data,
+            ),
+            int(data.shape[0]),
+        )
+
+    def _upload_triangle_primitives(
+        self, scene: SceneBundle
+    ) -> tuple[Any | None, int, Any | None, int]:
+        scene_triangle_batches: list[np.ndarray] = []
+        scene_triangle_count = 0
+        for layer in scene.triangle_layers:
+            if len(layer.triangles_world) == 0:
+                continue
+            triangles = np.asarray(layer.triangles_world, dtype=np.float32)
+            if not bool(np.all(np.isfinite(triangles))):
+                bad = int(np.sum(~np.all(np.isfinite(triangles.reshape(-1, 9)), axis=1)))
+                print(
+                    f"[rasterizer] WARNING: dropping triangle layer "
+                    f"'{layer.layer_name}' — {bad} of {triangles.shape[0]} "
+                    "triangle(s) contain NaN/Inf.",
+                    flush=True,
+                )
+                continue
+            scene_triangle_count += int(triangles.shape[0])
+            scene_triangle_batches.append(
+                self._pack_triangle_batch(triangles, np.asarray(layer.color_rgba, dtype=np.float32))
+            )
+
+        polygon_triangle_batches: list[np.ndarray] = []
+        polygon_triangle_count = 0
+        for layer in scene.polygon_layers:
+            color = np.asarray(layer.color_rgba, dtype=np.float32)
+            for polygon_world in layer.polygons_world:
+                polygon_arr = np.asarray(polygon_world, dtype=np.float32)
+                if not bool(np.all(np.isfinite(polygon_arr))):
+                    print(
+                        f"[rasterizer] WARNING: skipping polygon in layer "
+                        f"'{layer.layer_name}' — vertices contain NaN/Inf.",
+                        flush=True,
+                    )
+                    continue
+                polygon_triangles = triangulate_polygon_xy(polygon_arr)
+                if len(polygon_triangles) == 0 or not bool(np.all(np.isfinite(polygon_triangles))):
+                    continue
+                polygon_triangle_count += int(len(polygon_triangles))
+                polygon_triangle_batches.append(self._pack_triangle_batch(polygon_triangles, color))
+
+        scene_triangle_buffer = None
+        if scene_triangle_batches:
+            scene_triangle_data = np.ascontiguousarray(np.concatenate(scene_triangle_batches, axis=0), dtype=np.float32)
+            scene_triangle_buffer = self._device.create_buffer(
+                usage=self._spy.BufferUsage.shader_resource,
+                label="scene_triangle_primitives",
+                data=scene_triangle_data,
+            )
+
+        polygon_triangle_buffer = None
+        if polygon_triangle_batches:
+            polygon_triangle_data = np.ascontiguousarray(np.concatenate(polygon_triangle_batches, axis=0), dtype=np.float32)
+            polygon_triangle_buffer = self._device.create_buffer(
+                usage=self._spy.BufferUsage.shader_resource,
+                label="polygon_triangle_primitives",
+                data=polygon_triangle_data,
+            )
+
+        return (
+            scene_triangle_buffer,
+            scene_triangle_count,
+            polygon_triangle_buffer,
+            polygon_triangle_count,
+        )
+
+    def _pack_triangle_batch(
+        self,
+        triangles_world: npt.NDArray[np.float32],
+        color_rgba: npt.NDArray[np.float32],
+    ) -> npt.NDArray[np.float32]:
+        triangles = np.asarray(triangles_world, dtype=np.float32)
+        if len(triangles) == 0:
+            return np.empty((0, 16), dtype=np.float32)
+        batch = np.zeros((triangles.shape[0], 16), dtype=np.float32)
+        batch[:, 0:3] = triangles[:, 0, :]
+        batch[:, 3] = 1.0
+        batch[:, 4:7] = triangles[:, 1, :]
+        batch[:, 7] = 1.0
+        batch[:, 8:11] = triangles[:, 2, :]
+        batch[:, 11] = 1.0
+        batch[:, 12:16] = np.asarray(color_rgba, dtype=np.float32)
+        return batch
+
+    def _create_u32_buffer(self, *, element_count: int, label: str) -> Any:
+        return self._device.create_buffer(
+            usage=(
+                self._spy.BufferUsage.shader_resource
+                | self._spy.BufferUsage.unordered_access
+                | self._spy.BufferUsage.copy_source
+                | self._spy.BufferUsage.copy_destination
+            ),
+            label=label,
+            data=np.zeros((element_count,), dtype=np.uint32),
+        )
+
+    def _read_u32_buffer(self, buffer: Any, *, count: int) -> npt.NDArray[np.uint32]:
+        raw = np.asarray(buffer.to_numpy(), dtype=np.uint8)
+        values = raw.view(np.uint32)
+        return values[:count].copy()
+
+    def _device_context(self):
+        if hasattr(self._device, "cuda_context_scope"):
+            return self._device.cuda_context_scope()
+        return nullcontext()
+
+
+class _CameraState:
+    """Per-camera GPU buffers and uniforms used by the Slang shader."""
+
+    __slots__ = (
+        "angle_to_radius_lut",
+        "angle_lut_count",
+        "angle_lut_max_angle",
+        "angle_lut_max_radius",
+        "angle_lut_tail_slope",
+        "radius_to_angle_lut",
+        "radius_lut_count",
+        "radius_lut_max_radius",
+        "radius_lut_tail_slope",
+        "principal_px",
+        "linear_row0",
+        "linear_row1",
+        "inv_linear_row0",
+        "inv_linear_row1",
+    )
+
+    def __init__(
+        self,
+        *,
+        angle_to_radius_lut: Any,
+        angle_lut_count: int,
+        angle_lut_max_angle: float,
+        angle_lut_max_radius: float,
+        angle_lut_tail_slope: float,
+        radius_to_angle_lut: Any,
+        radius_lut_count: int,
+        radius_lut_max_radius: float,
+        radius_lut_tail_slope: float,
+        principal_px: npt.NDArray[np.float32],
+        linear_row0: npt.NDArray[np.float32],
+        linear_row1: npt.NDArray[np.float32],
+        inv_linear_row0: npt.NDArray[np.float32],
+        inv_linear_row1: npt.NDArray[np.float32],
+    ) -> None:
+        self.angle_to_radius_lut = angle_to_radius_lut
+        self.angle_lut_count = angle_lut_count
+        self.angle_lut_max_angle = angle_lut_max_angle
+        self.angle_lut_max_radius = angle_lut_max_radius
+        self.angle_lut_tail_slope = angle_lut_tail_slope
+        self.radius_to_angle_lut = radius_to_angle_lut
+        self.radius_lut_count = radius_lut_count
+        self.radius_lut_max_radius = radius_lut_max_radius
+        self.radius_lut_tail_slope = radius_lut_tail_slope
+        self.principal_px = principal_px
+        self.linear_row0 = linear_row0
+        self.linear_row1 = linear_row1
+        self.inv_linear_row0 = inv_linear_row0
+        self.inv_linear_row1 = inv_linear_row1

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/scene_loader.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/scene_loader.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert flashdreams :class:`SceneData` into a :class:`SceneBundle`.
+
+flashdreams already loads CLIPGT parquet into a typed :class:`SceneData` (see
+:mod:`alpadreams.conditioning.world_scenario.clipgt_loader`). The Slang
+rasterizer consumes a flat, world-space layer representation
+(:class:`SceneBundle`), so this module is responsible for that one-time
+conversion.
+
+The mapping mirrors what ``ludus_renderer.load_clipgt_scene`` produced and
+what ``roaddreams.scene_loader`` builds when reading USDZ archives directly:
+
+* Lane lines are grouped by ``(color, width_px)`` with dash/dual patterning
+  applied, then emitted as line layers.
+* Road boundaries / wait lines / poles become solid line layers.
+* Traffic signs become triangle layers (cuboid plate faces).
+* Traffic lights become line layers (cuboid edges).
+* Crosswalks / road markings / intersection areas / road islands become
+  polygon layers (the rasterizer triangulates them on the CPU at upload time).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from alpadreams.conditioning.slang_renderer.colors import (
+    HDMAP_V3_COLORS,
+    LANE_LINE_STYLE_CONFIG,
+)
+from alpadreams.conditioning.slang_renderer.config import RasterConfig
+from alpadreams.conditioning.slang_renderer.math3d import quaternion_to_matrix_xyzw
+from alpadreams.conditioning.slang_renderer.patterns import (
+    apply_pattern,
+    concatenate_segments,
+    resample_polyline,
+    segments_from_polyline,
+    split_segment_runs,
+    subdivide_polyline,
+    triangulate_polygon_fan,
+)
+from alpadreams.conditioning.slang_renderer.types import (
+    SceneBundle,
+    WorldLineSegments,
+    WorldPolygonList,
+    WorldTriangleList,
+)
+from alpadreams.conditioning.world_scenario.data_types import (
+    PolygonElement,
+    PolylineElement,
+    SceneData,
+)
+
+
+def scene_data_to_bundle(scene_data: SceneData, raster: RasterConfig) -> SceneBundle:
+    """Convert a flashdreams :class:`SceneData` into a :class:`SceneBundle`."""
+    line_layers: list[WorldLineSegments] = []
+    triangle_layers: list[WorldTriangleList] = []
+    polygon_layers: list[WorldPolygonList] = []
+
+    line_layers.extend(_build_lane_segments(scene_data.lane_lines, raster))
+
+    if scene_data.road_boundaries:
+        line_layers.append(
+            _build_polyline_layer(
+                scene_data.road_boundaries,
+                layer_name="road_boundaries",
+                raster=raster,
+                width_px=raster.line_width_px,
+            )
+        )
+    if scene_data.wait_lines:
+        line_layers.append(
+            _build_polyline_layer(
+                scene_data.wait_lines,
+                layer_name="wait_lines",
+                raster=raster,
+                width_px=raster.line_width_px,
+            )
+        )
+    if scene_data.poles:
+        line_layers.append(
+            _build_polyline_layer(
+                scene_data.poles,
+                layer_name="poles",
+                raster=raster,
+                width_px=raster.pole_width_px,
+            )
+        )
+    if scene_data.traffic_signs:
+        triangle_layers.append(
+            _build_oriented_box_face_layer(
+                scene_data.traffic_signs, layer_name="traffic_signs"
+            )
+        )
+    if scene_data.traffic_lights:
+        line_layers.append(
+            _build_oriented_box_edge_layer(
+                scene_data.traffic_lights,
+                layer_name="traffic_lights",
+                width_px=raster.line_width_px,
+            )
+        )
+    if scene_data.crosswalks:
+        polygon_layers.append(
+            _build_polygon_layer(scene_data.crosswalks, layer_name="crosswalks")
+        )
+    if scene_data.road_markings:
+        polygon_layers.append(
+            _build_polygon_layer(scene_data.road_markings, layer_name="road_markings")
+        )
+    if scene_data.intersection_areas:
+        polygon_layers.append(
+            _build_polygon_layer(
+                scene_data.intersection_areas, layer_name="intersection_areas"
+            )
+        )
+    if scene_data.road_islands:
+        polygon_layers.append(
+            _build_polygon_layer(scene_data.road_islands, layer_name="road_islands")
+        )
+
+    return SceneBundle(
+        line_layers=tuple(line_layers),
+        triangle_layers=tuple(triangle_layers),
+        polygon_layers=tuple(polygon_layers),
+    )
+
+
+def _coarsen_segment_group(
+    segments_world: npt.NDArray[np.float32], interval_m: float
+) -> npt.NDArray[np.float32]:
+    coarsened_runs: list[npt.NDArray[np.float32]] = []
+    for run in split_segment_runs(segments_world):
+        if len(run) <= 2:
+            coarsened_runs.append(segments_from_polyline(run))
+            continue
+        sampled = resample_polyline(run, interval_m=interval_m)
+        coarsened_runs.append(segments_from_polyline(sampled))
+    return concatenate_segments(coarsened_runs)
+
+
+def _is_finite_polyline(points: npt.NDArray[np.float32], min_count: int) -> bool:
+    """True if ``points`` has at least ``min_count`` rows and is NaN/Inf-free.
+
+    A SINGLE non-finite value in a GPU vertex buffer poisons the whole raster
+    pass (NaN-vs-finite comparisons in the shader fail in ways that paint
+    unbounded regions, see commit
+    https://gitlab-master.nvidia.com/sil/omni-dreams/-/commit/92091220).
+    flashdreams' upstream :class:`ClipGTLoader` already guards most paths,
+    but we re-check here so a single stray null in a parquet row can't
+    destroy the entire conditioning frame.
+    """
+    if points.ndim != 2 or points.shape[0] < min_count:
+        return False
+    return bool(np.all(np.isfinite(points)))
+
+
+def _build_lane_segments(lane_lines: list[Any], raster: RasterConfig) -> list[WorldLineSegments]:
+    grouped_segments: dict[tuple[tuple[float, float, float, float], float], list[npt.NDArray[np.float32]]] = (
+        defaultdict(list)
+    )
+    grouped_names: dict[tuple[tuple[float, float, float, float], float], set[str]] = defaultdict(set)
+    skipped = 0
+
+    for lane_line in lane_lines:
+        polyline = np.asarray(lane_line.points, dtype=np.float32)
+        if not _is_finite_polyline(polyline, min_count=2):
+            skipped += 1
+            continue
+        type_hint = lane_line.lane_type.canonical_name
+        config = LANE_LINE_STYLE_CONFIG.get(type_hint, LANE_LINE_STYLE_CONFIG["OTHER"])
+        subdivided = subdivide_polyline(polyline, raster.lane_segment_interval_m)
+        base_segments = segments_from_polyline(subdivided)
+        patterned_segments = apply_pattern(
+            base_segments,
+            pattern=str(config.get("pattern", "solid")),
+            dual_pattern=config.get("dual_pattern"),  # type: ignore[arg-type]
+            dual_offset_m=raster.dual_line_offset_m,
+        )
+        color_rgba = tuple(float(value) for value in config["color"])  # type: ignore[arg-type]
+        width_px = raster.line_width_px * float(config.get("width_scale", 1.0))
+        group_key = (color_rgba, width_px)
+        for group in patterned_segments:
+            if len(group) == 0 or not bool(np.all(np.isfinite(group))):
+                continue
+            grouped_segments[group_key].append(
+                _coarsen_segment_group(group, interval_m=raster.polyline_segment_interval_m)
+            )
+            grouped_names[group_key].add(type_hint)
+
+    if skipped:
+        print(
+            f"[scene_loader] lanelines: skipped {skipped} of {len(lane_lines)} "
+            "polyline(s) with NaN/Inf vertices.",
+            flush=True,
+        )
+
+    layers: list[WorldLineSegments] = []
+    for key, segment_groups in grouped_segments.items():
+        color_rgba, width_px = key
+        style_names = "+".join(sorted(name.lower().replace(" ", "_") for name in grouped_names[key]))
+        merged = concatenate_segments(segment_groups)
+        if len(merged) == 0 or not bool(np.all(np.isfinite(merged))):
+            continue
+        layers.append(
+            WorldLineSegments(
+                segments_world=merged,
+                color_rgba=color_rgba,
+                width_px=width_px,
+                layer_name=f"lanelines_{style_names}",
+            )
+        )
+    return layers
+
+
+def _build_polyline_layer(
+    polylines: list[PolylineElement],
+    *,
+    layer_name: str,
+    raster: RasterConfig,
+    width_px: float,
+) -> WorldLineSegments:
+    segment_groups: list[npt.NDArray[np.float32]] = []
+    skipped = 0
+    for polyline_obj in polylines:
+        polyline = np.asarray(polyline_obj.points, dtype=np.float32)
+        if not _is_finite_polyline(polyline, min_count=2):
+            skipped += 1
+            continue
+        subdivided = subdivide_polyline(polyline, raster.polyline_segment_interval_m)
+        line_segments = segments_from_polyline(subdivided)
+        if len(line_segments) > 0 and bool(np.all(np.isfinite(line_segments))):
+            segment_groups.append(line_segments)
+    if skipped:
+        print(
+            f"[scene_loader] {layer_name}: skipped {skipped} of {len(polylines)} "
+            "polyline(s) with NaN/Inf vertices.",
+            flush=True,
+        )
+    return WorldLineSegments(
+        segments_world=concatenate_segments(segment_groups),
+        color_rgba=HDMAP_V3_COLORS[layer_name],
+        width_px=width_px,
+        layer_name=layer_name,
+    )
+
+
+def _build_polygon_layer(
+    polygons: list[PolygonElement],
+    *,
+    layer_name: str,
+) -> WorldPolygonList:
+    polygons_world: list[npt.NDArray[np.float32]] = []
+    skipped = 0
+    for polygon_obj in polygons:
+        vertices = np.asarray(polygon_obj.vertices, dtype=np.float32)
+        if not _is_finite_polyline(vertices, min_count=3):
+            skipped += 1
+            continue
+        if np.linalg.norm(vertices[0] - vertices[-1]) <= 1e-4:
+            vertices = vertices[:-1]
+        if vertices.shape[0] < 3:
+            continue
+        polygons_world.append(vertices.astype(np.float32))
+    if skipped:
+        print(
+            f"[scene_loader] {layer_name}: skipped {skipped} of {len(polygons)} "
+            "polygon(s) with NaN/Inf vertices.",
+            flush=True,
+        )
+    return WorldPolygonList(
+        polygons_world=tuple(polygons_world),
+        color_rgba=HDMAP_V3_COLORS[layer_name],
+        layer_name=layer_name,
+    )
+
+
+def _cuboid_corners(box: Any) -> npt.NDArray[np.float32]:
+    center = np.asarray(box.center, dtype=np.float32)
+    dimensions = np.asarray(box.dimensions, dtype=np.float32)
+    quat = (
+        float(box.orientation[0]),
+        float(box.orientation[1]),
+        float(box.orientation[2]),
+        float(box.orientation[3]),
+    )
+    rotation = quaternion_to_matrix_xyzw(quat)
+    half = dimensions * 0.5
+    corners = np.array(
+        [
+            [-half[0], -half[1], -half[2]],
+            [half[0], -half[1], -half[2]],
+            [half[0], half[1], -half[2]],
+            [-half[0], half[1], -half[2]],
+            [-half[0], -half[1], half[2]],
+            [half[0], -half[1], half[2]],
+            [half[0], half[1], half[2]],
+            [-half[0], half[1], half[2]],
+        ],
+        dtype=np.float32,
+    )
+    return ((corners @ rotation.T) + center).astype(np.float32)
+
+
+def _box_has_null_geometry(box: Any) -> bool:
+    """True if any field of an OrientedBoxElement is NaN/None.
+
+    Some CLIPGT scenes ship rows whose center / dimensions / orientation
+    are entirely null because upstream pose-fitting failed to localise
+    the feature. NumPy silently casts those nulls to NaN, and a single
+    NaN cuboid in a GPU primitive buffer corrupts the entire raster pass
+    (NaN-vs-finite comparisons fail, lane lines and road boundaries
+    collapse to noise specs). Skip such rows here.
+
+    See https://gitlab-master.nvidia.com/sil/omni-dreams/-/commit/92091220
+    for the original report on clipgt-065dcac9-...
+    """
+    for arr in (box.center, box.dimensions, box.orientation):
+        a = np.asarray(arr, dtype=np.float32)
+        if a.size == 0 or not np.all(np.isfinite(a)):
+            return True
+    return False
+
+
+def _build_oriented_box_face_layer(
+    boxes: list[Any], *, layer_name: str
+) -> WorldTriangleList:
+    triangles: list[npt.NDArray[np.float32]] = []
+    skipped = 0
+    for box in boxes:
+        if _box_has_null_geometry(box):
+            skipped += 1
+            continue
+        corners = _cuboid_corners(box)
+        thinnest_axis = int(np.argmin(np.asarray(box.dimensions, dtype=np.float32)))
+        face_indices_by_axis = {
+            0: ((0, 3, 7, 4), (1, 2, 6, 5)),
+            1: ((0, 1, 5, 4), (3, 2, 6, 7)),
+            2: ((0, 1, 2, 3), (4, 5, 6, 7)),
+        }
+        quads = [
+            corners[np.array(indices, dtype=np.int32)]
+            for indices in face_indices_by_axis[thinnest_axis]
+        ]
+        triangles.append(
+            np.concatenate([triangulate_polygon_fan(quad) for quad in quads], axis=0).astype(np.float32)
+        )
+    if skipped:
+        print(
+            f"[scene_loader] {layer_name}: skipped {skipped} of {len(boxes)} "
+            "row(s) with null/NaN center/dimensions/orientation. "
+            "Upstream dataset bug (missing pose-fit for some features).",
+            flush=True,
+        )
+    triangles_world = (
+        np.concatenate(triangles, axis=0).astype(np.float32)
+        if triangles
+        else np.empty((0, 3, 3), dtype=np.float32)
+    )
+    return WorldTriangleList(
+        triangles_world=triangles_world,
+        color_rgba=HDMAP_V3_COLORS[layer_name],
+        layer_name=layer_name,
+    )
+
+
+def _build_oriented_box_edge_layer(
+    boxes: list[Any], *, layer_name: str, width_px: float
+) -> WorldLineSegments:
+    edges = [
+        (0, 1), (1, 2), (2, 3), (3, 0),
+        (4, 5), (5, 6), (6, 7), (7, 4),
+        (0, 4), (1, 5), (2, 6), (3, 7),
+    ]
+    groups: list[npt.NDArray[np.float32]] = []
+    skipped = 0
+    for box in boxes:
+        if _box_has_null_geometry(box):
+            skipped += 1
+            continue
+        corners = _cuboid_corners(box)
+        groups.append(
+            np.array([[corners[a], corners[b]] for a, b in edges], dtype=np.float32)
+        )
+    if skipped:
+        print(
+            f"[scene_loader] {layer_name}: skipped {skipped} of {len(boxes)} "
+            "cuboid(s) with null/NaN center/dimensions/orientation. "
+            "Upstream dataset bug (missing pose-fit for some features).",
+            flush=True,
+        )
+    return WorldLineSegments(
+        segments_world=concatenate_segments(groups),
+        color_rgba=HDMAP_V3_COLORS[layer_name],
+        width_px=width_px,
+        layer_name=layer_name,
+    )

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/slang/rasterizer.slang
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/slang/rasterizer.slang
@@ -1,0 +1,887 @@
+import "slangpy";
+
+struct LinePrimitive
+{
+    float4 p0;
+    float4 p1;
+    float4 color;
+    float4 params;
+};
+
+struct TrianglePrimitive
+{
+    float4 p0;
+    float4 p1;
+    float4 p2;
+    float4 color;
+};
+
+float point_triangle_distance_squared(float3 p, float3 a, float3 b, float3 c)
+{
+    float3 ab = b - a;
+    float3 ac = c - a;
+    float3 ap = p - a;
+    float d1 = dot(ab, ap);
+    float d2 = dot(ac, ap);
+    if (d1 <= 0.0 && d2 <= 0.0)
+        return dot(ap, ap);
+
+    float3 bp = p - b;
+    float d3 = dot(ab, bp);
+    float d4 = dot(ac, bp);
+    if (d3 >= 0.0 && d4 <= d3)
+        return dot(bp, bp);
+
+    float vc = d1 * d4 - d3 * d2;
+    if (vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0)
+    {
+        float v = d1 / max(d1 - d3, 1e-6);
+        float3 closest = a + v * ab;
+        return dot(p - closest, p - closest);
+    }
+
+    float3 cp = p - c;
+    float d5 = dot(ab, cp);
+    float d6 = dot(ac, cp);
+    if (d6 >= 0.0 && d5 <= d6)
+        return dot(cp, cp);
+
+    float vb = d5 * d2 - d1 * d6;
+    if (vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0)
+    {
+        float w = d2 / max(d2 - d6, 1e-6);
+        float3 closest = a + w * ac;
+        return dot(p - closest, p - closest);
+    }
+
+    float va = d3 * d6 - d5 * d4;
+    if (va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0)
+    {
+        float3 bc = c - b;
+        float w = (d4 - d3) / max((d4 - d3) + (d5 - d6), 1e-6);
+        float3 closest = b + w * bc;
+        return dot(p - closest, p - closest);
+    }
+
+    float denom = 1.0 / max(va + vb + vc, 1e-6);
+    float v = vb * denom;
+    float w = vc * denom;
+    float3 closest = a + ab * v + ac * w;
+    return dot(p - closest, p - closest);
+}
+
+bool ray_triangle_intersect(
+    float3 ray_dir,
+    float3 v0,
+    float3 v1,
+    float3 v2,
+    out float t,
+    out float3 bary)
+{
+    float3 e1 = v1 - v0;
+    float3 e2 = v2 - v0;
+    float3 pvec = cross(ray_dir, e2);
+    float det = dot(e1, pvec);
+    if (abs(det) <= 1e-6)
+    {
+        t = 0.0;
+        bary = 0.0;
+        return false;
+    }
+
+    float inv_det = 1.0 / det;
+    float3 tvec = -v0;
+    float u = dot(tvec, pvec) * inv_det;
+    if (u < 0.0 || u > 1.0)
+    {
+        t = 0.0;
+        bary = 0.0;
+        return false;
+    }
+
+    float3 qvec = cross(tvec, e1);
+    float v = dot(ray_dir, qvec) * inv_det;
+    if (v < 0.0 || (u + v) > 1.0)
+    {
+        t = 0.0;
+        bary = 0.0;
+        return false;
+    }
+
+    t = dot(e2, qvec) * inv_det;
+    bary = float3(1.0 - u - v, u, v);
+    return t > 0.0;
+}
+
+float point_segment_distance(float2 p, float2 a, float2 b, out float t)
+{
+    float2 ab = b - a;
+    float denom = max(dot(ab, ab), 1e-6);
+    t = saturate(dot(p - a, ab) / denom);
+    float2 closest = a + t * ab;
+    return length(p - closest);
+}
+
+bool barycentrics(float2 p, float2 a, float2 b, float2 c, out float3 w)
+{
+    float2 v0 = b - a;
+    float2 v1 = c - a;
+    float2 v2 = p - a;
+    float denom = v0.x * v1.y - v1.x * v0.y;
+    if (abs(denom) < 1e-6)
+    {
+        w = 0.0;
+        return false;
+    }
+
+    float inv_denom = 1.0 / denom;
+    float v = (v2.x * v1.y - v1.x * v2.y) * inv_denom;
+    float u = (v0.x * v2.y - v2.x * v0.y) * inv_denom;
+    float w0 = 1.0 - u - v;
+    w = float3(w0, v, u);
+    return all(w >= 0.0);
+}
+
+float angle_to_radius(
+    float angle,
+    StructuredBuffer<float> angle_to_radius_lut,
+    uint lut_count,
+    float lut_max_angle,
+    float lut_max_radius,
+    float lut_tail_slope)
+{
+    if (lut_count == 0)
+        return 0.0;
+    if (lut_count == 1)
+        return angle_to_radius_lut[0];
+
+    if (angle > lut_max_angle)
+        return lut_max_radius + (angle - lut_max_angle) * lut_tail_slope;
+
+    float scaled = clamp(angle / max(lut_max_angle, 1e-6), 0.0, 1.0) * float(lut_count - 1);
+    uint i0 = min(uint(floor(scaled)), lut_count - 1);
+    uint i1 = min(i0 + 1, lut_count - 1);
+    float t = scaled - float(i0);
+    return lerp(angle_to_radius_lut[i0], angle_to_radius_lut[i1], t);
+}
+
+float radius_to_angle(
+    float radius,
+    StructuredBuffer<float> radius_to_angle_lut,
+    uint lut_count,
+    float lut_max_radius,
+    float lut_tail_slope)
+{
+    if (lut_count == 0)
+        return 0.0;
+    if (lut_count == 1)
+        return radius_to_angle_lut[0];
+
+    if (radius > lut_max_radius)
+        return radius_to_angle_lut[lut_count - 1] + (radius - lut_max_radius) * lut_tail_slope;
+
+    float scaled = clamp(radius / max(lut_max_radius, 1e-6), 0.0, 1.0) * float(lut_count - 1);
+    uint i0 = min(uint(floor(scaled)), lut_count - 1);
+    uint i1 = min(i0 + 1, lut_count - 1);
+    float t = scaled - float(i0);
+    return lerp(radius_to_angle_lut[i0], radius_to_angle_lut[i1], t);
+}
+
+float3 pixel_to_camera_ray(
+    float2 pixel_center,
+    float2 principal_px,
+    float2 inv_linear_row0,
+    float2 inv_linear_row1,
+    StructuredBuffer<float> radius_to_angle_lut,
+    uint lut_count,
+    float lut_max_radius,
+    float lut_tail_slope)
+{
+    float2 pixel_offset = pixel_center - principal_px;
+    float2 pixels_rel = float2(dot(inv_linear_row0, pixel_offset), dot(inv_linear_row1, pixel_offset));
+    float radius = length(pixels_rel);
+    float angle = radius_to_angle(radius, radius_to_angle_lut, lut_count, lut_max_radius, lut_tail_slope);
+    float2 dir_xy = radius > 1e-6 ? pixels_rel / radius : float2(0.0, 0.0);
+    float sin_angle = sin(angle);
+    return float3(dir_xy * sin_angle, cos(angle));
+}
+
+float2 project_to_polygon_plane(float3 point, uint dominant_axis)
+{
+    if (dominant_axis == 0)
+        return point.yz;
+    if (dominant_axis == 1)
+        return point.xz;
+    return point.xy;
+}
+
+bool point_in_polygon_camera(
+    float3 point,
+    StructuredBuffer<float4> polygon_vertices_camera,
+    uint vertex_offset,
+    uint vertex_count,
+    uint dominant_axis)
+{
+    if (vertex_count < 3)
+        return false;
+
+    float2 point_2d = project_to_polygon_plane(point, dominant_axis);
+    bool inside = false;
+    float2 previous = project_to_polygon_plane(polygon_vertices_camera[vertex_offset + vertex_count - 1].xyz, dominant_axis);
+
+    [loop]
+    for (uint i = 0; i < vertex_count; ++i)
+    {
+        float2 current = project_to_polygon_plane(polygon_vertices_camera[vertex_offset + i].xyz, dominant_axis);
+        float denom = previous.y - current.y;
+        if (abs(denom) <= 1e-6)
+            denom = denom >= 0.0 ? 1e-6 : -1e-6;
+        bool crosses = ((current.y > point_2d.y) != (previous.y > point_2d.y)) &&
+            (point_2d.x < (previous.x - current.x) * (point_2d.y - current.y) / denom + current.x);
+        if (crosses)
+            inside = !inside;
+        previous = current;
+    }
+
+    return inside;
+}
+
+struct ProjectedPoint
+{
+    bool valid;
+    float2 uv;
+    float forwardDepth;
+};
+
+float3 world_to_camera_point(float3 world_point, float4x4 world_to_camera_rdf)
+{
+    return mul(world_to_camera_rdf, float4(world_point, 1.0)).xyz;
+}
+
+ProjectedPoint project_camera_point(
+    float3 camera_point,
+    float2 principal_px,
+    float2 linear_row0,
+    float2 linear_row1,
+    float near_plane_m,
+    StructuredBuffer<float> angle_to_radius_lut,
+    uint lut_count,
+    float lut_max_angle,
+    float lut_max_radius,
+    float lut_tail_slope)
+{
+    float forward_depth = camera_point.z;
+    if (forward_depth <= near_plane_m)
+    {
+        return { false, float2(0.0, 0.0), 0.0 };
+    }
+
+    float xy_norm = length(camera_point.xy);
+    float ray_norm = length(camera_point);
+    float cos_alpha = clamp(forward_depth / max(ray_norm, 1e-6), -1.0, 1.0);
+    float alpha = acos(cos_alpha);
+    float radius = angle_to_radius(alpha, angle_to_radius_lut, lut_count, lut_max_angle, lut_max_radius, lut_tail_slope);
+
+    float2 pixels_rel = xy_norm > 1e-6 ? camera_point.xy * (radius / xy_norm) : float2(0.0, 0.0);
+    float2 uv = float2(dot(linear_row0, pixels_rel), dot(linear_row1, pixels_rel)) + principal_px;
+    return { true, uv, forward_depth };
+}
+
+ProjectedPoint project_point(
+    float3 world_point,
+    float4x4 world_to_camera_rdf,
+    float2 principal_px,
+    float2 linear_row0,
+    float2 linear_row1,
+    float near_plane_m,
+    StructuredBuffer<float> angle_to_radius_lut,
+    uint lut_count,
+    float lut_max_angle,
+    float lut_max_radius,
+    float lut_tail_slope)
+{
+    return project_camera_point(
+        world_to_camera_point(world_point, world_to_camera_rdf),
+        principal_px,
+        linear_row0,
+        linear_row1,
+        near_plane_m,
+        angle_to_radius_lut,
+        lut_count,
+        lut_max_angle,
+        lut_max_radius,
+        lut_tail_slope
+    );
+}
+
+uint clip_triangle_to_near_plane(float3 v0, float3 v1, float3 v2, float near_plane_m, out float3 clipped[4])
+{
+    float clip_plane_z = near_plane_m + 1e-4;
+    float3 input[3] = { v0, v1, v2 };
+    uint out_count = 0;
+    float3 previous = input[2];
+    bool previous_inside = previous.z >= clip_plane_z;
+
+    [unroll]
+    for (uint i = 0; i < 3; ++i)
+    {
+        float3 current = input[i];
+        bool current_inside = current.z >= clip_plane_z;
+
+        if (previous_inside != current_inside)
+        {
+            float denom = current.z - previous.z;
+            float t = abs(denom) > 1e-6 ? (clip_plane_z - previous.z) / denom : 0.0;
+            clipped[out_count++] = lerp(previous, current, saturate(t));
+        }
+
+        if (current_inside)
+            clipped[out_count++] = current;
+
+        previous = current;
+        previous_inside = current_inside;
+    }
+
+    return out_count;
+}
+
+float fog_amount(float depth_value, float fog_start_m, float fog_end_m, float fog_power)
+{
+    if (fog_end_m <= fog_start_m)
+        return 0.0;
+    float t = saturate((depth_value - fog_start_m) / max(fog_end_m - fog_start_m, 1e-6));
+    return pow(t, max(fog_power, 1e-3));
+}
+
+float4 apply_distance_fog(float4 color, float depth_value, float fog_start_m, float fog_end_m, float fog_power)
+{
+    float amount = fog_amount(depth_value, fog_start_m, fog_end_m, fog_power);
+    return float4(color.rgb * (1.0 - amount), color.a);
+}
+
+void rasterize_projected_triangle(
+    float2 a,
+    float za,
+    float2 b,
+    float zb,
+    float2 c,
+    float zc,
+    float4 color,
+    RWTensor<float4, 2> rgb,
+    RWTensor<float, 2> depth,
+    RWTensor<uint, 2> depth_bits,
+    uint image_width,
+    uint image_height,
+    float fog_start_m,
+    float fog_end_m,
+    float fog_power)
+{
+    int x0 = max(0, int(floor(min(a.x, min(b.x, c.x)))));
+    int y0 = max(0, int(floor(min(a.y, min(b.y, c.y)))));
+    int x1 = min(int(image_width) - 1, int(ceil(max(a.x, max(b.x, c.x)))));
+    int y1 = min(int(image_height) - 1, int(ceil(max(a.y, max(b.y, c.y)))));
+
+    for (int py = y0; py <= y1; ++py)
+    {
+        for (int px = x0; px <= x1; ++px)
+        {
+            float2 pixel_center = float2(px + 0.5, py + 0.5);
+            float3 weights;
+            if (!barycentrics(pixel_center, a, b, c, weights))
+                continue;
+
+            float depth_value = weights.x * za + weights.y * zb + weights.z * zc;
+            uint depth_value_bits = asuint(depth_value);
+            uint old_bits;
+            int linear_idx = py * int(depth_bits._strides[0]) + px * int(depth_bits._strides[1]) + int(depth_bits._offset);
+            InterlockedMin(depth_bits._data[linear_idx], depth_value_bits, old_bits);
+            if (depth_value_bits < old_bits)
+            {
+                depth.store(py, px, depth_value);
+                rgb.store(py, px, apply_distance_fog(color, depth_value, fog_start_m, fog_end_m, fog_power));
+            }
+        }
+    }
+}
+
+[shader("compute")]
+[numthreads(16, 16, 1)]
+void clear_targets(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform RWTensor<float4, 2> rgb,
+    uniform RWTensor<float, 2> depth,
+    uniform RWTensor<uint, 2> depth_bits,
+    uniform uint image_width,
+    uniform uint image_height,
+    uniform float clear_depth)
+{
+    if (dispatchThreadID.x >= image_width || dispatchThreadID.y >= image_height)
+        return;
+
+    int px = int(dispatchThreadID.x);
+    int py = int(dispatchThreadID.y);
+    rgb.store(py, px, float4(0.0, 0.0, 0.0, 1.0));
+    depth.store(py, px, clear_depth);
+    depth_bits.store(py, px, asuint(clear_depth));
+}
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void rasterize_lines_world(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform StructuredBuffer<LinePrimitive> lines,
+    uniform StructuredBuffer<float> angle_to_radius_lut,
+    uniform RWTensor<float4, 2> rgb,
+    uniform RWTensor<float, 2> depth,
+    uniform RWTensor<uint, 2> depth_bits,
+    uniform uint image_width,
+    uniform uint image_height,
+    uniform float4x4 world_to_camera_rdf,
+    uniform float2 principal_px,
+    uniform float2 linear_row0,
+    uniform float2 linear_row1,
+    uniform float near_plane_m,
+    uniform uint lut_count,
+    uniform float lut_max_angle,
+    uniform float lut_max_radius,
+    uniform float lut_tail_slope,
+    uniform float fog_start_m,
+    uniform float fog_end_m,
+    uniform float fog_power)
+{
+    uint idx = dispatchThreadID.x;
+    uint line_count;
+    uint line_stride;
+    lines.GetDimensions(line_count, line_stride);
+    if (idx >= line_count)
+        return;
+
+    LinePrimitive line = lines[idx];
+    ProjectedPoint p0 = project_point(
+        line.p0.xyz,
+        world_to_camera_rdf,
+        principal_px,
+        linear_row0,
+        linear_row1,
+        near_plane_m,
+        angle_to_radius_lut,
+        lut_count,
+        lut_max_angle,
+        lut_max_radius,
+        lut_tail_slope
+    );
+    ProjectedPoint p1 = project_point(
+        line.p1.xyz,
+        world_to_camera_rdf,
+        principal_px,
+        linear_row0,
+        linear_row1,
+        near_plane_m,
+        angle_to_radius_lut,
+        lut_count,
+        lut_max_angle,
+        lut_max_radius,
+        lut_tail_slope
+    );
+    if (!p0.valid || !p1.valid)
+        return;
+
+    float2 a = p0.uv;
+    float2 b = p1.uv;
+    float za = p0.forwardDepth;
+    float zb = p1.forwardDepth;
+    float4 color = line.color;
+    float half_width = max(line.params.x * 0.5, 0.5);
+
+    int x0 = max(0, int(floor(min(a.x, b.x) - half_width)));
+    int y0 = max(0, int(floor(min(a.y, b.y) - half_width)));
+    int x1 = min(int(image_width) - 1, int(ceil(max(a.x, b.x) + half_width)));
+    int y1 = min(int(image_height) - 1, int(ceil(max(a.y, b.y) + half_width)));
+
+    for (int py = y0; py <= y1; ++py)
+    {
+        for (int px = x0; px <= x1; ++px)
+        {
+            float2 pixel_center = float2(px + 0.5, py + 0.5);
+            float t;
+            float distance_to_line = point_segment_distance(pixel_center, a, b, t);
+            if (distance_to_line > half_width)
+                continue;
+
+            float depth_value = lerp(za, zb, t);
+            uint depth_value_bits = asuint(depth_value);
+            uint old_bits;
+            int linear_idx = py * int(depth_bits._strides[0]) + px * int(depth_bits._strides[1]) + int(depth_bits._offset);
+            InterlockedMin(depth_bits._data[linear_idx], depth_value_bits, old_bits);
+            if (depth_value_bits < old_bits)
+            {
+                depth.store(py, px, depth_value);
+                rgb.store(py, px, apply_distance_fog(color, depth_value, fog_start_m, fog_end_m, fog_power));
+            }
+        }
+    }
+}
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void rasterize_triangles_world(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform StructuredBuffer<TrianglePrimitive> triangles,
+    uniform StructuredBuffer<uint> near_triangle_mask,
+    uniform StructuredBuffer<float> angle_to_radius_lut,
+    uniform RWTensor<float4, 2> rgb,
+    uniform RWTensor<float, 2> depth,
+    uniform RWTensor<uint, 2> depth_bits,
+    uniform uint image_width,
+    uniform uint image_height,
+    uniform float4x4 world_to_camera_rdf,
+    uniform float2 principal_px,
+    uniform float2 linear_row0,
+    uniform float2 linear_row1,
+    uniform float near_plane_m,
+    uniform uint lut_count,
+    uniform float lut_max_angle,
+    uniform float lut_max_radius,
+    uniform float lut_tail_slope,
+    uniform uint skip_masked,
+    uniform float fog_start_m,
+    uniform float fog_end_m,
+    uniform float fog_power)
+{
+    uint idx = dispatchThreadID.x;
+    uint triangle_count;
+    uint triangle_stride;
+    triangles.GetDimensions(triangle_count, triangle_stride);
+    if (idx >= triangle_count)
+        return;
+    if (skip_masked != 0 && near_triangle_mask[idx] != 0)
+        return;
+
+    TrianglePrimitive tri = triangles[idx];
+    float3 clipped_camera_points[4];
+    uint clipped_count = clip_triangle_to_near_plane(
+        world_to_camera_point(tri.p0.xyz, world_to_camera_rdf),
+        world_to_camera_point(tri.p1.xyz, world_to_camera_rdf),
+        world_to_camera_point(tri.p2.xyz, world_to_camera_rdf),
+        near_plane_m,
+        clipped_camera_points
+    );
+    if (clipped_count < 3)
+        return;
+
+    ProjectedPoint projected[4];
+    [unroll]
+    for (uint i = 0; i < clipped_count; ++i)
+    {
+        projected[i] = project_camera_point(
+            clipped_camera_points[i],
+            principal_px,
+            linear_row0,
+            linear_row1,
+            near_plane_m,
+            angle_to_radius_lut,
+            lut_count,
+            lut_max_angle,
+            lut_max_radius,
+            lut_tail_slope
+        );
+    }
+
+    float4 color = tri.color;
+    rasterize_projected_triangle(
+        projected[0].uv,
+        projected[0].forwardDepth,
+        projected[1].uv,
+        projected[1].forwardDepth,
+        projected[2].uv,
+        projected[2].forwardDepth,
+        color,
+        rgb,
+        depth,
+        depth_bits,
+        image_width,
+        image_height,
+        fog_start_m,
+        fog_end_m,
+        fog_power
+    );
+
+    if (clipped_count == 4)
+    {
+        rasterize_projected_triangle(
+            projected[0].uv,
+            projected[0].forwardDepth,
+            projected[2].uv,
+            projected[2].forwardDepth,
+            projected[3].uv,
+            projected[3].forwardDepth,
+            color,
+            rgb,
+            depth,
+            depth_bits,
+            image_width,
+            image_height,
+            fog_start_m,
+            fog_end_m,
+            fog_power
+        );
+    }
+}
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void classify_near_triangles_world(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform StructuredBuffer<TrianglePrimitive> triangles,
+    uniform RWStructuredBuffer<uint> near_triangle_mask,
+    uniform RWStructuredBuffer<uint> near_triangle_indices,
+    uniform RWStructuredBuffer<uint> counters,
+    uniform float4x4 world_to_camera_rdf,
+    uniform float triangle_raytrace_distance_m)
+{
+    uint idx = dispatchThreadID.x;
+    uint triangle_count;
+    uint triangle_stride;
+    triangles.GetDimensions(triangle_count, triangle_stride);
+    if (idx >= triangle_count)
+        return;
+
+    TrianglePrimitive tri = triangles[idx];
+    float3 v0 = world_to_camera_point(tri.p0.xyz, world_to_camera_rdf);
+    float3 v1 = world_to_camera_point(tri.p1.xyz, world_to_camera_rdf);
+    float3 v2 = world_to_camera_point(tri.p2.xyz, world_to_camera_rdf);
+    float max_depth = max(v0.z, max(v1.z, v2.z));
+    if (max_depth <= 0.0)
+        return;
+
+    float threshold_sq = triangle_raytrace_distance_m * triangle_raytrace_distance_m;
+    float distance_sq = point_triangle_distance_squared(float3(0.0, 0.0, 0.0), v0, v1, v2);
+    if (distance_sq >= threshold_sq)
+        return;
+
+    near_triangle_mask[idx] = 1;
+    uint near_slot;
+    InterlockedAdd(counters[0], 1, near_slot);
+    uint index_capacity;
+    uint index_stride;
+    near_triangle_indices.GetDimensions(index_capacity, index_stride);
+    if (near_slot < index_capacity)
+        near_triangle_indices[near_slot] = idx;
+}
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void raytrace_triangles_world(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform StructuredBuffer<uint> near_triangle_indices,
+    uniform StructuredBuffer<TrianglePrimitive> triangles,
+    uniform StructuredBuffer<float> radius_to_angle_lut,
+    uniform RWTensor<float4, 2> rgb,
+    uniform RWTensor<float, 2> depth,
+    uniform RWTensor<uint, 2> depth_bits,
+    uniform uint image_width,
+    uniform uint image_height,
+    uniform float4x4 world_to_camera_rdf,
+    uniform float2 principal_px,
+    uniform float2 inv_linear_row0,
+    uniform float2 inv_linear_row1,
+    uniform float near_plane_m,
+    uniform uint radius_lut_count,
+    uniform float radius_lut_max_radius,
+    uniform float radius_lut_tail_slope,
+    uniform uint near_triangle_count,
+    uniform float fog_start_m,
+    uniform float fog_end_m,
+    uniform float fog_power)
+{
+    uint px = dispatchThreadID.x;
+    uint py = dispatchThreadID.y;
+    if (px >= image_width || py >= image_height || near_triangle_count == 0)
+        return;
+
+    float2 pixel_center = float2(float(px) + 0.5, float(py) + 0.5);
+    float3 ray_dir = pixel_to_camera_ray(
+        pixel_center,
+        principal_px,
+        inv_linear_row0,
+        inv_linear_row1,
+        radius_to_angle_lut,
+        radius_lut_count,
+        radius_lut_max_radius,
+        radius_lut_tail_slope
+    );
+
+    float best_depth = depth.load(int(py), int(px));
+    float4 best_color = rgb.load(int(py), int(px));
+    bool found_closer_hit = false;
+
+    [loop]
+    for (uint near_idx = 0; near_idx < near_triangle_count; ++near_idx)
+    {
+        uint triangle_index = near_triangle_indices[near_idx];
+        TrianglePrimitive tri = triangles[triangle_index];
+        float3 v0 = world_to_camera_point(tri.p0.xyz, world_to_camera_rdf);
+        float3 v1 = world_to_camera_point(tri.p1.xyz, world_to_camera_rdf);
+        float3 v2 = world_to_camera_point(tri.p2.xyz, world_to_camera_rdf);
+
+        float max_depth = max(v0.z, max(v1.z, v2.z));
+        if (max_depth <= near_plane_m)
+            continue;
+
+        float t;
+        float3 bary;
+        if (!ray_triangle_intersect(ray_dir, v0, v1, v2, t, bary))
+            continue;
+
+        float3 hit = ray_dir * t;
+        if (hit.z <= near_plane_m || hit.z >= best_depth)
+            continue;
+
+        best_depth = hit.z;
+        best_color = apply_distance_fog(tri.color, hit.z, fog_start_m, fog_end_m, fog_power);
+        found_closer_hit = true;
+    }
+
+    if (found_closer_hit)
+    {
+        depth.store(int(py), int(px), best_depth);
+        depth_bits.store(int(py), int(px), asuint(best_depth));
+        rgb.store(int(py), int(px), best_color);
+    }
+}
+
+[shader("compute")]
+[numthreads(16, 16, 1)]
+void pack_rgb_to_rgba8(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform RWTensor<float4, 2> rgb,
+    uniform RWTensor<uint, 2> rgba8,
+    uniform uint image_width,
+    uniform uint image_height)
+{
+    if (dispatchThreadID.x >= image_width || dispatchThreadID.y >= image_height)
+        return;
+
+    int px = int(dispatchThreadID.x);
+    int py = int(dispatchThreadID.y);
+    float4 color = saturate(rgb.load(py, px));
+    uint r = uint(color.x * 255.0 + 0.5);
+    uint g = uint(color.y * 255.0 + 0.5);
+    uint b = uint(color.z * 255.0 + 0.5);
+    uint a = uint(color.w * 255.0 + 0.5);
+    rgba8.store(py, px, r | (g << 8) | (b << 16) | (a << 24));
+}
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void rasterize_triangles_screen(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform StructuredBuffer<TrianglePrimitive> triangles,
+    uniform RWTensor<float4, 2> rgb,
+    uniform RWTensor<float, 2> depth,
+    uniform RWTensor<uint, 2> depth_bits,
+    uniform uint image_width,
+    uniform uint image_height,
+    uniform float fog_start_m,
+    uniform float fog_end_m,
+    uniform float fog_power)
+{
+    uint idx = dispatchThreadID.x;
+    uint triangle_count;
+    uint triangle_stride;
+    triangles.GetDimensions(triangle_count, triangle_stride);
+    if (idx >= triangle_count)
+        return;
+
+    TrianglePrimitive tri = triangles[idx];
+    rasterize_projected_triangle(
+        tri.p0.xy,
+        tri.p0.z,
+        tri.p1.xy,
+        tri.p1.z,
+        tri.p2.xy,
+        tri.p2.z,
+        tri.color,
+        rgb,
+        depth,
+        depth_bits,
+        image_width,
+        image_height,
+        fog_start_m,
+        fog_end_m,
+        fog_power
+    );
+}
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void raytrace_polygon_camera(
+    uint3 dispatchThreadID : SV_DispatchThreadID,
+    uniform StructuredBuffer<float4> polygon_vertices_camera,
+    uniform StructuredBuffer<float> radius_to_angle_lut,
+    uniform RWTensor<float4, 2> rgb,
+    uniform RWTensor<float, 2> depth,
+    uniform RWTensor<uint, 2> depth_bits,
+    uniform uint image_width,
+    uniform uint image_height,
+    uniform uint bbox_x0,
+    uniform uint bbox_y0,
+    uniform uint vertex_offset,
+    uniform uint vertex_count,
+    uniform float4 plane_camera,
+    uniform uint dominant_axis,
+    uniform float2 principal_px,
+    uniform float2 inv_linear_row0,
+    uniform float2 inv_linear_row1,
+    uniform float near_plane_m,
+    uniform uint lut_count,
+    uniform float lut_max_radius,
+    uniform float lut_tail_slope,
+    uniform float4 color,
+    uniform float fog_start_m,
+    uniform float fog_end_m,
+    uniform float fog_power)
+{
+    uint px = bbox_x0 + dispatchThreadID.x;
+    uint py = bbox_y0 + dispatchThreadID.y;
+    if (px >= image_width || py >= image_height)
+        return;
+
+    float2 pixel_center = float2(float(px) + 0.5, float(py) + 0.5);
+    float3 ray_dir = pixel_to_camera_ray(
+        pixel_center,
+        principal_px,
+        inv_linear_row0,
+        inv_linear_row1,
+        radius_to_angle_lut,
+        lut_count,
+        lut_max_radius,
+        lut_tail_slope
+    );
+
+    float denom = dot(plane_camera.xyz, ray_dir);
+    if (abs(denom) <= 1e-6)
+        return;
+
+    float t = -plane_camera.w / denom;
+    if (t <= 0.0)
+        return;
+
+    float3 hit = ray_dir * t;
+    if (hit.z <= near_plane_m)
+        return;
+
+    if (!point_in_polygon_camera(hit, polygon_vertices_camera, vertex_offset, vertex_count, dominant_axis))
+        return;
+
+    float depth_value = hit.z;
+    uint depth_value_bits = asuint(depth_value);
+    uint old_bits;
+    int linear_idx = int(py) * int(depth_bits._strides[0]) + int(px) * int(depth_bits._strides[1]) + int(depth_bits._offset);
+    InterlockedMin(depth_bits._data[linear_idx], depth_value_bits, old_bits);
+    if (depth_value_bits < old_bits)
+    {
+        depth.store(int(py), int(px), depth_value);
+        rgb.store(int(py), int(px), apply_distance_fog(color, depth_value, fog_start_m, fog_end_m, fog_power));
+    }
+}

--- a/integrations/alpadreams/alpadreams/conditioning/slang_renderer/types.py
+++ b/integrations/alpadreams/alpadreams/conditioning/slang_renderer/types.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SceneBundle and layer dataclasses consumed by the SlangPy rasterizer.
+
+Adapted from ``roaddreams.types``; the Bundle is the static, world-space view
+of an HD map that the Slang kernels expect. It does not carry any timestamp
+dimension because flashdreams only uses static HD-map conditioning today.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+FloatArray = npt.NDArray[np.float32]
+
+
+@dataclass(frozen=True)
+class WorldLineSegments:
+    """A pool of world-space line segments sharing one color and width."""
+
+    segments_world: FloatArray  # shape (N, 2, 3)
+    color_rgba: tuple[float, float, float, float]
+    width_px: float
+    layer_name: str
+
+
+@dataclass(frozen=True)
+class WorldTriangleList:
+    """A pool of world-space triangles sharing one color."""
+
+    triangles_world: FloatArray  # shape (N, 3, 3)
+    color_rgba: tuple[float, float, float, float]
+    layer_name: str
+
+
+@dataclass(frozen=True)
+class WorldPolygonList:
+    """A pool of world-space planar polygons sharing one color.
+
+    Each polygon is an ``(M, 3)`` array of vertices; ``M`` may differ between
+    polygons. The rasterizer triangulates polygons on the CPU before upload.
+    """
+
+    polygons_world: tuple[FloatArray, ...]
+    color_rgba: tuple[float, float, float, float]
+    layer_name: str
+
+
+@dataclass(frozen=True)
+class SceneBundle:
+    """Container for the world-space HD-map geometry the rasterizer consumes."""
+
+    line_layers: tuple[WorldLineSegments, ...] = ()
+    triangle_layers: tuple[WorldTriangleList, ...] = ()
+    polygon_layers: tuple[WorldPolygonList, ...] = ()

--- a/integrations/alpadreams/alpadreams/grpc/server.py
+++ b/integrations/alpadreams/alpadreams/grpc/server.py
@@ -70,7 +70,7 @@ from alpadreams.grpc.utils import (
     trajectory_to_camera_poses,
 )
 from loguru import logger
-from ludus_renderer import nvjpeg
+from torchvision.io import encode_jpeg
 
 from flashdreams.core.distributed import init as distributed_init
 from flashdreams.core.distributed.context_parallel import (
@@ -821,7 +821,12 @@ class WorldModelEngine:
 
     def _encode_images(self, images: torch.Tensor) -> list[video_model_pb2.Image]:
         """
-        Encode a batch of images using nvjpeg.
+        Encode a batch of images.
+
+        For JPEG, ``torchvision.io.encode_jpeg`` runs on the same CUDA device
+        as ``images`` and replaces the previous ``ludus_renderer.nvjpeg``
+        path. For PNG (and any other configured format) we fall back to the
+        CPU encoder.
 
         Args:
             images: Tensor of shape [B, 3, H, W] uint8.
@@ -831,14 +836,16 @@ class WorldModelEngine:
         """
         assert self.device.type == "cuda", "Images must be on GPU"
         if self.output_format == "jpeg":
-            jpeg_list = nvjpeg.encode(
-                images, quality=self.jpeg_quality, device_index=self.device.index
-            )  # Encode to JPEG with quality using ludus_renderer
+            frames = [images[i] for i in range(images.shape[0])]
+            encoded_tensors = encode_jpeg(frames, quality=self.jpeg_quality)
+            if isinstance(encoded_tensors, torch.Tensor):
+                encoded_tensors = [encoded_tensors]
             return [
                 video_model_pb2.Image(
-                    data=jpeg, format=video_model_pb2.ImageFormat.JPEG
+                    data=bytes(encoded.cpu().numpy()),
+                    format=video_model_pb2.ImageFormat.JPEG,
                 )
-                for jpeg in jpeg_list
+                for encoded in encoded_tensors
             ]
         else:
             frame_msgs = []

--- a/integrations/alpadreams/alpadreams/grpc/utils.py
+++ b/integrations/alpadreams/alpadreams/grpc/utils.py
@@ -40,7 +40,10 @@ import torch
 from alpadreams.conditioning.renderer import load_and_attach_ludus_scene
 from alpadreams.conditioning.world_scenario.data_loaders import load_scene
 from alpadreams.conditioning.world_scenario.data_types import SceneData
-from alpadreams.conditioning.world_scenario.data_utils import convert_pose_flu_to_rdf
+from alpadreams.conditioning.world_scenario.data_utils import (
+    FLU_TO_RDF_MATRIX,
+    convert_pose_flu_to_rdf,
+)
 from alpadreams.conditioning.world_scenario.ftheta import FThetaCamera
 from alpadreams.conditioning.world_scenario.settings import SETTINGS
 from google.protobuf.json_format import MessageToDict
@@ -435,18 +438,54 @@ def compute_camera_poses_from_rig(
 
         camera_to_world[t] = rig_to_world[t]  @  rig_to_camera
 
+    The gRPC client sends both ``rig_poses`` and ``rig_to_camera`` in the
+    FLU convention. flashdreams' :class:`ClipGTLoader` stores the entire
+    HD-map scene in OpenCV RDF (``scene_data.metadata['coordinate_frame']
+    == 'opencv_rdf'``), so the camera poses we hand to ``LudusRenderer``
+    must also be in RDF; otherwise the camera and the world disagree by
+    a 90 degrees rotation and the rendered HD map looks like the camera
+    is underground / driving sideways. Apply the FLU -> RDF basis change
+    here, after the matmul, so callers don't have to remember.
+
     Args:
-        rig_poses: Array of shape ``[N, 4, 4]`` — rig-to-world transforms per frame.
-        rig_to_camera: A single ``[4, 4]`` rig-to-camera transform.
+        rig_poses: Array of shape ``[N, 4, 4]`` — rig-to-world transforms per
+            frame, in the client's FLU convention.
+        rig_to_camera: A single ``[4, 4]`` rig-to-camera transform, also in FLU.
 
     Returns:
-        Array of shape ``[N, 4, 4]`` — camera-to-world transforms per frame.
+        Array of shape ``[N, 4, 4]`` — camera-to-world transforms per frame in
+        OpenCV RDF.
     """
-    # Vectorised matmul over the batch dimension
     if isinstance(rig_poses, torch.Tensor):
-        return torch.einsum("nij,jk->nik", rig_poses, rig_to_camera)
+        camera_to_world_flu = torch.einsum("nij,jk->nik", rig_poses, rig_to_camera)
+        flu_to_rdf = torch.tensor(
+            FLU_TO_RDF_MATRIX, dtype=camera_to_world_flu.dtype, device=camera_to_world_flu.device
+        )
+        rdf_to_flu = flu_to_rdf.transpose(-1, -2)
+        # Basis change: pose_rdf = M @ pose_flu @ M^T (with the homogeneous
+        # row left untouched). Translation rotates by M; rotation conjugates.
+        rotation_flu = camera_to_world_flu[:, :3, :3]
+        translation_flu = camera_to_world_flu[:, :3, 3]
+        rotation_rdf = torch.einsum("ij,njk,kl->nil", flu_to_rdf, rotation_flu, rdf_to_flu)
+        translation_rdf = torch.einsum("ij,nj->ni", flu_to_rdf, translation_flu)
+        camera_to_world_rdf = torch.zeros_like(camera_to_world_flu)
+        camera_to_world_rdf[:, :3, :3] = rotation_rdf
+        camera_to_world_rdf[:, :3, 3] = translation_rdf
+        camera_to_world_rdf[:, 3, 3] = 1.0
+        return camera_to_world_rdf
     else:
-        return np.einsum("nij,jk->nik", rig_poses, rig_to_camera).astype(np.float32)
+        camera_to_world_flu = np.einsum("nij,jk->nik", rig_poses, rig_to_camera).astype(np.float32)
+        rotation_flu = camera_to_world_flu[:, :3, :3]
+        translation_flu = camera_to_world_flu[:, :3, 3]
+        rotation_rdf = np.einsum(
+            "ij,njk,kl->nil", FLU_TO_RDF_MATRIX, rotation_flu, FLU_TO_RDF_MATRIX.T
+        )
+        translation_rdf = np.einsum("ij,nj->ni", FLU_TO_RDF_MATRIX, translation_flu)
+        camera_to_world_rdf = np.zeros_like(camera_to_world_flu)
+        camera_to_world_rdf[:, :3, :3] = rotation_rdf
+        camera_to_world_rdf[:, :3, 3] = translation_rdf
+        camera_to_world_rdf[:, 3, 3] = 1.0
+        return camera_to_world_rdf.astype(np.float32)
 
 
 # =============================================================================

--- a/integrations/alpadreams/pyproject.toml
+++ b/integrations/alpadreams/pyproject.toml
@@ -26,21 +26,21 @@ requires-python = ">=3.12"
 dependencies = [
     "flashdreams",
     "mediapy>=1.1",
-    "ludus-renderer==0.5.0+cuda",
+    "slangpy>=0.7.0",
+    "torchvision>=0.22",
     "grpcio-tools",
     "grpcio",
     "opencv-python-headless",
-    "shapely"
+    "shapely",
+    # Previously transitive via ludus-renderer; now declared directly.
+    "scipy>=1.11",
+    "pandas>=2.1",
+    "pyarrow>=14",
+    "imageio>=2.34",
 ]
 
 [tool.uv.sources]
 flashdreams = { workspace = true }
-ludus-renderer = { index = "ludus_renderer_gitlab" }
-
-[[tool.uv.index]]
-name = "ludus_renderer_gitlab"
-url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple"
-explicit = true
 
 [project.optional-dependencies]
 dev = [
@@ -50,3 +50,6 @@ dev = [
 
 [tool.setuptools.packages.find]
 exclude = ["tests"]
+
+[tool.setuptools.package-data]
+"alpadreams.conditioning.slang_renderer" = ["slang/*.slang"]

--- a/integrations/alpadreams/scripts/render_hdmap_preview.py
+++ b/integrations/alpadreams/scripts/render_hdmap_preview.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render a short HD-map preview using the SlangPy rasterizer.
+
+Standalone script for verifying that the new SlangPy-based
+:class:`LudusRenderer` produces sensible HD-map conditioning frames. Runs
+the rasterizer directly (no gRPC server, no video model), feeds it a
+CLIPGT scene + the ego trajectory as camera poses, and writes the result
+out as an MP4 + the first frame as a PNG so you can eyeball it.
+
+Example::
+
+    # Inside the docker container, after running `bash assets/download.sh`
+    uv run --package flash-alpadreams \\
+      python integrations/alpadreams/scripts/render_hdmap_preview.py
+
+    # With explicit args
+    uv run --package flash-alpadreams \\
+      python integrations/alpadreams/scripts/render_hdmap_preview.py \\
+        --scene assets/example_data/alpadreams/clipgt.zip \\
+        --output outputs/hdmap_preview.mp4 \\
+        --frames 90 --stride 5 --fps 15
+
+The first run is slow because SlangPy compiles the kernels on demand;
+subsequent runs hit the shader cache.
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+import zipfile
+from pathlib import Path
+
+import mediapy
+import numpy as np
+import torch
+from alpadreams.conditioning.renderer import LudusRenderer, load_and_attach_ludus_scene
+from alpadreams.conditioning.world_scenario.data_loaders import load_scene
+from alpadreams.conditioning.world_scenario.ftheta import FThetaCamera
+from scipy.spatial.transform import Rotation
+
+# flashdreams' ClipGTLoader stores ego poses with `double_sided=True`
+# basis change, so both the local frame and the world frame are OpenCV
+# RDF. The slang shader also expects RDF (camera +x=right, +y=down,
+# +z=forward). So we can pass ego_to_world straight through as
+# camera_to_world -- no rig_to_camera basis change is needed for this
+# script's synthetic pinhole camera.
+
+DEFAULT_SCENE = Path("assets/example_data/alpadreams/clipgt.zip")
+DEFAULT_OUTPUT = Path("outputs/hdmap_preview.mp4")
+DEFAULT_CAMERA = "camera_front_wide_120fov"
+
+# Mount the synthetic camera 1.5 m above the rig origin (typical dashcam
+# height). Without this offset the camera ends up at the rig's local
+# y=0 -- which in CLIPGT's RDF data is essentially "vehicle-origin
+# altitude", *not* "1.5 m above the road surface". Real road geometry
+# (lane lines, crosswalks, road islands, ...) sits at y ≈ 0 too, so
+# without the offset the camera is at the same vertical level as the
+# road and ground polygons collapse into thin horizontal slices that
+# fan out across the screen.
+_CAMERA_HEIGHT_M = 1.5
+
+
+def _make_default_camera(width: int, height: int) -> FThetaCamera:
+    """Build a 120-FOV F-theta camera at the requested framebuffer size."""
+    f = width / (2.0 * np.radians(60.0))
+    intrinsics = np.array(
+        [width / 2.0, height / 2.0, width, height, f, 0, 0, 0, 0, 0, 0.0, 1.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    return FThetaCamera.from_numpy(intrinsics)
+
+
+def _ego_poses_to_camera_matrices(
+    ego_poses: list, count: int, stride: int, camera_height_m: float
+) -> tuple[np.ndarray, list[int]]:
+    """Sample every Nth ego pose and convert to camera-to-world matrices.
+
+    flashdreams' loader stores ego poses in RDF (with double-sided basis
+    change), so we use them directly as ``camera_to_world``. We bake a
+    ``rig_to_camera`` translation of (0, -camera_height_m, 0) -- minus
+    Y in RDF means UP -- to lift the camera off the rig origin.
+    """
+    selected = ego_poses[: count * stride : stride]
+    if len(selected) == 0:
+        raise RuntimeError(
+            f"Scene has no ego poses (or stride {stride} skipped them all). "
+            f"Got {len(ego_poses)} total poses."
+        )
+    rig_to_camera = np.eye(4, dtype=np.float32)
+    rig_to_camera[:3, 3] = np.array([0.0, -camera_height_m, 0.0], dtype=np.float32)
+
+    matrices = []
+    timestamps: list[int] = []
+    for ego in selected:
+        rot = Rotation.from_quat(ego.orientation).as_matrix().astype(np.float32)
+        rig_to_world = np.eye(4, dtype=np.float32)
+        rig_to_world[:3, :3] = rot
+        rig_to_world[:3, 3] = np.asarray(ego.position, dtype=np.float32)
+        camera_to_world = rig_to_world @ rig_to_camera
+        matrices.append(camera_to_world)
+        timestamps.append(int(ego.timestamp))
+    return np.stack(matrices, axis=0).astype(np.float32), timestamps
+
+
+def _open_scene(scene_path: Path) -> tuple[Path, "tempfile.TemporaryDirectory[str] | None"]:
+    """If ``scene_path`` is a zip, extract to a temp dir; otherwise return it as-is."""
+    if scene_path.is_dir():
+        return scene_path, None
+    if scene_path.suffix == ".zip":
+        tmp = tempfile.TemporaryDirectory()
+        extract_dir = Path(tmp.name) / "scene"
+        extract_dir.mkdir()
+        with zipfile.ZipFile(scene_path) as zf:
+            zf.extractall(extract_dir)
+        children = list(extract_dir.iterdir())
+        # Some clipgt zips wrap their contents in a single subdirectory.
+        data_path = children[0] if len(children) == 1 and children[0].is_dir() else extract_dir
+        return data_path, tmp
+    raise FileNotFoundError(f"Scene path is neither a directory nor a zip: {scene_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--scene", type=Path, default=DEFAULT_SCENE,
+                        help=f"CLIPGT zip or directory (default: {DEFAULT_SCENE})")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT,
+                        help=f"MP4 output path (default: {DEFAULT_OUTPUT})")
+    parser.add_argument("--camera-name", default=DEFAULT_CAMERA,
+                        help="Camera name passed to load_scene")
+    parser.add_argument("--width", type=int, default=1280)
+    parser.add_argument("--height", type=int, default=704)
+    parser.add_argument("--frames", type=int, default=60,
+                        help="How many frames to render")
+    parser.add_argument("--stride", type=int, default=10,
+                        help="Subsample the ego trajectory by this stride")
+    parser.add_argument("--fps", type=int, default=10,
+                        help="Output video FPS")
+    parser.add_argument("--camera-height-m", type=float, default=_CAMERA_HEIGHT_M,
+                        help=f"Camera mount height above the rig origin (default: {_CAMERA_HEIGHT_M})")
+    args = parser.parse_args()
+
+    if not args.scene.exists():
+        raise SystemExit(
+            f"Scene not found at {args.scene}. Run `bash assets/download.sh` "
+            "to fetch the bundled example, or pass --scene explicitly."
+        )
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required (the SlangPy rasterizer renders on GPU).")
+
+    device = torch.device("cuda")
+    data_path, tmp_holder = _open_scene(args.scene)
+    try:
+        scene_data = load_scene(
+            data_path,
+            camera_names=[args.camera_name],
+            max_frames=-1,
+            input_pose_fps=30,
+            resize_resolution_hw=[args.height, args.width],
+        )
+        scene_data = load_and_attach_ludus_scene(data_path, scene_data, device=device)
+
+        print(f"Scene id            : {scene_data.scene_id}")
+        print(f"Ego poses           : {len(scene_data.ego_poses)}")
+        print(f"Lane lines          : {len(scene_data.lane_lines)}")
+        print(f"Road boundaries    : {len(scene_data.road_boundaries)}")
+        print(f"Crosswalks          : {len(scene_data.crosswalks)}")
+        print(f"Road markings       : {len(scene_data.road_markings)}")
+        print(f"Wait lines          : {len(scene_data.wait_lines)}")
+        print(f"Poles               : {len(scene_data.poles)}")
+        print(f"Traffic signs       : {len(scene_data.traffic_signs)}")
+        print(f"Traffic lights      : {len(scene_data.traffic_lights)}")
+        print(f"Intersection areas : {len(scene_data.intersection_areas)}")
+        print(f"Road islands        : {len(scene_data.road_islands)}")
+
+        # Prefer the real camera calibration from the scene if present;
+        # the loader populates ``scene_data.camera_models`` with intrinsics
+        # parsed from the CLIPGT calibration parquet (right cx/cy, full
+        # F-theta polynomial, real lens distortion, real sensor_to_rig
+        # transform). Falling back to a synthetic 120 FOV pinhole
+        # would mismatch every CLIPGT-recorded frame and especially
+        # break for fisheye / wide-angle automotive cameras.
+        loaded_camera = scene_data.camera_models.get(args.camera_name)
+        if isinstance(loaded_camera, FThetaCamera):
+            print(
+                f"Using calibrated camera '{args.camera_name}' from scene"
+                f" (width={loaded_camera.width}, height={loaded_camera.height})"
+            )
+            if loaded_camera.height != args.height or loaded_camera.width != args.width:
+                scale_h = args.height / loaded_camera.height
+                scale_w = args.width / loaded_camera.width
+                loaded_camera = FThetaCamera.from_numpy(loaded_camera.intrinsics.copy())
+                loaded_camera.rescale(ratio_h=scale_h, ratio_w=scale_w)
+            camera = loaded_camera
+        else:
+            print("Scene has no calibrated camera; using synthetic 120 FOV pinhole.")
+            camera = _make_default_camera(args.width, args.height)
+        renderer = LudusRenderer(
+            scene_data=scene_data,
+            camera_models={args.camera_name: camera},
+            device=device,
+        )
+
+        coordinate_frame = str(scene_data.metadata.get("coordinate_frame", "flu"))
+        print(f"Coordinate frame    : {coordinate_frame}")
+        print(f"Camera mount height : {args.camera_height_m} m above rig origin")
+        camera_poses_np, timestamps = _ego_poses_to_camera_matrices(
+            scene_data.ego_poses,
+            count=args.frames,
+            stride=args.stride,
+            camera_height_m=args.camera_height_m,
+        )
+        # Print the bounding range of every layer's vertices and the
+        # first ego pose. With the loader storing everything in OpenCV
+        # RDF, expect: x range = horizontal extent (right is +), y range
+        # ~= 0 (ground) for road geometry / negative for ego (above
+        # ground), z range = forward extent.
+        ego0 = scene_data.ego_poses[0]
+        print(f"Ego[0] position rdf: {tuple(ego0.position.tolist())}")
+        print(f"Ego[0] orientation : {tuple(ego0.orientation.tolist())} (xyzw)")
+        forward_axis_world = (
+            Rotation.from_quat(ego0.orientation).as_matrix()[:, 2].tolist()
+        )
+        print(f"Ego[0] +Z (forward): {forward_axis_world}")
+        print(f"Camera[0] world pos: ({camera_poses_np[0, 0, 3]:.3f}, "
+              f"{camera_poses_np[0, 1, 3]:.3f}, {camera_poses_np[0, 2, 3]:.3f})")
+        all_y = []
+        if scene_data.lane_lines:
+            for ll in scene_data.lane_lines[:5]:
+                if ll.points.size:
+                    all_y.append(("laneline", ll.points[:, 1].min(), ll.points[:, 1].max()))
+        if scene_data.crosswalks:
+            for cw in scene_data.crosswalks[:5]:
+                if cw.vertices.size:
+                    all_y.append(("crosswalk", cw.vertices[:, 1].min(), cw.vertices[:, 1].max()))
+        if scene_data.road_boundaries:
+            for rb in scene_data.road_boundaries[:5]:
+                if rb.points.size:
+                    all_y.append(("road_bound", rb.points[:, 1].min(), rb.points[:, 1].max()))
+        for name, ymin, ymax in all_y:
+            print(f"  {name:12s} y range = [{ymin:.2f}, {ymax:.2f}]")
+        print(f"Rendering {len(timestamps)} frames at {args.width}x{args.height}...")
+        camera_poses = torch.from_numpy(camera_poses_np).to(device)
+
+        rendered = renderer.render_all_frames_and_cameras(
+            camera_names=[args.camera_name],
+            camera_poses_per_camera={args.camera_name: camera_poses},
+            frame_timestamps_us=timestamps,
+        )
+        # rendered shape: [V, T, 3, H, W] uint8 on CUDA.
+        frames_hwc = rendered[0].permute(0, 2, 3, 1).cpu().numpy()
+        print(f"Rendered tensor: shape={tuple(rendered.shape)} dtype={rendered.dtype}")
+
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        mediapy.write_video(args.output, frames_hwc, fps=args.fps)
+        print(f"Wrote video    : {args.output}")
+
+        png_path = args.output.with_suffix(".png")
+        mediapy.write_image(png_path, frames_hwc[0])
+        print(f"Wrote first frame: {png_path}")
+    finally:
+        if tmp_holder is not None:
+            tmp_holder.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ invalid-method-override = "ignore"
 
 [tool.ty.analysis]
 # These packages have no type stubs or are unavailable in CI; treat imports as Any
-replace-imports-with-any = ["transformer_engine.**", "ludus_renderer.**"]
+replace-imports-with-any = ["transformer_engine.**", "slangpy.**"]
 
 [dependency-groups]
 lint = ["pre-commit>=4.3.0", "ty>=0.0.33"]

--- a/uv.lock
+++ b/uv.lock
@@ -535,12 +535,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ffmpeg"
-version = "1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz", hash = "sha256:6931692c890ff21d39938433c2189747815dca0c60ddc7f9bb97f199dba0b5b9", size = 5055, upload-time = "2018-10-08T07:50:05.748Z" }
-
-[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -557,10 +551,16 @@ dependencies = [
     { name = "flashdreams" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
-    { name = "ludus-renderer" },
+    { name = "imageio" },
     { name = "mediapy" },
     { name = "opencv-python-headless" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "scipy" },
     { name = "shapely" },
+    { name = "slangpy" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -574,12 +574,17 @@ requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
-    { name = "ludus-renderer", specifier = "==0.5.0+cuda", index = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple" },
+    { name = "imageio", specifier = ">=2.34" },
     { name = "mediapy", specifier = ">=1.1" },
     { name = "opencv-python-headless" },
+    { name = "pandas", specifier = ">=2.1" },
+    { name = "pyarrow", specifier = ">=14" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-manual-marker", marker = "extra == 'dev'" },
+    { name = "scipy", specifier = ">=1.11" },
     { name = "shapely" },
+    { name = "slangpy", specifier = ">=0.7.0" },
+    { name = "torchvision", specifier = ">=0.22" },
 ]
 provides-extras = ["dev"]
 
@@ -1010,30 +1015,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ludus-renderer"
-version = "0.5.0+cuda"
-source = { registry = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple" }
-dependencies = [
-    { name = "ffmpeg" },
-    { name = "imageio" },
-    { name = "ninja" },
-    { name = "numpy" },
-    { name = "opencv-python" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "pyarrow" },
-    { name = "pynvvideocodec" },
-    { name = "scipy" },
-    { name = "setuptools" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/files/99403b745029880c011c287903b744ab3dde5400eaf7305af7df8c79f85f97da/ludus_renderer-0.5.0+cuda.tar.gz", hash = "sha256:99403b745029880c011c287903b744ab3dde5400eaf7305af7df8c79f85f97da" }
-wheels = [
-    { url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/files/0f1f32f34ac4d7472bb8b447ed36ec19c8a30e50f7c5568cd1b7fc4bccc2c926/ludus_renderer-0.5.0+cuda-py3-none-any.whl", hash = "sha256:0f1f32f34ac4d7472bb8b447ed36ec19c8a30e50f7c5568cd1b7fc4bccc2c926" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1183,32 +1164,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
-]
-
-[[package]]
-name = "ninja"
-version = "1.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/73/79a0b22fc731989c708068427579e840a6cf4e937fe7ae5c5d0b7356ac22/ninja-1.13.0.tar.gz", hash = "sha256:4a40ce995ded54d9dc24f8ea37ff3bf62ad192b547f6c7126e7e25045e76f978", size = 242558, upload-time = "2025-08-11T15:10:19.421Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/74/d02409ed2aa865e051b7edda22ad416a39d81a84980f544f8de717cab133/ninja-1.13.0-py3-none-macosx_10_9_universal2.whl", hash = "sha256:fa2a8bfc62e31b08f83127d1613d10821775a0eb334197154c4d6067b7068ff1", size = 310125, upload-time = "2025-08-11T15:09:50.971Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/de/6e1cd6b84b412ac1ef327b76f0641aeb5dcc01e9d3f9eee0286d0c34fd93/ninja-1.13.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3d00c692fb717fd511abeb44b8c5d00340c36938c12d6538ba989fe764e79630", size = 177467, upload-time = "2025-08-11T15:09:52.767Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/83/49320fb6e58ae3c079381e333575fdbcf1cca3506ee160a2dcce775046fa/ninja-1.13.0-py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:be7f478ff9f96a128b599a964fc60a6a87b9fa332ee1bd44fa243ac88d50291c", size = 187834, upload-time = "2025-08-11T15:09:54.115Z" },
-    { url = "https://files.pythonhosted.org/packages/56/c7/ba22748fb59f7f896b609cd3e568d28a0a367a6d953c24c461fe04fc4433/ninja-1.13.0-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:60056592cf495e9a6a4bea3cd178903056ecb0943e4de45a2ea825edb6dc8d3e", size = 202736, upload-time = "2025-08-11T15:09:55.745Z" },
-    { url = "https://files.pythonhosted.org/packages/79/22/d1de07632b78ac8e6b785f41fa9aad7a978ec8c0a1bf15772def36d77aac/ninja-1.13.0-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:1c97223cdda0417f414bf864cfb73b72d8777e57ebb279c5f6de368de0062988", size = 179034, upload-time = "2025-08-11T15:09:57.394Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/de/0e6edf44d6a04dabd0318a519125ed0415ce437ad5a1ec9b9be03d9048cf/ninja-1.13.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fb46acf6b93b8dd0322adc3a4945452a4e774b75b91293bafcc7b7f8e6517dfa", size = 180716, upload-time = "2025-08-11T15:09:58.696Z" },
-    { url = "https://files.pythonhosted.org/packages/54/28/938b562f9057aaa4d6bfbeaa05e81899a47aebb3ba6751e36c027a7f5ff7/ninja-1.13.0-py3-none-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4be9c1b082d244b1ad7ef41eb8ab088aae8c109a9f3f0b3e56a252d3e00f42c1", size = 146843, upload-time = "2025-08-11T15:10:00.046Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fb/d06a3838de4f8ab866e44ee52a797b5491df823901c54943b2adb0389fbb/ninja-1.13.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6739d3352073341ad284246f81339a384eec091d9851a886dfa5b00a6d48b3e2", size = 154402, upload-time = "2025-08-11T15:10:01.657Z" },
-    { url = "https://files.pythonhosted.org/packages/31/bf/0d7808af695ceddc763cf251b84a9892cd7f51622dc8b4c89d5012779f06/ninja-1.13.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11be2d22027bde06f14c343f01d31446747dbb51e72d00decca2eb99be911e2f", size = 552388, upload-time = "2025-08-11T15:10:03.349Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/70/c99d0c2c809f992752453cce312848abb3b1607e56d4cd1b6cded317351a/ninja-1.13.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aa45b4037b313c2f698bc13306239b8b93b4680eb47e287773156ac9e9304714", size = 472501, upload-time = "2025-08-11T15:10:04.735Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/43/c217b1153f0e499652f5e0766da8523ce3480f0a951039c7af115e224d55/ninja-1.13.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f8e1e8a1a30835eeb51db05cf5a67151ad37542f5a4af2a438e9490915e5b72", size = 638280, upload-time = "2025-08-11T15:10:06.512Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/45/9151bba2c8d0ae2b6260f71696330590de5850e5574b7b5694dce6023e20/ninja-1.13.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:3d7d7779d12cb20c6d054c61b702139fd23a7a964ec8f2c823f1ab1b084150db", size = 642420, upload-time = "2025-08-11T15:10:08.35Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fb/95752eb635bb8ad27d101d71bef15bc63049de23f299e312878fc21cb2da/ninja-1.13.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:d741a5e6754e0bda767e3274a0f0deeef4807f1fec6c0d7921a0244018926ae5", size = 585106, upload-time = "2025-08-11T15:10:09.818Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/31/aa56a1a286703800c0cbe39fb4e82811c277772dc8cd084f442dd8e2938a/ninja-1.13.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:e8bad11f8a00b64137e9b315b137d8bb6cbf3086fbdc43bf1f90fd33324d2e96", size = 707138, upload-time = "2025-08-11T15:10:11.366Z" },
-    { url = "https://files.pythonhosted.org/packages/34/6f/5f5a54a1041af945130abdb2b8529cbef0cdcbbf9bcf3f4195378319d29a/ninja-1.13.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b4f2a072db3c0f944c32793e91532d8948d20d9ab83da9c0c7c15b5768072200", size = 581758, upload-time = "2025-08-11T15:10:13.295Z" },
-    { url = "https://files.pythonhosted.org/packages/95/97/51359c77527d45943fe7a94d00a3843b81162e6c4244b3579fe8fc54cb9c/ninja-1.13.0-py3-none-win32.whl", hash = "sha256:8cfbb80b4a53456ae8a39f90ae3d7a2129f45ea164f43fadfa15dc38c4aef1c9", size = 267201, upload-time = "2025-08-11T15:10:15.158Z" },
-    { url = "https://files.pythonhosted.org/packages/29/45/c0adfbfb0b5895aa18cec400c535b4f7ff3e52536e0403602fc1a23f7de9/ninja-1.13.0-py3-none-win_amd64.whl", hash = "sha256:fb8ee8719f8af47fed145cced4a85f0755dd55d45b2bddaf7431fa89803c5f3e", size = 309975, upload-time = "2025-08-11T15:10:16.697Z" },
-    { url = "https://files.pythonhosted.org/packages/df/93/a7b983643d1253bb223234b5b226e69de6cda02b76cdca7770f684b795f5/ninja-1.13.0-py3-none-win_arm64.whl", hash = "sha256:3c0b40b1f0bba764644385319028650087b4c1b18cdfa6f45cb39a3669b81aa9", size = 290806, upload-time = "2025-08-11T15:10:18.018Z" },
 ]
 
 [[package]]
@@ -1472,24 +1427,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/99/fd948eba63ba65b52265a4cd09a14f96bb9f5b730fcef58876c4358bf406/onnxscript-0.7.0.tar.gz", hash = "sha256:c95ed7b339b02cface56ee27689565c46612e1fc542c562298dddfdad5268dc5", size = 612032, upload-time = "2026-04-20T17:09:19.775Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/ce/2ed92575cc3be4ea1db5f38f16f20765f9b20b69b14d6c1d9972658a8ee9/onnxscript-0.7.0-py3-none-any.whl", hash = "sha256:5b356907d4501e9919f8599c91d8da967406a37b1fac2b40caa55a49acf242ea", size = 714842, upload-time = "2026-04-20T17:09:22.089Z" },
-]
-
-[[package]]
-name = "opencv-python"
-version = "4.13.0.92"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ac/6c98c44c650b8114a0fb901691351cfb3956d502e8e9b5cd27f4ee7fbf2f/opencv_python-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:5868a8c028a0b37561579bfb8ac1875babdc69546d236249fff296a8c010ccf9", size = 32568781, upload-time = "2026-02-05T07:01:41.379Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/51/82fed528b45173bf629fa44effb76dff8bc9f4eeaee759038362dfa60237/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bc2596e68f972ca452d80f444bc404e08807d021fbba40df26b61b18e01838a", size = 47685527, upload-time = "2026-02-05T06:59:11.24Z" },
-    { url = "https://files.pythonhosted.org/packages/db/07/90b34a8e2cf9c50fe8ed25cac9011cde0676b4d9d9c973751ac7616223a2/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:402033cddf9d294693094de5ef532339f14ce821da3ad7df7c9f6e8316da32cf", size = 70460872, upload-time = "2026-02-05T06:59:19.162Z" },
-    { url = "https://files.pythonhosted.org/packages/02/6d/7a9cc719b3eaf4377b9c2e3edeb7ed3a81de41f96421510c0a169ca3cfd4/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bccaabf9eb7f897ca61880ce2869dcd9b25b72129c28478e7f2a5e8dee945616", size = 46708208, upload-time = "2026-02-05T06:59:15.419Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
 ]
 
 [[package]]
@@ -1827,16 +1764,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pynvvideocodec"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/e7/21cf5d01286aebfacad92f3a78f24c05b373d9bce754b689c5bb3a81bc9d/pynvvideocodec-2.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:af7e44d13cfb524626c72d947f12a3b192cfa1deb4b598a7778bd4aa1e6fd4ac", size = 46251588, upload-time = "2026-01-30T12:03:08.327Z" },
-    { url = "https://files.pythonhosted.org/packages/67/dd/99ab1d310aaadc7e20d434cf27b387a5a0878f1dfbb3788c365905647c7b/pynvvideocodec-2.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c317fbad725b1b81936b863edcd98920bc4be423b9965719657030359d7afe29", size = 36745131, upload-time = "2026-01-30T12:03:06.838Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/59/639cc6ba3a0cc9ff37b64b8bcc6ab063e562bd21c8d0b7294e215f8929ff/pynvvideocodec-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:09cdd222c761855cde9b05ddc13d21893473cebae50077eca20b4eac0fed8acb", size = 38533044, upload-time = "2026-01-30T12:03:10.507Z" },
-]
-
-[[package]]
 name = "pyopenssl"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2116,6 +2043,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slangpy"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/84/f8fad9695885030e4a9fbfde6106ef9fc669787d4edfdd8e9f1e5ddf410e/slangpy-0.41.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:8b88c38ea5a00421bdf8eccce9dd3bb6395c4d183b257649d62497fe76a540dc", size = 36047392, upload-time = "2026-04-16T04:52:16.717Z" },
+    { url = "https://files.pythonhosted.org/packages/47/12/64fceb1e98ec0cc55bfb2411cd9cc10a541c3fbbc2c1a7da8c873016d1d9/slangpy-0.41.0-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:dbbc984e8e819270f7eba52083807bcfeabce25d19ea4048341fe59977799751", size = 79752629, upload-time = "2026-04-16T04:52:20.393Z" },
+    { url = "https://files.pythonhosted.org/packages/50/5f/4b56a11ea85c8c6f1900ee28b7089d05e287ce29b2dbbb8617314aaee4ac/slangpy-0.41.0-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:7bdcfed10bd36b4a6a780aeb1fafee66e69f04f549c419d44bb6f4264fdaff23", size = 81286793, upload-time = "2026-04-16T04:52:24.467Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5d/f42b8bc17e75d488699a0ffb5ec0c92d0e09dd0faa76507b84f37338a2ff/slangpy-0.41.0-cp312-cp312-win_amd64.whl", hash = "sha256:84ce78b28b77c53423adac8096624351bafffbe9d967369121bc3166e5a41109", size = 77999008, upload-time = "2026-04-16T04:52:28.564Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The closed-source `cudaraster` C++/CUDA backend that ludus-renderer's CUDA path links against can't ship publicly, which has been blocking release of the Alpadreams gRPC server. This change drops the entire `ludus-renderer==0.5.0+cuda` dependency from `flash-alpadreams` and replaces both the HD-map rasterizer and the JPEG encoder with permissively-licensed alternatives:

- HD-map rasterizer: new `slang_renderer/` subpackage built on top of `slangpy`. Slang compute kernels (lifted from `references/omni-dreams-slangpy/samples/roaddreams`) handle line, triangle, and polygon raster + a per-pixel raytrace pass for near-camera polygons. The slangpy device is constructed via `spy.create_torch_device(...)` so it shares PyTorch's CUDA context; rendered RGBA8 lands in the same address space and is exposed back to PyTorch zero-copy via `Tensor.to_torch()`.
- JPEG encoder: `ludus_renderer.nvjpeg.encode(...)` → `torchvision.io.encode_jpeg(...)`.

The public API of `LudusRenderer` (class name, `__init__` signature, `render_all_frames_and_cameras`, `cleanup`, `load_and_attach_ludus_scene`) is preserved, so neither `AlpadreamsConditioningWrapper` nor `grpc/utils.py` need any changes — the SceneBundle is just attached to `scene_data.metadata['ludus_scene']` like the old SceneAdapter was.

Notable gotchas surfaced and fixed during bring-up:
* `FThetaCameraModel.__post_init__` branches on `reference_poly` because synthetic / single-coefficient forward polynomials make `_compute_bw_poly`'s least-squares inverse unstable, blowing up the angle→radius LUT.
* `triangulate_polygon_xy` auto-picks the dominant plane via `argmin(spread)` instead of always projecting onto (x, y); the flashdreams CLIPGT loader emits ground polygons in OpenCV RDF where y=0, and the original (x, y) projection collapsed every polygon to fan-triangulated wedges.
* `_box_has_null_geometry` and `_is_finite_polyline` guards on every layer builder + a final NaN guard at the GPU upload boundary, since a single non-finite vertex in the line/triangle buffers poisons the entire raster pass via NaN-vs-finite comparison failures (see https://gitlab-master.nvidia.com/sil/omni-dreams/-/commit/92091220).

Workspace + CI plumbing:
* `pyproject.toml` (workspace): drop `ludus_renderer.**` from ty's `replace-imports-with-any` list.
* `pyproject.toml` (alpadreams): drop `ludus-renderer==0.5.0+cuda` and the `ludus_renderer_gitlab` source/index, add `slangpy>=0.7.0`, `torchvision>=0.22`, and the previously-transitive deps (`scipy`, `pandas`, `pyarrow`, `imageio`).
* `.github/workflows/ci.yml`: drop the `--no-install-package ludus-renderer` workaround.
* `uv.lock`: regenerated; `slangpy` 0.41.0 resolved from PyPI.

Also adds `integrations/alpadreams/scripts/render_hdmap_preview.py` which renders an HD-map preview MP4 + first-frame PNG from a CLIPGT scene without standing up the gRPC server, useful for spot-checking the rasterizer and visual parity vs the old ludus path.

Known parity gaps (unchanged from migration plan):
* MSAA: ludus path ran 4x; the Slang software rasterizer ships without AA in v1. Add 2x supersample if diffusion output regresses.
* bbox tracks / dynamic geometry: not ported (default flashdreams config doesn't use them).
* Performance: compute-shader raster is likely slower than CudaRaster; benchmark on representative batch sizes before tuning.

Made-with: Cursor