### PR TITLE
chore: enable uv managed mode across pyproject files

### DIFF
--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -126,3 +126,6 @@ torch = [
 torchvision = [
     { index = "pytorch-cu130", marker = "sys_platform == 'win32'" },
 ]
+
+[tool.uv]
+managed = true

--- a/integrations/alpadreams/ludus-renderer/pyproject.toml
+++ b/integrations/alpadreams/ludus-renderer/pyproject.toml
@@ -81,3 +81,6 @@ packages = [
     "_cpp/loader/*.cpp",
     "_cpp/loader/*.cu",
 ]
+
+[tool.uv]
+managed = true

--- a/integrations/alpadreams/pyproject.toml
+++ b/integrations/alpadreams/pyproject.toml
@@ -67,3 +67,6 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["alpadreams*"]
 exclude = ["tests"]
+
+[tool.uv]
+managed = true

--- a/integrations/causal_forcing/pyproject.toml
+++ b/integrations/causal_forcing/pyproject.toml
@@ -49,3 +49,6 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["causal_forcing*"]
 exclude = ["tests"]
+
+[tool.uv]
+managed = true

--- a/integrations/cosmos_predict2/pyproject.toml
+++ b/integrations/cosmos_predict2/pyproject.toml
@@ -47,3 +47,6 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["cosmos_predict2*"]
 exclude = ["tests"]
+
+[tool.uv]
+managed = true

--- a/integrations/fastvideo_causal_wan22/pyproject.toml
+++ b/integrations/fastvideo_causal_wan22/pyproject.toml
@@ -46,3 +46,6 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["fastvideo_causal_wan22*"]
 exclude = ["tests"]
+
+[tool.uv]
+managed = true

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -52,3 +52,6 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["lingbot*"]
 exclude = ["tests"]
+
+[tool.uv]
+managed = true

--- a/integrations/lingbot/tests/parity_check/pyproject.toml
+++ b/integrations/lingbot/tests/parity_check/pyproject.toml
@@ -24,3 +24,6 @@ dependencies = [
 # flashdreams is not on PyPI; install it from the local source tree
 # (../../../../flashdreams relative to this directory).
 flashdreams = { path = "../../../../flashdreams", editable = true }
+
+[tool.uv]
+managed = true

--- a/integrations/self_forcing/pyproject.toml
+++ b/integrations/self_forcing/pyproject.toml
@@ -48,3 +48,6 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["self_forcing*"]
 exclude = ["tests"]
+
+[tool.uv]
+managed = true

--- a/integrations/self_forcing/tests/parity_check/pyproject.toml
+++ b/integrations/self_forcing/tests/parity_check/pyproject.toml
@@ -22,3 +22,6 @@ dependencies = [
 # flashdreams is not on PyPI; install it from the local source tree
 # (../../../../flashdreams relative to this directory).
 flashdreams = { path = "../../../../flashdreams", editable = true }
+
+[tool.uv]
+managed = true

--- a/integrations/wan21/pyproject.toml
+++ b/integrations/wan21/pyproject.toml
@@ -48,3 +48,6 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["wan21*"]
 exclude = ["tests"]
+
+[tool.uv]
+managed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ members = [
 # compiled against cuBLAS 13.4.x, while torch 2.11 pins nvidia-cublas 13.1.0.3.
 # cuBLAS 13.4 is backwards compatible with 13.1.
 [tool.uv]
+managed = true
 required-version = ">=0.11.8"
 override-dependencies = ["nvidia-cublas>=13.4"]
 


### PR DESCRIPTION
Set [tool.uv] managed = true in all flashdreams pyproject.toml files to prepare
for vulnerability scanning workflows.