### PR TITLE
Benchmark against fastvideo

### DIFF
--- a/integrations/cosmos_predict2/cosmos_predict2/config.py
+++ b/integrations/cosmos_predict2/cosmos_predict2/config.py
@@ -54,7 +54,7 @@ PIPELINE_COSMOS2_T2V_2B_720P = CosmosInferencePipelineConfig(
             # Official code uses formula with 7.0: cond + guidance * (cond - uncond)
             # Equivalent to our formula with 8.0: uncond + guidance * (cond - uncond)
             guidance_scale=8.0,
-            compile_network=False,
+            compile_network=True,
             use_cuda_graph=False,
         ),
         scheduler=FlowMatchUniPCSchedulerConfig(
@@ -87,7 +87,7 @@ PIPELINE_COSMOS2_I2V_2B_720P = CosmosInferencePipelineConfig(
             len_t=24,
             window_size_t=24,
             guidance_scale=8.0,
-            compile_network=False,
+            compile_network=True,
             use_cuda_graph=False,
             conditional_frame_timestep=0.1,
         ),

--- a/integrations/cosmos_predict2/tests/baseline_fastvideo/README.md
+++ b/integrations/cosmos_predict2/tests/baseline_fastvideo/README.md
@@ -8,7 +8,7 @@ This harness:
 - clones upstream FastVideo at a pinned commit,
 - applies `changes.patch`,
 - uses an isolated `uv` env with FastVideo-compatible deps, then installs local
-  `flashdreams` (no-deps) so the benchmark can import `flashdreams.infra.profiler`,
+  `flashdreams` (no-deps) to keep the parity env aligned with the main workspace,
 - runs a Cosmos benchmark script that emits parity-style timing JSON.
 
 ## Run
@@ -38,8 +38,8 @@ The benchmark runs with:
 This enforces a fast-path configuration and applies strict cuDNN SDPA forcing
 inside FastVideo's SDPA backend when the env flag is set.
 
-`flashdreams` is installed with `uv pip install --no-deps -e ...` to expose the
-profiler module without forcing flashdreams' full dependency set into this
+`flashdreams` is installed with `uv pip install --no-deps -e ...` for environment
+alignment, without forcing flashdreams' full dependency set into this
 FastVideo/Cosmos parity environment.
 
 ## Files tracked here

--- a/integrations/cosmos_predict2/tests/baseline_fastvideo/changes.patch
+++ b/integrations/cosmos_predict2/tests/baseline_fastvideo/changes.patch
@@ -1,8 +1,8 @@
 diff --git a/examples/inference/basic/basic_cosmos2_5_t2w.py b/examples/inference/basic/basic_cosmos2_5_t2w.py
-index 2296ca7b..5d49445a 100644
+index 2296ca7b..0c053c68 100644
 --- a/examples/inference/basic/basic_cosmos2_5_t2w.py
 +++ b/examples/inference/basic/basic_cosmos2_5_t2w.py
-@@ -12,8 +12,10 @@ def main():
+@@ -12,12 +12,19 @@ def main():
          use_fsdp_inference=False,  # set True if GPU is out of memory
          dit_cpu_offload=False,
          vae_cpu_offload=False,
@@ -15,6 +15,15 @@ index 2296ca7b..5d49445a 100644
      )
  
      # Load default sampling parameters (negative_prompt, resolution, steps, etc.)
+     sampling_param = SamplingParam.from_pretrained(model_path)
++    sampling_param.num_frames = 93
++    sampling_param.height = 720
++    sampling_param.width = 1280
++    sampling_param.fps = 16
++    sampling_param.guidance_scale = 7.0
+ 
+     prompt = (
+         "A high-definition video captures the precision of robotic welding in an industrial setting. "
 diff --git a/fastvideo/attention/backends/sdpa.py b/fastvideo/attention/backends/sdpa.py
 index 5d9b2159..55c14263 100644
 --- a/fastvideo/attention/backends/sdpa.py

--- a/integrations/cosmos_predict2/tests/baseline_fastvideo/changes.patch
+++ b/integrations/cosmos_predict2/tests/baseline_fastvideo/changes.patch
@@ -1,99 +1,20 @@
-diff --git a/examples/inference/basic/benchmark_cosmos2_5_t2w.py b/examples/inference/basic/benchmark_cosmos2_5_t2w.py
-new file mode 100644
-index 00000000..24282e6e
---- /dev/null
-+++ b/examples/inference/basic/benchmark_cosmos2_5_t2w.py
-@@ -0,0 +1,90 @@
-+#!/usr/bin/env python
-+# SPDX-License-Identifier: Apache-2.0
-+"""Cosmos 2.5 T2W benchmark with parity-style timing output."""
-+
-+import argparse
-+import json
-+import os
-+from pathlib import Path
-+
-+from fastvideo import VideoGenerator
-+from fastvideo.api.sampling_param import SamplingParam
-+
-+DEFAULT_PROMPT = (
-+    "A high-definition video captures the precision of robotic welding in an industrial setting. "
-+    "The first frame showcases a robotic arm, equipped with a welding torch, positioned over a large metal structure. "
-+    "The welding process is in full swing, with bright sparks and intense light illuminating the scene, "
-+    "creating a vivid display of blue and white hues. "
-+    "A significant amount of smoke billows around the welding area, partially obscuring the view but emphasizing the heat and activity. "
-+    "The background reveals parts of the workshop environment, including a ventilation system and various pieces of machinery, "
-+    "indicating a busy and functional industrial workspace. "
-+    "As the video progresses, the robotic arm maintains its steady position, continuing the welding process and moving to its left. "
-+    "The welding torch consistently emits sparks and light, and the smoke continues to rise, diffusing slightly as it moves upward. "
-+    "The metal surface beneath the torch shows ongoing signs of heating and melting. "
-+    "The scene retains its industrial ambiance, with the welding sparks and smoke dominating the visual field, "
-+    "underscoring the ongoing nature of the welding operation."
-+)
-+
-+
-+def parse_args() -> argparse.Namespace:
-+    parser = argparse.ArgumentParser(description=__doc__)
-+    parser.add_argument("--model_name", type=str, default="KyleShao/Cosmos-Predict2.5-2B-Diffusers")
-+    parser.add_argument("--prompt", type=str, default=DEFAULT_PROMPT)
-+    parser.add_argument("--seed", type=int, default=42)
-+    parser.add_argument("--output", type=str, default="./videos/offline.mp4")
-+    parser.add_argument("--stats_output", type=str, default="./videos/stats_offline.json")
-+    parser.add_argument("--num_gpus", type=int, default=1)
-+    parser.add_argument("--enable_torch_compile", action="store_true")
-+    return parser.parse_args()
-+
-+
-+def configure_runtime(stats_output: str) -> None:
-+    os.environ["FASTVIDEO_ATTENTION_BACKEND"] = "TORCH_SDPA"
-+    os.environ["FASTVIDEO_FORCE_CUDNN_SDPA"] = "1"
-+    os.environ["FASTVIDEO_PARITY_STATS_PATH"] = stats_output
-+
-+
-+def main() -> None:
-+    args = parse_args()
-+    configure_runtime(stats_output=args.stats_output)
-+
-+    output_path = Path(args.output)
-+    output_path.parent.mkdir(parents=True, exist_ok=True)
-+    stats_path = Path(args.stats_output)
-+    stats_path.parent.mkdir(parents=True, exist_ok=True)
-+
-+    generator = VideoGenerator.from_pretrained(
-+        args.model_name,
-+        num_gpus=args.num_gpus,
-+        use_fsdp_inference=False,
-+        dit_cpu_offload=False,
-+        vae_cpu_offload=False,
+diff --git a/examples/inference/basic/basic_cosmos2_5_t2w.py b/examples/inference/basic/basic_cosmos2_5_t2w.py
+index 2296ca7b..5d49445a 100644
+--- a/examples/inference/basic/basic_cosmos2_5_t2w.py
++++ b/examples/inference/basic/basic_cosmos2_5_t2w.py
+@@ -12,8 +12,10 @@ def main():
+         use_fsdp_inference=False,  # set True if GPU is out of memory
+         dit_cpu_offload=False,
+         vae_cpu_offload=False,
+-        text_encoder_cpu_offload=True,
+-        pin_cpu_memory=True,
 +        text_encoder_cpu_offload=False,
 +        pin_cpu_memory=False,
-+        enable_torch_compile=args.enable_torch_compile,
++        enable_torch_compile=True,
 +        torch_compile_kwargs={"mode": "max-autotune-no-cudagraphs"},
-+    )
-+
-+    sampling_param = SamplingParam.from_pretrained(args.model_name)
-+    sampling_param.update(
-+        {
-+            "seed": args.seed,
-+            "output_path": str(output_path),
-+            "save_video": True,
-+            "return_frames": False,
-+        }
-+    )
-+    result = generator.generate_video(args.prompt, sampling_param=sampling_param)
-+    print(f"Video saved to: {result.get('video_path')}")
-+
-+    if not stats_path.exists():
-+        raise RuntimeError(f"Expected timing stats at {stats_path}, but file was not generated")
-+    with stats_path.open("r", encoding="utf-8") as f:
-+        stats = json.load(f)
-+    print(f"Per-run stats saved to: {stats_path} ({len(stats)} entries)")
-+
-+    generator.shutdown()
-+
-+
-+if __name__ == "__main__":
-+    main()
+     )
+ 
+     # Load default sampling parameters (negative_prompt, resolution, steps, etc.)
 diff --git a/fastvideo/attention/backends/sdpa.py b/fastvideo/attention/backends/sdpa.py
 index 5d9b2159..55c14263 100644
 --- a/fastvideo/attention/backends/sdpa.py
