### PR TITLE
docs(arch): FlashDreams SADD + TAVA (Jira MVSB-32946)

### DIFF
--- a/agentic/skills/flashdreams-security-architect/SKILL.md
+++ b/agentic/skills/flashdreams-security-architect/SKILL.md
@@ -1,11 +1,6 @@
-<!--
-SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
--->
-
 ---
 name: flashdreams-security-architect
-description: Author / review / verify the FlashDreams TAVA + SADD + FSR test surface. Compact recipe scoped to the flashdreams repo (recipes, core, infra, integrations/{alpadreams,lingbot,…}) — companion to the broader omni-dreams + flashdreams skill at omni-dreams/docs/arch/SKILL.md.
+description: Author, review, and verify the FlashDreams TAVA, SADD, and FSR sheet — update one of the four architecture views (static / dynamic / data / deployment) after a code change, cross-reference a TAVA threat or FSR_FD_NN to the relevant view section, add a new FSR contract seam under `flashdreams/tests/security/`, sanity-check mermaid syntax, and walk the 4-C consistency check before sign-off. Use when editing anything under `docs/arch/`, when adding or revising a security-contract test, when triaging a Greptile review comment on the security surface, or when the user asks how to update / acknowledge the TAVA against MVSB-32946. Compact subset of the broader omni-dreams + flashdreams skill.
 ---
 
 # FlashDreams — security-architect skill (compact)
@@ -14,10 +9,10 @@ Agent-runnable recipe for security-architect work on the **flashdreams** repo. U
 
 - Update one of the four architecture views (static / dynamic / data / deployment) after a code change.
 - Cross-reference a TAVA threat (`T-<NAME>-N`) or FSR (`FSR_FD_NN`) to the relevant view section.
-- Add a new FSR contract seam under `flashdreams/tests/security/` (planned) and wire it into the canonical FSR sheet here.
+- Add a new FSR contract seam under `flashdreams/tests/security/` (planned) and wire it into the canonical FSR sheet.
 - Form a defensible opinion on the design before signing off the TAVA against MVSB-32946.
 
-This skill is the FlashDreams-scoped subset of the broader omni-dreams + flashdreams skill at `omni-dreams/docs/arch/SKILL.md` and its reviewer companion `omni-dreams/docs/arch/review/SKILL.md`. The broader skill remains the source of truth when a change crosses the omni-dreams / flashdreams boundary (e.g. the interactive-drive sample, the post-training stack).
+This skill is the FlashDreams-scoped subset of the broader omni-dreams + flashdreams skill at `../../../../omni-dreams/docs/arch/SKILL.md` and its reviewer companion `../../../../omni-dreams/docs/arch/review/SKILL.md`. The broader skill remains the source of truth when a change crosses the omni-dreams / flashdreams boundary (e.g. the interactive-drive sample, the post-training stack).
 
 ## TOE shape (one-paragraph mental model)
 
