### PR TITLE
Make CI inline-SPDX-header check strict + cover 8 remaining files

### DIFF
--- a/.github/workflows/reuse-lint.yml
+++ b/.github/workflows/reuse-lint.yml
@@ -91,7 +91,7 @@ jobs:
               continue
             fi
             if ! head -n 20 "$f" | grep -q "SPDX-License-Identifier"; then
-              echo "::warning file=$f::missing SPDX-License-Identifier in first 20 lines (covered by REUSE.toml aggregate; prefer inline header)"
+              echo "::error file=$f::missing SPDX-License-Identifier in first 20 lines"
               missing=$((missing + 1))
             fi
           done < <(git ls-files \
@@ -99,13 +99,11 @@ jobs:
                      '*.c' '*.cc' '*.cpp' '*.cxx' \
                      '*.h' '*.hh' '*.hpp' '*.hxx' \
                      '*.cu' '*.cuh' '*.inl')
-          echo "Source files without inline SPDX header: $missing"
-          # Reported as warnings only; tighten to a fail by setting
-          # REUSE_LINT_INLINE_STRICT=1 in the workflow env.
-          if [ "${REUSE_LINT_INLINE_STRICT:-0}" = "1" ] && [ "$missing" -gt 0 ]; then
+          if [ "$missing" -gt 0 ]; then
             echo "::error::$missing source file(s) missing inline SPDX header"
             exit 1
           fi
+          echo "OK: every tracked source file carries an inline SPDX-License-Identifier"
 
       - name: No NVIDIA proprietary banners
         run: |

--- a/.github/workflows/reuse-lint.yml
+++ b/.github/workflows/reuse-lint.yml
@@ -1,0 +1,123 @@
+name: reuse-lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  reuse:
+    name: REUSE 3.3 compliance (repo-wide)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # REUSE 3.3 lint: every file in the repo must have a copyright + license
+      # identifier, either as an in-file SPDX header or via REUSE.toml.
+      - name: REUSE lint
+        uses: fsfe/reuse-action@v5
+
+  collateral:
+    name: OSRB collateral sanity check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: LICENSE and LICENSES/Apache-2.0.txt are byte-identical Apache-2.0
+        run: |
+          set -euo pipefail
+          if ! diff -q LICENSE LICENSES/Apache-2.0.txt >/dev/null; then
+            echo "::error::LICENSE and LICENSES/Apache-2.0.txt diverge"
+            diff LICENSE LICENSES/Apache-2.0.txt | head -20
+            exit 1
+          fi
+          # Sentinel strings unique to the canonical Apache-2.0 text.
+          for line in \
+            "Apache License" \
+            "Version 2.0, January 2004" \
+            "http://www.apache.org/licenses/" \
+            "END OF TERMS AND CONDITIONS" \
+            "APPENDIX: How to apply the Apache License to your work."
+          do
+            if ! grep -qF "$line" LICENSE; then
+              echo "::error file=LICENSE::missing canonical Apache-2.0 sentinel: $line"
+              exit 1
+            fi
+          done
+          echo "OK: LICENSE == LICENSES/Apache-2.0.txt, canonical Apache-2.0 text"
+
+      - name: Required OSRB collateral present at repo root
+        run: |
+          set -euo pipefail
+          for f in LICENSE LICENSES/Apache-2.0.txt CONTRIBUTING.md NOTICE REUSE.toml; do
+            if [ ! -f "$f" ]; then
+              echo "::error::missing required OSRB file: $f"
+              exit 1
+            fi
+            echo "OK: $f"
+          done
+
+      - name: CONTRIBUTING.md references the DCO / sign-off
+        run: |
+          set -euo pipefail
+          if ! grep -qE "Developer.{1,40}Certificate.{1,10}of.{1,10}Origin|Signed-off-by|sign-off" CONTRIBUTING.md; then
+            echo "::error::CONTRIBUTING.md does not reference DCO / sign-off"
+            exit 1
+          fi
+          echo "OK: CONTRIBUTING.md references DCO / sign-off"
+
+      # Inline SPDX-License-Identifier on first-party source files.
+      # REUSE.toml provides aggregate coverage so 'reuse lint' is green even
+      # without inline headers, but inline tags are the OSRB-preferred form
+      # and catch new files copied in without attribution.
+      #
+      # Paths covered by REUSE.toml `override` annotations (vendored upstream
+      # whose original BSD-3-Clause / Zlib banners are kept verbatim, plus
+      # generated protobuf stubs) are exempt.
+      - name: Inline SPDX headers on first-party source files
+        run: |
+          set -euo pipefail
+          excludes='^integrations/alpadreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/'
+          excludes+='|^integrations/alpadreams/alpadreams/grpc/protos/.*_pb2'
+          missing=0
+          while IFS= read -r f; do
+            if printf '%s\n' "$f" | grep -qE "$excludes"; then
+              continue
+            fi
+            if ! head -n 20 "$f" | grep -q "SPDX-License-Identifier"; then
+              echo "::warning file=$f::missing SPDX-License-Identifier in first 20 lines (covered by REUSE.toml aggregate; prefer inline header)"
+              missing=$((missing + 1))
+            fi
+          done < <(git ls-files \
+                     '*.py' '*.pyx' '*.pyi' \
+                     '*.c' '*.cc' '*.cpp' '*.cxx' \
+                     '*.h' '*.hh' '*.hpp' '*.hxx' \
+                     '*.cu' '*.cuh' '*.inl')
+          echo "Source files without inline SPDX header: $missing"
+          # Reported as warnings only; tighten to a fail by setting
+          # REUSE_LINT_INLINE_STRICT=1 in the workflow env.
+          if [ "${REUSE_LINT_INLINE_STRICT:-0}" = "1" ] && [ "$missing" -gt 0 ]; then
+            echo "::error::$missing source file(s) missing inline SPDX header"
+            exit 1
+          fi
+
+      - name: No NVIDIA proprietary banners
+        run: |
+          set -euo pipefail
+          # Exclude this workflow file itself, which references the banner
+          # strings as grep patterns. Catches the NVIDIA proprietary banner
+          # that pre-dates the Apache-2.0 distribution decision.
+          if git grep -nI \
+               -e "NVIDIA CORPORATION is strictly prohibited" \
+               -e "proprietary rights in and to this software" \
+               -- ':!.github/workflows/reuse-lint.yml'; then
+            echo "::error::NVIDIA proprietary banner found in repository"
+            exit 1
+          fi
+          echo "OK: no legacy proprietary banners"

