### PR TITLE
Fix HF example-data UUID listing in alpadreams runner

### DIFF
--- a/flashdreams/flashdreams/recipes/alpadreams/runner.py
+++ b/flashdreams/flashdreams/recipes/alpadreams/runner.py
@@ -105,6 +105,7 @@ def _ensure_hf_single_view_example_data_synced(
     from :data:`EXAMPLE_DATA_HF_REPO` (the hdmap filename is per-clip so
     we list the dir first to find it). Returns ``((hdmap,), (first_frame,))``."""
     from huggingface_hub import HfApi, hf_hub_download
+    from huggingface_hub.hf_api import RepoFile
 
     subdir = f"data/single_view/{uuid}"
     api = HfApi()
@@ -114,7 +115,7 @@ def _ensure_hf_single_view_example_data_synced(
         path_in_repo=subdir,
         recursive=False,
     )
-    files = [entry.path for entry in entries if getattr(entry, "type", None) == "file"]
+    files = [entry.path for entry in entries if isinstance(entry, RepoFile)]
     hdmap_candidates = [f for f in files if f.endswith("_hdmap.mp4")]
     if not hdmap_candidates:
         raise FileNotFoundError(


### PR DESCRIPTION
`HfApi.list_repo_tree` in huggingface_hub 0.36 returns `RepoFile` / `RepoFolder` dataclass instances that do not expose a `.type` attribute, so the previous `getattr(entry, "type", None) == "file"` filter dropped every entry and `_ensure_hf_single_view_example_data_synced` always raised `FileNotFoundError` (even for UUIDs whose `*_hdmap.mp4` exists on HF). Switch the filter to `isinstance(entry, RepoFile)`, which is the canonical hf_hub idiom.

Upstreamed from nv-tlabs/flashdreams-partner-waabi PR #2 (commit 839200d). Reproduced against huggingface_hub 0.36.2 on a clean checkout: calling `_ensure_hf_single_view_example_data_synced(DEFAULT_EXAMPLE_DATA_UUID_1V)` raises `FileNotFoundError`; with this patch it returns the expected hdmap + first_frame paths.