### PR TITLE
ci(reuse-lint): add merge_group trigger for merge queue

### DIFF
--- a/.github/workflows/reuse-lint.yml
+++ b/.github/workflows/reuse-lint.yml
@@ -2,6 +2,8 @@ name: reuse-lint
 
 on:
   pull_request:
+  merge_group:
+    branches: [main]
   push:
     branches:
       - main


### PR DESCRIPTION
The `reuse-lint` workflow (`REUSE 3.3 compliance (repo-wide)` and
`OSRB collateral sanity check`) is a required check in branch protection
but was not updated in #138 to fire on `merge_group` events. This causes
the merge queue to stall indefinitely waiting for checks that never start.

Adds the same `merge_group: branches: [main]` trigger that `ci.yml` and
`doc.yml` received in #138.

**Impact without this fix:** any PR entering the merge queue hangs until
timeout because the two reuse-lint jobs never run on the queue ref.