### PR TITLE
FlashVSR prerequisite

### DIFF
--- a/flashdreams/flashdreams/core/checkpoint/load.py
+++ b/flashdreams/flashdreams/core/checkpoint/load.py
@@ -15,6 +15,7 @@
 
 """Unified checkpoint loader that dispatches by source URL."""
 
+import hashlib
 import io
 import json
 import os
@@ -22,6 +23,7 @@ from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from typing import Literal, overload
 from urllib.parse import unquote, urlparse
+from urllib.request import Request, urlopen
 
 import torch
 from huggingface_hub import hf_hub_download
@@ -302,6 +304,60 @@ def _download_checkpoint_from_huggingface_url(url: str) -> str:
     return local_path
 
 
+def _is_generic_http_url(path: str) -> bool:
+    """True if ``path`` is an HTTP(S) URL that is *not* a Hugging Face URL.
+
+    Hugging Face URLs go through ``hf_hub_download`` and live under the HF
+    cache; everything else (raw GitHub mirrors, generic web hosts, internal
+    artifact stores, etc.) is streamed via
+    :func:`_download_checkpoint_from_http_url` into
+    ``<local_cache_dir>/http_checkpoints/``.
+    """
+    if not path.startswith(("http://", "https://")):
+        return False
+    return not _is_huggingface_checkpoint_url(path)
+
+
+def _http_checkpoint_cache_path(url: str, local_cache_dir: str) -> str:
+    """Stable per-URL cache path for a generic HTTP checkpoint.
+
+    Uses a short SHA-256 of the full URL plus the basename so two distinct
+    URLs that happen to share a basename (e.g. ``model.pt`` from different
+    hosts) don't collide, while the cached files stay human-recognizable.
+    """
+    parsed = urlparse(url)
+    basename = os.path.basename(unquote(parsed.path)) or "checkpoint"
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+    return os.path.join(local_cache_dir, "http_checkpoints", f"{digest}__{basename}")
+
+
+def _download_checkpoint_from_http_url(url: str, local_cache_dir: str) -> str:
+    """Stream a generic HTTP(S) checkpoint to local cache; return cached path.
+
+    Subsequent calls with the same URL return the cached file without
+    re-downloading. Streams in 1 MiB chunks to a ``.part`` sibling and then
+    ``os.replace``s into place, so a partial fetch (interrupted process,
+    OOM, etc.) never poisons the cache. No cross-process locking: if two
+    workers race on the same URL they'll both download, but the rename is
+    atomic so the cached file is always complete.
+    """
+    cache_path = _http_checkpoint_cache_path(url, local_cache_dir)
+    if os.path.exists(cache_path):
+        logger.info(f"Loading from local HTTP cache: {cache_path}")
+        return cache_path
+
+    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+    tmp_path = cache_path + ".part"
+    logger.info(f"Downloading checkpoint from HTTP: {url}")
+    req = Request(url, headers={"User-Agent": "flashdreams/load_checkpoint"})
+    with urlopen(req) as resp, open(tmp_path, "wb") as out:
+        for chunk in iter(lambda: resp.read(1024 * 1024), b""):
+            out.write(chunk)
+    os.replace(tmp_path, cache_path)
+    logger.info(f"Checkpoint downloaded to: {cache_path}")
+    return cache_path
+
+
 def get_storage_reader(
     checkpoint_path: str, credential_path: str = _ALPADREAMS_CHECKPOINT_CREDENTIAL_PATH
 ) -> FileSystemReader:
@@ -414,25 +470,27 @@ def load_single_checkpoint(
     credential_path: str = _ALPADREAMS_CHECKPOINT_CREDENTIAL_PATH,
     map_location: str | torch.device = "cpu",
 ) -> dict[str, torch.Tensor]:
-    """Load a single-file checkpoint from local disk, S3, or a Hugging Face URL.
+    """Load a single-file checkpoint from local disk, S3, HF, or HTTP(S).
 
-    S3 paths are cached locally for faster subsequent loads. HF file URLs are
-    downloaded via ``hf_hub_download``.
+    S3 paths are cached locally for faster subsequent loads. HF file URLs
+    are downloaded via ``hf_hub_download``. Generic HTTP(S) URLs (raw
+    GitHub mirrors, internal artifact hosts, etc.) are streamed once into
+    ``<local_cache_dir>/http_checkpoints/`` and reused on subsequent calls.
 
     Args:
