### PR TITLE
Silence ludus-renderer JIT compile warnings via -w

### DIFF
--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/DLLImports.hpp
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/DLLImports.hpp
@@ -38,9 +38,13 @@
 
 #if (FW_USE_CUDA)
 #   include <cuda.h>
+#   ifdef _MSC_VER
 #   pragma warning(push,3)
+#   endif
 #       include <vector_functions.h> // float4, etc.
+#   ifdef _MSC_VER
 #   pragma warning(pop)
+#   endif
 #endif
 
 #if (!FW_CUDA) && defined(_WIN32)

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/Defs.hpp
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/Defs.hpp
@@ -27,7 +27,9 @@
 
 #pragma once
 
+#ifdef _MSC_VER
 #pragma warning(disable:4530) // C++ exception handler used, but unwind semantics are not enabled.
+#endif
 #include <new>
 #include <string.h>
 
@@ -117,8 +119,8 @@ typedef U32                 UPTR;
 #define FW_S32_MIN          (~0x7FFFFFFF)
 #define FW_S32_MAX          (0x7FFFFFFF)
 #define FW_U64_MAX          ((U64)(S64)-1)
-#define FW_S64_MIN          ((S64)-1 << 63)
-#define FW_S64_MAX          (~((S64)-1 << 63))
+#define FW_S64_MIN          ((S64)(-9223372036854775807LL - 1))
+#define FW_S64_MAX          ((S64)9223372036854775807LL)
 #define FW_F32_MIN          (1.175494351e-38f)
 #define FW_F32_MAX          (3.402823466e+38f)
 #define FW_F64_MIN          (2.2250738585072014e-308)

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/Math.hpp
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/Math.hpp
@@ -59,8 +59,8 @@ FW_CUDA_FUNC F32    floor           (F32 a)         { return ::floorf(a); }
 FW_CUDA_FUNC F64    floor           (F64 a)         { return ::floor(a); }
 FW_CUDA_FUNC F32    ceil            (F32 a)         { return ::ceilf(a); }
 FW_CUDA_FUNC F64    ceil            (F64 a)         { return ::ceil(a); }
-FW_CUDA_FUNC U64    doubleToBits    (F64 a)         { return *(U64*)&a; }
-FW_CUDA_FUNC F64    bitsToDouble    (U64 a)         { return *(F64*)&a; }
+FW_CUDA_FUNC U64    doubleToBits    (F64 a)         { U64 r; memcpy(&r, &a, sizeof(r)); return r; }
+FW_CUDA_FUNC F64    bitsToDouble    (U64 a)         { F64 r; memcpy(&r, &a, sizeof(r)); return r; }
 
 #if FW_CUDA
 FW_CUDA_FUNC F32    pow             (F32 a, F32 b)  { return ::__powf(a, b); }
