### PR TITLE
Add cuDNN Frontend uv dependency

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,6 +23,7 @@ ftfy                   Apache-2.0   https://github.com/rspeer/python-ftfy
 huggingface-hub        Apache-2.0   https://github.com/huggingface/huggingface_hub
 loguru                 MIT          https://github.com/Delgan/loguru
 numpy                  BSD-3-Clause https://github.com/numpy/numpy
+nvidia-cudnn-frontend MIT          https://github.com/NVIDIA/cudnn-frontend
 nvidia-ml-py           BSD-3-Clause https://pypi.org/project/nvidia-ml-py/
 safetensors            Apache-2.0   https://github.com/huggingface/safetensors
 torch                  BSD-3-Clause https://pytorch.org

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "huggingface-hub>=0.33",
     "loguru>=0.7",
     "numpy>=1.24",
+    "nvidia-cudnn-frontend==1.22.1",
     "nvidia-ml-py>=12.0",
     "safetensors>=0.4",
     "tqdm>=4.60",

--- a/uv.lock
+++ b/uv.lock
@@ -596,6 +596,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "loguru" },
     { name = "numpy" },
+    { name = "nvidia-cudnn-frontend" },
     { name = "nvidia-ml-py" },
     { name = "safetensors" },
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
@@ -638,6 +639,7 @@ requires-dist = [
     { name = "mediapy", marker = "extra == 'examples'", specifier = ">=1.1" },
     { name = "mediapy", marker = "extra == 'runners'", specifier = ">=1.1" },
     { name = "numpy", specifier = ">=1.24" },
+    { name = "nvidia-cudnn-frontend", specifier = "==1.22.1" },
     { name = "nvidia-ml-py", specifier = ">=12.0" },
     { name = "opencv-python-headless", marker = "extra == 'examples'" },
     { name = "opencv-python-headless", marker = "extra == 'runners'" },
@@ -1462,6 +1464,16 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
     { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-frontend"
+version = "1.22.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/3f/523fb08d9b7be15242ade6e2a641900d05c0e9cfffab8260de37a04ac0d2/nvidia_cudnn_frontend-1.22.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f64fb4e0a45b7a8bb126f91a71d8afc03facf14b82dade51744ca48cf20d2974", size = 2722597, upload-time = "2026-04-10T17:33:54.366Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b7/35c87c334d553bd45809ec957b53f3d7dd13c5a407e853c9eea29fcc5b3c/nvidia_cudnn_frontend-1.22.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:933275df405053001888875ee75d2138b20dc4e8bf4057461b1c74ca68b0e270", size = 2863367, upload-time = "2026-04-10T17:29:22.838Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/42/af975c8937a4c331b1215a0b2bdd2a742d792c6f777f919fd70480d63762/nvidia_cudnn_frontend-1.22.1-cp312-cp312-win_amd64.whl", hash = "sha256:2da1c277f008ee64273a48a5cb8d07efbb6d6774fdc08bd889476cce93b2f69a", size = 2310595, upload-time = "2026-04-10T17:37:24.776Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
- Add nvidia-cudnn-frontend==1.22.1 as a FlashDreams runtime dependency.
- Update uv.lock for the resolved PyPI wheels.
- Add the cuDNN Frontend MIT attribution to NOTICE.

Validation:
- uv lock --check