### PR TITLE
Remove stdout logging when skipping KV cache finalize

### DIFF
--- a/flashdreams/flashdreams/recipes/cosmos/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/cosmos/transformer/__init__.py
@@ -531,10 +531,9 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not self.config.skip_finalize_kv_cache:
-            super().finalize_kv_cache(*args, **kwargs)
-        else:
-            print("Skipping KV cache finalize")
+        if self.config.skip_finalize_kv_cache:
+            return
+        super().finalize_kv_cache(*args, **kwargs)
 
     def patchify_and_maybe_split_cp(self, x: Tensor) -> Tensor:
         """Patchify and CP-split a video-shaped tensor ``[..., T, C, H, W]``.

--- a/integrations/alpadreams/alpadreams/transformer/__init__.py
+++ b/integrations/alpadreams/alpadreams/transformer/__init__.py
@@ -644,7 +644,6 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not self.config.skip_finalize_kv_cache:
-            super().finalize_kv_cache(*args, **kwargs)
-        else:
-            print("Skipping KV cache finalize")
+        if self.config.skip_finalize_kv_cache:
+            return
+        super().finalize_kv_cache(*args, **kwargs)


### PR DESCRIPTION
Stop printing "Skipping KV cache finalize" when `skip_finalize_kv_cache=True`
Cosmos and Alpadreams transformers now return early with no stdout noise.