### PR TITLE
Add shared OmniDreams native acceleration policy

### DIFF
--- a/integrations/alpadreams/alpadreams/native/__init__.py
+++ b/integrations/alpadreams/alpadreams/native/__init__.py
@@ -15,16 +15,32 @@
 
 """Native acceleration helpers for AlpaDreams integrations."""
 
+from .acceleration import (
+    NativeAccelerationConfig,
+    NativeAccelerationMode,
+    NativeAccelerationUnavailable,
+    NativeBackendSelection,
+    require_extension_symbols,
+    select_native_extension,
+)
 from .omnidreams_singleview import (
     build_info,
     load_extension,
     prepare_cutlass_stage,
+    select_backend,
     validate_thirdparty,
 )
 
 __all__ = [
+    "NativeAccelerationConfig",
+    "NativeAccelerationMode",
+    "NativeAccelerationUnavailable",
+    "NativeBackendSelection",
     "build_info",
     "load_extension",
     "prepare_cutlass_stage",
+    "require_extension_symbols",
+    "select_backend",
+    "select_native_extension",
     "validate_thirdparty",
 ]

--- a/integrations/alpadreams/alpadreams/native/acceleration.py
+++ b/integrations/alpadreams/alpadreams/native/acceleration.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared native acceleration policy helpers.
+
+The DiT and VAE native ports should share the same opt-in semantics:
+
+- ``disabled`` never loads native code.
+- ``auto`` uses native code only when it is available and compatible.
+- ``required`` raises instead of silently falling back.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Callable, Literal, Protocol, get_args
+
+NativeAccelerationMode = Literal["auto", "disabled", "required"]
+
+
+class NativeExtensionLoader(Protocol):
+    def __call__(
+        self,
+        *,
+        build_root: str | None = None,
+        max_jobs: int | str | None = None,
+        verbose: bool = False,
+    ) -> ModuleType | None: ...
+
+
+NativeAvailabilityCheck = Callable[[ModuleType], bool | tuple[bool, str]]
+
+
+class NativeAccelerationUnavailable(RuntimeError):
+    """Raised when native execution is required but unavailable."""
+
+
+@dataclass(kw_only=True)
+class NativeAccelerationConfig:
+    """Common native acceleration knobs for pipeline components."""
+
+    mode: NativeAccelerationMode = "auto"
+    """Native execution policy: ``auto``, ``disabled``, or ``required``."""
+
+    build_root: str | None = None
+    """Optional native build/cache root forwarded to the extension loader."""
+
+    max_jobs: int | str | None = None
+    """Optional PyTorch/Ninja job cap forwarded to the extension loader."""
+
+    verbose_build: bool = False
+    """Forward verbose build output from the extension loader."""
+
+    def __post_init__(self) -> None:
+        if self.mode not in get_args(NativeAccelerationMode):
+            raise ValueError(
+                f"mode must be one of {get_args(NativeAccelerationMode)}, "
+                f"got {self.mode!r}"
+            )
+
+
+@dataclass(frozen=True)
+class NativeBackendSelection:
+    """Resolved native backend choice for one pipeline component."""
+
+    component: str
+    mode: NativeAccelerationMode
+    enabled: bool
+    reason: str
+    extension: ModuleType | None = field(default=None, repr=False, compare=False)
+    error: Exception | None = field(default=None, repr=False, compare=False)
+
+    def require_extension(self) -> ModuleType:
+        """Return the loaded extension or raise with this selection's reason."""
+
+        if self.enabled and self.extension is not None:
+            return self.extension
+        raise NativeAccelerationUnavailable(self.reason)
+
+
+def require_extension_symbols(*symbols: str) -> NativeAvailabilityCheck:
+    """Return an availability check for extension symbols needed by a component."""
+
+    def check(extension: ModuleType) -> tuple[bool, str]:
+        missing = tuple(symbol for symbol in symbols if not hasattr(extension, symbol))
+        if missing:
+            return False, "missing native symbol(s): " + ", ".join(missing)
+        return True, "required native symbols are available"
+
+    return check
+
+
+def select_native_extension(
+    config: NativeAccelerationConfig,
+    *,
+    component: str,
+    extension_loader: NativeExtensionLoader,
+    extension_error: Callable[[], Exception | None],
+    availability_check: NativeAvailabilityCheck | None = None,
+) -> NativeBackendSelection:
+    """Resolve native use for one component without changing caller behavior."""
+
+    if config.mode == "disabled":
+        return NativeBackendSelection(
+            component=component,
+            mode=config.mode,
+            enabled=False,
+            reason=f"native acceleration disabled for {component}",
+        )
+
+    try:
+        extension = extension_loader(
+            build_root=config.build_root,
+            max_jobs=config.max_jobs,
+            verbose=config.verbose_build,
+        )
+    except Exception as exc:
+        return _unavailable_or_raise(config, component, str(exc), error=exc)
+
+    if extension is None:
+        error = extension_error()
+        reason = (
+            f"native extension unavailable for {component}"
+            if error is None
+            else f"native extension unavailable for {component}: {error}"
+        )
+        return _unavailable_or_raise(config, component, reason, error=error)
+
+    check = availability_check or _default_availability_check
+    try:
+        ok, reason = _normalize_availability_result(check(extension))
+    except Exception as exc:
+        return _unavailable_or_raise(config, component, str(exc), error=exc)
+    if not ok:
+        return _unavailable_or_raise(config, component, reason)
+
+    return NativeBackendSelection(
+        component=component,
+        mode=config.mode,
+        enabled=True,
+        reason=reason,
+        extension=extension,
+    )
+
+
+def _unavailable_or_raise(
+    config: NativeAccelerationConfig,
+    component: str,
+    reason: str,
+    *,
+    error: Exception | None = None,
+) -> NativeBackendSelection:
+    if config.mode == "required":
+        raise NativeAccelerationUnavailable(reason) from error
+    return NativeBackendSelection(
+        component=component,
+        mode=config.mode,
+        enabled=False,
+        reason=reason,
+        error=error,
+    )
+
+
+def _default_availability_check(extension: ModuleType) -> bool | tuple[bool, str]:
+    is_available = getattr(extension, "is_available", None)
+    if is_available is None:
+        return True, "native extension loaded"
+    if not callable(is_available):
+        return False, "native extension is_available is not callable"
+    return bool(is_available()), "native extension is_available returned true"
+
+
+def _normalize_availability_result(
+    result: bool | tuple[bool, str],
+) -> tuple[bool, str]:
+    if isinstance(result, tuple):
+        ok, reason = result
+        return ok, reason
+    if result:
+        return True, "native extension is available"
+    return False, "native extension is not available"

