### PR TITLE
[Verification] Lingbot world implementation details align with public code

### DIFF
--- a/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/fm.py
@@ -59,13 +59,26 @@ class FlowMatchSchedulerConfig(SchedulerConfig):
     num_train_timesteps: int = 1000
     """Length of the training sigma table."""
 
+    sigma_max: float = 1.0
+    """Top of the linspace before warping; ``1.0`` matches DiffSynth, upstream
+    Wan / Lingbot ships ``0.999``."""
+
     sigma_min: float = 0.0
-    """Floor of the warped sigma schedule. Only ``0.0`` is supported here;
-    asserted at construction."""
+    """Bottom of the linspace before warping. Reserved for upstream parity;
+    only ``0.0`` is exercised."""
 
     extra_one_step: bool = True
-    """Append the ``sigma=0`` step to the schedule. Only ``True`` is
-    supported here; asserted at construction."""
+    """If ``True``, build the schedule from
+    ``linspace(sigma_max, sigma_min, N+1)[:-1]`` (matches DiffSynth /
+    upstream Wan); ``False`` uses ``N`` points and is kept for non-Wan
+    recipes."""
+
+    timestep_dtype: torch.dtype = torch.float32
+    """Dtype of ``denoising_step_list``. Set to an integer dtype (e.g.
+    ``torch.int64``) when the network's time embedding is sensitive to the
+    fractional part of the warped timestep — upstream Wan stores
+    ``scheduler.timesteps`` as ``int64`` and lets the embedding upcast to
+    ``float64`` internally."""
 
 
 class FlowMatchScheduler(Scheduler):
@@ -109,17 +122,19 @@ class FlowMatchScheduler(Scheduler):
             f"num_inference_steps ({config.num_inference_steps}) must equal "
             f"len(denoising_timesteps) ({len(config.denoising_timesteps)})"
         )
-        assert config.extra_one_step, "extra_one_step=False not exercised; not ported"
-        assert config.sigma_min == 0.0, "sigma_min != 0 not exercised; not ported"
-
         # Full warped schedule: identical to DiffSynth's
         #   sigmas = linspace(1, 0, N + 1)[:-1]
         #   sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
         # (matches reference exactly in fp32).
-        full_sigmas = _warp(
-            torch.linspace(1.0, 0.0, N + 1, dtype=torch.float32)[:-1],
-            config.shift,
-        )
+        if config.extra_one_step:
+            sigmas = torch.linspace(
+                config.sigma_max, config.sigma_min, N + 1, dtype=torch.float32
+            )[:-1]
+        else:
+            sigmas = torch.linspace(
+                config.sigma_max, config.sigma_min, N, dtype=torch.float32
+            )
+        full_sigmas = _warp(sigmas, config.shift)
         full_timesteps = full_sigmas * N
 
         # Pre-resolve per-step (sigma, timestep) so sample() does no
@@ -151,7 +166,7 @@ class FlowMatchScheduler(Scheduler):
         # the sigma table.
         self.register_buffer(
             "denoising_step_list",
-            torch.tensor(step_list, dtype=torch.float32),
+            torch.tensor(step_list, dtype=config.timestep_dtype),
             persistent=False,
         )
         self.register_buffer(

--- a/flashdreams/flashdreams/recipes/lingbot_world/config.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/config.py
@@ -28,14 +28,13 @@ from __future__ import annotations
 
 from typing import cast
 
+import torch
+
 from flashdreams.configs.registry import register_runner
 from flashdreams.infra.config import derive_config
 from flashdreams.infra.diffusion.model import DiffusionModelConfig
 from flashdreams.infra.diffusion.scheduler.fm import FlowMatchSchedulerConfig
 from flashdreams.infra.runner import RunnerConfig
-from flashdreams.recipes.alpadreams.encoder.pixel_shuffle import (
-    PixelShuffleVAEEncoderConfig,
-)
 from flashdreams.recipes.lingbot_world.encoder.camctrl import (
     I2VCamCtrlEncoderConfig,
 )
@@ -61,6 +60,21 @@ AVAILABLE_LINGBOT_WORLD_CHECKPOINT_PATHS: dict[str, str] = {
     "LingBot-World-Fast": "https://huggingface.co/robbyant/lingbot-world-fast/blob/main/diffusion_pytorch_model.safetensors.index.json",
 }
 
+
+## Canonical Lingbot World streaming defaults
+
+_DEFAULT_DENOISING_TIMESTEPS = [1000, 1000 - 179, 1000 - 358, 1000 - 679]
+"""Upstream Fast 4-step distilled schedule (matches the LingBot-World-Fast checkpoint)."""
+
+_DEFAULT_NUM_TRAIN_TIMESTEPS = 1000
+"""Length of the training sigma table the schedule warps against."""
+
+_DEFAULT_BATCH_SHAPE: tuple[int, ...] = (1, 1)
+"""Single-view, single-batch streaming layout ``[B=1, V=1]``."""
+
+_DEFAULT_LEN_T_LATENT = 3
+"""Latent frames the transformer consumes per AR chunk."""
+
 DEFAULT_VIDEO_HEIGHT = 464
 """Canonical pixel-space height; callers pass the matching latent
 ``(height, width)`` into :meth:`WanInferencePipeline.initialize_cache`."""
@@ -81,9 +95,6 @@ LINGBOT_WORLD_FAST = LingbotWorldInferencePipelineConfig(
                 checkpoint_path=AVAILABLE_WAN_VAE_CHECKPOINT_PATHS["vae"],
             ),
         ),