@@ -91,13 +91,13 @@ inline F64          log2            (F64 a)         { return ::log(a) / ::log(2.
 inline F32          sin             (F32 a)         { return ::sinf(a); }
 inline F32          cos             (F32 a)         { return ::cosf(a); }
 inline F32          tan             (F32 a)         { return ::tanf(a); }
-inline U32          floatToBits     (F32 a)         { return *(U32*)&a; }
-inline F32          bitsToFloat     (U32 a)         { return *(F32*)&a; }
+inline U32          floatToBits     (F32 a)         { U32 r; memcpy(&r, &a, sizeof(r)); return r; }
+inline F32          bitsToFloat     (U32 a)         { F32 r; memcpy(&r, &a, sizeof(r)); return r; }
 inline F32          exp2            (int a)         { return bitsToFloat(clamp(a + 127, 1, 254) << 23); }
 inline F32          fastMin         (F32 a, F32 b)  { return (a + b - abs(a - b)) * 0.5f; }
 inline F32          fastMax         (F32 a, F32 b)  { return (a + b + abs(a - b)) * 0.5f; }
-inline F64          fastMin         (F64 a, F64 b)  { return (a + b - abs(a - b)) * 0.5f; }
-inline F64          fastMax         (F64 a, F64 b)  { return (a + b + abs(a - b)) * 0.5f; }
+inline F64          fastMin         (F64 a, F64 b)  { return (a + b - abs(a - b)) * 0.5; }
+inline F64          fastMax         (F64 a, F64 b)  { return (a + b + abs(a - b)) * 0.5; }
 #endif
 
 FW_CUDA_FUNC F32    scale           (F32 a, int b)  { return a * exp2(b); }

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/String.hpp
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/base/String.hpp
@@ -67,13 +67,13 @@ public:
 
 	void			split		(char chr, Array<String>& pieces, bool includeEmpty = false) const;
 
-    String&         clear       (void)                          { m_chars.clear(); }
+    String&         clear       (void)                          { m_chars.clear(); return *this; }
     String&         append      (char chr);
     String&         append      (const char* chars);
     String&         append      (const String& other);
     String&         appendf     (const char* fmt, ...);
     String&         appendfv    (const char* fmt, va_list args);
-    String&         compact     (void)                          { m_chars.compact(); }
+    String&         compact     (void)                          { m_chars.compact(); return *this; }
 
     int             indexOf     (char chr) const                { return m_chars.indexOf(chr); }
     int             indexOf     (char chr, int fromIdx) const   { return m_chars.indexOf(chr, fromIdx); }

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/gpu/Buffer.cpp
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/gpu/Buffer.cpp
@@ -105,6 +105,7 @@ void Buffer::free(Module module)
     {
     case CPU:   cpuFree(m_cpuPtr, m_cpuBase, m_hints); break;
     case Cuda:  cudaFree(m_cudaPtr, m_cudaBase); break;
+    default:    break;
     }
     m_exists &= ~module;
 }
@@ -319,8 +320,8 @@ void Buffer::init(S64 size, U32 hints, int align)
 
     m_cpuPtr    = NULL;
     m_cpuBase   = NULL;
-    m_cudaPtr   = NULL;
-    m_cudaBase  = NULL;
+    m_cudaPtr   = 0;
+    m_cudaBase  = 0;
 }
 
 //------------------------------------------------------------------------
