### PR TITLE
Disclose cudaraster + LodePNG redistributions for OSRB

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/Zlib.txt
+++ b/LICENSES/Zlib.txt
@@ -1,0 +1,22 @@
+zlib License
+
+Copyright (c) <year> <copyright holders>
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+   not claim that you wrote the original software. If you use this
+   software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must
+   not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+   distribution.

--- a/NOTICE
+++ b/NOTICE
@@ -6,11 +6,13 @@ This product is licensed under the Apache License, Version 2.0 (see LICENSE).
 ================================================================================
 
 This product includes or depends on software from third-party projects.
-Each dependency is consumed unmodified at runtime through Python's import
-system (i.e. dynamic linking via the interpreter); none of the third-party
-source listed below is redistributed in this repository. The licenses
-named below are SPDX identifiers; the full text of each license is
-available from the upstream project's URL.
+Most dependencies are consumed unmodified at runtime through Python's
+import system (i.e. dynamic linking via the interpreter); their source
+is not redistributed in this repository. The licenses named below are
+SPDX identifiers; the full text of each license is available from the
+upstream project's URL. Source-level redistributions (third-party source
+code physically present in this repository) are disclosed in the
+"Source-level redistributions" section at the end of this file.
 
 --------------------------------------------------------------------------------
 Direct runtime dependencies
@@ -65,5 +67,47 @@ Optional integration: integrations/lingbot
 aiohttp                Apache-2.0   https://github.com/aio-libs/aiohttp
 aiortc                 BSD-3-Clause https://github.com/aiortc/aiortc
 opencv-python-headless Apache-2.0   https://github.com/opencv/opencv-python
+
+================================================================================
+Source-level redistributions
+================================================================================
+
+The following third-party source is physically present in this repository
+(not just consumed at runtime). Each file retains its original copyright
+notice inline; license texts are reproduced under LICENSES/.
+
+--------------------------------------------------------------------------------
+HPG-2011 NVIDIA CUDA Rasterizer port
+--------------------------------------------------------------------------------
+
+Path:    integrations/alpadreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/
+License: BSD-3-Clause (see LICENSES/BSD-3-Clause.txt)
+         Copyright (c) 2009-2026, NVIDIA Corporation. All rights reserved.
+
+The cudaraster subtree is a port of NVIDIA Research's HPG-2011 CUDA
+Rasterizer (Laine & Karras). It is NVIDIA-authored and is redistributed
+under the 3-clause BSD license carried in
+ludus_renderer/_cpp/cudaraster/LICENSE. The tile-level rasterization
+pipeline (triangle setup, bin / coarse / fine raster) is upstream code;
+the host wrapper, viewport / multi-image plumbing, and deterministic
+tiebreaker are local modifications. See
+ludus_renderer/_cpp/cudaraster/PORT_NOTES.md for the full list of
+deviations.
+
+--------------------------------------------------------------------------------
+LodePNG
+--------------------------------------------------------------------------------
+
+Path:     integrations/alpadreams/ludus-renderer/ludus_renderer/_cpp/
+          cudaraster/framework/3rdparty/lodepng/{lodepng.h, lodepng.cpp}
+License:  Zlib (see LICENSES/Zlib.txt)
+          Copyright (c) 2005-2011 Lode Vandevenne
+Upstream: https://lodev.org/lodepng/
+
+LodePNG is a PNG codec implementation embedded by the upstream
+cudaraster framework. It is the only non-NVIDIA source physically
+redistributed in this repository. The inline notice in lodepng.h
+preserves the upstream copyright notice as required by the Zlib
+license; LICENSES/Zlib.txt reproduces the license text in full.
 
 ================================================================================

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -91,3 +91,27 @@ path = [
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved."
 SPDX-License-Identifier = "Apache-2.0"
+
+# --- HPG-2011 NVIDIA CUDA Rasterizer port (NVIDIA-authored, BSD-3-Clause).
+#     This subtree is documented in NOTICE and in
+#     ludus_renderer/_cpp/cudaraster/PORT_NOTES.md. The inline file headers
+#     carry the full BSD-3-Clause text; this annotation provides the
+#     SPDX identifiers REUSE needs (the inline headers predate the SPDX
+#     tag convention). `override` prevents the project-default Apache-2.0
+#     aggregate from being merged in. ---
+[[annotations]]
+path = "integrations/alpadreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/**"
+precedence = "override"
+SPDX-FileCopyrightText = "Copyright (c) 2009-2026, NVIDIA Corporation. All rights reserved."
+SPDX-License-Identifier = "BSD-3-Clause"
+
+# --- LodePNG, embedded by the upstream cudaraster framework (third-party,
+#     Zlib license). The inline header in lodepng.h preserves the upstream
+#     copyright as required by the Zlib license; the full text is reproduced
+#     in LICENSES/Zlib.txt. This annotation comes after the cudaraster
+#     `override` above so the more specific path wins. ---
+[[annotations]]
+path = "integrations/alpadreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/3rdparty/lodepng/**"
+precedence = "override"
+SPDX-FileCopyrightText = "Copyright (c) 2005-2011 Lode Vandevenne"
+SPDX-License-Identifier = "Zlib"


### PR DESCRIPTION
Disclose the in-source third-party redistributions in NOTICE, reproduce the BSD-3-Clause and Zlib license texts under LICENSES/, and rename reuse.toml to REUSE.toml so REUSE 3.3 / reuse-tool 6.x actually applies the project's annotations. With the rename the project reaches full REUSE 3.3 compliance (464/464 files covered).