### PR TITLE
docs: document build-performance env vars for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,10 @@ issue and we'll fix it.
 4. [Submitting a pull request](#submitting-a-pull-request)
 5. [Code review and merge](#code-review-and-merge)
 6. [Coding conventions](#coding-conventions)
-7. [Licensing of contributions](#licensing-of-contributions)
-8. [Filing issues and security reports](#filing-issues-and-security-reports)
-9. [Code of Conduct](#code-of-conduct)
+7. [Speeding up local builds](#speeding-up-local-builds)
+8. [Licensing of contributions](#licensing-of-contributions)
+9. [Filing issues and security reports](#filing-issues-and-security-reports)
+10. [Code of Conduct](#code-of-conduct)
 
 ## Ways to contribute
 
@@ -272,6 +273,98 @@ uv run pytest -m ci_cpu          # CPU-safe tests only
 uv run pytest -m ci_gpu          # GPU tests only (needs CUDA)
 uv run pytest -m "not manual"    # everything that runs in CI
 uv run pytest                    # all tests including manual
+```
+
+## Speeding up local builds
+
+The first `uv sync` in a fresh environment compiles several CUDA
+extensions from source (transformer-engine, block-sparse-attn). On a
+workstation this can take 30+ minutes. The environment variables below --
+the same ones used in CI -- dramatically reduce that time by limiting
+compilation to your GPU's architecture and controlling parallelism.
+
+### Detect your GPU architecture
+
+```bash
+# Returns e.g. "12.0" for an RTX 5090 / Blackwell
+nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1
+```
+
+Strip the dot to get the nvcc arch code (e.g. `12.0` -> `120`,
+`8.9` -> `89`).
+
+### Recommended environment variables
+
+```bash
+# Detect arch automatically (paste into your shell or .envrc):
+CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader \
+  | head -1 | tr -d '.')
+
+# Only compile CUDA kernels for YOUR GPU (instead of all supported archs)
+export NVTE_CUDA_ARCHS="${CUDA_ARCH}"              # transformer-engine
+export BLOCK_SPARSE_ATTN_CUDA_ARCHS="${CUDA_ARCH}" # block-sparse-attn
+
+# Limit parallel nvcc jobs to avoid OOM (each job uses ~9GB peak memory).
+# Set this to (available_RAM_GB / 9), capped at your CPU core count.
+export MAX_JOBS=8
+
+# If you don't need block-sparse-attn CUDA kernels at all (e.g. only
+# running CPU tests or working on non-FlashVSR code), skip the build
+# entirely:
+# export BLOCK_SPARSE_ATTN_SKIP_CUDA_BUILD=TRUE
+```
+
+| Variable | Effect | Typical speedup |
+|----------|--------|-----------------|
+| `NVTE_CUDA_ARCHS` | Restricts transformer-engine compilation to listed SM arch(es) | ~10min -> ~1min |
+| `BLOCK_SPARSE_ATTN_CUDA_ARCHS` | Restricts block-sparse-attn compilation to listed SM arch(es) | ~80min -> ~8min |
+| `MAX_JOBS` | Caps parallel nvcc processes (prevents OOM) | Avoids killed builds |
+| `BLOCK_SPARSE_ATTN_SKIP_CUDA_BUILD` | Skips block-sparse-attn CUDA compilation entirely | ~80min -> seconds |
+
+### Putting it together
+
+A typical developer `.envrc` (if using [direnv](https://direnv.net/)):
+
+```bash
+# .envrc (not committed -- already in .gitignore)
+export CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader \
+  | head -1 | tr -d '.')
+export NVTE_CUDA_ARCHS="${CUDA_ARCH}"
+export BLOCK_SPARSE_ATTN_CUDA_ARCHS="${CUDA_ARCH}"
+export MAX_JOBS=8
+```
+
+Then `uv sync --extra dev` will only compile for your local GPU.
+
+### Working with a single integration package
+
+The workspace contains many integration packages under `integrations/`.
+A full `uv sync` installs dependencies for *all* of them. If you only
+need one (e.g. you're working on `omnidreams`), use `--package` to sync
+only that package's dependencies:
+
+```bash
+# Only install omnidreams + its deps (skips unrelated heavy packages)
+uv sync --package omnidreams --extra dev
+
+# Run a script/test from that integration only
+uv run --package omnidreams pytest tests/ -m ci_gpu
+```
+
+This avoids pulling in (and compiling) dependencies that other
+integrations require but yours does not, further reducing setup time.
+
+Available integration packages:
+
+```
+integrations/causal_forcing
+integrations/cosmos_predict2
+integrations/fastvideo_causal_wan22
+integrations/flashvsr
+integrations/lingbot
+integrations/omnidreams
+integrations/self_forcing
+integrations/wan21
 ```
 
 ## Licensing of contributions

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -64,6 +64,24 @@ Most model runs need Hugging Face authentication:
    export HF_TOKEN=<your-hf-token>
    export HF_HOME=~/.cache/huggingface  # optional
 
+.. _build-performance:
+
+Speeding up CUDA builds
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The first ``uv sync`` compiles CUDA extensions from source, which can be
+slow. Set these variables to only compile for your local GPU architecture:
+
+.. code-block:: bash
+
+   CUDA_ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d '.')
+   export NVTE_CUDA_ARCHS="${CUDA_ARCH}"
+   export BLOCK_SPARSE_ATTN_CUDA_ARCHS="${CUDA_ARCH}"
+   export MAX_JOBS=8
+
+See the `Contributing Guide <https://github.com/NVIDIA/flashdreams/blob/main/CONTRIBUTING.md#speeding-up-local-builds>`_
+for full details on each variable and recommended ``.envrc`` setup.
+
 For more environment and container details, see the project
 `README <https://github.com/NVIDIA/flashdreams/blob/main/README.md>`_ and
 the model pages under :doc:`/models/index`.


### PR DESCRIPTION
## Summary

Documents the environment variables that CI uses to speed up CUDA extension
compilation, making them discoverable for developers setting up local builds.

### Problem

A fresh `uv sync` compiles transformer-engine and block-sparse-attn from
source for *all* supported GPU architectures, which can take 30-80+ minutes.
CI already uses env vars to restrict compilation to the runner's architecture,
but this wasn't documented anywhere for local development.

### Changes

**CONTRIBUTING.md** -- new "Speeding up local builds" section:
- How to detect your GPU's compute capability via `nvidia-smi`
- Recommended env vars (`NVTE_CUDA_ARCHS`, `BLOCK_SPARSE_ATTN_CUDA_ARCHS`,
  `MAX_JOBS`, `BLOCK_SPARSE_ATTN_SKIP_CUDA_BUILD`) with explanations
- Summary table with typical speedups
- Sample `.envrc` for direnv users

**docs/source/getting_started/installation.rst** -- brief cross-reference:
- Adds a "Speeding up CUDA builds" subsection under "Environment variables"
  with the essential snippet and a link to the full CONTRIBUTING.md docs

### Context

These optimizations were introduced across several CI PRs:
- #121 -- `NVTE_CUDA_ARCHS`, `MAX_JOBS`, GPU arch detection
- PR #66 merge commits -- `BLOCK_SPARSE_ATTN_SKIP_CUDA_BUILD`, `BLOCK_SPARSE_ATTN_CUDA_ARCHS`