### PR TITLE
ci: enable GPU unit tests in CI gpu job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,10 @@ jobs:
 
       - name: Run GPU unit tests
         run: |
-          uv run --no-sync pytest -m ci_gpu -v
+          uv run --no-sync pytest -m ci_gpu -v \
+            --import-mode=importlib \
+            -c flashdreams/pyproject.toml \
+            flashdreams/tests/
 
   # ===========================================================================
   # Publish to Test PyPI -- runs only on main after lint passes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,15 +67,20 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
       - name: Verify GPU availability
         run: |
           echo "Verifying GPU access..."
           nvidia-smi
 
-      - name: Run world model diffusion
+      - name: Run GPU unit tests
         run: |
-          echo "Running world model diffusion workloads..."
-          # Add your world model diffusion commands here
+          uv run --no-sync pytest -m ci_gpu --run-manual -v
 
   # ===========================================================================
   # Publish to Test PyPI -- runs only on main after lint passes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,12 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: |
+          # transformer-engine-torch is source-only and requires the CUDA
+          # toolkit (nvcc) to compile.  Skip it -- tests that need TE will
+          # gracefully skip via @_requires_te / skipif guards.
+          uv sync --extra dev \
+            --no-install-package transformer-engine-torch
 
       - name: Verify GPU availability
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run GPU unit tests
         run: |
-          uv run --no-sync pytest -m ci_gpu --include-manual -v
+          uv run --no-sync pytest -m ci_gpu -v
 
   # ===========================================================================
   # Publish to Test PyPI -- runs only on main after lint passes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run GPU unit tests
         run: |
-          uv run --no-sync pytest -m ci_gpu --run-manual -v
+          uv run --no-sync pytest -m ci_gpu --include-manual -v
 
   # ===========================================================================
   # Publish to Test PyPI -- runs only on main after lint passes.

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -124,5 +124,6 @@ torchvision = [
 addopts = "--import-mode=importlib"
 markers = [
     "manual: requires GPU and/or network access (opt-in only)",
+    "ci_gpu: GPU test safe to run in CI on RTX Pro 6000 runners",
     "slow: long-running test",
 ]

--- a/flashdreams/tests/test_attention.py
+++ b/flashdreams/tests/test_attention.py
@@ -22,6 +22,7 @@ Multi-GPU test can be run with:
 
 import os
 
+import pytest
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
@@ -30,6 +31,7 @@ from torch.distributed.tensor import Shard, distribute_tensor
 from flashdreams.core.attention import NativeAttention, RingAttention
 
 
+@pytest.mark.ci_gpu
 def test_attention():
     # Run multi gpu test with
     # PYTHONPATH=. torchrun --nproc_per_node=2 -m pytest ...

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -159,6 +159,7 @@ def test_block_kvcache_matches_baseline(
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA required for cudagraph test"
 )
+@pytest.mark.ci_gpu
 @pytest.mark.parametrize("sink_size,window_size", [(0, 8), (0, 24), (3, 5), (3, 21)])
 def test_block_kvcache_cudagraph_matches_baseline(
     dtype: torch.dtype,

--- a/flashdreams/tests/test_rope_kernel.py
+++ b/flashdreams/tests/test_rope_kernel.py
@@ -58,6 +58,10 @@ _requires_te = pytest.mark.skipif(
     not _TE_AVAILABLE, reason="transformer_engine not available"
 )
 
+# All tests in this module require CUDA; the cuda_device fixture skips
+# if unavailable.  ci_gpu opts them into the GPU CI runner.
+pytestmark = pytest.mark.ci_gpu
+
 
 def _te_reference(x: Tensor, freqs: Tensor, interleaved: bool) -> Tensor:
     """Run TE's fused RoPE for use as the parity / perf reference."""

--- a/flashdreams/tests/test_template.py
+++ b/flashdreams/tests/test_template.py
@@ -200,8 +200,11 @@ _CUDA_REQUIRED = pytest.mark.skipif(
     reason="template recipe uses RingAttention which requires CUDA.",
 )
 
+_CI_GPU = pytest.mark.ci_gpu
+
 
 @_CUDA_REQUIRED
+@_CI_GPU
 @pytest.mark.parametrize("seed", [0, 42])
 def test_template_bidirectional(seed: int) -> None:
     """``TEMPLATE_OFFLINE`` runs a single AR step end-to-end."""
@@ -244,6 +247,7 @@ def test_template_bidirectional(seed: int) -> None:
 
 
 @_CUDA_REQUIRED
+@_CI_GPU
 def test_template_no_control() -> None:
     """Rollout with no encoder + ``input=None`` skips the control bias.
 
@@ -314,6 +318,7 @@ def test_template_no_control() -> None:
 
 
 @_CUDA_REQUIRED
+@_CI_GPU
 def test_template_streaming_cfg() -> None:
     """``TEMPLATE_AUTOREGRESSIVE`` runs multi-step AR with CFG on."""
     config = _with_cfg(_autoregressive(seed=0), guidance_scale=2.0)
@@ -356,6 +361,7 @@ def test_template_streaming_cfg() -> None:
 
 
 @_CUDA_REQUIRED
+@_CI_GPU
 def test_template_cfg_rejects_missing_negative_context() -> None:
     """CFG on without negative context must fail at cache build time."""
     config = _with_cfg(_autoregressive(seed=0), guidance_scale=2.0)
@@ -378,6 +384,7 @@ def test_template_cfg_rejects_missing_negative_context() -> None:
 
 
 @_CUDA_REQUIRED
+@_CI_GPU
 def test_template_latent_shape_respects_cp_size() -> None:
     """``latent_shape`` reflects the per-rollout, per-rank ``L`` partition.
 
@@ -427,6 +434,7 @@ def _with_cfg(
     not torch.cuda.is_available(),
     reason="torch.compile + CUDAGraphWrapper equivalence requires CUDA.",
 )
+@_CI_GPU
 def test_template_compile_and_cudagraph_equivalence() -> None:
     """Eager vs ``torch.compile`` + ``CUDAGraphWrapper`` agree numerically.
 
@@ -610,6 +618,7 @@ def _cp_one_predict_flow(
     return cat_outputs_cp(flow_local, seq_dim=1, cp_group=transformer._cp_group)
 
 
+@_CI_GPU
 def test_template_cp_equivalence() -> None:
     """Non-distributed vs ``cp_size=world_size`` produce the same global output.
 


### PR DESCRIPTION
## Summary

Enable GPU unit tests in the CI `gpu` job on the `linux-amd64-gpu-rtxpro6000-latest-2` runner (2x RTX Pro 6000, 48GB each).

**Phase 1 (this PR):** Low-risk GPU tests with no network/model download dependencies:
- `test_attention` -- NativeAttention vs RingAttention parity (single-GPU)
- `test_rope_kernel` -- Triton RoPE kernel parity + perf vs Transformer Engine
- `test_kvcache` -- BlockKVCache CUDA graph correctness
- `test_template` -- template recipe smoke tests, compile+cudagraph equivalence, CP equivalence

**Changes:**
- Added `ci_gpu` pytest marker alongside the existing `manual` marker
- Updated the `gpu` CI job to install deps via `uv sync --extra dev` and run `pytest -m ci_gpu --run-manual -v`
- Marked all CUDA-requiring tests with `@pytest.mark.ci_gpu`

**Follow-up phases (subsequent commits on this PR):**
- Phase 2: Add model instantiation tests (HF_TOKEN wiring)
- Phase 3: Enable risky large-model tests (14B DiT)
- Phase 4: Investigate ludus renderer tests