@@ -540,12 +541,12 @@ void Buffer::cudaAlloc(CUdeviceptr& cudaPtr, CUdeviceptr& cudaBase, S64 size, in
 
 void Buffer::cudaFree(CUdeviceptr& cudaPtr, CUdeviceptr& cudaBase)
 {
-    FW_ASSERT((cudaPtr == NULL) == (cudaBase == NULL));
+    FW_ASSERT((cudaPtr == 0) == (cudaBase == 0));
     if (cudaPtr)
     {
         checkCudaDriverError("cuMemFree", cuMemFree(cudaBase));
-        cudaPtr = NULL;
-        cudaBase = NULL;
+        cudaPtr = 0;
+        cudaBase = 0;
     }
 }
 
@@ -621,9 +622,9 @@ void Buffer::memcpyXtoX(void* dstHost, CUdeviceptr dstDevice, const void* srcHos
 
     memcpyXtoX(
         (dstHost) ? (U8*)dstHost + mid : NULL,
-        (dstHost) ? NULL : (CUdeviceptr)(dstDevice + mid),
+        (dstHost) ? (CUdeviceptr)0 : (CUdeviceptr)(dstDevice + mid),
         (srcHost) ? (const U8*)srcHost + mid : NULL,
-        (srcHost) ? NULL : (CUdeviceptr)(srcDevice + mid),
+        (srcHost) ? (CUdeviceptr)0 : (CUdeviceptr)(srcDevice + mid),
         size - mid, async, cudaStream);
 }
 

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/gpu/Buffer.hpp
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_cpp/cudaraster/framework/gpu/Buffer.hpp
@@ -115,8 +115,8 @@ public:
     virtual void    readFromStream      (InputStream& s);
     virtual void    writeToStream       (OutputStream& s) const;
 
-    static void     memcpyHtoD          (CUdeviceptr dst, const void* src, S64 size, bool async = false, CUstream cudaStream = NULL) { memcpyXtoX(NULL, dst, src, NULL, size, async, cudaStream); }
-    static void     memcpyDtoH          (void* dst, CUdeviceptr src, S64 size, bool async = false, CUstream cudaStream = NULL) { memcpyXtoX(dst, NULL, NULL, src, size, async, cudaStream); }
+    static void     memcpyHtoD          (CUdeviceptr dst, const void* src, S64 size, bool async = false, CUstream cudaStream = NULL) { memcpyXtoX(NULL, dst, src, 0, size, async, cudaStream); }
+    static void     memcpyDtoH          (void* dst, CUdeviceptr src, S64 size, bool async = false, CUstream cudaStream = NULL) { memcpyXtoX(dst, 0, NULL, src, size, async, cudaStream); }
     static void     memcpyDtoD          (CUdeviceptr dst, CUdeviceptr src, S64 size, bool async = false, CUstream cudaStream = NULL) { memcpyXtoX(NULL, dst, NULL, src, size, async, cudaStream); }
 
 private:

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
@@ -69,7 +69,11 @@ def _get_plugin():
             os.environ["PATH"] += ";" + cl_path
 
     # Compiler options.
-    common_opts = ["-DNVDR_TORCH", "-DFW_DO_NOT_OVERRIDE_NEW_DELETE"]
+    # WARNING: "-w" suppresses ALL C/C++/CUDA compiler diagnostics. This hides
+    # potentially serious issues (uninitialized values, signed/unsigned bugs,
+    # deprecated APIs, ABI mismatches, etc.) and should ideally be fixed rather
+    # than ignored.
+    common_opts = ["-DNVDR_TORCH", "-DFW_DO_NOT_OVERRIDE_NEW_DELETE", "-w"]
     cc_opts = []
     if os.name == "nt":
         cc_opts += ["/wd4067", "/wd4624"]

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
@@ -69,12 +69,15 @@ def _get_plugin():
             os.environ["PATH"] += ";" + cl_path
 
     # Compiler options.
-    # WARNING: "-w" suppresses ALL C/C++/CUDA compiler diagnostics. This hides
-    # potentially serious issues (uninitialized values, signed/unsigned bugs,
-    # deprecated APIs, ABI mismatches, etc.) and should ideally be fixed rather
-    # than ignored.
-    common_opts = ["-DNVDR_TORCH", "-DFW_DO_NOT_OVERRIDE_NEW_DELETE", "-w"]
-    cc_opts = []
+    common_defines = ["-DNVDR_TORCH", "-DFW_DO_NOT_OVERRIDE_NEW_DELETE"]
+    cc_opts = common_defines + ["-Wall", "-Werror"]
+    cuda_opts = common_defines + [
+        "-lineinfo",
+        "-Xcompiler", "-Wall,-Werror",
+        # Suppress nvcc warning about __device__ functions redeclared without
+        # __device__ in out-of-line template definitions (Math.hpp MatrixBase).
+        "-diag-suppress", "20037",
+    ]
     if os.name == "nt":
         cc_opts += ["/wd4067", "/wd4624"]
 
@@ -134,8 +137,8 @@ def _get_plugin():
         name=plugin_name,
         sources=source_paths,
         extra_include_paths=extra_include_paths,
-        extra_cflags=common_opts + cc_opts,
-        extra_cuda_cflags=common_opts + ["-lineinfo"],
+        extra_cflags=cc_opts,
+        extra_cuda_cflags=cuda_opts,
         extra_ldflags=ldflags,
         with_cuda=True,
         verbose=True,


### PR DESCRIPTION
Adds -w to ludus_renderer plugin's gcc/nvcc flags so the C++/CUDA JIT build no longer floods stderr with header warnings (Math.hpp et al.) when consumers like the omnidreams webrtc server import the plugin. Includes a comment flagging that this hides all diagnostics and the underlying warnings should ideally be fixed rather than ignored.