-        checkpoint_path: Path/URL to a ``.pt`` / ``.pth`` / ``.safetensors``
-            file, or to an HF-style ``*.safetensors.index.json`` (shards are
-            merged on first load and cached).
-        local_cache_dir: Directory for S3 / merged-safetensors caches.
+        checkpoint_path: Path/URL to a ``.pt`` / ``.pth`` / ``.ckpt`` /
+            ``.safetensors`` file, or to an HF-style ``*.safetensors.index.json``
+            (shards are merged on first load and cached).
+        local_cache_dir: Directory for S3 / merged-safetensors / HTTP caches.
         credential_path: S3 credentials path.
-        map_location: Device to map tensors to (``.pt`` / ``.pth`` only).
+        map_location: Device to map tensors to (``.pt`` / ``.pth`` / ``.ckpt`` only).
 
     Returns:
         State dict.
 
     Raises:
-        ValueError: Unsupported file extension or unsupported S3 sharded
-            index input.
+        ValueError: Unsupported file extension, unsupported S3 sharded
+            index input, or HTTP URL with no ``local_cache_dir``.
     """
     if _is_sharded_safetensors_index_checkpoint(checkpoint_path):
         if checkpoint_path.startswith("s3://"):
@@ -440,23 +498,42 @@ def load_single_checkpoint(
                 "Sharded safetensors index checkpoints are not supported on S3; "
                 "use a Hugging Face file URL or a local index path."
             )
+        if _is_generic_http_url(checkpoint_path):
+            raise ValueError(
+                "Sharded safetensors index checkpoints are only supported for "
+                "Hugging Face URLs and local paths; got generic HTTP URL: "
+                f"{checkpoint_path}"
+            )
         return _load_sharded_safetensors_index_checkpoint(
             checkpoint_path, local_cache_dir, map_location
         )
 
     is_s3_path = checkpoint_path.startswith("s3://")
     is_hf_url = _is_huggingface_checkpoint_url(checkpoint_path)
+    is_http_url = _is_generic_http_url(checkpoint_path)
 
     # Determine file extension
     ext = _get_checkpoint_extension(checkpoint_path)
-    if ext not in (".pt", ".pth", ".safetensors"):
+    if ext not in (".pt", ".pth", ".ckpt", ".safetensors"):
         raise ValueError(
-            f"Unsupported checkpoint extension: {ext}. Supported: .pt, .pth, .safetensors"
+            f"Unsupported checkpoint extension: {ext}. "
+            f"Supported: .pt, .pth, .ckpt, .safetensors"
         )
 
     # For Hugging Face URLs, use HF cache and then load locally.
     if is_hf_url:
         local_path = _download_checkpoint_from_huggingface_url(checkpoint_path)
+        return _load_checkpoint_from_local(local_path, ext, map_location)
+
+    # Generic HTTP(S) URLs: stream to local cache once, then load locally.
+    if is_http_url:
+        if local_cache_dir is None:
+            raise ValueError(
+                "local_cache_dir is required to cache HTTP(S) checkpoint downloads"
+            )
+        local_path = _download_checkpoint_from_http_url(
+            checkpoint_path, local_cache_dir
+        )
         return _load_checkpoint_from_local(local_path, ext, map_location)
 
     # For S3 paths, check local cache first
@@ -561,14 +638,16 @@ def load_checkpoint(
     map_location: str | torch.device = "cpu",
     check_success: bool = False,
 ) -> dict[str, torch.Tensor] | torch.nn.Module:
-    """Load checkpoints from S3, local disk, or Hugging Face.
+    """Load checkpoints from S3, local disk, Hugging Face, or HTTP(S).
 
-    Handles single-file checkpoints (``.pt`` / ``.pth`` / ``.safetensors``) and
-    distributed checkpoints (DCP). Detection is automatic by default.
+    Handles single-file checkpoints (``.pt`` / ``.pth`` / ``.ckpt`` /
+    ``.safetensors``) and distributed checkpoints (DCP). Detection is
+    automatic by default.
 
     Args:
-        checkpoint_path: ``s3://`` URI, local path, or HF URL. Single-file or
-            DCP directory.
+        checkpoint_path: ``s3://`` URI, local path, HF URL, or generic
+            HTTP(S) URL. Single-file or DCP directory (DCP only supports
+            local / S3).
         model: Model to load weights into. Required for DCP. Optional for
             single-file: when provided, ``load_state_dict`` is called.
         checkpoint_type: ``"auto"``, ``"single"``, or ``"distributed"``.
@@ -588,6 +667,12 @@ def load_checkpoint(
     Examples:
 
       >>> state = load_checkpoint("s3://bucket/foo.safetensors")
+      >>> state = load_checkpoint(
+      ...     "https://huggingface.co/foo/bar/resolve/main/model.pt"
+      ... )
+      >>> state = load_checkpoint(
+      ...     "https://raw.githubusercontent.com/org/repo/main/posi_prompt.pth"
+      ... )
       >>> model = load_checkpoint("s3://bucket/dcp_dir/", model=my_model)
     """
     # Auto-detect checkpoint type
