### PR TITLE
ci: replace path restrictions with per-test ci_cpu/ci_gpu/manual markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
 
   cpu:
     runs-on: linux-amd64-cpu8
+    container:
+      image: ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566
+    env:
+      UV_PROJECT_ENVIRONMENT: /tmp/flashdreams-venv
     steps:
       - name: Get PR info
         if: startsWith(github.ref_name, 'pull-request/')
@@ -53,17 +57,11 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          uv sync --extra dev \
-            --no-install-package transformer-engine-torch
+          uv venv --clear
+          uv sync --extra dev
 
       - name: Run CPU unit tests
-        run: |
-          # Restricted to paths that do not transitively import cv2
-          # (cv2 needs libGL.so.1 which is unavailable on the CPU runner).
-          # The GPU job runs the full test suite without path restrictions.
-          uv run --no-sync pytest -m "not ci_gpu" -v \
-            flashdreams/tests/ \
-            integrations/lingbot/tests/test_controls.py
+        run: uv run --no-sync pytest -m ci_cpu -v
 
       # Documentation is built and deployed by `.github/workflows/doc.yml`.
 
@@ -102,11 +100,10 @@ jobs:
           echo "Verifying GPU access..."
           nvidia-smi
 
-      - name: Run unit tests
+      - name: Run GPU unit tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          uv run --no-sync pytest -m "not slow" -v
+        run: uv run --no-sync pytest -m ci_gpu -v
 
   # ===========================================================================
   # Publish to Test PyPI -- runs only on main after lint passes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,14 +148,16 @@ The short version:
 1. Fork the repo on GitHub and create a feature branch from `main`.
 2. Make your changes. Keep PRs small and focused; a 200-line PR that
    does one thing reviews much faster than a 2000-line PR that does ten.