--- a/integrations/alpadreams/alpadreams/native/omnidreams_singleview.py
+++ b/integrations/alpadreams/alpadreams/native/omnidreams_singleview.py
@@ -27,6 +27,13 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Iterator
 
+from alpadreams.native.acceleration import (
+    NativeAccelerationConfig,
+    NativeAvailabilityCheck,
+    NativeBackendSelection,
+    select_native_extension,
+)
+
 _ROOT = Path(__file__).resolve().parents[2] / "omnidreams_singleview"
 _NATIVE_BUILD_PATH = _ROOT / "tools" / "native_build.py"
 _EXTENSION_SOURCE = _ROOT / "src" / "omnidreams_singleview_ext.cpp"
@@ -221,3 +228,20 @@ def extension_load_error() -> Exception | None:
     """Return the last native extension load error, if any."""
 
     return _extension_load_error
+
+
+def select_backend(
+    component: str,
+    config: NativeAccelerationConfig | None = None,
+    *,
+    availability_check: NativeAvailabilityCheck | None = None,
+) -> NativeBackendSelection:
+    """Resolve OmniDreams single-view native use for a pipeline component."""
+
+    return select_native_extension(
+        config or NativeAccelerationConfig(),
+        component=component,
+        extension_loader=load_extension,
+        extension_error=extension_load_error,
+        availability_check=availability_check,
+    )

--- a/integrations/alpadreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/alpadreams/tests/test_omnidreams_singleview_native.py
@@ -22,6 +22,12 @@ from types import SimpleNamespace
 
 import pytest
 
+from alpadreams.native.acceleration import (
+    NativeAccelerationConfig,
+    NativeAccelerationUnavailable,
+    require_extension_symbols,
+    select_native_extension,
+)
 from alpadreams.native import omnidreams_singleview as native
 
 
