### PR TITLE
Fix Lingbot Overlay Resizing and Held Controls

### DIFF
--- a/integrations/lingbot/lingbot/webrtc/web/request_session.css
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.css
@@ -388,12 +388,12 @@ body[data-status="generating"] .connectButton {
   bottom: clamp(20px, 4vh, 40px);
   display: grid;
   grid-template-columns:
-    minmax(72px, 0.7fr)
-    minmax(120px, 1fr)
-    minmax(132px, 1.15fr)
-    minmax(72px, 0.7fr)
-    minmax(150px, 1.45fr);
-  width: min(760px, calc(100vw - 36px));
+    minmax(max-content, 0.7fr)
+    minmax(max-content, 1fr)
+    minmax(max-content, 1.15fr)
+    minmax(max-content, 0.7fr)
+    minmax(max-content, 1.45fr);
+  width: min(960px, calc(100vw - 36px));
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 8px;
@@ -405,11 +405,11 @@ body[data-status="generating"] .connectButton {
 
 .metric {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: max-content max-content;
   align-items: center;
   justify-content: center;
   gap: 10px;
-  min-width: 0;
+  min-width: max-content;
   min-height: 42px;
   padding: 0 16px;
   border-right: 1px solid rgba(255, 255, 255, 0.11);
@@ -423,17 +423,11 @@ body[data-status="generating"] .connectButton {
 
 .metric span {
   color: var(--muted);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .metric strong {
-  min-width: 0;
-  overflow: hidden;
   text-align: left;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 760;
 }

--- a/integrations/lingbot/lingbot/webrtc/web/request_session.css
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.css
@@ -387,7 +387,13 @@ body[data-status="generating"] .connectButton {
   left: 50%;
   bottom: clamp(20px, 4vh, 40px);
   display: grid;
-  grid-template-columns: repeat(5, minmax(112px, auto));
+  grid-template-columns:
+    minmax(72px, 0.7fr)
+    minmax(120px, 1fr)
+    minmax(132px, 1.15fr)
+    minmax(72px, 0.7fr)
+    minmax(150px, 1.45fr);
+  width: min(760px, calc(100vw - 36px));
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 8px;
@@ -398,16 +404,17 @@ body[data-status="generating"] .connectButton {
 }
 
 .metric {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   justify-content: center;
   gap: 10px;
+  min-width: 0;
   min-height: 42px;
-  padding: 0 20px;
+  padding: 0 16px;
   border-right: 1px solid rgba(255, 255, 255, 0.11);
   font-size: 0.88rem;
   text-align: center;
-  white-space: nowrap;
 }
 
 .metric:last-child {
@@ -416,9 +423,18 @@ body[data-status="generating"] .connectButton {
 
 .metric span {
   color: var(--muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .metric strong {
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 760;
 }
 
@@ -477,13 +493,20 @@ body[data-status="generating"] .statusLine strong {
     right: 18px;
     bottom: 18px;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: auto;
     transform: none;
   }
 
   .metric {
-    justify-content: space-between;
-    min-width: 0;
     padding: 0 14px;
+  }
+
+  .metric:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .metric:last-child {
+    grid-column: 1 / -1;
   }
 }
 
@@ -507,6 +530,17 @@ body[data-status="generating"] .statusLine strong {
   }
 
   .metricsBar {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
+  }
+
+  .metric {
+    min-height: 36px;
+    border-right: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.11);
+  }
+
+  .metric:last-child {
+    grid-column: auto;
+    border-bottom: 0;
   }
 }

--- a/integrations/lingbot/lingbot/webrtc/web/request_session.js
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.js
@@ -31,6 +31,7 @@ const params = new URLSearchParams(window.location.search)
 const mockMode = params.has("mock") && params.get("mock") !== "0"
 const allowedKeys = new Set(["w", "a", "s", "d", "q", "e", "i", "j", "k", "l"])
 const keySources = new Map()
+const heldKeyOrder = new Map()
 const activeKeys = new Set()
 const frameTimes = []
 const pendingActions = []
@@ -41,6 +42,7 @@ let controlChannel = null
 let statsTimer = null
 let inferenceInFlight = false
 let connected = false
+let heldKeySequence = 0
 let mockChunkIndex = 0
 let mockGenerationStarted = false
 let mockChunkTimer = null
@@ -246,6 +248,15 @@ function enqueueAction(action) {
   }
 }
 
+function enqueueHeldKeyRepeats() {
+  const heldKeys = Array.from(activeKeys).sort((a, b) => {
+    return (heldKeyOrder.get(a) || 0) - (heldKeyOrder.get(b) || 0)
+  })
+  for (const key of heldKeys) {
+    enqueueAction({ event: "keydown", key })
+  }
+}
+
 function setKeyHeld(key, source, held) {
   const normalized = normalizeKey(key)
   if (!allowedKeys.has(normalized)) {
@@ -268,9 +279,12 @@ function setKeyHeld(key, source, held) {
   updateControlHighlights()
 
   if (held && !wasActive && isActive) {
+    heldKeySequence += 1
+    heldKeyOrder.set(normalized, heldKeySequence)
     enqueueAction({ event: "keydown", key: normalized })
   }
   if (!held && wasActive && !isActive) {
+    heldKeyOrder.delete(normalized)
     enqueueAction({ event: "keyup", key: normalized })
   }
 }
@@ -280,6 +294,7 @@ function releaseAllKeys() {
     const sources = keySources.get(key)
     if (sources && sources.size > 0) {
       sources.clear()
+      heldKeyOrder.delete(key)
       updateControlHighlights()
       enqueueAction({ event: "keyup", key })
     }
@@ -321,6 +336,9 @@ function handleControlMessage(rawMessage) {
     logEvent(parts.join(", "))
     setStatus(activeKeys.size > 0 ? "Generating" : "Waiting", activeKeys.size > 0 ? "generating" : "waiting")
     setFlow(`chunk ${payload.chunk_index} complete`)
+    if (activeKeys.size > 0) {
+      enqueueHeldKeyRepeats()
+    }
     return
   }
 


### PR DESCRIPTION
# Fix Lingbot Overlay Resizing and Held Controls

## Summary

This MR updates the Lingbot WebRTC overlay so the telemetry bar remains readable across window sizes and held movement keys keep driving generation continuously. It builds on the previously merged overlay UI work and keeps the change scoped to the browser client CSS and input handling.

## Changes

- Restores continuous held-key behavior for Lingbot controls. When a movement key remains pressed, the client now sends another `keydown` after each `chunk_done` message so actions like holding `W` continue marching forward instead of only sending one keydown/keyup pair.
- Tracks held key order so repeated keydown messages are sent deterministically when multiple controls are held.
- Keeps key release behavior intact by clearing held state and sending keyup when keyboard or pointer input is released.
- Improves the bottom metrics bar responsiveness by adding explicit desktop width constraints and stacked layouts for smaller windows.
- Prevents telemetry labels and values from overlapping by using content-aware metric column minimums and removing ellipsis behavior when there is enough horizontal space.