-        plucker=PixelShuffleVAEEncoderConfig(
-            frame_selection_mode="last_frame",
-        ),
     ),
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(
@@ -92,42 +103,44 @@ LINGBOT_WORLD_FAST = LingbotWorldInferencePipelineConfig(
             network=LingbotWorldDiTNetwork14BConfig(
                 patch_embedding_type="conv3d",
                 control_type="cam",
+                # 16 noise channels + 4-channel mask + 16-channel image latent
+                # (channel-concat I2V layout). Must match the
+                # ``concat_image_mask_to_latent=True`` setting below.
                 in_dim=16 + 4 + 16,
             ),
             checkpoint_path=AVAILABLE_LINGBOT_WORLD_CHECKPOINT_PATHS[
                 "LingBot-World-Fast"
             ],
-            batch_shape=(1, 1),
-            len_t=3,
+            batch_shape=_DEFAULT_BATCH_SHAPE,
+            len_t=_DEFAULT_LEN_T_LATENT,
+            # CFG off by default to match the upstream Lingbot checkpoint.
             guidance_scale=1.0,
-            window_size_t=60,
+            window_size_t=63,
             sink_size_t=0,
+            # I2V channel-concat (mask + first-frame latent), not stamping.
             stamp_image_latent=False,
             concat_image_mask_to_latent=True,
             compile_network=True,
         ),
         scheduler=FlowMatchSchedulerConfig(
-            num_inference_steps=4,
-            denoising_timesteps=[999, 978, 947, 825],
-            warp_denoising_step=False,
-            shift=8.0,
+            num_inference_steps=len(_DEFAULT_DENOISING_TIMESTEPS),
+            denoising_timesteps=_DEFAULT_DENOISING_TIMESTEPS,
+            warp_denoising_step=True,
+            shift=10.0,
+            sigma_max=0.999,
             sigma_min=0.0,
             extra_one_step=True,
-            num_train_timesteps=1000,
+            num_train_timesteps=_DEFAULT_NUM_TRAIN_TIMESTEPS,
+            timestep_dtype=torch.int64,
         ),
     ),
 )
 """LingBot-World-Fast: streaming camera-control I2V chassis.
 
-Wan 2.1 14B with the camera-control block (LingbotWorldDiTNetwork14B).
-Composite per-AR-step encoder = Wan VAE I2V + Plücker PixelShuffle.
-Wan VAE decoder, 4-step distilled flow-match schedule
-``[999, 978, 947, 825]``. ``window_size_t=60`` / ``sink_size_t=0``
-are the upstream Lingbot Fast defaults.
-
-``in_dim = 16 + 4 + 16``: 16 noise channels + 4-channel mask +
-16-channel image latent (channel-concat I2V layout). Must match
-``concat_image_mask_to_latent=True``.
+Wan 2.1 14B with the camera-control block (LingbotWorldDiTNetwork14B),
+Wan VAE I2V encoder (Plücker volume rendered inline by the encoder),
+Wan VAE decoder, and the upstream Fast 4-step distilled flow-match
+schedule.
 """
 
 LINGBOT_WORLD_FAST_FLASH = cast(
@@ -144,10 +157,10 @@ LINGBOT_WORLD_FAST_FLASH = cast(
         ),
     ),
 )
-"""LingBot-World-Fast-Flash: TAEHV decoder + tighter streaming window.
+"""LingBot-World-Fast-Flash: lowest-latency preset.
 
-``window_size_t=15`` / ``sink_size_t=3`` and the LightTAE (TAEHV)
-decoder for the lowest-latency streaming preset.
+Swaps in the LightTAE (TAEHV) decoder and tightens the streaming
+window for fast interactive playback.
 """
 
 

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/camctrl.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""I2V control encoder with Plücker camera control for Lingbot World."""
+"""I2V + Plücker camera-control encoder for Lingbot World."""
 
 from __future__ import annotations
 