@@ -121,62 +42,3 @@ index 5d9b2159..55c14263 100644
 +            output = torch.nn.functional.scaled_dot_product_attention(query, key, value, **attn_kwargs)
          output = output.transpose(1, 2)
          return output
-diff --git a/fastvideo/pipelines/stages/denoising.py b/fastvideo/pipelines/stages/denoising.py
-index c112f48c..e9fa2b65 100644
---- a/fastvideo/pipelines/stages/denoising.py
-+++ b/fastvideo/pipelines/stages/denoising.py
-@@ -4,6 +4,8 @@ Denoising stage for diffusion pipelines.
- """
- 
- import inspect
-+import json
-+import os
- import weakref
- from collections.abc import Iterable
- from typing import Any
-@@ -41,6 +43,8 @@ except ImportError:
- 
- logger = init_logger(__name__)
- 
-+from flashdreams.infra.profiler import EventProfiler
-+
- 
- class DenoisingStage(PipelineStage):
-     """
-@@ -879,6 +883,9 @@ class Cosmos25DenoisingStage(CosmosDenoisingStage):
-         init_noise_4d = init_noise_4d.to(state_dtype)
- 
-         clamp_every_step = bool(getattr(cfg, "cosmos25_clamp_every_step", True)) if is_conditioned else False
-+        stats_path = os.getenv("FASTVIDEO_PARITY_STATS_PATH", "").strip()
-+        collect_timing = bool(stats_path)
-+        denoise_profiler = EventProfiler() if collect_timing else None
- 
-         with self.progress_bar(total=len(timesteps)) as progress_bar:
-             for i, t in enumerate(timesteps):
-@@ -960,6 +967,26 @@ class Cosmos25DenoisingStage(CosmosDenoisingStage):
- 
-                 progress_bar.update()
- 
-+        if denoise_profiler is not None:
-+            denoise_profiler.record("denoise")
-+            stages_ms = denoise_profiler.sync_and_summarize()
-+            total_ms = float(sum(stages_ms.values()))
-+            stats: dict[str, float | int] = {f"{stage}_ms": float(ms) for stage, ms in stages_ms.items()}
-+            stats["kv_update_ms"] = 0.0
-+            stats["decode_ms"] = 0.0
-+            stats["total_ms"] = total_ms
-+            stats["total_ms_wo_finalize"] = total_ms
-+            if torch.cuda.is_available():
-+                device = torch.cuda.current_device()
-+                gib = 1024**3
-+                stats["mem_alloc_gib"] = torch.cuda.memory_allocated(device) / gib
-+                stats["mem_reserved_gib"] = torch.cuda.memory_reserved(device) / gib
-+                stats["mem_peak_gib"] = torch.cuda.max_memory_allocated(device) / gib
-+            stats_dir = os.path.dirname(stats_path) or "."
-+            os.makedirs(stats_dir, exist_ok=True)
-+            with open(stats_path, "w", encoding="utf-8") as f:
-+                json.dump([{"autoregressive_index": 0, **stats}], f, indent=2)
-+
-         batch.latents = latents_4d.to(target_dtype).unsqueeze(0)
-         return batch
- 

--- a/integrations/cosmos_predict2/tests/baseline_fastvideo/run.sh
+++ b/integrations/cosmos_predict2/tests/baseline_fastvideo/run.sh
@@ -45,14 +45,12 @@ fi
 echo "[setup] ensuring Python deps via uv sync (isolated venv)"
 ( cd "${SCRIPT_DIR}" && uv sync )
 
-echo "[setup] installing flashdreams package for profiler access (no-deps)"
+echo "[setup] installing flashdreams package for env alignment (no-deps)"
 ( cd "${SCRIPT_DIR}" && uv pip install --no-deps -e "${REPO_ROOT}/flashdreams" )
 
 echo "[run] starting FastVideo Cosmos 2.5 T2W benchmark"
 FASTVIDEO_ATTENTION_BACKEND=TORCH_SDPA \
 FASTVIDEO_FORCE_CUDNN_SDPA=1 \
+FASTVIDEO_PARITY_STATS_PATH="./videos/stats_offline.json" \
 PYTHONPATH="${REPO_DIR}:${PYTHONPATH:-}" \
-"${SCRIPT_DIR}/.venv/bin/python" "${REPO_DIR}/examples/inference/basic/benchmark_cosmos2_5_t2w.py" \
-    --enable_torch_compile \
-    --output "./videos/offline.mp4" \
-    --stats_output "./videos/stats_offline.json"
+"${SCRIPT_DIR}/.venv/bin/python" "${REPO_DIR}/examples/inference/basic/basic_cosmos2_5_t2w.py"

