### PR TITLE
build: wire vendored ludus-renderer v0.9.0 into alpadreams workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,8 @@ jobs:
           # ty needs third-party packages to resolve imports. Skip packages
           # that cannot be installed on CPU-only runners:
           # - transformer-engine-torch: source-only, requires CUDA to compile
-          # - ludus-renderer: unavailable in CI
           uv sync --extra dev --group lint \
-            --no-install-package transformer-engine-torch \
-            --no-install-package ludus-renderer
+            --no-install-package transformer-engine-torch
 
       - name: Run linter checks
         run: uv run --no-sync pre-commit run -a

--- a/integrations/alpadreams/alpadreams/conditioning/renderer.py
+++ b/integrations/alpadreams/alpadreams/conditioning/renderer.py
@@ -37,7 +37,7 @@ from ludus_renderer.render_utils import (
     SceneAdapter,
 )
 from ludus_renderer.torch import (
-    LudusCudaTimestampedContext,
+    LudusTimestampedContext,
 )
 from ludus_renderer.torch.ops import (
     CAMERA_TYPE_REGULAR,
@@ -117,7 +117,7 @@ class LudusRenderer:
         )
 
         # Create context
-        self.ctx = LudusCudaTimestampedContext(device=self.device)
+        self.ctx = LudusTimestampedContext(device=self.device)
         self.ctx.set_depth_scaling(True)
         self.ctx.set_msaa_samples(4)
         self.ctx.set_max_tessellation_levels(cube=0)
@@ -237,7 +237,7 @@ class LudusRenderer:
 
     def cleanup(self) -> None:
         """Cleanup the renderer."""
-        # LudusCudaTimestampedContext handles cleanup in its destructor
+        # LudusTimestampedContext handles cleanup in its destructor
         pass
 
 

