### PR TITLE
Add OmniDreams single-view native scaffold

### DIFF
--- a/integrations/alpadreams/alpadreams/native/__init__.py
+++ b/integrations/alpadreams/alpadreams/native/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native acceleration helpers for AlpaDreams integrations."""
+
+from .omnidreams_singleview import (
+    build_info,
+    load_extension,
+    prepare_cutlass_stage,
+    validate_thirdparty,
+)
+
+__all__ = [
+    "build_info",
+    "load_extension",
+    "prepare_cutlass_stage",
+    "validate_thirdparty",
+]

--- a/integrations/alpadreams/alpadreams/native/omnidreams_singleview.py
+++ b/integrations/alpadreams/alpadreams/native/omnidreams_singleview.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lazy native extension loading for OmniDreams single-view acceleration."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator
+
+_ROOT = Path(__file__).resolve().parents[2] / "omnidreams_singleview"
+_NATIVE_BUILD_PATH = _ROOT / "tools" / "native_build.py"
+_EXTENSION_SOURCE = _ROOT / "src" / "omnidreams_singleview_ext.cpp"
+_NATIVE_MAX_JOBS_ENV = "OMNIDREAMS_SINGLEVIEW_NATIVE_MAX_JOBS"
+_PYTORCH_MAX_JOBS_ENV = "MAX_JOBS"
+_DEFAULT_NATIVE_MAX_JOBS = "1"
+
+_native_build_module: ModuleType | None = None
+_extension: ModuleType | None = None
+_extension_load_error: Exception | None = None
+
+
+def _native_build() -> ModuleType:
+    global _native_build_module
+    if _native_build_module is not None:
+        return _native_build_module
+
+    spec = importlib.util.spec_from_file_location(
+        "alpadreams_omnidreams_singleview_native_build",
+        _NATIVE_BUILD_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot import native build helpers from {_NATIVE_BUILD_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    _native_build_module = module
+    return module
+
+
+def validate_thirdparty() -> dict[str, Any]:
+    """Validate native source submodules and return their pinned provenance."""
+
+    return {
+        name: info.as_dict()
+        for name, info in _native_build().validate_thirdparty().items()
+    }
+
+
+def prepare_cutlass_stage(
+    build_root: Path | str | None = None,
+    *,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Prepare and return metadata for the patched CUTLASS build stage."""
+
+    return _native_build().prepare_cutlass_stage(
+        build_root=build_root,
+        force=force,
+    ).as_dict()
+
+
+def build_info(
+    build_root: Path | str | None = None,
+    *,
+    prepare_cutlass: bool = False,
+) -> dict[str, Any]:
+    """Return native source provenance without compiling the extension."""
+
+    return _native_build().native_provenance(
+        build_root=build_root,
+        prepare_cutlass=prepare_cutlass,
+    )
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _extension_name(
+    stage_info: dict[str, Any],
+    thirdparty_info: dict[str, Any],
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(_file_sha256(_EXTENSION_SOURCE).encode("ascii"))
+    digest.update(json.dumps(stage_info["manifest"], sort_keys=True).encode("utf-8"))
+    digest.update(json.dumps(thirdparty_info, sort_keys=True).encode("utf-8"))
+    return f"alpadreams_omnidreams_singleview_native_{digest.hexdigest()[:12]}"
+
+
+def _validate_max_jobs(value: int | str) -> str:
+    text = str(value).strip()
+    try:
+        jobs = int(text)
+    except ValueError as exc:
+        raise ValueError(
+            f"Native max jobs must be a positive integer, got {value!r}"
+        ) from exc
+    if jobs < 1:
+        raise ValueError(f"Native max jobs must be a positive integer, got {value!r}")
+    return str(jobs)
+
+
+def _resolved_max_jobs(max_jobs: int | str | None) -> str | None:
+    if max_jobs is not None:
+        return _validate_max_jobs(max_jobs)
+    if os.environ.get(_PYTORCH_MAX_JOBS_ENV):
+        return None
+    return _validate_max_jobs(
+        os.environ.get(_NATIVE_MAX_JOBS_ENV, _DEFAULT_NATIVE_MAX_JOBS)
+    )
+
+
+@contextlib.contextmanager
+def _scoped_torch_max_jobs(max_jobs: int | str | None) -> Iterator[None]:
+    resolved = _resolved_max_jobs(max_jobs)
+    if resolved is None:
+        yield
+        return
+
+    previous = os.environ.get(_PYTORCH_MAX_JOBS_ENV)
+    os.environ[_PYTORCH_MAX_JOBS_ENV] = resolved
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(_PYTORCH_MAX_JOBS_ENV, None)
+        else:
+            os.environ[_PYTORCH_MAX_JOBS_ENV] = previous
+
+
+def load_extension(
+    build_root: Path | str | None = None,
+    *,
+    max_jobs: int | str | None = None,
+    verbose: bool = False,
+) -> ModuleType | None:
+    """Compile and load the diagnostic native extension on demand.
+
+    PyTorch's extension builder uses ``MAX_JOBS`` for Ninja fanout. If the caller
+    has not already set it, this loader defaults to one compile job to avoid
+    surprising memory spikes in local clean builds.
+
+    Returns ``None`` if the extension cannot be built on the current host. The
+    full exception is retained and exposed through ``extension_load_error()``.
+    """
+
+    global _extension, _extension_load_error
+    if _extension is not None:
+        return _extension
+    if _extension_load_error is not None:
+        return None
+
+    try:
+        from torch.utils.cpp_extension import load as load_torch_extension
+
+        stage_info = prepare_cutlass_stage(build_root=build_root)
+        thirdparty_info = validate_thirdparty()
+        extension_name = _extension_name(stage_info, thirdparty_info)
+        stage_path = Path(stage_info["path"])
+        cutlass_include = stage_path / "include"
+        extension_build_dir = stage_path.parent.parent / "torch_extensions" / extension_name
+        extension_build_dir.mkdir(parents=True, exist_ok=True)
+        manifest = stage_info["manifest"]
+
+        with _scoped_torch_max_jobs(max_jobs):
+            _extension = load_torch_extension(
+                name=extension_name,
+                sources=[str(_EXTENSION_SOURCE)],
+                build_directory=str(extension_build_dir),
+                extra_include_paths=[str(cutlass_include)],
+                extra_cflags=[
+                    "-O3",
+                    "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_SHA="
+                    f"\\\"{manifest['cutlass_sha']}\\\"",
+                    "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_PATCH_SHA="
+                    f"\\\"{manifest['patch_sha256']}\\\"",
+                    "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_OVERLAY_SHA="
+                    f"\\\"{manifest['overlay_include_sha256']}\\\"",
+                    "-DOMNIDREAMS_SINGLEVIEW_SOURCE_SHA="
+                    f"\\\"{_file_sha256(_EXTENSION_SOURCE)}\\\"",
+                    "-DOMNIDREAMS_SINGLEVIEW_SAGE_ATTENTION_SHA="
+                    f"\\\"{thirdparty_info['SageAttention']['head_sha']}\\\"",
+                    "-DOMNIDREAMS_SINGLEVIEW_SPARGE_ATTN_SHA="
+                    f"\\\"{thirdparty_info['SpargeAttn']['head_sha']}\\\"",
+                ],
+                with_cuda=False,
+                verbose=verbose,
+            )
+    except Exception as exc:  # pragma: no cover - environment-specific build path
+        _extension_load_error = exc
+        return None
+    return _extension
+
+
+def extension_load_error() -> Exception | None:
+    """Return the last native extension load error, if any."""
+
+    return _extension_load_error

--- a/integrations/alpadreams/omnidreams_singleview/patches/cutlass/include/cute/atom/detail/tma_descriptor_pool.hpp
+++ b/integrations/alpadreams/omnidreams_singleview/patches/cutlass/include/cute/atom/detail/tma_descriptor_pool.hpp
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/***************************************************************************************************
+ * Host-side TMA descriptor pool with content-based caching.
+ *
+ * Problem: on SM120 (Blackwell), nvcc 13.0/13.2 materializes `__grid_constant__`
+ * kernel parameters that embed a `TmaDescriptor` (128-byte, alignas(64)) into
+ * thread-local memory before the address resolves to a state space. The PTX
+ * instructions `prefetch.tensormap` and `cp.async.bulk.tensor` reject any
+ * address that resolves to `.shared` or `.local` state space, aborting the
+ * kernel with "Misaligned shared or local address". This is a compiler bug
+ * affecting CUTLASS 4.2.x on SM120 + CUDA 13.x.
+ *
+ * Workaround: keep the actual TMA descriptor bytes in `cudaMalloc`'d global
+ * memory (which is unambiguously `.global` state space), and store only a
+ * `TmaDescriptor const*` pointer inside `Copy_Traits<SM90_TMA_*>`. Kernel
+ * params then carry an 8-byte pointer (which can live in .local or registers
+ * without issue) and the PTX TMA instructions dereference through the pointer
+ * to the global descriptor.
+ *
+ * Cache: `make_tma_copy_atom` is called inside `Gemm::initialize()`, which may
+ * execute under CUDA Graph capture. cudaMemcpy/cudaMemcpyAsync from default
+ * stream during capture is illegal. To avoid this, the pool deduplicates by
+ * descriptor content (linear search through a small list — typically <100
+ * entries across a process lifetime). The first call for a unique descriptor
+ * (in warmup, outside capture) allocates + copies; subsequent calls (during
+ * capture for the same descriptor) hit the cache and do no CUDA work.
+ *
+ * Pool design:
+ *   - One process-wide pool with persistent (leaked-at-exit) cudaMalloc slots.
+ *   - Each slot is a 128-byte 64-aligned region.
+ *   - Backing storage: 4 MB blocks (32k slots each), grown on demand.
+ *   - Cache: linear list of (host_desc bytes, device ptr) for content dedup.
+ *
+ * This file is included from `cute/atom/copy_traits_sm90_tma.hpp` and friends.
+ * It only needs to be visible in host-side translation units; device code never
+ * touches the pool, only reads through pointers returned by `pin_tma_descriptor`.
+ **************************************************************************************************/
+
+#pragma once
+
+#include <cute/arch/copy_sm90_desc.hpp>
+
+#if !defined(__CUDACC_RTC__)
+#include <cuda_runtime.h>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <utility>
+#include <vector>
+#endif
+
+namespace cute {
+namespace detail {
+
+#if !defined(__CUDACC_RTC__)
+
+// Single TMA descriptor slot is exactly the size of CUtensorMap on this build.
+// Note: alignof(TmaDescriptor) is 8 (it's just `CUtensorMap = struct { uint64_t opaque[16]; }`
+// in CUDA 12+ driver headers), but the `prefetch.tensormap` / `cp.async.bulk.tensor`
+// PTX instructions require the descriptor *address* to be 64-byte aligned. Since
+// cudaMalloc returns at least 256-byte-aligned pointers and our slot stride is
+// 128 bytes (a multiple of 64), every slot ptr is naturally 64-aligned.
+static constexpr size_t kTmaDescriptorSlotBytes = sizeof(TmaDescriptor);
+static_assert(kTmaDescriptorSlotBytes == 128,
+              "Expected TmaDescriptor to be 128 bytes for SM90+ TMA");
+static_assert(kTmaDescriptorSlotBytes % 64 == 0,
+              "Slot stride must be a multiple of 64 for TMA descriptor alignment");
+
+// Default block size: 32k slots (~4 MB). Most workloads use <100 descriptors
+// across their lifetime, so this is comfortably oversized.
+static constexpr size_t kTmaDescriptorBlockSlots = 32 * 1024;
+// Hard cap on total pool size: 16 MB = 4 blocks.
+static constexpr size_t kTmaDescriptorMaxBlocks = 4;
+
+struct TmaDescriptorPool {
+  static TmaDescriptorPool& instance() {
+    static TmaDescriptorPool pool;
+    return pool;
+  }
+
+  // Look up or pin `host_desc` and return its device pointer.
+  // - Cache hit: returns the cached device pointer with NO CUDA calls
+  //   (safe to call under CUDA Graph capture).
+  // - Cache miss: allocates a fresh slot, cudaMemcpy's `host_desc` bytes into
+  //   it, stores the mapping, returns the new device pointer.
+  // Returns nullptr on cudaMalloc / cudaMemcpy failure.
+  TmaDescriptor const* pin(TmaDescriptor const& host_desc) {
+    std::lock_guard<std::mutex> guard(mutex_);
+
+    // Cache hit: linear search through the entries. With <100 unique
+    // descriptors typical for inference workloads, this is fast.
+    for (auto const& entry : entries_) {
+      if (std::memcmp(&entry.first, &host_desc, kTmaDescriptorSlotBytes) == 0) {
+        return entry.second;
+      }
+    }
+
+    // Cache miss: allocate + copy.
+    void* slot = acquire_slot_locked();
+    if (slot == nullptr) {
+      return nullptr;
+    }
+    // Synchronous cudaMemcpy: the pool guarantees the device-side bytes are
+    // ready before this returns. This MUST be called outside CUDA Graph
+    // capture; the cache above ensures repeated calls during capture are
+    // satisfied without touching the runtime.
+    cudaError_t e = cudaMemcpy(slot, &host_desc, kTmaDescriptorSlotBytes,
+                               cudaMemcpyHostToDevice);
+    if (e != cudaSuccess) {
+      std::fprintf(stderr,
+                   "[cute::TmaDescriptorPool] cudaMemcpy failed: %s\n",
+                   cudaGetErrorString(e));
+      return nullptr;
+    }
+    auto const* device_ptr = static_cast<TmaDescriptor const*>(slot);
+    entries_.emplace_back(host_desc, device_ptr);
+    return device_ptr;
+  }
+
+  // For tests/diagnostics: number of unique descriptors pinned.
+  size_t entry_count() const {
+    return entries_.size();
+  }
+
+ private:
+  TmaDescriptorPool() {
+    entries_.reserve(256);  // Typical workload upper bound.
+  }
+  ~TmaDescriptorPool() {
+    // Leak: process exit. Avoids ordering issues with cuda runtime teardown.
+  }
+
+  TmaDescriptorPool(TmaDescriptorPool const&) = delete;
+  TmaDescriptorPool& operator=(TmaDescriptorPool const&) = delete;
+
+  // Returns a 128-byte slot from the current block, expanding on demand.
+  // Must be called with `mutex_` held.
+  void* acquire_slot_locked() {
+    if (next_slot_index_ >= blocks_allocated_ * kTmaDescriptorBlockSlots) {
+      if (!expand_locked()) {
+        return nullptr;
+      }
+    }
+    size_t idx = next_slot_index_++;
+    size_t block = idx / kTmaDescriptorBlockSlots;
+    size_t slot_in_block = idx % kTmaDescriptorBlockSlots;
+    char* base = static_cast<char*>(blocks_[block]);
+    return base + slot_in_block * kTmaDescriptorSlotBytes;
+  }
+
+  bool expand_locked() {
+    if (blocks_allocated_ >= kTmaDescriptorMaxBlocks) {
+      std::fprintf(stderr,
+                   "[cute::TmaDescriptorPool] hit %zu-block cap (%zu slots); "
+                   "TMA descriptor allocation will fail.\n",
+                   kTmaDescriptorMaxBlocks,
+                   kTmaDescriptorMaxBlocks * kTmaDescriptorBlockSlots);
+      return false;
+    }
+    void* new_block = nullptr;
+    cudaError_t e = cudaMalloc(&new_block, kTmaDescriptorBlockSlots * kTmaDescriptorSlotBytes);
+    if (e != cudaSuccess || new_block == nullptr) {
+      std::fprintf(stderr,
+                   "[cute::TmaDescriptorPool] cudaMalloc(%zu MB) failed: %s\n",
+                   (kTmaDescriptorBlockSlots * kTmaDescriptorSlotBytes) >> 20,
+                   cudaGetErrorString(e));
+      return false;
+    }
+    blocks_[blocks_allocated_++] = new_block;
+    return true;
+  }
+
+  // Persistent storage. Each block is one cudaMalloc; never freed.
+  void* blocks_[kTmaDescriptorMaxBlocks] = {nullptr};
+  size_t blocks_allocated_ = 0;
+  size_t next_slot_index_ = 0;
+
+  // Cache for content-based dedup. Vector of (host_desc bytes, device ptr).
+  std::vector<std::pair<TmaDescriptor, TmaDescriptor const*>> entries_;
+
+  std::mutex mutex_;
+};
+
+// Convenience wrapper used from `make_tma_copy_atom`. Pins the host-built
+// `TmaDescriptor` into a pool slot and returns the device pointer. Returns
+// nullptr on failure (caller should assert).
+inline TmaDescriptor const* pin_tma_descriptor(TmaDescriptor const& host_desc) {
+  return TmaDescriptorPool::instance().pin(host_desc);
+}
+
+#endif  // !defined(__CUDACC_RTC__)
+
+}  // namespace detail
+}  // namespace cute

--- a/integrations/alpadreams/omnidreams_singleview/patches/cutlass/sm120-tma-pool.patch
+++ b/integrations/alpadreams/omnidreams_singleview/patches/cutlass/sm120-tma-pool.patch
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+diff --git a/include/cute/arch/copy_sm90_desc.hpp b/include/cute/arch/copy_sm90_desc.hpp
+index 63bfb563..786b361b 100644
+--- a/include/cute/arch/copy_sm90_desc.hpp
++++ b/include/cute/arch/copy_sm90_desc.hpp
+@@ -303,7 +303,7 @@ CUTE_HOST_DEVICE
+ void
+ prefetch_tma_descriptor(TmaDescriptor const* desc_ptr)
+ {
+-#if defined(CUTE_ARCH_TMA_SM90_ENABLED)
++#if defined(CUTE_ARCH_TMA_SM90_ENABLED) && (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 1200)
+   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(desc_ptr);
+   // Prefetch TMA Descriptor using generic addressing (i.e. no specific state space: const or param)
+   asm volatile (
+@@ -311,6 +311,16 @@ prefetch_tma_descriptor(TmaDescriptor const* desc_ptr)
+     :
+     : "l"(gmem_int_desc)
+     : "memory");
++#elif defined(CUTE_ARCH_TMA_SM90_ENABLED)
++  // OmniDreams patch: On SM120+ (Blackwell), nvcc 13.x can materialize a
++  // __grid_constant__ kernel-param TMA descriptor into local memory before the
++  // generic-address load resolves its state space. The `prefetch.tensormap`
++  // PTX instruction rejects .shared / .local state-space addresses and aborts
++  // the kernel with "misaligned shared or local address". The prefetch is
++  // purely a performance hint (warms the descriptor cache on first TMA use)
++  // and the kernel is functionally correct without it. Skip on SM120+ until a
++  // compiler/CUTLASS fix lands upstream.
++  (void)desc_ptr;
+ #else
+   CUTE_INVALID_CONTROL_PATH("Trying to use TMA Descriptor Prefetch without CUTE_ARCH_TMA_SM90_ENABLED.");
+ #endif
+diff --git a/include/cute/atom/copy_traits_sm90_tma.hpp b/include/cute/atom/copy_traits_sm90_tma.hpp
+index 3be30af7..47abafee 100644
+--- a/include/cute/atom/copy_traits_sm90_tma.hpp
++++ b/include/cute/atom/copy_traits_sm90_tma.hpp
+@@ -44,6 +44,10 @@
+
+ #include <cutlass/cuda_host_adapter.hpp>
+
++// OmniDreams patch: host-side TMA descriptor pool used to keep descriptors
++// in `.global` state space, working around the nvcc 13.x SM120 spill bug.
++#include <cute/atom/detail/tma_descriptor_pool.hpp>
++
+ namespace cute
+ {
+
+@@ -94,6 +98,14 @@ struct SM90_TMA_LOAD_OP : SM90_TMA_LOAD {};
+
+ // The non-executable SM90_TMA_LOAD with tma_desc and no tma_mbar
+ // Use .with(tma_mbar) to construct an executable version
++//
++// OmniDreams patch: `tma_desc_` is a `TmaDescriptor const*` pointing into
++// a `cudaMalloc`'d global-memory slot (managed by `cute::detail::TmaDescriptorPool`)
++// rather than an embedded by-value descriptor. This works around an nvcc 13.x
++// bug on SM120 where embedded TMA descriptors inside __grid_constant__ kernel
++// params get materialized into thread-local memory, causing
++// `prefetch.tensormap` / `cp.async.bulk.tensor` to abort with "Misaligned
++// shared or local address".
+ template <class NumBitsPerTMA, class AuxParams_>
+ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
+ {
+@@ -106,7 +118,8 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
+   using RefLayout = SrcLayout;
+
+   // SM90_TMA_LOAD arguments
+-  TmaDescriptor tma_desc_;
++  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory (was: TmaDescriptor by value).
++  TmaDescriptor const* tma_desc_;
+   using AuxParams = AuxParams_;
+   AuxParams aux_params_;
+
+@@ -114,7 +127,7 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
+   CUTE_HOST_DEVICE constexpr
+   TmaDescriptor const*
+   get_tma_descriptor() const {
+-    return &tma_desc_;
++    return tma_desc_;
+   }
+
+   // Construct an executable SM90_TMA_LOAD with tma_mbar
+@@ -125,7 +138,7 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
+     [[maybe_unused]] uint16_t const& multicast_mask = 0,
+     TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
+     // We accept multicast_mask here to keep the API for both atoms consistent
+-    return {&tma_desc_, &tma_mbar, static_cast<uint64_t>(cache_hint)};
++    return {tma_desc_, &tma_mbar, static_cast<uint64_t>(cache_hint)};
+   }
+
+   // Construct an executable SM90_TMA_LOAD with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
+@@ -157,11 +170,14 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
+               Tensor<TS,SLayout> const& src,
+               Tensor<TD,DLayout>      & dst) = delete;
+
+-  // Construct with updated TMA descriptor only (no barrier change)
++  // Construct with updated TMA descriptor only (no barrier change).
++  // OmniDreams patch: with pointer storage, we just store the new pointer directly
++  // (the caller is expected to keep the underlying descriptor alive in
++  // .global state space, e.g. via the pool).
+   CUTE_HOST_DEVICE constexpr
+   Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
+   with(TmaDescriptor const* new_tma_desc) const {
+-    return {*new_tma_desc, aux_params_};
++    return {new_tma_desc, aux_params_};
+   }
+ };
+
+@@ -252,6 +268,9 @@ struct SM90_TMA_LOAD_MULTICAST_OP : SM90_TMA_LOAD_MULTICAST {};
+
+ // The non-executable SM90_TMA_LOAD_MULTICAST with tma_desc and no tma_mbar
+ // Use .with(tma_mbar, multicast_mask) to construct an executable version
++//
++// OmniDreams patch: see comment on Copy_Traits<SM90_TMA_LOAD>. Same
++// pointer-storage workaround for the nvcc 13.x SM120 __grid_constant__ spill bug.
+ template <class NumBitsPerTMA, class AuxParams_>
+ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST, NumBitsPerTMA, AuxParams_>
+ {
+@@ -264,7 +283,8 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST, NumBitsPerTMA, AuxParams_>
+   using RefLayout = SrcLayout;
+
+   // SM90_TMA_LOAD_MULTICAST arguments
+-  TmaDescriptor tma_desc_;
++  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory.
++  TmaDescriptor const* tma_desc_;
+   using AuxParams = AuxParams_;
+   AuxParams aux_params_;
+
+@@ -272,7 +292,7 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST, NumBitsPerTMA, AuxParams_>
+   CUTE_HOST_DEVICE constexpr
+   TmaDescriptor const*
+   get_tma_descriptor() const {
+-    return &tma_desc_;
++    return tma_desc_;
+   }
+
+   // Construct an executable SM90_TMA_LOAD_MULTICAST with tma_mbar
+@@ -282,7 +302,7 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST, NumBitsPerTMA, AuxParams_>
+     uint64_t& tma_load_mbar,
+     uint16_t const& multicast_mask,
+     TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
+-    return {&tma_desc_, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint)};
++    return {tma_desc_, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint)};
+   }
+
+   // Construct an executable SM90_TMA_LOAD_MULTICAST_OP with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
+@@ -354,6 +374,9 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST_OP, NumBitsPerTMA>
+ struct SM90_TMA_STORE_PTR : SM90_TMA_STORE {};
+
+ // The executable SM90_TMA_STORE with tma_desc
++//
++// OmniDreams patch: see comment on Copy_Traits<SM90_TMA_LOAD>. Same
++// pointer-storage workaround for the nvcc 13.x SM120 __grid_constant__ spill bug.
+ template <class NumBitsPerTMA, class AuxParams_>
+ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
+ {
+@@ -366,7 +389,8 @@ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
+   using RefLayout = SrcLayout;
+
+   // SM90_TMA_STORE arguments
+-  TmaDescriptor tma_desc_;
++  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory.
++  TmaDescriptor const* tma_desc_;
+   using AuxParams = AuxParams_;
+   AuxParams aux_params_;
+
+@@ -374,7 +398,7 @@ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
+   CUTE_HOST_DEVICE constexpr
+   TmaDescriptor const*
+   get_tma_descriptor() const {
+-    return &tma_desc_;
++    return tma_desc_;
+   }
+
+   // Generate the TMA coord tensor
+@@ -403,7 +427,8 @@ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
+     static_assert(is_smem<TS>::value, "Expected smem src for SM90_TMA_STORE");
+     //static_assert(is_gmem<TD>::value, "Expected gmem dst for SM90_TMA_STORE");  // TMA spoofed src tensor
+
+-    void const* const desc_ptr = &(traits.tma_desc_);
++    // OmniDreams patch: tma_desc_ is already a pointer; no address-of needed.
++    void const* const desc_ptr = traits.tma_desc_;
+     void const* const src_ptr  = cute::raw_pointer_cast(src.data());
+     auto dst_coord = dst.data().coord_;
+ #if 0
+@@ -465,6 +490,9 @@ struct Copy_Traits<SM90_TMA_STORE_PTR, NumBitsPerTMA>
+ //////////////////////////////////////////////////////////////////////////////
+
+ // The executable SM90_TMA_REDUCE_ADD with tma_desc
++//
++// OmniDreams patch: see comment on Copy_Traits<SM90_TMA_LOAD>. Same
++// pointer-storage workaround for the nvcc 13.x SM120 __grid_constant__ spill bug.
+ template <class NumBitsPerTMA, class AuxParams_>
+ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
+ {
+@@ -479,7 +507,8 @@ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
+   using RefLayout = SrcLayout;
+
+   // SM90_TMA_REDUCE_ADD arguments
+-  TmaDescriptor tma_desc_;
++  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory.
++  TmaDescriptor const* tma_desc_;
+   using AuxParams = AuxParams_;
+   AuxParams aux_params_;
+
+@@ -487,7 +516,7 @@ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
+   CUTE_HOST_DEVICE constexpr
+   TmaDescriptor const*
+   get_tma_descriptor() const {
+-    return &tma_desc_;
++    return tma_desc_;
+   }
+
+   // Generate the TMA coord tensor
+@@ -513,7 +542,8 @@ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
+            int32_t(c0), int32_t(c1), int32_t(c2), int32_t(c3), int32_t(c4), src_ptr);
+ #endif
+
+-    SM90_TMA_REDUCE_ADD::copy(&tma_desc_,
++    // OmniDreams patch: tma_desc_ is already a pointer; no address-of needed.
++    SM90_TMA_REDUCE_ADD::copy(tma_desc_,
+                          src_ptr, get<Is>(dst_coord)...);
+   }
+
+@@ -1151,7 +1181,33 @@ make_tma_copy_atom(CopyOp,
+   using Traits = Copy_Traits<CopyOp, cute::C<num_bits_per_tma>, decltype(aux_params)>;
+   using Atom   = Copy_Atom<Traits, typename GEngine::value_type>;
+
+-  Traits tma_traits{tma_desc, aux_params};
++  // OmniDreams patch: pin the host-built TMA descriptor into a cudaMalloc'd
++  // global-memory slot so that subsequent kernel-side accesses (prefetch /
++  // cp.async.bulk.tensor) resolve to `.global` state space. Without this, on
++  // SM120 + nvcc 13.x, the embedded-by-value descriptor inside __grid_constant__
++  // params materializes to thread-local memory and the PTX instructions abort
++  // with "Misaligned shared or local address". The pool storage lasts for the
++  // process lifetime (intentional leak) and dedupes by content so subsequent
++  // calls during CUDA Graph capture are pure cache hits.
++#if !defined(__CUDACC_RTC__)
++  TmaDescriptor const* tma_desc_ptr = cute::detail::pin_tma_descriptor(tma_desc);
++  if (tma_desc_ptr == nullptr) {
++    // Pool exhausted or cudaMalloc failed; abort host-side construction. The
++    // caller (Gemm::initialize) will surface a generic CUTLASS failure and the
++    // dispatch will fall back to the cuBLASLt path.
++    std::fprintf(stderr,
++                 "[cute::make_tma_copy_atom] TmaDescriptorPool::pin returned null; "
++                 "TMA atom construction failed.\n");
++    std::abort();
++  }
++  Traits tma_traits{tma_desc_ptr, aux_params};
++#else
++  // NVRTC path: no pool available. Force a compile error if this path is
++  // instantiated under NVRTC since the SM90 TMA collectives we use are AOT.
++  static_assert(sizeof(TmaInternalType) == 0,
++                "OmniDreams patch: TMA descriptor pool unavailable under NVRTC. "
++                "Compile this kernel ahead-of-time instead.");
++#endif
+
+ #if 0
+   print("num_bits_per_tma :  "); print(num_bits_per_tma); print("\n");

--- a/integrations/alpadreams/omnidreams_singleview/src/omnidreams_singleview_ext.cpp
+++ b/integrations/alpadreams/omnidreams_singleview/src/omnidreams_singleview_ext.cpp
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <torch/extension.h>
+
+#ifndef OMNIDREAMS_SINGLEVIEW_CUTLASS_SHA
+#define OMNIDREAMS_SINGLEVIEW_CUTLASS_SHA "unknown"
+#endif
+
+#ifndef OMNIDREAMS_SINGLEVIEW_CUTLASS_PATCH_SHA
+#define OMNIDREAMS_SINGLEVIEW_CUTLASS_PATCH_SHA "unknown"
+#endif
+
+#ifndef OMNIDREAMS_SINGLEVIEW_CUTLASS_OVERLAY_SHA
+#define OMNIDREAMS_SINGLEVIEW_CUTLASS_OVERLAY_SHA "unknown"
+#endif
+
+#ifndef OMNIDREAMS_SINGLEVIEW_SOURCE_SHA
+#define OMNIDREAMS_SINGLEVIEW_SOURCE_SHA "unknown"
+#endif
+
+#ifndef OMNIDREAMS_SINGLEVIEW_SAGE_ATTENTION_SHA
+#define OMNIDREAMS_SINGLEVIEW_SAGE_ATTENTION_SHA "unknown"
+#endif
+
+#ifndef OMNIDREAMS_SINGLEVIEW_SPARGE_ATTN_SHA
+#define OMNIDREAMS_SINGLEVIEW_SPARGE_ATTN_SHA "unknown"
+#endif
+
+namespace {
+
+bool is_available() {
+  return true;
+}
+
+pybind11::dict build_info() {
+  pybind11::dict info;
+  info["cutlass_sha"] = OMNIDREAMS_SINGLEVIEW_CUTLASS_SHA;
+  info["cutlass_patch_sha256"] = OMNIDREAMS_SINGLEVIEW_CUTLASS_PATCH_SHA;
+  info["cutlass_overlay_sha256"] = OMNIDREAMS_SINGLEVIEW_CUTLASS_OVERLAY_SHA;
+  info["extension_source_sha256"] = OMNIDREAMS_SINGLEVIEW_SOURCE_SHA;
+  info["sage_attention_sha"] = OMNIDREAMS_SINGLEVIEW_SAGE_ATTENTION_SHA;
+  info["sparge_attn_sha"] = OMNIDREAMS_SINGLEVIEW_SPARGE_ATTN_SHA;
+  info["with_cuda"] = false;
+  return info;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  module.def("is_available", &is_available);
+  module.def("build_info", &build_info);
+}

--- a/integrations/alpadreams/omnidreams_singleview/tools/native_build.py
+++ b/integrations/alpadreams/omnidreams_singleview/tools/native_build.py
@@ -1,0 +1,361 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build preparation helpers for the OmniDreams single-view native path."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parents[2]
+
+THIRDPARTY_DIR = ROOT / "3rdparty"
+CUTLASS_DIR = THIRDPARTY_DIR / "cutlass"
+SAGE_ATTENTION_DIR = THIRDPARTY_DIR / "SageAttention"
+SPARGE_ATTN_DIR = THIRDPARTY_DIR / "SpargeAttn"
+
+PATCH_DIR = ROOT / "patches" / "cutlass"
+CUTLASS_PATCH = PATCH_DIR / "sm120-tma-pool.patch"
+CUTLASS_OVERLAY_INCLUDE = PATCH_DIR / "include"
+
+_DEFAULT_BUILD_ROOT_ENV = "OMNIDREAMS_SINGLEVIEW_NATIVE_BUILD_ROOT"
+_STAGE_SCHEMA_VERSION = 1
+
+
+class NativeBuildError(RuntimeError):
+    """Raised when native build preparation cannot safely continue."""
+
+
+@dataclass(frozen=True)
+class SubmoduleInfo:
+    """Validated source submodule state."""
+
+    name: str
+    path: Path
+    relative_path: str
+    recorded_sha: str
+    head_sha: str
+    tracked_status: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "path": self.relative_path,
+            "recorded_sha": self.recorded_sha,
+            "head_sha": self.head_sha,
+            "tracked_status": list(self.tracked_status),
+        }
+
+
+@dataclass(frozen=True)
+class CutlassStageInfo:
+    """Prepared CUTLASS stage metadata."""
+
+    path: Path
+    manifest_path: Path
+    manifest: Mapping[str, object]
+    reused: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "path": str(self.path),
+            "manifest_path": str(self.manifest_path),
+            "manifest": dict(self.manifest),
+            "reused": self.reused,
+        }
+
+
+def _run_git(cwd: Path, args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode != 0:
+        message = proc.stderr.strip() or proc.stdout.strip()
+        raise NativeBuildError(f"git {' '.join(args)} failed in {cwd}: {message}")
+    return proc.stdout.strip()
+
+
+def _repo_relative(path: Path) -> str:
+    return path.resolve().relative_to(REPO_ROOT).as_posix()
+
+
+def _submodule_head(path: Path) -> str:
+    try:
+        return _run_git(path, ["rev-parse", "HEAD"])
+    except NativeBuildError as exc:
+        raise NativeBuildError(
+            f"{_repo_relative(path)} is not an initialized git submodule"
+        ) from exc
+
+
+def _recorded_gitlink(relative_path: str) -> str:
+    try:
+        return _run_git(REPO_ROOT, ["rev-parse", f"HEAD:{relative_path}"])
+    except NativeBuildError as exc:
+        raise NativeBuildError(
+            f"{relative_path} is not recorded as a submodule in the parent commit"
+        ) from exc
+
+
+def _tracked_status(path: Path) -> tuple[str, ...]:
+    output = _run_git(path, ["status", "--short", "--untracked-files=no"])
+    return tuple(line for line in output.splitlines() if line)
+
+
+def validate_submodule(name: str, path: Path) -> SubmoduleInfo:
+    """Validate that a source submodule is initialized, clean, and pinned."""
+
+    if not path.exists():
+        raise NativeBuildError(f"Missing required source submodule: {path}")
+
+    relative_path = _repo_relative(path)
+    head_sha = _submodule_head(path)
+    recorded_sha = _recorded_gitlink(relative_path)
+    tracked_status = _tracked_status(path)
+
+    if head_sha != recorded_sha:
+        raise NativeBuildError(
+            f"{relative_path} is checked out at {head_sha}, "
+            f"but the parent commit records {recorded_sha}"
+        )
+    if tracked_status:
+        details = "\n".join(tracked_status)
+        raise NativeBuildError(
+            f"{relative_path} has tracked-file modifications:\n{details}"
+        )
+
+    return SubmoduleInfo(
+        name=name,
+        path=path,
+        relative_path=relative_path,
+        recorded_sha=recorded_sha,
+        head_sha=head_sha,
+        tracked_status=tracked_status,
+    )
+
+
+def validate_thirdparty() -> dict[str, SubmoduleInfo]:
+    """Validate all source submodules required by the native path."""
+
+    return {
+        "cutlass": validate_submodule("cutlass", CUTLASS_DIR),
+        "SageAttention": validate_submodule("SageAttention", SAGE_ATTENTION_DIR),
+        "SpargeAttn": validate_submodule("SpargeAttn", SPARGE_ATTN_DIR),
+    }
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _hash_tree(path: Path) -> str:
+    digest = hashlib.sha256()
+    if not path.exists():
+        return digest.hexdigest()
+
+    for file_path in sorted(p for p in path.rglob("*") if p.is_file()):
+        relative_path = file_path.relative_to(path).as_posix()
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(_hash_file(file_path).encode("ascii"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def cutlass_patch_fingerprint() -> dict[str, str]:
+    """Return the content hashes that determine the patched CUTLASS stage."""
+
+    return {
+        "patch_sha256": _hash_file(CUTLASS_PATCH),
+        "overlay_include_sha256": _hash_tree(CUTLASS_OVERLAY_INCLUDE),
+    }
+
+
+def _default_build_root() -> Path:
+    override = os.environ.get(_DEFAULT_BUILD_ROOT_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return ROOT / "build"
+
+
+def _expected_manifest(cutlass_info: SubmoduleInfo) -> dict[str, object]:
+    return {
+        "schema_version": _STAGE_SCHEMA_VERSION,
+        "cutlass_sha": cutlass_info.head_sha,
+        **cutlass_patch_fingerprint(),
+    }
+
+
+def _read_manifest(path: Path) -> dict[str, object] | None:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as exc:
+        raise NativeBuildError(f"Invalid CUTLASS stage manifest at {path}: {exc}")
+
+    if not isinstance(data, dict):
+        raise NativeBuildError(f"Invalid CUTLASS stage manifest at {path}: not a dict")
+    return data
+
+
+def _write_manifest(path: Path, manifest: Mapping[str, object]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+@contextlib.contextmanager
+def _stage_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _extract_git_archive(source: Path, destination: Path) -> None:
+    with subprocess.Popen(
+        ["git", "archive", "--format=tar", "HEAD"],
+        cwd=source,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ) as proc:
+        assert proc.stdout is not None
+        with tarfile.open(fileobj=proc.stdout, mode="r|") as archive:
+            archive.extractall(destination, filter="data")
+        assert proc.stderr is not None
+        stderr = proc.stderr.read()
+        proc.wait()
+        if proc.returncode != 0:
+            message = stderr.decode("utf-8", errors="replace").strip()
+            raise NativeBuildError(f"git archive failed for {source}: {message}")
+
+
+def _apply_patch(stage_path: Path, patch_path: Path) -> None:
+    for args in (
+        ["apply", "--check", str(patch_path)],
+        ["apply", str(patch_path)],
+    ):
+        try:
+            _run_git(stage_path, args)
+        except NativeBuildError as exc:
+            raise NativeBuildError(
+                f"Failed to apply CUTLASS patch {patch_path} in {stage_path}"
+            ) from exc
+
+
+def _refresh_cutlass_stage(stage_path: Path) -> None:
+    if stage_path.exists():
+        shutil.rmtree(stage_path)
+    stage_path.mkdir(parents=True)
+    _extract_git_archive(CUTLASS_DIR, stage_path)
+    _apply_patch(stage_path, CUTLASS_PATCH)
+    shutil.copytree(
+        CUTLASS_OVERLAY_INCLUDE,
+        stage_path / "include",
+        dirs_exist_ok=True,
+    )
+
+
+def prepare_cutlass_stage(
+    build_root: Path | str | None = None,
+    *,
+    force: bool = False,
+) -> CutlassStageInfo:
+    """Prepare a patched CUTLASS copy without modifying the submodule worktree."""
+
+    thirdparty = validate_thirdparty()
+    cutlass_info = thirdparty["cutlass"]
+    manifest = _expected_manifest(cutlass_info)
+
+    resolved_build_root = Path(build_root).resolve() if build_root else _default_build_root()
+    deps_root = resolved_build_root / "_deps"
+    stage_path = deps_root / "cutlass-patched"
+    manifest_path = stage_path / ".omnidreams_cutlass_stage.json"
+    lock_path = deps_root / ".cutlass-stage.lock"
+
+    with _stage_lock(lock_path):
+        existing_manifest = _read_manifest(manifest_path)
+        if not force and stage_path.exists() and existing_manifest == manifest:
+            return CutlassStageInfo(
+                path=stage_path,
+                manifest_path=manifest_path,
+                manifest=manifest,
+                reused=True,
+            )
+
+        _refresh_cutlass_stage(stage_path)
+        _write_manifest(manifest_path, manifest)
+
+    return CutlassStageInfo(
+        path=stage_path,
+        manifest_path=manifest_path,
+        manifest=manifest,
+        reused=False,
+    )
+
+
+def native_provenance(
+    build_root: Path | str | None = None,
+    *,
+    prepare_cutlass: bool = False,
+) -> dict[str, object]:
+    """Return source provenance without compiling the native extension."""
+
+    thirdparty = validate_thirdparty()
+    provenance: dict[str, object] = {
+        "root": str(ROOT),
+        "thirdparty": {name: info.as_dict() for name, info in thirdparty.items()},
+        "cutlass_patch": cutlass_patch_fingerprint(),
+    }
+    if prepare_cutlass:
+        provenance["cutlass_stage"] = prepare_cutlass_stage(build_root).as_dict()
+    return provenance

--- a/integrations/alpadreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/alpadreams/tests/test_omnidreams_singleview_native.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from alpadreams.native import omnidreams_singleview as native
+
+
+_FAKE_THIRDPARTY_INFO = {
+    "cutlass": {
+        "name": "cutlass",
+        "path": "integrations/alpadreams/omnidreams_singleview/3rdparty/cutlass",
+        "recorded_sha": "cutlass-test-sha",
+        "head_sha": "cutlass-test-sha",
+        "tracked_status": [],
+    },
+    "SageAttention": {
+        "name": "SageAttention",
+        "path": "integrations/alpadreams/omnidreams_singleview/3rdparty/SageAttention",
+        "recorded_sha": "sage-test-sha",
+        "head_sha": "sage-test-sha",
+        "tracked_status": [],
+    },
+    "SpargeAttn": {
+        "name": "SpargeAttn",
+        "path": "integrations/alpadreams/omnidreams_singleview/3rdparty/SpargeAttn",
+        "recorded_sha": "sparge-test-sha",
+        "head_sha": "sparge-test-sha",
+        "tracked_status": [],
+    },
+}
+
+
+def _run_git(cwd: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+@pytest.mark.ci_cpu
+def test_thirdparty_submodules_match_parent_gitlinks() -> None:
+    info = native.validate_thirdparty()
+
+    assert set(info) == {"cutlass", "SageAttention", "SpargeAttn"}
+    for submodule_info in info.values():
+        assert submodule_info["head_sha"] == submodule_info["recorded_sha"]
+        assert submodule_info["tracked_status"] == []
+
+
+@pytest.mark.ci_cpu
+def test_cutlass_patch_applies_to_pinned_submodule() -> None:
+    helper = native._native_build()
+    _run_git(helper.CUTLASS_DIR, "apply", "--check", str(helper.CUTLASS_PATCH))
+
+
+@pytest.mark.ci_cpu
+def test_cutlass_stage_refreshes_and_reuses_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper = native._native_build()
+
+    fake_cutlass = tmp_path / "cutlass"
+    fake_cutlass.mkdir()
+    _run_git(tmp_path, "init", str(fake_cutlass))
+    (fake_cutlass / "include" / "cute").mkdir(parents=True)
+    (fake_cutlass / "include" / "cute" / "example.hpp").write_text(
+        "original\n",
+        encoding="utf-8",
+    )
+    _run_git(fake_cutlass, "add", ".")
+    _run_git(
+        fake_cutlass,
+        "-c",
+        "user.name=FlashDreams Test",
+        "-c",
+        "user.email=flashdreams-test@nvidia.com",
+        "commit",
+        "-m",
+        "seed fake cutlass",
+    )
+
+    patch = tmp_path / "patch.diff"
+    patch.write_text(
+        """diff --git a/include/cute/example.hpp b/include/cute/example.hpp
+--- a/include/cute/example.hpp
++++ b/include/cute/example.hpp
+@@ -1 +1,2 @@
+ original
++patched
+""",
+        encoding="utf-8",
+    )
+    overlay = tmp_path / "overlay"
+    (overlay / "cute" / "atom" / "detail").mkdir(parents=True)
+    (overlay / "cute" / "atom" / "detail" / "extra.hpp").write_text(
+        "overlay\n",
+        encoding="utf-8",
+    )
+
+    fake_info = helper.SubmoduleInfo(
+        name="cutlass",
+        path=fake_cutlass,
+        relative_path="fake/cutlass",
+        recorded_sha="fake-sha",
+        head_sha="fake-sha",
+        tracked_status=(),
+    )
+    monkeypatch.setattr(helper, "CUTLASS_DIR", fake_cutlass)
+    monkeypatch.setattr(helper, "CUTLASS_PATCH", patch)
+    monkeypatch.setattr(helper, "CUTLASS_OVERLAY_INCLUDE", overlay)
+    monkeypatch.setattr(
+        helper,
+        "validate_thirdparty",
+        lambda: {
+            "cutlass": fake_info,
+            "SageAttention": fake_info,
+            "SpargeAttn": fake_info,
+        },
+    )
+
+    first_stage = helper.prepare_cutlass_stage(tmp_path / "build")
+    assert first_stage.reused is False
+    assert (
+        first_stage.path / "include" / "cute" / "example.hpp"
+    ).read_text(encoding="utf-8") == "original\npatched\n"
+    assert (
+        first_stage.path / "include" / "cute" / "atom" / "detail" / "extra.hpp"
+    ).exists()
+    assert first_stage.manifest["cutlass_sha"] == "fake-sha"
+
+    second_stage = helper.prepare_cutlass_stage(tmp_path / "build")
+    assert second_stage.reused is True
+    assert _run_git(fake_cutlass, "status", "--short", "--untracked-files=no") == ""
+
+
+@pytest.mark.ci_cpu
+def test_load_extension_uses_build_root_for_torch_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch.utils.cpp_extension as cpp_extension
+
+    build_root = tmp_path / "native-build"
+    stage_path = build_root / "_deps" / "cutlass-patched"
+    (stage_path / "include").mkdir(parents=True)
+
+    stage_info = {
+        "path": str(stage_path),
+        "manifest_path": str(stage_path / ".omnidreams_cutlass_stage.json"),
+        "manifest": {
+            "cutlass_sha": "cutlass-test-sha",
+            "patch_sha256": "patch-test-sha",
+            "overlay_include_sha256": "overlay-test-sha",
+        },
+        "reused": False,
+    }
+    captured: dict[str, object] = {}
+
+    def fake_load_torch_extension(**kwargs: object) -> object:
+        captured.update(kwargs)
+        captured["max_jobs_env"] = os.environ.get("MAX_JOBS")
+        return SimpleNamespace()
+
+    monkeypatch.setattr(native, "_extension", None)
+    monkeypatch.setattr(native, "_extension_load_error", None)
+    monkeypatch.setattr(native, "prepare_cutlass_stage", lambda **_: stage_info)
+    monkeypatch.setattr(native, "validate_thirdparty", lambda: _FAKE_THIRDPARTY_INFO)
+    monkeypatch.setattr(cpp_extension, "load", fake_load_torch_extension)
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.delenv("OMNIDREAMS_SINGLEVIEW_NATIVE_MAX_JOBS", raising=False)
+
+    extension = native.load_extension(build_root=build_root)
+
+    assert extension is not None
+    extension_name = captured["name"]
+    assert captured["build_directory"] == str(
+        build_root / "torch_extensions" / str(extension_name)
+    )
+    assert captured["extra_include_paths"] == [str(stage_path / "include")]
+    assert (
+        "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_SHA=\\\"cutlass-test-sha\\\""
+        in captured["extra_cflags"]
+    )
+    assert (
+        "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_PATCH_SHA=\\\"patch-test-sha\\\""
+        in captured["extra_cflags"]
+    )
+    assert (
+        "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_OVERLAY_SHA=\\\"overlay-test-sha\\\""
+        in captured["extra_cflags"]
+    )
+    assert (
+        "-DOMNIDREAMS_SINGLEVIEW_SAGE_ATTENTION_SHA=\\\"sage-test-sha\\\""
+        in captured["extra_cflags"]
+    )
+    assert (
+        "-DOMNIDREAMS_SINGLEVIEW_SPARGE_ATTN_SHA=\\\"sparge-test-sha\\\""
+        in captured["extra_cflags"]
+    )
+    assert captured["with_cuda"] is False
+    assert captured["max_jobs_env"] == "1"
+    assert "MAX_JOBS" not in os.environ
+
+
+@pytest.mark.ci_cpu
+def test_load_extension_respects_existing_max_jobs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch.utils.cpp_extension as cpp_extension
+
+    build_root = tmp_path / "native-build"
+    stage_path = build_root / "_deps" / "cutlass-patched"
+    (stage_path / "include").mkdir(parents=True)
+
+    stage_info = {
+        "path": str(stage_path),
+        "manifest_path": str(stage_path / ".omnidreams_cutlass_stage.json"),
+        "manifest": {
+            "cutlass_sha": "cutlass-test-sha",
+            "patch_sha256": "patch-test-sha",
+            "overlay_include_sha256": "overlay-test-sha",
+        },
+        "reused": False,
+    }
+    captured: dict[str, object] = {}
+
+    def fake_load_torch_extension(**kwargs: object) -> object:
+        captured["max_jobs_env"] = os.environ.get("MAX_JOBS")
+        return SimpleNamespace()
+
+    monkeypatch.setattr(native, "_extension", None)
+    monkeypatch.setattr(native, "_extension_load_error", None)
+    monkeypatch.setattr(native, "prepare_cutlass_stage", lambda **_: stage_info)
+    monkeypatch.setattr(native, "validate_thirdparty", lambda: _FAKE_THIRDPARTY_INFO)
+    monkeypatch.setattr(cpp_extension, "load", fake_load_torch_extension)
+    monkeypatch.setenv("MAX_JOBS", "3")
+
+    extension = native.load_extension(build_root=build_root)
+
+    assert extension is not None
+    assert captured["max_jobs_env"] == "3"
+    assert os.environ["MAX_JOBS"] == "3"
+
+
+@pytest.mark.ci_cpu
+@pytest.mark.skipif(
+    os.environ.get("OMNIDREAMS_SINGLEVIEW_RUN_NATIVE_BUILD_TEST") != "1",
+    reason="Set OMNIDREAMS_SINGLEVIEW_RUN_NATIVE_BUILD_TEST=1 to build the native extension.",
+)
+def test_diagnostic_native_extension_builds(tmp_path: Path) -> None:
+    extension = native.load_extension(build_root=tmp_path)
+
+    assert extension is not None, native.extension_load_error()
+    assert extension.is_available()
+    assert extension.build_info()["with_cuda"] is False


### PR DESCRIPTION
## Summary

- Adds the public OmniDreams single-view native scaffold under the AlpaDreams integration.
- Adds a lazy Python loader, native build helper, staged CUTLASS patch preparation, and diagnostic C++ extension.
- Adds CPU-safe tests for submodule validation, staged patching, build-directory routing, and `MAX_JOBS` behavior.

## Stack

This PR is intentionally stacked on top of `dev/mchock/omnidreams-thirdparty-submodules`.
Do not retarget it to `main` until the third-party-submodules PR has landed.

## Validation

- `python -m py_compile integrations/alpadreams/alpadreams/native/omnidreams_singleview.py integrations/alpadreams/omnidreams_singleview/tools/native_build.py integrations/alpadreams/tests/test_omnidreams_singleview_native.py`
- `.venv/bin/python -m pytest -q integrations/alpadreams/tests/test_omnidreams_singleview_native.py -m ci_cpu`
- `OMNIDREAMS_SINGLEVIEW_RUN_NATIVE_BUILD_TEST=1 .venv/bin/python -m pytest -q integrations/alpadreams/tests/test_omnidreams_singleview_native.py::test_diagnostic_native_extension_builds`
- `git diff --check HEAD~1..HEAD`
- Forbidden-name grep over the new public native paths returned no matches.

`reuse lint` was also run and failed on pre-existing repository-wide metadata gaps outside this scaffold; the new native scaffold files include inline SPDX headers.