--- a/integrations/cosmos_predict2/tests/parity_check/changes.patch
+++ b/integrations/cosmos_predict2/tests/parity_check/changes.patch
@@ -74,3 +74,95 @@ index 2757553..b073353 100644
      assert resolution in IMAGE_RES_SIZE_INFO.keys(), "The provided resolution cannot be found in IMAGE_RES_SIZE_INFO."
      assert object_store in ["s3", "swiftstack", "gcp"], "We support s3, gcp and swiftstack only."
      assert dataset_resolution_type in [
+diff --git a/cosmos_predict2/_src/predict2/inference/video2world.py b/cosmos_predict2/_src/predict2/inference/video2world.py
+index 4129bc0..8e1fd87 100644
+--- a/cosmos_predict2/_src/predict2/inference/video2world.py
++++ b/cosmos_predict2/_src/predict2/inference/video2world.py
+@@ -305,6 +305,12 @@ class Video2WorldInference:
+         # Load the model and config
+         if experiment_opts is None:
+             experiment_opts = []
++        force_torch_attn = os.getenv("COSMOS_FORCE_TORCH_ATTN", "0") == "1"
++        force_torch_compile = os.getenv("COSMOS_FORCE_TORCH_COMPILE", "0") == "1"
++        if force_torch_attn:
++            # Route all attention through the torch SDPA path so FORCE_CUDNN_ATTN can
++            # enforce cuDNN attention globally in the denoising loop.
++            experiment_opts.append("model.config.net.atten_backend=torch")
+         if not INTERNAL:
+             experiment_opts.append("~data_train")
+ 
+@@ -370,6 +376,16 @@ class Video2WorldInference:
+         if self.context_parallel_size > 1:
+             model.net.enable_context_parallel(self.process_group)
+ 
++        if force_torch_compile:
++            if self.offload_diffusion_model:
++                log.warning("Skipping torch.compile because offload_diffusion_model=True")
++            elif not torch.cuda.is_available():
++                log.warning("Skipping torch.compile because CUDA is unavailable")
++            else:
++                compile_mode = os.getenv("COSMOS_TORCH_COMPILE_MODE", "default")
++                log.info(f"[Perf] Compiling diffusion network with torch.compile(mode={compile_mode})")
++                model.net = torch.compile(model.net, mode=compile_mode)
++
+         self.model = model
+         self.config = config
+         self.batch_size = 1
+diff --git a/cosmos_predict2/_src/predict2/models/text2world_model.py b/cosmos_predict2/_src/predict2/models/text2world_model.py
+index 7855133..c41631c 100644
+--- a/cosmos_predict2/_src/predict2/models/text2world_model.py
++++ b/cosmos_predict2/_src/predict2/models/text2world_model.py
+@@ -18,7 +18,7 @@ from __future__ import annotations
+ import collections
+ import math
+ import os
+-from contextlib import contextmanager
++from contextlib import contextmanager, nullcontext
+ from typing import Any, Callable, Dict, Mapping, Optional, Tuple
+ 
+ import attrs
+@@ -624,7 +624,14 @@ class DiffusionModel(ImaginaireModel):
+ 
+                     # our model supports 0-1 while the t is 0-1000
+                     timestep = torch.stack(timestep) / 1000
+-                    noise_pred = x0_fn(latent_model_input, timestep.unsqueeze(0))
++                    force_cudnn_attn = os.getenv("FORCE_CUDNN_ATTN", "0") == "1"
++                    attn_context = (
++                        torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.CUDNN_ATTENTION)
++                        if force_cudnn_attn and torch.cuda.is_available()
++                        else nullcontext()
++                    )
++                    with attn_context:
++                        noise_pred = x0_fn(latent_model_input, timestep.unsqueeze(0))
+                     temp_x0 = sample_scheduler.step(
+                         noise_pred.unsqueeze(0), t, latents[0].unsqueeze(0), return_dict=False, generator=seed_g
+                     )[0]
+diff --git a/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py b/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
+index 95d5130..6137a43 100644
+--- a/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
++++ b/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
+@@ -17,7 +17,7 @@ from __future__ import annotations
+ 
+ import collections
+ import os
+-from contextlib import contextmanager
++from contextlib import contextmanager, nullcontext
+ from typing import Callable, Dict, Mapping, Optional, Tuple
+ 
+ import attrs
+@@ -578,7 +578,14 @@ class Text2WorldModelRectifiedFlow(ImaginaireModel):
+ 
+             timestep = torch.stack(timestep)
+ 
+-            velocity_pred = velocity_fn(noise, latent_model_input, timestep.unsqueeze(0))
++            force_cudnn_attn = os.getenv("FORCE_CUDNN_ATTN", "0") == "1"
++            attn_context = (
++                torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.CUDNN_ATTENTION)
++                if force_cudnn_attn and torch.cuda.is_available()
++                else nullcontext()
++            )
++            with attn_context:
++                velocity_pred = velocity_fn(noise, latent_model_input, timestep.unsqueeze(0))
+             temp_x0 = self.sample_scheduler.step(
+                 velocity_pred.unsqueeze(0), t, latents.unsqueeze(0), return_dict=False, generator=seed_g
+             )[0]

--- a/integrations/cosmos_predict2/tests/parity_check/changes.patch
+++ b/integrations/cosmos_predict2/tests/parity_check/changes.patch
@@ -1,120 +1,76 @@
-diff --git a/cosmos_predict2/_src/predict2/models/text2world_model.py b/cosmos_predict2/_src/predict2/models/text2world_model.py
-index 7855133..490d40b 100644
---- a/cosmos_predict2/_src/predict2/models/text2world_model.py
-+++ b/cosmos_predict2/_src/predict2/models/text2world_model.py
-@@ -584,15 +584,26 @@ class DiffusionModel(ImaginaireModel):
-             sample_scheduler = FlowUniPCMultistepScheduler(
-                 num_train_timesteps=1000, shift=1, use_dynamic_shifting=False
-             )
--            noise = misc.arch_invariant_rand(
--                (n_sample,) + tuple(state_shape),
--                torch.float32,
--                self.tensor_kwargs["device"],
--                seed,
--            )
-+            # noise = misc.arch_invariant_rand(
-+            #     (n_sample,) + tuple(state_shape),
-+            #     torch.float32,
-+            #     self.tensor_kwargs["device"],
-+            #     seed,
-+            # )
+diff --git a/cosmos_predict2/_src/predict2/configs/common/defaults/dataloader.py b/cosmos_predict2/_src/predict2/configs/common/defaults/dataloader.py
+index d56b9eb..cf374cd 100644
+--- a/cosmos_predict2/_src/predict2/configs/common/defaults/dataloader.py
++++ b/cosmos_predict2/_src/predict2/configs/common/defaults/dataloader.py
+@@ -23,11 +23,12 @@ from cosmos_predict2._src.predict2.configs.common.mock_data import (
+     MOCK_DATA_VIDEO_ONLY_CONFIG,
+ )
+ from cosmos_predict2._src.predict2.datasets.cached_replay_dataloader import get_cached_replay_dataloader
+-from cosmos_predict2._src.predict2.datasets.dataset_provider import get_image_dataset, get_video_dataset
+ from cosmos_predict2._src.predict2.datasets.joint_dataloader import IterativeJointDataLoader
  
