### PR TITLE
build: update package metadata and bump version to 0.1.0a2

### DIFF
--- a/flashdreams/PYPI_README.md
+++ b/flashdreams/PYPI_README.md
@@ -1,0 +1,35 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# flashdreams
+
+A high-performance streaming inference framework for video diffusion models
+with a plugin architecture for model backends.
+
+## Features
+
+- **Streaming Inference** -- Autoregressive chunk-wise video generation with
+  per-rollout cache state for bounded VRAM and arbitrarily long rollouts
+- **Plugin Architecture** -- Entry-point-based model discovery; third-party
+  packages register runner configs that appear automatically in the CLI
+- **Multi-GPU** -- Context parallelism via torchrun with automatic sharding
+  across ranks
+- **Performance** -- torch.compile support with CUDA graph capture and replay
+- **Serving** -- WebRTC and gRPC integrations for real-time interactive
+  applications
+
+## Supported Models
+
+Wan 2.1/2.2, Cosmos Predict2, and more via first-party integration packages.
+
+## Installation
+
+```bash
+pip install flashdreams
+```
+
+## Documentation
+
+<https://github.com/NVIDIA/flashdreams>

--- a/flashdreams/flashdreams/_version.py
+++ b/flashdreams/flashdreams/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.0a2"

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -20,8 +20,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "flashdreams"
 dynamic = ["version"]
-description = "Flash video simulation pipeline"
-readme = "README.md"
+description = "High-performance streaming video diffusion framework with pluggable model backends"
+readme = "PYPI_README.md"
+license = "Apache-2.0"
 requires-python = ">=3.12,<3.13"
 dependencies = [
     "boto3>=1.35",
@@ -61,6 +62,11 @@ dependencies = [
 # Mirrors nerfstudio's ``ns-train`` console script shape (one hyphenated
 # binary, tyro union over runners as direct subcommands).
 flashdreams-run = "flashdreams.scripts.cli:entrypoint"
+
+[project.urls]
+Homepage = "https://github.com/NVIDIA/flashdreams"
+Repository = "https://github.com/NVIDIA/flashdreams"
+"Bug Tracker" = "https://github.com/NVIDIA/flashdreams/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/integrations/alpadreams/pyproject.toml
+++ b/integrations/alpadreams/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flash-alpadreams"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Alpadreams inference with flashdreams"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/causal_forcing/pyproject.toml
+++ b/integrations/causal_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-causal-forcing"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Causal-Forcing chunkwise / framewise streaming T2V + I2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/cosmos_predict2/pyproject.toml
+++ b/integrations/cosmos_predict2/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-cosmos-predict2"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Cosmos-Predict2 T2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/fastvideo_causal_wan22/pyproject.toml
+++ b/integrations/fastvideo_causal_wan22/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-fastvideo-causal-wan22"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "FastVideo CausalWan 2.2 14B MoE distilled streaming T2V inference, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flash-lingbot"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Lingbot WebRTC integration for flashdreams"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/self_forcing/pyproject.toml
+++ b/integrations/self_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-self-forcing"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Self-Forcing distilled streaming T2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/wan21/pyproject.toml
+++ b/integrations/wan21/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-wan21"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Wan 2.1 T2V + I2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Update core package description to "High-performance streaming video diffusion framework with pluggable model backends"
- Add `PYPI_README.md` with features, supported models, installation, and documentation links (modeled after ncore)
- Add `license = "Apache-2.0"` and `[project.urls]` (Homepage, Repository, Bug Tracker) to core pyproject.toml
- Fix `readme` field pointing to nonexistent `README.md` -> now points to `PYPI_README.md`
- Bump version `0.1.0a1` -> `0.1.0a2` across core (`_version.py`) and all 7 integration packages

Closes #79