### PR TITLE
fix: update license in ludus-renderer project file

### DIFF
--- a/integrations/alpadreams/ludus-renderer/pyproject.toml
+++ b/integrations/alpadreams/ludus-renderer/pyproject.toml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [project]
 name = "ludus-renderer"
 version = "0.9.0"


### PR DESCRIPTION
This pull request adds standard SPDX license and copyright headers to the `pyproject.toml` file for the `ludus-renderer` integration.

- Licensing and compliance:
  * Added SPDX copyright and Apache-2.0 license headers to the top of `pyproject.toml` to clarify licensing and usage terms.