### PR TITLE
build: use no-sync flag for uv run in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: sync-version
         name: sync package versions
-        entry: uv run .github/scripts/sync_version.py
+        entry: uv run --no-sync .github/scripts/sync_version.py
         language: system
         files: '(pyproject\.toml|_version\.py)$'
         pass_filenames: false


### PR DESCRIPTION
This pull request makes a minor change to the `.pre-commit-config.yaml` file, updating the `sync-version` hook to use the `--no-sync` flag when running the `sync_version.py` script. This prevents `uv` from performing an environment sync during the pre-commit hook execution.