### PR TITLE
ci: skip Test PyPI publish when version already exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,22 @@ jobs:
       - name: Build wheel
         run: uv build --wheel --package flashdreams
 
+      - name: Previously published check
+        id: previously_published
+        run: |
+          version=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' flashdreams/flashdreams/_version.py)
+          echo "version=$version"
+          if curl -sSf "https://test.pypi.org/simple/flashdreams/" \
+             | grep -q "flashdreams-${version}-"; then
+            echo "Version $version already exists on Test PyPI -- skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version $version not found on Test PyPI -- will publish"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to Test PyPI
-        # --check-url skips uploads when the exact same file already exists
-        # on the index. CI is the sole publisher so hashes will always match
-        # for repeated builds of the same version.
+        if: steps.previously_published.outputs.skip != 'true'
         run: >
           uv publish
           --publish-url https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

- Adds a "Previously published check" step that queries the Test PyPI simple index before attempting to publish
- Skips the publish step entirely if the version is already present, fixing the hash mismatch error from `uv publish --check-url`

## Problem

Every push to `main` rebuilds the wheel, producing a different hash. When the version hasn't been bumped, `uv publish --check-url` sees the version exists with a different hash and errors out (exit code 2), e.g.:

```
error: Local file and index file do not match for flashdreams-0.1.0a2-py3-none-any.whl.
Local: sha256=b77ab1d..., Remote: sha256=eab15cd...
```

https://github.com/NVIDIA/flashdreams/actions/runs/26015910425/job/76465925267

## Fix

Parse the version from `_version.py`, check if it already exists on the Test PyPI simple index, and skip the publish step if so.