### PR TITLE
build: add PyPI deployment pipeline and unified versioning

### DIFF
--- a/.github/scripts/sync_version.py
+++ b/.github/scripts/sync_version.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sync the canonical version from flashdreams/_version.py to all pyproject.toml files.
+
+The version in ``flashdreams/flashdreams/_version.py`` is the single source of
+truth for the entire monorepo.  This script reads it and updates the
+``version = "..."`` line in every workspace-member ``pyproject.toml``, except
+for packages with independent versioning (ludus-renderer, self-forcing
+parity-check).
+
+Intended to run as a pre-commit hook and as a CI safety-net step.
+
+Exit codes:
+    0 -- all versions were already in sync (no files changed).
+    1 -- one or more files were updated (pre-commit will re-stage them).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Packages that maintain their own independent version.
+SKIP_PACKAGES = {
+    "ludus-renderer",
+    "self-forcing-parity-check",
+}
+
+# Regex to extract __version__ = "X.Y.Z" from _version.py.
+_VERSION_RE = re.compile(r'^__version__\s*=\s*"([^"]+)"', re.MULTILINE)
+
+# Regex to replace version = "..." in pyproject.toml (under [project]).
+_TOML_VERSION_RE = re.compile(r'^(version\s*=\s*)"[^"]*"', re.MULTILINE)
+
+# Regex to read the project name from pyproject.toml.
+_TOML_NAME_RE = re.compile(r'^name\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def read_canonical_version() -> str:
+    """Read the version string from flashdreams/_version.py."""
+    version_file = REPO_ROOT / "flashdreams" / "flashdreams" / "_version.py"
+    text = version_file.read_text()
+    match = _VERSION_RE.search(text)
+    if not match:
+        print(f"ERROR: could not parse version from {version_file}", file=sys.stderr)
+        sys.exit(2)
+    return match.group(1)
+
+
+def find_pyproject_files() -> list[Path]:
+    """Return all pyproject.toml files under the repo root."""
+    return sorted(REPO_ROOT.rglob("pyproject.toml"))
+
+
+def should_skip(path: Path, text: str) -> bool:
+    """Return True if this pyproject.toml should not be version-synced."""
+    # Skip the root workspace config (has no [project] section).
+    if path == REPO_ROOT / "pyproject.toml":
+        return True
+    # Skip the canonical source itself.
+    if path == REPO_ROOT / "flashdreams" / "pyproject.toml":
+        return True
+    # Skip packages with independent versioning.
+    name_match = _TOML_NAME_RE.search(text)
+    if name_match and name_match.group(1) in SKIP_PACKAGES:
+        return True
+    # Skip files that don't have a version field (e.g. root config).
+    if not _TOML_VERSION_RE.search(text):
+        return True
+    return False
+
+
+def sync_version(version: str) -> list[Path]:
+    """Update all pyproject.toml files and return the list of changed paths."""
+    changed: list[Path] = []
+    for path in find_pyproject_files():
+        text = path.read_text()
+        if should_skip(path, text):
+            continue
+        new_text = _TOML_VERSION_RE.sub(rf'\g<1>"{version}"', text)
+        if new_text != text:
+            path.write_text(new_text)
+            changed.append(path)
+    return changed
+
+
+def main() -> None:
+    version = read_canonical_version()
+    changed = sync_version(version)
+    if changed:
+        for path in changed:
+            rel = path.relative_to(REPO_ROOT)
+            print(f"Updated {rel} -> {version}")
+        # Non-zero exit tells pre-commit that files were modified.
+        sys.exit(1)
+    else:
+        print(f"All versions already at {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,13 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
 
-      - name: Run wheel build
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build flashdreams wheel
         run: |
-          echo "Building wheels..."
-          # Add your wheel build commands here
+          uv run .github/scripts/sync_version.py || true
+          uv build --wheel --package flashdreams
 
       # Documentation is built and deployed by `.github/workflows/doc.yml`.
 
@@ -73,3 +76,36 @@ jobs:
         run: |
           echo "Running world model diffusion workloads..."
           # Add your world model diffusion commands here
+
+  # ===========================================================================
+  # Publish to Test PyPI -- runs only on main after lint passes.
+  # TEMPORARY: targets test.pypi.org while the project is pre-release.
+  # Switch --publish-url/--check-url to the real PyPI endpoints and the
+  # secret to PYPI_API_TOKEN when going public.
+  # ===========================================================================
+  publish-testpypi:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [lint]
+    runs-on: linux-amd64-cpu8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Sync versions
+        run: uv run .github/scripts/sync_version.py || true
+
+      - name: Build wheel
+        run: uv build --wheel --package flashdreams
+
+      - name: Publish to Test PyPI
+        # --check-url queries the index before uploading and silently skips
+        # files whose version already exists (equivalent to twine --skip-existing).
+        run: >
+          uv publish
+          --publish-url https://test.pypi.org/legacy/
+          --check-url https://test.pypi.org/simple/
+          --token ${{ secrets.TEST_PYPI_API_TOKEN }}
+          dist/*

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,11 +36,12 @@ jobs:
           uv sync --only-group docs --only-group docs-ci --python 3.12
           uv pip install --no-deps ./flashdreams
 
-      # Read version from `flashdreams/pyproject.toml` so we can deploy
-      # under `versions/<version>/` on releases (mirrors gsplat's layout).
+      # Read version from `flashdreams/flashdreams/_version.py` (the single
+      # source of truth) so we can deploy under `versions/<version>/` on
+      # releases (mirrors gsplat's layout).
       - name: Get version + subdirectory
         run: |
-          VERSION=$(python -c "import tomllib; print(tomllib.load(open('flashdreams/pyproject.toml','rb'))['project']['version'])")
+          VERSION=$(python -c "import re, pathlib; m=re.search(r'__version__\s*=\s*\"([^\"]+)\"', pathlib.Path('flashdreams/flashdreams/_version.py').read_text()); print(m.group(1))")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "DOCS_SUBDIR=versions/$VERSION" >> $GITHUB_ENV
 
@@ -50,7 +51,7 @@ jobs:
       - name: Override version + subdirectory for main / manual builds
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
-          sed -i 's/^version = ".*"/version = "main"/' flashdreams/pyproject.toml
+          sed -i 's/^__version__ = ".*"/__version__ = "main"/' flashdreams/flashdreams/_version.py
           echo "DOCS_SUBDIR=main" >> $GITHUB_ENV
 
       - name: Sphinx build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,12 @@ repos:
       - id: ruff-format
   - repo: local
     hooks:
+      - id: sync-version
+        name: sync package versions
+        entry: uv run .github/scripts/sync_version.py
+        language: system
+        files: '(pyproject\.toml|_version\.py)$'
+        pass_filenames: false
       - id: ty
         name: ty type check
         entry: ty check

--- a/DEV.md
+++ b/DEV.md
@@ -22,3 +22,72 @@ Servring:
 - https://github.com/softicelee2/aishare/blob/main/271/app.py
 - https://github.com/softicelee2/aishare/blob/main/0009/app.py
 - https://github.com/inin-zou/Rewind/blob/main/modal-deploy/hy_worldplay_ar.py
+
+---
+
+# Versioning and PyPI Publishing
+
+## Version source of truth
+
+The canonical version for the entire monorepo lives in
+`flashdreams/flashdreams/_version.py`:
+
+```python
+__version__ = "0.1.0"
+```
+
+All other package `pyproject.toml` files are kept in sync automatically
+by `.github/scripts/sync_version.py`, which runs as a pre-commit hook.
+
+## How to bump the version
+
+1. Edit `__version__` in `flashdreams/flashdreams/_version.py`.
+2. Commit.  The pre-commit hook updates all integration `pyproject.toml`
+   files to match.
+3. Push to `main`.  CI builds the wheel and uploads it.
+
+## What gets published
+
+Only `flashdreams` is published to PyPI (pure-Python wheel, `py3-none-any`).
+
+**TEMPORARY:** The CI currently publishes to **test.pypi.org**.  When the
+project goes public, switch the CI job to target real PyPI by changing
+`--repository testpypi` to `--repository pypi` and the secret from
+`TEST_PYPI_API_TOKEN` to `PYPI_API_TOKEN` in `.github/workflows/ci.yml`.
+
+## Integration packages (git-installable)
+
+Integration packages are not published to PyPI.  External consumers
+install them from the git repo:
+
+```bash
+pip install "flashdreams-wan21 @ git+https://github.com/NVIDIA/flashdreams.git#subdirectory=integrations/wan21"
+```
+
+Or with uv:
+
+```bash
+uv pip install "flashdreams-wan21 @ git+https://github.com/NVIDIA/flashdreams.git#subdirectory=integrations/wan21"
+```
+
+## Package inventory
+
+| Package | Published | Version |
+|---------|-----------|---------|
+| flashdreams | Test PyPI | canonical (from `_version.py`) |
+| flashdreams-wan21 | git only | synced |
+| flashdreams-self-forcing | git only | synced |
+| flashdreams-causal-forcing | git only | synced |
+| flashdreams-fastvideo-causal-wan22 | git only | synced |
+| flash-alpadreams | git only | synced |
+| flash-lingbot | git only | synced |
+| ludus-renderer | git only | independent (0.9.0) |
+
+## CI secrets required
+
+| Secret name | Where to create | Purpose |
+|-------------|-----------------|---------|
+| `TEST_PYPI_API_TOKEN` | https://test.pypi.org/manage/account/token/ | Upload to Test PyPI |
+| `PYPI_API_TOKEN` (future) | https://pypi.org/manage/account/token/ | Upload to real PyPI |
+
+Add secrets in GitHub repo Settings -> Secrets and variables -> Actions.

--- a/flashdreams/flashdreams/_version.py
+++ b/flashdreams/flashdreams/_version.py
@@ -13,8 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Streaming inference recipes for video diffusion models."""
-
-from flashdreams._version import __version__
-
-__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/flashdreams/flashdreams/_version.py
+++ b/flashdreams/flashdreams/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0"
+__version__ = "0.1.0a0"

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Flash video simulation pipeline"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -89,6 +89,12 @@ runners = [
     "opencv-python-headless",
     "scipy>=1.11",
 ]
+
+[tool.setuptools.dynamic]
+# Resolve version from _version.py (not __init__.py) so setuptools never
+# imports the full package at build time -- avoids triggering transitive
+# imports of heavy dependencies like torch / transformer-engine.
+version = {attr = "flashdreams._version.__version__"}
 
 [tool.setuptools.packages.find]
 include = ["flashdreams*"]

--- a/integrations/alpadreams/pyproject.toml
+++ b/integrations/alpadreams/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flash-alpadreams"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Alpadreams inference with flashdreams"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/causal_forcing/pyproject.toml
+++ b/integrations/causal_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-causal-forcing"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Causal-Forcing chunkwise / framewise streaming T2V + I2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/cosmos_predict2/pyproject.toml
+++ b/integrations/cosmos_predict2/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-cosmos-predict2"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Cosmos-Predict2 T2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/fastvideo_causal_wan22/pyproject.toml
+++ b/integrations/fastvideo_causal_wan22/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-fastvideo-causal-wan22"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "FastVideo CausalWan 2.2 14B MoE distilled streaming T2V inference, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flash-lingbot"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Lingbot WebRTC integration for flashdreams"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/self_forcing/pyproject.toml
+++ b/integrations/self_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-self-forcing"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Self-Forcing distilled streaming T2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/wan21/pyproject.toml
+++ b/integrations/wan21/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-wan21"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Wan 2.1 T2V + I2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Adds unified versioning with `flashdreams/flashdreams/_version.py` as the single source of truth (currently `0.1.0a0`)
- Adds `.github/scripts/sync_version.py` + pre-commit hook to propagate version to all integration `pyproject.toml` files
- Switches `flashdreams/pyproject.toml` to `dynamic = ["version"]` via setuptools `attr`
- Adds `publish-testpypi` CI job that builds a pure-Python wheel and uploads to Test PyPI on every push to `main` (`--skip-existing --non-interactive`)
- Fills in the `cpu` job placeholder with actual `uv build --wheel` command
- Fixes docs CI to read version from `_version.py` instead of the removed static `pyproject.toml` field
- Adds `twine` to a `ci` dependency group in root `pyproject.toml`
- Documents versioning scheme and publishing in `DEV.md`

## Test PyPI

Published and verified: https://test.pypi.org/project/flashdreams/0.1.0a0

To test the core package:

```bash
uv venv --python 3.12
uv pip install --index-url https://test.pypi.org/simple/ --no-deps flashdreams==0.1.0a0

python -c "import flashdreams; print(flashdreams.__version__)"
# 0.1.0a0
```

`TEST_PYPI_API_TOKEN` secret is configured. The `publish-testpypi` job runs on pushes to `main` only.

**TEMPORARY:** Test PyPI is used while the project is pre-release. When going public, change `--repository testpypi` to `--repository pypi` and the secret from `TEST_PYPI_API_TOKEN` to `PYPI_API_TOKEN` in `.github/workflows/ci.yml`.

## Installing integration packages

Integration packages are not published to PyPI. Install them directly from the git repo:

```bash
# From main
uv pip install "flashdreams-wan21 @ git+https://github.com/NVIDIA/flashdreams.git@main#subdirectory=integrations/wan21"

# From a specific branch
uv pip install "flashdreams-wan21 @ git+https://github.com/NVIDIA/flashdreams.git@dev/janickm/pypi-deployment#subdirectory=integrations/wan21"

# From a specific commit
uv pip install "flashdreams-wan21 @ git+https://github.com/NVIDIA/flashdreams.git@3606e610#subdirectory=integrations/wan21"
```

Available integration packages:

| Package | Subdirectory |
|---------|-------------|
| `flashdreams-wan21` | `integrations/wan21` |
| `flashdreams-self-forcing` | `integrations/self_forcing` |
| `flashdreams-causal-forcing` | `integrations/causal_forcing` |
| `flashdreams-fastvideo-causal-wan22` | `integrations/fastvideo_causal_wan22` |
| `flash-alpadreams` | `integrations/alpadreams` |
| `flash-lingbot` | `integrations/lingbot` |

## Versioning scheme

| Package | Published | Version |
|---------|-----------|---------|
| flashdreams | Test PyPI | canonical (from `_version.py`) |
| flashdreams-wan21 | git only | synced |
| flashdreams-self-forcing | git only | synced |
| flashdreams-causal-forcing | git only | synced |
| flashdreams-fastvideo-causal-wan22 | git only | synced |
| flash-alpadreams | git only | synced |
| flash-lingbot | git only | synced |
| ludus-renderer | git only | independent |

## How to bump

1. Edit `__version__` in `flashdreams/flashdreams/_version.py`
2. Commit -- pre-commit hook syncs all integration `pyproject.toml` files
3. Push to `main` -- CI builds and uploads the wheel