-             seed_g = torch.Generator(device=self.tensor_kwargs["device"])
-             seed_g.manual_seed(seed)
-+            noise = torch.randn(
-+                [
-+                    n_sample,
-+                    self.tokenizer.get_latent_num_frames(_T),
-+                    self.config.state_ch,
-+                    _H // self.tokenizer.spatial_compression_factor,
-+                    _W // self.tokenizer.spatial_compression_factor,
-+                ],
-+                device=self.tensor_kwargs["device"],
-+                generator=seed_g,
-+            ).permute(0, 2, 1, 3, 4).contiguous()
  
-             sample_scheduler.set_timesteps(num_steps, device=self.tensor_kwargs["device"], shift=5)
+ def get_image_dataloader(dataset_name: str, object_store: str) -> omegaconf.dictconfig.DictConfig:
++    from cosmos_predict2._src.predict2.datasets.dataset_provider import get_image_dataset
++
+     return L(get_cached_replay_dataloader)(
+         dataset=L(get_image_dataset)(
+             dataset_name=dataset_name,
+@@ -46,6 +47,8 @@ def get_image_dataloader(dataset_name: str, object_store: str) -> omegaconf.dict
  
-diff --git a/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py b/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
-index 95d5130..c52df1e 100644
---- a/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
-+++ b/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
-@@ -529,15 +529,26 @@ class Text2WorldModelRectifiedFlow(ImaginaireModel):
-                 _W // self.tokenizer.spatial_compression_factor,
-             ]
  
--        noise = misc.arch_invariant_rand(
--            (n_sample,) + tuple(state_shape),
--            torch.float32,
--            self.tensor_kwargs["device"],
--            seed,
--        )
-+        # noise = misc.arch_invariant_rand(
-+        #     (n_sample,) + tuple(state_shape),
-+        #     torch.float32,
-+        #     self.tensor_kwargs["device"],
-+        #     seed,
-+        # )
+ def get_video_dataloader(dataset_name: str, object_store: str) -> omegaconf.dictconfig.DictConfig:
++    from cosmos_predict2._src.predict2.datasets.dataset_provider import get_video_dataset
++
+     return L(get_cached_replay_dataloader)(
+         dataset=L(get_video_dataset)(
+             dataset_name=dataset_name,
+diff --git a/cosmos_predict2/_src/predict2/configs/video2world/config.py b/cosmos_predict2/_src/predict2/configs/video2world/config.py
+index 5f39717..d953f9f 100644
+--- a/cosmos_predict2/_src/predict2/configs/video2world/config.py
++++ b/cosmos_predict2/_src/predict2/configs/video2world/config.py
+@@ -102,6 +102,5 @@ def make_config() -> Config:
+             import_all_modules_from_package("cosmos_predict2.experiments.internal", reload=True)
+     except ModuleNotFoundError:
+         pass  # Module or parent package doesn't exist
+-    import_all_modules_from_package("cosmos_predict2.experiments", reload=True)
  
-         seed_g = torch.Generator(device=self.tensor_kwargs["device"])
-         seed_g.manual_seed(seed)
-+        noise = torch.randn(
-+            [
-+                n_sample,
-+                self.tokenizer.get_latent_num_frames(_T),
-+                self.config.state_ch,
-+                _H // self.tokenizer.spatial_compression_factor,
-+                _W // self.tokenizer.spatial_compression_factor,
-+            ],
-+            device=self.tensor_kwargs["device"],
-+            generator=seed_g,
-+        ).permute(0, 2, 1, 3, 4).contiguous()
+     return c
+diff --git a/cosmos_predict2/_src/predict2/datasets/dataset_provider.py b/cosmos_predict2/_src/predict2/datasets/dataset_provider.py
+index 2757553..b073353 100644
+--- a/cosmos_predict2/_src/predict2/datasets/dataset_provider.py
++++ b/cosmos_predict2/_src/predict2/datasets/dataset_provider.py
+@@ -28,12 +28,10 @@ from webdataset.handlers import warn_and_continue
+ import cosmos_predict2._src.imaginaire.datasets.webdataset.decoders.image as image_decoders
+ import cosmos_predict2._src.imaginaire.datasets.webdataset.decoders.pickle as pickle_decoders
+ import cosmos_predict2._src.imaginaire.datasets.webdataset.distributors as distributors
+-import cosmos_predict2._src.predict2.datasets.decoders.video_decoder as video_decoder
+ import cosmos_predict2._src.predict2.datasets.distributor.parallel_sync_multi_aspect_ratio as parallel_sync_multi_aspect_ratio
+ import cosmos_predict2._src.predict2.datasets.webdataset as webdataset
+ from cosmos_predict2._src.imaginaire.datasets.webdataset.config.schema import DatasetConfig
+ from cosmos_predict2._src.imaginaire.utils import log
+-from cosmos_predict2._src.predict2.datasets.augmentor_provider import AUGMENTOR_OPTIONS
+ from cosmos_predict2._src.predict2.datasets.data_sources.data_registration import DATASET_OPTIONS
+ from cosmos_predict2._src.predict2.datasets.utils import IMAGE_RES_SIZE_INFO, VIDEO_RES_SIZE_INFO
  
-         self.sample_scheduler.set_timesteps(
-             num_steps,
-@@ -639,15 +650,26 @@ class Text2WorldModelRectifiedFlow(ImaginaireModel):
-                 _W // self.tokenizer.spatial_compression_factor,
-             ]
- 
--        noise = misc.arch_invariant_rand(
--            (n_sample,) + tuple(state_shape),
--            torch.float32,
--            self.tensor_kwargs["device"],
--            seed,
--        )
-+        # noise = misc.arch_invariant_rand(
-+        #     (n_sample,) + tuple(state_shape),
-+        #     torch.float32,
-+        #     self.tensor_kwargs["device"],
-+        #     seed,
-+        # )
- 
-         seed_g = torch.Generator(device=self.tensor_kwargs["device"])
-         seed_g.manual_seed(seed)
-+        noise = torch.randn(
-+            [
-+                n_sample,
-+                self.tokenizer.get_latent_num_frames(_T),
-+                self.config.state_ch,
-+                _H // self.tokenizer.spatial_compression_factor,
-+                _W // self.tokenizer.spatial_compression_factor,
-+            ],
-+            device=self.tensor_kwargs["device"],
-+            generator=seed_g,
-+        ).permute(0, 2, 1, 3, 4).contiguous()
- 
-         self.sample_scheduler.set_timesteps(
-             num_steps,
-diff --git a/cosmos_predict2/config.py b/cosmos_predict2/config.py
-index 1e3b872..67cb451 100644
---- a/cosmos_predict2/config.py
-+++ b/cosmos_predict2/config.py
-@@ -468,7 +468,7 @@ class InferenceArguments(CommonInferenceArguments):
-     # pyrefly: ignore  # bad-override
-     negative_prompt: str = DEFAULT_NEGATIVE_PROMPT
-     "Negative prompt - describing what you don't want in the generated video."
--    seed: int = 0
-+    seed: int = 42
-     "Seed for generation randomness."
-     guidance: Guidance = 7
-     """Range from 0 to 7: the higher the value, the closer the generated video adheres to the prompt."""
+@@ -64,6 +62,11 @@ def get_video_dataset(
+     use_random_interleaved_frames: bool = False,  # If True, enable random interleaved (non-consecutive) frame sampling for fractional fps upsampling/downsampling (e.g., 24->30fps), producing temporally varied clips by mixing frame strides.
+     prefer_crop_over_pad: bool = False,
+ ) -> omegaconf.dictconfig.DictConfig:
++    # Delay importing the video decoder backend until video datasets are actually built.
++    # This avoids importing ``decord`` during unrelated config-module registration.
++    import cosmos_predict2._src.predict2.datasets.decoders.video_decoder as video_decoder
++    from cosmos_predict2._src.predict2.datasets.augmentor_provider import AUGMENTOR_OPTIONS
++
+     assert resolution in VIDEO_RES_SIZE_INFO.keys(), "The provided resolution cannot be found in VIDEO_RES_SIZE_INFO."
+     assert object_store in [
+         "s3",
+@@ -183,6 +186,8 @@ def get_image_dataset(
+     caption_type: str = "ai_v3p1",
+     embedding_type: str = "t5_xxl",
+ ) -> omegaconf.dictconfig.DictConfig:
++    from cosmos_predict2._src.predict2.datasets.augmentor_provider import AUGMENTOR_OPTIONS
++
+     assert resolution in IMAGE_RES_SIZE_INFO.keys(), "The provided resolution cannot be found in IMAGE_RES_SIZE_INFO."
+     assert object_store in ["s3", "swiftstack", "gcp"], "We support s3, gcp and swiftstack only."
+     assert dataset_resolution_type in [

--- a/integrations/cosmos_predict2/tests/parity_check/run.sh
+++ b/integrations/cosmos_predict2/tests/parity_check/run.sh
@@ -160,6 +160,7 @@ uv sync --extra=cu130
 
 # ----------------------------------------------------------- inference T2V
 echo "[run] T2V: assets/base/robot_welding.json -> outputs/base_text2world"
+export COSMOS_PARITY_STATS_PATH="outputs/base_text2world/step_stats.json"
 uv run --extra=cu130 python examples/inference.py \
     -i assets/base/robot_welding.json \
     -o outputs/base_text2world \
@@ -168,6 +169,7 @@ uv run --extra=cu130 python examples/inference.py \
 
 # ----------------------------------------------------------- inference I2V
 echo "[run] I2V: assets/base/robot_welding.json -> outputs/base_image2world"
+export COSMOS_PARITY_STATS_PATH="outputs/base_image2world/step_stats.json"
 uv run --extra=cu130 python examples/inference.py \
     -i assets/base/robot_welding.json \
     -o outputs/base_image2world \

--- a/integrations/cosmos_predict2/tests/parity_check/run.sh
+++ b/integrations/cosmos_predict2/tests/parity_check/run.sh
@@ -161,17 +161,27 @@ uv sync --extra=cu130
 # ----------------------------------------------------------- inference T2V
 echo "[run] T2V: assets/base/robot_welding.json -> outputs/base_text2world"
 export COSMOS_PARITY_STATS_PATH="outputs/base_text2world/step_stats.json"
+export FORCE_CUDNN_ATTN=1
+export COSMOS_FORCE_TORCH_ATTN=1
+export COSMOS_FORCE_TORCH_COMPILE=1
+export COSMOS_TORCH_COMPILE_MODE=default
 uv run --extra=cu130 python examples/inference.py \
     -i assets/base/robot_welding.json \
     -o outputs/base_text2world \
     --inference-type=text2world \
-    --model=2B/post-trained
+    --model=2B/post-trained \
+    --disable-guardrails \
+    --num-output-frames=93 \
+    --resolution=720,1280
 
-# ----------------------------------------------------------- inference I2V
-echo "[run] I2V: assets/base/robot_welding.json -> outputs/base_image2world"
-export COSMOS_PARITY_STATS_PATH="outputs/base_image2world/step_stats.json"
-uv run --extra=cu130 python examples/inference.py \
-    -i assets/base/robot_welding.json \
-    -o outputs/base_image2world \
-    --inference-type=image2world \
-    --model=2B/post-trained
+# ----------------------------------------------------------- inference I2V (disabled for apples-to-apples T2V perf)
+# echo "[run] I2V: assets/base/robot_welding.json -> outputs/base_image2world"
+# export COSMOS_PARITY_STATS_PATH="outputs/base_image2world/step_stats.json"
+# uv run --extra=cu130 python examples/inference.py \
+#     -i assets/base/robot_welding.json \
+#     -o outputs/base_image2world \
+#     --inference-type=image2world \
+#     --model=2B/post-trained \
+#     --disable-guardrails \
+#     --num-output-frames=93 \
+#     --resolution=720,1280

--- a/integrations/wan21/tests/baseline_fastvideo/README.md
+++ b/integrations/wan21/tests/baseline_fastvideo/README.md
@@ -7,7 +7,7 @@ This harness:
 - clones upstream FastVideo at a pinned commit,
 - applies `changes.patch`,
 - uses an isolated `uv` env with FastVideo-compatible deps, then installs local
-  `flashdreams` (no-deps) so the benchmark can import `flashdreams.infra.profiler`,
+  `flashdreams` (no-deps) to keep the parity env aligned with the main workspace,
 - runs a Wan 2.1 benchmark script that emits parity-style timing JSON.
 
 ## Run
@@ -37,8 +37,8 @@ The benchmark runs with:
 This enforces a fast-path configuration and applies strict cuDNN SDPA forcing
 inside FastVideo's SDPA backend when the env flag is set.
 
-`flashdreams` is installed with `uv pip install --no-deps -e ...` to expose the
-profiler module without forcing flashdreams' full dependency set into this
+`flashdreams` is installed with `uv pip install --no-deps -e ...` for environment
+alignment, without forcing flashdreams' full dependency set into this
 FastVideo/Wan parity environment.
 
 ## Files tracked here

--- a/integrations/wan21/tests/baseline_fastvideo/changes.patch
+++ b/integrations/wan21/tests/baseline_fastvideo/changes.patch
@@ -1,78 +1,20 @@
-diff --git a/examples/inference/basic/benchmark_wan2_1_t2v.py b/examples/inference/basic/benchmark_wan2_1_t2v.py
-new file mode 100644
-index 00000000..f25d8881
---- /dev/null
-+++ b/examples/inference/basic/benchmark_wan2_1_t2v.py
-@@ -0,0 +1,69 @@
-+#!/usr/bin/env python
-+# SPDX-License-Identifier: Apache-2.0
-+"""Wan 2.1 T2V benchmark with parity-style timing output."""
-+
-+import argparse
-+import json
-+import os
-+from pathlib import Path
-+
-+from fastvideo import VideoGenerator
-+from fastvideo.api.sampling_param import SamplingParam
-+
-+DEFAULT_PROMPT = (
-+    "A curious raccoon peers through a vibrant field of yellow sunflowers, its eyes "
-+    "wide with interest. The playful yet serene atmosphere is complemented by soft "
-+    "natural light filtering through the petals. Mid-shot, warm and cheerful tones."
-+)
-+
-+
-+def parse_args() -> argparse.Namespace:
-+    parser = argparse.ArgumentParser(description=__doc__)
-+    parser.add_argument("--model_name", type=str, default="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
-+    parser.add_argument("--prompt", type=str, default=DEFAULT_PROMPT)
-+    parser.add_argument("--seed", type=int, default=42)
-+    parser.add_argument("--output", type=str, default="./videos/offline.mp4")
-+    parser.add_argument("--stats_output", type=str, default="./videos/stats_offline.json")
-+    parser.add_argument("--num_gpus", type=int, default=1)
-+    parser.add_argument("--enable_torch_compile", action="store_true")
-+    return parser.parse_args()
-+
-+
-+def main() -> None:
-+    args = parse_args()
-+    os.environ["FASTVIDEO_ATTENTION_BACKEND"] = "TORCH_SDPA"
-+    os.environ["FASTVIDEO_FORCE_CUDNN_SDPA"] = "1"
-+    os.environ["FASTVIDEO_PARITY_STATS_PATH"] = args.stats_output
-+
-+    output_path = Path(args.output)
-+    output_path.parent.mkdir(parents=True, exist_ok=True)
-+    stats_path = Path(args.stats_output)
-+    stats_path.parent.mkdir(parents=True, exist_ok=True)
-+
-+    generator = VideoGenerator.from_pretrained(
-+        args.model_name,
-+        num_gpus=args.num_gpus,
-+        use_fsdp_inference=False,
-+        dit_cpu_offload=False,
-+        vae_cpu_offload=False,
+diff --git a/examples/inference/basic/basic.py b/examples/inference/basic/basic.py
+index 766b9bd7..eb2fcd29 100644
+--- a/examples/inference/basic/basic.py
++++ b/examples/inference/basic/basic.py
+@@ -15,8 +15,10 @@ def main():
+         use_fsdp_inference=False, # set to True if GPU is out of memory
+         dit_cpu_offload=False,
+         vae_cpu_offload=False,
+-        text_encoder_cpu_offload=True,
+-        pin_cpu_memory=True, # set to false if low CPU RAM or hit obscure "CUDA error: Invalid argument"
 +        text_encoder_cpu_offload=False,
-+        pin_cpu_memory=False,
-+        enable_torch_compile=args.enable_torch_compile,
++        pin_cpu_memory=False, # keep settings aligned for parity benchmarking
++        enable_torch_compile=True,
 +        torch_compile_kwargs={"mode": "max-autotune-no-cudagraphs"},
-+    )
-+
-+    sampling_param = SamplingParam.from_pretrained(args.model_name)
-+    sampling_param.update({"seed": args.seed, "output_path": str(output_path), "save_video": True, "return_frames": False})
-+    result = generator.generate_video(args.prompt, sampling_param=sampling_param)
-+    print(f"Video saved to: {result.get('video_path')}")
-+
-+    if not stats_path.exists():
-+        raise RuntimeError(f"Expected timing stats at {stats_path}, but file was not generated")
-+    with stats_path.open("r", encoding="utf-8") as f:
-+        stats = json.load(f)
-+    print(f"Per-run stats saved to: {stats_path} ({len(stats)} entries)")
-+    generator.shutdown()
-+
-+
-+if __name__ == "__main__":
-+    main()
+         # image_encoder_cpu_offload=False,
+     )
+ 
 diff --git a/fastvideo/attention/backends/sdpa.py b/fastvideo/attention/backends/sdpa.py
 index 5d9b2159..55c14263 100644
 --- a/fastvideo/attention/backends/sdpa.py
@@ -100,61 +42,3 @@ index 5d9b2159..55c14263 100644
 +            output = torch.nn.functional.scaled_dot_product_attention(query, key, value, **attn_kwargs)
          output = output.transpose(1, 2)
          return output
-diff --git a/fastvideo/pipelines/stages/denoising.py b/fastvideo/pipelines/stages/denoising.py
-index c112f48c..de4f7ed0 100644
---- a/fastvideo/pipelines/stages/denoising.py
-+++ b/fastvideo/pipelines/stages/denoising.py
-@@ -4,6 +4,8 @@ Denoising stage for diffusion pipelines.
- """
- 
- import inspect
-+import json
-+import os
- import weakref
- from collections.abc import Iterable
- from typing import Any
-@@ -42,5 +44,7 @@ except ImportError:
- 
- logger = init_logger(__name__)
- 
-+from flashdreams.infra.profiler import EventProfiler
-+
- 
- class DenoisingStage(PipelineStage):
-@@ -84,6 +88,9 @@ class DenoisingStage(PipelineStage):
-         """
-         pipeline = self.pipeline() if self.pipeline else None
-+        stats_path = os.getenv("FASTVIDEO_PARITY_STATS_PATH", "").strip()
-+        collect_timing = bool(stats_path)
-+        denoise_profiler = EventProfiler() if collect_timing else None
-         if not fastvideo_args.model_loaded["transformer"]:
-             loader = TransformerLoader()
-             self.transformer = loader.load(fastvideo_args.model_paths["transformer"], fastvideo_args)
-             if pipeline:
-@@ -411,6 +418,26 @@ class DenoisingStage(PipelineStage):
-                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and
-                                                (i + 1) % self.scheduler.order == 0 and progress_bar is not None):
-                     progress_bar.update()
-+
-+        if denoise_profiler is not None:
-+            denoise_profiler.record("denoise")
-+            stages_ms = denoise_profiler.sync_and_summarize()
-+            total_ms = float(sum(stages_ms.values()))
-+            stats: dict[str, float | int] = {f"{stage}_ms": float(ms) for stage, ms in stages_ms.items()}
-+            stats["kv_update_ms"] = 0.0
-+            stats["decode_ms"] = 0.0
-+            stats["total_ms"] = total_ms
-+            stats["total_ms_wo_finalize"] = total_ms
-+            if torch.cuda.is_available():
-+                device = torch.cuda.current_device()
-+                gib = 1024**3
-+                stats["mem_alloc_gib"] = torch.cuda.memory_allocated(device) / gib
-+                stats["mem_reserved_gib"] = torch.cuda.memory_reserved(device) / gib
-+                stats["mem_peak_gib"] = torch.cuda.max_memory_allocated(device) / gib
-+            stats_dir = os.path.dirname(stats_path) or "."
-+            os.makedirs(stats_dir, exist_ok=True)
-+            with open(stats_path, "w", encoding="utf-8") as f:
-+                json.dump([{"autoregressive_index": 0, **stats}], f, indent=2)
- 
-         trajectory_tensor: torch.Tensor | None = None
-         if trajectory_latents:

--- a/integrations/wan21/tests/baseline_fastvideo/run.sh
+++ b/integrations/wan21/tests/baseline_fastvideo/run.sh
@@ -45,14 +45,12 @@ fi
 echo "[setup] ensuring Python deps via uv sync (isolated venv)"
 ( cd "${SCRIPT_DIR}" && uv sync )
 
-echo "[setup] installing flashdreams package for profiler access (no-deps)"
+echo "[setup] installing flashdreams package for env alignment (no-deps)"
 ( cd "${SCRIPT_DIR}" && uv pip install --no-deps -e "${REPO_ROOT}/flashdreams" )
 
 echo "[run] starting FastVideo Wan 2.1 T2V benchmark"
 FASTVIDEO_ATTENTION_BACKEND=TORCH_SDPA \
 FASTVIDEO_FORCE_CUDNN_SDPA=1 \
+FASTVIDEO_PARITY_STATS_PATH="./videos/stats_offline.json" \
 PYTHONPATH="${REPO_DIR}:${PYTHONPATH:-}" \
-"${SCRIPT_DIR}/.venv/bin/python" "${REPO_DIR}/examples/inference/basic/benchmark_wan2_1_t2v.py" \
-    --enable_torch_compile \
-    --output "./videos/offline.mp4" \
-    --stats_output "./videos/stats_offline.json"
+"${SCRIPT_DIR}/.venv/bin/python" "${REPO_DIR}/examples/inference/basic/basic.py"

--- a/integrations/wan21/tests/parity_check_official/.gitignore
+++ b/integrations/wan21/tests/parity_check_official/.gitignore
@@ -1,0 +1,4 @@
+/Wan2.1/
+/.venv/
+__pycache__/
+*.pyc

--- a/integrations/wan21/tests/parity_check_official/README.md
+++ b/integrations/wan21/tests/parity_check_official/README.md
@@ -1,0 +1,26 @@
+# Wan2.1 official parity check
+
+This test runs the official Wan2.1 repository with the same command-line setup
+from upstream README for `t2v-1.3B`, while forcing the cuDNN SDPA backend.
+
+## What this harness does
+
+1. Clones `Wan-Video/Wan2.1` and checks out a pinned commit.
+2. Applies `changes.patch` (cuDNN SDPA enforcement in fallback attention path).
+3. Creates an isolated `.venv` and installs upstream requirements.
+4. Installs `huggingface_hub[cli]`.
+5. Installs local `flashdreams` editable package with `--no-deps` for environment alignment.
+6. Downloads `Wan-AI/Wan2.1-T2V-1.3B` if missing.
+7. Runs:
+
+```bash
+python generate.py --task t2v-1.3B --size 832*480 --ckpt_dir ./Wan2.1-T2V-1.3B --sample_shift 8 --sample_guide_scale 6 --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
+```
+
+The upstream official code path already uses `tqdm` over diffusion timesteps in `wan/text2video.py`.
+
+## Run
+
+```bash
+bash integrations/wan21/tests/parity_check_official/run.sh
+```

--- a/integrations/wan21/tests/parity_check_official/changes.patch
+++ b/integrations/wan21/tests/parity_check_official/changes.patch
@@ -1,0 +1,146 @@
+diff --git a/wan/modules/__init__.py b/wan/modules/__init__.py
+index a8172ca..c9a474c 100644
+--- a/wan/modules/__init__.py
++++ b/wan/modules/__init__.py
+@@ -1,4 +1,4 @@
+-from .attention import flash_attention
++from .attention import attention, flash_attention
+ from .model import WanModel
+ from .t5 import T5Decoder, T5Encoder, T5EncoderModel, T5Model
+ from .tokenizers import HuggingfaceTokenizer
+@@ -14,5 +14,6 @@ __all__ = [
+     'T5Decoder',
+     'T5EncoderModel',
+     'HuggingfaceTokenizer',
++    'attention',
+     'flash_attention',
+ ]
+diff --git a/wan/modules/attention.py b/wan/modules/attention.py
+index 4dbbe03..8a8de49 100644
+--- a/wan/modules/attention.py
++++ b/wan/modules/attention.py
+@@ -1,4 +1,7 @@
+ # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
++import os
++from contextlib import nullcontext
++
+ import torch
+ 
+ try:
+@@ -15,6 +18,12 @@ except ModuleNotFoundError:
+ 
+ import warnings
+ 
++try:
++    from torch.nn.attention import SDPBackend, sdpa_kernel
++except ImportError:
++    SDPBackend = None
++    sdpa_kernel = None
++
+ __all__ = [
+     'flash_attention',
+     'attention',
+@@ -145,7 +154,11 @@ def attention(
+     dtype=torch.bfloat16,
+     fa_version=None,
+ ):
+-    if FLASH_ATTN_2_AVAILABLE or FLASH_ATTN_3_AVAILABLE:
++    force_cudnn_sdpa = (
++        os.getenv("FORCE_CUDNN_ATTN", "0") == "1"
++        or os.getenv("WAN_FORCE_CUDNN_SDPA", "0") == "1"
++    )
++    if (FLASH_ATTN_2_AVAILABLE or FLASH_ATTN_3_AVAILABLE) and not force_cudnn_sdpa:
+         return flash_attention(
+             q=q,
+             k=k,
+@@ -172,8 +185,14 @@ def attention(
+         k = k.transpose(1, 2).to(dtype)
+         v = v.transpose(1, 2).to(dtype)
+ 
+-        out = torch.nn.functional.scaled_dot_product_attention(
+-            q, k, v, attn_mask=attn_mask, is_causal=causal, dropout_p=dropout_p)
++        if sdpa_kernel is not None and SDPBackend is not None and force_cudnn_sdpa:
++            cudnn_attn_context = sdpa_kernel(SDPBackend.CUDNN_ATTENTION)
++        else:
++            cudnn_attn_context = nullcontext()
++
++        with cudnn_attn_context:
++            out = torch.nn.functional.scaled_dot_product_attention(
++                q, k, v, attn_mask=attn_mask, is_causal=causal, dropout_p=dropout_p)
+ 
+         out = out.transpose(1, 2).contiguous()
+         return out
+diff --git a/wan/modules/clip.py b/wan/modules/clip.py
+index 42dda04..633deb6 100644
+--- a/wan/modules/clip.py
++++ b/wan/modules/clip.py
+@@ -8,7 +8,7 @@ import torch.nn as nn
+ import torch.nn.functional as F
+ import torchvision.transforms as T
+ 
+-from .attention import flash_attention
++from .attention import attention
+ from .tokenizers import HuggingfaceTokenizer
+ from .xlm_roberta import XLMRoberta
+ 
+@@ -82,7 +82,7 @@ class SelfAttention(nn.Module):
+ 
+         # compute attention
+         p = self.attn_dropout if self.training else 0.0
+-        x = flash_attention(q, k, v, dropout_p=p, causal=self.causal, version=2)
++        x = attention(q, k, v, dropout_p=p, causal=self.causal, fa_version=2)
+         x = x.reshape(b, s, c)
+ 
+         # output
+@@ -194,7 +194,7 @@ class AttentionPool(nn.Module):
+         k, v = self.to_kv(x).view(b, s, 2, n, d).unbind(2)
+ 
+         # compute attention
+-        x = flash_attention(q, k, v, version=2)
++        x = attention(q, k, v, fa_version=2)
+         x = x.reshape(b, 1, c)
+ 
+         # output
+diff --git a/wan/modules/model.py b/wan/modules/model.py
+index a5425da..d11cf2f 100644
+--- a/wan/modules/model.py
++++ b/wan/modules/model.py
+@@ -7,7 +7,7 @@ import torch.nn as nn
+ from diffusers.configuration_utils import ConfigMixin, register_to_config
+ from diffusers.models.modeling_utils import ModelMixin
+ 
+-from .attention import flash_attention
++from .attention import attention
+ 
+ __all__ = ['WanModel']
+ 
+@@ -146,7 +146,7 @@ class WanSelfAttention(nn.Module):
+ 
+         q, k, v = qkv_fn(x)
+ 
+-        x = flash_attention(
++        x = attention(
+             q=rope_apply(q, grid_sizes, freqs),
+             k=rope_apply(k, grid_sizes, freqs),
+             v=v,
+@@ -176,7 +176,7 @@ class WanT2VCrossAttention(WanSelfAttention):
+         v = self.v(context).view(b, -1, n, d)
+ 
+         # compute attention
+-        x = flash_attention(q, k, v, k_lens=context_lens)
++        x = attention(q, k, v, k_lens=context_lens)
+ 
+         # output
+         x = x.flatten(2)
+@@ -217,9 +217,9 @@ class WanI2VCrossAttention(WanSelfAttention):
+         v = self.v(context).view(b, -1, n, d)
+         k_img = self.norm_k_img(self.k_img(context_img)).view(b, -1, n, d)
+         v_img = self.v_img(context_img).view(b, -1, n, d)
+-        img_x = flash_attention(q, k_img, v_img, k_lens=None)
++        img_x = attention(q, k_img, v_img, k_lens=None)
+         # compute attention
+-        x = flash_attention(q, k, v, k_lens=context_lens)
++        x = attention(q, k, v, k_lens=context_lens)
+ 
+         # output
+         x = x.flatten(2)

--- a/integrations/wan21/tests/parity_check_official/run.sh
+++ b/integrations/wan21/tests/parity_check_official/run.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${SCRIPT_DIR}/Wan2.1"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+PATCH_FILE="${SCRIPT_DIR}/changes.patch"
+REPO_URL="https://github.com/Wan-Video/Wan2.1.git"
+PIN_COMMIT="9737cba9c1c3c4d04b33fcad41c111989865d315"
+VENV_PYTHON="${SCRIPT_DIR}/.venv/bin/python"
+CKPT_DIR="${REPO_DIR}/Wan2.1-T2V-1.3B"
+
+if [[ ! -d "${REPO_DIR}/.git" ]]; then
+    echo "[setup] cloning ${REPO_URL} -> ${REPO_DIR}"
+    git clone "${REPO_URL}" "${REPO_DIR}"
+else
+    echo "[setup] repo already present at ${REPO_DIR}, skipping clone"
+fi
+
+cd "${REPO_DIR}"
+
+CURRENT_COMMIT="$(git rev-parse HEAD)"
+if [[ "${CURRENT_COMMIT}" != "${PIN_COMMIT}" ]]; then
+    echo "[setup] checking out pinned commit ${PIN_COMMIT}"
+    git checkout "${PIN_COMMIT}"
+else
+    echo "[setup] already at pinned commit ${PIN_COMMIT}, skipping checkout"
+fi
+
+if [[ -f "${PATCH_FILE}" ]]; then
+    if git apply --reverse --check "${PATCH_FILE}" >/dev/null 2>&1; then
+        echo "[setup] patch already applied, skipping"
+    elif git apply --check "${PATCH_FILE}" >/dev/null 2>&1; then
+        echo "[setup] applying ${PATCH_FILE}"
+        git apply "${PATCH_FILE}"
+    else
+        echo "[setup] ERROR: ${PATCH_FILE} neither applies cleanly nor is already applied." >&2
+        exit 1
+    fi
+else
+    echo "[setup] no patch file at ${PATCH_FILE}, skipping"
+fi
+
+if [[ ! -x "${VENV_PYTHON}" ]]; then
+    echo "[setup] creating isolated venv at ${SCRIPT_DIR}/.venv"
+    uv venv --python 3.12 "${SCRIPT_DIR}/.venv"
+fi
+
+echo "[setup] installing Wan2.1 requirements"
+uv pip install --python "${VENV_PYTHON}" "torch>=2.4.0" "torchvision>=0.19.0"
+
+FILTERED_REQUIREMENTS="$(mktemp)"
+"${VENV_PYTHON}" - <<'PY' "${REPO_DIR}/requirements.txt" "${FILTERED_REQUIREMENTS}"
+import re
+import sys
+
+src_path, dst_path = sys.argv[1], sys.argv[2]
+skip = re.compile(r"^\s*(torch|torchvision|flash_attn)\b")
+
+with open(src_path, encoding="utf-8") as src, open(dst_path, "w", encoding="utf-8") as dst:
+    for line in src:
+        if skip.match(line):
+            continue
+        dst.write(line)
+PY
+
+uv pip install --python "${VENV_PYTHON}" -r "${FILTERED_REQUIREMENTS}"
+rm -f "${FILTERED_REQUIREMENTS}"
+
+echo "[setup] installing huggingface_hub CLI"
+uv pip install --python "${VENV_PYTHON}" "huggingface_hub[cli]"
+
+echo "[setup] installing flashdreams package for env alignment (no-deps)"
+uv pip install --python "${VENV_PYTHON}" --no-deps -e "${REPO_ROOT}/flashdreams"
+
+if [[ ! -d "${CKPT_DIR}" ]] || [[ -z "$(ls -A "${CKPT_DIR}" 2>/dev/null)" ]]; then
+    echo "[setup] downloading Wan2.1-T2V-1.3B checkpoint"
+    "${SCRIPT_DIR}/.venv/bin/hf" download \
+        Wan-AI/Wan2.1-T2V-1.3B \
+        --local-dir "${CKPT_DIR}"
+else
+    echo "[setup] checkpoint already present at ${CKPT_DIR}, skipping download"
+fi
+
+echo "[run] starting official Wan2.1 parity run with forced cuDNN SDPA"
+FORCE_CUDNN_ATTN=1 \
+PYTHONPATH="${REPO_DIR}:${PYTHONPATH:-}" \
+"${VENV_PYTHON}" "${REPO_DIR}/generate.py" \
+    --task t2v-1.3B \
+    --size 832*480 \
+    --ckpt_dir "${CKPT_DIR}" \
+    --sample_shift 8 \
+    --sample_guide_scale 6 \
+    --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."

--- a/integrations/wan21/wan21/config.py
+++ b/integrations/wan21/wan21/config.py
@@ -61,6 +61,7 @@ PIPELINE_WAN21_T2V_1PT3B_480P = WanInferencePipelineConfig(
         scheduler=FlowMatchUniPCSchedulerConfig(
             num_inference_steps=50,
             shift=8.0,
+            enable_tqdm=True,
         ),
     ),
 )
@@ -94,6 +95,7 @@ PIPELINE_WAN21_I2V_14B_480P = WanInferencePipelineConfig(
         scheduler=FlowMatchUniPCSchedulerConfig(
             num_inference_steps=40,
             shift=3.0,
+            enable_tqdm=True,
         ),
     ),
     image_encoder=CLIPImageEncoderConfig(


### PR DESCRIPTION
Configuration fix and alignment between flashdreams v.s. fashvideo v.s. official for cosmos-predict2 bidirectional. The similar runtime now makes sense [before it has a huge difference]
 
Setting: Cosmos-Predict2.5-2B T2V

DiT (per step w/ CFG). 720P. 93 frames

<img width="520" height="87" alt="Screenshot 2026-05-21 at 5 36 08 PM" src="https://github.com/user-attachments/assets/f82b79a5-1f1e-4ffa-9ef8-e1c5d752c23b" />

all uses torch.compile with CUDNN attn backend.