@@ -25,10 +20,10 @@ The FlashDreams TOE is the runtime process tree that loads a recipe (`cosmos`, `
 
 ## Inputs the skill assumes are already in place
 
-- [`architecture.md`](architecture.md) — four-view architecture for the FlashDreams TOE.
-- [`sadd.md`](sadd.md) — Software Architecture and Design Document per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL`.
-- [`tava.md`](tava.md) — FlashDreams-scoped TAVA 2.0 (MVSB-32946 subset).
-- [`fsr_table.md`](fsr_table.md) — canonical FSR sheet in the **Excel-Based Simple TAVA Template** column structure.
+- [`docs/arch/architecture.md`](../../../docs/arch/architecture.md) — four-view architecture for the FlashDreams TOE.
+- [`docs/arch/sadd.md`](../../../docs/arch/sadd.md) — Software Architecture and Design Document per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL`.
+- [`docs/arch/tava.md`](../../../docs/arch/tava.md) — FlashDreams-scoped TAVA 2.0 (MVSB-32946 subset).
+- [`docs/arch/fsr_table.md`](../../../docs/arch/fsr_table.md) — canonical FSR sheet in the **Excel-Based Simple TAVA Template** column structure.
 - Security test seams (planned): `flashdreams/tests/security/` (mirrors the omni-dreams `internal/tests/security/` package one-to-one).
 
 ## Quick workflows
@@ -54,7 +49,7 @@ grep -nE '^##|^###' docs/arch/architecture.md | head -20
 # 2. Write positive + negative tests in flashdreams/tests/security/test_<topic>.py
 # 3. Run the suite (CPU-only, no GPU weights):
 uv run pytest flashdreams/tests/security/ -v
-# 4. Add a row to fsr_table.md keyed by FSR_FD_NN, then update tava.md § 3.2.
+# 4. Add a row to docs/arch/fsr_table.md keyed by FSR_FD_NN, then update docs/arch/tava.md § 3.2.
 # 5. Commit with subject: "test(security): FSR_FD_NN <topic>"
 ```
 
@@ -70,7 +65,7 @@ Mermaid 10.7.0 (the user's preview) is strict. Quote labels containing any of `<
 | `{a,b,c}` in a class member or edge label | Plain text without braces |
 | `--` em-dash in subgraph label | Quote: `subgraph X["label — with dash"]` |
 
-Quick scan for hazards inside the mermaid code blocks of `architecture.md`:
+Quick scan for hazards inside the mermaid code blocks of `docs/arch/architecture.md`:
 
 ```bash
 awk '/^```mermaid/{in_mm=1} /^```$/{in_mm=0} in_mm' docs/arch/architecture.md \
@@ -79,7 +74,7 @@ awk '/^```mermaid/{in_mm=1} /^```$/{in_mm=0} in_mm' docs/arch/architecture.md \
 
 ## Cross-reference invariants (the **4-C** self-review)
 
-When you change anything in `architecture.md`, check the following five places stay consistent:
+When you change anything in `docs/arch/architecture.md`, check the following five places stay consistent:
 
 1. **Consistent** — component names, interface names, trust-boundary labels match across all four views, the SADD interface table, and the TAVA asset table.
 2. **Correct** — diagrams reflect code as of HEAD; cite file paths inline so reviewers can verify.
@@ -90,7 +85,7 @@ When you change anything in `architecture.md`, check the following five places s
 
 ## Operating-environment assumptions (do not silently weaken)
 
-Documented in [`tava.md`](tava.md) § 1.3:
+Documented in [`docs/arch/tava.md`](../../../docs/arch/tava.md) § 1.3:
 
 - **OE-1** — operator-trusted hardware; the Docker `--network=host --ipc=host` invocation collapses container/host trust.
 - **OE-2** — Slurm cluster admin enforces tenant isolation (out of scope for flashdreams TOE; relevant for the omni-dreams post-training consumer).
@@ -104,20 +99,21 @@ Documented in [`tava.md`](tava.md) § 1.3:
 
 | Concern | Where |
 |---|---|
-| Architecture diagrams (four views) | [`architecture.md`](architecture.md) |
-| SADD (PLC-L1 template) | [`sadd.md`](sadd.md) |
-| TAVA report (FlashDreams subset of MVSB-32946) | [`tava.md`](tava.md) |
-| Canonical FSR sheet (Excel-style columns) | [`fsr_table.md`](fsr_table.md) |
-| Upstream skill (omni-dreams + flashdreams) | `../../../omni-dreams/docs/arch/SKILL.md` |
-| Upstream review skill | `../../../omni-dreams/docs/arch/review/SKILL.md` |
-| Upstream canonical TAVA + asset inventory | `../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md` |
-| Upstream FSR contract+stub tests | `../../../omni-dreams/internal/tests/security/` |
+| Architecture diagrams (four views) | [`docs/arch/architecture.md`](../../../docs/arch/architecture.md) |
+| SADD (PLC-L1 template) | [`docs/arch/sadd.md`](../../../docs/arch/sadd.md) |
+| TAVA report (FlashDreams subset of MVSB-32946) | [`docs/arch/tava.md`](../../../docs/arch/tava.md) |
+| Canonical FSR sheet (Excel-style columns) | [`docs/arch/fsr_table.md`](../../../docs/arch/fsr_table.md) |
+| Doc-set index | [`docs/arch/README.md`](../../../docs/arch/README.md) |
+| Upstream skill (omni-dreams + flashdreams) | `../../../../omni-dreams/docs/arch/SKILL.md` |
+| Upstream review skill | `../../../../omni-dreams/docs/arch/review/SKILL.md` |
+| Upstream canonical TAVA + asset inventory | `../../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md` |
+| Upstream FSR contract+stub tests | `../../../../omni-dreams/internal/tests/security/` |
 | Planned FlashDreams security tests | `flashdreams/tests/security/` (mirror, to be landed) |
 
 ## Do not
 
-- Do not edit `architecture.md` and forget to update the cross-reference sites above.
-- Do not weaken the architectural invariants asserted in `internal/tests/security/*.py` upstream (e.g. "no inference SHALL run on a rejected verdict"; "untrusted factory MUST NOT be called during refusal"; "loader_fn SHALL NOT be invoked on checksum mismatch") when you mirror them here.
-- Do not approve a control without first articulating the threat it closes (`tava.md` § 2.3).
+- Do not edit `docs/arch/architecture.md` and forget to update the cross-reference sites above.
+- Do not weaken the architectural invariants asserted in `omni-dreams/internal/tests/security/*.py` upstream (e.g. "no inference SHALL run on a rejected verdict"; "untrusted factory MUST NOT be called during refusal"; "loader_fn SHALL NOT be invoked on checksum mismatch") when you mirror them into FlashDreams.
+- Do not approve a control without first articulating the threat it closes ([`docs/arch/tava.md`](../../../docs/arch/tava.md) § 2.3).
 - Do not treat OE-1..OE-7 as code-enforced — they are delegations to operator / cluster admin / upstream registry.
-- Do not fabricate test counts. Test/Measurement cells in [`fsr_table.md`](fsr_table.md) cite the as-built upstream test file when applicable; if no test exists for an FSR yet, say so explicitly.
+- Do not fabricate test counts. Test/Measurement cells in [`docs/arch/fsr_table.md`](../../../docs/arch/fsr_table.md) cite the as-built upstream test file when applicable; if no test exists for an FSR yet, say so explicitly.

--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# FlashDreams architecture, TAVA, and FSR documentation
+
+This directory holds the FlashDreams-scoped architecture documents that
+support the manual TAVA 2.0 acknowledgment path for
+[MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946).
+
+| Document | Purpose |
+| --- | --- |
+| [`SKILL.md`](SKILL.md) | Agent-runnable workflow for FlashDreams security-architect work (compact subset of the omni-dreams + flashdreams skill). |
+| [`architecture.md`](architecture.md) | Four-view architecture (Static / Dynamic / Data / Deployment) for the FlashDreams TOE. |
+| [`sadd.md`](sadd.md) | Software Architecture and Design Document per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL`. |
+| [`tava.md`](tava.md) | FlashDreams-scoped TAVA narrative (assets, threats, risk, security objectives, POA&M). |
+| [`fsr_table.md`](fsr_table.md) | Canonical FSR sheet in the Excel-Based Simple TAVA Template column structure (FSR_FD_01..36). |
+
+## Relationship to the upstream omni-dreams documents
+
+The single source of truth across both repos is the upstream pair at
+`omni-dreams/docs/arch/architecture.md` and
+`omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md`.
+This directory is the **FlashDreams-scoped subset** of that source, narrowed
+to:
+
+- `flashdreams/flashdreams/` (recipes, core, infra, plugins, scripts)
+- `flashdreams/integrations/` (alpadreams gRPC, lingbot WebRTC, plus other adapters)
+- The supply chain that loads these (HuggingFace, S3, GHCR)
+
+The `omni-dreams/samples/interactive-drive` consumer and the
+`omni-dreams/post-training` trainer are out of scope here — they are
+covered in the upstream omni-dreams + flashdreams documents.
+
+## Where the as-built tests live
+
+FSR contract+stub tests landed upstream at
+`omni-dreams/internal/tests/security/`. As of the upstream station check
+on 2026-05-15, 20 of 24 FSRs have passing contract+stub tests
+(230 / 230 passing in 1.86 s). The FlashDreams-side mirror at
+`flashdreams/tests/security/` is queued for a follow-up MR — see
+[`tava.md`](tava.md) § Step 6, Q-06.

--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -11,11 +11,12 @@ support the manual TAVA 2.0 acknowledgment path for
 
 | Document | Purpose |
 | --- | --- |
-| [`SKILL.md`](SKILL.md) | Agent-runnable workflow for FlashDreams security-architect work (compact subset of the omni-dreams + flashdreams skill). |
 | [`architecture.md`](architecture.md) | Four-view architecture (Static / Dynamic / Data / Deployment) for the FlashDreams TOE. |
 | [`sadd.md`](sadd.md) | Software Architecture and Design Document per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL`. |
 | [`tava.md`](tava.md) | FlashDreams-scoped TAVA narrative (assets, threats, risk, security objectives, POA&M). |
 | [`fsr_table.md`](fsr_table.md) | Canonical FSR sheet in the Excel-Based Simple TAVA Template column structure (FSR_FD_01..36). |
+
+The agent-runnable workflow for this surface lives as a project skill at [`../../agentic/skills/flashdreams-security-architect/SKILL.md`](../../agentic/skills/flashdreams-security-architect/SKILL.md) — follow the `agentic/skills/README.md` opt-in instructions to symlink it into `.claude/skills/` or `.cursor/skills/`.
 
 ## Relationship to the upstream omni-dreams documents
 

--- a/docs/arch/SKILL.md
+++ b/docs/arch/SKILL.md
@@ -1,0 +1,123 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+name: flashdreams-security-architect
+description: Author / review / verify the FlashDreams TAVA + SADD + FSR test surface. Compact recipe scoped to the flashdreams repo (recipes, core, infra, integrations/{alpadreams,lingbot,…}) — companion to the broader omni-dreams + flashdreams skill at omni-dreams/docs/arch/SKILL.md.
+---
+
+# FlashDreams — security-architect skill (compact)
+
+Agent-runnable recipe for security-architect work on the **flashdreams** repo. Use when you need to:
+
+- Update one of the four architecture views (static / dynamic / data / deployment) after a code change.
+- Cross-reference a TAVA threat (`T-<NAME>-N`) or FSR (`FSR_FD_NN`) to the relevant view section.
+- Add a new FSR contract seam under `flashdreams/tests/security/` (planned) and wire it into the canonical FSR sheet here.
+- Form a defensible opinion on the design before signing off the TAVA against MVSB-32946.
+
+This skill is the FlashDreams-scoped subset of the broader omni-dreams + flashdreams skill at `omni-dreams/docs/arch/SKILL.md` and its reviewer companion `omni-dreams/docs/arch/review/SKILL.md`. The broader skill remains the source of truth when a change crosses the omni-dreams / flashdreams boundary (e.g. the interactive-drive sample, the post-training stack).
+
+## TOE shape (one-paragraph mental model)
+
+The FlashDreams TOE is the runtime process tree that loads a recipe (`cosmos`, `taehv`, `template`, `wan`, plus integration-registered slugs such as `wan21-*`, `lingbot_world`, `alpadreams`) into memory via `flashdreams-run`, fetches weights from HuggingFace or S3 through `FD-CKPT`, builds a `Pipeline = DiT + encoder + VAE/TAE`, and either runs to completion (offline generation) or enters a serving loop (lingbot WebRTC `:8089`; alpadreams gRPC; profiling server). FlashDreams ships **no canonical pre-published container image**: operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` (OE-7 narrows the supply-chain threat correspondingly). There is **no NVIDIA-side ingress, egress, or storage of operator data** — this is the central architectural invariant the TAVA preserves.
+
+## Inputs the skill assumes are already in place
+
+- [`architecture.md`](architecture.md) — four-view architecture for the FlashDreams TOE.
+- [`sadd.md`](sadd.md) — Software Architecture and Design Document per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL`.
+- [`tava.md`](tava.md) — FlashDreams-scoped TAVA 2.0 (MVSB-32946 subset).
+- [`fsr_table.md`](fsr_table.md) — canonical FSR sheet in the **Excel-Based Simple TAVA Template** column structure.
+- Security test seams (planned): `flashdreams/tests/security/` (mirrors the omni-dreams `internal/tests/security/` package one-to-one).
+
+## Quick workflows
+
+### 1. Update an architecture view to reflect a code change
+
+```bash
+# Find which view section to edit
+grep -nE '^##|^###' docs/arch/architecture.md | head -20
+
+# After editing, propagate any renamed identifiers to:
+#   docs/arch/architecture.md § "Naming index"
+#   docs/arch/sadd.md § 3.2.2 (Interface table)
+#   docs/arch/tava.md § 1.6 (Asset table) + § 3.2 (FSR responsibility column)
+#   docs/arch/fsr_table.md (canonical sheet)
+```
+
+### 2. Add a new FSR contract seam (planned home: `flashdreams/tests/security/`)
+
+```bash
+# 1. Define the Protocol / stub in flashdreams/tests/security/<topic>.py
+#    (mirror the structure used in omni-dreams/internal/tests/security/<topic>.py)
+# 2. Write positive + negative tests in flashdreams/tests/security/test_<topic>.py
+# 3. Run the suite (CPU-only, no GPU weights):
+uv run pytest flashdreams/tests/security/ -v
+# 4. Add a row to fsr_table.md keyed by FSR_FD_NN, then update tava.md § 3.2.
+# 5. Commit with subject: "test(security): FSR_FD_NN <topic>"
+```
+
+### 3. Sanity-check mermaid syntax before committing
+
+Mermaid 10.7.0 (the user's preview) is strict. Quote labels containing any of `< > / : { } " — · …`. The most common pitfalls:
+
+| Hazard | Fix |
+|---|---|
+| `<digit` in a label | Replace with `under`, `≤`, or spell-out |
+| `[/text]` without closing `/` | Quote as `Node["/text"]` |
+| `[/path/with/slashes/]` | Use `Node["path with slashes"]` |
+| `{a,b,c}` in a class member or edge label | Plain text without braces |
+| `--` em-dash in subgraph label | Quote: `subgraph X["label — with dash"]` |
+
+Quick scan for hazards inside the mermaid code blocks of `architecture.md`:
+
+```bash
+awk '/^```mermaid/{in_mm=1} /^```$/{in_mm=0} in_mm' docs/arch/architecture.md \
+  | grep -nE '<[0-9]|\[/[^]"]*[^/"]\]|^\s*[A-Za-z_]+\.[A-Za-z_]+\s*-->'
+```
+
+## Cross-reference invariants (the **4-C** self-review)
+
+When you change anything in `architecture.md`, check the following five places stay consistent:
+
+1. **Consistent** — component names, interface names, trust-boundary labels match across all four views, the SADD interface table, and the TAVA asset table.
+2. **Correct** — diagrams reflect code as of HEAD; cite file paths inline so reviewers can verify.
+3. **Complete** — all TAVA v3 required sections present (Intro, TOE, Architecture Diagram, DFD, Security Assets, Attacker Model, Threats, Risk Analysis, Security Objectives, FSRs, POA&M).
+4. **Concise** — no prose where a diagram suffices; no diagram where a table suffices.
+
+(Fifth implicit C: **Codified** — every H-or-higher threat has a P0 FSR with a planned product-side wiring OR an as-built contract+stub test.)
+
+## Operating-environment assumptions (do not silently weaken)
+
+Documented in [`tava.md`](tava.md) § 1.3:
+
+- **OE-1** — operator-trusted hardware; the Docker `--network=host --ipc=host` invocation collapses container/host trust.
+- **OE-2** — Slurm cluster admin enforces tenant isolation (out of scope for flashdreams TOE; relevant for the omni-dreams post-training consumer).
+- **OE-3** — operator credentials least-privilege + revocable + not in git.
+- **OE-4** — host kernel + driver patched.
+- **OE-5** — Cosmos-Guardrail weights from `nvidia/Cosmos-1.0-Guardrail` or NVIDIA mirror.
+- **OE-6** — operator network may block `huggingface.co`; weights pre-stage required.
+- **OE-7** — FlashDreams ships **no canonical pre-published container image**: operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` (per commit `ab74b58`). Any operator-built image lives under the operator's own registry / access controls; supply-chain trust delegates upward to the upstream `nvidia/cuda` base image.
+
+## Where things live (FlashDreams scope)
+
+| Concern | Where |
+|---|---|
+| Architecture diagrams (four views) | [`architecture.md`](architecture.md) |
+| SADD (PLC-L1 template) | [`sadd.md`](sadd.md) |
+| TAVA report (FlashDreams subset of MVSB-32946) | [`tava.md`](tava.md) |
+| Canonical FSR sheet (Excel-style columns) | [`fsr_table.md`](fsr_table.md) |
+| Upstream skill (omni-dreams + flashdreams) | `../../../omni-dreams/docs/arch/SKILL.md` |
+| Upstream review skill | `../../../omni-dreams/docs/arch/review/SKILL.md` |
+| Upstream canonical TAVA + asset inventory | `../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md` |
+| Upstream FSR contract+stub tests | `../../../omni-dreams/internal/tests/security/` |
+| Planned FlashDreams security tests | `flashdreams/tests/security/` (mirror, to be landed) |
+
+## Do not
+
+- Do not edit `architecture.md` and forget to update the cross-reference sites above.
+- Do not weaken the architectural invariants asserted in `internal/tests/security/*.py` upstream (e.g. "no inference SHALL run on a rejected verdict"; "untrusted factory MUST NOT be called during refusal"; "loader_fn SHALL NOT be invoked on checksum mismatch") when you mirror them here.
+- Do not approve a control without first articulating the threat it closes (`tava.md` § 2.3).
+- Do not treat OE-1..OE-7 as code-enforced — they are delegations to operator / cluster admin / NVIDIA-internal ACL.
+- Do not fabricate test counts. Test/Measurement cells in [`fsr_table.md`](fsr_table.md) cite the as-built upstream test file when applicable; if no test exists for an FSR yet, say so explicitly.

--- a/docs/arch/SKILL.md
+++ b/docs/arch/SKILL.md
@@ -119,5 +119,5 @@ Documented in [`tava.md`](tava.md) § 1.3:
 - Do not edit `architecture.md` and forget to update the cross-reference sites above.
 - Do not weaken the architectural invariants asserted in `internal/tests/security/*.py` upstream (e.g. "no inference SHALL run on a rejected verdict"; "untrusted factory MUST NOT be called during refusal"; "loader_fn SHALL NOT be invoked on checksum mismatch") when you mirror them here.
 - Do not approve a control without first articulating the threat it closes (`tava.md` § 2.3).
-- Do not treat OE-1..OE-7 as code-enforced — they are delegations to operator / cluster admin / NVIDIA-internal ACL.
+- Do not treat OE-1..OE-7 as code-enforced — they are delegations to operator / cluster admin / upstream registry.
 - Do not fabricate test counts. Test/Measurement cells in [`fsr_table.md`](fsr_table.md) cite the as-built upstream test file when applicable; if no test exists for an FSR yet, say so explicitly.

--- a/docs/arch/architecture.md
+++ b/docs/arch/architecture.md
@@ -54,7 +54,7 @@ flowchart LR
     FD_INT_LING -.weights.-> HF
     FD_REC -.weights.-> HF
     FD_REC -.optional internal storage.-> S3
-    FD_CORE -.operator-built container · docker/Dockerfile.-> CUDA_BASE
+    CUDA_BASE -.docker build · docker/Dockerfile.-> FD_CORE
 ```
 
 **Key facts:**
@@ -177,7 +177,7 @@ flowchart LR
     ALPA_PROTO -.generate stubs.-> GRPC_CLIENT
 ```
 
-> **Trust boundary preview:** Both adapters expose a **local-server** surface (loopback by default once FSR_FD_10 lands; documented `--host 0.0.0.0` in lingbot README today). See [Data view](#data-view).
+> **Trust boundary preview:** Both adapters expose a **local-server** surface. Today both default to `--host 0.0.0.0` (lingbot per README; alpadreams gRPC via `add_insecure_port`). FSR_FD_10 flips the default to loopback. See [Data view](#data-view).
 
 ### 4. Naming index
 
@@ -621,10 +621,10 @@ flowchart TB
 
 | Component | Default bind (today) | Default port | Auth | Encryption | Recommended target |
 |---|---|---|---|---|---|
-| LING-RTC (HTTP signaling) | `0.0.0.0` per README | `8089` | none | none | **127.0.0.1** (FSR_FD_10); TLS (FSR_FD_01) + token (FSR_FD_12) when public |
+| LING-RTC (HTTP signaling) | `0.0.0.0` (`integrations/lingbot/lingbot/webrtc/server.py:66`) | `8089` | none | none | **127.0.0.1** (FSR_FD_10); TLS (FSR_FD_01) + token (FSR_FD_12) when public |
 | LING-RTC (WebRTC media) | dynamic UDP | ephemeral | DTLS-SRTP (aiortc) | yes | OK as-is |
-| ALPA-GRPC | configurable | configurable | none in dev | none in dev | **127.0.0.1** (FSR_FD_10); mTLS + token interceptor (FSR_FD_12) |
-| ALPA-PROF (profiling) | configurable | configurable | none in dev | none in dev | **127.0.0.1** (FSR_FD_11); separate opt-in from main server |
+| ALPA-GRPC | `0.0.0.0` (`integrations/alpadreams/alpadreams/grpc/server.py:1336`); uses `add_insecure_port` | configurable | none | none | **127.0.0.1** (FSR_FD_10); mTLS + token interceptor (FSR_FD_12) |
+| ALPA-PROF (profiling) | configurable | configurable | none | none | **127.0.0.1** (FSR_FD_11); separate opt-in from main server |
 | torch.distributed | depends on launcher | depends | none | none | trust cluster network only; no public exposure |
 | HF / S3 / upstream `nvidia/cuda` registry | outbound | 443 | token / sigv4 | TLS | OK |
 

--- a/docs/arch/architecture.md
+++ b/docs/arch/architecture.md
@@ -5,29 +5,15 @@ SPDX-License-Identifier: Apache-2.0
 
 # Architecture — FlashDreams
 
-Compact, FlashDreams-scoped four-view architecture (static / dynamic / data / deployment) for the `flashdreams` repo. The broader omni-dreams + flashdreams architecture lives in [`../../../omni-dreams/docs/arch/architecture.md`](../../../omni-dreams/docs/arch/architecture.md); this document carries the **TOE = flashdreams** subset that the TAVA in [`tava.md`](tava.md) and the SADD in [`sadd.md`](sadd.md) reference.
+Compact, FlashDreams-scoped four-view architecture (static / dynamic / data / deployment) for the `flashdreams` repo. The broader omni-dreams + flashdreams architecture lives in [`../../../omni-dreams/docs/arch/architecture.md`](../../../omni-dreams/docs/arch/architecture.md); this document is the **TOE = flashdreams** subset that the [`sadd.md`](sadd.md), [`tava.md`](tava.md), and [`fsr_table.md`](fsr_table.md) reference.
 
-## As-built vs. recommended
+Diagram-marker convention used throughout:
 
-| Marker in diagram | Meaning |
+| Marker | Meaning |
 |---|---|
-| Unannotated node / edge | **As-built** on HEAD (`flashdreams/`, `integrations/`) |
-| Node / edge marked **(FSR_FD_NN)** | **TAVA-recommended** — contract+stub upstream at `../../../omni-dreams/internal/tests/security/<topic>.py`; product-side wiring planned in flashdreams |
-| OE-1..OE-7 callouts | **Operational-environment assumption** — not enforced by the TOE |
-
-> **Companion documents**
-> - [`sadd.md`](sadd.md) — Software Architecture and Design Document per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL`.
-> - [`tava.md`](tava.md) — FlashDreams-scoped TAVA 2.0 (MVSB-32946 subset).
-> - [`fsr_table.md`](fsr_table.md) — canonical FSR sheet in the Excel-Based Simple TAVA Template column structure.
-
----
-
-## Contents
-
-- [Static view](#static-view) — components, classes, integration adapters
-- [Dynamic view](#dynamic-view) — lingbot WebRTC, alpadreams gRPC, offline recipes, checkpoint resolution
-- [Data view](#data-view) — DFDs with trust boundaries
-- [Deployment view](#deployment-view) — single-node serving, container layering, network exposure
+| Unannotated node / edge | As-built on HEAD |
+| Node / edge marked **(FSR_FD_NN)** | TAVA-recommended; contract+stub upstream at `../../../omni-dreams/internal/tests/security/<topic>.py` |
+| OE-1..OE-7 callouts | Operational-environment assumption; not enforced by the TOE |
 
 ---
 

--- a/docs/arch/architecture.md
+++ b/docs/arch/architecture.md
@@ -1,0 +1,645 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture — FlashDreams
+
+Compact, FlashDreams-scoped four-view architecture (static / dynamic / data / deployment) for the `flashdreams` repo. The broader omni-dreams + flashdreams architecture lives in [`../../../omni-dreams/docs/arch/architecture.md`](../../../omni-dreams/docs/arch/architecture.md); this document carries the **TOE = flashdreams** subset that the TAVA in [`tava.md`](tava.md) and the SADD in [`sadd.md`](sadd.md) reference.
+
+## As-built vs. recommended
+
+| Marker in diagram | Meaning |
+|---|---|
+| Unannotated node / edge | **As-built** on HEAD (`flashdreams/`, `integrations/`) |
+| Node / edge marked **(FSR_FD_NN)** | **TAVA-recommended** — contract+stub upstream at `../../../omni-dreams/internal/tests/security/<topic>.py`; product-side wiring planned in flashdreams |
+| OE-1..OE-7 callouts | **Operational-environment assumption** — not enforced by the TOE |
+
+> **Companion documents**
+> - [`sadd.md`](sadd.md) — Software Architecture and Design Document per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL`.
+> - [`tava.md`](tava.md) — FlashDreams-scoped TAVA 2.0 (MVSB-32946 subset).
+> - [`fsr_table.md`](fsr_table.md) — canonical FSR sheet in the Excel-Based Simple TAVA Template column structure.
+
+---
+
+## Contents
+
+- [Static view](#static-view) — components, classes, integration adapters
+- [Dynamic view](#dynamic-view) — lingbot WebRTC, alpadreams gRPC, offline recipes, checkpoint resolution
+- [Data view](#data-view) — DFDs with trust boundaries
+- [Deployment view](#deployment-view) — single-node serving, container layering, network exposure
+
+---
+
+## Static view
+
+### 1. System
+
+```mermaid
+flowchart LR
+    classDef pkg fill:#eef,stroke:#447
+    classDef ext fill:#ffe,stroke:#a82,stroke-dasharray: 3 3
+    classDef adapter fill:#efe,stroke:#272
+
+    subgraph FD[flashdreams repo]
+        FD_CORE[flashdreams.core attention · distributed · checkpoint · io]:::pkg
+        FD_INFRA[flashdreams.infra pipeline · diffusion · encoder · decoder · runner]:::pkg
+        FD_REC[flashdreams.recipes cosmos · taehv · template · wan]:::pkg
+        FD_PLUG[flashdreams.plugins registry · discovery]:::pkg
+        FD_CLI[flashdreams.scripts.cli  console: flashdreams-run]:::pkg
+        FD_INT_ALPA[integrations alpadreams · ludus-renderer]:::adapter
+        FD_INT_LING[integrations lingbot]:::adapter
+        FD_INT_OTHERS[integrations cosmos_predict2 · wan21 · self_forcing · causal_forcing · fastvideo_causal_wan22]:::adapter
+    end
+
+    HF[(HuggingFace nvidia/omni-dreams-* · nvidia/Cosmos-1.0-Guardrail)]:::ext
+    S3[(S3 s3 flashdreams pdx.s8k.io)]:::ext
+    CUDA_BASE[(nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04 upstream base image)]:::ext
+
+    FD_CLI --> FD_PLUG
+    FD_PLUG --> FD_REC
+    FD_INT_ALPA -->|registers runner_name slug| FD_PLUG
+    FD_INT_LING -->|registers runner_name slug| FD_PLUG
+    FD_INT_OTHERS -->|registers runner_name slugs| FD_PLUG
+    FD_REC --> FD_INFRA
+    FD_REC --> FD_CORE
+    FD_INFRA --> FD_CORE
+    FD_INT_ALPA -.weights.-> HF
+    FD_INT_LING -.weights.-> HF
+    FD_REC -.weights.-> HF
+    FD_REC -.optional internal storage.-> S3
+    FD_CORE -.operator-built container · docker/Dockerfile.-> CUDA_BASE
+```
+
+**Key facts:**
+- Single console script `flashdreams-run` declared at `flashdreams/pyproject.toml`; entrypoint at `flashdreams/flashdreams/scripts/cli.py`.
+- Recipes registered via Python entry-points; integrations register additional slugs via the same registry (`flashdreams/flashdreams/plugins/registry.py`).
+- Integration adapters live under `integrations/` as separately-installable workspace packages.
+- FlashDreams publishes **no canonical container image**: operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` (commit `ab74b58`); CI runs against the upstream CUDA image directly with inline `apt-get` bootstrap.
+
+### 2. flashdreams package / class structure
+
+```mermaid
+classDiagram
+    direction LR
+
+    class FlashdreamsRunCLI {
+        +entrypoint()
+        -registry: RunnerRegistry
+        -dispatch(slug)
+    }
+
+    class RunnerRegistry {
+        +register(slug, RunnerCls)
+        +discover_plugins()
+        +get(slug) Runner
+    }
+
+    class Runner {
+        <<abstract>>
+        +local_rank: int
+        +world_size: int
+        +is_rank_zero: bool
+        +run()
+        #init_distributed()
+        #pin_device()
+    }
+
+    class Pipeline {
+        <<abstract>>
+        +diffusion_model
+        +encoder
+        +decoder
+        +generate(prompt, conditioning) Frames
+    }
+
+    class DiTTransformer {
+        <<abstract>>
+        +len_t
+        +chunk_size
+        +context_parallel_size
+        +forward(x, t, ctx) x_out
+    }
+
+    class VAEEncoderDecoder {
+        <<abstract>>
+        +encode(rgb) latents
+        +decode(latents) rgb
+    }
+
+    class CheckpointLoader {
+        +load(uri) state_dict
+        -resolve_uri(uri)
+        -verify_integrity()?
+    }
+
+    class DistributedManager {
+        +init(world_size)
+        +local_rank()
+    }
+
+    FlashdreamsRunCLI --> RunnerRegistry
+    RunnerRegistry --> Runner
+    Runner --> Pipeline
+    Pipeline --> DiTTransformer
+    Pipeline --> VAEEncoderDecoder
+    Pipeline --> CheckpointLoader
+    Runner --> DistributedManager
+```
+
+> **Path cites** — `flashdreams/flashdreams/{recipes,core,infra,plugins,scripts}/`. The `Runner` abstract class lives in `flashdreams/flashdreams/infra/runner.py`; `Pipeline` in `flashdreams/flashdreams/infra/pipeline/`; `CheckpointLoader` in `flashdreams/flashdreams/core/checkpoint/`.
+
+### 3. Integration adapters
+
+Each integration is a workspace package that *wraps* a flashdreams recipe with an over-the-network or pluggable serving surface.
+
+```mermaid
+flowchart LR
+    classDef adapter fill:#efe,stroke:#272
+    classDef recipe fill:#eef,stroke:#447
+    classDef ext fill:#ffe,stroke:#a82
+
+    subgraph ALPA["integrations/alpadreams"]
+        ALPA_GRPC["alpadreams/grpc/server.py · session_recorder · recording_io · profiling_server"]:::adapter
+        ALPA_COND["alpadreams/conditioning · renderer"]:::adapter
+        ALPA_PROTO["grpc/protos/*.proto · compile_protos.sh"]:::adapter
+        LUDUS["ludus-renderer (HD-map rasterizer)"]:::adapter
+    end
+
+    subgraph LING["integrations/lingbot"]
+        LING_SERVER["lingbot/webrtc/server.py  GET /request_session  POST /api/webrtc/offer"]:::adapter
+        LING_SESSION["lingbot/webrtc/session.py"]:::adapter
+        LING_MEDIA["lingbot/webrtc/media.py"]:::adapter
+        LING_CTRL["lingbot/webrtc/controls.py  DataChannel actions {keydown, keyup, step}"]:::adapter
+    end
+
+    REC_ALPA["AlpadreamsRunner (registered slug)"]:::recipe
+    REC_LING["LingbotWorldRunner (registered slug)"]:::recipe
+
+    BROWSER[("Browser viewer")]:::ext
+    GRPC_CLIENT[("gRPC client")]:::ext
+
+    BROWSER <-->|"WebRTC SDP · DataChannel · video track"| LING_SERVER
+    LING_SERVER --> LING_SESSION --> REC_LING
+    LING_CTRL --> REC_LING
+
+    GRPC_CLIENT <-->|"gRPC unary + streaming"| ALPA_GRPC
+    ALPA_GRPC --> REC_ALPA
+    ALPA_COND --> REC_ALPA
+    LUDUS -->|"HD-map raster"| ALPA_COND
+    ALPA_PROTO -.generate stubs.-> ALPA_GRPC
+    ALPA_PROTO -.generate stubs.-> GRPC_CLIENT
+```
+
+> **Trust boundary preview:** Both adapters expose a **local-server** surface (loopback by default once FSR_FD_10 lands; documented `--host 0.0.0.0` in lingbot README today). See [Data view](#data-view).
+
+### 4. Naming index
+
+| Short name | Long name | Where it lives |
+|---|---|---|
+| **FD-RUN** | `flashdreams-run` console entry | `flashdreams/pyproject.toml` → `flashdreams/flashdreams/scripts/cli.py` |
+| **FD-REG** | Runner / plugin registry | `flashdreams/flashdreams/plugins/registry.py` |
+| **FD-CKPT** | CheckpointLoader | `flashdreams/flashdreams/core/checkpoint/` |
+| **FD-CORE** | `flashdreams.core.distributed` (torch.dist init) | `flashdreams/flashdreams/core/distributed/` |
+| **FD-INFRA** | Pipeline / Runner base + diffusion / encoder / decoder | `flashdreams/flashdreams/infra/` |
+| **FD-COSMOS** | Cosmos DiT recipe | `flashdreams/flashdreams/recipes/cosmos/` |
+| **FD-WAN** | Wan recipe (t2v / i2v) | `flashdreams/flashdreams/recipes/wan/` |
+| **FD-TAEHV** | TAEHV recipe | `flashdreams/flashdreams/recipes/taehv/` |
+| **ALPA-GRPC** | Alpadreams gRPC server | `integrations/alpadreams/alpadreams/grpc/server.py` |
+| **ALPA-PROF** | Alpadreams profiling server | `integrations/alpadreams/alpadreams/grpc/profiling_server.py` |
+| **LING-RTC** | Lingbot WebRTC server | `integrations/lingbot/lingbot/webrtc/server.py` |
+| **LUDUS** | Ludus HD-map rasterizer | `integrations/alpadreams/ludus-renderer/` |
+
+This naming is used consistently in the dynamic, data, and deployment views.
+
+---
+
+## Dynamic view
+
+### 1. Offline generation — `flashdreams-run <slug>` (CLI cold-path)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Operator
+    participant CLI as FD-RUN (flashdreams-run)
+    participant REG as FD-REG (RunnerRegistry)
+    participant RUN as Runner (recipe-specific)
+    participant CKPT as FD-CKPT
+    participant HF as HF / S3 store
+    participant PIPE as Pipeline (DiT + enc + dec)
+
+    Operator->>CLI: flashdreams-run wan21-t2v-1.3b-480p --prompt "..."
+    CLI->>REG: discover_plugins() + get("wan21-t2v-1.3b-480p")
+    REG-->>CLI: RunnerCls
+    CLI->>RUN: instantiate(config)
+    RUN->>RUN: init_distributed() · pin_device()
+    RUN->>CKPT: load(model_uri)
+    CKPT->>HF: GET checkpoint (token-auth)
+    HF-->>CKPT: state_dict (.pt / .safetensors)
+    Note over CKPT: verify_integrity()?  ← FSR_FD_04 (gap today)
+    CKPT-->>RUN: weights pinned to cuda
+    RUN->>PIPE: build(transformer, encoder, decoder)
+    RUN->>PIPE: generate(prompt, conditioning)
+    PIPE-->>RUN: frames
+    RUN-->>Operator: video file (rank-zero I/O)
+```
+
+### 2. lingbot WebRTC interactive session
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Operator as Operator (browser)
+    participant LING_RTC as LING-RTC (aiohttp + aiortc)
+    participant LING_SESS as LingbotSession
+    participant LR as LingbotWorldRunner
+    participant Gate as Input content gate  (FSR_FD_06)
+
+    Operator->>LING_RTC: GET /request_session
+    LING_RTC-->>Operator: viewer page (HTML/CSS/JS)
+    Operator->>LING_RTC: POST /api/webrtc/offer (SDP offer)
+    LING_RTC->>LING_SESS: new session (only 1 active)
+    opt initial RGB conditioning
+        LING_SESS->>Gate: classify(initial_rgb)
+        Gate-->>LING_SESS: ok | REJECT (FSR_FD_06)
+        Note right of Gate: on REJECT: tear down session, no inference
+    end
+    LING_SESS-->>LING_RTC: SDP answer
+    LING_RTC-->>Operator: SDP answer
+    Note over Operator,LING_SESS: ICE handshake (STUN/TURN if configured)
+
+    loop interactive
+        Operator->>LING_SESS: DataChannel action ({keydown|keyup|step}, key ≤256 B)
+        Note right of LING_SESS: schema validate (FSR_FD_13); drop on miss
+        LING_SESS->>LR: enqueue(action)
+        LR->>LR: AR inference chunk
+        LR-->>LING_SESS: chunk frames
+        LING_SESS-->>Operator: video track (RTP)
+        LING_SESS-->>Operator: DataChannel "chunk_done"
+    end
+```
+
+> Runtime + model preload happens before request handling (`integrations/lingbot/lingbot/webrtc/server.py`). Single active WebRTC session per server process.
+
+### 3. alpadreams gRPC inference + optional session recording
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as gRPC Client (replay_client / external)
+    participant Server as ALPA-GRPC (grpc.aio.Server)
+    participant Auth as Token interceptor  (FSR_FD_12)
+    participant Gate as Input content gate  (FSR_FD_06)
+    participant PIPE as AlpadreamsPipeline
+    participant Rec as session_recorder
+    participant Disk as recording_io (.pt / .json)
+
+    Client->>Server: InitializeSession(request)
+    Server->>Auth: validate Authorization: Bearer …
+    Auth-->>Server: ok | REJECT (FSR_FD_12)
+    Server->>Gate: classify(first frame / scene)
+    Gate-->>Server: ok | REJECT (FSR_FD_06)
+    Server-->>Client: session_id (high-entropy)
+
+    loop streamed
+        Client->>Server: Step(action, hdmap_chunk)
+        Server->>PIPE: generate(chunk)
+        PIPE-->>Server: frames
+        opt --record enabled
+            Server->>Rec: record(action, frames)
+            Rec->>Disk: append (mode 0600, under HOME)
+        end
+        Server-->>Client: frames (stream)
+    end
+
+    Client->>Server: CloseSession(session_id)
+    Server->>PIPE: clear_and_zero session state  (FSR_FD_18)
+    Server->>Rec: flush()
+    Server-->>Client: ok
+```
+
+### 4. Checkpoint resolution / fallback
+
+```mermaid
+stateDiagram-v2
+    state "Resolve URI" as ResolveURI
+    state "Check FLASHDREAMS_INTERNAL_STORAGE env" as CheckEnvFlag
+    state "S3 path" as S3Path
+    state "Reject (non internal-storage user)" as Reject
+    state "HF route" as HFRoute
+    state "Check OMNI_DREAMS_HF_ORG against allowlist (FSR_FD_08)" as CheckOrg
+    state "nvidia-omni-dreams-lha (internal mirror)" as LHA
+    state "nvidia (default)" as DefaultOrg
+    state "Fetch" as Fetch
+    state "Verify integrity (FSR_FD_04 today gap)" as VerifyIntegrity
+    state "Load state_dict" as LoadStateDict
+
+    [*] --> ResolveURI
+    ResolveURI --> CheckEnvFlag : URI starts with s3
+    CheckEnvFlag --> S3Path : env set
+    CheckEnvFlag --> Reject : env unset
+    ResolveURI --> HFRoute : URI starts with hf
+    HFRoute --> CheckOrg : env or CLI flag set
+    CheckOrg --> LHA : hf-org equals nvidia-omni-dreams-lha
+    CheckOrg --> DefaultOrg : unset / default
+    LHA --> Fetch
+    DefaultOrg --> Fetch
+    S3Path --> Fetch
+    Fetch --> VerifyIntegrity
+    VerifyIntegrity --> LoadStateDict : ok
+    VerifyIntegrity --> Reject : mismatch
+    LoadStateDict --> [*]
+    Reject --> [*]
+```
+
+> **Threat hook for TAVA**: today the `Fetch → VerifyIntegrity` arrow is **dashed in code** — there is no in-process signature/SHA check beyond HTTPS-level transport auth and HF/S3 ACLs. Promoting this to a code-level check is **FSR_FD_04** (see [`fsr_table.md`](fsr_table.md)).
+
+### 5. Distributed init (cross-cutting)
+
+```mermaid
+stateDiagram-v2
+    state "torchrun spawn" as TorchrunSpawn
+    state "Runner __init__" as RunnerInit
+    state "Init process group  (backend nccl)" as InitProcessGroup
+    state "Pin device cuda LOCAL_RANK" as PinDevice
+    state "Derive CP size from WORLD group" as DeriveCP
+    state "Run recipe" as RunRecipe
+    state "Rank-zero I/O (mp4, stats.json, logs)" as RankZeroIO
+
+    [*] --> TorchrunSpawn
+    TorchrunSpawn --> RunnerInit
+    RunnerInit --> InitProcessGroup
+    InitProcessGroup --> PinDevice
+    PinDevice --> DeriveCP
+    DeriveCP --> RunRecipe
+    RunRecipe --> RankZeroIO : is_rank_zero gate
+    RankZeroIO --> [*]
+```
+
+---
+
+## Data view
+
+DFD legend: **Process** = rounded box; **Data store** = cylinder; **External entity** = square; **Dataflow** = labelled arrow; **Trust boundary** = dotted region; crossings are where STRIDE threats land.
+
+### 1. Level-0 — FlashDreams as one TOE
+
+```mermaid
+flowchart LR
+    classDef proc fill:#dfd,stroke:#272,rx:10,ry:10
+    classDef ds fill:#eef,stroke:#447
+    classDef ext fill:#ffe,stroke:#a82
+    classDef filt fill:#fcd,stroke:#a44,stroke-dasharray:4 2
+
+    Op[Operator]:::ext
+    HF[(HuggingFace)]:::ds
+    S3[(S3 s3 flashdreams)]:::ds
+    CUDA[(nvidia/cuda upstream base image · OE-7)]:::ds
+
+    Gate[Input content gate  Cosmos-Guardrail pre-Guard  FSR_FD_06]:::filt
+    Infer[Inference / world model  FD-COSMOS · FD-WAN · FD-TAEHV · adapters]:::proc
+    Anon[Output anonymizer  Cosmos-Guardrail post-Guard  FSR_FD_07]:::filt
+    Serve[Serving  LING-RTC · ALPA-GRPC · CLI]:::proc
+
+    Logs[(Local logs / metrics)]:::ds
+    Ckpt[(Local ckpt cache)]:::ds
+
+    subgraph TB1[Trust boundary — operator workstation]
+        Gate
+        Infer
+        Anon
+        Serve
+        Logs
+        Ckpt
+    end
+
+    Op -->|prompt · WebRTC SDP · gRPC requests · keystrokes| Serve
+    Op -->|--synthetic-initial-rgb image · scene path| Gate
+    Gate -->|cleared init frame · hdmap| Infer
+    Gate -.reject.-> Op
+    HF -->|weights · scenes| Ckpt
+    S3 -->|weights| Ckpt
+    CUDA -.operator-built image · docker/Dockerfile.-> Infer
+    Ckpt --> Infer
+    Infer --> Anon
+    Anon --> Serve
+    Serve -->|video frames · status| Op
+    Serve --> Logs
+    Infer --> Logs
+```
+
+> **Architecturally** the TOE is a self-contained workstation process tree; there is **no NVIDIA-side ingress / egress / storage** of operator-generated data (architectural invariant restated from MVSB-32946 ticket comment).
+
+#### Filter staging — input vs. output asymmetry
+
+| Stage | When it runs | Cost | Default |
+|---|---|---|---|
+| Input content gate (FSR_FD_06) — **Cosmos-Guardrail pre-Guard, image side** | One-shot at session init / scene load | One model invocation, ≤200 ms on a single GPU; reject → session never starts | **on** when Cosmos-Guardrail weights are present |
+| Output anonymizer (FSR_FD_07) — **Cosmos-Guardrail post-Guard (RetinaFace + plate + blur)** | Per chunk post-VAE — every ~900 ms steady-state | Few-step network designed for this; ≤50 ms / chunk budget on a co-resident GPU slot | **off** by default; opt-in via `--anonymize` |
+
+### 2. Level-1 — lingbot WebRTC server
+
+```mermaid
+flowchart LR
+    classDef proc fill:#dfd,stroke:#272,rx:10,ry:10
+    classDef ext fill:#ffe,stroke:#a82
+    classDef ds fill:#eef,stroke:#447
+    classDef filt fill:#fcd,stroke:#a44,stroke-dasharray:4 2
+
+    Browser["Operator browser"]:::ext
+    Static[("HTML CSS JS viewer assets on disk")]:::ds
+
+    HTTP["HTTP routes: GET /request_session  POST /api/webrtc/offer"]:::proc
+    AuthHTTP["Token check (FSR_FD_12; required if non-loopback bind)"]:::filt
+    Session["Single active WebRTC session (aiortc PeerConnection)"]:::proc
+    DataCh["DataChannel handler: keydown · keyup · step  (FSR_FD_13 schema)"]:::proc
+    Gate["Input content gate  (FSR_FD_06)"]:::filt
+    Lingbot["LingbotPipeline AR inference"]:::proc
+    Anon["Output anonymizer  (FSR_FD_07)"]:::filt
+    Track["Video track / RTP encoder"]:::proc
+
+    subgraph TB_NET["Trust boundary — LAN / public internet if host=0.0.0.0"]
+        Browser
+    end
+    subgraph TB_SERVER["Trust boundary — flashdreams server process"]
+        HTTP
+        AuthHTTP
+        Session
+        DataCh
+        Gate
+        Lingbot
+        Anon
+        Track
+        Static
+    end
+
+    Browser -->|"TLS (FSR_FD_01) · SDP offer"| HTTP
+    HTTP --> AuthHTTP --> Session
+    HTTP --> Static
+    Static -->|"viewer page"| Browser
+    Session <-->|"ICE / DTLS / SRTP"| Browser
+    Browser -->|"DataChannel action"| Session
+    Session --> DataCh
+    DataCh -->|"action ∈ {keydown,keyup,step}"| Lingbot
+    Lingbot -->|"frames"| Anon
+    Anon --> Track
+    Track -->|"video RTP"| Browser
+    Session -->|"chunk_done DataChannel"| Browser
+
+    Browser -.optional init frame.-> Gate
+    Gate --> Lingbot
+    Gate -.reject.-> Session
+```
+
+> **Risk hot-spots:**
+> - **Single active session**: simplifies STRIDE-D analysis but is a DoS pinhole (T-DOS-1).
+> - **`--host 0.0.0.0`**: documented default in the README; binds publicly on any non-loopback interface (T-NET-1).
+> - **DataChannel actions are JSON**: validate types and keys server-side (FSR_FD_13).
+
+### 3. Level-1 — alpadreams gRPC server
+
+```mermaid
+flowchart LR
+    classDef proc fill:#dfd,stroke:#272,rx:10,ry:10
+    classDef ext fill:#ffe,stroke:#a82
+    classDef ds fill:#eef,stroke:#447
+    classDef filt fill:#fcd,stroke:#a44,stroke-dasharray:4 2
+
+    Client[gRPC client]:::ext
+
+    Server["grpc.aio.Server  protos: alpadreams/grpc/protos/*.proto"]:::proc
+    AuthG["Token interceptor (FSR_FD_12)"]:::filt
+    Cond["ConditioningWrapper · renderer · hdmap"]:::proc
+    Gate["Input content gate (FSR_FD_06)"]:::filt
+    Alpa["AlpadreamsPipeline"]:::proc
+    Rec["session_recorder"]:::proc
+    Recordings[("recording_io .pt / .json  (FSR_FD_21: 0600 + opt-in)")]:::ds
+    Prof["profiling_server  (FSR_FD_11: loopback default)"]:::proc
+    Anon["Output anonymizer (FSR_FD_07)"]:::filt
+    Stream["server-streaming response"]:::proc
+
+    LudusRenderer["Ludus HD-map renderer"]:::proc
+
+    subgraph TB_CLIENT["Trust boundary — gRPC client side"]
+        Client
+    end
+    subgraph TB_SERVER["Trust boundary — alpadreams server process"]
+        Server
+        AuthG
+        Cond
+        Gate
+        LudusRenderer
+        Alpa
+        Rec
+        Recordings
+        Prof
+        Anon
+        Stream
+    end
+
+    Client -->|"InitializeSession · Step · Close (TLS: FSR_FD_01)"| Server
+    Server --> AuthG --> Cond
+    Cond --> LudusRenderer
+    LudusRenderer --> Cond
+    Cond --> Gate
+    Gate --> Alpa
+    Gate -.reject.-> Server
+    Alpa --> Anon
+    Anon --> Stream
+    Stream -->|"frame stream"| Client
+    Alpa --> Rec
+    Rec --> Recordings
+    Server --> Prof
+```
+
+### 4. Data classification (per dataflow)
+
+| Dataflow | Direction | Classification | Notes |
+|---|---|---|---|
+| Operator prompt / keystroke | Op → Pipeline | **Operator-confidential** (synthetic / non-PII by default) | Don't log raw inputs above DEBUG (FSR_FD_02, FSR_FD_03) |
+| Initial RGB frame | Op → Pipeline | **Possibly PII** (faces / plates if real photo) | FSR_FD_06 input gate |
+| HD-map raster | Op → Pipeline | Public (synthetic) | |
+| Generated video frames | Pipeline → Op | **Possibly PII** (model may emit identifiable faces / plates) | FSR_FD_07 output anonymizer; FSR_FD_19 per-session routing |
+| Checkpoint weights | HF / S3 → Process | **NVIDIA proprietary** until license-class flips at GA | Integrity check FSR_FD_04 |
+| Container image | upstream `nvidia/cuda` → operator build → Host | **Operator-owned** (FlashDreams ships no canonical image; OE-7) | Trust delegates upward to the `nvidia/cuda` base image; operator-side build is the new tamper surface |
+| Logs / metrics | Process → Disk | Operator-confidential | Scrubbing on export only |
+| Session recording (.pt) | Process → Disk | **Operator-confidential** | Off by default (FSR_FD_21) |
+| S3 credentials file | Disk → Process | **Secret** | `credentials/s3_checkpoint.secret` — chmod 600, never committed |
+
+---
+
+## Deployment view
+
+### 1. Single-node multi-GPU (lingbot WebRTC / alpadreams gRPC)
+
+```mermaid
+flowchart TB
+    classDef cont fill:#eef,stroke:#447
+    classDef gpu fill:#ffe,stroke:#a82
+
+    Host["Workstation / DGX node"]
+    Browser["Browser viewer / gRPC client"]
+
+    subgraph Cont["Operator-built container (docker/Dockerfile · nvidia/cuda:13.2.1 base · OE-7)"]
+        Launcher["torchrun --nproc_per_node=N"]:::cont
+        R0["Rank 0 · cuda:0  (terminates serving listener)"]:::cont
+        R1["Rank 1 · cuda:1"]:::cont
+        R2["Rank 2 · cuda:2"]:::cont
+        R3["Rank 3 · cuda:3"]:::cont
+        Server["LING-RTC :8089  OR  ALPA-GRPC :PORT"]:::cont
+    end
+
+    subgraph GPUs["N × GPU"]
+        G0["GPU 0"]:::gpu
+        G1["GPU 1"]:::gpu
+        G2["GPU 2"]:::gpu
+        G3["GPU 3"]:::gpu
+    end
+
+    Host --> Cont
+    Launcher --> R0
+    Launcher --> R1
+    Launcher --> R2
+    Launcher --> R3
+    R0 --> G0
+    R1 --> G1
+    R2 --> G2
+    R3 --> G3
+    R0 ---|"NCCL WORLD group"| R1
+    R1 ---|"NCCL"| R2
+    R2 ---|"NCCL"| R3
+    R0 --> Server
+    Server <-->|"WebRTC OR gRPC (TLS: FSR_FD_01)"| Browser
+```
+
+> Only **rank 0** terminates the WebRTC / gRPC connection (rank-zero I/O invariant). Other ranks do compute; they have no exposed listener.
+
+### 2. Container layering
+
+```mermaid
+flowchart TB
+    classDef img fill:#eef,stroke:#447
+    classDef layer fill:#fff,stroke:#999
+
+    Base["nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04 (upstream)"]:::img
+    Build["docker/Dockerfile  apt: py3.12 + ffmpeg + libnccl-dev + uv + AWS CLI v2"]:::layer
+    Local["operator-built image  (operator's registry / local daemon)"]:::img
+
+    Base --> Build --> Local
+```
+
+> FlashDreams publishes **no canonical container image** (commit `ab74b58`). The Dockerfile lives at `docker/Dockerfile`; operators run `docker build` (or `docker/build_with_docker.sh <registry>/<tag>`) to produce an image under their own registry / access controls. Sigstore signing (formerly FSR_FD_05) is therefore an **operator guidance** item rather than a FlashDreams-side enforcement (see [`fsr_table.md`](fsr_table.md) FSR_FD_05).
+
+### 3. Network exposure summary (for the TAVA)
+
+| Component | Default bind (today) | Default port | Auth | Encryption | Recommended target |
+|---|---|---|---|---|---|
+| LING-RTC (HTTP signaling) | `0.0.0.0` per README | `8089` | none | none | **127.0.0.1** (FSR_FD_10); TLS (FSR_FD_01) + token (FSR_FD_12) when public |
+| LING-RTC (WebRTC media) | dynamic UDP | ephemeral | DTLS-SRTP (aiortc) | yes | OK as-is |
+| ALPA-GRPC | configurable | configurable | none in dev | none in dev | **127.0.0.1** (FSR_FD_10); mTLS + token interceptor (FSR_FD_12) |
+| ALPA-PROF (profiling) | configurable | configurable | none in dev | none in dev | **127.0.0.1** (FSR_FD_11); separate opt-in from main server |
+| torch.distributed | depends on launcher | depends | none | none | trust cluster network only; no public exposure |
+| HF / S3 / upstream `nvidia/cuda` registry | outbound | 443 | token / sigv4 | TLS | OK |
+
+> The `0.0.0.0` default binds are an audit hot-spot — see threat T-NET-1 in [`tava.md`](tava.md) § 2.3.

--- a/docs/arch/fsr_table.md
+++ b/docs/arch/fsr_table.md
@@ -373,18 +373,17 @@ Every row uses the column structure the user supplied:
 
 ### FSR_FD_22 — Trust-collapse docs (OE-1)
 
-- **Functional Security Requirement.** The FlashDreams + omni-dreams README docker-run sections SHALL document the trust-collapse caused by `--network=host` + `--ipc=host` + Wayland-socket mount + SSH-agent forward (OE-1), and SHALL provide a narrower default invocation for non-interactive batch / inference-server runs.
+- **Functional Security Requirement.** Documentation of the FlashDreams TOE and its omni-dreams consumer SHALL flag the trust-collapse caused by `--network=host` + `--ipc=host` + Wayland-socket mount + SSH-agent forward (OE-1). The FlashDreams README + `docs/security/SECURITY.md` SHALL note that the FlashDreams `docker run` flow does NOT require those flags; the upstream omni-dreams interactive-drive README SHALL carry the trust-collapse callout where those flags are still documented.
 - **Risk Level.** Moderate.
 - **Risk Response.** Share.
 - **Responsibility.** Documentation + SIL Engineering.
 - **Priority Level.** P1.
 - **Test / Measurement.**
   - SQA Test Steps:
-    1. Inspect FlashDreams `README.md` → confirm GitHub-flavored `[!IMPORTANT]` callout naming `--network=host`, `--ipc=host`, Wayland socket, SSH-agent forward, citing FSR_FD_22 / OE-1.
-    2. Confirm cross-link to `docs/security/SECURITY.md` (or upstream `omni-dreams/docs/security/SECURITY.md`) for the operator checklist.
-    3. Confirm the narrower non-interactive invocation snippet appears in the README.
-  - PASS: doc review confirms the callout and the narrower snippet.
-  - FAIL: callout missing or trust-collapse not mentioned.
+    1. Confirm `docs/security/SECURITY.md` carries a "container-flag hygiene" section that names `--network=host`, `--ipc=host`, Wayland socket, SSH-agent forward and links to OE-1.
+    2. Confirm `omni-dreams/samples/interactive-drive/README.md` carries the `[!IMPORTANT]` callout citing FSR_FD_22 / OE-1 (upstream invariant).
+  - PASS: both doc sections present.
+  - FAIL: callout missing in either location.
 
 ### FSR_FD_23 — Slurm IMEX banner + collision check
 
@@ -444,7 +443,7 @@ The user-supplied NIM TAVA template enumerates `FSR_<TOE>_01..36`. Slots 25–36
 | Status | Count | FSRs |
 |---|---|---|
 | ✅ As-built contract+stub tests passing upstream (mirror to FlashDreams planned) | 20 | FSR_FD_01, _02, _03, _04, _06, _08, _09, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _23 |
-| 📄 Documented control landed (no test seam needed) | 1 | FSR_FD_22 |
+| 📄 Documented control (no test seam needed) | 1 | FSR_FD_22 (trust-collapse callout) |
 | ⏳ Externally blocked or operator-side | 3 | FSR_FD_05 (operator guidance — FlashDreams ships no canonical image), FSR_FD_07 (Cosmos-Guardrail real backend — HF egress), FSR_FD_24 (OSS-Fuzz post-GA) |
 | 🔁 Mapped onto an existing FSR_FD_NN | 9 | FSR_FD_25, _27, _28, _29, _30, _31, _32, _33, _36 |
 | 🚫 Avoided by FlashDreams TOE architecture invariant | 3 | FSR_FD_26 (no managed SLA), FSR_FD_34, FSR_FD_35 (no Triton in TOE) |

--- a/docs/arch/fsr_table.md
+++ b/docs/arch/fsr_table.md
@@ -1,0 +1,465 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# FlashDreams FSR table — Excel-Based Simple TAVA Template
+
+**Canonical Functional Security Requirement (FSR) sheet for the FlashDreams TOE**, in the column structure used by the NIM TAVA template that the user supplied for MVSB-32946:
+
+`FSR ID | Functional Security Requirement | Risk Level | Risk Response | Responsibility | Priority Level | Test / Measurement`
+
+Companion to:
+
+- [`architecture.md`](architecture.md) — four-view FlashDreams architecture
+- [`sadd.md`](sadd.md) — Software Architecture and Design Document
+- [`tava.md`](tava.md) — TAVA narrative (assets, threats, risk, objectives, POA&M)
+
+Conventions:
+
+- FSR IDs prefixed `FSR_FD_NN` (FD = FlashDreams). The leading 24 rows mirror the canonical upstream omni-dreams + flashdreams sheet at [`../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md`](../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md) §3.2.1.
+- The user-supplied NIM template enumerated 36 FSR slots (`FSR_<TOE>_01..36`). FSR slots `FSR_FD_25..36` cover NIM-template areas (e.g. mandatory-AuthN/AuthZ, scaling, non-prod parity, request-scope memory) that map to existing `FSR_FD_*` SHALL-statements or are out-of-scope for the FlashDreams TOE (no NVIDIA-side ingress / egress / storage; no NGC publishing pipeline; no NIM API surface). For each, the **Risk Response** column captures the mapping (Map / Transfer / Avoid / Accept).
+- Risk-level enum: Very Low / Low / Moderate / High / Very High.
+- Risk-response enum: Remediate / Transfer / Share / Avoid / Accept (extended with **Map** to indicate this row maps onto an existing FSR_FD_NN).
+- Priority enum: P0 (Must Implement) / P1 (Will not block GA if not implemented) / R2 (research / recommended post-GA).
+
+---
+
+## FSR ID column structure (per row)
+
+Every row uses the column structure the user supplied:
+
+> **Functional Security Requirement** — Detailed security requirement decomposed from the high-level security objectives; provides the development team rationale and actionable direction on what priority countermeasures need to be considered in the architecture and design.
+> **Risk Level** — Calculated risk level associated with the risk that the FSR mitigates (Very Low / Low / Moderate / High / Very High), drawn from [`tava.md`](tava.md) § 2.4.2.
+> **Risk Response** — Risk response associated with the risk that the FSR mitigates (Remediate / Transfer / Share / Avoid / Accept / Map).
+> **Responsibility** — Team / org / element responsible for implementing the FSR.
+> **Priority Level** — P0 (Must Implement) / P1 (Will not block if not implemented) / R2.
+> **Test / Measurement** — Whether the FSR is testable by SQA, and the test steps that verify it.
+
+---
+
+## Canonical FSR sheet
+
+### FSR_FD_01 — TLS on non-loopback endpoints
+
+- **Functional Security Requirement.** All non-loopback access to FlashDreams server endpoints (LING-RTC HTTP signaling, ALPA-GRPC, ALPA-PROF) SHALL be encrypted with TLS 1.2 or better when bound non-loopback, and SHALL meet the specifications in the prodsec wiki. Where available, prefer profiles such as `ELBSecurityPolicy-TLS-1-2-2017-01` for AWS-fronted deployments. WebRTC media SHALL continue to use DTLS-SRTP (aiortc default — equivalent to TLS for media). Loopback-only deployments MAY skip TLS per operator policy.
+- **Risk Level.** High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Serving (flashdreams `integrations/alpadreams/alpadreams/grpc/server.py`, `integrations/lingbot/lingbot/webrtc/server.py`).
+- **Priority Level.** P0 (non-loopback) / P1 (loopback).
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Pre-stage TLS profile config (`modern`, `compat`, or `mtls`).
+    2. Start LING-RTC + ALPA-GRPC with `--allow-public-bind` and the configured TLS profile.
+    3. Run `pytest internal/tests/security/test_tls_profile.py -v` (upstream — to be mirrored into `flashdreams/tests/security/test_tls_profile.py`).
+  - PASS: `modern` returns TLS 1.3; `compat` returns TLS 1.2 with AEAD-only ciphers (no RC4 / 3DES / CBC-SHA1); `mtls` requires client cert; loopback-skip allowed. `tls10` / `tls11` / `sslv3` / `weak` / `any` and unknown profiles explicitly refused. Sweep test asserts every defined profile meets the TLS-1.2 floor.
+  - FAIL: any non-loopback endpoint accepts an unencrypted or TLS < 1.2 connection.
+  - Pentest: `nmap --script ssl-enum-ciphers -p <port>` against a public-bound LING-RTC reports no TLS 1.0 / 1.1 / SSLv3 acceptance.
+
+### FSR_FD_02 — Logs SHALL strip secrets
+
+- **Functional Security Requirement.** Service log data stored locally or transmitted remotely SHALL NOT contain NVIDIA confidential data such as personal and enterprise secrets, API keys, cryptographic keys, or authentication tokens (`HF_TOKEN`, `GITHUB_PAT`, AWS access / secret keys, bearer tokens, full `Authorization` headers).
+- **Risk Level.** High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Logging (`flashdreams/flashdreams/core/io/`).
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Configure FlashDreams with a fake `HF_TOKEN` (e.g. `hf_…`), a synthetic GitHub PAT (`ghp_…`), and an AWS access-key pair.
+    2. Run `flashdreams-run <slug>` and exercise representative code paths (CLI offline run; lingbot session; gRPC `InitializeSession → Step → Close`).
+    3. Run `pytest internal/tests/security/test_log_redactor.py -v` (upstream — 11 secrets-redaction tests + the `logging.Filter` end-to-end test) against the production log writer.
+  - PASS: 11 / 11 redaction cases; the `logging.Filter` end-to-end test confirms secret bytes never reach the sink. As-built upstream on station 2026-05-15: 11 / 11 ✅.
+  - FAIL: any pattern reaches the sink unredacted.
+  - Pentest: grep the on-disk log files for `hf_`, `ghp_`, `AKIA`, `Bearer ` — no matches.
+
+### FSR_FD_03 — Logs SHALL strip PII
+
+- **Functional Security Requirement.** Service log data (excluding log fields that contain customer-supplied data clearly labelled as such) SHALL NOT contain personally identifiable information such as real-person face crops extracted from generated frames, license-plate strings extracted from frames, NVIDIA-internal emails, Slack handles, or operator network identifiers beyond what is needed for a single debug session.
+- **Risk Level.** Moderate.
+- **Risk Response.** Share (FlashDreams logging filter + operator's own scrubbing on export).
+- **Responsibility.** SIL Engineering — Logging + Operator.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Configure FlashDreams with sample PII payloads in prompts and frames (synthetic faces / plates).
+    2. Run representative paths.
+    3. Run `pytest internal/tests/security/test_log_redactor.py -v` — 11 PII tests on top of the 11 FSR_FD_02 secrets tests.
+  - PASS: positive coverage for NVIDIA email (incl. regional `nvidia-<region>.com`), ALPR plate shapes (`ABC123`, `123ABC`, `ABC-1234`), Slack user / channel / DM IDs; anti-bypass for "external-domain emails MUST NOT be silently scrubbed" and "all-caps words like CHECKPOINT MUST NOT match the Slack-ID regex". Upstream on station 2026-05-15: 22 / 22 in the combined redactor file ✅.
+  - FAIL: any PII pattern reaches the sink unredacted.
+
+### FSR_FD_04 — Checkpoint integrity before `torch.load`
+
+- **Functional Security Requirement.** Model checkpoints loaded by `FD-CKPT` SHALL be verified against a trusted manifest (SHA-256 today, Sigstore signature once FSR_FD_05 lands) **before** invoking `torch.load`. Prefer `safetensors` for new internal artifacts. Parties downloading published checkpoints SHALL have the ability to verify integrity and authenticity via signature verification (in the OSS flow, the manifest + signature ship alongside the weight files).
+- **Risk Level.** Very High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Pipeline (`flashdreams/flashdreams/core/checkpoint/`).
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Pre-stage a checkpoint + manifest pair (`weights.safetensors` + `manifest.json` with sha256).
+    2. Run `flashdreams-run <slug>` and verify load succeeds.
+    3. Tamper with a single byte in `weights.safetensors` (`dd if=/dev/urandom of=weights.safetensors bs=1 count=1 conv=notrunc seek=1024`).
+    4. Re-run; verify the loader rejects the checkpoint BEFORE `torch.load`.
+    5. Run `pytest internal/tests/security/test_checkpoint_verifier.py -v` (upstream).
+  - PASS: 9 / 9, including the single-byte-tamper assertion that `loader_fn.invocations == []` on every failure mode (mismatch, missing-manifest, missing-file, wrong-path-type, `/proc` TOCTOU). Upstream on station 2026-05-15: 9 / 9 ✅.
+  - FAIL: tampered checkpoint is loaded into memory.
+
+### FSR_FD_05 — Operator-side container-image signing guidance
+
+- **Functional Security Requirement.** FlashDreams ships **no canonical pre-published container image** (per commit `ab74b58`); operators build locally from `docker/Dockerfile`. When an operator publishes a FlashDreams container to their own registry, the build/publish pipeline SHOULD Sigstore-sign the image and the documented `docker pull` flow SHOULD `cosign verify` the signature before the image is allowed to start. The FlashDreams `docs/security/SECURITY.md` SHALL carry this guidance.
+- **Risk Level.** Low (downgraded from High once OE-7 / commit `ab74b58` removed the canonical image — see [`tava.md`](tava.md) § 2.4.2 T-IMG-1).
+- **Risk Response.** Share (operator-side build, FlashDreams documentation).
+- **Responsibility.** Documentation + SIL Engineering (with the operator).
+- **Priority Level.** P2 (operator guidance).
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Confirm `docs/security/SECURITY.md` carries a "container-image signing" section recommending `cosign sign` at publish time and `cosign verify` at pull time.
+    2. (Operator-side, illustrative only — not part of FlashDreams CI:) `cosign verify <operator-registry>/flashdreams:<tag>` → expect success on a signed image; non-zero on a tampered or unsigned image.
+  - PASS: doc section present; operator-side verification command documented.
+  - FAIL: no doc section, or the doc fails to mention the upstream `nvidia/cuda` base image as the trust root.
+
+### FSR_FD_06 — Input content gate at session init
+
+- **Functional Security Requirement.** The session SHALL run **Cosmos-1.0-Guardrail pre-Guard** (image side, sourced from `imaginaire/auxiliary/guardrail/video_content_safety_filter/`) on the initial RGB frame (`--synthetic-initial-rgb`, scene first frame, WebRTC `request_session` first frame) once per session. On hit, the session SHALL be rejected with a documented error code; **no inference runs**.
+- **Risk Level.** Very High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Safety + Security PIC.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Pre-stage `nvidia/Cosmos-1.0-Guardrail` weights (OE-5; pre-staged per OE-6).
+    2. Start LING-RTC; submit a synthetic CSAM / gore probe image as the initial RGB.
+    3. Verify the session is rejected with the documented error code; verify no inference call is made (`pipeline.invocations == 0`).
+    4. Run `pytest internal/tests/security/test_input_content_gate.py -v` (upstream).
+  - PASS: 5 / 5; the negative case asserts `pipeline.invocations == 0` on reject. Upstream on station 2026-05-15: 5 / 5 stub ✅; real backend pending [`cosmos_guardrail_benchmark.md`](../../../omni-dreams/internal/docs/planning/cosmos_guardrail_benchmark.md).
+  - FAIL: a probe image classified by the gate as unsafe still results in pipeline invocation.
+
+### FSR_FD_07 — Output anonymizer (opt-in `--anonymize`)
+
+- **Functional Security Requirement.** When `--anonymize` is set, the session SHALL run **Cosmos-1.0-Guardrail post-Guard** (RetinaFace + plate detect + Gaussian blur, sourced from `imaginaire/auxiliary/guardrail/face_blur_filter/`) on every generated chunk, blurring detected face and license-plate regions. Steady-state overhead SHALL be ≤50 ms / chunk.
+- **Risk Level.** High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Pipeline + Privacy.
+- **Priority Level.** P1 (1.0) / P0 (post-GA if regulator scope shifts).
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Pre-stage Cosmos-Guardrail weights.
+    2. Run with `--anonymize` against a frame containing a synthetic face → output frame has face region blurred above SSIM threshold.
+    3. Repeat with a plate region.
+    4. Measure per-chunk overhead → assert ≤50 ms median on reference HW.
+  - PASS: blur SSIM threshold met on face + plate; overhead ≤50 ms median; opt-out path leaves frames unmodified.
+  - FAIL: face / plate visible above threshold, or overhead exceeds 50 ms median. Latency-budget validation pending [`cosmos_guardrail_benchmark.md`](../../../omni-dreams/internal/docs/planning/cosmos_guardrail_benchmark.md).
+
+### FSR_FD_08 — HF-org allowlist
+
+- **Functional Security Requirement.** `OMNI_DREAMS_HF_ORG` SHALL be validated against a code-resident allowlist `{nvidia, nvidia-omni-dreams-lha}` (default: `nvidia`, per `integrations/alpadreams/alpadreams/hf.py:DEFAULT_OMNI_DREAMS_HF_ORG`). Unknown values SHALL be rejected at config parse, BEFORE any HF resolver runs. (There is no `--hf-org` CLI flag today — the env-var is the single configuration surface; if a flag is added later, the same validation SHALL apply.)
+- **Risk Level.** High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Adapter HF resolver (`integrations/alpadreams/alpadreams/hf.py`) and any other recipe / adapter consuming the env-var.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Set `OMNI_DREAMS_HF_ORG=attacker-controlled-org` and run `flashdreams-run <slug>` → expect immediate reject at config parse, no HF resolver invocation.
+    2. Set `OMNI_DREAMS_HF_ORG=NVIDIA-OMNI-DREAMS-LHA` (case smuggling) → expect reject unless the allowlist is explicitly case-insensitive (and the doc says so).
+    3. Run the existing `integrations/alpadreams/tests/test_internal_storage.py` and the upstream `pytest internal/tests/security/test_hf_org_allowlist.py -v`.
+  - PASS: 9 / 9 upstream; typo-squat rejection. Default `nvidia` accepted; `nvidia-omni-dreams-lha` accepted; everything else rejected.
+  - FAIL: an unknown org reaches the HF resolver.
+
+### FSR_FD_09 — Plugin registry default-deny
+
+- **Functional Security Requirement.** The FlashDreams runner registry SHALL refuse to register a third-party plugin whose origin module is not in the `FLASHDREAMS_TRUSTED_PLUGINS` allowlist, unless `--allow-untrusted-plugins` is passed. A plugin attempting to register a slug that an in-tree runner already owns SHALL be rejected unconditionally.
+- **Risk Level.** Very High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Recipe Registry (`flashdreams/flashdreams/plugins/registry.py`).
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Install a synthetic out-of-tree plugin that exposes a `flashdreams.runners` entry-point claiming an unknown slug.
+    2. Run `flashdreams-run --help` → expect plugin NOT registered; factory NOT called.
+    3. Install a plugin that claims an in-tree slug (`wan21-t2v-1.3b-480p`) → expect unconditional reject.
+    4. Run `pytest internal/tests/security/test_plugin_registry.py -v` (upstream).
+  - PASS: 11 / 11, including the invariant `untrusted_factory.calls == 0` during refusal and the in-tree-slug-shadow-rejection assertion. Upstream on station 2026-05-15: 11 / 11 ✅.
+  - FAIL: an untrusted plugin is imported by `flashdreams-run`.
+
+### FSR_FD_10 — Default-loopback bind
+
+- **Functional Security Requirement.** All FlashDreams network listeners (LING-RTC, ALPA-GRPC, ALPA-PROF) SHALL default to `127.0.0.1`. Any non-loopback bind (wildcard OR specific routable IP) SHALL require an explicit `allow_public_bind=True` / `--allow-public-bind` opt-in and SHALL emit a warning banner naming the co-requisite FSR_FD_01 (TLS) and FSR_FD_12 (auth).
+- **Risk Level.** High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Serving.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Start LING-RTC and ALPA-GRPC with default flags; verify `ss -ltn` shows binding to `127.0.0.1` only.
+    2. Pass `--host 0.0.0.0` without `--allow-public-bind` → expect refusal at startup.
+    3. Pass `--allow-public-bind` → expect bind succeeds and stderr emits the FSR_FD_10 warning banner.
+    4. Pass `--host 10.0.0.5` (specific routable) without opt-in → expect refusal.
+    5. Run `pytest internal/tests/security/test_bind_address.py -v` (upstream).
+  - PASS: 12 / 12, including the anti-bypass "specific routable IP without opt-in is refused". Upstream on station 2026-05-15: 12 / 12 ✅.
+  - FAIL: any listener binds non-loopback without opt-in.
+
+### FSR_FD_11 — Profiling server bind loopback by default
+
+- **Functional Security Requirement.** The alpadreams profiling server SHALL bind loopback by default; non-loopback exposure SHALL require a separate explicit flag (`--allow-public-profiling`) distinct from the main server's `--host`.
+- **Risk Level.** Moderate.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Serving (`integrations/alpadreams/alpadreams/grpc/profiling_server.py`).
+- **Priority Level.** P1.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Start ALPA-GRPC with `--allow-public-bind` (FSR_FD_10) but no profiling-specific opt-in; verify profiling server still binds loopback.
+    2. Pass `--allow-public-profiling` → expect non-loopback bind + the profiling-specific banner naming FSR_FD_11.
+    3. Run `pytest internal/tests/security/test_profiling_bind.py -v` (upstream).
+  - PASS: 8 / 8, including the architectural anti-bypass test asserting the profiling endpoint MUST NOT follow the main listener without its own opt-in. Upstream on station 2026-05-15: 8 / 8 ✅.
+  - FAIL: profiling server binds non-loopback without its own opt-in.
+
+### FSR_FD_12 — Token interceptor (mandatory non-loopback)
+
+- **Functional Security Requirement.** The alpadreams gRPC server and the lingbot signaling HTTP endpoint SHALL support a token interceptor that authenticates every call. Interceptor SHALL be mandatory when the listener is bound non-loopback (FSR_FD_10 opt-in).
+- **Risk Level.** Very High.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Serving.
+- **Priority Level.** P0 (non-loopback) / P1 (loopback).
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Configure ALPA-GRPC with a bearer-token allowlist.
+    2. Call `InitializeSession` without an `Authorization` header → expect refusal; verify `handler.calls == 0`.
+    3. Repeat with wrong token, lowercase header, multiple Authorization headers (smuggling), constant-time partial prefix.
+    4. Run `pytest internal/tests/security/test_auth_interceptor.py -v` (upstream).
+  - PASS: 12 / 12. Golden bearer path succeeds; every failure mode asserts `handler.calls == 0`. Upstream on station 2026-05-15: 12 / 12 ✅.
+  - FAIL: any unauthorized request reaches the handler.
+
+### FSR_FD_13 — DataChannel schema validation
+
+- **Functional Security Requirement.** The lingbot DataChannel SHALL validate each message as `{action ∈ {keydown, keyup, step}, key? ∈ {w, a, s, d, space, shift, ctrl}}` with payload ≤256 bytes. Messages outside this schema SHALL be dropped silently without disturbing the active session.
+- **Risk Level.** Moderate.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Serving (`integrations/lingbot/lingbot/webrtc/session.py`).
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Send well-formed actions; verify enqueue.
+    2. Send malformed JSON, oversized payloads, unknown action / key fields; verify silent drop and the session remains active.
+    3. Run `pytest internal/tests/security/test_datachannel_validator.py -v` (upstream).
+  - PASS: 15 / 15, including the 11-case adversarial sweep that asserts the validator never raises. Upstream on station 2026-05-15: 15 / 15 ✅.
+  - FAIL: a malformed payload crashes the session or reaches the runner.
+
+### FSR_FD_14 — Text input validation
+
+- **Functional Security Requirement.** All text inputs to FlashDreams APIs (`--prompt`, recipe CLI text fields, gRPC `Step` prompt) SHALL be length-bounded (≤4096 chars default), Unicode-validated (reject the `U+E0020..U+E007F` "tag" range and other non-printables), and parameter-typed before being passed to `text_encoder`.
+- **Risk Level.** Low.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Pipeline.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Send a prompt with a tag-char (e.g. `U+E0041` inside or appended), a Trojan-Source bidi-override, a lone surrogate, ZWJ flood (>16), null / bell / DEL controls, oversize (>4096) → each rejected.
+    2. Send legitimate multilingual text, emoji-ZWJ, tab / newline / CR → accepted.
+    3. Run `pytest internal/tests/security/test_text_input_validator.py -v` (upstream).
+  - PASS: 17 / 17. Every reject asserts `encoder.calls == 0`; adversarial-sweep test asserts the validator never raises. Upstream on station 2026-05-15: 17 / 17 ✅.
+  - FAIL: any invalid input reaches the encoder.
+
+### FSR_FD_15 — Media-file input validation
+
+- **Functional Security Requirement.** All media-file inputs (JPEG / PNG initial RGB, mp4 reference clips, USDZ scenes when consumed via downstream samples) SHALL be size-bounded (≤512 MiB default), MIME-validated, magic-byte-validated, and rejected on parse failure BEFORE any downstream rendering or inference. Reject array-batched media inputs above 16 elements (`MAX_BATCH_SIZE`).
+- **Risk Level.** Moderate.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — CLI + adapter input layers.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Submit valid JPEG / PNG / mp4 (with matching `ftyp`) / USDZ → accepted.
+    2. Submit oversize, empty, unknown-extension, smuggled magic (`.jpg` with PNG bytes), non-`ftyp` mp4, directory, nonexistent path → each rejected.
+    3. Submit a batch of 17 → expect whole-batch reject.
+    4. Run `pytest internal/tests/security/test_media_file_validator.py -v` (upstream).
+  - PASS: 18 / 18. Every reject asserts `parser.calls == 0`. Upstream on station 2026-05-15: 18 / 18 ✅.
+  - FAIL: an invalid media file reaches the parser.
+
+### FSR_FD_16 — Media-parsing sandbox
+
+- **Functional Security Requirement.** Media-parsing libraries used by FlashDreams adapters (and any image / video decoders called by `--synthetic-initial-rgb`) SHALL be sandboxed (subprocess with seccomp filter or equivalent) to limit syscalls and memory access from a malicious media file.
+- **Risk Level.** Moderate.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Adapter input layer.
+- **Priority Level.** P1 (1.0) / P0 (post-GA).
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Confirm parsing runs in a `multiprocessing.Process` (spawn context) with `PR_SET_NO_NEW_PRIVS=1` via ctypes/prctl.
+    2. Submit an input that causes the parser to raise; verify `SandboxFailure(reason=child-raised:...)`; verify parent globals unaffected.
+    3. Submit an input that hangs; verify killed at `timeout=0.5s`.
+    4. Run `pytest internal/tests/security/test_parser_sandbox.py -v` (upstream).
+  - PASS: 9 / 9. Linux-only assertion: child's `/proc/self/status` reports `NoNewPrivs: 1`. Upstream on station 2026-05-15: 9 / 9 ✅.
+  - FAIL: a parser crash propagates to the parent, or a hang exceeds the timeout.
+
+### FSR_FD_17 — Media-parser format restriction
+
+- **Functional Security Requirement.** The media-parsing library SHALL be restricted to the relevant format (JPEG / PNG for `--synthetic-initial-rgb`; mp4 for reference clips); other formats SHALL be rejected at the format-dispatch layer, not deeper in a generic parser.
+- **Risk Level.** Moderate.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Adapter input layer.
+- **Priority Level.** P1.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Submit a JPEG to the synthetic-initial-rgb dispatch → accepted.
+    2. Submit an mp4 to the synthetic-initial-rgb dispatch → expect refusal at dispatch (parser MUST NOT be called even though it's registered — anti-bypass).
+    3. Run `pytest internal/tests/security/test_format_dispatch.py -v` (upstream).
+  - PASS: 9 / 9; full audit-context in exception. Upstream on station 2026-05-15: 9 / 9 ✅.
+  - FAIL: a non-permitted format reaches the parser.
+
+### FSR_FD_18 — Session state deallocation + GPU zero
+
+- **Functional Security Requirement.** FlashDreams SHALL NOT persist inference request inputs (prompts, init frames, intermediate latents) in memory or on disk beyond the active session scope. On session close (WebRTC tear-down, gRPC `CloseSession`, CLI exit), all per-session tensors and buffers SHALL be deallocated and the GPU memory zeroed before another session is accepted.
+- **Risk Level.** Moderate.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Pipeline.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Open session A; submit prompt + frames; close.
+    2. Open session B; assert no residual bytes from A reach B (aliased-reference test).
+    3. Attempt to reuse a non-empty session state object → expect `SessionLifecycleError`.
+    4. Run `pytest internal/tests/security/test_session_state.py -v` (upstream).
+  - PASS: 11 / 11. Bytearrays AND latent buffers zeroed in place BEFORE truncation; two-session round-trip carries 0 bytes. Upstream on station 2026-05-15: 11 / 11 ✅.
+  - FAIL: any bytes from A observable in B.
+
+### FSR_FD_19 — Per-session response routing
+
+- **Functional Security Requirement.** FlashDreams SHALL restrict disclosure of inference responses (RTP video track, gRPC Step response, generated mp4) to the session that submitted the originating request. The single-active-session invariant in lingbot is the architectural enforcement; alpadreams gRPC SHALL enforce via session_id correlation.
+- **Risk Level.** Moderate.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Serving.
+- **Priority Level.** P0.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Open multiple gRPC sessions; verify each session's sink receives only its own frames.
+    2. Attempt to address a sink with another session's `session_id` → expect `UnknownSession`; verify `target_sink.received == []`.
+    3. Close a session; attempt to route to it → expect refusal.
+    4. Run `pytest internal/tests/security/test_session_router.py -v` (upstream).
+  - PASS: 10 / 10. `new_session_id()` is high-entropy (1000 unique). Upstream on station 2026-05-15: 10 / 10 ✅.
+  - FAIL: a frame for session A reaches session B's sink.
+
+### FSR_FD_20 — Per-client rate limits
+
+- **Functional Security Requirement.** FlashDreams server endpoints (LING-RTC signaling, ALPA-GRPC) SHALL apply per-client rate limits: ≤10 SDP offers / minute / source IP for lingbot; ≤60 Step calls / minute / session_id for ALPA-GRPC. Rate-limit violations SHALL log and drop, not crash. (Maps to NIM API4:2023 Unrestricted Resource Consumption.)
+- **Risk Level.** Low.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Serving.
+- **Priority Level.** P1.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Burst 11 SDP offers / minute / source → 11th and beyond denied.
+    2. Idle bucket for 5 minutes; verify capacity does not extend by idle (no accrual attack).
+    3. Independent buckets per client key; clock-rollback does not credit tokens.
+    4. Run `pytest internal/tests/security/test_rate_limiter.py -v` (upstream).
+  - PASS: 13 / 13 on a token-bucket with injectable monotonic clock (hermetic, no `sleep`). Upstream on station 2026-05-15: 13 / 13 ✅.
+  - FAIL: a burst over capacity is accepted.
+
+### FSR_FD_21 — Recording mode 0600 + opt-in
+
+- **Functional Security Requirement.** The alpadreams `session_recorder` SHALL write recording files (`.pt`, `.json`) with mode `0600` and to a path under the operator's home directory only. Recording SHALL be **off** by default; enabling requires an explicit `--record` flag whose use is logged.
+- **Risk Level.** Low.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — gRPC.
+- **Priority Level.** P1.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Start ALPA-GRPC without `--record`; submit `InitializeSession → Step → Close`; verify no `.pt` or `.json` on disk.
+    2. Start with `--record /tmp/outside-home` → expect refusal.
+    3. Start with `--record $HOME/sessions/`; submit a session → verify resulting files at mode `0o600`.
+    4. Place an existing `.pt` with mode `0o666` at the target path; start with `--record`; verify recorder refuses to overwrite (TOCTOU defense).
+    5. Run `pytest internal/tests/security/test_recording_perms.py -v` (upstream).
+  - PASS: 8 / 8. Upstream on station 2026-05-15: 8 / 8 ✅.
+  - FAIL: a recording file lands with wider mode than `0o600`.
+
+### FSR_FD_22 — Trust-collapse docs (OE-1)
+
+- **Functional Security Requirement.** The FlashDreams + omni-dreams README docker-run sections SHALL document the trust-collapse caused by `--network=host` + `--ipc=host` + Wayland-socket mount + SSH-agent forward (OE-1), and SHALL provide a narrower default invocation for non-interactive batch / inference-server runs.
+- **Risk Level.** Moderate.
+- **Risk Response.** Share.
+- **Responsibility.** Documentation + SIL Engineering.
+- **Priority Level.** P1.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Inspect FlashDreams `README.md` → confirm GitHub-flavored `[!IMPORTANT]` callout naming `--network=host`, `--ipc=host`, Wayland socket, SSH-agent forward, citing FSR_FD_22 / OE-1.
+    2. Confirm cross-link to `docs/security/SECURITY.md` (or upstream `omni-dreams/docs/security/SECURITY.md`) for the operator checklist.
+    3. Confirm the narrower non-interactive invocation snippet appears in the README.
+  - PASS: doc review confirms the callout and the narrower snippet.
+  - FAIL: callout missing or trust-collapse not mentioned.
+
+### FSR_FD_23 — Slurm IMEX banner + collision check
+
+- **Functional Security Requirement.** The Slurm launch helper for `post-training` (omni-dreams consumer of FlashDreams) SHALL emit a banner reminding the operator of OE-2 (tenant-isolation assumption) and SHALL refuse to start if it detects an obviously shared IMEX channel name pattern.
+- **Risk Level.** Moderate.
+- **Risk Response.** Share.
+- **Responsibility.** Cluster Operations + SIL Engineering (`omni-dreams` repo).
+- **Priority Level.** P1.
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Launch with a unique channel name → accepted; banner references OE-2 + FSR_FD_23 + "cluster administrator".
+    2. Launch with forbidden names (`default`, `imex`, `test`, `demo`, `shared`, `channel`, `ipp`, `pub`, `public`) → refused.
+    3. Active-peer collision (case-insensitive) → refused.
+    4. Run `pytest internal/tests/security/test_slurm_imex.py -v` (upstream).
+  - PASS: 12 / 12. Upstream on station 2026-05-15: 12 / 12 ✅.
+  - FAIL: a colliding channel name reaches the launcher.
+
+### FSR_FD_24 — Continuous fuzz coverage
+
+- **Functional Security Requirement.** Continuous fuzz coverage SHALL include the alpadreams protobuf decoders and any media-parse surface exposed by FlashDreams adapters. Findings shall be reported via PSIRT and fed back into FSR_FD_15 / FSR_FD_16 / FSR_FD_17 bounds.
+- **Risk Level.** Low.
+- **Risk Response.** Remediate.
+- **Responsibility.** SIL Engineering — Pipeline.
+- **Priority Level.** R2 (post-GA).
+- **Test / Measurement.**
+  - SQA Test Steps:
+    1. Confirm OSS-Fuzz integration (or local AFL harness) targets the ALPA-GRPC proto decoders and any USDZ parser used by adapters.
+    2. Track fuzz findings in PSIRT.
+  - PASS: OSS-Fuzz target lands and runs continuously; ad-hoc AFL run on the proto / USDZ corpus before each release.
+  - FAIL: a release ships without a fuzz run on these surfaces.
+
+---
+
+## NIM-template FSR slots 25–36 (mapping to FlashDreams TOE)
+
+The user-supplied NIM TAVA template enumerates `FSR_<TOE>_01..36`. Slots 25–36 in that template cover NIM-API-specific concerns (mandatory AuthN/AuthZ, scaling, non-prod parity, request-scope memory, etc.). For the FlashDreams TOE, each maps onto an existing `FSR_FD_NN` row above or is **Avoided** by the architecture invariant ("no NVIDIA-side ingress / egress / storage of operator data"). Each row uses the same column structure; **Risk Response** is `Map` (mapped onto an existing FlashDreams FSR) or `Avoid` (the asset / surface does not exist in the FlashDreams TOE).
+
+| Slot | NIM-template intent | FlashDreams mapping | Risk Level | Risk Response | Responsibility | Priority | Test / Measurement |
+|---|---|---|---|---|---|---|---|
+| **FSR_FD_25** | Operator (NIM customer in NIM template) SHALL provide AuthN/AuthZ to limit access to API endpoints to authorized and authenticated users / processes (NIM template FSR 24). | **Map → FSR_FD_12** (token interceptor). When the operator chooses public-bind (FSR_FD_10 opt-in), the token interceptor is mandatory. | Very High | Map | SIL Engineering — Serving + Operator | P0 (non-loopback) / P1 (loopback) | See FSR_FD_12 Test / Measurement above. |
+| **FSR_FD_26** | Operator SHALL configure compute / storage / memory / network scaling to meet service SLA (NIM template FSR 25). | **Avoid** — FlashDreams has no managed availability SLA. Single-process / single-active-session by architecture. Operator owns scaling end-to-end. | Very Low | Avoid | Operator | P1 | Documented in SADD § 3.6.2 (High Availability) and § 3.6.3 (Scalability). |
+| **FSR_FD_27** | Operator SHALL configure API calls to be transmitted using authenticated encryption (TLS 1.2+) to prevent disclosure / modification (NIM template FSR 26). | **Map → FSR_FD_01** (TLS) + **FSR_FD_12** (token). Mandatory on non-loopback. | Moderate | Map | Operator + SIL Engineering — Serving | P0 (non-loopback) / P1 (loopback) | See FSR_FD_01 and FSR_FD_12 Test / Measurement above. |
+| **FSR_FD_28** | Non-production API deployments SHALL be secured similarly to production (NIM template FSR 27). | **Map → FSR_FD_01 + FSR_FD_10 + FSR_FD_12**. Documented in `SECURITY.md`: any FlashDreams listener that processes operator data is treated as production-grade regardless of label. | Very Low | Map | SIL Engineering | P1 | Doc review: confirm `SECURITY.md` carries the "non-prod parity" callout. |
+| **FSR_FD_29** | Per-client rate-limits to prevent resource abuse and overconsumption (NIM template FSR 28; OWASP API4:2023). | **Map → FSR_FD_20.** | Very Low | Map | SIL Engineering — Serving | P1 | See FSR_FD_20 Test / Measurement above. |
+| **FSR_FD_30** | SHALL NOT persist inference request data beyond request scope; SHALL validate memory used to process one user's request is freed before another user's request (NIM template FSR 29). | **Map → FSR_FD_18** (session state deallocation + GPU zero). | Moderate | Map | SIL Engineering — Pipeline | P0 | See FSR_FD_18 Test / Measurement above. |
+| **FSR_FD_31** | SHALL logically isolate processing of inference requests from one user to another (NIM template FSR 30). | **Map → FSR_FD_19** (per-session response routing) + the single-active-session invariant in LING-RTC. | Low | Map | SIL Engineering — Serving | P0 | See FSR_FD_19 Test / Measurement above. |
+| **FSR_FD_32** | SHALL restrict disclosure of responses to the user that submitted the request (NIM template FSR 31). | **Map → FSR_FD_19.** | Moderate | Map | SIL Engineering — Serving | P0 | See FSR_FD_19 Test / Measurement above. |
+| **FSR_FD_33** | Front-end API server SHALL be configured with secure protocols and to open only needed ports; restrict access to those ports to authorized users / processes (NIM template FSR 32). | **Map → FSR_FD_01 + FSR_FD_10 + FSR_FD_12.** LING-RTC HTTP signaling on `:8089` (loopback default); ALPA-GRPC on a configurable port; no other listeners. | Moderate | Map | SIL Engineering — Serving | P0 | See FSR_FD_10, FSR_FD_01, FSR_FD_12 Test / Measurement above. |
+| **FSR_FD_34** | Triton Inference Server (NIM) SHALL be configured with secure protocols and to open only needed ports; restrict access to those ports to authorized users / processes (NIM template FSR 33). | **Avoid** — FlashDreams does not run a Triton Inference Server in the TOE. The recipe pipelines call torch directly (FD-INFRA). When deployed downstream behind a Triton, that Triton is governed by the operator's serving stack, not by FlashDreams. | Moderate | Avoid | Operator | P0 (operator-managed if Triton is added downstream) | Doc note in `SECURITY.md`: "If you place FlashDreams behind Triton or another inference server, that server's hardening is outside the FlashDreams TOE." |
+| **FSR_FD_35** | Access to Triton Inference Server resources SHALL be accessible only via the FlashDreams API (NIM template FSR 34). | **Avoid** — see FSR_FD_34. The flashdreams Pipeline is in-process; there is no separate Triton resource layer in the TOE. | Moderate | Avoid | Operator | P0 (operator-managed if Triton is added downstream) | Doc note in `SECURITY.md`. |
+| **FSR_FD_36** | Media parsing library sandboxed (NIM template FSR 35) + restricted to relevant format (NIM template FSR 36). | **Map → FSR_FD_16 + FSR_FD_17.** | Moderate | Map | SIL Engineering — Adapter input layer | P1 (1.0) / P0 (post-GA) | See FSR_FD_16 and FSR_FD_17 Test / Measurement above. |
+
+---
+
+## Coverage summary
+
+| Status | Count | FSRs |
+|---|---|---|
+| ✅ As-built contract+stub tests passing upstream (mirror to FlashDreams planned) | 20 | FSR_FD_01, _02, _03, _04, _06, _08, _09, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _23 |
+| 📄 Documented control landed (no test seam needed) | 1 | FSR_FD_22 |
+| ⏳ Externally blocked or operator-side | 3 | FSR_FD_05 (operator guidance — FlashDreams ships no canonical image), FSR_FD_07 (Cosmos-Guardrail real backend — HF egress), FSR_FD_24 (OSS-Fuzz post-GA) |
+| 🔁 Mapped onto an existing FSR_FD_NN | 9 | FSR_FD_25, _27, _28, _29, _30, _31, _32, _33, _36 |
+| 🚫 Avoided by FlashDreams TOE architecture invariant | 3 | FSR_FD_26 (no managed SLA), FSR_FD_34, FSR_FD_35 (no Triton in TOE) |
+| **Total slots covered** | **36** | (24 canonical + 12 NIM-template mapping rows) |
+
+---
+
+## Notes on the NIM-template mapping
+
+The user-supplied template covered the NIM (NeMo Inference Microservices) TOE. FlashDreams differs from NIM in three architecturally load-bearing ways, which is why several NIM FSRs map rather than apply:
+
+1. **No managed service SLA.** FlashDreams is a developer / researcher inference stack; the operator owns availability. NIM-template FSR 25 (compute scaling) becomes an operator-side concern (Avoid).
+2. **No Triton in the TOE.** FlashDreams pipelines call torch directly via `FD-INFRA`. There is no separate Triton Inference Server inside the FlashDreams TOE, so NIM-template FSRs 33 / 34 are noted as "operator-managed if a Triton is added downstream" (Avoid).
+3. **No NGC / NVAIE / API Catalog publishing of FlashDreams models.** FlashDreams publishes weights through HuggingFace (`nvidia/omni-dreams-*`) and S3 (`pdx.s8k.io`). Several NIM-template FSRs (e.g. NGC mandatory access controls, NGC encryption-at-rest, nSpect Helm-chart NSPECT-ID tagging, NIM-model byte-code malware scanning, NIM-model source-code OSS scanning) are addressed by NVIDIA-wide controls outside the FlashDreams TOE. These have been folded into the surviving `FSR_FD_04` (checkpoint integrity at the FlashDreams loader) and `FSR_FD_05` (operator-side container-image signing guidance) rather than enumerated separately.
+
+4. **No canonical FlashDreams container image.** Per commit `ab74b58`, FlashDreams ships no pre-published image; operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`. NIM-template FSRs that assumed a canonical NVIDIA-published image (e.g. "container hardened and scanned per the NVIDIA OCI Container Security Hardening SRD", NIM template FSR 20) become **operator-side responsibilities** for FlashDreams. The FlashDreams `docker/Dockerfile` follows reasonable hygiene defaults (minimal layers; explicit version pinning; no secrets in build args), and `docs/security/SECURITY.md` will surface this as operator guidance.
+
+The intent of the mapping rows (`FSR_FD_25..36`) is to provide a clear "this NIM-template slot is covered by FlashDreams FSR X" or "this NIM-template slot does not apply to the FlashDreams TOE because Y", so that the Security PIC can sign off the TAVA against MVSB-32946 without having to re-derive the mapping at acknowledgment time.

--- a/docs/arch/fsr_table.md
+++ b/docs/arch/fsr_table.md
@@ -58,7 +58,7 @@ Every row uses the column structure the user supplied:
 
 ### FSR_FD_02 — Logs SHALL strip secrets
 
-- **Functional Security Requirement.** Service log data stored locally or transmitted remotely SHALL NOT contain NVIDIA confidential data such as personal and enterprise secrets, API keys, cryptographic keys, or authentication tokens (`HF_TOKEN`, `GITHUB_PAT`, AWS access / secret keys, bearer tokens, full `Authorization` headers).
+- **Functional Security Requirement.** Service log data stored locally or transmitted remotely SHALL NOT contain NVIDIA confidential data such as personal and enterprise secrets, API keys, cryptographic keys, or authentication tokens (`HF_TOKEN`, AWS access / secret keys, bearer tokens, full `Authorization` headers, plus any operator-managed container-registry token now that FlashDreams ships no canonical image per OE-7).
 - **Risk Level.** High.
 - **Risk Response.** Remediate.
 - **Responsibility.** SIL Engineering — Logging (`flashdreams/flashdreams/core/io/`).

--- a/docs/arch/mvsb_32946_comments.md
+++ b/docs/arch/mvsb_32946_comments.md
@@ -1,0 +1,74 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Comments to post on MVSB-32946
+
+Two prepared Jira comments for [MVSB-32946 — *Security: TAVA - Submit and Acknowledge - [flashdreams] [GA and OSS]*](https://jirasw.nvidia.com/browse/MVSB-32946). The Jira CLI on this worktree is not authenticated, and the MaaS-Jira MCP requires interactive browser OAuth, so these were generated for the user to paste manually (or to drop in via `jira-cli issue comment MVSB-32946 -b "$(cat …)"` once `jira-cli auth set-token` has been run).
+
+---
+
+## Comment 1 — FlashDreams-scoped TAVA / SADD / FSR doc set has landed in-tree
+
+**Subject:** TAVA doc set landed in `flashdreams/docs/arch/`
+
+Posting the FlashDreams-scoped subset of the TAVA materials in-tree under `flashdreams/docs/arch/` on branch `worktree-dev/jmccaffrey/arch-tava`:
+
+| Doc | Purpose |
+| --- | --- |
+| `docs/arch/README.md` | Index + cross-refs to the upstream omni-dreams doc set |
+| `docs/arch/SKILL.md` | Agent-runnable security-architect workflow (compact subset of the upstream skill) |
+| `docs/arch/architecture.md` | Four-view architecture (Static / Dynamic / Data / Deployment) narrowed to the FlashDreams TOE |
+| `docs/arch/sadd.md` | SADD per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL` |
+| `docs/arch/tava.md` | TAVA narrative (assets / threats / risk / objectives / POA&M) for the FlashDreams TOE |
+| `docs/arch/fsr_table.md` | Canonical FSR sheet in the Excel-Based Simple TAVA Template column structure (FSR_FD_01..36) |
+
+**TOE shape (FlashDreams subset):**
+
+In scope: `flashdreams/flashdreams/` (recipes `cosmos`/`taehv`/`template`/`wan`, core, infra, plugins, scripts) plus `integrations/{alpadreams, lingbot, cosmos_predict2, wan21, self_forcing, causal_forcing, fastvideo_causal_wan22}`. Supply chain: HuggingFace + S3 (`pdx.s8k.io`) + upstream `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` base image.
+
+Out of scope: `omni-dreams/samples/interactive-drive` and `omni-dreams/post-training` (covered upstream in [`omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md`](https://gitlab-master.nvidia.com/sil/omni-dreams)).
+
+**Key drift correction vs. the upstream 2026-05-15 TAVA snapshot:** per commit `ab74b58` ("Remove ghcr.io/nvidia/flashdreams base image from CI and scripts"), FlashDreams ships **no canonical pre-published container image**. Operators build locally from `docker/Dockerfile`. As a result:
+
+- OE-7 reframed from "GHCR ACL'd image" to "no canonical NVIDIA-published image; supply-chain trust delegates upward to upstream `nvidia/cuda`".
+- T-IMG-1 risk **downgraded from M to L** (likelihood drops because there is no central NVIDIA distribution point).
+- FSR_FD_05 (Sigstore) **downgraded from P1 to P2** and reframed as **operator-side guidance** ("if you publish a FlashDreams container, `cosign sign`; if you pull one, `cosign verify`"). The FlashDreams-side enforcement disappears.
+
+**FSR sheet column structure** matches the NIM TAVA template you referenced in the parent ticket: `FSR ID | Functional Security Requirement | Risk Level | Risk Response | Responsibility | Priority Level | Test / Measurement`. NIM-template slots 25..36 are mapped onto existing `FSR_FD_*` rows (or marked **Avoid** where the FlashDreams TOE invariants — no NIM API surface, no Triton in the TOE, no NGC publishing of FlashDreams models — make the slot moot). The mapping table is at the bottom of `docs/arch/fsr_table.md`.
+
+Ready for Security PIC review pending the MVSB-32940 export classification outcome (which decides whether we go through nSpect TAVA 3.0 ack or stay on the manual TAVA 2.0 link). I'll watch this ticket for sign-off; let me know if the FSR risk levels / responsibilities need adjustment before that.
+
+---
+
+## Comment 2 — FSR coverage status + open questions before acknowledgment
+
+**Subject:** FSR coverage at acknowledgment-time + open questions
+
+Coverage as of `worktree-dev/jmccaffrey/arch-tava` HEAD:
+
+| Status | Count | FSRs |
+| --- | --- | --- |
+| ✅ As-built contract+stub tests passing upstream (mirror to `flashdreams/tests/security/` planned) | 20 | FSR_FD_01, _02, _03, _04, _06, _08, _09, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _23 |
+| 📄 Documented control (no test seam needed) | 1 | FSR_FD_22 (trust-collapse callout — split between FlashDreams `docs/security/SECURITY.md` and the upstream interactive-drive README) |
+| ⏳ Externally blocked or operator-side | 3 | FSR_FD_05 (operator-side image-signing guidance), FSR_FD_07 (Cosmos-Guardrail real backend pending HF-egress benchmark — see `omni-dreams/internal/docs/planning/cosmos_guardrail_benchmark.md`), FSR_FD_24 (OSS-Fuzz post-GA) |
+| 🔁 NIM-template slots mapped onto an existing `FSR_FD_NN` | 9 | FSR_FD_25, _27, _28, _29, _30, _31, _32, _33, _36 |
+| 🚫 NIM-template slots avoided by FlashDreams TOE architecture invariant | 3 | FSR_FD_26 (no managed SLA), FSR_FD_34, _35 (no Triton in TOE) |
+| **Total slots covered** | **36** | 24 canonical + 12 NIM-template mapping rows |
+
+**Highest-leverage residual ask before FlashDreams 1.0 GA**: land Cosmos-1.0-Guardrail pre-Guard (FSR_FD_06) as a default-on hard gate at session init. One model call per session; closes the highest-impact threat (T-CONT-1 — operator-supplied CSAM/gore initial frame amplified by the world model). The reference implementation exists; the seam is already prototyped upstream.
+
+**Week-1 mitigation candidates** (all P0; ~3.75 engineering-days total): see `docs/arch/tava.md` Step 7 Recommended Next Steps. Six items have working contract+stub tests upstream that need product-side wiring in the FlashDreams repo (loopback bind default + warning banner; log-redaction filter; HF-org allowlist at config parse; plugin-allowlist default-deny; session-init input gate plumbing; DataChannel JSON schema validation).
+
+**Open questions blocking specific FSR sign-off** (full list in `docs/arch/tava.md` Step 6):
+
+1. **Q-01** — auth mechanism for ALPA-GRPC + lingbot HTTP signaling: mTLS, JWT, both? Blocks FSR_FD_01 + FSR_FD_12.
+2. **Q-02** — should operators pre-stage Cosmos-1.0-Guardrail weights in their FlashDreams container, or fetch at first run? Pre-staging closes OE-6 in restricted-egress environments. Blocks FSR_FD_06 + FSR_FD_07.
+3. **Q-03** — canonical FSR_FD_08 allowlist on GA: today the env-var defaults to `nvidia` (per `integrations/alpadreams/alpadreams/hf.py`); the documented internal mirror is `nvidia-omni-dreams-lha`. Confirm GA retains both or rotates. Blocks FSR_FD_08.
+4. **Q-04** — are entry-point-discovered plugins expected at all on GA? If not, FSR_FD_09 tightens from allowlist to **always-deny**. Blocks FSR_FD_09 hardening.
+5. **Q-06** — when does the FlashDreams-side `flashdreams/tests/security/` mirror of the upstream `omni-dreams/internal/tests/security/` package land? (Without it, the FSR coverage table cites upstream test counts, which is fine for the TAVA acknowledgment but suboptimal for an external operator inspecting the FlashDreams repo alone.)
+6. **Q-07** — MVSB-32940 export classification outcome (decides TAVA 3.0 vs. manual TAVA 2.0 ack path).
+7. **Q-08** — named Security PIC for the FlashDreams 1.0 GA release? (Closeout requires PIC review + acknowledgment.)
+
+Requesting Security PIC review when convenient. Happy to walk through any of the above on a quick sync.

--- a/docs/arch/mvsb_32946_comments.md
+++ b/docs/arch/mvsb_32946_comments.md
@@ -18,7 +18,7 @@ Posting the FlashDreams-scoped subset of the TAVA materials in-tree under `flash
 | Doc | Purpose |
 | --- | --- |
 | `docs/arch/README.md` | Index + cross-refs to the upstream omni-dreams doc set |
-| `docs/arch/SKILL.md` | Agent-runnable security-architect workflow (compact subset of the upstream skill) |
+| `agentic/skills/flashdreams-security-architect/SKILL.md` | Agent-runnable security-architect workflow as a project skill (compact subset of the upstream skill) |
 | `docs/arch/architecture.md` | Four-view architecture (Static / Dynamic / Data / Deployment) narrowed to the FlashDreams TOE |
 | `docs/arch/sadd.md` | SADD per `SWE-PLC-L1-002-BasicPLC-SADD-TMPL` |
 | `docs/arch/tava.md` | TAVA narrative (assets / threats / risk / objectives / POA&M) for the FlashDreams TOE |

--- a/docs/arch/sadd.md
+++ b/docs/arch/sadd.md
@@ -1,0 +1,330 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# FlashDreams — Software Architecture and Design Document (SADD)
+
+Following `SWE-PLC-L1-002-BasicPLC-SADD-TMPL` (Oct 5, 2023 baseline). FlashDreams-scoped subset of the broader omni-dreams + flashdreams SADD ([`../../../omni-dreams/docs/arch/sadd.md`](../../../omni-dreams/docs/arch/sadd.md)), narrowed to the `flashdreams` repo for the MVSB-32946 acknowledgment path.
+
+## Documentation Control
+
+| Item | Description |
+|---|---|
+| Title | FlashDreams SADD |
+| Author(s) | Jonathan McCaffrey (jmccaffrey@nvidia.com) — PLC Security PIC for FlashDreams; AI assist (Claude Opus 4.7, 1M context) |
+| Revision | 2026-05-20 (draft) |
+| State | Development |
+| Reviewed in | GitHub PR on `github.com/NVIDIA/flashdreams` (worktree branch `dev/jmccaffrey/arch-tava`) |
+| PLC-L1 SADD Template Revision | SWE-PLC-L1-002-BasicPLC-SADD-TMPL, Oct. 5, 2023 |
+
+### Approvers
+
+| Date | Name | Notes |
+|---|---|---|
+| TBD | Security PIC (flashdreams) | TAVA acknowledgment (MVSB-32946) |
+| TBD | Program Lead (Aditya Mahajan / Sanja Fidler) | Architecture sign-off |
+
+### Reviewers
+
+| Date | Name | Notes |
+|---|---|---|
+| TBD | Sean Kunde (GTC Export) | Export classification (MVSB-32940) |
+| TBD | OSRB liaison | OSS exposure of architecture surfaces |
+
+### Revision History
+
+| Date | Author | Summary |
+|---|---|---|
+| 2026-05-20 | jmccaffrey | Extract FlashDreams-scoped SADD from upstream omni-dreams + flashdreams SADD; pull-up of TAVA prerequisites for MVSB-32946. |
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose and Scope
+
+This document records the architectural details for **FlashDreams** — a generative video world-model inference stack (offline recipes via `flashdreams-run` + interactive server adapters under `integrations/`) — sufficient to serve as input to the manual TAVA 2.0 process tracked in [MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946) and to satisfy the SADD requirement for PLC-L1.
+
+**In scope (FlashDreams TOE):**
+
+- `flashdreams/flashdreams/` — recipes (`cosmos`, `taehv`, `template`, `wan`), core (attention / distributed / checkpoint / io), infra (pipeline / diffusion / encoder / decoder / runner), plugins (registry), scripts (`flashdreams-run` CLI).
+- `integrations/alpadreams/` — gRPC server + Ludus HD-map renderer + profiling server.
+- `integrations/lingbot/` — WebRTC server (single active session).
+- `integrations/{cosmos_predict2, wan21, self_forcing, causal_forcing, fastvideo_causal_wan22}/` — additional recipe / framework adapters.
+- The supply chain that loads these into memory: HuggingFace, S3 (`pdx.s8k.io`), and the upstream `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` base image. FlashDreams ships **no canonical pre-published container**: operators build locally from `docker/Dockerfile` (commit `ab74b58`).
+
+**Out of scope (Operational Environment, OE):**
+
+- `omni-dreams/samples/interactive-drive` — operator-facing consumer of FlashDreams; covered by the upstream omni-dreams + flashdreams SADD.
+- `omni-dreams/post-training` — fine-tune training stack; covered upstream.
+- Upstream Cosmos2 / Wan / Cosmos-Reason1 / LightVAE / TAEHV source trees (vendored under `post-training/omnidreams/_src/` in omni-dreams).
+
+### 1.2 Assumptions
+
+1. Operator runs the inference servers (lingbot, alpadreams gRPC) on **trusted private hardware**; bind-host defaults of `0.0.0.0` are operationally rebound to loopback for sensitive sessions (OE-1).
+2. Operator HuggingFace and S3 credentials are correctly scoped (least-privilege; revocable) and not committed to git (OE-3). When the operator uses a private registry for their FlashDreams container, the registry's PAT / token is also operator-managed.
+3. Multi-node deployments rely on a cluster admin to enforce tenant isolation at the IMEX / shared-FS layer (OE-2; relevant only to the omni-dreams post-training consumer).
+4. No NVIDIA-side ingress, egress, or storage of operator-generated prompts, frames, or session data (architecture invariant, restated from the MVSB-32946 ticket comment).
+5. FlashDreams ships **no canonical pre-published container image** (OE-7); operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`. The supply-chain trust delegates upward to the upstream `nvidia/cuda` base image.
+
+### 1.3 Constraints
+
+1. **Platforms:** Linux (DGX Station with GB300 reference; RTX 6000 Pro Blackwell Max-Q verified for offline recipes).
+2. **Distribution:** Open-source under Apache 2.0 on `github.com/NVIDIA/flashdreams` (open-model weights via `huggingface.co/nvidia/omni-dreams-*` once MVSB-33270 / 33271 close).
+3. **Steady-state latency:** ~900 ms / chunk in interactive serving on a single GPU. Any added post-decode filter must fit within ≤50 ms / chunk to avoid degrading user-visible interactivity below 1 Hz.
+4. **Python 3.12, torch / CUDA / NCCL** versions pinned in `uv.lock` for reproducibility.
+5. **Container runtime**: operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` (no canonical pre-published image); native installs (`uv sync` on a host with CUDA + ffmpeg + libnccl-dev pre-installed) are also supported.
+
+### 1.4 Dependencies
+
+| Team / Company | Deliverable | Ref |
+|---|---|---|
+| Cosmos2 (NVIDIA) | Cosmos2 SV-HDMap world-model weights | § 3.2.2 HF interface |
+| Cosmos-Reason1 (NVIDIA) | Cosmos-Reason1-7B text encoder | § 3.2.2 HF interface |
+| LightX2V | Autoencoders (LightVAE / LightTAE) | § 3.2.2 HF interface |
+| HuggingFace | Hosting for `nvidia/omni-dreams-*` and `nvidia-omni-dreams-lha/*` mirror | § 3.2.2 HF interface |
+| NVIDIA SIL S3 (`pdx.s8k.io`) | Pre-release / internal checkpoint hosting | § 3.2.2 S3 interface |
+| OSRB | Apache 2.0 contrib approval for flashdreams | MVSB-33271 (PR plan) |
+| Product Legal | Open Model License v2.0 vs Apache 2.0 weights decision | MVSB-33270 |
+| Privacy Review | Sign-off on no-PII posture; review of input-gate / output-anonymizer FSRs | MVSB-33273 |
+
+### 1.5 Definitions, Acronyms, Abbreviations
+
+| Term | Description |
+|---|---|
+| TOE | Target of Evaluation (TAVA term) — FlashDreams for this analysis |
+| DFD | Data Flow Diagram |
+| CP | Context Parallelism (torch.distributed group) |
+| FSDP | Fully Sharded Data Parallel |
+| DiT | Diffusion Transformer |
+| VAE / TAE | Variational / Temporal Auto-Encoder |
+| HD-map | High-definition vector map raster, used as per-frame conditioning |
+| Anonymizer | Output post-processing filter that blurs faces and license plates |
+| Content gate | Input safety filter that rejects CSAM / gore at session init |
+| STRIDE | Spoofing / Tampering / Repudiation / Information disclosure / DoS / Elevation of privilege |
+| FSR | Functional Security Requirement (TAVA v3 step 3) |
+| POA&M | Plan of Action and Milestones (TAVA v3 step 4) |
+| OE | Operational Environment assumption |
+
+### 1.6 References
+
+| SWE # | Input Work Product | Revision | Location |
+|---|---|---|---|
+| — | MVSB-32946 Jira ticket | 2026-05-20 | https://jirasw.nvidia.com/browse/MVSB-32946 |
+| — | TAVA v3 (Oct 31, 2024) guidance | Approved by Darrell Hunt | Confluence PRODSEC |
+| — | TAVA 2.0 manual page | — | https://nvidia.atlassian.net/wiki/spaces/PRODSEC/pages/2569277880 |
+| — | Excel-Based Simple TAVA Template | — | NVIDIA SharePoint (Software Product Security) |
+| SWE-PLC-L1-002 | BasicPLC SADD template | Oct. 5, 2023 | Glean → Google Docs (id `1EOU6o4nMUA_lGKa9_DsnByamLv3T_VvcTKMACfz153Q`) |
+| — | NIST SP 800-30 Rev 1 | 2012 | NIST |
+| — | Upstream omni-dreams + flashdreams TAVA | 2026-05-15 | [`../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md`](../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md) |
+| — | This MR's architecture views | 2026-05-20 | [Static view](architecture.md#static-view), [Dynamic view](architecture.md#dynamic-view), [Data view](architecture.md#data-view), [Deployment view](architecture.md#deployment-view) |
+
+---
+
+## 2. Architectural Details
+
+The FlashDreams runtime is a single Python process tree on operator-controlled hardware that loads a recipe via the unified `flashdreams-run` console script, builds a `Pipeline = DiT + encoder + VAE/TAE` from a checkpoint resolved via `FD-CKPT`, and either runs to completion (offline generation) or enters a serving loop. Two adapter packages expose FlashDreams over the network locally:
+
+- **lingbot** — minimal WebRTC server (`GET /request_session`, `POST /api/webrtc/offer`, DataChannel actions `{keydown, keyup, step}`). Single active session per server process.
+- **alpadreams** — gRPC server (InitializeSession / Step / CloseSession), with optional session-recording to disk and a separate profiling server. Protobuf stubs compiled from `integrations/alpadreams/alpadreams/grpc/protos/*.proto` via `compile_protos.sh`.
+
+Full block diagrams in [Static view](architecture.md#static-view); runtime interactions in [Dynamic view](architecture.md#dynamic-view); dataflow with trust boundaries in [Data view](architecture.md#data-view); physical placement in [Deployment view](architecture.md#deployment-view).
+
+### Key architectural assumptions and limitations
+
+1. **Single-host trust collapse** — when consumed from `omni-dreams/samples/interactive-drive`'s documented `docker run`, the container uses `--network=host --ipc=host`, mounts the Wayland socket, and forwards `$SSH_AUTH_SOCK`. The container is effectively trusted-equal-to-host. Acceptable for local dev; documented as OE-1.
+2. **One active session per server process** (lingbot) — simplifies STRIDE-D analysis but is a DoS pinhole if exposed beyond loopback (T-DOS-1).
+3. **No in-process integrity check on downloaded checkpoints** — relies on HTTPS + HF/S3 ACLs; a poisoned cache survives container restarts (FSR_FD_04).
+4. **Default network bind is `0.0.0.0`** in the documented lingbot invocation — an audit hot-spot to be tightened (FSR_FD_10).
+5. **Few-step output anonymizer is the only architecturally viable design**: a full general-purpose face/plate detector would push chunk wall-clock past the interactive budget. The architecture treats per-chunk output anonymization as **opt-in** (FSR_FD_07); the **input content gate** is **on-by-default** (FSR_FD_06).
+6. **Reference implementation for both filters**: [`nvidia/Cosmos-1.0-Guardrail`](https://huggingface.co/nvidia/Cosmos-1.0-Guardrail). Pre-Guard image side serves the CSAM/gore gate; post-Guard (RetinaFace + plate + blur) is the few-step network sized for the ≤50 ms / chunk budget on a small auxiliary GPU slot.
+
+---
+
+## 3. Design Details
+
+### 3.1 Design Alternatives
+
+| Alternative | Considered | Chosen because |
+|---|---|---|
+| **Single-binary monolith** vs **recipe registry + plugin discovery** | both | Recipe registry lets external teams ship new model integrations without forking flashdreams. Plugin discovery is a known TAVA hot-spot (FSR_FD_09). |
+| **Inference over REST** vs **WebRTC + gRPC** | both | WebRTC for interactive (low-latency video track + DataChannel for actions); gRPC for streaming inference. REST was rejected for steady-state video. |
+| **Pickle checkpoints (`.pt`)** vs **safetensors** | both | Mixed: pickle for internal HF/S3, safetensors where upstream provides them. Pickle is an arbitrary-code-execution surface (STRIDE-T); captured as FSR_FD_04. |
+| **Output anonymizer always-on** vs **opt-in** | both | Opt-in chosen because a full detector pass at every chunk doubles steady-state latency on a single GPU; **input content gate is always-on** because it runs once per session. |
+
+### 3.2 Static Design
+
+See [Static view](architecture.md#static-view) for full component / class diagrams.
+
+#### 3.2.1 Configuration Data
+
+| Source | Purpose | Attack-surface notes |
+|---|---|---|
+| `FLASHDREAMS_INTERNAL_STORAGE` env | flip checkpoint URLs to `s3://flashdreams` | env-var injection redirects fetch; defaults to off |
+| `OMNI_DREAMS_HF_ORG` env var | choose `nvidia` (default) vs `nvidia-omni-dreams-lha` mirror — see `integrations/alpadreams/alpadreams/hf.py` | swap to attacker-controlled HF org is the supply-chain pivot — pin to known orgs in code (FSR_FD_08). No CLI flag today; env-only. |
+| `HF_TOKEN` env | HuggingFace authentication | secret in env; leaked logs are a disclosure vector (FSR_FD_02) |
+| Operator's registry token (if container is pulled rather than locally built) | container pull | secret in env or in `docker login`; operator-managed |
+| `credentials/s3_checkpoint.secret` file | S3 AWS keys | secret on disk; chmod 600; never committed |
+| YAML configs (per-recipe) | model + pipeline overrides | untrusted-yaml safe-load only |
+| `--config_name`, `--prompt`, `--image-path`, `--synthetic-initial-rgb` | CLI flags | length / Unicode-validated (FSR_FD_14); MIME / magic-validated (FSR_FD_15) |
+| Slurm `--container-image` (omni-dreams consumer) | runtime image | pinned by digest in CI; tag-only at dev |
+| `FLASHDREAMS_TRUSTED_PLUGINS` env | plugin allowlist | feeds FSR_FD_09 default-deny |
+
+#### 3.2.2 External Interface and Specification
+
+| Name of software | Owner | Type | Operational implications | Data |
+|---|---|---|---|---|
+| HuggingFace Hub | HF (3rd party) | HTTPS, token-auth | Outbound only. Token can grant private-repo read; revocable. | Models (.pt / .safetensors), datasets, tokenizers. Wire format: HF resolver URLs, range-GET on LFS objects. |
+| Upstream CUDA registry (`nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`) | NVIDIA (DockerHub / NGC) | HTTPS | Outbound only; pulled at `docker build` time. FlashDreams ships no canonical pre-published image (OE-7). | OCI base image. |
+| S3 (`pdx.s8k.io`) | NVIDIA SIL | HTTPS, AWS sig v4 | Outbound only; pre-signed for downloads. | Checkpoints. Wire format: bucket / key. |
+| Browser viewer (lingbot WebRTC) | n/a (operator) | HTTP + WebRTC | Inbound; default bind `0.0.0.0:8089` per README today (FSR_FD_10 target: `127.0.0.1`). Single active session. | HTML/CSS/JS viewer assets; SDP offer/answer; DataChannel JSON `{action: keydown|keyup|step}`; SRTP video track. |
+| gRPC clients (`replay_client`, external integrators) | NVIDIA / external | HTTP/2 + protobuf | Inbound or loopback. | Stubs from `alpadreams/grpc/protos/*.proto`: InitializeSession, Step, CloseSession. |
+| `flashdreams-run` CLI | n/a (operator) | stdin / argv | Local. | text prompt; image path; recipe slug. |
+
+#### 3.2.3 Dependencies
+
+See § 1.4. Integration validation plan below.
+
+##### 3.2.3.1 Integration Validation Plan
+
+| Functionality to Validate | Teams Participating | Interfaces Covered | Date Complete |
+|---|---|---|---|
+| HuggingFace checkpoint fetch + load (wan, cosmos, taehv recipes) | SIL eng | HF interface, FD-CKPT | TBD |
+| S3 internal-storage fallback toggled by `FLASHDREAMS_INTERNAL_STORAGE` | SIL eng | S3 interface, FD-CKPT | TBD |
+| LING-RTC end-to-end browser session (loopback) | SIL eng | LING-RTC HTTP + WebRTC | TBD |
+| ALPA-GRPC InitializeSession → Step → Close | SIL eng | ALPA-GRPC | TBD |
+| Input content gate rejects CSAM / gore probe image | Privacy + SIL | Gate at session init | TBD |
+| Output anonymizer blurs faces/plates within ≤50 ms/chunk budget | Privacy + SIL | Anon stage in FD-INFRA | TBD |
+| `flashdreams-run` plugin registry default-deny | SIL eng | FD-REG | TBD |
+
+### 3.3 Dynamic Design
+
+See [Dynamic view](architecture.md#dynamic-view) for sequence diagrams.
+
+#### 3.3.1 Functionality and Behavior
+
+- **`flashdreams-run` offline**: cold-start loads checkpoint, builds a Pipeline, runs to completion, writes mp4 + JSON via rank-0 I/O gate.
+- **lingbot WebRTC**: warm at server start (preload runtime + model + config), then per session: `GET /request_session` → `POST /api/webrtc/offer` → optional input gate on initial RGB → SDP negotiation → DataChannel actions → AR inference per chunk → video track + `chunk_done` event.
+- **alpadreams gRPC**: stateless across InitializeSession boundaries (session ID returned); per-step streamed responses; optional disk recording behind `--record`; profiling server bound loopback by default.
+
+#### 3.3.2 Control Flow
+
+See [Dynamic view](architecture.md#dynamic-view) §§ 1–5.
+
+#### 3.3.3 Data Flow
+
+See [Data view](architecture.md#data-view) §§ 1–4.
+
+#### 3.3.4 Error Handling
+
+| Failure | Behavior |
+|---|---|
+| HF / S3 download error (4xx / 5xx) | Fail-fast at cold-start; CLI returns non-zero. README documents `401/403` path for missing token. |
+| Checkpoint integrity violation (FSR_FD_04 once wired) | Fail-fast before pinning to CUDA; log the URI but not the bytes. |
+| Input content gate hit | Reject the session at init; return `403` (HTTP path) or pre-RUN abort (CLI path). Do not retry. |
+| WebRTC negotiation timeout | Tear down the single active session; logs to local file only. |
+| gRPC client disconnect mid-Step | Server-side cleanup of `session_id`; recording flushes if enabled; per-session GPU buffers zeroed (FSR_FD_18). |
+| Distributed init failure (NCCL) | All ranks abort; torchrun returns non-zero; rank 0 captures the stack to local logs. |
+| GPU OOM | Fail-fast with documented `--len_t` knob to shrink chunk size. |
+| Unknown plugin entry-point | Refused unless in `FLASHDREAMS_TRUSTED_PLUGINS` (FSR_FD_09). |
+
+All logs are local; no centralized log shipping is part of the TOE. Log scrubbing per FSR_FD_02 / FSR_FD_03 is the responsibility of the core logger filter once wired.
+
+#### 3.3.5 Logging and Debugging
+
+- Rank-0-only logs in distributed runs (architectural invariant).
+- Profiling server (`alpadreams/grpc/profiling_server.py`) exposes CPU/GPU profile traces; binds to a configurable port and **should bind loopback in production** (FSR_FD_11).
+- Session recordings (`session_recorder` → `recording_io`) are opt-in (`--record`) and write `.pt` + `.json` to disk with mode `0600` (FSR_FD_21).
+
+#### 3.3.6 State Machine
+
+See [Dynamic view](architecture.md#dynamic-view) § 4 (checkpoint resolution) and § 5 (distributed init).
+
+### 3.4 Security Design
+
+#### What is an FSR?
+
+A **Functional Security Requirement** (FSR) is a detailed security requirement decomposed from a high-level Security Objective. Each FSR is a SHALL-statement bound to a specific control: it traces back to one or more **threats** (what it mitigates), forward to one or more **Security Objectives** (what it supports), and out to a **Test/Measurement** (how SQA verifies it). FSRs are the actionable contract that the development team owns.
+
+The column layout used in the canonical sheet follows the **Excel-Based Simple TAVA Template** (mirroring the NIM TAVA template column structure used by the broader Product Security community):
+`FSR ID | Functional Security Requirement | Risk Level | Risk Response | Responsibility | Priority Level | Test / Measurement`.
+
+In this program every FSR is prefixed `FSR_FD_NN` (FD = FlashDreams).
+
+#### Canonical FSR sheet — pointer
+
+The single source of truth is [`fsr_table.md`](fsr_table.md). See [`tava.md`](tava.md) § 3.2 for the cross-references back to threats and security objectives.
+
+The 24 FSRs at a glance:
+
+| FSR ID | One-line statement | Priority |
+|---|---|---|
+| FSR_FD_01 | TLS 1.2+ on non-loopback endpoints | P0 (non-loopback) / P1 (loopback) |
+| FSR_FD_02 | Logs SHALL strip secrets (HF / GitHub / AWS / Bearer / Authorization) | P0 |
+| FSR_FD_03 | Logs SHALL strip PII (face / plate / NVIDIA email / Slack ID) | P0 |
+| FSR_FD_04 | `FD-CKPT` SHALL verify checkpoint sha256 / signature before `torch.load` | P0 |
+| FSR_FD_05 | When an operator publishes a FlashDreams container image to their registry, the build/publish pipeline SHOULD Sigstore-sign and the pull flow SHOULD `cosign verify`. (Operator guidance — FlashDreams ships no canonical image.) | P2 (operator guidance) |
+| FSR_FD_06 | Session init SHALL run **Cosmos-1.0-Guardrail pre-Guard** on initial RGB | P0 |
+| FSR_FD_07 | `--anonymize` SHALL run **Cosmos-1.0-Guardrail post-Guard** per chunk, ≤50 ms | P1 / P0 (post-GA if regulated) |
+| FSR_FD_08 | `OMNI_DREAMS_HF_ORG` validated against code-resident allowlist | P0 |
+| FSR_FD_09 | Plugin registry SHALL deny third-party plugins absent allowlist | P0 |
+| FSR_FD_10 | Listeners SHALL default to `127.0.0.1`; non-loopback requires opt-in | P0 |
+| FSR_FD_11 | Profiling server SHALL bind loopback by default | P1 |
+| FSR_FD_12 | gRPC + HTTP signaling SHALL support token interceptor (mandatory non-loopback) | P0 (non-loopback) / P1 (loopback) |
+| FSR_FD_13 | Lingbot DataChannel SHALL validate JSON schema; ≤256 B; drop on miss | P0 |
+| FSR_FD_14 | Text input SHALL be length-bounded, Unicode-validated, parameter-typed | P0 |
+| FSR_FD_15 | Media input (USDZ / JPEG / PNG / mp4) SHALL be size + MIME + magic-validated | P0 |
+| FSR_FD_16 | Media parsing libraries SHALL be sandboxed (seccomp / subprocess) | P1 → P0 post-GA |
+| FSR_FD_17 | Media parser SHALL be restricted to the format dispatched | P1 |
+| FSR_FD_18 | Inference state SHALL be deallocated between sessions; GPU mem zeroed | P0 |
+| FSR_FD_19 | Inference responses SHALL be restricted to the originating session | P0 |
+| FSR_FD_20 | Per-client rate limits on signaling endpoints | P1 |
+| FSR_FD_21 | Session recording mode `0600`; off by default; explicit `--record` flag | P1 |
+| FSR_FD_22 | Docs SHALL document `--network=host` + `--ipc=host` trust collapse (OE-1) | P1 |
+| FSR_FD_23 | Slurm launch helper SHALL emit OE-2 banner; refuse colliding IMEX channel | P1 (omni-dreams consumer only) |
+| FSR_FD_24 | Continuous fuzz coverage on SceneLoader USDZ + ALPA-GRPC proto | R2 (post-GA) |
+
+As of upstream station check 2026-05-15, **20 of 24 FSRs have as-built contract+stub tests passing** in `omni-dreams/internal/tests/security/`, **230 / 230** tests in 1.86 s. Coverage is mirrored 1-to-1 into FlashDreams once `flashdreams/tests/security/` lands (planned follow-up MR).
+
+### 3.5 Test Automation
+
+| Category | Approach |
+|---|---|
+| Open box (white box) | Unit tests in `flashdreams/tests/` (CPU-safe via `pytest -m "not manual"`), `integrations/*/tests/`. Pre-commit runs ruff + ty. |
+| Closed box (black box) | gRPC integration tests in `integrations/alpadreams/tests/`; lingbot WebRTC route tests in `integrations/lingbot/tests/`. |
+| Security in CI/CD | Pre-commit (ruff + ty + REUSE/SPDX lint), SBOM scan (nSpect) on release candidates, container-image digest pinning. |
+| Compiler / code sanitization | Python type-check via `ty`; no native compile chain beyond Triton kernels. |
+| Fuzzing | **Recommended** (FSR_FD_24): target ALPA-GRPC protobuf decode + any USDZ ingest path. POA&M item. |
+| Security-focused testing | Mirror the upstream `internal/tests/security/` Protocol + stub + positive/negative test pairs into `flashdreams/tests/security/`. |
+| Offensive security | Out of scope for the MVSB-32946 deliverable; recommended ad-hoc review once the input gate / anonymizer land. |
+
+### 3.6 Other Design Considerations
+
+#### 3.6.1 Resource Limits
+
+| Software Module | Resource | Requirement |
+|---|---|---|
+| FD-INFRA (Pipeline) | GPU DRAM | Fits within one GPU at `chunk_size=2`; ~40–80 GB depending on recipe + CP size |
+| FD-INFRA | Wall-clock per chunk | ~900 ms steady-state on single H100 reference |
+| LING-RTC | Active sessions | **1** per process (architectural invariant) |
+| Output anonymizer | Wall-clock per chunk | ≤50 ms / chunk hard budget |
+| Input content gate | Wall-clock per session | ≤200 ms one-shot at init |
+
+#### 3.6.2 High Availability
+
+FlashDreams is **not** a high-availability service. Each server process is single-tenant. Recovery is by operator restart. This is consistent with the "no NVIDIA-side ingress/egress/storage" invariant — there is no production hosting plane.
+
+#### 3.6.3 Scalability
+
+- **Inference**: scales sideways by spinning up additional independent server processes on distinct GPU sets (no shared session state across processes).
+- **Multi-GPU**: scales up via `torchrun --nproc_per_node=N` with FSDP × CP context-parallelism; only rank 0 terminates the serving listener.
+
+#### 3.6.4 Future Work
+
+1. **Land FSR_FD_04** (checkpoint integrity) before the 1.1 GA Apache-2.0 flip.
+2. **Default the network binds to loopback** (FSR_FD_10) in OSS-facing docs and CLI.
+3. **Land the input content gate** (FSR_FD_06) — single Cosmos-1.0-Guardrail call at session init.
+4. **Specify a few-step output anonymizer reference** for downstream adopters (FSR_FD_07).
+5. **Document operator-side Sigstore guidance** in `docs/security/SECURITY.md` so operators who publish a FlashDreams container know to sign and verify (FSR_FD_05).
+6. **Mirror upstream `internal/tests/security/` into `flashdreams/tests/security/`** so FlashDreams stands alone as the FSR-coverage source-of-truth for external operators.

--- a/docs/arch/sadd.md
+++ b/docs/arch/sadd.md
@@ -136,7 +136,7 @@ Full block diagrams in [Static view](architecture.md#static-view); runtime inter
 1. **Single-host trust collapse** — when consumed from `omni-dreams/samples/interactive-drive`'s documented `docker run`, the container uses `--network=host --ipc=host`, mounts the Wayland socket, and forwards `$SSH_AUTH_SOCK`. The container is effectively trusted-equal-to-host. Acceptable for local dev; documented as OE-1.
 2. **One active session per server process** (lingbot) — simplifies STRIDE-D analysis but is a DoS pinhole if exposed beyond loopback (T-DOS-1).
 3. **No in-process integrity check on downloaded checkpoints** — relies on HTTPS + HF/S3 ACLs; a poisoned cache survives container restarts (FSR_FD_04).
-4. **Default network bind is `0.0.0.0`** in the documented lingbot invocation — an audit hot-spot to be tightened (FSR_FD_10).
+4. **Default network bind is `0.0.0.0`** in both lingbot (`integrations/lingbot/lingbot/webrtc/server.py:66`) and alpadreams gRPC (`integrations/alpadreams/alpadreams/grpc/server.py:1336`, `add_insecure_port`) — an audit hot-spot to be tightened (FSR_FD_10).
 5. **Few-step output anonymizer is the only architecturally viable design**: a full general-purpose face/plate detector would push chunk wall-clock past the interactive budget. The architecture treats per-chunk output anonymization as **opt-in** (FSR_FD_07); the **input content gate** is **on-by-default** (FSR_FD_06).
 6. **Reference implementation for both filters**: [`nvidia/Cosmos-1.0-Guardrail`](https://huggingface.co/nvidia/Cosmos-1.0-Guardrail). Pre-Guard image side serves the CSAM/gore gate; post-Guard (RetinaFace + plate + blur) is the few-step network sized for the ≤50 ms / chunk budget on a small auxiliary GPU slot.
 

--- a/docs/arch/sadd.md
+++ b/docs/arch/sadd.md
@@ -243,49 +243,13 @@ See [Dynamic view](architecture.md#dynamic-view) § 4 (checkpoint resolution) an
 
 ### 3.4 Security Design
 
-#### What is an FSR?
-
-A **Functional Security Requirement** (FSR) is a detailed security requirement decomposed from a high-level Security Objective. Each FSR is a SHALL-statement bound to a specific control: it traces back to one or more **threats** (what it mitigates), forward to one or more **Security Objectives** (what it supports), and out to a **Test/Measurement** (how SQA verifies it). FSRs are the actionable contract that the development team owns.
-
-The column layout used in the canonical sheet follows the **Excel-Based Simple TAVA Template** (mirroring the NIM TAVA template column structure used by the broader Product Security community):
-`FSR ID | Functional Security Requirement | Risk Level | Risk Response | Responsibility | Priority Level | Test / Measurement`.
-
-In this program every FSR is prefixed `FSR_FD_NN` (FD = FlashDreams).
+An FSR (Functional Security Requirement) is a SHALL-statement bound to a specific control that traces back to one or more threats (what it mitigates), forward to one or more security objectives (what it supports), and out to a Test/Measurement (how SQA verifies it). FlashDreams uses the **Excel-Based Simple TAVA Template** column structure: `FSR ID | Functional Security Requirement | Risk Level | Risk Response | Responsibility | Priority Level | Test / Measurement`. Every FSR is prefixed `FSR_FD_NN`.
 
 #### Canonical FSR sheet — pointer
 
-The single source of truth is [`fsr_table.md`](fsr_table.md). See [`tava.md`](tava.md) § 3.2 for the cross-references back to threats and security objectives.
+The single source of truth is [`fsr_table.md`](fsr_table.md) — 24 canonical `FSR_FD_NN` rows plus 12 NIM-template mapping rows, in the Excel-Based Simple TAVA Template column structure. See [`tava.md`](tava.md) § 2.4.2 for the per-threat risk levels each FSR mitigates, and § 3.1 for the security objectives each FSR supports.
 
-The 24 FSRs at a glance:
-
-| FSR ID | One-line statement | Priority |
-|---|---|---|
-| FSR_FD_01 | TLS 1.2+ on non-loopback endpoints | P0 (non-loopback) / P1 (loopback) |
-| FSR_FD_02 | Logs SHALL strip secrets (HF / GitHub / AWS / Bearer / Authorization) | P0 |
-| FSR_FD_03 | Logs SHALL strip PII (face / plate / NVIDIA email / Slack ID) | P0 |
-| FSR_FD_04 | `FD-CKPT` SHALL verify checkpoint sha256 / signature before `torch.load` | P0 |
-| FSR_FD_05 | When an operator publishes a FlashDreams container image to their registry, the build/publish pipeline SHOULD Sigstore-sign and the pull flow SHOULD `cosign verify`. (Operator guidance — FlashDreams ships no canonical image.) | P2 (operator guidance) |
-| FSR_FD_06 | Session init SHALL run **Cosmos-1.0-Guardrail pre-Guard** on initial RGB | P0 |
-| FSR_FD_07 | `--anonymize` SHALL run **Cosmos-1.0-Guardrail post-Guard** per chunk, ≤50 ms | P1 / P0 (post-GA if regulated) |
-| FSR_FD_08 | `OMNI_DREAMS_HF_ORG` validated against code-resident allowlist | P0 |
-| FSR_FD_09 | Plugin registry SHALL deny third-party plugins absent allowlist | P0 |
-| FSR_FD_10 | Listeners SHALL default to `127.0.0.1`; non-loopback requires opt-in | P0 |
-| FSR_FD_11 | Profiling server SHALL bind loopback by default | P1 |
-| FSR_FD_12 | gRPC + HTTP signaling SHALL support token interceptor (mandatory non-loopback) | P0 (non-loopback) / P1 (loopback) |
-| FSR_FD_13 | Lingbot DataChannel SHALL validate JSON schema; ≤256 B; drop on miss | P0 |
-| FSR_FD_14 | Text input SHALL be length-bounded, Unicode-validated, parameter-typed | P0 |
-| FSR_FD_15 | Media input (USDZ / JPEG / PNG / mp4) SHALL be size + MIME + magic-validated | P0 |
-| FSR_FD_16 | Media parsing libraries SHALL be sandboxed (seccomp / subprocess) | P1 → P0 post-GA |
-| FSR_FD_17 | Media parser SHALL be restricted to the format dispatched | P1 |
-| FSR_FD_18 | Inference state SHALL be deallocated between sessions; GPU mem zeroed | P0 |
-| FSR_FD_19 | Inference responses SHALL be restricted to the originating session | P0 |
-| FSR_FD_20 | Per-client rate limits on signaling endpoints | P1 |
-| FSR_FD_21 | Session recording mode `0600`; off by default; explicit `--record` flag | P1 |
-| FSR_FD_22 | Docs SHALL document `--network=host` + `--ipc=host` trust collapse (OE-1) | P1 |
-| FSR_FD_23 | Slurm launch helper SHALL emit OE-2 banner; refuse colliding IMEX channel | P1 (omni-dreams consumer only) |
-| FSR_FD_24 | Continuous fuzz coverage on SceneLoader USDZ + ALPA-GRPC proto | R2 (post-GA) |
-
-As of upstream station check 2026-05-15, **20 of 24 FSRs have as-built contract+stub tests passing** in `omni-dreams/internal/tests/security/`, **230 / 230** tests in 1.86 s. Coverage is mirrored 1-to-1 into FlashDreams once `flashdreams/tests/security/` lands (planned follow-up MR).
+As of upstream station check 2026-05-15, **20 of 24 FSRs have as-built contract+stub tests passing** in `omni-dreams/internal/tests/security/` (**230 / 230** tests in 1.86 s). FSR_FD_05 is reframed as operator-side guidance because FlashDreams ships no canonical container image (commit `ab74b58`). The FlashDreams-side mirror at `flashdreams/tests/security/` is queued as a follow-up — see [`tava.md`](tava.md) § 6 Q-06.
 
 ### 3.5 Test Automation
 

--- a/docs/arch/tava.md
+++ b/docs/arch/tava.md
@@ -1,0 +1,348 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# TAVA — FlashDreams (MVSB-32946 subset)
+
+**Document Type:** Threat and Vulnerability Analysis (Manual TAVA 2.0)
+**Process:** TAVA v3 (Oct 31, 2024) Confluence guidance — 4 steps (Assets → Threats → FSRs → POA&M)
+**Based On:** Architecture views in [`architecture.md`](architecture.md) (Static / Dynamic / Data / Deployment) @ commit HEAD; flashdreams `base-v0.3-YYYYMMDD-SHA`; FlashDreams 1.0 GA target tracked by [MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946)
+**Calibration peer:** [SDGW-361 AutoGrader Unification TAVA](https://jirasw.nvidia.com/browse/SDGW-361) (structure / risk language / stakeholder sections)
+**Author:** Jonathan McCaffrey (TAVA PIC) with AI assist (Claude Opus 4.7, 1M context)
+**Status:** Draft, 2026-05-20. Subject to Security PIC review prior to nSpect acknowledgment under MVSB-32946.
+
+> **Relationship to the upstream TAVA**: this document is the **FlashDreams-scoped subset** of [`../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md`](../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md). It restates the assets, attacker model, threats, risk analysis, security objectives, and FSRs narrowed to the **flashdreams TOE** (recipes + core + infra + integrations; excluding omni-dreams interactive-drive and post-training). The upstream document remains the single source of truth where the two TOEs overlap. Coverage numbers cited as "as-built on station 2026-05-15" reference the upstream `omni-dreams/internal/tests/security/` package; the FlashDreams test mirror is planned for a follow-up MR.
+
+---
+
+## Executive Summary
+
+FlashDreams is a generative video world-model inference stack (offline recipes + interactive WebRTC / gRPC adapters). Distribution will be **public open-source via GitHub + HuggingFace** under Apache 2.0 (code) plus an open-model license (weights) once MVSB-33270 / MVSB-33271 close. That distribution flip — Eval-license private to Apache 2.0 public — is the single largest reason this TAVA exists.
+
+The core threat surfaces are:
+
+- **Generative-AI safety surface** — operator-supplied initial frames can drive the model to amplify harmful content (CSAM / gore / non-consensual real-person likenesses) downstream into video output (T-CONT-1 / T-PRIV-1).
+- **Server endpoints exposed by default on `0.0.0.0`** — lingbot WebRTC (`:8089`) and (configurably) the alpadreams gRPC + profiling server — without authentication or encryption in the documented developer flow (T-NET-1 / T-AUTH-1).
+- **Supply-chain integrity** of model weights (HF `nvidia/omni-dreams-*` and `nvidia/Cosmos-1.0-Guardrail`, S3 `s3://flashdreams`) — `torch.load` on a poisoned `.pt` is arbitrary-code execution (T-CKPT-1). FlashDreams ships **no canonical pre-published container image** (OE-7, commit `ab74b58`); operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`, so the container-image threat shape collapses to "upstream `nvidia/cuda` base image" + "operator-side build pipeline".
+- **Plugin discovery** via Python entry-points (`flashdreams-run`) — third-party packages installed in the operator's venv get imported and executed at module-import time (T-PLUG-1).
+
+**Overall risk rating: HIGH** — driven by (1) AI-safety surface on operator-supplied media, (2) public OSS distribution amplifying supply-chain blast radius, and (3) default-on `0.0.0.0` exposure without auth or TLS. The risk is **tractable** because every H-or-higher threat has a clear architectural seam already prototyped upstream and ready to mirror into `flashdreams/tests/security/`.
+
+The single highest-leverage residual ask before flashdreams 1.0 GA is to land **Cosmos-1.0-Guardrail pre-Guard** (FSR_FD_06) as a default-on hard gate at session init — one model invocation per session that drops T-CONT-1 from Critical to residual Low.
+
+---
+
+## Step 0 — Introduction
+
+| Field | Value |
+|---|---|
+| NSPECT ID | NSPECT-6O5R-39LY (flashdreams) — from MVSB-32946 comment |
+| Program name | FlashDreams (GA + OSS) |
+| Version | flashdreams v0.3 (`base-v0.3-YYYYMMDD-SHA`) |
+| Jira ticket | [MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946) |
+| PLC level | L1 |
+| Risk-indicator hit | Commercially Released; Sensitive Data (pre-release weights, internal HF / S3 endpoints) |
+| TAVA PIC | Jonathan McCaffrey (Security PIC TBD for ack) |
+| Architecture inputs | [Static view](architecture.md#static-view) · [Dynamic view](architecture.md#dynamic-view) · [Data view](architecture.md#data-view) · [Deployment view](architecture.md#deployment-view) |
+| SADD | [`sadd.md`](sadd.md) |
+| Methodology | NIST SP 800-30r1 qualitative risk; STRIDE for threat ID; AI/ML supplement implicit in pipeline assets |
+| Why manual TAVA 2.0 | Export-control-gated by MVSB-32940; AI-assist content in the draft must be reviewed by Security PIC before nSpect acknowledgment per parent ticket guidance |
+
+---
+
+## Step 1 — Security Assets (TOE, Architecture, DFD, Asset Inventory)
+
+### 1.1 Target of Evaluation (TOE)
+
+The TOE is the **runtime process tree** that executes FlashDreams inference, including:
+
+**In scope:**
+
+- `flashdreams/flashdreams/` — recipe + core + infra packages and the `flashdreams-run` CLI
+- `flashdreams/integrations/alpadreams/` — gRPC server + Ludus HD-map renderer + profiling server
+- `flashdreams/integrations/lingbot/` — WebRTC server (single active session)
+- `flashdreams/integrations/{cosmos_predict2,wan21,self_forcing,causal_forcing,fastvideo_causal_wan22}/`
+- The supply chain that loads these into memory: HuggingFace, S3 (`pdx.s8k.io`), and the upstream `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` base image. FlashDreams ships **no canonical pre-published container image** (commit `ab74b58`); operators build locally from `docker/Dockerfile`.
+
+**Out of scope (Operational Environment, OE):**
+
+- The host Linux kernel + NVIDIA driver
+- Operator's browser
+- `omni-dreams/samples/interactive-drive` — consumer of FlashDreams; covered upstream
+- `omni-dreams/post-training` — fine-tune training stack; covered upstream
+- Slurm cluster admin posture (relevant only to the omni-dreams post-training consumer)
+- Upstream Cosmos2 / Wan / Cosmos-Reason1 / LightVAE source trees (vendored under `post-training/omnidreams/_src/` in omni-dreams)
+
+### 1.2 TOE Description
+
+See [Static view](architecture.md#static-view) for the full block diagram. Summary:
+
+1. The operator launches a flashdreams-run-derived process (CLI, gRPC server, or WebRTC server). That process loads a checkpoint from HF or S3, builds a DiT + VAE/TAE pipeline, and either runs to completion (offline generation) or enters a server loop.
+2. Inputs arriving at runtime: keyboard / WebRTC DataChannel actions, optional initial RGB image, HD-map raster from Ludus, text prompt, scene file.
+3. Outputs: RGB frames (served via WebRTC video track or streamed as gRPC frames), optional disk recordings, logs.
+4. No NVIDIA-side ingress, egress, or storage of operator data is in scope (architecture invariant from MVSB-32946 comment).
+
+### 1.3 Security Assumptions (OE)
+
+| ID | Assumption |
+|---|---|
+| OE-1 | Operator runs the inference servers on **trusted private hardware** with the documented `--network=host --ipc=host` Docker invocation (when consumed via `omni-dreams/samples/interactive-drive`). Servers bound to non-loopback addresses are only exposed on trusted LANs. |
+| OE-2 | Out-of-scope for FlashDreams TOE; relevant for the omni-dreams post-training consumer (Slurm cluster admin enforces tenant isolation). |
+| OE-3 | Operator HuggingFace and S3 credentials are correctly scoped (least-privilege; revocable) and not committed to git. When the operator uses a private registry for their FlashDreams container, the registry's PAT / token is also operator-managed. |
+| OE-4 | The host Linux kernel + NVIDIA driver are patched per NVIDIA's PLC standard. |
+| OE-5 | Cosmos-Guardrail weights are sourced from `huggingface.co/nvidia/Cosmos-1.0-Guardrail` or an NVIDIA-published mirror; the Guardrail itself is treated as a trusted, NVIDIA-evaluated artifact. |
+| OE-6 | Operator network policy may block outbound `huggingface.co` egress. In that environment, Cosmos-Guardrail weights MUST be pre-staged on local disk by the operator. Stations without egress and without pre-staged weights SHALL refuse to start a session rather than silently bypass the gate. |
+| OE-7 | FlashDreams ships **no canonical pre-published container image** (per commit `ab74b58`). Operators build locally from `docker/Dockerfile` against the upstream `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` base image, or `uv sync` natively against a host CUDA stack. Any operator-built image lives under the operator's own registry / access controls. The container-image supply-chain trust delegates upward to the upstream `nvidia/cuda` base image; T-IMG-1 narrows from "external supply-chain compromise of an NVIDIA-published FlashDreams image" to "tampered `nvidia/cuda` base or tampered operator build pipeline". FSR_FD_05 becomes **operator guidance** (Sigstore-sign if you publish; `cosign verify` if you pull) rather than a FlashDreams-side enforcement. |
+
+### 1.4 Architecture Diagram
+
+Submitted alongside this TAVA: [Static view](architecture.md#static-view), [Dynamic view](architecture.md#dynamic-view), [Deployment view](architecture.md#deployment-view).
+
+### 1.5 Dataflow Diagram
+
+[Data view](architecture.md#data-view) §§ 1–3 with explicit trust boundaries.
+
+### 1.6 Security Asset Inventory
+
+| Asset ID | Asset | Where it lives | C/I/A | Sensitivity |
+|---|---|---|---|---|
+| A-CKPT | Model weights (cosmos, wan, taehv, plus recipe checkpoints fetched by adapters: alpadreams, lingbot_world, predict2 / predict2_multiview) | HF, S3, GPU DRAM at runtime | C+I | NVIDIA-proprietary pre-GA; Apache 2.0 / OML at GA |
+| A-CFG | YAML recipe configs and `--config_name` registry | Repo + GPU DRAM | I | Public on GA |
+| A-PROMPT | Operator text prompts | RAM, possibly disk logs | C | Operator-confidential |
+| A-INPUT-RGB | Operator-supplied initial RGB / scene first frame | RAM, scene cache | C (if PII) | Possibly PII |
+| A-FRAME | Generated video frames | RAM, WebRTC track, gRPC stream, optional disk | C+I | Operator-confidential; possibly contains identifiable faces/plates |
+| A-HDMAP | HD-map raster (Ludus output / cached PNG) | RAM, disk | I | Public synthetic |
+| A-SESSION | Active session state (WebRTC PeerConnection, gRPC session_id) | Server RAM | C+I+A | Operator-confidential |
+| A-RECORDING | Optional session recording (`.pt` + `.json`) | Disk | C+I | Operator-confidential |
+| A-SECRET | HF_TOKEN, GITHUB_PAT, `credentials/s3_checkpoint.secret` | Env, disk | C+I | Secret |
+| A-IMG | Operator-built FlashDreams container image (from `docker/Dockerfile` on top of upstream `nvidia/cuda:13.2.1`) | Disk, operator's registry | I | Operator-owned (FlashDreams ships no canonical image — see OE-7) |
+| A-LOGS | Logs, profiling traces | Disk | C | Operator-confidential |
+| A-PLUGIN | Plugin registry / entry-point loaded code | Process | I | Code execution surface |
+| A-RUNTIME | Python process / GPU context / NCCL group | RAM, GPU | I+A | Process integrity |
+
+---
+
+## Step 2 — Security Threats
+
+### 2.1 Attacker Modeling
+
+| Actor | Intent | Capability | Access | Notes |
+|---|---|---|---|---|
+| **Curious LAN-mate** | View someone else's interactive session, exfiltrate generated frames | Network-only; default browser tooling | LAN broadcast / WiFi co-tenant | Triggered by `0.0.0.0` default binds (LING-RTC `:8089`; ALPA-GRPC configurable) |
+| **Supply-chain attacker** | Place poisoned weights or container bytes on the path between NVIDIA / upstream and operator | Cloud-side compromise of HF mirror; or compromise of upstream `nvidia/cuda` base image; or operator-side build-pipeline compromise (OE-7) | Indirect; requires HF mirror / upstream-CUDA compromise OR operator-side CI access | Highest blast radius is the HF weights path; container-image path narrowed to "operator-owned build" after OE-7 |
+| **Malicious recipe / plugin author** | Register a plugin under the flashdreams entry-point that runs code on `flashdreams-run` | Local install via `uv pip install` | Operator's venv | T-PLUG-1 |
+| **Operator under coercion / mistake** | Process attacker-supplied input image to elicit harmful generations (CSAM, gore, deepfakes of real people) | Submit a crafted initial RGB | Local CLI / WebRTC | T-CONT-1, T-PRIV-1 |
+| **Insider with repo write** | Backdoor in pre-GA code | Git push | git remote | Mitigated by code review + signed commits; out of TAVA scope but acknowledged |
+| **State-level actor** | Steal pre-release weights or training data | Sophisticated supply chain + endpoint compromise | Any | Treated as ceiling; mitigations are NVIDIA-wide controls, not TOE-specific |
+
+### 2.2 Trust Boundaries
+
+| ID | Boundary | Crossing point(s) |
+|---|---|---|
+| TB-1 | Operator workstation ↔ external networks | HF / S3 / upstream `nvidia/cuda` outbound; LING-RTC + ALPA-GRPC inbound |
+| TB-2 | Operator browser / gRPC client ↔ inference server (loopback or LAN) | HTTP signaling, WebRTC media, gRPC streaming |
+| TB-3 | Container ↔ host (`--network=host` + `--ipc=host`) | Effective trust collapse documented as OE-1 |
+| TB-4 | Pipeline ↔ disk (recordings, logs) | session_recorder I/O |
+| TB-5 | Pre-Guard / post-Guard ↔ inference pipeline | Cosmos-Guardrail integration seam |
+
+### 2.3 Threat Inventory (STRIDE)
+
+| Threat ID | STRIDE | Asset(s) | Attack path |
+|---|---|---|---|
+| T-NET-1 | S, T, I, D | A-SESSION, A-FRAME | LAN-mate connects to lingbot `:8089` while LING-RTC bound `0.0.0.0` and hijacks the active WebRTC session |
+| T-NET-2 | I | A-LOGS | LAN-mate reaches the profiling server (alpadreams) |
+| T-AUTH-1 | S | A-SESSION | gRPC client impersonates legitimate operator (no auth interceptor) |
+| T-CKPT-1 | T, E | A-CKPT, A-RUNTIME | Poisoned `.pt` pickle on HF/S3 path executes arbitrary code at `torch.load` |
+| T-CKPT-2 | T | A-CKPT | Substituted weights generate biased / dangerous output without RCE |
+| T-CFG-1 | T | A-CFG | `OMNI_DREAMS_HF_ORG` redirected to attacker-controlled HF org pulls poisoned weights |
+| T-PLUG-1 | E | A-PLUGIN, A-RUNTIME | Malicious entry-point-registered plugin gets `import`-ed by `flashdreams-run` |
+| T-CONT-1 | I | A-FRAME, reputation | Operator (or attacker via WebRTC) supplies a CSAM / gore initial frame; the world model amplifies into a generated video |
+| T-PRIV-1 | I | A-FRAME | Model emits a recognizable face or license plate (training-data echo) |
+| T-INPUT-1 | T, D | A-SESSION | Malformed JSON / oversized payload on WebRTC DataChannel crashes or wedges the server |
+| T-RECORD-1 | I | A-RECORDING, A-PROMPT | Disk-resident `.pt` recordings readable by other local users |
+| T-SECRET-1 | I | A-SECRET | HF_TOKEN / S3 key leak into logs or stderr |
+| T-IMG-1 | T | A-IMG | Tampered upstream `nvidia/cuda` base image, or operator-side build-pipeline compromise (narrowed by OE-7 — FlashDreams ships no canonical pre-published image) |
+| T-MOUNT-1 | E | A-RUNTIME | Container compromise pivots to host via Wayland socket, SSH agent forward, shared IPC (architecturally accepted under OE-1 when consumed via interactive-drive) |
+| T-DOS-1 | D | A-SESSION | LAN-mate floods lingbot signaling; single active session forces eviction of legitimate user |
+| T-FUZZ-1 | T, E | A-RUNTIME | Malformed protobuf at ALPA-GRPC; malformed media at SceneLoader (consumer-side) |
+
+### 2.4 Risk Analysis (NIST SP 800-30 Rev 1, qualitative)
+
+Likelihood and Impact each scored on 5-level scale (VL, L, M, H, VH). Overall Likelihood combines *threat-causes-adverse-impact* with *threat-occurs* (default: take the lower of the two unless one is VL). Risk = Overall Likelihood × Impact. Acceptance criteria: **H or VH risk must have a P1 FSR** with a near-term POA&M; **M risk** must have a P2 FSR or documented residual; **L/VL** may be accepted with rationale.
+
+#### 2.4.1 Risk matrix
+
+| Likelihood ↓ \ Impact → | VL | L | M | H | VH |
+|---|---|---|---|---|---|
+| **VH** | L | M | H | VH | VH |
+| **H** | L | M | M | H | VH |
+| **M** | VL | L | M | H | H |
+| **L** | VL | L | L | M | M |
+| **VL** | VL | VL | L | L | M |
+
+#### 2.4.2 Per-threat risk table
+
+| Threat | Likelihood (occur × cause-adverse) | Impact | Risk | Rationale |
+|---|---|---|---|---|
+| T-NET-1 (LAN-mate session hijack) | M × M = M | H (operator-confidential content disclosed) | **H** | `0.0.0.0` is the documented default; impact gated by whether real prompts contain sensitive content |
+| T-NET-2 (profiling server reach) | L × M = L | M | **L** | Off by default; FSR_FD_11 sets loopback-default |
+| T-AUTH-1 (gRPC spoofing) | L × M = L | M | **L** | Dev configs unauth'd; rises to M if exposed |
+| **T-CKPT-1 (pickle RCE)** | L × H = L | **VH** (RCE in operator process) | **M→H** | Likelihood ceiling raised by mirror/HF-org spoofing chain (T-CFG-1) |
+| T-CKPT-2 (silent weight swap) | L × H = L | H | **M** | Output integrity / brand |
+| T-CFG-1 (HF org redirect) | L × H = L | H | **M** | Defensible with a code-pinned allowlist (FSR_FD_08) |
+| **T-PLUG-1 (plugin RCE)** | L × H = L | **VH** | **M→H** | Entry-point discovery is uplift-style attack on dev workstation |
+| **T-CONT-1 (CSAM/gore in init RGB)** | M × H = M | **VH** (legal, reputational) | **H** | Mitigated by Cosmos-Guardrail pre-Guard (FSR_FD_06) |
+| **T-PRIV-1 (face / plate emission)** | M × M = M | H (privacy regulator + brand) | **H** | Mitigated by Cosmos-Guardrail post-Guard (FSR_FD_07); opt-in for now |
+| T-INPUT-1 (DataChannel DoS) | M × M = M | M | **M** | Single active session amplifies |
+| T-RECORD-1 (recording perm) | M × M = M | M | **M** | Disk perms control (FSR_FD_21) |
+| T-SECRET-1 (token in logs) | M × H = M | H | **H** | Standard hygiene (FSR_FD_02) |
+| T-IMG-1 (image tamper) | VL × H = VL | H | **L** | OE-7 collapses the threat to upstream `nvidia/cuda` + operator-side build; FSR_FD_05 is operator guidance |
+| T-MOUNT-1 (container pivot) | L × H = L | H | **M** | OE-1 accepted; docs FSR (FSR_FD_22) |
+| T-DOS-1 (signaling flood) | M × M = M | M | **M** | Single-session invariant amplifies; FSR_FD_20 rate limits |
+| T-FUZZ-1 (proto / scene parse) | L × M = L | M | **L** | Parse surfaces narrow today; FSR_FD_15 / FSR_FD_17 / FSR_FD_24 |
+
+---
+
+## Step 3 — Security Objectives and Functional Security Requirements
+
+### 3.1 Security Objectives
+
+| ID | Objective | C/I/A/Authenticity/Accountability |
+|---|---|---|
+| SO-1 | Preserve confidentiality of operator-supplied prompts, frames, and session content. | C |
+| SO-2 | Guarantee that only NVIDIA-published model weights and container images execute in the TOE. | I, Authenticity |
+| SO-3 | Prevent the TOE from generating or amplifying CSAM, gore, or disclosing real-person likenesses without consent. | I, accountability (under privacy regulation) |
+| SO-4 | Limit blast radius of any TOE compromise to the operator's session — no privilege escalation to host. | I, A |
+| SO-5 | Protect secrets (HF_TOKEN, S3 keys, GitHub PAT) in transit and at rest. | C |
+| SO-6 | Maintain availability of the single active session under expected operator load. | A |
+
+### 3.2 Functional Security Requirements (FSRs)
+
+The canonical FSR sheet is [`fsr_table.md`](fsr_table.md), in the **Excel-Based Simple TAVA Template** column structure (`FSR ID | Functional Security Requirement | Risk Level | Risk Response | Responsibility | Priority Level | Test / Measurement`).
+
+`fsr_table.md` populates the NIM TAVA template form (`FSR_<TOE>_NN`) for the FlashDreams TOE by mapping each row to the canonical `FSR_FD_NN` upstream FSR and citing the upstream as-built test (`omni-dreams/internal/tests/security/test_*.py`) where one exists.
+
+Risk-level enum: Very Low / Low / Moderate / High / Very High.
+Risk-response enum: Remediate / Transfer / Share / Avoid / Accept.
+Priority enum: P0 (Must Implement) / P1 (Will not block GA if not implemented) / R2 (research / recommended post-GA).
+
+### 3.2.1 FSR coverage summary
+
+| Status | Count | FSRs |
+|---|---|---|
+| ✅ As-built contract+stub tests passing upstream (mirror to FlashDreams planned) | 20 | FSR_FD_01, _02, _03, _04, _06, _08, _09, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _23 |
+| 📄 Documented control landed (no test seam needed) | 1 | FSR_FD_22 (README trust-collapse callout) |
+| ⏳ Externally blocked or operator-side | 3 | FSR_FD_05 (operator guidance — FlashDreams ships no canonical image), FSR_FD_07 (Cosmos-Guardrail real backend — HF egress per OE-6), FSR_FD_24 (OSS-Fuzz post-GA) |
+
+---
+
+## Step 4 — Plan of Actions and Milestones (POA&M)
+
+Risks are assigned a treatment (Avoid / Accept / Remediate / Transfer / Share) and a target. Items already in flight in the omni-dreams 1.1 plan are cross-linked.
+
+| FSR ID | Item | Risk Response | Target | Owner | Cross-link |
+|---|---|---|---|---|---|
+| FSR_FD_06 | Input content gate via Cosmos-Guardrail pre-Guard | Remediate | Land in repo + tests before 1.0 GA | SIL eng + Security PIC | Upstream MR (positive/negative test pair landed; real backend pending) |
+| FSR_FD_07 | Cosmos-Guardrail post-Guard `--anonymize` opt-in | Remediate | Land `--anonymize` flag + benchmark before 1.0 GA | SIL eng | `omni-dreams/internal/docs/planning/cosmos_guardrail_benchmark.md` |
+| FSR_FD_10 | Default-loopback bind | Remediate | Flip defaults; warning banner; ≤2 wk after MR review | SIL eng | Upstream `bind_address.py` |
+| FSR_FD_12 | gRPC / HTTP token interceptor | Remediate | Land gRPC interceptor + lingbot HTTP token check before non-loopback bind ships | SIL eng | |
+| FSR_FD_04 | Checkpoint integrity manifest | Remediate | Manifest + safetensors-preferred; before 1.1 OSRB close | SIL eng | MVSB-33271; upstream `checkpoint_verifier.py` |
+| FSR_FD_08 | HF-org allowlist | Remediate | Land at CLI parse; before 1.0 GA | SIL eng | Upstream `hf_org_allowlist.py` |
+| FSR_FD_09 | Plugin allowlist | Remediate | Default-deny in `RunnerRegistry.discover_plugin`; before 1.0 GA | SIL eng | Upstream `plugin_registry.py` |
+| FSR_FD_02 | Log redaction of secrets | Remediate | Patch into core logger; before 1.1 GA | SIL eng | Upstream `log_redactor.py` |
+| FSR_FD_03 | Log redaction of PII | Share | Land scrubber for face/plate strings; before 1.1 GA | SIL eng + Operator | (paired with FSR_FD_07 output) |
+| FSR_FD_13 | DataChannel schema validation | Remediate | Patch lingbot DataChannel handler; before 1.0 GA | SIL eng | Upstream `datachannel_validator.py` |
+| FSR_FD_05 | Operator-side image-signing guidance (no canonical NVIDIA image post-`ab74b58`) | Share | Add a `docs/security/SECURITY.md` section recommending `cosign sign` / `cosign verify` for operators who publish FlashDreams containers | Documentation + SIL eng | |
+| FSR_FD_01 | TLS 1.2+ on non-loopback endpoints | Remediate | Add reverse-proxy invocation snippet + native TLS support; before non-loopback bind ships | SIL eng | (paired with FSR_FD_10) |
+| FSR_FD_11 | Profiling-server separate exposure flag | Remediate | After FSR_FD_10 lands | SIL eng | |
+| FSR_FD_14 | Text input validation | Remediate | Add length + Unicode + parameter validation at CLI / gRPC parse | SIL eng | |
+| FSR_FD_15 | Media-file input validation | Remediate | Add MIME / magic / size validation on `--synthetic-initial-rgb` + adapter inputs | SIL eng | (input to FSR_FD_06) |
+| FSR_FD_16 | Media-parsing sandbox (seccomp) | Remediate | Subprocess-isolate media parsing; post-GA | SIL eng | |
+| FSR_FD_17 | Media-parsing format restriction | Remediate | Dispatch-layer format check before parser entry | SIL eng | |
+| FSR_FD_18 | Inference state cleared between sessions | Remediate | Audit + zero per-session GPU buffers on tear-down | SIL eng | |
+| FSR_FD_19 | Response restricted to requesting session | Remediate | Enforce session_id correlation in ALPA-GRPC | SIL eng | (lingbot already enforces via single-session invariant) |
+| FSR_FD_20 | Per-client rate limits | Remediate | Token-bucket on signaling endpoints | SIL eng | |
+| FSR_FD_21 | Session recording mode 0600 + off-by-default | Remediate | Tiny patch to recording_io | SIL eng | |
+| FSR_FD_22 | Trust-collapse docs for `--network=host` | Share | Reference upstream README docker-run section + add a FlashDreams security note | Documentation + SIL eng | |
+| FSR_FD_23 | Slurm tenant isolation banner + IMEX check (omni-dreams consumer) | Share | Banner-only in 1.0; full check post-GA | SIL eng + Cluster Ops | |
+| FSR_FD_24 | OSS-Fuzz coverage of parsers | Remediate | Post-GA / dot release | SIL eng | |
+| T-MOUNT-1 residual | Accept the trust-collapse for interactive Docker invocation (with OE-1 docs) | Accept | n/a | Security PIC | |
+
+---
+
+## Step 5 — TAVA Closeout Checklist
+
+- [ ] All four arch views attached.
+- [ ] SADD attached.
+- [ ] All threats traced to ≥1 FSR or a documented accept/transfer rationale.
+- [ ] All H-or-higher risks have a P1 FSR.
+- [ ] POA&M items have an owner and a milestone.
+- [ ] Security PIC review (TBD).
+- [ ] Export classification MVSB-32940 decided → pick TAVA 3.0 nSpect ack path or manual TAVA 2.0 link in nSpect.
+- [ ] Acknowledge in NSPECT-6O5R-39LY (TAVA 3.0 path) **or** link this doc in `Lifecycle & Documentation → Threat and Vulnerability Analysis (TAVA)` (manual TAVA 2.0 path).
+- [ ] MVSB-32946 → Done.
+
+---
+
+## Step 6 — Open Questions for Engineering / Stakeholders
+
+| # | Question | Blocks FSR(s) | Owner |
+|---|---|---|---|
+| Q-01 | What auth mechanism will alpadreams gRPC + lingbot HTTP support? mTLS, JWT, both? Does it differ between operator-LAN and cross-internet deployments? | FSR_FD_01, FSR_FD_12 | SIL eng + Security PIC |
+| Q-02 | When operators publish a FlashDreams container, should Cosmos-1.0-Guardrail weights be pre-staged in the image, or fetched at first run? Pre-staging closes OE-6 in restricted-egress environments. | FSR_FD_06, FSR_FD_07 | Documentation + SIL eng |
+| Q-03 | What is the canonical FSR_FD_08 allowlist on GA? Today the env-var defaults to `nvidia` (per `integrations/alpadreams/alpadreams/hf.py`); the documented internal mirror is `nvidia-omni-dreams-lha`. Confirm whether GA retains both or rotates. | FSR_FD_08 | Product Lead |
+| Q-04 | Are entry-point-discovered plugins expected at all on GA? If not, FSR_FD_09 can be tightened from allowlist to **always-deny**. | FSR_FD_09 | SIL eng |
+| Q-05 | What's the retention policy for opt-in session recordings (`.pt` / `.json`)? Strictly local? | FSR_FD_21, FSR_FD_03 | Privacy Review (MVSB-33273) |
+| Q-06 | When does the FlashDreams-side `flashdreams/tests/security/` mirror of the upstream `omni-dreams/internal/tests/security/` package land? | All FSRs with as-built tests | SIL eng |
+| Q-07 | What is the export-classification outcome of [MVSB-32940](https://jirasw.nvidia.com/browse/MVSB-32940)? | TAVA closeout path | Export Compliance |
+| Q-08 | Is there a named **Security PIC** for the FlashDreams 1.0 GA release? Closeout requires PIC review and acknowledgment. | All P0 FSRs | Program Management |
+
+---
+
+## Step 7 — Recommended Next Steps
+
+| Priority | Action | Owner | MR / Ticket |
+|---|---|---|---|
+| **P0** | Land Cosmos-1.0-Guardrail pre-Guard real backend at session init (FSR_FD_06) | SIL eng + Security PIC | Upstream + benchmark follow-up |
+| **P0** | Flip default network bind to loopback in lingbot + alpadreams (FSR_FD_10); warning banner when `--allow-public-bind` set | SIL eng | Upstream `bind_address.py` |
+| **P0** | Land checkpoint integrity verifier in `FD-CKPT` path before `torch.load` (FSR_FD_04) | SIL eng | Upstream + MVSB-33271 |
+| **P0** | Wire log-redaction filter into core logger (FSR_FD_02) + PII scrub for face/plate strings (FSR_FD_03) | SIL eng | Upstream `log_redactor.py` |
+| **P0** | Wire HF-org allowlist into CLI parse (FSR_FD_08) | SIL eng | Upstream `hf_org_allowlist.py` |
+| **P0** | Wire plugin allowlist into `RunnerRegistry.discover_plugin` (FSR_FD_09); decide whether GA permits plugins at all (Q-04) | SIL eng | Upstream `plugin_registry.py` |
+| **P0** | Wire DataChannel schema validator into lingbot.webrtc.session (FSR_FD_13) | SIL eng | Upstream `datachannel_validator.py` |
+| **P0** | Define and implement gRPC + HTTP token interceptor (FSR_FD_12); mandatory when non-loopback | SIL eng | Follow-up MR |
+| **P0** | Mirror upstream `internal/tests/security/` into `flashdreams/tests/security/` | SIL eng | This MR + follow-up |
+| **P1** | Land `--anonymize` post-Guard opt-in on output (FSR_FD_07) | SIL eng | Cosmos-Guardrail benchmark plan |
+| **P1** | Document operator-side Sigstore guidance in `docs/security/SECURITY.md` (FSR_FD_05) — FlashDreams ships no canonical image, so this is "if you publish, sign and verify" | Documentation + SIL eng | Follow-up MR |
+| **P1** | Add text + media input validation (FSR_FD_14, FSR_FD_15) | SIL eng | Follow-up MR |
+| **P1** | Audit per-session GPU buffer cleanup (FSR_FD_18); test cross-session leak (FSR_FD_19) | SIL eng | Follow-up MR |
+| **P1** | Rate-limit signaling endpoints (FSR_FD_20) | SIL eng | Follow-up MR |
+| **R2** | Media-parsing seccomp sandbox (FSR_FD_16) and format-dispatch restriction (FSR_FD_17) | SIL eng | Post-GA dot release |
+| **R2** | OSS-Fuzz integration for proto / parse seams (FSR_FD_24) | SIL eng | Post-GA dot release |
+
+---
+
+## Appendix A — Recommendations summary
+
+> The single highest-leverage change is to land **Cosmos-1.0-Guardrail pre-Guard at session init** as a default-on hard gate (FSR_FD_06) — it closes the highest-impact threat (T-CONT-1) with one model call per session, and the reference implementation already exists. Pair it with **default loopback binds for all listeners** (FSR_FD_10) and a **checkpoint-integrity manifest** (FSR_FD_04), and the highest-risk threats reduce to residual M-level operational controls before FlashDreams 1.0 GA.
+
+---
+
+## Appendix B — Mapping to Excel-Based Simple TAVA Template
+
+| Excel tab | Source in this doc |
+|---|---|
+| Introduction | Step 0 (table) + Executive Summary |
+| Target of Evaluation | Step 1.1, 1.2, 1.3 (OE-1..OE-7) |
+| Architecture | Step 1.4 (links to `architecture.md`) |
+| Dataflow | Step 1.5 (links to `architecture.md` Data view) |
+| Security Assets | Step 1.6 (C/I/A sensitivity grid) |
+| Attacker Model | Step 2.1 |
+| Threat Model | Step 2.2 (trust boundaries) + 2.3 (STRIDE inventory) |
+| Risk Analysis | Step 2.4 (NIST SP 800-30r1 qualitative; matrix + per-threat table) |
+| Security Objectives | Step 3.1 (SO-1..SO-6) |
+| FSRs | [`fsr_table.md`](fsr_table.md) (canonical `FSR_FD_NN` sheet with Excel column layout) |
+| POA&M | Step 4 (FSR_FD_NN-keyed) |
+| Open Questions | Step 6 |
+| Recommended Next Steps | Step 7 |

--- a/docs/arch/tava.md
+++ b/docs/arch/tava.md
@@ -22,7 +22,7 @@ FlashDreams is a generative video world-model inference stack (offline recipes +
 The core threat surfaces are:
 
 - **Generative-AI safety surface** — operator-supplied initial frames can drive the model to amplify harmful content (CSAM / gore / non-consensual real-person likenesses) downstream into video output (T-CONT-1 / T-PRIV-1).
-- **Server endpoints exposed by default on `0.0.0.0`** — lingbot WebRTC (`:8089`) and (configurably) the alpadreams gRPC + profiling server — without authentication or encryption in the documented developer flow (T-NET-1 / T-AUTH-1).
+- **Server endpoints exposed by default on `0.0.0.0`** — both lingbot WebRTC (`:8089`, `integrations/lingbot/lingbot/webrtc/server.py:66`) and alpadreams gRPC (`integrations/alpadreams/alpadreams/grpc/server.py:1336`, using `add_insecure_port`) — without authentication or encryption in the documented developer flow (T-NET-1 / T-AUTH-1).
 - **Supply-chain integrity** of model weights (HF `nvidia/omni-dreams-*` and `nvidia/Cosmos-1.0-Guardrail`, S3 `s3://flashdreams`) — `torch.load` on a poisoned `.pt` is arbitrary-code execution (T-CKPT-1). FlashDreams ships **no canonical pre-published container image** (OE-7, commit `ab74b58`); operators build locally from `docker/Dockerfile` against `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`, so the container-image threat shape collapses to "upstream `nvidia/cuda` base image" + "operator-side build pipeline".
 - **Plugin discovery** via Python entry-points (`flashdreams-run`) — third-party packages installed in the operator's venv get imported and executed at module-import time (T-PLUG-1).
 
@@ -54,9 +54,9 @@ The TOE is the **runtime process tree** that executes FlashDreams inference, inc
 **In scope:**
 
 - `flashdreams/flashdreams/` — recipe + core + infra packages and the `flashdreams-run` CLI
-- `flashdreams/integrations/alpadreams/` — gRPC server + Ludus HD-map renderer + profiling server
-- `flashdreams/integrations/lingbot/` — WebRTC server (single active session)
-- `flashdreams/integrations/{cosmos_predict2,wan21,self_forcing,causal_forcing,fastvideo_causal_wan22}/`
+- `integrations/alpadreams/` — gRPC server + Ludus HD-map renderer + profiling server
+- `integrations/lingbot/` — WebRTC server (single active session)
+- `integrations/{cosmos_predict2,wan21,self_forcing,causal_forcing,fastvideo_causal_wan22}/`
 - The supply chain that loads these into memory: HuggingFace, S3 (`pdx.s8k.io`), and the upstream `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` base image. FlashDreams ships **no canonical pre-published container image** (commit `ab74b58`); operators build locally from `docker/Dockerfile`.
 
 **Out of scope (Operational Environment, OE):**
@@ -109,7 +109,7 @@ Submitted alongside this TAVA: [Static view](architecture.md#static-view), [Dyna
 | A-HDMAP | HD-map raster (Ludus output / cached PNG) | RAM, disk | I | Public synthetic |
 | A-SESSION | Active session state (WebRTC PeerConnection, gRPC session_id) | Server RAM | C+I+A | Operator-confidential |
 | A-RECORDING | Optional session recording (`.pt` + `.json`) | Disk | C+I | Operator-confidential |
-| A-SECRET | HF_TOKEN, GITHUB_PAT, `credentials/s3_checkpoint.secret` | Env, disk | C+I | Secret |
+| A-SECRET | HF_TOKEN, `credentials/s3_checkpoint.secret`, plus any operator-managed container-registry token (post-`ab74b58`) | Env, disk | C+I | Secret |
 | A-IMG | Operator-built FlashDreams container image (from `docker/Dockerfile` on top of upstream `nvidia/cuda:13.2.1`) | Disk, operator's registry | I | Operator-owned (FlashDreams ships no canonical image — see OE-7) |
 | A-LOGS | Logs, profiling traces | Disk | C | Operator-confidential |
 | A-PLUGIN | Plugin registry / entry-point loaded code | Process | I | Code execution surface |
@@ -205,10 +205,10 @@ Likelihood and Impact each scored on 5-level scale (VL, L, M, H, VH). Overall Li
 | ID | Objective | C/I/A/Authenticity/Accountability |
 |---|---|---|
 | SO-1 | Preserve confidentiality of operator-supplied prompts, frames, and session content. | C |
-| SO-2 | Guarantee that only NVIDIA-published model weights and container images execute in the TOE. | I, Authenticity |
+| SO-2 | Guarantee that only NVIDIA-published model weights load in the TOE; if the operator publishes a FlashDreams container, only signed images verified by `cosign` execute. (FlashDreams ships no canonical image; SO-2's container half is operator-side per OE-7.) | I, Authenticity |
 | SO-3 | Prevent the TOE from generating or amplifying CSAM, gore, or disclosing real-person likenesses without consent. | I, accountability (under privacy regulation) |
 | SO-4 | Limit blast radius of any TOE compromise to the operator's session — no privilege escalation to host. | I, A |
-| SO-5 | Protect secrets (HF_TOKEN, S3 keys, GitHub PAT) in transit and at rest. | C |
+| SO-5 | Protect secrets (HF_TOKEN, S3 keys, plus any registry token the operator uses for their FlashDreams container) in transit and at rest. | C |
 | SO-6 | Maintain availability of the single active session under expected operator load. | A |
 
 ### 3.2 Functional Security Requirements (FSRs)

--- a/docs/arch/tava.md
+++ b/docs/arch/tava.md
@@ -6,13 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 # TAVA — FlashDreams (MVSB-32946 subset)
 
 **Document Type:** Threat and Vulnerability Analysis (Manual TAVA 2.0)
-**Process:** TAVA v3 (Oct 31, 2024) Confluence guidance — 4 steps (Assets → Threats → FSRs → POA&M)
-**Based On:** Architecture views in [`architecture.md`](architecture.md) (Static / Dynamic / Data / Deployment) @ commit HEAD; flashdreams `base-v0.3-YYYYMMDD-SHA`; FlashDreams 1.0 GA target tracked by [MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946)
-**Calibration peer:** [SDGW-361 AutoGrader Unification TAVA](https://jirasw.nvidia.com/browse/SDGW-361) (structure / risk language / stakeholder sections)
+**Process:** TAVA v3 (Oct 31, 2024) Confluence guidance — Assets → Threats → FSRs → POA&M
+**Based On:** [`architecture.md`](architecture.md) @ HEAD; flashdreams v0.3
 **Author:** Jonathan McCaffrey (TAVA PIC) with AI assist (Claude Opus 4.7, 1M context)
-**Status:** Draft, 2026-05-20. Subject to Security PIC review prior to nSpect acknowledgment under MVSB-32946.
+**Status:** Draft 2026-05-20; pending Security PIC review under MVSB-32946
 
-> **Relationship to the upstream TAVA**: this document is the **FlashDreams-scoped subset** of [`../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md`](../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md). It restates the assets, attacker model, threats, risk analysis, security objectives, and FSRs narrowed to the **flashdreams TOE** (recipes + core + infra + integrations; excluding omni-dreams interactive-drive and post-training). The upstream document remains the single source of truth where the two TOEs overlap. Coverage numbers cited as "as-built on station 2026-05-15" reference the upstream `omni-dreams/internal/tests/security/` package; the FlashDreams test mirror is planned for a follow-up MR.
+> **Relationship to the upstream TAVA**: this is the FlashDreams-scoped subset of [`../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md`](../../../omni-dreams/internal/docs/planning/tava_omni_dreams_flashdreams.md), narrowed to the **flashdreams TOE** (recipes + core + infra + integrations; excluding omni-dreams interactive-drive and post-training). The upstream document remains the source of truth where the two TOEs overlap. Coverage numbers cited as "as-built on station 2026-05-15" reference the upstream `omni-dreams/internal/tests/security/` package; the FlashDreams test mirror is planned for a follow-up MR.
 
 ---
 
@@ -37,17 +36,12 @@ The single highest-leverage residual ask before flashdreams 1.0 GA is to land **
 
 | Field | Value |
 |---|---|
-| NSPECT ID | NSPECT-6O5R-39LY (flashdreams) — from MVSB-32946 comment |
-| Program name | FlashDreams (GA + OSS) |
-| Version | flashdreams v0.3 (`base-v0.3-YYYYMMDD-SHA`) |
-| Jira ticket | [MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946) |
-| PLC level | L1 |
-| Risk-indicator hit | Commercially Released; Sensitive Data (pre-release weights, internal HF / S3 endpoints) |
+| NSPECT ID | NSPECT-6O5R-39LY (flashdreams) |
+| Program | FlashDreams (GA + OSS) — v0.3 |
+| Jira | [MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946); PLC L1; manual TAVA 2.0 path (gated by MVSB-32940 export classification) |
 | TAVA PIC | Jonathan McCaffrey (Security PIC TBD for ack) |
-| Architecture inputs | [Static view](architecture.md#static-view) · [Dynamic view](architecture.md#dynamic-view) · [Data view](architecture.md#data-view) · [Deployment view](architecture.md#deployment-view) |
-| SADD | [`sadd.md`](sadd.md) |
-| Methodology | NIST SP 800-30r1 qualitative risk; STRIDE for threat ID; AI/ML supplement implicit in pipeline assets |
-| Why manual TAVA 2.0 | Export-control-gated by MVSB-32940; AI-assist content in the draft must be reviewed by Security PIC before nSpect acknowledgment per parent ticket guidance |
+| Inputs | [Static](architecture.md#static-view) · [Dynamic](architecture.md#dynamic-view) · [Data](architecture.md#data-view) · [Deployment](architecture.md#deployment-view) · [`sadd.md`](sadd.md) |
+| Methodology | NIST SP 800-30r1 qualitative risk; STRIDE for threat ID |
 
 ---
 

--- a/docs/arch/tava.md
+++ b/docs/arch/tava.md
@@ -226,7 +226,7 @@ Priority enum: P0 (Must Implement) / P1 (Will not block GA if not implemented) /
 | Status | Count | FSRs |
 |---|---|---|
 | ✅ As-built contract+stub tests passing upstream (mirror to FlashDreams planned) | 20 | FSR_FD_01, _02, _03, _04, _06, _08, _09, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _23 |
-| 📄 Documented control landed (no test seam needed) | 1 | FSR_FD_22 (README trust-collapse callout) |
+| 📄 Documented control (no test seam needed) | 1 | FSR_FD_22 (trust-collapse callout in FlashDreams `docs/security/SECURITY.md` + upstream interactive-drive README) |
 | ⏳ Externally blocked or operator-side | 3 | FSR_FD_05 (operator guidance — FlashDreams ships no canonical image), FSR_FD_07 (Cosmos-Guardrail real backend — HF egress per OE-6), FSR_FD_24 (OSS-Fuzz post-GA) |
 
 ---


### PR DESCRIPTION
  - Land the FlashDreams-scoped TAVA / SADD / FSR documentation under
    `docs/arch/` that supports the manual TAVA 2.0 acknowledgment path for
    [MVSB-32946](https://jirasw.nvidia.com/browse/MVSB-32946):
    `architecture.md` (four views), `sadd.md` (per PLC-L1 template),
    `tava.md` (assets / threats / risk / objectives / POA&M), `fsr_table.md`
    (Excel-Based Simple TAVA Template column structure, FSR_FD_01..36).
  - agent-runnable security-architect workflow to
    `agentic/skills/flashdreams-security-architect/SKILL.md` 