-3. Add or update tests where it makes sense. CPU-only tests are
-   preferred for portability; GPU tests are welcome and gated with the
-   `manual` pytest marker.
+3. Add or update tests where it makes sense. Every test must carry
+   exactly one CI tier marker (`@pytest.mark.ci_cpu`,
+   `@pytest.mark.ci_gpu`, or `@pytest.mark.manual`); see
+   [Testing](#testing) below. The project enforces this at collection
+   time -- pytest will error if a test is missing a marker.
 4. Run the project's checks locally:
 
    ```bash
    uv run pre-commit run -a       # format + lint + type-check
-   uv run pytest -m "not manual"  # CPU tests
+   uv run pytest -m ci_cpu         # CPU tests (no GPU required)
    ```
 
 5. Sign off your commits (`git commit --signoff`) and push to your fork.
@@ -194,7 +196,8 @@ short ping comment.
 - Prefer small, well-named functions over long functions with comments
   explaining each block. Comments should explain *why*, not *what*.
 - Tests live in `flashdreams/tests/` and `integrations/*/tests/`. Use
-  `pytest` and prefer existing fixtures over hand-rolled setup.
+  `pytest` and prefer existing fixtures over hand-rolled setup. See
+  [Testing](#testing) for marker requirements.
 - Every source file added by a contribution must include the SPDX
   header used elsewhere in the project:
 
@@ -218,6 +221,48 @@ short ping comment.
   External contributors should add their own copyright line *above* the
   NVIDIA line if they wish to be attributed; both attributions are
   retained.
+
+## Testing
+
+Every test function must be marked with exactly one **CI tier marker**.
+A pytest plugin (`flashdreams._pytest_plugins.marker_enforcement`)
+enforces this at collection time -- tests without a marker are
+rejected, and tests with both `ci_cpu` and `ci_gpu` are rejected.
+
+| Marker | When to use | CI runner |
+|--------|-------------|-----------|
+| `@pytest.mark.ci_cpu` | Pure CPU logic, no GPU or `libGL` needed | CPU runner |
+| `@pytest.mark.ci_gpu` | Needs CUDA, `libGL`, or transitive `cv2` | GPU runner (RTX Pro 6000) |
+| `@pytest.mark.manual` | Heavy (OOM risk), flaky, needs credentials or large downloads | Not run in CI |
+
+Use a module-level `pytestmark` when every test in a file shares the
+same marker:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.ci_cpu
+```
+
+Use per-function markers when tests in the same file have different
+tiers:
+
+```python
+@pytest.mark.ci_cpu
+def test_basic_math(): ...
+
+@pytest.mark.ci_gpu
+def test_cudagraph_path(): ...
+```
+
+Running tests locally:
+
+```bash
+uv run pytest -m ci_cpu          # CPU-safe tests only
+uv run pytest -m ci_gpu          # GPU tests only (needs CUDA)
+uv run pytest -m "not manual"    # everything that runs in CI
+uv run pytest                    # all tests including manual
+```
 
 ## Licensing of contributions
 

--- a/flashdreams/flashdreams/_pytest_plugins/marker_enforcement.py
+++ b/flashdreams/flashdreams/_pytest_plugins/marker_enforcement.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pytest plugin that enforces CI tier markers on every test.
+
+Every test must carry exactly one of ``ci_cpu``, ``ci_gpu``, or
+``manual`` -- either via a module-level ``pytestmark`` or a per-function
+decorator.  ``manual`` may be combined with ``ci_cpu`` or ``ci_gpu``
+to opt a single function out of a module-level tier (manual takes
+precedence).  Having both ``ci_cpu`` and ``ci_gpu`` is rejected.
+Tests without any tier marker are rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_CI_TIER_MARKERS = frozenset({"ci_cpu", "ci_gpu", "manual"})
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Reject unmarked tests and ci_cpu + ci_gpu conflicts."""
+    missing: list[str] = []
+    conflicting: list[str] = []
+
+    for item in items:
+        item_markers = {m.name for m in item.iter_markers()} & _CI_TIER_MARKERS
+
+        if not item_markers:
+            missing.append(item.nodeid)
+        elif {"ci_cpu", "ci_gpu"} <= item_markers:
+            conflicting.append(item.nodeid)
+
+    errors: list[str] = []
+    if missing:
+        formatted = "\n".join(f"  {nodeid}" for nodeid in missing)
+        errors.append(
+            f"Tests missing a CI tier marker (ci_cpu, ci_gpu, or manual):\n{formatted}"
+        )
+    if conflicting:
+        formatted = "\n".join(f"  {nodeid}" for nodeid in conflicting)
+        errors.append(
+            f"Tests marked with both ci_cpu and ci_gpu "
+            f"(pick exactly one, or use manual to opt out):\n"
+            f"{formatted}"
+        )
+
+    if errors:
+        raise pytest.UsageError("\n\n".join(errors))

--- a/flashdreams/flashdreams/core/experimental/test_block_kvcache.py
+++ b/flashdreams/flashdreams/core/experimental/test_block_kvcache.py
@@ -20,6 +20,8 @@ import torch
 
 from flashdreams.core.experimental.kvcache import BlockKVCache
 
+pytestmark = pytest.mark.ci_cpu
+
 
 class _NaiveKVCache:
     """Baseline: full sequence via torch.cat; view = [sink | last window] or full. Shape [B, S, H, D]."""

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -104,7 +104,7 @@ version = {attr = "flashdreams._version.__version__"}
 
 [tool.setuptools.packages.find]
 include = ["flashdreams*"]
-exclude = ["tests"]
+exclude = ["tests", "flashdreams._pytest_plugins*"]
 
 # PyPI's default ``torch`` is the CPU build on Windows. The truesight CUDA
 # extensions (built by ``uv run build-truesight``) need a CUDA-enabled
@@ -124,12 +124,4 @@ torch = [
 ]
 torchvision = [
     { index = "pytorch-cu130", marker = "sys_platform == 'win32'" },
-]
-
-[tool.pytest.ini_options]
-addopts = "--import-mode=importlib"
-markers = [
-    "manual: requires GPU and/or network access (opt-in only)",
-    "ci_gpu: GPU test safe to run in CI on RTX Pro 6000 runners",
-    "slow: long-running test",
 ]

--- a/flashdreams/tests/test_alpadreams.py
+++ b/flashdreams/tests/test_alpadreams.py
@@ -19,6 +19,8 @@ from typing import Any, cast
 import pytest
 import torch
 
+# Mixed markers: most tests are ci_cpu; streaming_inference is manual.
+# Per-function markers used below.
 from flashdreams.infra.diffusion.scheduler.fm_unipc import (
     FlowMatchUniPCSchedulerConfig,
 )
@@ -50,6 +52,7 @@ def _make_uninitialized_alpadreams_pipeline() -> AlpadreamsPipeline:
     return pipeline
 
 
+@pytest.mark.ci_cpu
 def test_alpadreams_initialize_cache_from_embeddings_negative_text_optional(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -92,6 +95,7 @@ def test_alpadreams_initialize_cache_from_embeddings_negative_text_optional(
     assert captured_contexts[-1]["negative_text_embeddings"] is negative_text_embeddings
 
 
+@pytest.mark.ci_cpu
 def test_alpadreams_initialize_cache_encodes_cfg_negative_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -144,6 +148,7 @@ def test_alpadreams_initialize_cache_encodes_cfg_negative_prompt(
     assert captured_embeddings["negative_text_embeddings"] is not None
 
 
+@pytest.mark.ci_cpu
 def test_bidirectional_transformer_requires_and_wires_negative_embeddings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -247,6 +252,7 @@ def test_bidirectional_transformer_requires_and_wires_negative_embeddings(
     assert fake_network.cache_kwargs[-1]["context"] is negative_text_embeddings
 
 
+@pytest.mark.ci_cpu
 @pytest.mark.parametrize(
     (
         "config_name",

--- a/flashdreams/tests/test_context_parallel_strategy.py
+++ b/flashdreams/tests/test_context_parallel_strategy.py
@@ -21,6 +21,8 @@ from flashdreams.recipes.alpadreams.transformer.impl.context_parallel import (
     create_hierarchical_cp_groups,
 )
 
+pytestmark = pytest.mark.ci_cpu
+
 
 def _get_expected_groups(world_size: int, V: int, T: int) -> dict:
     """Return expected group configurations for various world_size, V, T combinations."""

--- a/flashdreams/tests/test_internal_storage.py
+++ b/flashdreams/tests/test_internal_storage.py
@@ -22,6 +22,8 @@ import pytest
 from flashdreams.core.io import internal
 from flashdreams.recipes.alpadreams import hf
 
+pytestmark = pytest.mark.ci_cpu
+
 
 @pytest.fixture(autouse=True)
 def _scrub_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -84,6 +84,7 @@ def dtype() -> torch.dtype:
     return torch.float32
 
 
+@pytest.mark.ci_cpu
 @pytest.mark.parametrize("sink_size,window_size", [(0, 8), (0, 24), (3, 5), (3, 21)])
 def test_block_kvcache_matches_baseline(
     device: torch.device,

--- a/flashdreams/tests/test_rank_orchestration.py
+++ b/flashdreams/tests/test_rank_orchestration.py
@@ -29,6 +29,8 @@ from flashdreams.core.distributed.rank_orchestration import (
     distributed_op,
 )
 
+pytestmark = pytest.mark.ci_cpu
+
 
 class _Signal(IntEnum):
     STEP = 0

--- a/flashdreams/tests/test_recipe_configs.py
+++ b/flashdreams/tests/test_recipe_configs.py
@@ -24,6 +24,8 @@ pipeline.recipe_name drift (which would surface as confusing
 
 from __future__ import annotations
 
+import pytest
+
 # Importing ``runner_configs`` triggers each in-tree recipe's
 # self-registration side effects. Without this import the registry
 # would be empty when tests run in isolation.
@@ -31,6 +33,8 @@ import flashdreams.configs.runner_configs  # noqa: F401
 from flashdreams.configs.registry import supported_runners
 from flashdreams.recipes.alpadreams.config import ALPADREAMS_RUNNERS
 from flashdreams.recipes.template.config import TEMPLATE_RUNNERS
+
+pytestmark = pytest.mark.ci_cpu
 
 
 def test_supported_runners_keys_match_runner_name() -> None:

--- a/flashdreams/tests/test_recipe_plugins.py
+++ b/flashdreams/tests/test_recipe_plugins.py
@@ -41,6 +41,8 @@ from flashdreams.plugins import discover_runners
 from flashdreams.plugins.registry import ENV_VAR
 from flashdreams.recipes.template.config import TEMPLATE_OFFLINE_RUNNER
 
+pytestmark = pytest.mark.ci_cpu
+
 
 @pytest.fixture
 def fake_plugin_module() -> Iterator[str]:

--- a/flashdreams/tests/test_rope_kernel.py
+++ b/flashdreams/tests/test_rope_kernel.py
@@ -256,7 +256,7 @@ _PERF_SHAPES = [
 
 
 @_requires_te
-@pytest.mark.slow
+@pytest.mark.manual
 @pytest.mark.parametrize("interleaved", [False, True])
 @pytest.mark.parametrize("shape", _PERF_SHAPES)
 def test_perf_vs_te(cuda_device, shape, interleaved):
@@ -266,7 +266,7 @@ def test_perf_vs_te(cuda_device, shape, interleaved):
     loose so cluster noise does not flake CI; the printed
     ``triton vs TE`` line is the actual signal across kernel edits.
 
-    Excluded from CI (``@pytest.mark.slow``) because the ratio varies
+    Excluded from CI (``@pytest.mark.manual``) because the ratio varies
     across GPU architectures and can flake on shared runners.
     """
     B, S, H, D = shape

--- a/flashdreams/tests/test_video_vae_tyro_cli.py
+++ b/flashdreams/tests/test_video_vae_tyro_cli.py
@@ -27,6 +27,8 @@ from flashdreams.recipes.taehv import (
 )
 from flashdreams.recipes.wan.autoencoder.vae import WanVAEEncoder, WanVAEEncoderConfig
 
+pytestmark = pytest.mark.ci_cpu
+
 
 @pytest.mark.parametrize(
     ("config_cls", "target_cls"),

--- a/flashdreams/tests/test_wan_context_parallel.py
+++ b/flashdreams/tests/test_wan_context_parallel.py
@@ -14,6 +14,8 @@ from flashdreams.recipes.wan.transformer.wan21 import (
     Wan21TransformerConfig,
 )
 
+pytestmark = pytest.mark.ci_cpu
+
 
 class _FakeProcessGroup:
     def __init__(self, world_size: int, rank: int) -> None:

--- a/flashdreams/tests/test_wan_pipeline.py
+++ b/flashdreams/tests/test_wan_pipeline.py
@@ -20,6 +20,8 @@ from flashdreams.recipes.wan import pipeline as wan_pipeline_module
 from flashdreams.recipes.wan.pipeline import WanInferencePipeline
 from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerConfig
 
+pytestmark = pytest.mark.ci_cpu
+
 
 class _FakeTextEncoder:
     def __init__(self, calls: list[list[str]]) -> None:

--- a/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_api.py
+++ b/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_api.py
@@ -239,6 +239,8 @@ import pytest
 import torch
 from ludus_renderer._ops._plugin import _get_plugin
 
+pytestmark = pytest.mark.ci_gpu
+
 
 def _require_cuda() -> None:
     if not torch.cuda.is_available():

--- a/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_port_invariants.py
+++ b/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_port_invariants.py
@@ -26,6 +26,8 @@ from test_cudaraster_api import (
     _to_vertices,
 )
 
+pytestmark = pytest.mark.ci_gpu
+
 ROOT = Path(__file__).resolve().parents[1] / "ludus_renderer" / "_cpp" / "cudaraster"
 
 

--- a/integrations/alpadreams/ludus-renderer/tests/test_nvjpeg.py
+++ b/integrations/alpadreams/ludus-renderer/tests/test_nvjpeg.py
@@ -16,8 +16,9 @@
 
 import pytest
 import torch
-
 from ludus_renderer import nvjpeg
+
+pytestmark = pytest.mark.ci_gpu
 
 
 def _nvjpeg_available():

--- a/integrations/alpadreams/tests/test_conditioning_wrapper.py
+++ b/integrations/alpadreams/tests/test_conditioning_wrapper.py
@@ -39,6 +39,8 @@ from alpadreams.conditioning.conditioning_wrapper import (
 )
 from torch import nn
 
+pytestmark = pytest.mark.ci_gpu
+
 
 class _FakePipeline:
     def __init__(self) -> None:

--- a/integrations/alpadreams/tests/test_grpc_server_initialize_distributed.py
+++ b/integrations/alpadreams/tests/test_grpc_server_initialize_distributed.py
@@ -19,6 +19,8 @@ import pytest
 import torch
 from alpadreams.grpc import server
 
+pytestmark = pytest.mark.ci_gpu
+
 
 def test_initialize_distributed_single_process_defaults(
     monkeypatch: pytest.MonkeyPatch,

--- a/integrations/alpadreams/tests/test_grpc_server_integration.py
+++ b/integrations/alpadreams/tests/test_grpc_server_integration.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import grpc
 import numpy as np
+import pytest
 from alpadreams.grpc.protos import (
     camera_pb2,
     common_pb2,
@@ -33,6 +34,8 @@ from alpadreams.grpc.protos import (
     video_model_pb2_grpc,
 )
 from PIL import Image
+
+pytestmark = pytest.mark.ci_gpu
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 

--- a/integrations/alpadreams/tests/test_service_composition.py
+++ b/integrations/alpadreams/tests/test_service_composition.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
 from alpadreams.grpc.server import WorldModelService
+
+pytestmark = pytest.mark.ci_gpu
 
 
 class _DummyWrapper:

--- a/integrations/alpadreams/tests/test_world_scenario_loader.py
+++ b/integrations/alpadreams/tests/test_world_scenario_loader.py
@@ -19,10 +19,13 @@ import io
 import zipfile
 from pathlib import Path
 
+import pytest
 from alpadreams.conditioning.world_scenario.data_loaders import (
     list_loaders,
     load_scene,
 )
+
+pytestmark = pytest.mark.ci_gpu
 
 
 def test_load_scene_direct_from_example_zip(

--- a/integrations/causal_forcing/tests/test_smoke.py
+++ b/integrations/causal_forcing/tests/test_smoke.py
@@ -36,6 +36,8 @@ from causal_forcing.config import RUNNER_CONFIGS
 
 from flashdreams.infra.runner import RunnerConfig
 
+pytestmark = pytest.mark.ci_gpu
+
 ENTRY_POINT_GROUP = "flashdreams.runner_configs"
 
 

--- a/integrations/fastvideo_causal_wan22/tests/test_smoke.py
+++ b/integrations/fastvideo_causal_wan22/tests/test_smoke.py
@@ -28,6 +28,8 @@ from fastvideo_causal_wan22.config import RUNNER_CONFIGS
 
 from flashdreams.infra.runner import RunnerConfig
 
+pytestmark = pytest.mark.ci_cpu
+
 ENTRY_POINT_GROUP = "flashdreams.runner_configs"
 
 

--- a/integrations/lingbot/tests/test_camera_utils.py
+++ b/integrations/lingbot/tests/test_camera_utils.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 from lingbot.encoder.utils import (
     compute_relative_poses,
     compute_relative_poses_causal,
 )
+
+pytestmark = pytest.mark.ci_cpu
 
 
 def random_SO3(batch_size: tuple[int], device="cpu"):

--- a/integrations/lingbot/tests/test_controls.py
+++ b/integrations/lingbot/tests/test_controls.py
@@ -26,6 +26,8 @@ from lingbot.webrtc.controls import (
     PoseSegment,
 )
 
+pytestmark = pytest.mark.ci_cpu
+
 ## KeyboardState basics (unchanged from the old design)
 
 

--- a/integrations/lingbot/tests/test_distributed_server_main.py
+++ b/integrations/lingbot/tests/test_distributed_server_main.py
@@ -6,6 +6,8 @@ import pytest
 import torch
 from lingbot.webrtc import server
 
+pytestmark = pytest.mark.ci_gpu
+
 
 class _FakeSessionManager:
     def __init__(self) -> None:

--- a/integrations/lingbot/tests/test_server_routes.py
+++ b/integrations/lingbot/tests/test_server_routes.py
@@ -20,6 +20,8 @@ from aiohttp.test_utils import TestClient, TestServer
 from lingbot.webrtc.server import create_app
 from lingbot.webrtc.session import SessionBusyError
 
+pytestmark = pytest.mark.ci_gpu
+
 
 class FakeSessionManager:
     def __init__(self) -> None:

--- a/integrations/lingbot/tests/test_smoke.py
+++ b/integrations/lingbot/tests/test_smoke.py
@@ -28,6 +28,8 @@ from lingbot.config import RUNNER_CONFIGS
 
 from flashdreams.infra.runner import RunnerConfig
 
+pytestmark = pytest.mark.ci_cpu
+
 ENTRY_POINT_GROUP = "flashdreams.runner_configs"
 
 

--- a/integrations/lingbot/tests/test_transformer_cp.py
+++ b/integrations/lingbot/tests/test_transformer_cp.py
@@ -15,6 +15,7 @@
 
 """Context-parallel patchify smoke test for the Lingbot World transformer."""
 
+import pytest
 import torch
 from lingbot.encoder.camctrl import I2VCamCtrlEmbeddings
 from lingbot.transformer import (
@@ -26,6 +27,8 @@ from lingbot.transformer.impl.network import (
 )
 
 from flashdreams.recipes.wan.autoencoder.i2v import I2VCtrl
+
+pytestmark = pytest.mark.ci_cpu
 
 
 def test_lingbot_patchify_marks_i2v_and_plucker_as_patchified() -> None:

--- a/integrations/lingbot/tests/test_webrtc_runtime_distributed.py
+++ b/integrations/lingbot/tests/test_webrtc_runtime_distributed.py
@@ -10,6 +10,8 @@ import torch
 import torch.distributed as dist
 from lingbot.webrtc import session
 
+pytestmark = pytest.mark.ci_gpu
+
 
 def _write_minimal_assets(data_dir: Path) -> None:
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -177,6 +179,7 @@ def test_initialize_sync_keeps_base_seed_without_context_parallel(
     assert derive_calls[0]["diffusion_model"]["seed"] == 10
 
 
+@pytest.mark.manual
 def test_runtime_distributed_ops_use_world_cp_and_rank_seed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/integrations/self_forcing/tests/test_smoke.py
+++ b/integrations/self_forcing/tests/test_smoke.py
@@ -28,6 +28,8 @@ from self_forcing.config import RUNNER_CONFIGS
 
 from flashdreams.infra.runner import RunnerConfig
 
+pytestmark = pytest.mark.ci_cpu
+
 ENTRY_POINT_GROUP = "flashdreams.runner_configs"
 
 

--- a/integrations/wan21/tests/test_smoke.py
+++ b/integrations/wan21/tests/test_smoke.py
@@ -28,6 +28,8 @@ from wan21.config import RUNNER_CONFIGS
 
 from flashdreams.infra.runner import RunnerConfig
 
+pytestmark = pytest.mark.ci_gpu
+
 ENTRY_POINT_GROUP = "flashdreams.runner_configs"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,11 +91,11 @@ invalid-method-override = "ignore"
 replace-imports-with-any = ["transformer_engine.**", "triton.**"]
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib -p flashdreams._pytest_plugins.marker_enforcement"
 markers = [
-    "manual: requires GPU and/or network access (opt-in only)",
-    "ci_gpu: GPU test safe to run in CI on RTX Pro 6000 runners",
-    "slow: long-running test",
+    "ci_cpu: CPU-safe test, runs on the CPU CI runner",
+    "ci_gpu: requires GPU or libGL (cv2), runs on the GPU CI runner",
+    "manual: heavy or environment-specific test, opt-in only",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

Replace the hardcoded path restrictions in the CPU CI job with exhaustive per-test markers. Every test now carries exactly one of `ci_cpu`, `ci_gpu`, or `manual`.

- **CPU job**: `pytest -m ci_cpu` (no path filter)
- **GPU job**: `pytest -m ci_gpu` (no path filter)
- **manual**: opt-in only (heavy, flaky, needs credentials)

Collapses `slow` into `manual`. Adds a pytest plugin (`flashdreams._pytest_plugins.marker_enforcement`) that errors at collection time if any test is missing a tier marker.