--- a/integrations/alpadreams/pyproject.toml
+++ b/integrations/alpadreams/pyproject.toml
@@ -26,7 +26,8 @@ requires-python = ">=3.12"
 dependencies = [
     "flashdreams",
     "mediapy>=1.1",
-    "ludus-renderer==0.5.0+cuda",
+    "ludus-renderer",
+    "imageio",
     "grpcio-tools",
     "grpcio",
     "opencv-python-headless",
@@ -35,12 +36,7 @@ dependencies = [
 
 [tool.uv.sources]
 flashdreams = { workspace = true }
-ludus-renderer = { index = "ludus_renderer_gitlab" }
-
-[[tool.uv.index]]
-name = "ludus_renderer_gitlab"
-url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple"
-explicit = true
+ludus-renderer = { workspace = true }
 
 [project.optional-dependencies]
 dev = [

--- a/integrations/alpadreams/tests/test_ludus_renderer.py
+++ b/integrations/alpadreams/tests/test_ludus_renderer.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for the vendored ludus-renderer EGL/OpenGL backend.
+
+These tests require a CUDA GPU with EGL support (Turing+) and are excluded
+from the default test run.  Run explicitly with::
+
+    uv run pytest integrations/alpadreams/tests/test_ludus_renderer.py -m manual
+"""
+
+from __future__ import annotations
+
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLIPGT_ZIP = REPO_ROOT / "assets" / "example_data" / "alpadreams" / "clipgt.zip"
+
+
+@pytest.fixture(scope="module")
+def clipgt_scene_dir() -> Path:
+    """Extract clipgt.zip to a temporary directory (shared across the module)."""
+    assert CLIPGT_ZIP.exists(), f"clipgt.zip not found at {CLIPGT_ZIP}"
+    tmpdir = tempfile.mkdtemp(prefix="ludus_test_")
+    with zipfile.ZipFile(CLIPGT_ZIP, "r") as zf:
+        zf.extractall(tmpdir)
+    return Path(tmpdir)
+
+
+# ---------------------------------------------------------------------------
+# Low-level: LudusTimestampedContext renders without crashing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.manual
+def test_ludus_timestamped_context_renders_frame(clipgt_scene_dir: Path) -> None:
+    """JIT-compile the EGL plugin, load a clipgt scene, render one frame."""
+    from ludus_renderer import load_clipgt_scene
+    from ludus_renderer.render_utils import compute_camera_poses, create_camera
+    from ludus_renderer.torch import LudusTimestampedContext
+    from ludus_renderer.torch.ops import CAMERA_TYPE_REGULAR
+    from ludus_renderer.util import resample_timestamps
+
+    device = torch.device("cuda")
+    width, height = 640, 360  # small resolution for speed
+
+    # Load scene
+    scene_raw = load_clipgt_scene(str(clipgt_scene_dir), device=device)
+    from ludus_renderer.render_utils import SceneAdapter
+
+    scene = SceneAdapter(scene_raw)
+
+    # Resample timestamps to 10 Hz, take just the first frame
+    timestamps = resample_timestamps(scene.ego_tracks.timestamps, 100_000, 20_000_000)
+    assert len(timestamps) > 0, "No timestamps after resampling"
+
+    # Create context + camera
+    ctx = LudusTimestampedContext(device=device)
+    ctx.set_depth_scaling(True)
+    camera = create_camera(width, height, device, scene=scene)
+    ctx.upload_cameras([camera])
+    scene_id = ctx.upload_scene(scene.timestamped_scene)
+
+    # Compute pose for first frame
+    poses, _ = compute_camera_poses(scene, timestamps[:1], device)
+
+    # Render
+    images = ctx.render(
+        torch.tensor([scene_id], dtype=torch.int32, device=device),
+        torch.zeros(1, dtype=torch.int32, device=device),
+        timestamps[:1].to(torch.int64),
+        torch.full((1,), CAMERA_TYPE_REGULAR, dtype=torch.int32, device=device),
+        poses,
+        resolution=(height, width),
+    )
+
+    # Validate
+    assert images.shape == (1, height, width, 4), f"Unexpected shape {images.shape}"
+    assert images.dtype == torch.uint8
+    # Ensure the frame is not entirely black (renderer actually produced output)
+    rgb = images[0, :, :, :3]
+    assert rgb.any(), "Rendered frame is entirely black -- renderer may have failed"
+
+
+# ---------------------------------------------------------------------------
+# High-level: LudusRenderer wrapper used by the alpadreams pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.manual
+def test_ludus_renderer_wrapper_renders_frame(clipgt_scene_dir: Path) -> None:
+    """Exercise the ``LudusRenderer`` wrapper that the gRPC server uses."""
+    from alpadreams.conditioning.renderer import (
+        LudusRenderer,
+        load_and_attach_ludus_scene,
+    )
+    from alpadreams.conditioning.world_scenario.data_loaders import load_scene
+    from alpadreams.conditioning.world_scenario.ftheta import FThetaCamera
+    from alpadreams.conditioning.world_scenario.settings import SETTINGS
+
+    device = torch.device("cuda")
+    camera_name = "camera_front_wide_120fov"
+    target_h, target_w = 360, 640  # small for speed
+
+    # Load scene data via the ClipGT loader
+    scene_data = load_scene(
+        str(clipgt_scene_dir),
+        camera_names=[camera_name],
+        max_frames=-1,
+        input_pose_fps=SETTINGS["INPUT_POSE_FPS"],
+        resize_resolution_hw=[target_h, target_w],
+    )
+
+    # Attach the ludus GPU scene
+    scene_data = load_and_attach_ludus_scene(
+        str(clipgt_scene_dir),
+        scene_data,
+        device=device,
+    )
+
+    # Get camera model
+    assert camera_name in scene_data.camera_models
+    camera_model = scene_data.camera_models[camera_name]
+    assert isinstance(camera_model, FThetaCamera)
+
+    # Build renderer
+    renderer = LudusRenderer(
+        scene_data=scene_data,
+        camera_models={camera_name: camera_model},
+        device=device,
+    )
+
+    # Render two frames so the batch dimension survives squeeze(0) inside
+    # render_all_frames_and_cameras (single-image batches lose the dim).
+    # LudusRenderer expects camera-to-world transforms; it calls
+    # torch.linalg.inv internally. For a smoke test identity poses are
+    # fine -- the scene renders from the world origin and we just check
+    # shapes/dtypes.
+    n_frames = 2
+    camera_poses = torch.eye(4, device=device, dtype=torch.float32)
+    camera_poses = camera_poses.unsqueeze(0).expand(n_frames, -1, -1).contiguous()
+    timestamps_us = [int(scene_data.ego_poses[i].timestamp) for i in range(n_frames)]
+
+    output = renderer.render_all_frames_and_cameras(
+        camera_names=[camera_name],
+        camera_poses_per_camera={camera_name: camera_poses},
+        frame_timestamps_us=timestamps_us,
+    )
+
+    # [n_cameras=1, n_frames=2, 3, H, W]
+    assert output.shape == (1, n_frames, 3, target_h, target_w), f"Got {output.shape}"
+    assert output.device.type == "cuda"
+
+    renderer.cleanup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ members = [
     # folders alongside them are intentional placeholders for future
     # extractions and don't ship a ``pyproject.toml`` yet.
     "integrations/*",
+    # Nested sub-packages that the ``integrations/*`` glob does not reach.
+    "integrations/alpadreams/ludus-renderer",
 ]
 
 # Override nvidia-cublas to >=13.4 because transformer-engine-cu13 2.14.0 was
@@ -41,6 +43,7 @@ transformer-engine-torch = { git = "https://github.com/NVIDIA/TransformerEngine.
 extraPaths = [
     "flashdreams",
     "integrations/alpadreams",
+    "integrations/alpadreams/ludus-renderer",
     "integrations/causal_forcing",
     "integrations/cosmos_predict2",
     "integrations/fastvideo_causal_wan22",
@@ -60,6 +63,7 @@ python-version = "3.12"
 extra-paths = [
     "flashdreams",
     "integrations/alpadreams",
+    "integrations/alpadreams/ludus-renderer",
     "integrations/causal_forcing",
     "integrations/cosmos_predict2",
     "integrations/fastvideo_causal_wan22",

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ members = [
     "flashdreams-fastvideo-causal-wan22",
     "flashdreams-self-forcing",
     "flashdreams-wan21",
+    "ludus-renderer",
 ]
 overrides = [{ name = "nvidia-cublas", specifier = ">=13.4" }]
 
@@ -540,12 +541,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ffmpeg"
-version = "1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz", hash = "sha256:6931692c890ff21d39938433c2189747815dca0c60ddc7f9bb97f199dba0b5b9", size = 5055, upload-time = "2018-10-08T07:50:05.748Z" }
-
-[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -562,6 +557,7 @@ dependencies = [
     { name = "flashdreams" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
+    { name = "imageio" },
     { name = "ludus-renderer" },
     { name = "mediapy" },
     { name = "opencv-python-headless" },
@@ -579,7 +575,8 @@ requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
-    { name = "ludus-renderer", specifier = "==0.5.0+cuda", index = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple" },
+    { name = "imageio" },
+    { name = "ludus-renderer", editable = "integrations/alpadreams/ludus-renderer" },
     { name = "mediapy", specifier = ">=1.1" },
     { name = "opencv-python-headless" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1004,6 +1001,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
 name = "imagesize"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1142,14 +1153,12 @@ wheels = [
 
 [[package]]
 name = "ludus-renderer"
-version = "0.5.0+cuda"
-source = { registry = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/simple" }
+version = "0.9.0"
+source = { editable = "integrations/alpadreams/ludus-renderer" }
 dependencies = [
-    { name = "ffmpeg" },
-    { name = "imageio" },
     { name = "ninja" },
     { name = "numpy" },
-    { name = "opencv-python" },
+    { name = "nvidia-nvcomp-cu12" },
     { name = "pandas" },
     { name = "pillow" },
     { name = "pyarrow" },
@@ -1159,10 +1168,31 @@ dependencies = [
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/files/99403b745029880c011c287903b744ab3dde5400eaf7305af7df8c79f85f97da/ludus_renderer-0.5.0+cuda.tar.gz", hash = "sha256:99403b745029880c011c287903b744ab3dde5400eaf7305af7df8c79f85f97da" }
-wheels = [
-    { url = "https://gitlab-master.nvidia.com/api/v4/projects/265148/packages/pypi/files/0f1f32f34ac4d7472bb8b447ed36ec19c8a30e50f7c5568cd1b7fc4bccc2c926/ludus_renderer-0.5.0+cuda-py3-none-any.whl", hash = "sha256:0f1f32f34ac4d7472bb8b447ed36ec19c8a30e50f7c5568cd1b7fc4bccc2c926" },
+
+[package.optional-dependencies]
+dev = [
+    { name = "imageio-ffmpeg" },
+    { name = "opencv-python" },
+    { name = "pytest" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "imageio-ffmpeg", marker = "extra == 'dev'" },
+    { name = "ninja", specifier = ">=1.13.0" },
+    { name = "numpy" },
+    { name = "nvidia-nvcomp-cu12" },
+    { name = "opencv-python", marker = "extra == 'dev'" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "pyarrow" },
+    { name = "pynvvideocodec" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "scipy" },
+    { name = "setuptools" },
+    { name = "torch", specifier = ">=2.0" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "markdown-it-py"
@@ -1499,6 +1529,16 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-libnvcomp-cu12"
+version = "5.2.0.13"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/ce/29b900e92a0226372bb109f34d0d9210eafb1afe079cd054b1b51b3fe69e/nvidia_libnvcomp_cu12-5.2.0.13-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:0fa9e5599cc4a3eb140b8e6dc6e297bd4d2db90a21e2877042bdc320430acd06", size = 31900949, upload-time = "2026-04-08T17:24:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2a/2b3f41753a0943e6cd34285f896429fe0c7a60150821517d77d4a3b0d06f/nvidia_libnvcomp_cu12-5.2.0.13-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53fa199e91a0f3530ce713760da23287c204cbcfddb89a11f2c1bb49e24e3c57", size = 32251429, upload-time = "2026-04-08T17:20:53.404Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/14/9d1d468db734be50cb51d01925726c84ec17e5e5e41a51fd6807394cefdf/nvidia_libnvcomp_cu12-5.2.0.13-py3-none-win_amd64.whl", hash = "sha256:06f400eeb4f49c6828813f2bdf56a744f1e3fdef160b072735ba97d4b8a6c445", size = 30448968, upload-time = "2026-04-08T17:26:11.039Z" },
+]
+
+[[package]]
 name = "nvidia-ml-py"
 version = "13.595.45"
 source = { registry = "https://pypi.org/simple" }
@@ -1514,6 +1554,19 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
     { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+]
+
+[[package]]
+name = "nvidia-nvcomp-cu12"
+version = "5.2.0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-libnvcomp-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/a6/76464cc820f29fc02d21bc22ba369c53fe73ffe9cd62b94adadd5c6803f6/nvidia_nvcomp_cu12-5.2.0.13-py3-none-manylinux_2_26_aarch64.whl", hash = "sha256:c67cd3ca1089078078c0002d58f60c5783cd1905db346bea86499918bcb7bb2e", size = 3155816, upload-time = "2026-04-08T17:23:10.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/75/f9436615f16187d9e6d49c507fb00927d9dfab79ad3daf269a3761fb4c74/nvidia_nvcomp_cu12-5.2.0.13-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1797b45e041513af8bfc8aad2d727501f15ffbca633a419fd8a8e0ebb7b6a20", size = 3548705, upload-time = "2026-04-08T17:20:28.607Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/2a/0d02110d94d9dbf20f15d6a8ffa783b60ed681e4962342ee9d8e31d90de2/nvidia_nvcomp_cu12-5.2.0.13-py3-none-win_amd64.whl", hash = "sha256:673894e405f8a3a49790a1fe9de2125fb07a200d47faf8810fdecd4c0577dabe", size = 1733336, upload-time = "2026-04-08T17:25:47.265Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wire the vendored ludus-renderer v0.9.0 (EGL/OpenGL backend, landed in #68) into the alpadreams workspace so it replaces the unreachable private GitLab PyPI `ludus-renderer==0.5.0+cuda` wheel.

## Changes

- **Root `pyproject.toml`**: add `integrations/alpadreams/ludus-renderer` as explicit workspace member (the `integrations/*` glob only matches direct children), add to pyright/ty extra-paths
- **`integrations/alpadreams/pyproject.toml`**: switch `ludus-renderer` from pinned GitLab index to `{ workspace = true }`, remove `[[tool.uv.index]]` block, add `imageio` as direct dep (was transitive in old version)
- **`renderer.py`**: rename `LudusCudaTimestampedContext` -> `LudusTimestampedContext` (CUDA rasterizer was removed in v0.9.0; the GL context exposes the same API; `needs_vflip` is already handled)
- **CI workflow**: update comment explaining why ludus-renderer is still skipped on CPU lint runners (JIT needs EGL + CUDA headers)
- **New test**: GPU smoke tests (`@pytest.mark.manual`) for both the low-level `LudusTimestampedContext` and the high-level `LudusRenderer` wrapper, using the bundled `clipgt.zip` example data

## Verification

- `uv sync` resolves ludus-renderer 0.9.0 from workspace
- `pre-commit run -a` passes (ruff, ty, whitespace, EOF)
- `pytest -m "not manual"` -- no regressions (same 5 pre-existing failures: HF 404, CUDA OOM, importlib identity check)
- Full inference run (`flashdreams-run alpadreams-sv-2steps-chunk2-loc6-lightvae-lighttae --total-blocks 20 --example-data True`) completes all 20 AR steps
- `render_hdmap_scene.py` example script renders successfully with EGL backend
- Both new smoke tests pass (`pytest --runxfail integrations/alpadreams/tests/test_ludus_renderer.py`)

## Context

PR #68 vendored ludus-renderer v0.9.0 (EGL-only, cudaraster removed) into the tree, and PR #69 added Apache-2.0 SPDX headers. But neither wired it into the workspace -- alpadreams was still pulling `0.5.0+cuda` from the internal GitLab registry (unreachable from GitHub Actions). This PR completes the wiring that PR #44 had planned.