@@ -28,10 +28,6 @@ from flashdreams.infra.encoder import (
     EncoderConfig,
     StreamingEncoderCache,
     StreamingVideoEncoder,
-)
-from flashdreams.recipes.alpadreams.encoder.pixel_shuffle import (
-    PixelShuffleVAEEncoderCache,
-    PixelShuffleVAEEncoderConfig,
 )
 from flashdreams.recipes.wan.autoencoder.i2v import (
     I2VCtrl,
@@ -78,7 +74,8 @@ class I2VCamCtrlEmbeddings:
     """Output of the Wan-VAE I2V encoder branch."""
 
     plucker: Tensor
-    """Plücker pixel volume after the PixelShuffle encoder."""
+    """Plücker pixel volume of shape ``[..., T, 6 * 64, H/8, W/8]`` after the
+    inline 8x8 spatial unshuffle."""
 
     _is_patchified: bool = False
     """``True`` once the consuming transformer has patchified this payload in place."""
@@ -93,11 +90,6 @@ class I2VCamCtrlEncoderConfig(EncoderConfig):
     i2v: I2VCtrlEncoderConfig = field(default_factory=I2VCtrlEncoderConfig)
     """Config for the Wan-VAE I2V encoder branch."""
 
-    plucker: PixelShuffleVAEEncoderConfig = field(
-        default_factory=PixelShuffleVAEEncoderConfig
-    )
-    """Config for the PixelShuffle pseudo-VAE encoder applied to the Plücker volume."""
-
 
 @dataclass(kw_only=True)
 class I2VCamCtrlEncoderCache(StreamingEncoderCache):
@@ -106,26 +98,28 @@ class I2VCamCtrlEncoderCache(StreamingEncoderCache):
     i2v: I2VCtrlEncoderCache
     """Per-rollout cache for the I2V encoder branch."""
 
-    plucker: PixelShuffleVAEEncoderCache
-    """Per-rollout cache for the Plücker PixelShuffle encoder branch."""
-
     camera_last_pose: Tensor | None = None
     """Last-pose anchor used to make ``compute_relative_poses_causal``
     deterministic across AR steps; ``None`` at AR step 0."""
 
 
 class I2VCamCtrlEncoder(StreamingVideoEncoder[I2VCamCtrlEncoderCache]):
-    """Pairs a Wan-VAE I2V encoder with a PixelShuffle Plücker encoder."""
+    """Run the Wan-VAE I2V branch and render a per-AR-step Plücker volume.
+
+    The Plücker rendering selects the matching encoded frame inside each
+    ``temporal_compression_ratio``-sized window, computes framewise relative
+    poses anchored to the previous AR step, and unshuffles the result spatially
+    by 8x8 into channel dim — equivalent to the upstream Lingbot World pipeline
+    that runs Plücker through a PixelShuffle pseudo-VAE before the network.
+    """
 
     def __init__(self, config: I2VCamCtrlEncoderConfig) -> None:
         super().__init__(config)
         self.i2v_encoder = config.i2v.setup()
-        self.plucker_encoder = config.plucker.setup()
 
     def initialize_autoregressive_cache(self) -> I2VCamCtrlEncoderCache:
         return I2VCamCtrlEncoderCache(
             i2v=self.i2v_encoder.initialize_autoregressive_cache(),
-            plucker=self.plucker_encoder.initialize_autoregressive_cache(),
         )
 
     @torch.no_grad()
@@ -158,19 +152,31 @@ class I2VCamCtrlEncoder(StreamingVideoEncoder[I2VCamCtrlEncoderCache]):
             autoregressive_index=autoregressive_index,
             cache=cache.i2v,
         )
+
+        # keep the last frame of every 4 frames (the first frame is special)
+        # [0, 4, 8, 12, ...]
+        T = input.camctrl.poses.shape[-3]
+        chunk_size = self.temporal_compression_ratio
+        if autoregressive_index == 0:
+            indices = [0] + list(range(chunk_size, T, chunk_size))
+        else:
+            indices = list(range(chunk_size - 1, T, chunk_size))
+
+        intrinsics = input.camctrl.intrinsics[..., indices, :]
+        poses = input.camctrl.poses[..., indices, :, :]
+
         plucker = self._render_plucker(
             height=height,
             width=width,
-            intrinsics=input.camctrl.intrinsics,
-            poses=input.camctrl.poses,
+            intrinsics=intrinsics,
+            poses=poses,
             world_scale=input.camctrl.world_scale,
             cache=cache,
         )
