### PR TITLE
Load oneshot encoders on initialize_cache when not available

### DIFF
--- a/flashdreams/flashdreams/recipes/wan/pipeline.py
+++ b/flashdreams/flashdreams/recipes/wan/pipeline.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import gc
 from dataclasses import dataclass, field
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -136,12 +137,31 @@ class WanInferencePipeline(
 
     def __init__(self, config: WanInferencePipelineConfig) -> None:
         super().__init__(config)
+        self.config: WanInferencePipelineConfig = config
         self.text_encoder = (
             config.text_encoder.setup() if config.text_encoder is not None else None
         )
         self.image_encoder = (
             config.image_encoder.setup() if config.image_encoder is not None else None
         )
+
+    def _setup_oneshot_encoder(self, config: Any) -> Any:
+        encoder = config.setup()
+        if isinstance(encoder, torch.nn.Module):
+            encoder = encoder.to(device=self.device)
+        return encoder
+
+    def _ensure_oneshot_encoders_loaded(self) -> None:
+        """Reload one-shot encoders released after an earlier rollout."""
+        if self.text_encoder is None:
+            assert self.config.text_encoder is not None, (
+                "text_encoder is not set and config.text_encoder is None; "
+                "cannot encode raw prompts."
+            )
+            self.text_encoder = self._setup_oneshot_encoder(self.config.text_encoder)
+
+        if self.image_encoder is None and self.config.image_encoder is not None:
+            self.image_encoder = self._setup_oneshot_encoder(self.config.image_encoder)
 
     @property
     def _transformer_config(self) -> Wan21TransformerConfig | Wan22TransformerConfig:
@@ -159,6 +179,7 @@ class WanInferencePipeline(
         *,
         height: int | None = None,
         width: int | None = None,
+        release_oneshot_encoders: bool = True,
     ) -> WanInferencePipelineCache:
         """Initialize the per-rollout cache for a batch of prompts.
 
@@ -174,6 +195,9 @@ class WanInferencePipeline(
                 I2V — derived from ``image`` when omitted; required for T2V.
             width: Pre-patchify latent width (post-VAE). Same rules as
                 ``height``.
+            release_oneshot_encoders: Free the text and image encoders after
+                the cache is initialized. Later calls reload them from
+                ``self.config`` before encoding new prompts/images.
 
         Returns:
             Cache to thread through ``generate`` / ``finalize``.
@@ -181,6 +205,7 @@ class WanInferencePipeline(
         assert len(text) > 0, "text must be non-empty"
         n = len(text)
 
+        self._ensure_oneshot_encoders_loaded()
         assert self.text_encoder is not None, "text_encoder is not set"
         text_embeddings = self.text_encoder(text)  # [B, L, D]
 
@@ -258,8 +283,8 @@ class WanInferencePipeline(
             },
         )
 
-        # For lower VRAM usage, release the oneshot encoders after initialize_cache.
-        self.release_oneshot_encoders()
+        if release_oneshot_encoders:
+            self.release_oneshot_encoders()
 
         return WanInferencePipelineCache(
             transformer_cache=parent.transformer_cache,
@@ -297,7 +322,11 @@ class WanInferencePipeline(
             )
 
     def release_oneshot_encoders(self) -> None:
-        """Free the per-rollout text and first-frame image encoders."""
+        """Free the per-rollout text and first-frame image encoders.
+
+        Idempotent. A later :meth:`initialize_cache` call can reload the
+        encoders from ``self.config`` before encoding raw prompts/images.
+        """
         # None instead of delattr so initialize_cache's `is not None` guard
         # fires with a useful message rather than an AttributeError.
         self.text_encoder = None

--- a/flashdreams/tests/test_wan_pipeline.py
+++ b/flashdreams/tests/test_wan_pipeline.py
@@ -22,12 +22,22 @@ from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerConfig
 
 
 class _FakeTextEncoder:
-    def __init__(self) -> None:
-        self.calls: list[list[str]] = []
+    def __init__(self, calls: list[list[str]]) -> None:
+        self.calls = calls
 
     def __call__(self, prompts: list[str]) -> torch.Tensor:
         self.calls.append(list(prompts))
         return torch.full((len(prompts), 2, 3), float(len(self.calls)))
+
+
+class _FakeTextEncoderConfig:
+    def __init__(self, calls: list[list[str]]) -> None:
+        self.calls = calls
+        self.setup_calls = 0
+
+    def setup(self) -> _FakeTextEncoder:
+        self.setup_calls += 1
+        return _FakeTextEncoder(self.calls)
 
 
 class _FakeStreamingVideoDecoder:
@@ -69,8 +79,13 @@ def test_wan_initialize_cache_can_be_reused_for_multiple_rollouts(
 
     pipeline = WanInferencePipeline.__new__(WanInferencePipeline)
     torch.nn.Module.__init__(pipeline)
-    text_encoder = _FakeTextEncoder()
-    pipeline.text_encoder = text_encoder
+    text_encoder_calls: list[list[str]] = []
+    text_encoder_config = _FakeTextEncoderConfig(text_encoder_calls)
+    pipeline.config = SimpleNamespace(
+        text_encoder=text_encoder_config,
+        image_encoder=None,
+    )
+    pipeline.text_encoder = text_encoder_config.setup()
     pipeline.image_encoder = None
     pipeline.encoder = object()
     pipeline.decoder = _FakeStreamingVideoDecoder()
@@ -85,7 +100,79 @@ def test_wan_initialize_cache_can_be_reused_for_multiple_rollouts(
 
     assert first_cache.image is image
     assert second_cache.image is image
-    assert text_encoder.calls == [["first prompt"], ["second prompt"]]
+    assert text_encoder_calls == [["first prompt"], ["second prompt"]]
+    assert text_encoder_config.setup_calls == 2
+    assert pipeline.text_encoder is None
+    assert captured_contexts[0]["height"] == 2
+    assert captured_contexts[0]["width"] == 2
+    assert captured_contexts[1]["height"] == 2
+    assert captured_contexts[1]["width"] == 2
+
+
+def test_wan_initialize_cache_can_keep_oneshot_encoders_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_contexts: list[dict[str, Any]] = []
+
+    def capture_initialize_cache(
+        self: StreamInferencePipeline,
+        *,
+        transformer_context: dict[str, Any] | None = None,
+        encoder_context: dict[str, Any] | None = None,
+        decoder_context: dict[str, Any] | None = None,
+    ) -> StreamInferencePipelineCache[Any, Any, Any]:
+        del self, encoder_context, decoder_context
+        assert transformer_context is not None
+        captured_contexts.append(transformer_context)
+        return StreamInferencePipelineCache(
+            transformer_cache=TransformerAutoregressiveCache(),
+            encoder_cache=StreamingEncoderCache(),
+            decoder_cache=StreamingDecoderCache(),
+        )
+
+    monkeypatch.setattr(
+        StreamInferencePipeline,
+        "initialize_cache",
+        capture_initialize_cache,
+    )
+    monkeypatch.setattr(
+        wan_pipeline_module,
+        "StreamingVideoDecoder",
+        _FakeStreamingVideoDecoder,
+    )
+
+    pipeline = WanInferencePipeline.__new__(WanInferencePipeline)
+    torch.nn.Module.__init__(pipeline)
+    text_encoder_calls: list[list[str]] = []
+    text_encoder_config = _FakeTextEncoderConfig(text_encoder_calls)
+    pipeline.config = SimpleNamespace(
+        text_encoder=text_encoder_config,
+        image_encoder=None,
+    )
+    pipeline.text_encoder = text_encoder_config.setup()
+    pipeline.image_encoder = None
+    pipeline.encoder = object()
+    pipeline.decoder = _FakeStreamingVideoDecoder()
+    pipeline.diffusion_model = SimpleNamespace(
+        transformer=SimpleNamespace(config=Wan21TransformerConfig(guidance_scale=1.0))
+    )
+
+    image = torch.zeros(1, 1, 1, 3, 4, 4)
+
+    pipeline.initialize_cache(
+        text=["first prompt"],
+        image=image,
+        release_oneshot_encoders=False,
+    )
+    pipeline.initialize_cache(
+        text=["second prompt"],
+        image=image,
+        release_oneshot_encoders=False,
+    )
+
+    assert text_encoder_calls == [["first prompt"], ["second prompt"]]
+    assert text_encoder_config.setup_calls == 1
+    assert pipeline.text_encoder is not None
     assert captured_contexts[0]["height"] == 2
     assert captured_contexts[0]["width"] == 2
     assert captured_contexts[1]["height"] == 2

--- a/flashdreams/tests/test_wan_pipeline.py
+++ b/flashdreams/tests/test_wan_pipeline.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from flashdreams.infra.decoder import StreamingDecoderCache
+from flashdreams.infra.diffusion.transformer import TransformerAutoregressiveCache
+from flashdreams.infra.encoder import StreamingEncoderCache
+from flashdreams.infra.pipeline import (
+    StreamInferencePipeline,
+    StreamInferencePipelineCache,
+)
+from flashdreams.recipes.wan import pipeline as wan_pipeline_module
+from flashdreams.recipes.wan.pipeline import WanInferencePipeline
+from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerConfig
+
+
+class _FakeTextEncoder:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, prompts: list[str]) -> torch.Tensor:
+        self.calls.append(list(prompts))
+        return torch.full((len(prompts), 2, 3), float(len(self.calls)))
+
+
+class _FakeStreamingVideoDecoder:
+    spatial_compression_ratio = 2
+
+
+def test_wan_initialize_cache_can_be_reused_for_multiple_rollouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long-lived hosts reuse one pipeline instance across session resets."""
+    captured_contexts: list[dict[str, Any]] = []
+
+    def capture_initialize_cache(
+        self: StreamInferencePipeline,
+        *,
+        transformer_context: dict[str, Any] | None = None,
+        encoder_context: dict[str, Any] | None = None,
+        decoder_context: dict[str, Any] | None = None,
+    ) -> StreamInferencePipelineCache[Any, Any, Any]:
+        del self, encoder_context, decoder_context
+        assert transformer_context is not None
+        captured_contexts.append(transformer_context)
+        return StreamInferencePipelineCache(
+            transformer_cache=TransformerAutoregressiveCache(),
+            encoder_cache=StreamingEncoderCache(),
+            decoder_cache=StreamingDecoderCache(),
+        )
+
+    monkeypatch.setattr(
+        StreamInferencePipeline,
+        "initialize_cache",
+        capture_initialize_cache,
+    )
+    monkeypatch.setattr(
+        wan_pipeline_module,
+        "StreamingVideoDecoder",
+        _FakeStreamingVideoDecoder,
+    )
+
+    pipeline = WanInferencePipeline.__new__(WanInferencePipeline)
+    torch.nn.Module.__init__(pipeline)
+    text_encoder = _FakeTextEncoder()
+    pipeline.text_encoder = text_encoder
+    pipeline.image_encoder = None
+    pipeline.encoder = object()
+    pipeline.decoder = _FakeStreamingVideoDecoder()
+    pipeline.diffusion_model = SimpleNamespace(
+        transformer=SimpleNamespace(config=Wan21TransformerConfig(guidance_scale=1.0))
+    )
+
+    image = torch.zeros(1, 1, 1, 3, 4, 4)
+
+    first_cache = pipeline.initialize_cache(text=["first prompt"], image=image)
+    second_cache = pipeline.initialize_cache(text=["second prompt"], image=image)
+
+    assert first_cache.image is image
+    assert second_cache.image is image
+    assert text_encoder.calls == [["first prompt"], ["second prompt"]]
+    assert captured_contexts[0]["height"] == 2
+    assert captured_contexts[0]["width"] == 2
+    assert captured_contexts[1]["height"] == 2
+    assert captured_contexts[1]["width"] == 2


### PR DESCRIPTION
https://github.com/NVIDIA/flashdreams/pull/88 broke lingbot webrtc server as the Wan pipeline would unload the text encoder before the user gets to request their session. This PR fixes this by making `initialize_session` check for encoder availability and loading encoders on demand if missing.