### PR TITLE
feat(flashvsr) enable Multi-GPU for FlashVSR (with full attention)

### DIFF
--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
@@ -26,7 +26,7 @@ import torch.nn as nn
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from flashdreams.core.attention import BlockKVCache, RingAttention
+from flashdreams.core.attention import BlockKVCache, NativeAttention, RingAttention
 from flashdreams.core.attention.rope import apply_rope_freqs
 
 
@@ -133,6 +133,8 @@ class Head(nn.Module):
 
 class MultiHeadAttention(nn.Module):
     """Multi-head attention with KV cache and optional RoPE."""
+
+    attn_op: NativeAttention
 
     def __init__(
         self,

--- a/integrations/flashvsr/README.md
+++ b/integrations/flashvsr/README.md
@@ -76,6 +76,10 @@ uv run flashdreams-run flashvsr-v1.1-sparse-ratio-2.0 --input-path /path/to/clip
 # Faster preset (sparse_ratio=1.5).
 uv run flashdreams-run flashvsr-v1.1-sparse-ratio-1.5 --input-path /path/to/clip.mp4
 
+# Dense full-attention preset. This changes model behavior, enables DiT
+# torch.compile + CUDA graph by default, and supports multi-GPU CP.
+uv run flashdreams-run flashvsr-v1.1-full-attn --input-path /path/to/clip.mp4
+
 # Reduce per-chunk peak VRAM (single DiT iter per chunk: first=5, subseq=8).
 uv run flashdreams-run flashvsr-v1.1-sparse-ratio-2.0 --input-path /path/to/clip.mp4 \
     --chunk-size 8
@@ -94,7 +98,20 @@ uv run flashdreams-run flashvsr-v1.1-sparse-ratio-2.0 --input-path /path/to/clip
 
 ## Multi-GPU Run via context-parallelism:
 
-Not yet supported due to the use of block-sparse attention.
+Supported only by the dense full-attention preset. The legacy sparse presets
+remain single-GPU because `block_sparse_attn` is not context-parallel aware
+and is intentionally not being extended here.
+
+```bash
+uv run torchrun --nproc_per_node=2 --no-python flashdreams-run \
+    flashvsr-v1.1-full-attn --input-path /path/to/clip.mp4
+```
+
+Full attention uses the existing CP-aware Wan dense attention stack with DiT
+compile + CUDA graph enabled by default, so peak memory is much higher than the
+sparse presets. Use smaller inputs, `--chunk-size 8`, fewer GPUs, or override
+`--pipeline.diffusion-model.transformer.use-cuda-graph False` if the dense run
+OOMs.
 
 
 ## Streaming chunk contract

--- a/integrations/flashvsr/flashvsr/config.py
+++ b/integrations/flashvsr/flashvsr/config.py
@@ -48,9 +48,11 @@ from flashvsr.transformer.network import FlashVSRDiTNetworkConfig
 __all__ = [
     "AVAILABLE_FLASHVSR_CHECKPOINT_PATHS",
     "FLASHVSR_CONFIG_BUILDERS",
+    "PIPELINE_FLASHVSR_V1_1_FULL_ATTN",
     "PIPELINE_FLASHVSR_V1_1_SPARSE_1_5",
     "PIPELINE_FLASHVSR_V1_1_SPARSE_2_0",
     "RUNNER_CONFIGS",
+    "RUNNER_FLASHVSR_V1_1_FULL_ATTN",
     "RUNNER_FLASHVSR_V1_1_SPARSE_1_5",
     "RUNNER_FLASHVSR_V1_1_SPARSE_2_0",
     "build_flashvsr_v1_1",
@@ -116,6 +118,7 @@ def _transformer_config(
     compile_network: bool,
     use_cuda_graph: bool,
     dtype: torch.dtype,
+    attention_mode: Literal["sparse", "full"],
 ) -> FlashVSRTransformerConfig:
     """FlashVSR transformer config at a given target resolution.
 
@@ -128,7 +131,8 @@ def _transformer_config(
     :meth:`FlashVSRPipeline.initialize_cache`, not baked in here.
     """
     return FlashVSRTransformerConfig(
-        network=FlashVSRDiTNetworkConfig(),  # ``flashvsr_tiny_long`` defaults
+        # ``flashvsr_tiny_long`` defaults, with the requested attention backend.
+        network=FlashVSRDiTNetworkConfig(attention_mode=attention_mode),
         dtype=dtype,
         checkpoint_path=dit_checkpoint_path,
         batch_shape=(1,),
@@ -137,6 +141,7 @@ def _transformer_config(
         topk_ratio=sparse_ratio * 768 * 1280 / (target_H * target_W),
         kv_ratio=kv_ratio,
         local_range=local_range,
+        attention_mode=attention_mode,
         compile_network=compile_network,
         use_cuda_graph=use_cuda_graph,
     )
@@ -160,6 +165,7 @@ def build_flashvsr_v1_1(
     dtype: torch.dtype = torch.bfloat16,
     seed: int = 0,
     recipe_name: str = "flashvsr-v1.1",
+    attention_mode: Literal["sparse", "full"] = "sparse",
 ) -> FlashVSRPipelineConfig:
     """Default FlashVSR-v1.1 streaming VSR pipeline.
 
@@ -172,6 +178,9 @@ def build_flashvsr_v1_1(
         kv_ratio: Prior chunks kept in streaming self-attn KV; buffer
             holds ``kv_ratio + 1`` at attention time.
         local_range: Local-block window radius for the top-k draft mask.
+        attention_mode: ``"sparse"`` preserves FlashVSR's legacy block-sparse
+            self-attention. ``"full"`` uses dense Wan self-attention and is the
+            supported path for multi-GPU context parallelism.
         compile_network: Single ``torch.compile`` switch for DiT +
             encoder projector + decoder. Maps to
             :attr:`FlashVSRTransformerConfig.compile_network` plus the
@@ -245,6 +254,7 @@ def build_flashvsr_v1_1(
                 compile_network=compile_network,
                 use_cuda_graph=use_cuda_graph,
                 dtype=dtype,
+                attention_mode=attention_mode,
             ),
             scheduler=_scheduler_config(),
         ),
@@ -312,11 +322,32 @@ PIPELINE_FLASHVSR_V1_1_SPARSE_1_5, RUNNER_FLASHVSR_V1_1_SPARSE_1_5 = (
     _build_sparse_ratio_variant(sparse_ratio=1.5, preset_label="faster")
 )
 
+PIPELINE_FLASHVSR_V1_1_FULL_ATTN = build_flashvsr_v1_1(
+    recipe_name="flashvsr-v1.1-full-attn",
+    input_H=704,
+    input_W=1280,
+    scale=2,
+    attention_mode="full",
+    compile_network=True,
+    use_cuda_graph=True,
+    enable_sync_and_profile=True,
+)
+RUNNER_FLASHVSR_V1_1_FULL_ATTN = FlashVSRRunnerConfig(
+    runner_name=PIPELINE_FLASHVSR_V1_1_FULL_ATTN.recipe_name,
+    description=(
+        "FlashVSR-v1.1 streaming video super-resolution "
+        "(2x; dense full attention; supports multi-GPU context parallelism; "
+        "pipeline dims track the input video)."
+    ),
+    pipeline=PIPELINE_FLASHVSR_V1_1_FULL_ATTN,
+)
+
 RUNNER_CONFIGS: dict[str, RunnerConfig] = {
     cfg.runner_name: cfg
     for cfg in (
         RUNNER_FLASHVSR_V1_1_SPARSE_2_0,
         RUNNER_FLASHVSR_V1_1_SPARSE_1_5,
+        RUNNER_FLASHVSR_V1_1_FULL_ATTN,
     )
 }
 """``{runner_name -> RunnerConfig}`` entry-point map exported under

--- a/integrations/flashvsr/flashvsr/pipeline.py
+++ b/integrations/flashvsr/flashvsr/pipeline.py
@@ -13,32 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""FlashVSR streaming inference pipeline (LR projector + DiT + TC decoder).
-
-Subclasses :class:`StreamInferencePipeline`; one
-``pipeline.generate(autoregressive_index, cache, input)`` call processes
-one full FlashVSR chunk. The 5-step algorithm (encoder -> sample noise
--> per-iter DiT -> noise - flow -> decoder) mirrors the legacy
-``UltraFlashVSRUpsampler.forward`` exactly. See the sibling ``README.md``
-for the full streaming chunk contract and per-component knob list.
-
-Three FlashVSR-specific quirks the abstract pipeline doesn't natively
-handle, and why ``generate`` is fully inlined instead of calling
-``super().generate``:
-
-- The encoder's output is a ``list[Tensor]`` of per-block LR latent
-  slices; :class:`FlashVSRTransformer` overrides
-  ``patchify_and_maybe_split_cp`` to pass lists through.
-- The TC decoder needs the bicubic upres as ``cond``; the encoder
-  stashes it on its own cache and the pipeline forwards it.
-- Sampling noise once per chunk (then slicing pre-patchify) is needed
-  for parity with the legacy ``generate_noise(n_latent)`` -- the
-  inherited ``DiffusionModel.generate`` re-samples per AR step.
-
-FlashVSR's distilled DiT was trained with KV cache K/V derived from the
-**noisy** latent (sigma=1, t=1000); we preserve this by overriding
-:meth:`FlashVSRTransformer.finalize_kv_cache` to a no-op.
-"""
+"""FlashVSR streaming inference pipeline."""
 
 from __future__ import annotations
 
@@ -50,6 +25,7 @@ from typing import TypeAlias
 import torch
 from torch import Tensor
 
+from flashdreams.core.distributed.context_parallel import cat_outputs_cp
 from flashdreams.core.io.download import download_to_cache
 from flashdreams.infra.diffusion.model import DiffusionModel
 from flashdreams.infra.pipeline import (
@@ -85,18 +61,24 @@ PROMPT_CACHE_DIR = (
     Path(os.path.expanduser(os.getenv("FLASHDREAMS_CACHE_DIR", "~/.cache/flashdreams")))
     / "flashvsr"
 )
-"""User-writable cache for the precomputed UMT5 prompt tensor."""
+"""User-writable cache for downloaded frozen UMT5 prompt tensors."""
 
 
 def _load_prompt_tensor(prompt_path: str) -> Tensor:
-    """Load FlashVSR's frozen UMT5 prompt tensor from a local path or HTTP URL.
+    """Load FlashVSR's frozen UMT5 prompt tensor.
 
-    ``http(s)://`` strings are atomically fetched into
-    :data:`PROMPT_CACHE_DIR` (via :func:`download_to_cache`) on first use;
-    local paths pass through unchanged. ``posi_prompt.pth`` pickles a
-    bare ``Tensor`` (not a state dict), so we deserialize with
-    ``torch.load`` directly rather than routing through
-    ``load_checkpoint``.
+    URL inputs are downloaded once into :data:`PROMPT_CACHE_DIR` through
+    :func:`download_to_cache`; filesystem paths are loaded directly.
+    ``posi_prompt.pth`` is a bare ``Tensor`` saved with ``torch.save`` rather
+    than a checkpoint state dict, so the pipeline deserializes it with
+    ``torch.load`` and validates the object type here.
+
+    Args:
+        prompt_path: Local filesystem path or HTTP(S) URL for
+            ``posi_prompt.pth``.
+
+    Returns:
+        Prompt embedding loaded on CPU.
     """
     if prompt_path.startswith(("http://", "https://")):
         local_path = download_to_cache(prompt_path, cache_dir=PROMPT_CACHE_DIR)
@@ -113,11 +95,12 @@ def _load_prompt_tensor(prompt_path: str) -> Tensor:
 class FlashVSRPipelineConfig(StreamInferencePipelineConfig):
     """Configuration for :class:`FlashVSRPipeline`.
 
-    Required fields are inherited from :class:`StreamInferencePipelineConfig`
-    (``diffusion_model``); the encoder / decoder slots are pinned to the
-    FlashVSR-specific configs because the pipeline subclass relies on the
-    encoder's ``last_upres`` side-channel and the decoder's
-    ``cond``-aware forward.
+    The required ``diffusion_model`` field is inherited from
+    :class:`StreamInferencePipelineConfig`. The encoder and decoder fields are
+    narrowed to the FlashVSR implementations because :class:`FlashVSRPipeline`
+    relies on their cache side channels: the encoder records the chunk's
+    bicubic upres and internal-iteration count, and the decoder consumes that
+    upres as both conditioning and color reference.
     """
 
     _target: type["FlashVSRPipeline"] = field(  # type: ignore[assignment]
@@ -135,12 +118,14 @@ class FlashVSRPipelineConfig(StreamInferencePipelineConfig):
     """TC decoder + AdaIN color corrector."""
 
     prompt_path: str | None = None
-    """Path to ``posi_prompt.pth`` (``[1, 512, 4096]`` UMT5 embedding).
-    Loaded once at pipeline construction and forwarded to
-    :meth:`FlashVSRTransformer.initialize_autoregressive_cache` via the
-    ``text_embeddings=`` kwarg on every :meth:`FlashVSRPipeline.initialize_cache`
-    call. Set to ``None`` to require callers to pass ``prompt_tensor``
-    explicitly."""
+    """Path or URL for ``posi_prompt.pth``.
+
+    The tensor is the frozen UMT5 prompt embedding used by the FlashVSR DiT,
+    typically shaped ``[1, 512, 4096]`` for the shipped checkpoint. When this
+    is set, the pipeline loads the tensor once during construction and reuses
+    it for every :meth:`FlashVSRPipeline.initialize_cache` call. Leave it as
+    ``None`` only when callers will pass ``prompt_tensor=...`` explicitly.
+    """
 
 
 class FlashVSRPipeline(
@@ -151,6 +136,12 @@ class FlashVSRPipeline(
     ]
 ):
     """FlashVSR streaming video super-resolution pipeline.
+
+    Construct through ``flashvsr.config.build_flashvsr_v1_1`` or one of the
+    shipped config literals so the encoder dimensions, prompt tensor, DiT
+    checkpoint, and decoder checkpoint stay in sync. A cache represents one
+    rollout over a video; call :meth:`generate` and then :meth:`finalize` for
+    each chunk in increasing ``autoregressive_index`` order.
 
     Examples:
 
@@ -185,11 +176,9 @@ class FlashVSRPipeline(
             f"{type(self.decoder).__name__}."
         )
 
-        # Loaded once on CPU and reused on every ``initialize_cache`` call;
-        # ``initialize_cache`` moves it to ``self.device``. ``posi_prompt.pth``
-        # is a precomputed UMT5 prompt tensor (a bare Tensor pickled with
-        # ``torch.save``), not a checkpoint state dict, so we deserialize via
-        # ``download_to_cache`` + ``torch.load`` rather than ``load_checkpoint``.
+        # Keep the configured prompt on CPU and move/cast it per rollout in
+        # ``initialize_cache``. Callers that pass ``prompt_tensor=...`` bypass
+        # this cached copy.
         self._prompt_tensor: Tensor | None = (
             _load_prompt_tensor(config.prompt_path)
             if config.prompt_path is not None
@@ -201,13 +190,27 @@ class FlashVSRPipeline(
         self,
         prompt_tensor: Tensor | None = None,
     ) -> FlashVSRPipelineCache:
-        """Build a fresh per-rollout cache.
+        """Build the cache state for one FlashVSR rollout.
+
+        The returned cache owns the encoder projector tail buffers, the rolling
+        transformer KV cache, the decoder streaming state, and the per-step
+        side-channel slots used inside :meth:`generate`. A cache should be
+        threaded through all chunks from one video stream and not reused for an
+        unrelated stream.
+
+        The prompt tensor is moved to ``self.device`` and cast to the DiT dtype
+        before it is forwarded as ``text_embeddings``. The transformer's latent
+        height and width are derived from the encoder's cropped high-resolution
+        target dimensions using Wan's 8x spatial compression.
 
         Args:
-            prompt_tensor: Optional ``[1, text_len, text_dim]`` UMT5 prompt
-                embedding to seed the DiT cross-attention KV cache. Falls
-                back to the prompt tensor loaded from ``config.prompt_path``
-                if not provided. Required if neither is set.
+            prompt_tensor: UMT5 prompt embedding
+                ``[1, text_len, text_dim]`` for the DiT cross-attention cache;
+                ``None`` uses the tensor loaded from ``config.prompt_path``.
+                One of these two sources must be available.
+
+        Returns:
+            Fresh cache to thread through one video stream.
         """
         prompt = prompt_tensor if prompt_tensor is not None else self._prompt_tensor
         assert prompt is not None, (
@@ -215,10 +218,7 @@ class FlashVSRPipeline(
             "pass prompt_tensor=... or set FlashVSRPipelineConfig.prompt_path."
         )
         prompt = prompt.to(device=self.device, dtype=self.diffusion_model.dtype)
-        # Per-rollout latent (height, width) for the DiT cache, derived from
-        # the encoder's pixel-space upres dims via Wan VAE's 8x spatial
-        # compression. ``Wan21Transformer.initialize_autoregressive_cache``
-        # consumes them via ``transformer_context``.
+        # The Wan cache stores latent spatial size, not pixel size.
         latent_height = self.encoder.target_H // 8
         latent_width = self.encoder.target_W // 8
         return super().initialize_cache(
@@ -238,25 +238,37 @@ class FlashVSRPipeline(
         cache: FlashVSRPipelineCache,
         input: Tensor,
     ) -> Tensor:
-        """Process one full FlashVSR chunk (8 or 16 raw frames).
+        """Upsample one complete FlashVSR chunk.
 
-        See module docstring for the 5-step algorithm. The profiler emits
-        seven events (``pad`` / ``bicubic`` / ``projector`` / ``dit_concat``
-        / ``denoise`` / ``decoder`` / ``color``) because steps 1 and 3 each
-        record sub-stages. Mirrors the legacy
-        ``UltraFlashVSRUpsampler.forward`` exactly.
+        The first chunk may contain 5 or 13 raw frames; steady-state chunks
+        contain 8 or 16 raw frames. The encoder pads cold-start chunks
+        internally, reports whether the padded chunk requires one or two
+        internal DiT iterations, and leaves the bicubic upres on its cache for
+        the decoder.
+
+        Callers must invoke :meth:`finalize` with the same
+        ``autoregressive_index`` after consuming the returned tensor. For
+        FlashVSR, finalization advances the transformer's rolling KV cache and,
+        when profiling is enabled, records the final timing event.
 
         Args:
             autoregressive_index: Must be ``cache.autoregressive_index + 1``,
                 or ``0`` for the first call after ``initialize_cache``.
             cache: Per-rollout cache from ``initialize_cache``.
             input: Low-resolution frames ``[B, 3, T, H, W]`` in ``[-1, 1]``.
-                See :class:`FlashVSREncoderConfig` for the per-step ``T``
-                contract.
+                ``T`` must be one of the chunk sizes accepted by
+                :class:`FlashVSREncoderConfig`.
 
         Returns:
             Upsampled RGB frames ``[B, 3, T_out, target_H, target_W]`` in
-            ``[-1, 1]``. ``T_out`` matches the un-padded input frame count.
+            ``[-1, 1]``. ``T_out`` matches the unpadded input frame count.
+
+        Note:
+            With ``enable_sync_and_profile=True``, this method contributes
+            ``pad``, ``bicubic``, ``projector``, ``dit_concat``, ``denoise``,
+            ``decoder``, and ``color`` events. The inherited
+            :meth:`StreamInferencePipeline.finalize` appends ``finalize`` and
+            returns the summarized timings.
         """
         prev = cache.autoregressive_index
         expected = (prev + 1) if prev is not None else 0
@@ -266,23 +278,17 @@ class FlashVSRPipeline(
         )
         cache.autoregressive_index = autoregressive_index
 
-        # Profiling. Allocate one shared :class:`EventProfiler` on the
-        # parent cache; both encoder and decoder receive it as an explicit
-        # ``event_profiler`` kwarg below (no per-sub-cache duplication).
-        # Per-AR-step record order is the legacy 7-stage breakdown
-        # (``pad`` -> ``bicubic`` -> ``projector`` -> ``dit_concat``
-        # -> ``denoise`` -> ``decoder`` -> ``color``); the inherited
-        # :meth:`StreamInferencePipeline.finalize` appends the ``finalize``
-        # event and sync-summarizes, so the runner's existing summary
-        # block consumes it unchanged.
+        # One profiler lives on the parent cache for the whole public AR step.
+        # The encoder and decoder record into it through explicit kwargs.
         if self.config.enable_sync_and_profile:
             cache.event_profiler = EventProfiler()
         event_profiler = cache.event_profiler
 
-        # ----- 1. Encoder -----
-        # Bicubic + projector. Side-stashes ``last_upres`` and
-        # ``last_n_iters`` on cache.encoder_cache. Records ``pad``,
-        # ``bicubic`` and ``projector`` against the shared profiler.
+        ## Encoder
+
+        # Produces per-block LR token tensors and records two side channels:
+        # ``last_n_iters`` for the DiT loop below and ``last_upres`` for the
+        # decoder conditioning path.
         assert cache.encoder_cache is not None  # invariant: paired with encoder
         per_block_latents = self.encoder(
             input=input,
@@ -295,29 +301,25 @@ class FlashVSRPipeline(
             f"FlashVSREncoder.last_n_iters must be 1 or 2 (got {n_iters})."
         )
 
-        # Forward the encoder's upres to the decoder cache. The TC decoder
-        # reads ``last_upres`` as ``cond`` and the color corrector uses it
-        # as the AdaIN reference.
+        # The decoder reads this as both TC-decoder conditioning and the AdaIN
+        # color reference. Keep the tensor unpadded so output length matches
+        # the user-visible input length.
         assert cache.decoder_cache is not None  # invariant: paired with decoder
         cache.decoder_cache.last_upres = cache.encoder_cache.last_upres
 
-        # ----- 2. Sample noise once for the full chunk -----
-        # Pre-patchify shape ``[B, in_dim, n_latent, latent_H, latent_W]``,
-        # matching the legacy ``UltraFlashVSRUpsampler.generate_noise(n_latent)``.
-        # Sampling once and slicing in pre-patchify space (vs sampling per
-        # iter post-patchify) is required for parity with the legacy: the
-        # patchify rearrange interleaves spatial + temporal axes, so the
-        # per-iter noise vectors differ between the two approaches.
+        ## Chunk noise
+
+        # Legacy FlashVSR samples ``[B, C, n_latent, H, W]`` before patchify.
+        # Preserve that order; patchify interleaves space and time, so slicing
+        # a previously patchified full-chunk noise tensor would not be equal.
         transformer = self.diffusion_model.transformer
-        # Narrow from the abstract base ``Wan21Transformer`` (with
-        # ``config: InstantiateConfig[Any]``) to the concrete subclass
-        # asserted in ``__init__``. Required for ty + readability.
+        # Narrow from the abstract Wan base to the subclass asserted in
+        # ``__init__`` so the FlashVSR-specific config fields are visible.
         assert isinstance(transformer, FlashVSRTransformer)
         cfg = transformer.config
         assert isinstance(cfg, FlashVSRTransformerConfig)
-        # Per-rollout latent (height, width) and patchified (pH, pW) live on
-        # the transformer instance after ``initialize_autoregressive_cache``;
-        # ``initialize_cache`` above seeds them via ``transformer_context``.
+        # ``initialize_cache`` seeds these per-rollout latent dimensions via
+        # ``transformer_context``.
         latent_h = transformer._output_height
         latent_w = transformer._output_width
         assert latent_h is not None and latent_w is not None, (
@@ -336,36 +338,23 @@ class FlashVSRPipeline(
             generator=self.diffusion_model.rng,
         )
 
-        # ----- 3. Loop n_iters internal DiT iterations -----
-        # Each iter consumes a 2-latent-frame slice of the noise and a
-        # ``L_per_iter``-token slice of the per-block LR latents. The
-        # internal AR step index advances by 1 per iter so the rolling
-        # KV cache rolls at the right cadence (matches legacy
-        # ``cur_process_idx = chunk_idx * n_iters + idx``).
+        ## Internal DiT iterations
+
+        # Each iteration consumes two latent frames and one matching slice of
+        # every per-block LR-token tensor. The internal AR index advances once
+        # per iteration, matching the legacy ``chunk_idx * n_iters + idx``.
         #
-        # ``flow_full`` is pre-allocated once and each iter's flow is
-        # ``copy_``-ed into its slot immediately after ``predict_flow``.
-        # This is required for ``compile_network=True`` paths that fall
-        # back into Inductor cudagraphs (``mode="max-autotune"`` or
-        # similar): the DiT's compiled output lives in a static
-        # cudagraph buffer that gets clobbered by the next iter's call,
-        # so the original ``flow_parts.append(flow)`` + post-loop
-        # ``torch.cat`` pattern crashes with "accessing tensor output
-        # of CUDAGraphs that has been overwritten by a subsequent run".
-        # The slice-copy materialises each iter's flow into a stable,
-        # caller-owned tensor before the next call. Hoisting
-        # ``full_noise_patched`` lets us use it as the ``empty_like``
-        # template and reuse it for the post-loop ``noise - flow``
-        # subtract.
+        # Context parallelism must split each DiT call independently. If a
+        # 16-frame chunk were split after concatenating both iterations, ranks
+        # could receive different iteration ranges instead of shards of the
+        # same iteration. Gather each iteration's clean tokens before joining.
         L_per_iter = len_t * pH * pW
-        # FlashVSR's distilled DiT is fixed at t=1000 every chunk.
+        # FlashVSR's distilled DiT uses the same sigma=1 / t=1000 point for
+        # every internal iteration.
         timestep = torch.tensor(
             [1000.0], device=transformer.device, dtype=transformer.dtype
         )
-        full_noise_patched = transformer.patchify_and_maybe_split_cp(
-            full_noise.transpose(1, 2)
-        )
-        flow_full = torch.empty_like(full_noise_patched)
+        clean_parts: list[Tensor] = []
         for idx in range(n_iters):
             internal_ar_idx = autoregressive_index * n_iters + idx
             cache.transformer_cache.start(autoregressive_index=internal_ar_idx)
@@ -374,15 +363,10 @@ class FlashVSRPipeline(
                 L[:, idx * L_per_iter : (idx + 1) * L_per_iter, :]
                 for L in per_block_latents
             ]
+            per_iter_lq = transformer.patchify_and_maybe_split_cp(per_iter_lq)
 
-            # Slice the chunk-shared noise to this iter's 2 latent frames
-            # (pre-patchify), then route through the transformer's standard
-            # patchify hook to get ``[B, L_per_iter, D]``. Note: this is
-            # *not* equivalent to slicing ``full_noise_patched`` post-
-            # patchify -- the patchify rearrange interleaves spatial and
-            # temporal axes, so per-iter parity with the legacy upsampler
-            # requires slicing pre-patchify and patchifying each slice
-            # independently.
+            # Slice before patchify for legacy parity; the transformer's hook
+            # then rearranges and CP-splits this iteration only.
             noise_slice = full_noise[:, :, idx * len_t : (idx + 1) * len_t, :, :]
             noisy_patched = transformer.patchify_and_maybe_split_cp(
                 noise_slice.transpose(1, 2)
@@ -393,34 +377,32 @@ class FlashVSRPipeline(
                 cache=cache.transformer_cache,
                 input=per_iter_lq,
             )
-            flow_full[..., idx * L_per_iter : (idx + 1) * L_per_iter, :].copy_(flow)
+            clean_iter = noisy_patched - flow
+            clean_parts.append(
+                cat_outputs_cp(clean_iter, seq_dim=-2, cp_group=transformer._cp_group)
+            )
 
-            # Per-iter cache lifecycle: ``start()`` ran before predict_flow
-            # (hoisted ``before_update``); pair it with ``finalize()``
-            # (``after_update``) here for all but the last iter. The last
-            # iter's ``after_update`` is deferred to the inherited
-            # ``StreamInferencePipeline.finalize`` -> ``DiffusionModel.finalize``
-            # -> ``final_state.cache.finalize(...)``, which lands on the
-            # right index thanks to the ``FinalState`` we stash below.
+            # Pair every internal ``start`` with an ``after_update``. The last
+            # one is deferred to the public ``finalize`` call via ``FinalState``
+            # so the caller-facing lifecycle remains generate -> finalize.
             if idx < n_iters - 1:
                 cache.transformer_cache.finalize(autoregressive_index=internal_ar_idx)
 
         record_event(event_profiler, "dit_concat")
 
-        # ----- 4. clean = noise - flow at sigma=1 -----
-        clean_patched = full_noise_patched - flow_full
-        clean_latent = transformer.unpatchify_and_maybe_gather_cp(clean_patched)
+        ## Clean latent reassembly
 
-        # Stash ``FinalState`` so the inherited ``StreamInferencePipeline.finalize``
-        # routes to ``DiffusionModel.finalize``, which for FlashVSR collapses
-        # to a single ``cache.finalize(autoregressive_index)`` call
-        # (``context_noise == 0`` skips re-noise; ``FlashVSRTransformer.finalize_kv_cache``
-        # is a no-op). The ``autoregressive_index`` is the **last internal**
-        # iter index so that call advances the per-block KV cache at the
-        # right cadence (one ``after_update`` per internal iter). ``clean_latent``
-        # is never read by ``DiffusionModel.finalize`` for FlashVSR (both branches
-        # that consume it are short-circuited), but the dataclass requires it; we
-        # pass the patchified clean latent for honesty.
+        clean_patched = torch.cat(clean_parts, dim=-2)
+        clean_latent = transformer.network.unpatchify_and_maybe_gather_cp(
+            pH=pH,
+            pW=pW,
+            x=clean_patched,
+        )
+
+        # Stash enough state for the inherited ``finalize`` to close the final
+        # internal DiT iteration. FlashVSR's ``finalize_kv_cache`` is a no-op
+        # and ``context_noise == 0`` skips re-noising, so the meaningful side
+        # effect is ``cache.finalize(last_internal_ar_idx)``.
         cache.final_state = DiffusionModel.FinalState(
             clean_latent=clean_patched,
             autoregressive_index=autoregressive_index * n_iters + (n_iters - 1),
@@ -428,10 +410,10 @@ class FlashVSRPipeline(
         )
         record_event(event_profiler, "denoise")
 
-        # ----- 5. Decoder -----
-        # TC decoder + color corrector. Reads ``last_upres`` from
-        # cache.decoder_cache. Records ``decoder`` and ``color`` against the
-        # shared profiler from inside :meth:`FlashVSRDecoder.forward`.
+        ## Decoder
+
+        # TC decoder + color corrector. Both consume the bicubic upres that was
+        # forwarded to ``cache.decoder_cache.last_upres`` above.
         return self.decoder(
             input=clean_latent,
             autoregressive_index=autoregressive_index,

--- a/integrations/flashvsr/flashvsr/runner.py
+++ b/integrations/flashvsr/flashvsr/runner.py
@@ -13,20 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""FlashVSR streaming video super-resolution runner.
-
-Pipeline construction is deferred from ``Runner.__init__`` to
-:meth:`FlashVSRRunner.run` so the encoder's ``input_H`` / ``input_W``
-can be set to the input video's native pixel dims. The
-``PIPELINE_FLASHVSR_V1_1_SPARSE_*`` literals in :mod:`flashvsr.config`
-therefore act as a scaffold supplying every non-resolution knob; the
-runner overrides ``encoder.input_H`` / ``encoder.input_W`` per video
-via ``derive_config`` before calling ``setup()``, and also re-derives
-``diffusion_model.transformer.topk_ratio`` from the per-video
-post-crop target dims so it matches upstream FlashVSR's
-``sparse_ratio * 768*1280 / (th*tw)`` formula (the placeholder value
-baked at builder time is stale for every non-scaffold input).
-"""
+"""FlashVSR streaming video super-resolution runner."""
 
 from __future__ import annotations
 
@@ -51,6 +38,7 @@ from flashvsr.pipeline import (
     FlashVSRPipelineCache,
     FlashVSRPipelineConfig,
 )
+from flashvsr.transformer import FlashVSRTransformerConfig
 
 __all__ = [
     "FlashVSRRunnerConfig",
@@ -58,14 +46,19 @@ __all__ = [
 ]
 
 
-def _chunk_modes() -> dict[int, tuple[int, int]]:
-    """``{steady_size: (cold_size, steady_size)}`` derived from the encoder.
+## Chunk planning helpers
 
-    Single-source-of-truth: invert :data:`FlashVSREncoder._CHUNK_FRAME_TARGETS`
-    (``{raw -> padded}``) into a ``{padded -> raw_cold}`` map and pair each
-    ``padded`` with itself as the steady size. Currently yields
-    ``{8: (5, 8), 16: (13, 16)}`` -- the legacy
-    ``_CHUNK_TARGET = {5: 8, 13: 16, 8: 8, 16: 16}`` table.
+
+def _chunk_modes() -> dict[int, tuple[int, int]]:
+    """Return supported runner chunk modes from the encoder contract.
+
+    :data:`FlashVSREncoder._CHUNK_FRAME_TARGETS` maps each accepted raw frame
+    count to the padded frame count consumed by the projector. Runner modes are
+    keyed by the steady-state size and store the corresponding cold-start size:
+    ``{steady_size: (cold_size, steady_size)}``.
+
+    Returns:
+        Mapping such as ``{8: (5, 8), 16: (13, 16)}``.
     """
     targets = FlashVSREncoder._CHUNK_FRAME_TARGETS
     cold_for: dict[int, int] = {}
@@ -85,11 +78,21 @@ _CHUNK_MODES: dict[int, tuple[int, int]] = _chunk_modes()
 def _build_chunks(
     total_frames: int, first_size: int, subseq_size: int
 ) -> list[tuple[int, int]]:
-    """Return list of (start, size) pairs for each AR step.
+    """Build contiguous ``(start, size)`` chunks for one rollout.
 
-    The first chunk is ``first_size`` frames (cold-start; pad-left
-    replicated by the encoder); subsequent chunks are ``subseq_size`` each.
-    A trailing partial chunk is dropped with a warning.
+    The first chunk uses the cold-start size, which the encoder pad-left
+    replicates to the matching steady-state length. Subsequent chunks use the
+    steady-state size. Any trailing partial chunk is dropped because the
+    encoder accepts only the fixed FlashVSR chunk sizes.
+
+    Args:
+        total_frames: Number of frames available in the input video.
+        first_size: Raw frame count for the cold-start chunk.
+        subseq_size: Raw frame count for each steady-state chunk.
+
+    Returns:
+        Start offsets and raw frame counts to pass to
+        :meth:`FlashVSRPipeline.generate`.
     """
     chunks: list[tuple[int, int]] = []
     pos = 0
@@ -112,19 +115,25 @@ def _build_chunks(
 def _resolve_target_and_topk_ratio(
     *, input_H: int, input_W: int, scale: int, sparse_ratio: float
 ) -> tuple[int, int, float]:
-    """Post-crop target dims + matching ``topk_ratio`` for one input.
+    """Resolve cropped target dimensions and FlashVSR ``topk_ratio``.
 
-    Mirrors the encoder's bicubic-then-128-multiple-crop rule (see
-    :class:`flashvsr.encoder.FlashVSREncoder`) plus upstream's per-input
-    ``topk_ratio = sparse_ratio * 768*1280 / (th*tw)`` formula (every
-    upstream inference script under ``examples/WanVSR/`` uses this
-    exact constant; see e.g. ``infer_flashvsr_v1.1_tiny.py:222``). Kept
-    as a free function so the test suite can exercise the math without
-    spinning up an actual rollout.
+    The encoder bicubic-upsamples to ``(input_H * scale, input_W * scale)``
+    and center-crops each axis down to the largest 128-multiple. The sparse
+    attention budget follows upstream FlashVSR:
+    ``topk_ratio = sparse_ratio * 768 * 1280 / (target_H * target_W)``.
 
-    Returns ``(target_H, target_W, topk_ratio)``. Raises
-    :class:`AssertionError` if either axis is too small to fit one
-    128-multiple post-scale.
+    Args:
+        input_H: Low-resolution input height after any runner-side crop.
+        input_W: Low-resolution input width after any runner-side crop.
+        scale: Pixel upsample factor.
+        sparse_ratio: User-facing sparse-attention budget multiplier.
+
+    Returns:
+        ``(target_H, target_W, topk_ratio)`` for the per-video pipeline config.
+
+    Raises:
+        AssertionError: Either scaled axis is too small to fit one
+            128-multiple target.
     """
     target_H = ((input_H * scale) // 128) * 128
     target_W = ((input_W * scale) // 128) * 128
@@ -138,7 +147,14 @@ def _resolve_target_and_topk_ratio(
 
 
 def _probe_input_fps(path: Path) -> float:
-    """Best-effort fps probe; falls back to 30.0 on failure."""
+    """Probe the input video's frame rate.
+
+    Args:
+        path: Video path readable by ``mediapy``.
+
+    Returns:
+        Probed frame rate, or ``30.0`` if metadata probing fails.
+    """
     try:
         # ``mediapy`` ships without type stubs so ty cannot see the
         # ``VideoMetadata.from_path`` classmethod (added in mediapy 1.1).
@@ -149,6 +165,9 @@ def _probe_input_fps(path: Path) -> float:
         return 30.0
 
 
+## Runner config
+
+
 @dataclass(kw_only=True)
 class FlashVSRRunnerConfig(RunnerConfig):
     """Runner config for the FlashVSR streaming video super-resolution pipeline."""
@@ -156,58 +175,75 @@ class FlashVSRRunnerConfig(RunnerConfig):
     _target: type = field(default_factory=lambda: FlashVSRRunner)
 
     input_path: Path = Path()
-    """Path to a low-resolution input video readable by ``mediapy``
-    (``.mp4`` and friends). Required; pass via ``--input-path <path>``.
-    The pipeline encoder's ``input_H`` / ``input_W`` are auto-set to
-    the video's native dimensions; non-128-aligned upres dims are
-    handled by the encoder via a symmetric crop (see
-    :class:`flashvsr.encoder.FlashVSREncoderConfig`)."""
+    """Low-resolution input video path. Must be readable by ``mediapy``."""
 
     chunk_size: Literal[8, 16] = 16
-    """Steady-state frames per AR step (cold-start uses ``chunk_size - 3``).
-    ``16`` (default) packs two DiT iters per ``pipeline.generate()`` call
-    (first=13, subseq=16). ``8`` runs one DiT iter per call (first=5,
-    subseq=8) and roughly halves per-chunk peak VRAM at the cost of
-    more boundary stitching overhead."""
+    """Steady-state frames per AR step; ``8`` uses one DiT iteration and
+    ``16`` uses two. The matching cold-start size is derived from the encoder
+    chunk table."""
 
     output_fps: float | None = None
-    """Output frame rate. ``None`` (default) falls back to the input
-    video's probed fps (30.0 if probing fails)."""
+    """Output frame rate; ``None`` uses the input fps, falling back to ``30.0``."""
 
     crop_region: Literal["none", "bottom_half", "top_half"] = "none"
-    """Crop input frames before upsampling. Use ``bottom_half`` to drop
-    the HDMap visualization stacked on top of Alpadreams outputs and
-    upscale only the generated RGB."""
+    """Input crop before upsampling. ``bottom_half`` keeps Alpadreams RGB
+    frames below the HDMap visualization."""
 
     sparse_ratio: float = 2.0
-    """Block-sparse attention budget multiplier used to re-derive
-    ``transformer.topk_ratio`` from the per-video post-crop target dims
-    inside :meth:`FlashVSRRunner.run` (mirrors upstream's
-    ``topk_ratio = sparse_ratio * 768*1280 / (th*tw)`` at every call
-    site in ``examples/WanVSR/infer_flashvsr_v1.1_tiny.py`` and
-    siblings). The shipped runners (``flashvsr-v1.1-sparse-ratio-1.5``,
-    ``flashvsr-v1.1-sparse-ratio-2.0``) set this to match their slug;
-    callers building a runner config by hand should set it to the
-    ``sparse_ratio`` they passed into :func:`build_flashvsr_v1_1`."""
+    """Sparse-attention budget multiplier used to re-derive
+    ``transformer.topk_ratio`` from each video's post-crop target area."""
+
+
+def _ensure_mgpu_config_supported(
+    config: FlashVSRRunnerConfig, world_size: int
+) -> None:
+    """Reject FlashVSR configs that cannot run with multiple GPUs.
+
+    Args:
+        config: Runner config about to be used.
+        world_size: Distributed world size; ``1`` means single-GPU or CPU.
+
+    Raises:
+        ValueError: ``world_size > 1`` with sparse ``block_sparse_attn``.
+    """
+    if world_size <= 1:
+        return
+
+    pipeline_cfg = config.pipeline
+    assert isinstance(pipeline_cfg, FlashVSRPipelineConfig)
+    transformer_cfg = pipeline_cfg.diffusion_model.transformer
+    assert isinstance(transformer_cfg, FlashVSRTransformerConfig)
+    if transformer_cfg.attention_mode == "full":
+        return
+
+    raise ValueError(
+        "FlashVSR multi-GPU execution is supported only by the "
+        "flashvsr-v1.1-full-attn preset (attention_mode='full'). Sparse "
+        "FlashVSR presets use block_sparse_attn, which is not "
+        "context-parallel aware and does not support multi-GPU execution. "
+        f"Got runner_name={config.runner_name!r}, "
+        f"attention_mode={transformer_cfg.attention_mode!r}."
+    )
+
+
+## Runner
 
 
 class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
     """FlashVSR streaming video super-resolution driver.
 
-    Overrides :meth:`Runner.__init__` to skip the parent's eager
-    ``config.pipeline.setup()`` call: the encoder's ``input_H`` /
-    ``input_W`` must track the input video's native pixel dims, so the
-    pipeline can only be built inside :meth:`run` once the video has
-    been read.
+    Unlike the base :class:`Runner`, this driver builds its pipeline in
+    :meth:`run` after reading the input video. The shipped pipeline literals are
+    scaffolds for every non-resolution knob; the runner fills in
+    ``encoder.input_H``, ``encoder.input_W``, and ``transformer.topk_ratio`` for
+    each video before calling ``setup()``.
     """
 
     config: FlashVSRRunnerConfig
 
     def __init__(self, config: FlashVSRRunnerConfig) -> None:
-        # Mirrors :meth:`flashdreams.infra.runner.Runner.__init__` minus
-        # the final ``self.pipeline = config.pipeline.setup()`` step.
-        # The pipeline is built in :meth:`run` once the input video's
-        # native ``(H, W)`` is known.
+        # Mirror ``Runner.__init__`` until pipeline construction; this runner
+        # needs video dimensions before ``config.pipeline.setup()`` is valid.
         if _is_torchrun_env() and not torch.distributed.is_initialized():
             init_distributed()
 
@@ -237,17 +273,22 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
                 ),
             )
         self.config = effective_config
+        _ensure_mgpu_config_supported(self.config, self.world_size)
         # ``self.pipeline`` intentionally unset until :meth:`run` reads
         # the input video and derives the per-video pipeline config.
 
     def _load_input_video(self) -> tuple[torch.Tensor, int, int, float]:
-        """Read the input video at native dims (no resize).
+        """Read the input video at native dimensions.
 
-        Returns ``(video_t, H, W, fps)`` where ``video_t`` is
-        ``[1, C, T, H, W]`` in ``[-1, 1]`` on CPU/float32, and ``(H, W)``
-        is the (post-crop) native pixel size. Conversion to the pipeline
-        device + dtype happens in :meth:`run` after the pipeline has
-        been built (we don't have ``self.pipeline.device`` yet here).
+        Cropping is applied before tensor conversion so the returned ``H`` and
+        ``W`` match the dimensions used to derive the per-video pipeline config.
+        Device and dtype placement are deferred until :meth:`run`, after the
+        pipeline has been constructed.
+
+        Returns:
+            ``(video_t, H, W, fps)`` where ``video_t`` is
+            ``[1, C, T, H, W]`` in ``[-1, 1]`` on CPU/float32, and ``H`` /
+            ``W`` are post-crop low-resolution pixel dimensions.
         """
         config = self.config
         path = config.input_path
@@ -281,43 +322,38 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
         return video_t, H, W, fps
 
     def _initialize_cache(self) -> FlashVSRPipelineCache:
-        """Build a fresh per-rollout cache.
+        """Build a fresh FlashVSR pipeline cache.
 
-        FlashVSR loads its frozen UMT5 prompt embedding from
-        ``config.pipeline.prompt_path`` at construction time, so the cache
-        seed is empty here."""
+        The configured prompt tensor is loaded during pipeline construction, so
+        the runner does not pass an explicit ``prompt_tensor`` here.
+
+        Returns:
+            Fresh cache for one video rollout.
+        """
         return self.pipeline.initialize_cache()
 
     def run(self) -> None:
         """Drive the FlashVSR rollout end-to-end.
 
-        Read the input video, build the pipeline at the video's native
-        ``(H, W)``, then loop the ``generate`` / ``finalize`` pair over
-        the per-AR-step chunks.
+        Reads the input video, builds the pipeline at the post-crop native
+        ``(H, W)``, loops over chunked ``generate`` / ``finalize`` calls, and
+        writes the assembled RGB video on rank zero.
         """
         config = self.config
-        # Narrow from the inherited ``RunnerConfig.pipeline:
-        # StreamInferencePipelineConfig`` to the FlashVSR-specific subclass
-        # so subsequent ``encoder.scale`` / ``transformer.topk_ratio``
-        # lookups type-check, and so ``derive_config`` (generic in the
-        # base type) returns ``FlashVSRPipelineConfig`` directly without
-        # a cast.
+        # Narrow the inherited pipeline field once so the FlashVSR-specific
+        # encoder scale and transformer top-k fields are visible below.
         pipeline_cfg = config.pipeline
         assert isinstance(pipeline_cfg, FlashVSRPipelineConfig)
+        transformer_cfg = pipeline_cfg.diffusion_model.transformer
+        assert isinstance(transformer_cfg, FlashVSRTransformerConfig)
 
         first_size, subseq_size = _CHUNK_MODES[config.chunk_size]
         video_t_cpu, H, W, fps = self._load_input_video()
         total_frames = video_t_cpu.shape[2]
 
-        # Build the pipeline at the input video's native (H, W). The
-        # encoder's bicubic-then-128-multiple-crop handles non-aligned
-        # dims internally (see :class:`flashvsr.encoder.FlashVSREncoder`);
-        # we mirror upstream's per-input ``topk_ratio = sparse_ratio *
-        # 768*1280 / (th*tw)`` (with ``(th, tw)`` the **post-crop**
-        # target) by overriding ``transformer.topk_ratio`` here, since
-        # the placeholder value baked at builder time used the recipe's
-        # scaffold ``input_H=704, input_W=1280`` and is stale for every
-        # other input.
+        # Build the pipeline for this video's post-crop dimensions. The encoder
+        # handles 128-multiple target cropping; top-k must be recomputed from
+        # that cropped target area to match upstream FlashVSR.
         target_H, target_W, topk_ratio = _resolve_target_and_topk_ratio(
             input_H=H,
             input_W=W,
@@ -325,10 +361,14 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
             sparse_ratio=config.sparse_ratio,
         )
         if self.is_rank_zero:
+            mode_note = (
+                f"topk_ratio={topk_ratio:.6f}"
+                if transformer_cfg.attention_mode == "sparse"
+                else "full attention (topk ignored)"
+            )
             logger.info(
                 f"Building FlashVSR pipeline at input_H={H}, input_W={W} "
-                f"(post-crop target {target_H}x{target_W}, "
-                f"topk_ratio={topk_ratio:.6f}) ..."
+                f"(post-crop target {target_H}x{target_W}, {mode_note}) ..."
             )
         pipeline_config = derive_config(
             pipeline_cfg,
@@ -367,16 +407,8 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
             )
             stats = self.pipeline.finalize(autoregressive_index=chunk_idx, cache=cache)
             if stats is not None:
-                # Per-chunk throughput. ``video_chunk.shape[2]`` is the
-                # post-trim output frame count (cold-start drops
-                # ``frames_to_trim`` frames so the cold + steady chunks
-                # both report their visible frame counts here);
-                # ``total_ms`` is the sum of pipeline.finalize's stage
-                # events, so this is the per-chunk realised FPS.
-                #
-                # Named ``chunk_fps`` (not ``fps``) so we don't shadow
-                # the outer ``fps`` that ``media.write_video`` consumes
-                # below.
+                # Report throughput against the visible output frames for this
+                # chunk. ``fps`` is reserved for the output video's frame rate.
                 chunk_frames = int(video_chunk.shape[2])
                 chunk_total_ms = stats["total_ms"]
                 chunk_fps = (

--- a/integrations/flashvsr/flashvsr/transformer/__init__.py
+++ b/integrations/flashvsr/flashvsr/transformer/__init__.py
@@ -33,11 +33,12 @@ used here).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import torch
 from torch import Tensor
 
+from flashdreams.core.distributed.context_parallel import split_inputs_cp
 from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.recipes.wan.transformer.impl.network import WanDiTNetworkConfig
 from flashdreams.recipes.wan.transformer.wan21 import (
@@ -70,6 +71,8 @@ class FlashVSRTransformerConfig(Wan21TransformerConfig):
       self-attention KV cache (the just-written chunk is also visible at
       attention time, so the buffer holds ``kv_ratio + 1`` chunks).
     - ``local_range``: spatial window radius for the local-block mask.
+    - ``attention_mode``: ``"sparse"`` preserves the legacy block-sparse path;
+      ``"full"`` uses the dense CP-aware Wan self-attention path.
 
     ``__post_init__`` enforces the parent's invariants and additionally:
 
@@ -102,6 +105,9 @@ class FlashVSRTransformerConfig(Wan21TransformerConfig):
 
     local_range: int = 11
     """Local-block window radius (in window units) for the draft mask."""
+
+    attention_mode: Literal["sparse", "full"] = "sparse"
+    """Self-attention implementation. Multi-GPU is supported only with ``"full"``."""
 
     use_cuda_graph: bool = False
     """Capture the **steady-state** DiT call into a CUDA graph and replay it.
@@ -136,6 +142,13 @@ class FlashVSRTransformerConfig(Wan21TransformerConfig):
             "FlashVSR does not support classifier-free guidance; "
             f"set guidance_scale=1.0 (got {self.guidance_scale})."
         )
+        if self.attention_mode not in ("sparse", "full"):
+            raise ValueError(
+                f"Unsupported attention_mode={self.attention_mode!r}; "
+                "expected 'sparse' or 'full'."
+            )
+        if isinstance(self.network, FlashVSRDiTNetworkConfig):
+            self.network.attention_mode = self.attention_mode
         # FlashVSR's KV cache holds ``kv_ratio + 1`` chunks at attention time
         # (the cached prior chunks plus the just-written one). Map this onto
         # the parent's pre-patchify frame-window knob so the inherited
@@ -151,6 +164,16 @@ class FlashVSRTransformer(Wan21Transformer):
     network: FlashVSRDiTNetwork
 
     def __init__(self, config: FlashVSRTransformerConfig) -> None:
+        if (
+            config.attention_mode == "sparse"
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_world_size() > 1
+        ):
+            raise ValueError(
+                "FlashVSR attention_mode='sparse' is single-GPU only because "
+                "block_sparse_attn is not context-parallel aware. Use "
+                "attention_mode='full' for multi-GPU context parallelism."
+            )
         super().__init__(config)
 
         # CUDA-graph wrapper for the steady-state DiT call. Lazy-initialised
@@ -167,20 +190,19 @@ class FlashVSRTransformer(Wan21Transformer):
         """No-op: FlashVSR keys its KV cache from the **noisy** forward."""
 
     def patchify_and_maybe_split_cp(self, x):  # type: ignore[override]
-        """Pass through ``list`` payloads; defer tensors to the standard path.
+        """CP-split LR-latent lists; defer tensors to the standard path.
 
         ``FlashVSREncoder.forward`` returns the per-block low-resolution
         latent slices as a ``list[Tensor]`` already in ``[B, L, D]``
         post-patchify space (the projector emits them that way). The
         infra ``DiffusionModel.generate`` calls
-        ``transformer.patchify_and_maybe_split_cp(input)`` unconditionally
-        on the encoder output; we pass the list straight through so the
-        per-block contract survives, while plain tensor inputs (e.g. an
-        unpatchified noisy latent in tests) still take the parent's
-        rearrange + linear path.
+        ``transformer.patchify_and_maybe_split_cp(input)`` unconditionally on
+        the encoder output; lists therefore only need token-axis CP splitting.
+        Plain tensor inputs (e.g. an unpatchified noisy latent in tests) still
+        take the parent's rearrange + linear path.
         """
         if isinstance(x, list):
-            return x
+            return [split_inputs_cp(t, seq_dim=-2, cp_group=self._cp_group) for t in x]
         return super().patchify_and_maybe_split_cp(x)
 
     def _is_steady_state(self, ar_idx: int) -> bool:

--- a/integrations/flashvsr/flashvsr/transformer/network.py
+++ b/integrations/flashvsr/flashvsr/transformer/network.py
@@ -55,24 +55,13 @@ checkpoint at ``flashvsr_tiny_long/dit_state_dict.pt`` loads drop-in.
 
 from __future__ import annotations
 
+import importlib
 import math
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
-
-# We deliberately import the underlying ``BlockSparseAttnFunc`` autograd
-# function instead of the public ``block_sparse_attn_func`` wrapper. The
-# wrapper unconditionally calls ``replace_ones_with_count(head_mask_type)``
-# which uses ``Tensor.masked_scatter`` -- a pybind C++ method dynamo cannot
-# trace -- forcing a graph break and a recompile cascade on every
-# fill-state shape transition (eventually hitting ``recompile_limit (8)``).
-# We pre-compute the renumbered head-mask in ``initialize_cache`` and call
-# the autograd function directly with all the static knobs spelled out.
-# Tracks ``block_sparse_attn==0.0.2``; bump the pin in ``uv.lock`` if the
-# ``BlockSparseAttnFunc.apply`` signature changes.
-from block_sparse_attn.block_sparse_attn_interface import BlockSparseAttnFunc
 from einops import rearrange
 from torch import Tensor
 
@@ -81,7 +70,9 @@ from flashdreams.core.attention.rope import apply_rope_freqs
 from flashdreams.recipes.wan.transformer.impl.modules import (
     Block,
     BlockCache,
+    CrossAttention,
     MultiHeadAttention,
+    SelfAttention,
     sinusoidal_embedding_1d,
 )
 from flashdreams.recipes.wan.transformer.impl.network import (
@@ -100,6 +91,32 @@ __all__ = [
     "_SELF_ATTN_WINDOW",
     "_SELF_ATTN_WINDOW_TOKENS",
 ]
+
+AttentionMode = Literal["sparse", "full"]
+
+
+def _get_block_sparse_attn_func():
+    """Import the sparse CUDA op only when the sparse path actually runs."""
+    try:
+        # We deliberately import the underlying ``BlockSparseAttnFunc`` autograd
+        # function instead of the public ``block_sparse_attn_func`` wrapper. The
+        # wrapper unconditionally calls ``replace_ones_with_count(head_mask_type)``
+        # which uses ``Tensor.masked_scatter`` -- a pybind C++ method dynamo cannot
+        # trace -- forcing a graph break and a recompile cascade on every
+        # fill-state shape transition (eventually hitting ``recompile_limit (8)``).
+        # We pre-compute the renumbered head-mask in ``initialize_cache`` and call
+        # the autograd function directly with all the static knobs spelled out.
+        # Tracks ``block_sparse_attn==0.0.2``; bump the pin in ``uv.lock`` if the
+        # ``BlockSparseAttnFunc.apply`` signature changes.
+        module = importlib.import_module(
+            "block_sparse_attn.block_sparse_attn_interface"
+        )
+        return module.BlockSparseAttnFunc
+    except ImportError as exc:
+        raise RuntimeError(
+            "FlashVSR attention_mode='sparse' requires the block_sparse_attn "
+            "CUDA extension. Use attention_mode='full' to run the dense path."
+        ) from exc
 
 
 ## FlashVSR sparse-attention helpers
@@ -532,7 +549,7 @@ class SparseSelfAttention(MultiHeadAttention):
         # recompile-cache thrash) from the per-layer hot path. All knobs
         # below are static for FlashVSR; spelled out here so a future
         # upstream signature shift fails loudly rather than silently.
-        out = BlockSparseAttnFunc.apply(
+        out = _get_block_sparse_attn_func().apply(
             q_in,
             k_in,
             v_in,
@@ -565,6 +582,9 @@ class SparseSelfAttention(MultiHeadAttention):
 class FlashVSRBlock(Block):
     """Wan 2.1 transformer block + FlashVSR sparse self-attention + LR-latent injection."""
 
+    self_attn: SelfAttention | SparseSelfAttention
+    cross_attn: CrossAttention
+
     def __init__(
         self,
         dim: int,
@@ -573,6 +593,7 @@ class FlashVSRBlock(Block):
         cross_attn_norm: bool = True,
         eps: float = 1e-6,
         i2v: bool = False,
+        attention_mode: AttentionMode = "sparse",
     ) -> None:
         super().__init__(
             dim=dim,
@@ -582,15 +603,24 @@ class FlashVSRBlock(Block):
             eps=eps,
             i2v=i2v,
         )
-        # Replace the dense ``SelfAttention`` allocated by ``Block.__init__``
-        # with the FlashVSR sparse one. Parameter naming
-        # (``self_attn.{q,k,v,o,norm_q,norm_k}``) is preserved.
-        self.self_attn = SparseSelfAttention(
-            query_dim=dim,
-            n_heads=num_heads,
-            head_dim=dim // num_heads,
-            eps=eps,
-        )
+        self.attention_mode: AttentionMode = attention_mode
+        if attention_mode == "sparse":
+            # Replace the dense ``SelfAttention`` allocated by ``Block.__init__``
+            # with the FlashVSR sparse one. Parameter naming
+            # (``self_attn.{q,k,v,o,norm_q,norm_k}``) is preserved.
+            self.self_attn = SparseSelfAttention(
+                query_dim=dim,
+                n_heads=num_heads,
+                head_dim=dim // num_heads,
+                eps=eps,
+            )
+        elif attention_mode == "full":
+            assert isinstance(self.self_attn, SelfAttention)
+        else:
+            raise ValueError(
+                f"Unsupported FlashVSR attention_mode={attention_mode!r}; "
+                "expected 'sparse' or 'full'."
+            )
 
     def forward(  # type: ignore[override]
         self,
@@ -629,16 +659,24 @@ class FlashVSRBlock(Block):
         e_chunks = (self.modulation + e).chunk(6, dim=-2)
 
         y = self.norm1(x) * (1 + e_chunks[1]) + e_chunks[0]
-        y = self.self_attn(
-            y,
-            kv_cache=cache.self_attn,
-            rope_freqs=rope_freqs,
-            f=f,
-            h=h,
-            w=w,
-            topk=topk,
-            local_range=local_range,
-        )
+        if self.attention_mode == "sparse":
+            assert isinstance(self.self_attn, SparseSelfAttention)
+            y = self.self_attn(
+                y,
+                kv_cache=cache.self_attn,
+                rope_freqs=rope_freqs,
+                f=f,
+                h=h,
+                w=w,
+                topk=topk,
+                local_range=local_range,
+            )
+        else:
+            y = self.self_attn(
+                y,
+                kv_cache=cache.self_attn,
+                rope_freqs=rope_freqs,
+            )
         x = x + (y * e_chunks[2])
 
         x = x + self.cross_attn(
@@ -678,6 +716,8 @@ class FlashVSRDiTNetworkConfig(WanDiTNetworkConfig):
     text_len: int = 512
     """Token length of the FlashVSR positive-prompt tensor."""
     patch_embedding_type: str = "conv3d"
+    attention_mode: AttentionMode = "sparse"
+    """Self-attention implementation: legacy block-sparse or dense full attention."""
 
 
 class FlashVSRDiTNetwork(WanDiTNetwork):
@@ -690,6 +730,12 @@ class FlashVSRDiTNetwork(WanDiTNetwork):
     through the block loop.
     """
 
+    attention_mode: AttentionMode
+
+    def __init__(self, config: FlashVSRDiTNetworkConfig) -> None:
+        object.__setattr__(self, "attention_mode", config.attention_mode)
+        super().__init__(config)
+
     def _build_block(self, layer_idx: int) -> Block:
         return FlashVSRBlock(
             dim=self.dim,
@@ -698,6 +744,7 @@ class FlashVSRDiTNetwork(WanDiTNetwork):
             cross_attn_norm=self.cross_attn_norm,
             eps=self.eps,
             i2v=self.cross_attn_enable_img,
+            attention_mode=self.attention_mode,
         )
 
     def forward(  # type: ignore[override]

--- a/integrations/flashvsr/pyproject.toml
+++ b/integrations/flashvsr/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
 [project.entry-points."flashdreams.runner_configs"]
 "flashvsr-v1.1-sparse-ratio-2.0" = "flashvsr.config:RUNNER_FLASHVSR_V1_1_SPARSE_2_0"
 "flashvsr-v1.1-sparse-ratio-1.5" = "flashvsr.config:RUNNER_FLASHVSR_V1_1_SPARSE_1_5"
+"flashvsr-v1.1-full-attn" = "flashvsr.config:RUNNER_FLASHVSR_V1_1_FULL_ATTN"
 
 [tool.setuptools.packages.find]
 include = ["flashvsr*"]

--- a/integrations/flashvsr/tests/test_flashvsr.py
+++ b/integrations/flashvsr/tests/test_flashvsr.py
@@ -30,6 +30,7 @@ import pytest
 import torch
 from flashvsr.config import (
     AVAILABLE_FLASHVSR_CHECKPOINT_PATHS,
+    RUNNER_FLASHVSR_V1_1_FULL_ATTN,
     RUNNER_FLASHVSR_V1_1_SPARSE_1_5,
     RUNNER_FLASHVSR_V1_1_SPARSE_2_0,
     build_flashvsr_v1_1,
@@ -38,9 +39,11 @@ from flashvsr.encoder import FlashVSREncoderConfig
 from flashvsr.pipeline import FlashVSRPipelineConfig
 from flashvsr.runner import (
     FlashVSRRunnerConfig,
+    _ensure_mgpu_config_supported,
     _resolve_target_and_topk_ratio,
 )
 from flashvsr.transformer import FlashVSRTransformerConfig
+from flashvsr.transformer.network import FlashVSRDiTNetworkConfig, SparseSelfAttention
 
 from flashdreams.infra.config import derive_config
 
@@ -70,6 +73,7 @@ def test_build_flashvsr_v1_1_wires_default_resolution() -> None:
     assert isinstance(transformer_config, FlashVSRTransformerConfig)
     assert transformer_config.len_t == 2
     assert transformer_config.kv_ratio == 3
+    assert transformer_config.attention_mode == "sparse"
     # Inherited Wan21 sizing: KV cache holds (kv_ratio + 1) * len_t pre-patchify frames.
     assert transformer_config.window_size_t == (3 + 1) * 2
 
@@ -78,6 +82,41 @@ def test_build_flashvsr_v1_1_wires_default_resolution() -> None:
     assert config.encoder.projector_checkpoint_path == _V1_1_PATHS["encoder"]
     assert config.decoder.tcdecoder_checkpoint_path == _V1_1_PATHS["decoder"]
     assert transformer_config.checkpoint_path == _V1_1_PATHS["dit"]
+
+
+def test_build_flashvsr_v1_1_wires_full_attention_mode() -> None:
+    """Full attention is an opt-in mode that also reaches the network config."""
+    config = build_flashvsr_v1_1(
+        input_H=384,
+        input_W=640,
+        attention_mode="full",
+        sparse_ratio=2.0,
+    )
+
+    transformer_config = config.diffusion_model.transformer
+    assert isinstance(transformer_config, FlashVSRTransformerConfig)
+    assert transformer_config.attention_mode == "full"
+    assert isinstance(transformer_config.network, FlashVSRDiTNetworkConfig)
+    assert transformer_config.network.attention_mode == "full"
+    # The legacy top-k knob is still populated so runner derivation remains
+    # stable, but the dense block ignores it at forward time.
+    assert transformer_config.topk_ratio == pytest.approx(2.0)
+
+    network = derive_config(
+        transformer_config.network,
+        dim=16,
+        ffn_dim=32,
+        num_heads=2,
+        num_layers=1,
+        in_dim=4,
+        out_dim=4,
+        text_dim=8,
+        freq_dim=8,
+        text_len=4,
+    ).setup()
+    block = network.blocks[0]
+    assert block.attention_mode == "full"
+    assert not isinstance(block.self_attn, SparseSelfAttention)
 
 
 def test_build_flashvsr_v1_1_crops_misaligned_resolution_to_128_multiple() -> None:
@@ -203,6 +242,24 @@ def test_shipped_runners_carry_their_sparse_ratio() -> None:
     assert RUNNER_FLASHVSR_V1_1_SPARSE_2_0.sparse_ratio == pytest.approx(2.0)
     assert isinstance(RUNNER_FLASHVSR_V1_1_SPARSE_1_5, FlashVSRRunnerConfig)
     assert RUNNER_FLASHVSR_V1_1_SPARSE_1_5.sparse_ratio == pytest.approx(1.5)
+    assert isinstance(RUNNER_FLASHVSR_V1_1_FULL_ATTN, FlashVSRRunnerConfig)
+    full_transformer = (
+        RUNNER_FLASHVSR_V1_1_FULL_ATTN.pipeline.diffusion_model.transformer
+    )
+    assert isinstance(full_transformer, FlashVSRTransformerConfig)
+    assert full_transformer.attention_mode == "full"
+
+
+def test_mgpu_guard_rejects_sparse_flashvsr_presets() -> None:
+    """Only the full-attention FlashVSR preset supports multi-GPU."""
+    for sparse_runner in (
+        RUNNER_FLASHVSR_V1_1_SPARSE_2_0,
+        RUNNER_FLASHVSR_V1_1_SPARSE_1_5,
+    ):
+        with pytest.raises(ValueError, match="block_sparse_attn"):
+            _ensure_mgpu_config_supported(sparse_runner, world_size=2)
+        _ensure_mgpu_config_supported(sparse_runner, world_size=1)
+    _ensure_mgpu_config_supported(RUNNER_FLASHVSR_V1_1_FULL_ATTN, world_size=2)
 
 
 @pytest.mark.parametrize(

--- a/integrations/flashvsr/tests/test_flashvsr_context_parallel.py
+++ b/integrations/flashvsr/tests/test_flashvsr_context_parallel.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context-parallel smoke test for FlashVSR's dense full-attention mode.
+
+Two-invocation protocol:
+
+.. code-block:: bash
+
+    uv run --extra dev pytest \
+        integrations/flashvsr/tests/test_flashvsr_context_parallel.py::test_flashvsr_full_attention_cp_equivalence -v
+    uv run --extra dev torchrun --nproc_per_node=2 -m pytest \
+        integrations/flashvsr/tests/test_flashvsr_context_parallel.py::test_flashvsr_full_attention_cp_equivalence -v
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import cast
+
+import pytest
+import torch
+import torch.distributed as dist
+from flashvsr.transformer import FlashVSRTransformer, FlashVSRTransformerConfig
+from flashvsr.transformer.network import FlashVSRBlock, FlashVSRDiTNetworkConfig
+
+from flashdreams.core.attention.native import NativeAttention
+from flashdreams.core.distributed.context_parallel import (
+    cat_outputs_cp,
+    split_inputs_cp,
+)
+
+pytestmark = pytest.mark.manual
+
+_CP_REFERENCE_PATH = Path(
+    os.environ.get(
+        "FLASHVSR_FULL_ATTN_CP_REF_PATH",
+        str(Path(tempfile.gettempdir()) / "flashdreams" / "flashvsr_full_cp.pt"),
+    )
+)
+
+
+def _force_math_sdpa(transformer: FlashVSRTransformer) -> None:
+    """Avoid cuDNN SDPA tiny-shape NaNs in this synthetic smoke test."""
+    for block in transformer.network.blocks:
+        block = cast(FlashVSRBlock, block)
+        qkv_format = block.self_attn.attn_op.qkv_format
+        block.self_attn.attn_op = NativeAttention(qkv_format=qkv_format, backend="math")
+        block.self_attn.set_context_parallel_group(transformer._cp_group)
+
+        qkv_format = block.cross_attn.attn_op.qkv_format
+        block.cross_attn.attn_op = NativeAttention(
+            qkv_format=qkv_format, backend="math"
+        )
+
+
+def _tiny_full_attention_transformer() -> FlashVSRTransformerConfig:
+    return FlashVSRTransformerConfig(
+        network=FlashVSRDiTNetworkConfig(
+            # Match the stable cuDNN SDPA test shape used by the template
+            # recipe. Smaller head_dims (16/8) can silently produce NaNs.
+            dim=128,
+            ffn_dim=256,
+            num_heads=2,
+            num_layers=1,
+            in_dim=4,
+            out_dim=4,
+            text_dim=32,
+            freq_dim=32,
+            text_len=4,
+            attention_mode="full",
+        ),
+        dtype=torch.float32,
+        checkpoint_path=None,
+        batch_shape=(1,),
+        len_t=2,
+        guidance_scale=1.0,
+        topk_ratio=2.0,
+        kv_ratio=1,
+        local_range=11,
+        attention_mode="full",
+        compile_network=False,
+        use_cuda_graph=False,
+    )
+
+
+@torch.no_grad()
+def _cp_one_predict_flow(device: torch.device, *, seed: int) -> torch.Tensor:
+    torch.manual_seed(seed)
+    transformer = _tiny_full_attention_transformer().setup().to(device).eval()
+    assert isinstance(transformer, FlashVSRTransformer)
+    _force_math_sdpa(transformer)
+
+    cfg = transformer.config
+    net_cfg = cfg.network
+    assert isinstance(net_cfg, FlashVSRDiTNetworkConfig)
+    kt, kh, kw = net_cfg.patch_size
+    height, width = 4, 4
+    pT, pH, pW = cfg.len_t // kt, height // kh, width // kw
+    L = pT * pH * pW
+    patch_volume = kt * kh * kw
+
+    gen = torch.Generator(device=device).manual_seed(seed + 17)
+    text_embeddings = torch.randn(
+        1,
+        net_cfg.text_len,
+        net_cfg.text_dim,
+        device=device,
+        generator=gen,
+        dtype=cfg.dtype,
+    )
+    noisy_global = torch.randn(
+        1,
+        L,
+        net_cfg.in_dim * patch_volume,
+        device=device,
+        generator=gen,
+        dtype=cfg.dtype,
+    )
+    lq_global = [
+        torch.randn(
+            1,
+            L,
+            net_cfg.dim,
+            device=device,
+            generator=gen,
+            dtype=cfg.dtype,
+        )
+        for _ in range(net_cfg.num_layers)
+    ]
+
+    cache = transformer.initialize_autoregressive_cache(
+        height=height,
+        width=width,
+        text_embeddings=text_embeddings,
+    )
+    noisy_local = split_inputs_cp(
+        noisy_global, seq_dim=1, cp_group=transformer._cp_group
+    )
+    lq_local = transformer.patchify_and_maybe_split_cp(lq_global)
+
+    cache.start(0)
+    flow_local = transformer.predict_flow(
+        noisy_latent=noisy_local,
+        timestep=torch.tensor(1000.0, device=device, dtype=cfg.dtype),
+        cache=cache,
+        input=lq_local,
+    )
+    cache.finalize(0)
+    return cat_outputs_cp(flow_local, seq_dim=1, cp_group=transformer._cp_group)
+
+
+def test_flashvsr_full_attention_cp_equivalence() -> None:
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    rank = int(os.environ.get("RANK", "0"))
+    local_rank = int(os.environ.get("LOCAL_RANK", str(rank)))
+
+    if not torch.cuda.is_available():
+        pytest.skip("FlashVSR full-attention CP equivalence requires CUDA.")
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    if world_size == 1:
+        # First invocation: run the dense full-attention path without CP and
+        # persist the global output. The torchrun branch below treats this as
+        # the reference tensor for equivalence.
+        flow_global = _cp_one_predict_flow(device, seed=0)
+        _CP_REFERENCE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({"flow_global": flow_global.detach().cpu()}, _CP_REFERENCE_PATH)
+        assert torch.isfinite(flow_global).all()
+
+    else:
+        # Second invocation: run under torchrun, gather the per-rank CP output,
+        # and compare rank 0 against the reference produced above. A missing
+        # reference is a usage error, not an environment skip.
+        if not _CP_REFERENCE_PATH.exists():
+            raise FileNotFoundError(
+                f"CP reference {_CP_REFERENCE_PATH} not found; run the single-GPU "
+                "branch first."
+            )
+
+        assert dist.is_nccl_available()
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="nccl",
+                init_method="env://",
+                world_size=world_size,
+                rank=rank,
+            )
+
+        try:
+            flow_global = _cp_one_predict_flow(device, seed=0)
+            if rank == 0:
+                reference = torch.load(_CP_REFERENCE_PATH, weights_only=True)[
+                    "flow_global"
+                ]
+                torch.testing.assert_close(
+                    flow_global.detach().cpu(),
+                    reference,
+                    rtol=2e-2,
+                    atol=2e-2,
+                )
+        finally:
+            if dist.is_initialized():
+                dist.barrier()
+                dist.destroy_process_group()


### PR DESCRIPTION
1 GPU, FlashVSR-v1.1, Sparse-Ratio = 2.0
```json
  {
    "autoregressive_index": 36,
    "pad_ms": 0.04073600098490715,
    "bicubic_ms": 1.3956799507141113,
    "projector_ms": 25.191776275634766,
    "dit_concat_ms": 546.0398559570312,
    "denoise_ms": 0.019711999222636223,
    "decoder_ms": 90.37391662597656,
    "color_ms": 0.9779199957847595,
    "finalize_ms": 0.11430399864912033,
    "total_ms": 664.1539008039981,
    "total_ms_wo_finalize": 664.039596805349,
    "mem_alloc_gib": 31.048234939575195,
    "mem_reserved_gib": 85.001953125,
    "mem_peak_gib": 58.74404287338257,
    "frames": 16,
    "fps": 24.09080181661365
  }
```

4 GPU, FlashVSR-v1.1, Full Attention
```json
  {
    "autoregressive_index": 36,
    "pad_ms": 0.03062400035560131,
    "bicubic_ms": 1.2078720331192017,
    "projector_ms": 23.34169578552246,
    "dit_concat_ms": 303.6495361328125,
    "denoise_ms": 0.01865600049495697,
    "decoder_ms": 91.0827865600586,
    "color_ms": 0.9594879746437073,
    "finalize_ms": 0.10361599922180176,
    "total_ms": 420.3942744862288,
    "total_ms_wo_finalize": 420.290658487007,
    "mem_alloc_gib": 16.45494508743286,
    "mem_reserved_gib": 83.18359375,
    "mem_peak_gib": 67.99736738204956,
    "frames": 16,
    "fps": 38.0595097769918
  }
```