-        plucker = self.plucker_encoder(
-            input=plucker,
-            autoregressive_index=autoregressive_index,
-            cache=cache.plucker,
+        plucker = rearrange(
+            plucker, "... t c (h h8) (w w8) -> ... t (c h8 w8) h w", h8=8, w8=8
         )
+
         return I2VCamCtrlEmbeddings(i2v=i2v, plucker=plucker)
 
     @property

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
@@ -15,8 +15,185 @@
 
 """Camera-pose math: SE(3) helpers, relative poses, and Plücker rays."""
 
+import numpy as np
 import torch
+from scipy.interpolate import interp1d
+from scipy.spatial.transform import Rotation, Slerp
 from torch import Tensor
+
+## Lingbot World example-data preprocessing
+
+_TEMPORAL_COMPRESSION_RATIO = 4
+"""Lingbot World VAE temporal stride; one encoded frame per N video frames."""
+
+_TRANSFORMER_LEN_T = 3
+"""Latent frames the transformer consumes per AR chunk."""
+
+
+def preprocess_example_poses(poses: np.ndarray) -> tuple[np.ndarray, float]:
+    """Preprocess the example poses carried over from the original Lingbot World repo.
+
+    Truncates the raw camera stream to the largest length compatible with
+    the AR-chunk grid, interpolates it down to the encoded length, computes
+    the world-scale normalizer on the encoded poses (matching upstream),
+    then re-expands the encoded poses back to per-pixel-frame cadence so
+    the encoder's stride-4 frame selection recovers the encoded sequence.
+
+    Args:
+        poses: Raw camera-to-world poses of shape ``[T, 4, 4]``.
+
+    Returns:
+        Tuple of ``(poses [T_clipped, 4, 4], world_scale)``.
+    """
+    assert poses.ndim == 3 and poses.shape[1:] == (4, 4), (
+        "Expected poses shape [T, 4, 4]"
+    )
+    T_raw = poses.shape[0]
+    T = (T_raw - 1) // _TEMPORAL_COMPRESSION_RATIO * _TEMPORAL_COMPRESSION_RATIO + 1
+    poses = poses[:T]
+
+    T_after_encoding = int((T - 1) // _TEMPORAL_COMPRESSION_RATIO) + 1
+    T_after_encoding = int(T_after_encoding - (T_after_encoding % _TRANSFORMER_LEN_T))
+
+    poses_after_encoding = interpolate_camera_poses(
+        src_indices=np.linspace(0, T - 1, T),
+        src_rot_mat=poses[:, :3, :3],
+        src_trans_vec=poses[:, :3, 3],
+        tgt_indices=np.linspace(0, T - 1, T_after_encoding),
+    )  # [T_after_encoding, 4, 4]
+
+    # Match upstream Lingbot World: world-scale normalizer is computed
+    # framewise on the *encoded-length* poses, not the raw stream.
+    _, trans_normalizer = compute_relative_poses(
+        torch.from_numpy(poses_after_encoding).float(),
+        framewise=True,
+        normalize_trans=True,
+    )
+
+    # Re-expand to per-pixel-frame cadence so the encoder's stride-4 frame
+    # selection ([0, 4, 8, ...] at AR step 0, [3, 7, 11, ...] later) recovers
+    # the encoded sequence exactly. The first encoded frame stays as the
+    # one-frame chunk; every subsequent encoded frame is repeated 4x.
+    poses = np.concatenate(
+        [
+            poses_after_encoding[:1],
+            np.repeat(poses_after_encoding[1:], _TEMPORAL_COMPRESSION_RATIO, axis=0),
+        ],
+        axis=0,
+    )  # [T, 4, 4]
+
+    # Sanity check that the encoder will recover the encoded poses.
+    indices = [0] + list(
+        range(_TEMPORAL_COMPRESSION_RATIO, poses.shape[0], _TEMPORAL_COMPRESSION_RATIO)
+    )
+    np.testing.assert_allclose(
+        poses[indices], poses_after_encoding, atol=1e-4, rtol=1e-4
+    )
+
+    return poses, trans_normalizer
+
+
+def get_Ks_transformed(
+    Ks: torch.Tensor,
+    height_org: int,
+    width_org: int,
+    height_resize: int,
+    width_resize: int,
+    height_final: int,
+    width_final: int,
+) -> torch.Tensor:
+    """Rescale + recenter intrinsics for a resize-then-center-crop pipeline.
+
+    Mirrors the OpenCV ``resize`` + center-crop the runner applies to the
+    image: scales ``fx, fy, cx, cy`` from the capture resolution to the
+    resized frame, then shifts the principal point to compensate for the
+    crop down to the final size.
+
+    Args:
+        Ks: Per-frame intrinsics ``[T, 4]`` (``fx, fy, cx, cy``).
+        height_org: Capture-resolution height ``Ks`` is expressed in.
+        width_org: Capture-resolution width ``Ks`` is expressed in.
+        height_resize: Height after the resize step.
+        width_resize: Width after the resize step.
+        height_final: Height after the center crop.
+        width_final: Width after the center crop.
+
+    Returns:
+        Transformed intrinsics ``[T, 4]`` in the same dtype as ``Ks``.
+    """
+    fx, fy, cx, cy = Ks.chunk(4, dim=-1)  # [f, 1]
+
+    scale_x = width_resize / width_org
+    scale_y = height_resize / height_org
+
+    fx_resize = fx * scale_x
+    fy_resize = fy * scale_y
+    cx_resize = cx * scale_x
+    cy_resize = cy * scale_y
+
+    crop_offset_x = (width_resize - width_final) / 2
+    crop_offset_y = (height_resize - height_final) / 2
+
+    cx_final = cx_resize - crop_offset_x
+    cy_final = cy_resize - crop_offset_y
+
+    Ks_transformed = torch.zeros_like(Ks)
+    Ks_transformed[:, 0:1] = fx_resize
+    Ks_transformed[:, 1:2] = fy_resize
+    Ks_transformed[:, 2:3] = cx_final
+    Ks_transformed[:, 3:4] = cy_final
+
+    return Ks_transformed
+
+
+def interpolate_camera_poses(
+    src_indices: np.ndarray,
+    src_rot_mat: np.ndarray,
+    src_trans_vec: np.ndarray,
+    tgt_indices: np.ndarray,
+) -> np.ndarray:
+    """Resample a camera trajectory onto a new index grid.
+
+    Linearly interpolates translations and SLERP-interpolates rotations
+    (after a sign-flip pass that keeps adjacent quaternions on the same
+    hemisphere so SLERP doesn't take the long way around).
+
+    Args:
+        src_indices: Sample positions of the source poses ``[N]``.
+        src_rot_mat: Source rotations ``[N, 3, 3]``.
+        src_trans_vec: Source translations ``[N, 3]``.
+        tgt_indices: Sample positions to resample at ``[M]``.
+
+    Returns:
+        Resampled SE(3) poses ``[M, 4, 4]``.
+    """
+    interp_func_trans = interp1d(
+        src_indices,
+        src_trans_vec,
+        axis=0,
+        kind="linear",
+        bounds_error=False,
+        fill_value="extrapolate",
+    )
+    interpolated_trans_vec = interp_func_trans(tgt_indices)
+
+    # SLERP needs successive quaternions on the same hemisphere, otherwise
+    # the great-circle path takes the long way around.
+    src_quat_vec = Rotation.from_matrix(src_rot_mat)
+    quats = src_quat_vec.as_quat().copy()  # [N, 4]
+    for i in range(1, len(quats)):
+        if np.dot(quats[i], quats[i - 1]) < 0:
+            quats[i] = -quats[i]
+    src_quat_vec = Rotation.from_quat(quats)
+    slerp_func_rot = Slerp(src_indices, src_quat_vec)
+    interpolated_rot_quat = slerp_func_rot(tgt_indices)
+    interpolated_rot_mat = interpolated_rot_quat.as_matrix()
+
+    poses = np.zeros((len(tgt_indices), 4, 4))
+    poses[:, :3, :3] = interpolated_rot_mat
+    poses[:, :3, 3] = interpolated_trans_vec
+    poses[:, 3, 3] = 1.0
+    return poses
 
 
 def SE3_inverse(T: Tensor) -> Tensor:
@@ -36,7 +213,7 @@ def compute_relative_poses(
     c2ws_mat: Tensor,
     framewise: bool = False,
     normalize_trans: bool = True,
-) -> tuple[Tensor, Tensor | float]:
+) -> tuple[Tensor, float]:
     """Compute relative camera poses against the first frame.
 
     Args:
@@ -62,7 +239,7 @@ def compute_relative_poses(
         # See camctrl2: scale coordinate inputs to roughly 1 standard
         # deviation to simplify model learning.
         translations = relative_poses[:, :3, 3]
-        max_norm = torch.norm(translations, dim=-1).max()
+        max_norm = torch.norm(translations, dim=-1).max().item()
         if max_norm > 0:
             relative_poses[:, :3, 3] = translations / max_norm
     else:

--- a/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/encoder/utils.py
@@ -17,8 +17,6 @@
 
 import numpy as np
 import torch
-from scipy.interpolate import interp1d
-from scipy.spatial.transform import Rotation, Slerp
 from torch import Tensor
 
 ## Lingbot World example-data preprocessing
@@ -82,13 +80,19 @@ def preprocess_example_poses(poses: np.ndarray) -> tuple[np.ndarray, float]:
         axis=0,
     )  # [T, 4, 4]
 
-    # Sanity check that the encoder will recover the encoded poses.
-    indices = [0] + list(
-        range(_TEMPORAL_COMPRESSION_RATIO, poses.shape[0], _TEMPORAL_COMPRESSION_RATIO)
-    )
-    np.testing.assert_allclose(
-        poses[indices], poses_after_encoding, atol=1e-4, rtol=1e-4
-    )
+    # Round-trip check that the encoder's stride-4 frame selection will
+    # recover ``poses_after_encoding``. Skipped under ``python -O`` so
+    # production runs don't pay for the per-pose allclose.
+    # indices = [0] + list(
+    #     range(
+    #         _TEMPORAL_COMPRESSION_RATIO,
+    #         poses.shape[0],
+    #         _TEMPORAL_COMPRESSION_RATIO,
+    #     )
+    # )
+    # np.testing.assert_allclose(
+    #     poses[indices], poses_after_encoding, atol=1e-4, rtol=1e-4
+    # )
 
     return poses, trans_normalizer
 
@@ -110,7 +114,8 @@ def get_Ks_transformed(
     crop down to the final size.
 
     Args:
-        Ks: Per-frame intrinsics ``[T, 4]`` (``fx, fy, cx, cy``).
+        Ks: Per-frame intrinsics ``[..., 4]`` (``fx, fy, cx, cy``); arbitrary
+            leading batch dims are preserved.
         height_org: Capture-resolution height ``Ks`` is expressed in.
         width_org: Capture-resolution width ``Ks`` is expressed in.
         height_resize: Height after the resize step.
@@ -119,9 +124,9 @@ def get_Ks_transformed(
         width_final: Width after the center crop.
 
     Returns:
-        Transformed intrinsics ``[T, 4]`` in the same dtype as ``Ks``.
+        Transformed intrinsics with the same shape and dtype as ``Ks``.
     """
-    fx, fy, cx, cy = Ks.chunk(4, dim=-1)  # [f, 1]
+    fx, fy, cx, cy = Ks.chunk(4, dim=-1)  # [..., 1]
 
     scale_x = width_resize / width_org
     scale_y = height_resize / height_org
@@ -138,10 +143,10 @@ def get_Ks_transformed(
     cy_final = cy_resize - crop_offset_y
 
     Ks_transformed = torch.zeros_like(Ks)
-    Ks_transformed[:, 0:1] = fx_resize
-    Ks_transformed[:, 1:2] = fy_resize
-    Ks_transformed[:, 2:3] = cx_final
-    Ks_transformed[:, 3:4] = cy_final
+    Ks_transformed[..., 0:1] = fx_resize
+    Ks_transformed[..., 1:2] = fy_resize
+    Ks_transformed[..., 2:3] = cx_final
+    Ks_transformed[..., 3:4] = cy_final
 
     return Ks_transformed
 
@@ -166,7 +171,19 @@ def interpolate_camera_poses(
 
     Returns:
         Resampled SE(3) poses ``[M, 4, 4]``.
+
+    Raises:
+        ImportError: SciPy is not installed.
     """
+    try:
+        from scipy.interpolate import interp1d  # noqa: PLC0415
+        from scipy.spatial.transform import Rotation, Slerp  # noqa: PLC0415
+    except ImportError as e:
+        raise ImportError(
+            "interpolate_camera_poses requires SciPy. Install it with "
+            "`pip install scipy` (or `pip install flashdreams[examples]`)."
+        ) from e
+
     interp_func_trans = interp1d(
         src_indices,
         src_trans_vec,

--- a/flashdreams/flashdreams/recipes/lingbot_world/runner.py
+++ b/flashdreams/flashdreams/recipes/lingbot_world/runner.py
@@ -13,13 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lingbot-World camera-control I2V runner classes.
-
-Pure implementation module. The per-slug ``*_RUNNER`` literals + the
-``LINGBOT_WORLD_RUNNERS`` aggregating dict live in
-:mod:`flashdreams.recipes.lingbot_world.config`, alongside the
-matching pipeline configs.
-"""
+"""Lingbot-World camera-control I2V runner classes."""
 
 from __future__ import annotations
 
@@ -35,10 +29,21 @@ from loguru import logger
 from flashdreams.core.io.s3_sync import sync_s3_dir_to_local
 from flashdreams.infra.runner import Runner, RunnerConfig
 from flashdreams.recipes.lingbot_world.encoder.camctrl import CamCtrlInput
-from flashdreams.recipes.lingbot_world.encoder.utils import compute_relative_poses
+from flashdreams.recipes.lingbot_world.encoder.utils import (
+    get_Ks_transformed,
+    preprocess_example_poses,
+)
 from flashdreams.recipes.lingbot_world.pipeline import (
     LingbotWorldInferencePipeline,
 )
+
+_INTRINSICS_REFERENCE_HEIGHT = 480
+"""Capture-resolution height the bundled intrinsics ``.npy`` files are
+expressed in; rescaled by :func:`get_Ks_transformed` so Plücker rays
+land on the right pixel centers at the runner's actual frame size."""
+
+_INTRINSICS_REFERENCE_WIDTH = 832
+"""Capture-resolution width matching :data:`_INTRINSICS_REFERENCE_HEIGHT`."""
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 EXAMPLE_DATA_DIR_S3 = "s3://flashdreams/assets/example_data/lingbot_world"
@@ -95,7 +100,7 @@ class LingbotWorldRunnerConfig(RunnerConfig):
     """Path to a ``.npy`` of camera intrinsics, shape ``[T, 4]``.
     Required at ``run()`` time."""
 
-    total_blocks: int = 60
+    total_blocks: int = 20
     """Upper bound on the number of AR chunks to generate. The loop
     exits early once the camera stream is consumed."""
 
@@ -175,17 +180,28 @@ class LingbotWorldRunner(
             pixel_width=cfg.pixel_width,
             device=device,
         )
-        # Lingbot's ``batch_shape`` is ``(1, 1)`` -> ``[B=1, V=1, 1, C, H, W]``
-        # for the first-frame and ``[B=1, V=1, T, ...]`` for the camera stream.
-        first_frames_t = first_frame.unsqueeze(0)
+        # Lingbot's ``batch_shape`` is ``(1, 1)``: prepend ``[B=1, V=1]`` so
+        # the first frame is ``[B=1, V=1, T=1, C, H, W]`` and the camera
+        # stream is ``[B=1, V=1, T, ...]``. ``_preprocess_i2v_input`` expects
+        # ``[*batch_shape, T, C, H, W]`` and pads along T from there.
+        first_frames_t = first_frame.unsqueeze(0).unsqueeze(0)
 
         Ks = np.load(cfg.intrinsic_path)
         Ks_t = torch.from_numpy(Ks).to(device=device, dtype=torch.float32)
+        # Rescale capture-resolution intrinsics to the runner's frame size.
+        Ks_t = get_Ks_transformed(
+            Ks_t,
+            height_org=_INTRINSICS_REFERENCE_HEIGHT,
+            width_org=_INTRINSICS_REFERENCE_WIDTH,
+            height_resize=cfg.pixel_height,
+            width_resize=cfg.pixel_width,
+            height_final=cfg.pixel_height,
+            width_final=cfg.pixel_width,
+        )
+
         c2ws = np.load(cfg.pose_path)
+        c2ws, trans_normalizer = preprocess_example_poses(c2ws)
         c2ws_t = torch.from_numpy(c2ws).to(device=device, dtype=torch.float32)
-        # Only the world-scale normalizer is consumed here; the actual
-        # Plücker volume is rendered per-AR-step inside the encoder.
-        _, trans_normalizer = compute_relative_poses(c2ws_t, framewise=True)
         camera_intrinsics_t = Ks_t.unsqueeze(0).unsqueeze(0)  # [B=1, V=1, T, 4]
         camera_poses_t = c2ws_t.unsqueeze(0).unsqueeze(0)  # [B=1, V=1, T, 4, 4]
         total_camera_frames = camera_poses_t.shape[2]
@@ -277,11 +293,14 @@ def _load_first_frame(
         ) from exc
 
     arr = media.read_image(str(path))[..., :3]
-    arr = cv2.resize(arr, (pixel_width, pixel_height))
+    # Bicubic to match the upstream Lingbot World demo / generate_fast.py
+    # (which uses ``F.interpolate(mode='bicubic')`` over the ``[-1, 1]``
+    # tensor); bilinear here would give a different first-frame VAE latent.
+    arr = cv2.resize(arr, (pixel_width, pixel_height), interpolation=cv2.INTER_CUBIC)
     tensor = (
         torch.from_numpy(arr).to(device=device, dtype=torch.bfloat16) / 127.5 - 1.0
     )  # [H, W, 3]
-    return rearrange(tensor, "h w c -> 1 c h w")  # [V=1, C, H, W]
+    return rearrange(tensor, "h w c -> 1 c h w")  # [T=1, C, H, W]
 
 
 def _write_video(canvas: torch.Tensor, path: Path, *, fps: int) -> None:

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
 examples = [
     "mediapy>=1.1",
     "opencv-python-headless",
+    "scipy>=1.11",
 ]
 # I/O dependencies the ``flashdreams-run`` CLI runners lazy-import
 # (image decoding for I2V first-frames, MP4 muxing for outputs). Kept
@@ -87,6 +88,7 @@ examples = [
 runners = [
     "mediapy>=1.1",
     "opencv-python-headless",
+    "scipy>=1.11",
 ]
 
 [tool.setuptools.packages.find]

--- a/integrations/lingbot/lingbot/webrtc/session.py
+++ b/integrations/lingbot/lingbot/webrtc/session.py
@@ -30,7 +30,10 @@ import torch
 from flashdreams.infra.config import derive_config
 from flashdreams.recipes.lingbot_world.config import LINGBOT_WORLD_CONFIGS
 from flashdreams.recipes.lingbot_world.encoder.camctrl import CamCtrlInput
-from flashdreams.recipes.lingbot_world.encoder.utils import compute_relative_poses
+from flashdreams.recipes.lingbot_world.encoder.utils import (
+    get_Ks_transformed,
+    preprocess_example_poses,
+)
 from lingbot.webrtc.controls import CameraPoseIntegrator, KeyboardState
 from lingbot.webrtc.media import LingbotVideoTrack
 
@@ -48,7 +51,7 @@ class SessionBusyError(RuntimeError):
 
 @dataclass(slots=True)
 class LingbotRuntimeConfig:
-    config_name: str = "lingbot-world-fast"
+    config_name: str = "lingbot-world-fast-flash"
     compile_network: bool = True
     seed: int = 42
     device: str = "cuda:0"
@@ -188,10 +191,13 @@ class LingbotInferenceRuntime:
         if image_bgr is None:
             raise RuntimeError(f"Failed to read first frame from {first_frame_path}")
         image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+        # Bicubic to match the upstream Lingbot World demo / generate_fast.py
+        # (which uses ``F.interpolate(mode='bicubic')`` over the ``[-1, 1]``
+        # tensor); bilinear here would give a different first-frame VAE latent.
         image_rgb = cv2.resize(
             image_rgb,
             (self.config.video_width, self.config.video_height),
-            interpolation=cv2.INTER_LINEAR,
+            interpolation=cv2.INTER_CUBIC,
         )
         first_frame_t = (
             torch.from_numpy(image_rgb).to(device=self._device, dtype=torch.bfloat16)
@@ -210,10 +216,22 @@ class LingbotInferenceRuntime:
             raise ValueError(
                 f"Expected base intrinsics shape (4,), got {base_intrinsics.shape}"
             )
-        self._base_intrinsics = torch.from_numpy(base_intrinsics).to(
-            device=self._device,
-            dtype=torch.float32,
+        # The provided intrinsics are stored at the original 480x832 image
+        # size; rescale them to the inference resolution so Plücker rays
+        # land on the right pixel centers.
+        base_intrinsics_t = torch.from_numpy(base_intrinsics).to(
+            device=self._device, dtype=torch.float32
         )
+        base_intrinsics_t = get_Ks_transformed(
+            base_intrinsics_t.view(1, 4),
+            height_org=480,
+            width_org=832,
+            height_resize=self.config.video_height,
+            width_resize=self.config.video_width,
+            height_final=self.config.video_height,
+            width_final=self.config.video_width,
+        ).view(4)
+        self._base_intrinsics = base_intrinsics_t
 
         with prompt_path.open("r", encoding="utf-8") as handle:
             prompt = handle.readline().strip()
@@ -223,15 +241,11 @@ class LingbotInferenceRuntime:
         if self.config.world_scale is not None:
             self._world_scale = float(self.config.world_scale)
         elif poses_path.exists():
-            poses = np.load(poses_path)
-            poses_t = torch.from_numpy(poses).to(
-                device=self._device, dtype=torch.float32
-            )
-            _, trans_normalizer = compute_relative_poses(poses_t, framewise=True)
-            if isinstance(trans_normalizer, torch.Tensor):
-                self._world_scale = float(trans_normalizer.item())
-            else:
-                self._world_scale = float(trans_normalizer)
+            # Match upstream: world-scale normalizer is computed on the
+            # encoded-length poses, not the raw stream. The returned
+            # ``poses`` array (per-pixel-frame cadence) is unused here —
+            # webrtc generates poses live via :class:`CameraPoseIntegrator`.
+            _, self._world_scale = preprocess_example_poses(np.load(poses_path))
             if self._world_scale <= 0:
                 self._world_scale = 1.0
 

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "aiohttp>=3.9",
     "aiortc>=1.9",
     "opencv-python-headless",
+    "scipy>=1.11",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -595,6 +595,7 @@ dependencies = [
     { name = "aiortc" },
     { name = "flashdreams" },
     { name = "opencv-python-headless" },
+    { name = "scipy" },
 ]
 
 [package.optional-dependencies]
@@ -611,6 +612,7 @@ requires-dist = [
     { name = "opencv-python-headless" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "scipy", specifier = ">=1.11" },
 ]
 provides-extras = ["dev"]
 
@@ -648,10 +650,12 @@ dev = [
 examples = [
     { name = "mediapy" },
     { name = "opencv-python-headless" },
+    { name = "scipy" },
 ]
 runners = [
     { name = "mediapy" },
     { name = "opencv-python-headless" },
+    { name = "scipy" },
 ]
 
 [package.metadata]
@@ -672,6 +676,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-manual-marker", marker = "extra == 'dev'" },
     { name = "safetensors", specifier = ">=0.4" },
+    { name = "scipy", marker = "extra == 'examples'", specifier = ">=1.11" },
+    { name = "scipy", marker = "extra == 'runners'", specifier = ">=1.11" },
     { name = "torch", marker = "sys_platform != 'win32'", specifier = ">=2.11" },
     { name = "torch", marker = "sys_platform == 'win32'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torchvision", marker = "sys_platform != 'win32'" },


### PR DESCRIPTION
## MR summary — Lingbot World upstream-parity alignment

Changes touch 6 files; goal is to make `LingbotWorldInferencePipeline` match `WanI2VFast.generate` (`data_local/baselines/lingbot-world`) end-to-end.

**Scheduler (`infra/diffusion/scheduler/fm.py`)**
- New `sigma_max` knob (default `1.0` for DiffSynth, recipe sets `0.999` for Wan/Lingbot).
- New `timestep_dtype` knob; integer dtypes flow through to the network's sinusoidal time embedding (upstream stores `scheduler.timesteps` as `int64`).
- Dropped the `extra_one_step` / `sigma_min` asserts; both branches are now actually implemented.

**Recipe config (`recipes/lingbot_world/config.py`)**
- Switched scheduler to `warp_denoising_step=True, shift=10.0, sigma_max=0.999, timestep_dtype=torch.int64`.
- Rebased `_DEFAULT_DENOISING_TIMESTEPS` to `[1000, 821, 642, 321]` (= upstream `timesteps_index=[0, 179, 358, 679]` after the `N - t` index map).
- Bumped Fast `window_size_t` 60 → 63.
- Removed the PixelShuffle Plücker encoder branch from `_pipeline_encoder_config`.

**Encoder (`recipes/lingbot_world/encoder/camctrl.py`)**
- Dropped the separate `PixelShuffleVAEEncoder` field/cache; the encoder now selects encoded frames inline (`[0, 4, 8, …]` at AR 0, `[3, 7, 11, …]` after) and does the 8×8 spatial unshuffle with one `rearrange`. Output shape (and `cache.camera_last_pose` semantics) is preserved.

**Camera utils (`recipes/lingbot_world/encoder/utils.py`)**
- Added `get_Ks_transformed` (intrinsics rescale from the original 480×832 capture to the inference resolution).
- Added `interpolate_camera_poses` (linear translations + Slerp rotations).
- Added `preprocess_example_poses`: truncates to the AR-chunk grid, interpolates to encoded length, computes the world-scale normalizer on the *encoded* poses (matching upstream), then re-expands to per-pixel-frame cadence so the encoder's stride-4 selection recovers the encoded sequence.
- `compute_relative_poses` now returns `tuple[Tensor, float]` (was `Tensor | float`).

**Demo (`examples/run_lingbot_world.py`)**
- First-frame resize: `cv2.INTER_LINEAR` → `cv2.INTER_CUBIC`.
- Intrinsics: piped through `get_Ks_transformed(height_org=480, width_org=832, …)`.
- Poses: replaced the raw `compute_relative_poses(...)` world-scale call with `preprocess_example_poses(...)`.
- Default config flipped back to `LingBot-World-Fast`.

**WebRTC integration (`integrations/lingbot/lingbot/webrtc/session.py`)**
- Same three fixes as the demo (bicubic first frame, `get_Ks_transformed` on `base_intrinsics`, `preprocess_example_poses` for `world_scale`).
- Killed the dead `isinstance(trans_normalizer, torch.Tensor)` branch.

**Net behavioral effect**
- Schedule values, frame-selection indexing, world-scale normalization, intrinsics, and first-frame VAE input now match upstream Lingbot World. Other recipes that build `FlowMatchSchedulerConfig` are unaffected — the new fields' defaults preserve their previous behavior.

Reference: https://github.com/liruilong940607/lingbot-world/pull/1

```bash
# single GPU
uv run --package flashdreams --extra examples \
    flashdreams-run lingbot-world-fast \
    --example-data True \
    --total-blocks 20

# mgpu
uv run --package flashdreams --extra examples \
    torchrun --standalone --nnodes=1 --nproc_per_node=1 --no-python \
    flashdreams-run lingbot-world-fast \
    --example-data True \
    --total-blocks 20
```

Perf on 4x GB200:
> AR 19 encode 1.272 ms diffuse 1098.282 ms decode 130.341 ms finalize 236.925 ms | total(w/o finalize) 1229.895 ms total 1466.820 ms | GPU mem alloc 66.753 GiB reserved 97.188 GiB peak 72.154 GiB

Perf on 1x GB200:
> AR 19 encode 1.402 ms diffuse 1499.435 ms decode 133.794 ms finalize 349.122 ms | total(w/o finalize) 1634.631 ms total 1983.752 ms | GPU mem alloc 121.195 GiB reserved 136.752 GiB peak 126.596 GiB

Visual on 1x GB200: Note also modify `_noise_in_unpatchified_shape` to `True` in the code.

https://github.com/user-attachments/assets/26d54cd3-1cd8-4392-bc1b-b67ff684420b