@@ -596,7 +681,7 @@ def load_checkpoint(
             checkpoint_type = "single"
         else:
             ext = _get_checkpoint_extension(checkpoint_path)
-            if ext in (".pt", ".pth", ".safetensors"):
+            if ext in (".pt", ".pth", ".ckpt", ".safetensors"):
                 checkpoint_type = "single"
             else:
                 checkpoint_type = "distributed"

--- a/flashdreams/flashdreams/infra/cuda_graph.py
+++ b/flashdreams/flashdreams/infra/cuda_graph.py
@@ -23,6 +23,30 @@ import torch
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
 
+def set_or_copy(
+    state: dict,
+    key: Any,
+    new_value: torch.Tensor,
+) -> None:
+    """Write ``new_value`` into ``state[key]``, preserving the storage pointer.
+
+    First write clones into a fresh buffer; subsequent same-shape writes
+    ``copy_`` in place. Pointer stability is required for CUDA-graph
+    capture, since captured kernels reference the slot's storage address.
+
+    ``state`` is intentionally typed as the loose ``dict`` because the
+    three call sites use incompatible parametrisations (``dict[str,
+    Tensor | None]`` for the FlashVSR projector cache, ``dict[int,
+    Tensor]`` for the Wan VAE and TAEHV streaming caches) and
+    ``MutableMapping`` is invariant in its value type.
+    """
+    cur = state.get(key)
+    if cur is not None and cur.shape == new_value.shape:
+        cur.copy_(new_value)
+    else:
+        state[key] = new_value.clone()
+
+
 class CUDAGraphWrapper:
     """Capture a stateful CUDA callable into a replayable graph.
 

--- a/flashdreams/flashdreams/infra/profiler.py
+++ b/flashdreams/flashdreams/infra/profiler.py
@@ -66,3 +66,9 @@ class EventProfiler:
         """``torch.cuda.synchronize()`` then return ``elapsed_ms``."""
         torch.cuda.synchronize()
         return self.elapsed_ms()
+
+
+def record_event(profiler: EventProfiler | None, stage: str) -> None:
+    """Record ``stage`` on ``profiler`` when it is not ``None``; no-op otherwise."""
+    if profiler is not None:
+        profiler.record(stage)

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -26,7 +26,7 @@ import torch.nn.functional as F
 
 from flashdreams.core.checkpoint.load import load_checkpoint
 from flashdreams.infra.compile import compile_module
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper, set_or_copy
 from flashdreams.infra.decoder import StreamingDecoderCache
 
 
@@ -40,22 +40,6 @@ class TAEHVCache(StreamingDecoderCache):
     """
 
     dec_state: Dict[int, torch.Tensor] = field(default_factory=dict)
-
-
-def _set_or_copy(
-    state: Dict[int, torch.Tensor], key: int, new_value: torch.Tensor
-) -> None:
-    """Write ``new_value`` into ``state[key]``, preserving the storage pointer.
-
-    In-place ``copy_`` once the slot exists at the matching shape, else
-    allocate a fresh clone. Pointer stability is required for CUDA-graph
-    capture, since captured kernels reference the slot's storage address.
-    """
-    cur = state.get(key)
-    if cur is not None and cur.shape == new_value.shape:
-        cur.copy_(new_value)
-    else:
-        state[key] = new_value.clone()
 
 
 def _conv(n_in: int, n_out: int, **kwargs) -> nn.Conv2d:
@@ -113,7 +97,7 @@ class MemBlock(nn.Module):
         else:
             past = torch.cat([prev, x5[:, :-1]], dim=1)
         out = self.forward(x, past.reshape(bt, c, h, w))
-        _set_or_copy(state, key, x5[:, -1:])
+        set_or_copy(state, key, x5[:, -1:])
         return out
 
 

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional
 
@@ -175,8 +176,27 @@ class Decoder(nn.Module):
         return x.reshape(b, bt // b, c_out, h_out, w_out)
 
 
+def _legacy_to_blocks_keys(
+    sd: Mapping[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Re-key legacy ``decoder.<i>.*`` weights to ``decoder.blocks.<i>.*``.
+
+    The current ``Decoder`` wraps its Sequential in a ``blocks`` attribute, so
+    older checkpoints whose keys flatten to ``decoder.<idx>.*`` need this
+    one-shot rewrite to line up with the module tree.
+    """
+    return {
+        (
+            k.replace("decoder.", "decoder.blocks.", 1)
+            if k.startswith("decoder.") and not k.startswith("decoder.blocks.")
+            else k
+        ): v
+        for k, v in sd.items()
+    }
+
+
 def _patch_tgrow_state_dict(
-    sd: Dict[str, torch.Tensor], decoder_blocks: nn.Sequential
+    sd: Mapping[str, torch.Tensor], decoder_blocks: nn.Sequential
 ) -> Dict[str, torch.Tensor]:
     """Truncate over-sized TGrow weights in ``sd`` to the model's expected channels.
 
@@ -222,6 +242,11 @@ class TAEHV(nn.Module):
 
     SUPPORTED_MODEL_TYPES = ("wan21", "wan22")
 
+    # Concrete types so ``self.decoder`` / ``self._decoder_call`` access
+    # doesn't go through ``nn.Module.__getattr__``'s ``Tensor | Module``.
+    decoder: "Decoder"
+    _decoder_call: Callable[..., torch.Tensor]
+
     def __init__(
         self,
         checkpoint_path: str = "taew2_1.pth",
@@ -229,6 +254,8 @@ class TAEHV(nn.Module):
         decoder_space_upscale: tuple[bool, bool, bool] = (True, True, True),
         patch_size: int = 1,
         latent_channels: int = 16,
+        channels: tuple[int, int, int, int] = (256, 128, 64, 64),
+        clamp_output: bool = True,
         model_type: str = "wan21",
         use_cuda_graph: bool = True,
         use_compile: bool = False,
@@ -255,15 +282,16 @@ class TAEHV(nn.Module):
         self.latent_channels = latent_channels
         self.image_channels = 3
         self.model_type = model_type
+        self.channels = channels
+        self.clamp_output = clamp_output
         # Frames the decoder drops from the front of its first chunk output
         # (matches the legacy 2 ** sum(time_upscale) - 1 formula).
         self.frames_to_trim = 2 ** sum(decoder_time_upscale) - 1
 
-        n_f = (256, 128, 64, 64)
         # Build on meta so only the checkpoint allocates real memory.
         with torch.device("meta"):
             self.decoder = Decoder(
-                n_f=n_f,
+                n_f=self.channels,
                 latent_channels=latent_channels,
                 image_channels=self.image_channels,
                 patch_size=patch_size,
@@ -272,18 +300,9 @@ class TAEHV(nn.Module):
                 act_func=act_func,
             )
 
+        self._post_model_init_hook()
+
         sd = load_checkpoint(checkpoint_path)
-        # Re-key legacy ``decoder.<i>.*`` to ``decoder.blocks.<i>.*`` because
-        # the new Decoder wraps the Sequential in an attribute.
-        sd = {
-            (
-                k.replace("decoder.", "decoder.blocks.", 1)
-                if k.startswith("decoder.") and not k.startswith("decoder.blocks.")
-                else k
-            ): v
-            for k, v in sd.items()
-        }
-        sd = _patch_tgrow_state_dict(sd, self.decoder.blocks)
         # assign=True: meta params become the checkpoint tensors directly;
         # strict=False: silently drop encoder-only weights.
         self.load_state_dict(sd, strict=False, assign=True)
@@ -299,8 +318,50 @@ class TAEHV(nn.Module):
             if use_cuda_graph
             else None
         )
-        self._decoder_call: Callable[..., torch.Tensor] = (
-            self._decoder_wrapper if self._decoder_wrapper is not None else self.decoder
+        # Plain ``self._decoder_call = <Module>`` would go through
+        # ``nn.Module.__setattr__`` and register the same module a second time,
+        # duplicating every key in ``state_dict`` under ``_decoder_call.*``.
+        # ``object.__setattr__`` skips that and stores it as a plain attribute.
+        object.__setattr__(
+            self,
+            "_decoder_call",
+            self._decoder_wrapper
+            if self._decoder_wrapper is not None
+            else self.decoder,
+        )
+
+    def _post_model_init_hook(self) -> None:
+        """Override to mutate the module tree after construction.
+
+        Runs once after ``self.decoder`` is built and before any checkpoint is
+        loaded. Default is a no-op; subclasses may insert/replace layers here
+        (e.g., FlashVSR-style identity-deepening of ``decoder.blocks``).
+        """
+
+    def _pre_load_state_dict_hook(
+        self, state_dict: Mapping[str, torch.Tensor]
+    ) -> Mapping[str, torch.Tensor]:
+        """Override to remap or patch a state dict before it is loaded.
+
+        Default applies the generic ``decoder.<i>.* -> decoder.blocks.<i>.*``
+        rewrite and the TGrow stride truncation. Subclasses can extend this
+        to perform additional adapter-specific remapping.
+        """
+        sd = _legacy_to_blocks_keys(state_dict)
+        sd = _patch_tgrow_state_dict(sd, self.decoder.blocks)
+        return sd
+
+    def load_state_dict(
+        self,
+        state_dict: Mapping[str, torch.Tensor],
+        strict: bool = True,
+        assign: bool = False,
+    ) -> torch.nn.modules.module._IncompatibleKeys:
+        """Route every state-dict load through ``_pre_load_state_dict_hook``."""
+        return super().load_state_dict(
+            self._pre_load_state_dict_hook(state_dict),
+            strict=strict,
+            assign=assign,
         )
 
     def prepare_cache(self) -> TAEHVCache:
@@ -316,7 +377,10 @@ class TAEHV(nn.Module):
 
     @torch.inference_mode()
     def decode(
-        self, z: torch.Tensor, cache: Optional[TAEHVCache] = None
+        self,
+        z: torch.Tensor,
+        cache: Optional[TAEHVCache] = None,
+        **_: object,
     ) -> torch.Tensor:
         """Streaming decode of an ``[N, T, C_z, H, W]`` latent.
 
@@ -343,7 +407,8 @@ class TAEHV(nn.Module):
         x = decoder(z, state, b)
         # Clamp / pixel-shuffle / trim happen outside the captured region;
         # the wrapper returns static_output.clone() so clamp_ is safe in-place.
-        x = x.clamp_(0, 1)
+        if self.clamp_output:
+            x = x.clamp_(0, 1)
         if self.patch_size > 1:
             n, t, c, h, w = x.shape
             x = F.pixel_shuffle(x.reshape(n * t, c, h, w), self.patch_size)

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -29,7 +29,7 @@ from torch import Tensor
 from flashdreams.core.checkpoint.load import load_checkpoint
 from flashdreams.core.io.internal import use_internal_storage
 from flashdreams.infra.compile import compile_module
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper, set_or_copy
 from flashdreams.infra.decoder import (
     DecoderConfig,
     StreamingDecoderCache,
@@ -60,22 +60,6 @@ AVAILABLE_WAN_VAE_CHECKPOINT_PATHS = (
 
 CACHE_T = 2
 TEMPORAL_WINDOW = 4
-
-
-def _set_or_copy(
-    state: Dict[int, torch.Tensor], key: int, new_value: torch.Tensor
-) -> None:
-    """Write ``new_value`` into ``state[key]``, preserving the storage pointer.
-
-    In-place ``copy_`` once the slot exists at the matching shape, else
-    allocate a fresh clone. Pointer stability is required for CUDA-graph
-    capture, since captured kernels reference the slot's storage address.
-    """
-    cur = state.get(key)
-    if cur is not None and cur.shape == new_value.shape:
-        cur.copy_(new_value)
-    else:
-        state[key] = new_value.clone()
 
 
 _LATENT_MEAN = (
@@ -180,7 +164,7 @@ class CausalConv3d(nn.Conv3d):
         new_tail = x[:, :, -CACHE_T:]
         if new_tail.shape[2] < CACHE_T and prev is not None:
             new_tail = torch.cat([prev[:, :, -1:], new_tail], dim=2)
-        _set_or_copy(state, key, new_tail)
+        set_or_copy(state, key, new_tail)
         return out
 
 
@@ -269,7 +253,7 @@ class Resample(nn.Module):
         if prev is not None:
             # Steady-state body: in-place write to the existing slot.
             x_up = self._interleave_time(self.time_conv(x, prev), b, c, t, h, w)
-            _set_or_copy(state, key, x[:, :, -CACHE_T:])
+            set_or_copy(state, key, x[:, :, -CACHE_T:])
             return x_up
 
         # Eager first-chunk path (shape varies, never captured).
@@ -293,7 +277,7 @@ class Resample(nn.Module):
         new_tail = x[:, :, -1:]
         if prev is not None:
             x = self.time_conv(torch.cat([prev, x], dim=2))
-        _set_or_copy(state, key, new_tail)
+        set_or_copy(state, key, new_tail)
         return x
 
     @staticmethod

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Optional, TypedDict
+from typing import Callable, Dict, Literal, Optional, TypedDict
 
 import torch
 import torch.nn as nn
@@ -118,14 +118,28 @@ class WanVAECache(StreamingEncoderCache, StreamingDecoderCache):
 
 
 class CausalConv3d(nn.Conv3d):
-    """3D conv with causal time padding and a streaming left-context slot."""
+    """3D conv with causal time padding and a streaming left-context slot.
+
+    ``pad_mode``:
+
+    - ``"zeros"`` (default; Wan VAE): zero-pad spatial + temporal halos.
+    - ``"replicate"`` (FlashVSR projector): replicate-pad both halos. The
+      FlashVSR projector relies on this so the cold-start chunk's first
+      frames remain bounded at the activation level.
+    """
 
     # Concrete attribute types so callers don't see ``Tensor | Module``.
     _spatial_pad: tuple[int, int, int, int]
     _has_spatial_pad: bool
     _time_pad: int
+    _pad_mode: Literal["constant", "replicate"]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        *args,
+        pad_mode: Literal["zeros", "replicate"] = "zeros",
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         # ``nn.Conv3d.padding`` is typed as the ``Union[int, _size, str]``
         # that the constructor accepts; narrow once here so the rest of
@@ -137,6 +151,9 @@ class CausalConv3d(nn.Conv3d):
         self._spatial_pad = (pw, pw, ph, ph)
         self._has_spatial_pad = ph > 0 or pw > 0
         self._time_pad = 2 * self.padding[0]
+        # ``F.pad`` mode names: zero-pad is ``"constant"``, replicate is
+        # ``"replicate"`` (matches the user-facing ``pad_mode`` enum).
+        self._pad_mode = "replicate" if pad_mode == "replicate" else "constant"
         self.padding = (0, 0, 0)
 
     def forward(
@@ -147,7 +164,7 @@ class CausalConv3d(nn.Conv3d):
             x = torch.cat([prev, x], dim=2)
             time_pad = max(0, time_pad - prev.shape[2])
         if time_pad or self._has_spatial_pad:
-            x = F.pad(x, (*self._spatial_pad, time_pad, 0))
+            x = F.pad(x, (*self._spatial_pad, time_pad, 0), mode=self._pad_mode)
         return super().forward(x)
 
     def cache_step(
@@ -169,19 +186,36 @@ class CausalConv3d(nn.Conv3d):
 
 
 class RMS_norm(nn.Module):
-    """RMS-normalisation with a learnable channel scale (no bias)."""
+    """RMS-normalisation with a learnable channel scale and optional bias.
 
-    def __init__(self, dim: int, channel_first: bool = True, images: bool = True):
+    ``bias=False`` (default; Wan VAE) keeps the parameter count at one
+    learnable scale per channel. ``bias=True`` adds a matching learnable
+    offset (FlashVSR projector convention).
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        channel_first: bool = True,
+        images: bool = True,
+        bias: bool = False,
+    ):
         super().__init__()
         broadcast = (1, 1, 1) if not images else (1, 1)
         shape = (dim, *broadcast) if channel_first else (dim,)
         self.channel_first = channel_first
         self.scale = dim**0.5
         self.gamma = nn.Parameter(torch.ones(shape))
+        # Sentinel scalar zero when no bias is requested -- avoids a
+        # branch in ``forward`` and lets ``self.bias`` be a tensor or a
+        # Python float without changing the call site.
+        self.bias: nn.Parameter | float = (
+            nn.Parameter(torch.zeros(shape)) if bias else 0.0
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         dim = 1 if self.channel_first else -1
-        return F.normalize(x, dim=dim) * self.scale * self.gamma
+        return F.normalize(x, dim=dim) * self.scale * self.gamma + self.bias
 
 
 def _bt_flatten(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
A few isolated changes needed to support FlashVSR
- auto-download checkpoints from github link.
- profiler helper
- move duplicated helper function into cuda graph infra for reuse.
- extend CausalConv3d and RMS_norm for FlashVSR 
- extend base TAE for FlashVSR post initialization hooks