### PR TITLE
Remove ghcr.io/nvidia/flashdreams base image; use upstream CUDA image directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   cpu:
     runs-on: linux-amd64-cpu8
     container:
-      image: ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566
+      image: nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04
     env:
       UV_PROJECT_ENVIRONMENT: /tmp/flashdreams-venv
     steps:
@@ -43,6 +43,17 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+            python3 python3-dev python3-venv \
+            ffmpeg \
+            gcc g++ ninja-build \
+            libnccl-dev \
+            curl git ca-certificates unzip
+          rm -rf /var/lib/apt/lists/*
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
@@ -69,7 +80,7 @@ jobs:
     runs-on: linux-amd64-gpu-rtxpro6000-latest-2
     timeout-minutes: 30
     container:
-      image: ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566
+      image: nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04
       options: --gpus all
     env:
       # Place the venv outside the workspace so uv does not interfere with
@@ -83,6 +94,17 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+            python3 python3-dev python3-venv \
+            ffmpeg \
+            gcc g++ ninja-build \
+            libnccl-dev \
+            curl git ca-certificates unzip
+          rm -rf /var/lib/apt/lists/*
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main

--- a/README.md
+++ b/README.md
@@ -128,15 +128,16 @@ the `nvidia` Hugging Face org by default (`nvidia/omni-dreams-models` and
 `nvidia-omni-dreams-lha`.
 
 ```bash
-# 0. request interactive node with the pre-built container [IPP5 cluster as example].
-# The image is a multi-arch manifest (linux/arm64 + linux/amd64); the runtime picks
-# the right variant automatically. See `docker/README.md` for how it is built.
+# 0. request interactive node with a flashdreams-ready container [IPP5 cluster as example].
+# Build the image locally with `bash docker/build_with_docker.sh <YOUR-REGISTRY/IMAGE:TAG>`
+# or use the CUDA base image directly: nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04
+# See `docker/README.md` for details.
 srun \
     --gpus-per-node=4 -q interactive --exclusive --nodes 1 --cpus-per-gpu 36 --pty \
     --partition=gtc_demo \
     --time=24:00:00  \
     --pty \
-    --container-image=ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566 \
+    --container-image=<YOUR-IMAGE> \
     --container-mounts=/dev/nvidia-caps-imex-channels:/dev/nvidia-caps-imex-channels,/home:/home,/cm:/cm,/usr/share/glvnd/egl_vendor.d:/usr/share/glvnd/egl_vendor.d \
     --container-remap-root \
     --container-mount-home \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,11 @@
-# `docker/` — flashdreams container image
+# `docker/` -- flashdreams container image
 
-This folder contains the recipe and tooling for the flashdreams base container
-image. Most users do **not** need anything here — they just reference the
-prebuilt image by tag, as documented in the top-level [README](../README.md#instructions-to-run-alpadreams-inference).
+This folder contains the Dockerfile and build tooling for a flashdreams-ready
+container image. Build it locally or push to your own registry.
 
-Rebuild only when the Dockerfile or pinned dependencies change.
+The image is based on `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` and adds
+Python 3.12, build tools (gcc, g++, ninja), ffmpeg, libnccl-dev, uv, and the
+AWS CLI v2 -- everything needed to compile and run flashdreams.
 
 ---
 
@@ -13,31 +14,46 @@ Rebuild only when the Dockerfile or pinned dependencies change.
 | File | Purpose |
 |---|---|
 | `Dockerfile` | Image recipe. Based on `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`. |
-| `build_with_docker.sh` | Build + push a multi-arch (`linux/arm64` + `linux/amd64`) image to `ghcr.io/nvidia/flashdreams`. |
+| `build_with_docker.sh` | Build + push a multi-arch (`linux/arm64` + `linux/amd64`) image to a registry you specify. |
 | `docker_farm_setup.sh` | One-time Buildx "farm" setup so arm64 builds run natively on `dgx-spark` instead of under QEMU emulation. |
 
 ---
 
-## Canonical image
+## Building locally
 
+For a quick single-arch local image (no registry push):
+
+```bash
+docker build -t flashdreams:local -f docker/Dockerfile .
 ```
-ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566
+
+Then use it with docker or Slurm:
+
+```bash
+docker run --rm --gpus all -it flashdreams:local bash
 ```
-
-Multi-arch (linux/arm64 + linux/amd64) — the container runtime picks the
-right variant automatically, so there is no arch-specific tag to choose
-between. To pull and run it inside an `srun` session, see the
-[top-level README](../README.md#instructions-to-run-alpadreams-inference).
-
-`build_with_docker.sh` additionally publishes dated, SHA-stamped tags of
-the form `base-v0.3-YYYYMMDD-<git-short-sha>` for traceability — use those
-when you need to pin to an exact build.
 
 ---
 
-## For maintainers: building a new image
+## Building + pushing (multi-arch)
 
-### 1. One-time — set up the build farm
+Use `build_with_docker.sh` to produce a multi-arch manifest (linux/arm64 +
+linux/amd64) and push it to your registry:
+
+```bash
+# Log in to your target registry first
+docker login <your-registry>
+
+# Build and push -- at least one fully-qualified tag is required
+bash docker/build_with_docker.sh <your-registry>/flashdreams:<your-tag>
+
+# Multiple tags are supported
+bash docker/build_with_docker.sh reg1/flashdreams:v1.0 reg2/flashdreams:latest
+```
+
+---
+
+## Multi-arch build farm (optional)
 
 Multi-arch builds are much faster when each arch runs on a native node.
 `docker_farm_setup.sh` wires a local `docker-container` driver plus an SSH
@@ -60,10 +76,10 @@ docker buildx inspect farm
 
 You should see two nodes with `linux/amd64` and `linux/arm64` respectively.
 
-Skip this step if you're fine with QEMU emulation for the non-native arch;
+Skip this step if you are fine with QEMU emulation for the non-native arch;
 `build_with_docker.sh` will still work, just slowly.
 
-#### About `dgx-spark`
+### About `dgx-spark`
 
 `dgx-spark` is the short `~/.ssh/config` alias for a shared NVIDIA DGX
 Spark workstation that the project uses as a native **arm64 (Grace)**
@@ -84,39 +100,9 @@ Using it requires:
 To request access and get the onboarding steps (SSH Host block, account
 provisioning), contact **qiwu@nvidia.com**.
 
-You don't need `dgx-spark` access to build images — dropping it just
+You don't need `dgx-spark` access to build images -- dropping it just
 means `build_with_docker.sh` will emulate arm64 via QEMU on your amd64
 workstation, which is correct but noticeably slower.
-
-### 2. Log in to the registry
-
-```bash
-docker login ghcr.io
-# username: your GitHub handle
-# password: a GitHub personal access token with read:packages + write:packages
-```
-
-### 3. Bump the tag (when the Dockerfile changes)
-
-Open `build_with_docker.sh` and bump `TAG` (e.g. `base-v0.3` → `base-v0.4`).
-The pushed tag is `$TAG-$(date +%Y%m%d)-$(git rev-parse --short HEAD)`, so
-every build is uniquely addressable.
-
-### 4. Build and push
-
-From the repo root:
-
-```bash
-bash docker/build_with_docker.sh
-```
-
-This builds `linux/arm64` + `linux/amd64`, bundles them into a single
-manifest list, and pushes with `--push` (no local image artifact produced).
-
-### 5. Update downstream references
-
-After a successful push, update the `--container-image=` tag in the
-top-level `README.md` so users pick up the new build.
 
 ---
 
@@ -141,7 +127,3 @@ bash docker/docker_farm_setup.sh
 `--load` imports a single image into the local Docker daemon and is
 incompatible with multi-arch output. Drop one of the `--platform` values
 if you need a local-only build for testing.
-
-**Tag already exists / can't overwrite.**
-The tag embeds the git short SHA, so make a new commit (even an empty
-`git commit --allow-empty`) to get a fresh SHA, or bump `TAG`.

--- a/docker/build_with_docker.sh
+++ b/docker/build_with_docker.sh
@@ -1,19 +1,25 @@
 #!/bin/bash
 # -----------------------------------------------------------------------------
-# build_with_docker.sh — Build & push the flashdreams base image (multi-arch)
+# build_with_docker.sh -- Build & push the flashdreams base image (multi-arch)
 # -----------------------------------------------------------------------------
 #
 # WHAT THIS SCRIPT DOES
 # ---------------------
 # Builds `docker/Dockerfile` for both linux/arm64 and linux/amd64 in a single
-# buildx invocation and pushes the resulting manifest list to the GitHub
-# Container Registry (GHCR).
+# buildx invocation and pushes the resulting manifest list to the target
+# registry/tag(s) you specify.
 #
-# Tag scheme:
-#     ghcr.io/nvidia/flashdreams:<TAG>-<YYYYMMDD>-<git-sha>
+# USAGE
+# -----
+#   bash docker/build_with_docker.sh REGISTRY/IMAGE:TAG [REGISTRY/IMAGE:TAG ...]
 #
-# The date + short git SHA make every build uniquely addressable, while the
-# TAG prefix (e.g. "base-v0.3") tracks the Dockerfile's major revision.
+# At least one fully-qualified image tag is required. Multiple tags are
+# supported (e.g. to push to more than one registry at once).
+#
+# Examples:
+#   bash docker/build_with_docker.sh ghcr.io/myorg/flashdreams:latest
+#   bash docker/build_with_docker.sh myregistry.example.com/flashdreams:v1.0
+#   bash docker/build_with_docker.sh reg1/img:tag reg2/img:tag
 #
 # PREREQUISITES
 # -------------
@@ -22,25 +28,19 @@
 #      The companion script `docker_farm_setup.sh` sets one up named "farm",
 #      using the shared NVIDIA DGX Spark host (aliased "dgx-spark" in
 #      ~/.ssh/config) as the native arm64 node. If you skip that, buildx
-#      falls back to QEMU emulation for the non-native arch — works but
+#      falls back to QEMU emulation for the non-native arch -- works but
 #      significantly slower.
 #      To request access to dgx-spark (SSH config, account), contact
 #      qiwu@nvidia.com.
-#   3. You are logged in to the GitHub Container Registry:
-#          docker login ghcr.io
-#      (use a GitHub personal access token with `write:packages` scope).
+#   3. You are logged in to your target container registry:
+#          docker login <registry>
 #   4. The working directory is the repo root (the build context is ".") and
 #      `docker/Dockerfile` is reachable. Invoke as:
-#          bash docker/build_with_docker.sh
-#   5. The working tree is a git checkout (the tag embeds `git rev-parse --short HEAD`).
+#          bash docker/build_with_docker.sh REGISTRY/IMAGE:TAG
 #
-# HOW TO RUN
-# ----------
-#   bash docker/build_with_docker.sh
-#
-# To build without pushing (for local testing), drop `--push` and add
-# `--load` instead — note that `--load` is single-arch only, so you'll also
-# need to drop one of the `--platform` values.
+# To build without pushing (for local testing), edit this script to replace
+# `--push` with `--load` -- note that `--load` is single-arch only, so you
+# will also need to drop one of the `--platform` values.
 #
 # FLAG NOTES
 # ----------
@@ -58,23 +58,24 @@
 #   --push
 #       Upload the resulting images and manifest list directly to the
 #       registry. Implies no local `docker images` entry for this build.
-#
-# TAG BUMP CHECKLIST
-# ------------------
-# When cutting a new base image (e.g. after a Dockerfile or dependency
-# change), bump TAG below (base-v0.3 -> base-v0.4), commit, then run this
-# script. Update the container references in the top-level README.md so
-# downstream users know which tag to pull.
 # -----------------------------------------------------------------------------
 
 set -eu -o pipefail
 
-TAG=base-v0.3-$(date +%Y%m%d)-$(git rev-parse --short HEAD)
+if [[ $# -eq 0 ]]; then
+    echo "Error: at least one target image tag is required." >&2
+    echo "" >&2
+    echo "Usage: bash docker/build_with_docker.sh REGISTRY/IMAGE:TAG [REGISTRY/IMAGE:TAG ...]" >&2
+    echo "" >&2
+    echo "Examples:" >&2
+    echo "  bash docker/build_with_docker.sh ghcr.io/myorg/flashdreams:latest" >&2
+    echo "  bash docker/build_with_docker.sh myregistry.example.com/flashdreams:v1.0" >&2
+    exit 1
+fi
 
-REGISTRIES=${@:-ghcr.io/nvidia/flashdreams}
-REGISTRIES_ARGS=()
-for registry in $REGISTRIES; do
-    REGISTRIES_ARGS+=(-t $registry:$TAG)
+TAG_ARGS=()
+for tag in "$@"; do
+    TAG_ARGS+=(-t "$tag")
 done
 
 docker buildx build \
@@ -82,5 +83,5 @@ docker buildx build \
     --allow network.host \
     --network host \
     --push \
-    "${REGISTRIES_ARGS[@]}" \
+    "${TAG_ARGS[@]}" \
     -f docker/Dockerfile .

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ is skipped.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `FLASHDREAMS_TEST_IMAGE` | `ghcr.io/nvidia/flashdreams:base-v0.3` | Container image used for the run. |
+| `FLASHDREAMS_TEST_IMAGE` | `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` | Container image used for the run. System deps and uv are installed at container start. |
 | `FLASHDREAMS_UV_CACHE_DIR` | `${HOME}/.cache/uv` | Host dir mounted to `/root/.cache/uv`. |
 | `FLASHDREAMS_HF_CACHE_DIR` | `${HOME}/.cache/huggingface` | Host dir mounted to `/root/.cache/huggingface`. |
 | `FLASHDREAMS_CACHE_DIR` | `${HOME}/.cache/flashdreams` | Host dir mounted to `/root/.cache/flashdreams`. |

--- a/tests/run_tests_docker.sh
+++ b/tests/run_tests_docker.sh
@@ -10,7 +10,7 @@
 #   ./tests/run_tests_docker.sh [TEST_TARGET...]
 #
 # Environment overrides:
-#   FLASHDREAMS_TEST_IMAGE         (default: ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566)
+#   FLASHDREAMS_TEST_IMAGE         (default: nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04)
 #   FLASHDREAMS_UV_CACHE_DIR       (default: ${HOME}/.cache/uv)
 #   FLASHDREAMS_HF_CACHE_DIR       (default: ${HOME}/.cache/huggingface)
 #   FLASHDREAMS_CACHE_DIR          (default: ${HOME}/.cache/flashdreams)
@@ -25,7 +25,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IMAGE="${FLASHDREAMS_TEST_IMAGE:-ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566}"
+IMAGE="${FLASHDREAMS_TEST_IMAGE:-nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04}"
 
 UV_CACHE_HOST="${FLASHDREAMS_UV_CACHE_DIR:-${HOME}/.cache/uv}"
 HF_CACHE_HOST="${FLASHDREAMS_HF_CACHE_DIR:-${HOME}/.cache/huggingface}"
@@ -53,6 +53,15 @@ docker run --rm -i \
     "${IMAGE}" \
     bash -s -- "$@" <<'EOF'
 set -euo pipefail
+
+# -- bootstrap: install system deps + uv into the raw CUDA base image --------
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+  python3 python3-dev python3-venv ffmpeg gcc g++ ninja-build \
+  libnccl-dev curl git ca-certificates unzip
+rm -rf /var/lib/apt/lists/*
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 
 # UV_PROJECT_ENVIRONMENT is set via docker -e so the venv lives outside the
 # bind-mounted workspace, avoiding root-owned .venv on the host.

--- a/tests/run_tests_slurm.sh
+++ b/tests/run_tests_slurm.sh
@@ -33,7 +33,7 @@
 #   --rebuild-image or `rm` the .sqsh file.
 #
 # Environment overrides:
-#   FLASHDREAMS_TEST_IMAGE        (default: ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566)
+#   FLASHDREAMS_TEST_IMAGE        (default: nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04)
 #   FLASHDREAMS_UV_CACHE_DIR      (default: ${HOME}/.cache/uv)
 #   FLASHDREAMS_HF_CACHE_DIR      (default: ${HOME}/.cache/huggingface)
 #   FLASHDREAMS_CACHE_DIR         (default: ${HOME}/.cache/flashdreams)
@@ -51,7 +51,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IMAGE="${FLASHDREAMS_TEST_IMAGE:-ghcr.io/nvidia/flashdreams:base-v0.3-20260424-55bd566}"
+IMAGE="${FLASHDREAMS_TEST_IMAGE:-nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04}"
 
 SLURM_PARTITION=""
 SLURM_ACCOUNT=""
@@ -198,6 +198,15 @@ printf "<<'EOF'\n"
 cat <<'EOF'
 set -euo pipefail
 
+# -- bootstrap: install system deps + uv into the raw CUDA base image --------
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+  python3 python3-dev python3-venv ffmpeg gcc g++ ninja-build \
+  libnccl-dev curl git ca-certificates unzip
+rm -rf /var/lib/apt/lists/*
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
 uv venv --clear
 uv sync --frozen --extra dev
 
@@ -208,6 +217,15 @@ echo "EOF"
 rc=0
 "${SRUN_CMD[@]}" <<'EOF' || rc=$?
 set -euo pipefail
+
+# -- bootstrap: install system deps + uv into the raw CUDA base image --------
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+  python3 python3-dev python3-venv ffmpeg gcc g++ ninja-build \
+  libnccl-dev curl git ca-certificates unzip
+rm -rf /var/lib/apt/lists/*
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 
 # UV_PROJECT_ENVIRONMENT is exported via srun --export so the venv lives
 # outside the bind-mounted workspace, avoiding root-owned .venv on the host.


### PR DESCRIPTION
## Summary

- Replace the pre-built `ghcr.io/nvidia/flashdreams:base-v0.3` container image with the upstream `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` image across CI and all scripts.
- CI (`cpu` + `gpu` jobs) now installs system dependencies (python3, build tools, ffmpeg, libnccl-dev) inline via `apt-get` before the existing `uv sync` step.
- Test scripts (`run_tests_docker.sh`, `run_tests_slurm.sh`) bootstrap system deps + uv inside the container heredoc so they work out of the box with the raw CUDA image.
- `docker/build_with_docker.sh` no longer hardcodes a ghcr.io default or tag scheme -- it now requires at least one explicit target image tag as a positional argument.
- `docker/README.md` reframed as a local build recipe (build your own image from the Dockerfile) instead of documenting a canonical pre-published registry image.
- `README.md` srun example updated to reference a user-provided image tag.

## Motivation

Eliminate the dependency on a team-maintained pre-built base image in GHCR because of licensing issues. The Dockerfile already starts from the public `nvidia/cuda` image, so CI and scripts can use that directly and install the small set of system packages they need. This removes the need to rebuild/push/version a custom base image whenever the Dockerfile changes.

## Test plan

CI should validate this end-to-end: the `lint`, `cpu`, and `gpu` jobs all run on this PR's branch.