### PR TITLE
Show Lingbot initial scene before first action

### DIFF
--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -96,6 +96,23 @@ def create_app(
     async def request_session_page(_: web.Request) -> web.StreamResponse:
         return web.FileResponse(WEB_DIR / "request_session.html")
 
+    async def initial_scene(request: web.Request) -> web.StreamResponse:
+        manager = request.app["session_manager"]
+        try:
+            return web.json_response(manager.get_initial_scene())
+        except FileNotFoundError as exc:
+            raise web.HTTPNotFound(reason=str(exc)) from exc
+        except Exception as exc:
+            LOGGER.exception("Failed to read Lingbot initial scene metadata.")
+            raise web.HTTPInternalServerError(reason=str(exc)) from exc
+
+    async def first_frame(request: web.Request) -> web.StreamResponse:
+        manager = request.app["session_manager"]
+        try:
+            return web.FileResponse(manager.get_first_frame_path())
+        except FileNotFoundError as exc:
+            raise web.HTTPNotFound(reason=str(exc)) from exc
+
     async def offer(request: web.Request) -> web.StreamResponse:
         try:
             payload = await request.json()
@@ -152,6 +169,8 @@ def create_app(
         await manager.shutdown()
 
     app.router.add_get("/request_session", request_session_page)
+    app.router.add_get("/api/session/initial_scene", initial_scene)
+    app.router.add_get("/api/session/first_frame", first_frame)
     app.router.add_post("/api/webrtc/offer", offer)
     app.router.add_get("/healthz", healthz)
     app.router.add_static("/static/", WEB_DIR, show_index=False)

--- a/integrations/lingbot/lingbot/webrtc/session.py
+++ b/integrations/lingbot/lingbot/webrtc/session.py
@@ -560,6 +560,38 @@ class LingbotWebRTCSessionManager:
     def is_runtime_ready(self) -> bool:
         return self._runtime_ready
 
+    def get_initial_scene(self) -> dict[str, Any]:
+        first_frame_path = self.get_first_frame_path()
+        prompt_path = (
+            self.runtime_config.example_data_dir / self.runtime_config.prompt_filename
+        )
+        if not prompt_path.exists():
+            raise FileNotFoundError(f"Missing Lingbot prompt: {prompt_path}")
+
+        with prompt_path.open("r", encoding="utf-8") as handle:
+            prompt = handle.readline().strip()
+        if not prompt:
+            raise ValueError("Prompt file is empty.")
+
+        return {
+            "first_frame_url": "/api/session/first_frame",
+            "prompt": prompt,
+            "model": self.runtime_config.config_name,
+            "resolution": {
+                "width": self.runtime_config.video_width,
+                "height": self.runtime_config.video_height,
+            },
+        }
+
+    def get_first_frame_path(self) -> Path:
+        first_frame_path = (
+            self.runtime_config.example_data_dir
+            / self.runtime_config.first_frame_filename
+        )
+        if not first_frame_path.exists():
+            raise FileNotFoundError(f"Missing Lingbot first frame: {first_frame_path}")
+        return first_frame_path
+
     async def preload_runtime(self) -> None:
         if self._runtime_ready:
             return

--- a/integrations/lingbot/lingbot/webrtc/web/mock_ui_server.py
+++ b/integrations/lingbot/lingbot/webrtc/web/mock_ui_server.py
@@ -16,16 +16,62 @@
 from __future__ import annotations
 
 import argparse
+import json
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlsplit
 
 WEB_DIR = Path(__file__).resolve().parent
+REPO_ROOT = WEB_DIR.parents[4]
+EXAMPLE_DATA_DIR = REPO_ROOT / "assets/example_data/lingbot_world"
+FIRST_FRAME_PATH = EXAMPLE_DATA_DIR / "image.jpg"
+PROMPT_PATH = EXAMPLE_DATA_DIR / "prompt.txt"
 
 
 class MockUIRequestHandler(SimpleHTTPRequestHandler):
     """Serve the static viewer without preloading the Lingbot runtime."""
+
+    def _send_json(self, payload: dict[str, object], *, head_only: bool) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if not head_only:
+            self.wfile.write(body)
+
+    def _send_first_frame(self, *, head_only: bool) -> None:
+        if not FIRST_FRAME_PATH.exists():
+            self.send_error(404, f"Missing first frame: {FIRST_FRAME_PATH}")
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "image/jpeg")
+        self.send_header("Content-Length", str(FIRST_FRAME_PATH.stat().st_size))
+        self.end_headers()
+        if not head_only:
+            with FIRST_FRAME_PATH.open("rb") as handle:
+                self.copyfile(handle, self.wfile)
+
+    def _handle_api(self, *, head_only: bool) -> bool:
+        path = urlsplit(self.path).path
+        if path == "/api/session/initial_scene":
+            prompt = PROMPT_PATH.read_text(encoding="utf-8").splitlines()[0].strip()
+            self._send_json(
+                {
+                    "first_frame_url": "/api/session/first_frame",
+                    "prompt": prompt,
+                    "model": "lingbot-world-fast-flash",
+                    "resolution": {"width": 832, "height": 464},
+                },
+                head_only=head_only,
+            )
+            return True
+        if path == "/api/session/first_frame":
+            self._send_first_frame(head_only=head_only)
+            return True
+        return False
 
     def _rewrite_path(self) -> bool:
         path = urlsplit(self.path).path
@@ -41,11 +87,15 @@ class MockUIRequestHandler(SimpleHTTPRequestHandler):
         return False
 
     def do_GET(self) -> None:
+        if self._handle_api(head_only=False):
+            return
         if self._rewrite_path():
             return
         super().do_GET()
 
     def do_HEAD(self) -> None:
+        if self._handle_api(head_only=True):
+            return
         if self._rewrite_path():
             return
         super().do_HEAD()

--- a/integrations/lingbot/lingbot/webrtc/web/request_session.css
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.css
@@ -64,6 +64,7 @@ button {
 
 .mockCanvas,
 .stageVideo,
+.firstFramePreview,
 .stageVignette {
   position: absolute;
   inset: 0;
@@ -88,7 +89,25 @@ body.has-video .stageVideo {
   opacity: 1;
 }
 
-body.has-video .mockCanvas {
+.firstFramePreview {
+  z-index: 1;
+  display: block;
+  object-fit: cover;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+}
+
+body.is-ready-preview .firstFramePreview {
+  opacity: 1;
+}
+
+body.has-video .firstFramePreview {
+  opacity: 0;
+}
+
+body.has-video .mockCanvas,
+body.is-ready-preview .mockCanvas {
   opacity: 0;
 }
 
@@ -150,6 +169,34 @@ body.has-video .mockCanvas {
   padding: 16px 18px;
   display: grid;
   gap: 10px;
+}
+
+.readyPromptCard {
+  position: absolute;
+  top: clamp(112px, 16vh, 168px);
+  left: 50%;
+  width: min(620px, calc(100vw - 36px));
+  display: grid;
+  gap: 10px;
+  padding: 16px 18px 18px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%);
+  transition: opacity 180ms ease;
+}
+
+body.is-ready-preview .readyPromptCard {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.readyPromptCard p {
+  margin: 0;
+  max-height: 6.6em;
+  overflow: hidden;
+  color: var(--text);
+  font-size: clamp(0.92rem, 1.4vw, 1.02rem);
+  line-height: 1.48;
 }
 
 .panelLabel {
@@ -465,6 +512,14 @@ body[data-status="generating"] .statusLine strong {
     top: 88px;
     left: 18px;
     right: auto;
+  }
+
+  .readyPromptCard {
+    top: 190px;
+    left: 18px;
+    right: 18px;
+    width: auto;
+    transform: none;
   }
 
   .controlCard,

--- a/integrations/lingbot/lingbot/webrtc/web/request_session.html
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.html
@@ -29,6 +29,7 @@ limitations under the License.
       <h1 class="srOnly">Lingbot WebRTC Viewer</h1>
       <canvas id="mockCanvas" class="mockCanvas" aria-hidden="true"></canvas>
       <video id="remoteVideo" class="stageVideo" autoplay playsinline muted></video>
+      <img id="firstFramePreview" class="firstFramePreview" alt="" aria-hidden="true">
       <div class="stageVignette" aria-hidden="true"></div>
 
       <header class="brandOverlay" aria-label="FlashDreams World Model">
@@ -46,6 +47,11 @@ limitations under the License.
           <span>Flow</span>
           <strong id="flowText">waiting</strong>
         </div>
+      </section>
+
+      <section id="readyPromptCard" class="readyPromptCard overlayPanel" aria-live="polite" hidden>
+        <span class="panelLabel">Initial Prompt</span>
+        <p id="readyPromptText"></p>
       </section>
 
       <section class="controlCard overlayPanel" aria-label="Controls">

--- a/integrations/lingbot/lingbot/webrtc/web/request_session.js
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.js
@@ -20,6 +20,9 @@ const eventLog = document.getElementById("eventLog")
 const logState = document.getElementById("logState")
 const remoteVideo = document.getElementById("remoteVideo")
 const mockCanvas = document.getElementById("mockCanvas")
+const firstFramePreview = document.getElementById("firstFramePreview")
+const readyPromptCard = document.getElementById("readyPromptCard")
+const readyPromptText = document.getElementById("readyPromptText")
 const fpsValue = document.getElementById("fpsValue")
 const latencyValue = document.getElementById("latencyValue")
 const resolutionValue = document.getElementById("resolutionValue")
@@ -36,16 +39,20 @@ const activeKeys = new Set()
 const frameTimes = []
 const pendingActions = []
 const maxPendingActions = 32
+const initialGenerationMessage = "Generating the initial frames, please wait"
 
 let peerConnection = null
 let controlChannel = null
 let statsTimer = null
 let inferenceInFlight = false
 let connected = false
+let actionStarted = false
 let heldKeySequence = 0
 let mockChunkIndex = 0
 let mockGenerationStarted = false
 let mockChunkTimer = null
+let initialScene = null
+let initialScenePromise = null
 
 const metrics = {
   fps: null,
@@ -104,10 +111,97 @@ function logEvent(message, { source = "server", level = "info" } = {}) {
   }
 }
 
+function updateReadyPreview() {
+  const status = document.body.dataset.status
+  const hasVideo = document.body.classList.contains("has-video")
+  const show =
+    connected &&
+    !hasVideo &&
+    initialScene !== null &&
+    (status === "waiting" || status === "generating")
+
+  readyPromptCard.hidden = !show
+  document.body.classList.toggle("is-ready-preview", show)
+  if (show) {
+    const prompt = typeof initialScene.prompt === "string" ? initialScene.prompt : ""
+    readyPromptText.textContent = actionStarted
+      ? initialGenerationMessage
+      : prompt
+  }
+}
+
+function applyInitialScene(payload) {
+  if (!payload || typeof payload !== "object") {
+    return
+  }
+
+  const prompt = typeof payload.prompt === "string" ? payload.prompt.trim() : ""
+  const firstFrameUrl =
+    typeof payload.first_frame_url === "string" ? payload.first_frame_url : ""
+  if (prompt) {
+    readyPromptText.textContent = prompt
+  }
+  if (firstFrameUrl && firstFramePreview.getAttribute("src") !== firstFrameUrl) {
+    firstFramePreview.src = firstFrameUrl
+  }
+
+  metrics.model =
+    typeof payload.model === "string" && payload.model ? payload.model : metrics.model
+  if (payload.resolution && typeof payload.resolution === "object") {
+    const width = Number(payload.resolution.width)
+    const height = Number(payload.resolution.height)
+    if (Number.isFinite(width) && Number.isFinite(height)) {
+      metrics.resolution = `${width}x${height}`
+    }
+  }
+  initialScene = payload
+  renderMetrics()
+  updateReadyPreview()
+}
+
+async function loadInitialScene() {
+  if (initialScene !== null) {
+    updateReadyPreview()
+    return initialScene
+  }
+  if (initialScenePromise !== null) {
+    return initialScenePromise
+  }
+
+  initialScenePromise = fetch("/api/session/initial_scene", {
+    headers: { Accept: "application/json" },
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`initial scene failed (${response.status})`)
+      }
+      return response.json()
+    })
+    .then((payload) => {
+      applyInitialScene(payload)
+      return payload
+    })
+    .catch((error) => {
+      logEvent(`initial scene unavailable: ${error.message}`, {
+        source: "client",
+        level: "error",
+      })
+      return null
+    })
+    .finally(() => {
+      initialScenePromise = null
+    })
+  return initialScenePromise
+}
+
 function setStatus(message, state = message.toLowerCase()) {
   statusText.textContent = message
   document.body.dataset.status = state
   logState.textContent = state === "idle" ? "Waiting" : message
+  if (state === "waiting" && connected && !actionStarted) {
+    void loadInitialScene()
+  }
+  updateReadyPreview()
 }
 
 function setFlow(message) {
@@ -116,6 +210,7 @@ function setFlow(message) {
 
 function setVideoVisible(visible) {
   document.body.classList.toggle("has-video", visible)
+  updateReadyPreview()
 }
 
 function renderMetrics() {
@@ -216,6 +311,7 @@ function sendControlAction(action) {
   if (mockMode && connected && !controlChannel) {
     inferenceInFlight = true
     mockGenerationStarted = true
+    actionStarted = true
     recordActionSent(action)
     setStatus("Generating", "generating")
     setFlow(`sent ${actionLabel(action)}, waiting=true`)
@@ -228,6 +324,7 @@ function sendControlAction(action) {
   }
 
   inferenceInFlight = true
+  actionStarted = true
   controlChannel.send(
     JSON.stringify({
       type: "action",
@@ -430,6 +527,9 @@ async function connectSession() {
   }
 
   connectButton.disabled = true
+  actionStarted = false
+  updateReadyPreview()
+  void loadInitialScene()
   setStatus("Connecting", "connecting")
   setFlow("creating peer connection")
   logEvent("connecting to server...", { source: "client" })
@@ -746,6 +846,9 @@ function ensureMockChunks() {
 
 async function startMockSession() {
   connectButton.disabled = true
+  actionStarted = false
+  updateReadyPreview()
+  void loadInitialScene()
   setStatus("Connecting", "connecting")
   setFlow("mock warmup")
   logEvent("connecting to mock server...", { source: "client" })

--- a/integrations/lingbot/tests/test_server_routes.py
+++ b/integrations/lingbot/tests/test_server_routes.py
@@ -15,6 +15,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
 from lingbot.webrtc.server import create_app
@@ -32,12 +34,24 @@ class FakeSessionManager:
         self.offers: list[tuple[str, str]] = []
         self.active = False
         self.runtime_ready = False
+        self.first_frame_path = Path(__file__)
 
     def has_active_session(self) -> bool:
         return self.active
 
     def is_runtime_ready(self) -> bool:
         return self.runtime_ready
+
+    def get_initial_scene(self) -> dict[str, object]:
+        return {
+            "first_frame_url": "/api/session/first_frame",
+            "prompt": "A quiet starting scene ready for control.",
+            "model": "test-lingbot-model",
+            "resolution": {"width": 832, "height": 464},
+        }
+
+    def get_first_frame_path(self) -> Path:
+        return self.first_frame_path
 
     async def preload_runtime(self) -> None:
         self.preload_calls += 1
@@ -77,6 +91,32 @@ async def test_request_session_serves_html() -> None:
         body = await response.text()
         assert response.status == 200
         assert "Lingbot WebRTC Viewer" in body
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_initial_scene_returns_first_frame_and_prompt() -> None:
+    manager = FakeSessionManager()
+    client = await _build_client(manager)
+    try:
+        response = await client.get("/api/session/initial_scene")
+        payload = await response.json()
+        assert response.status == 200
+        assert payload == manager.get_initial_scene()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_first_frame_route_serves_manager_frame() -> None:
+    manager = FakeSessionManager()
+    client = await _build_client(manager)
+    try:
+        response = await client.get("/api/session/first_frame")
+        body = await response.read()
+        assert response.status == 200
+        assert body.startswith(b"# SPDX-FileCopyrightText:")
     finally:
         await client.close()
 


### PR DESCRIPTION
# Show Lingbot Initial Scene Before First Action

## Summary

This MR improves the Lingbot WebRTC viewer startup experience. Once the session reaches the initial `Waiting` state and is ready for user input, the UI now presents the configured first frame and prompt instead of leaving the user on the generic background. When the first control action starts generation, the first frame remains visible and the prompt panel changes to `Generating the initial frames, please wait` until generated video frames begin playback.

## Changes

- Added `/api/session/initial_scene` to expose the Lingbot prompt, first-frame URL, model name, and configured resolution.
- Added `/api/session/first_frame` to serve the same first-frame image used by the Lingbot runtime.
- Added a first-frame preview layer and prompt overlay to the WebRTC viewer.
- Updated the client state logic so the preview appears during the initial ready-to-act `Waiting` state, stays visible during the first `Generating` phase, and hides once real video playback starts.
- Updated the lightweight mock UI server to serve the same initial-scene metadata and frame for faster UI iteration.
- Added route coverage for the new initial scene and first-frame endpoints.