--- a/flashdreams/flashdreams/_pytest_plugins/__init__.py
+++ b/flashdreams/flashdreams/_pytest_plugins/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/flashdreams/flashdreams/core/distributed/rank_orchestration.py
+++ b/flashdreams/flashdreams/core/distributed/rank_orchestration.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import functools

--- a/integrations/alpadreams/ludus-renderer/tests/conftest.py
+++ b/integrations/alpadreams/ludus-renderer/tests/conftest.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 from pathlib import Path
 

--- a/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_api.py
+++ b/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_api.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Contract suite for `FW::CudaRaster` (the C++ class under
 `ludus_renderer/_cpp/cudaraster/`).

--- a/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_port_invariants.py
+++ b/integrations/alpadreams/ludus-renderer/tests/test_cudaraster_port_invariants.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Focused invariants for the CudaRaster cleanroom port.
 
 These tests pin small, risky porting assumptions that are easier to verify

--- a/integrations/alpadreams/tests/test_service_composition.py
+++ b/integrations/alpadreams/tests/test_service_composition.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import pytest

--- a/integrations/lingbot/tests/test_distributed_server_main.py
+++ b/integrations/lingbot/tests/test_distributed_server_main.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from argparse import Namespace

--- a/integrations/lingbot/tests/test_webrtc_runtime_distributed.py
+++ b/integrations/lingbot/tests/test_webrtc_runtime_distributed.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
         Make CI inline-SPDX-header check strict + cover 8 remaining files

         Two changes that land together so CI is green on the first run:

         1. Add Apache-2.0 SPDX header to 8 first-party files that were relying on
            REUSE.toml aggregate coverage:
            - flashdreams/flashdreams/_pytest_plugins/__init__.py
            - flashdreams/flashdreams/core/distributed/rank_orchestration.py
            - integrations/alpadreams/ludus-renderer/tests/conftest.py
            - integrations/alpadreams/ludus-renderer/tests/test_cudaraster_api.py
            - integrations/alpadreams/ludus-renderer/tests/test_cudaraster_port_invariants.py
            - integrations/alpadreams/tests/test_service_composition.py
            - integrations/lingbot/tests/test_distributed_server_main.py
            - integrations/lingbot/tests/test_webrtc_runtime_distributed.py

         2. Flip the workflow's inline-SPDX-header check from warn-only to hard
            fail. Going forward, any new .py/.cpp/.cu/.h/.hpp/.inl/.cuh source
            file outside the vendored cudaraster + generated protobuf paths must
            carry an inline SPDX-License-Identifier or CI fails.

         Verified locally:
           - reuse lint: 408/408 files compliant
           - Inline SPDX header check: 0 missing
           - No NVIDIA proprietary banners anywhere