@@ -267,6 +273,138 @@ def test_load_extension_respects_existing_max_jobs(
     assert extension is not None
     assert captured["max_jobs_env"] == "3"
     assert os.environ["MAX_JOBS"] == "3"
+
+
+@pytest.mark.ci_cpu
+def test_native_acceleration_disabled_does_not_load_extension() -> None:
+    called = False
+
+    def loader(**_: object) -> None:
+        nonlocal called
+        called = True
+        return None
+
+    selection = select_native_extension(
+        NativeAccelerationConfig(mode="disabled"),
+        component="dit",
+        extension_loader=loader,
+        extension_error=lambda: None,
+    )
+
+    assert selection.component == "dit"
+    assert selection.mode == "disabled"
+    assert selection.enabled is False
+    assert "disabled" in selection.reason
+    assert called is False
+
+
+@pytest.mark.ci_cpu
+def test_native_acceleration_auto_falls_back_when_extension_is_missing() -> None:
+    error = RuntimeError("compile failed")
+
+    selection = select_native_extension(
+        NativeAccelerationConfig(mode="auto"),
+        component="vae_decoder",
+        extension_loader=lambda **_: None,
+        extension_error=lambda: error,
+    )
+
+    assert selection.enabled is False
+    assert selection.error is error
+    assert "vae_decoder" in selection.reason
+    assert "compile failed" in selection.reason
+
+
+@pytest.mark.ci_cpu
+def test_native_acceleration_required_raises_when_extension_is_missing() -> None:
+    with pytest.raises(NativeAccelerationUnavailable, match="native extension"):
+        select_native_extension(
+            NativeAccelerationConfig(mode="required"),
+            component="vae_encoder",
+            extension_loader=lambda **_: None,
+            extension_error=lambda: RuntimeError("not built"),
+        )
+
+
+@pytest.mark.ci_cpu
+def test_native_acceleration_symbol_check_gates_component_support() -> None:
+    extension = SimpleNamespace(is_available=lambda: True, run_dit_block=object())
+
+    selection = select_native_extension(
+        NativeAccelerationConfig(mode="auto"),
+        component="dit",
+        extension_loader=lambda **_: extension,
+        extension_error=lambda: None,
+        availability_check=require_extension_symbols("run_dit_block"),
+    )
+
+    assert selection.enabled is True
+    assert selection.require_extension() is extension
+
+    missing_selection = select_native_extension(
+        NativeAccelerationConfig(mode="auto"),
+        component="vae_decoder",
+        extension_loader=lambda **_: extension,
+        extension_error=lambda: None,
+        availability_check=require_extension_symbols("run_vae_decoder"),
+    )
+
+    assert missing_selection.enabled is False
+    assert "run_vae_decoder" in missing_selection.reason
+
+
+@pytest.mark.ci_cpu
+def test_native_acceleration_auto_falls_back_when_check_raises() -> None:
+    extension = SimpleNamespace(is_available=lambda: True)
+
+    def failing_check(_: object) -> bool:
+        raise RuntimeError("unsupported tensor layout")
+
+    selection = select_native_extension(
+        NativeAccelerationConfig(mode="auto"),
+        component="dit",
+        extension_loader=lambda **_: extension,
+        extension_error=lambda: None,
+        availability_check=failing_check,
+    )
+
+    assert selection.enabled is False
+    assert isinstance(selection.error, RuntimeError)
+    assert "unsupported tensor layout" in selection.reason
+
+
+@pytest.mark.ci_cpu
+def test_omnidreams_select_backend_forwards_build_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    extension = SimpleNamespace(is_available=lambda: True, run_vae_encoder=object())
+    captured: dict[str, object] = {}
+
+    def fake_load_extension(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return extension
+
+    monkeypatch.setattr(native, "load_extension", fake_load_extension)
+    monkeypatch.setattr(native, "extension_load_error", lambda: None)
+
+    selection = native.select_backend(
+        "vae_encoder",
+        NativeAccelerationConfig(
+            build_root=str(tmp_path),
+            max_jobs=2,
+            verbose_build=True,
+        ),
+        availability_check=require_extension_symbols("run_vae_encoder"),
+    )
+
+    assert selection.enabled is True
+    assert selection.require_extension() is extension
+    assert captured == {
+        "build_root": str(tmp_path),
+        "max_jobs": 2,
+        "verbose": True,
+    }
 
 
 @pytest.mark.ci_cpu


### PR DESCRIPTION
## Summary

- Adds a shared native acceleration policy layer for OmniDreams single-view follow-up work.
- Defines common `auto` / `disabled` / `required` semantics, required-mode failure handling, backend selection results, and extension symbol checks.
- Adds an OmniDreams wrapper that resolves component-native availability through the existing lazy extension loader.
- Adds CPU-safe tests for disabled mode, auto fallback, required failure, component symbol gating, availability-check failures, and build-option forwarding.

## Stack

This PR is intentionally stacked on top of #133:

- base: `dev/mchock/omnidreams-singleview-native`
- head: `mchock-nv:dev/mchock/omnidreams-native-acceleration-foundation`

Do not retarget this PR to `main` until #133 and its third-party-submodules dependency have landed.

## Validation

- `python -m py_compile integrations/alpadreams/alpadreams/native/acceleration.py integrations/alpadreams/alpadreams/native/omnidreams_singleview.py integrations/alpadreams/alpadreams/native/__init__.py integrations/alpadreams/tests/test_omnidreams_singleview_native.py`
- `.venv/bin/python -m pytest -q integrations/alpadreams/tests/test_omnidreams_singleview_native.py -m ci_cpu`
- `git diff --check dev/mchock/omnidreams-singleview-native..HEAD`
- Scoped forbidden-name grep over the touched public native paths returned no matches.

Pre-push CodeRabbit review was attempted with base `dev/mchock/omnidreams-singleview-native`; it connected and hung after setup without findings, then was terminated under the repo's best-effort review policy.
