### PR TITLE
Fix cuda graph recompilation issue (branchless KVCache)

### DIFF
--- a/flashdreams/flashdreams/core/attention/__init__.py
+++ b/flashdreams/flashdreams/core/attention/__init__.py
@@ -16,7 +16,12 @@
 """Attention primitives and KV cache for streaming inference."""
 
 from flashdreams.core.attention.cp import ContextParallelAttention
-from flashdreams.core.attention.kvcache import BlockKVCache
+from flashdreams.core.attention.kvcache import (
+    BlockKVCache,
+    KVRange,
+    PrefixBlockKVCache,
+    RollingBlockKVCache,
+)
 from flashdreams.core.attention.native import NativeAttention
 from flashdreams.core.attention.rope import (
     KVCacheRelativeRotaryPositionEmbedding3D,
@@ -28,6 +33,9 @@ __all__ = [
     "RotaryPositionEmbedding3D",
     "KVCacheRelativeRotaryPositionEmbedding3D",
     "BlockKVCache",
+    "RollingBlockKVCache",
+    "PrefixBlockKVCache",
+    "KVRange",
     "NativeAttention",
     "ContextParallelAttention",
     "apply_rope_freqs",

--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -16,44 +16,47 @@
 """Block KV cache for causal attention with a fixed-size local window."""
 
 from dataclasses import dataclass, field
+from typing import NamedTuple
 
 import torch
 from torch import Tensor
 from typing_extensions import Self
 
 
-@dataclass
-class BlockKVCache:
+class KVRange(NamedTuple):
+    """Branchless KV-cache write/read pair for a single AR step.
+
+    ``write_start`` is the per-AR-step in-place write offset for
+    :meth:`RollingBlockKVCache.update_at`; ``valid_len`` is the post-update
+    read length for :meth:`BlockKVCache.cached_k_at` /
+    :meth:`BlockKVCache.cached_v_at`. Both are precomputed in
+    :meth:`RollingBlockKVCache.before_update` and travel together through every
+    cross-layer forward (network -> block -> self-attn). Bundled into a
+    NamedTuple to keep cross-layer signatures concise; unpacked at the leaf
+    APIs, which each consume only one of the two ints.
     """
-    KV cache for causal attention with a fixed-size local window, CUDA-graph compatible.
 
-    Keys and values can have arbitrary shape ``[..., total_size, ...]``; the sequence
-    (rolling) dimension is given by ``seq_dim`` (dimension index, can be negative).
-    Layout along that dimension: [sink tokens | local window tokens]. Sink tokens are
-    never evicted; the local window rolls left as new chunks are added if full. Chunks are
-    non-overlapping: each update adds one chunk of ``chunk_size`` tokens at the
-    next logical position in the full sequence.
+    write_start: int
+    valid_len: int
 
-    Note: Currently only supports ``total_size`` (``sink_size + window_size``) divisible by ``chunk_size``.
 
-    Phases:
-        - Filling: cache not yet full; tokens are written contiguously;
-          ``cached_k()`` / ``cached_v()`` return only the valid prefix.
-        - Steady-state: cache full; each new chunk triggers a left-roll of the
-          local window and overwrites the rightmost positions;
-          ``cached_k()`` / ``cached_v()`` return the full buffer.
+@dataclass(kw_only=True)
+class BlockKVCache:
+    """Storage + branchless-read backbone shared by the two concrete caches.
 
-    The argument ``chunk_idx`` (0, 1, 2, ...) is the index of the new chunk in the full
-    sequence (not an index into the cache). If ``chunk_idx`` is greater than
-    the previous one, the chunk is appended (or, in steady-state, written after
-    the roll). If ``chunk_idx`` equals the previous one, the same cache positions
-    are overwritten.
+    Holds the K/V buffers (allocated in :meth:`__post_init__`) and the read API
+    (:meth:`cached_k_at` / :meth:`cached_v_at`) common to:
 
-    Per-step usage:
-        1. before_update(chunk_idx) — prepare (roll local window if steady-state).
-        2. update(k, v) — write the new chunk's keys/values into the cache.
-        3. cached_k() / cached_v() — get cached keys/values for attention.
-        4. after_update(chunk_idx) — update internal bookkeeping.
+    - :class:`RollingBlockKVCache` -- a self-contained fixed-size local-window
+      cache that rolls left as new chunks arrive (self-attention).
+    - :class:`PrefixBlockKVCache` -- an immutable one-shot prefix cache
+      (cross-attention text / image embeddings).
+
+    Keys and values can have arbitrary shape ``[..., total_size, ...]``; the
+    sequence dimension is :attr:`seq_dim` (a normalized non-negative index). The
+    base never mutates the buffers -- all writes live on
+    :class:`RollingBlockKVCache`. This class is abstract; do not instantiate it
+    directly.
     """
 
     k_shape: tuple[int, ...]
@@ -63,16 +66,11 @@ class BlockKVCache:
     """Shape of the values. Must be the same as the keys shape except for the last dimension."""
 
     seq_dim: int
-    """Sequence dimension that will be rolled. Can be negative."""
+    """Sequence-dimension index in the K/V tensor; may be negative (normalized
+    to a non-negative index in :meth:`__post_init__`).
 
-    chunk_size: int
-    """Number of tokens processed each time."""
-
-    window_size: int
-    """Size of the local attention window (excluding sink tokens)."""
-
-    sink_size: int = 0
-    """Number of sink tokens at the start of the cache that are never evicted. Defaults to 0."""
+    A rollout-constant read on the hot path (:meth:`_seq_slice` /
+    :meth:`cached_k_at`), so Dynamo constant-folds it in the traced region."""
 
     device: torch.device | str = torch.device("cuda")
     """Device to store the cache on."""
@@ -80,67 +78,16 @@ class BlockKVCache:
     dtype: torch.dtype = torch.float16
     """Data type to store the cache in."""
 
-    _prev_chunk_idx: int = -1
-    """Chunk index of the last written chunk; -1 when empty."""
-
-    _curr_chunk_idx: int | None = None
-    """The index of the current chunk that is being processed. None when empty."""
-
-    _n_cached: int = 0
-    """Number of valid tokens currently in the cache."""
-
     _k: Tensor = field(init=False)
-    """Cached keys. shape ``[..., total_size, ..., Dk]``, where the ``total_size`` is the length of the cache buffer at ``seq_dim`` dimension."""
+    """Cached keys. shape ``[..., total_size, ..., Dk]`` at ``seq_dim``."""
 
     _v: Tensor = field(init=False)
-    """Cached values. shape ``[..., total_size, ..., Dv]``, where the ``total_size`` is the length of the cache buffer at ``seq_dim`` dimension."""
-
-    @property
-    def size(self) -> int:
-        """Number of valid cached tokens visible to attention."""
-        if self._curr_chunk_idx is None:
-            return self._n_cached
-        if self.is_steady_state():
-            return self._k.shape[self.seq_dim]
-        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._n_cached + self.chunk_size
-        if self._curr_chunk_idx == self._prev_chunk_idx:
-            return self._n_cached
-        raise ValueError(
-            f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-        )
-
-    @property
-    def write_end(self) -> int:
-        """Right edge of the current chunk in the physical cache layout."""
-        assert self._curr_chunk_idx is not None, (
-            "Must call before_update() before write_end"
-        )
-        return self.size
-
-    @classmethod
-    def from_tensor(cls, k: Tensor, v: Tensor, seq_dim: int) -> Self:
-        """Build a single-chunk cache pre-filled with the given key and value tensors."""
-        cache = cls(
-            k_shape=k.shape,
-            v_shape=v.shape,
-            seq_dim=seq_dim,
-            chunk_size=k.shape[seq_dim],
-            window_size=k.shape[seq_dim],
-            device=k.device,
-            dtype=k.dtype,
-        )
-        cache.before_update(0)
-        cache.update(k, v)
-        cache.after_update(0)
-        cache._curr_chunk_idx = 0
-        return cache
+    """Cached values. shape ``[..., total_size, ..., Dv]`` at ``seq_dim``."""
 
     def __post_init__(self) -> None:
         assert self.k_shape[:-1] == self.v_shape[:-1], (
             "k and v must have the same shape except for the last dimension"
         )
-
         tensor_dim = len(self.k_shape)
         assert -tensor_dim <= self.seq_dim < tensor_dim, (
             f"seq_dim must be in [-{tensor_dim}, {tensor_dim}), got {self.seq_dim}"
@@ -148,18 +95,6 @@ class BlockKVCache:
         # Normalize seq_dim to a non-negative index so downstream
         # indexing math doesn't have to special-case negatives.
         self.seq_dim = self.seq_dim if self.seq_dim >= 0 else self.seq_dim + tensor_dim
-
-        assert self.sink_size >= 0, "sink_size must be non-negative"
-
-        expected_length = self.sink_size + self.window_size
-        assert self.k_shape[self.seq_dim] == expected_length, (
-            f"k_shape[seq_dim] ({self.k_shape[self.seq_dim]}) must equal sink_size + window_size ({expected_length})"
-        )
-
-        assert (self.window_size + self.sink_size) % self.chunk_size == 0, (
-            f"window_size + sink_size ({self.window_size + self.sink_size}) must be divisible by chunk_size ({self.chunk_size})"
-        )
-
         self._k = torch.empty(self.k_shape, device=self.device, dtype=self.dtype)
         self._v = torch.empty(self.v_shape, device=self.device, dtype=self.dtype)
 
@@ -169,8 +104,245 @@ class BlockKVCache:
         idx[self.seq_dim] = slice(start, end)
         return tuple(idx)
 
+    def cached_k_at(self, valid_len: int) -> Tensor:
+        """Return cached keys sliced to ``[:valid_len]`` on ``seq_dim``."""
+        return self._k[self._seq_slice(0, valid_len)]
+
+    def cached_v_at(self, valid_len: int) -> Tensor:
+        """Return cached values sliced to ``[:valid_len]`` on ``seq_dim``."""
+        return self._v[self._seq_slice(0, valid_len)]
+
+
+@dataclass(kw_only=True)
+class RollingBlockKVCache(BlockKVCache):
+    """Self-contained fixed-size local-window KV cache with CUDA-graph support.
+
+    Owns both its layout (``chunk_size`` / ``window_size`` / ``sink_size``) and
+    its rolling cursor. Layout along ``seq_dim``: [sink tokens | local window
+    tokens]; sink tokens are never evicted and the local window rolls left by
+    ``chunk_size`` once full. Chunks are non-overlapping: each update writes one
+    chunk at the next logical position. ``total_size``
+    (``sink_size + window_size``) must be divisible by ``chunk_size``.
+
+    Per-step usage (driven by the owning ``*TransformerCache`` cascade):
+        1. ``cache.before_update(chunk_idx)`` -- advance the cursor (precompute
+           :attr:`write_start` / :attr:`valid_len`) and roll the buffer left on a
+           steady-state advance. Runs **outside** the compiled forward.
+        2. ``cache.update_at(k, v, cache.write_start)`` -- branchless in-graph write.
+        3. ``cache.cached_k_at(cache.valid_len)`` / ``cached_v_at(...)`` -- read.
+        4. ``cache.after_update(chunk_idx)`` -- finalize the cursor.
+
+    Every self-attn cache in a DiT (and the cond/uncond CFG twins) shares the
+    same geometry and chunk sequence, so they advance in lock-step. There is no
+    shared lifecycle object; the owner reads the threaded :class:`KVRange` from
+    the first cache (``block_caches[0].self_attn``). The branchless leaf
+    (:meth:`update_at` / :meth:`cached_k_at`) only ever sees the two precomputed
+    ints, keeping the traced graph ``_n_cached``-agnostic.
+    """
+
+    chunk_size: int
+    """Number of tokens written per AR step."""
+
+    window_size: int
+    """Size of the rolling local-attention window (excludes sink tokens)."""
+
+    sink_size: int = 0
+    """Number of leading sink tokens that are never evicted."""
+
+    # ---- rolling cursor (advanced outside the compiled forward) ----
+    _n_cached: int = field(init=False, default=0)
+    _curr_chunk_idx: int | None = field(init=False, default=None)
+    _prev_chunk_idx: int = field(init=False, default=-1)
+    _needs_buffer_roll: bool = field(init=False, default=False)
+
+    write_start: int = field(init=False, default=0)
+    """Branchless write offset for the current AR step (set by :meth:`before_update`)."""
+
+    valid_len: int = field(init=False, default=0)
+    """Post-update read length for the current AR step (set by :meth:`before_update`)."""
+
+    @property
+    def total_size(self) -> int:
+        """``sink_size + window_size``; the physical length of the cache buffer."""
+        return self.sink_size + self.window_size
+
+    @property
+    def range(self) -> KVRange:
+        """Branchless write/read pair for the current AR step.
+
+        Cross-layer plumbing (TransformerCache -> network -> block -> self-attn)
+        takes a single :class:`KVRange`; the leaf APIs consume the unpacked
+        fields. Valid after :meth:`before_update`.
+        """
+        return KVRange(write_start=self.write_start, valid_len=self.valid_len)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert self.chunk_size > 0, "chunk_size must be positive"
+        assert self.window_size > 0, "window_size must be positive"
+        assert self.sink_size >= 0, "sink_size must be non-negative"
+        assert self.total_size % self.chunk_size == 0, (
+            f"total_size ({self.total_size}) must be divisible by "
+            f"chunk_size ({self.chunk_size})"
+        )
+        # Branchless steady-state write requires the rightmost slot
+        # (``total_size - chunk_size``) to fall outside the immutable sink
+        # prefix; equivalently ``chunk_size <= window_size``.
+        assert self.chunk_size <= self.window_size, (
+            f"chunk_size ({self.chunk_size}) must be <= window_size "
+            f"({self.window_size}) for branchless steady-state write."
+        )
+        assert self.k_shape[self.seq_dim] == self.total_size, (
+            f"k_shape[{self.seq_dim}] ({self.k_shape[self.seq_dim]}) must equal "
+            f"total_size ({self.total_size})"
+        )
+
+    # ---- cursor advance (Python, outside the compiled forward) ----
+
+    def is_steady_state(self) -> bool:
+        """True if the rolling window is full (post-fill phase).
+
+        Must be called after :meth:`before_update`, i.e. with ``_curr_chunk_idx``
+        set.
+        """
+        assert self._curr_chunk_idx is not None, (
+            "Must call before_update() before is_steady_state()"
+        )
+        is_full = self.total_size == self._n_cached
+        is_overlapping_with_sink = (
+            self.sink_size > 0
+            and self._curr_chunk_idx * self.chunk_size < self.sink_size
+        )
+        return is_full and not is_overlapping_with_sink
+
+    def before_update(self, chunk_idx: int) -> None:
+        """Advance the cursor for ``chunk_idx`` and roll the buffer if steady-state.
+
+        Idempotent within an AR step. Precomputes :attr:`write_start` /
+        :attr:`valid_len` and, on a steady-state advance, rolls the local window
+        left. Runs outside the compiled forward (the in-graph leaf only reads the
+        precomputed ints).
+
+        - First call with a new ``chunk_idx``: advances ``_curr_chunk_idx``,
+          precomputes the branchless params, and rolls on a steady-state advance.
+        - Subsequent calls with the same ``chunk_idx`` (a residual double-call):
+          no-op (the early return preserves "advance once").
+        - Repeating the previous ``chunk_idx`` (multi-step scheduler reuse):
+          recomputes the params for the reuse slot, no roll.
+        """
+        if self._curr_chunk_idx == chunk_idx:
+            return
+        assert self._curr_chunk_idx is None, (
+            "Must call after_update() before before_update() for a new chunk_idx; "
+            f"got chunk_idx={chunk_idx}, _curr_chunk_idx={self._curr_chunk_idx}"
+        )
+        self._curr_chunk_idx = chunk_idx
+        self._needs_buffer_roll = False
+
+        if chunk_idx == self._prev_chunk_idx + 1:
+            if self.is_steady_state():
+                self._needs_buffer_roll = True
+        elif chunk_idx == self._prev_chunk_idx:
+            # Multi-step scheduler reuses the same chunk: no buffer roll,
+            # ``_n_cached`` will not advance in ``after_update``, but write_start
+            # / valid_len need recomputing for the reuse-slot semantics
+            # (write_start rewinds onto the just-written slot rather than
+            # appending).
+            pass
+        else:
+            raise AssertionError(
+                "Expected the new chunk_idx to be either +1 from the previous "
+                "chunk_idx (advance) or equal to it (multi-step scheduler reuse), "
+                f"got {chunk_idx} vs _prev_chunk_idx={self._prev_chunk_idx}"
+            )
+
+        self.write_start = self._compute_write_start_now()
+        self.valid_len = self._compute_valid_len_now()
+        if self._needs_buffer_roll:
+            self._roll_local_window_left()
+
+    def after_update(self, chunk_idx: int) -> None:
+        """Finalize cursor bookkeeping for ``chunk_idx``. Idempotent within an AR step.
+
+        - First call with ``chunk_idx == _curr_chunk_idx``: advances
+          ``_n_cached`` (if filling) and ``_prev_chunk_idx``, clears
+          ``_curr_chunk_idx``.
+        - Subsequent calls: no-op (asserts the cursor was already finalized).
+        """
+        if self._curr_chunk_idx is None:
+            assert chunk_idx == self._prev_chunk_idx, (
+                f"after_update({chunk_idx}) re-entry expected _prev_chunk_idx="
+                f"{chunk_idx}, got {self._prev_chunk_idx}"
+            )
+            return
+
+        assert chunk_idx == self._curr_chunk_idx, (
+            f"Expected chunk_idx to be {self._curr_chunk_idx}, got {chunk_idx}"
+        )
+
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            if not self.is_steady_state():
+                self._n_cached += self.chunk_size
+            self._prev_chunk_idx += 1
+        elif self._curr_chunk_idx == self._prev_chunk_idx:
+            pass
+        else:
+            raise ValueError(
+                f"{self._curr_chunk_idx=} should be either "
+                f"{self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+            )
+
+        self._curr_chunk_idx = None
+
+    def size(self) -> int:
+        """Number of valid cached tokens visible to attention.
+
+        Before any ``before_update`` (``_curr_chunk_idx is None``): returns the
+        count from the previous AR step. After ``before_update``: returns the
+        precomputed :attr:`valid_len`.
+        """
+        if self._curr_chunk_idx is None:
+            return self._n_cached
+        return self.valid_len
+
+    def _compute_write_start_now(self) -> int:
+        """Branchless write offset from current cursor state.
+
+        * steady state: rightmost slot, ``total_size - chunk_size``.
+        * filling, advancing chunk (``_curr == _prev + 1``): append at ``_n_cached``.
+        * filling, same chunk (``_curr == _prev``): overwrite the just-written
+          rightmost slot at ``_n_cached - chunk_size``.
+        """
+        if self.is_steady_state():
+            return int(self.total_size - self.chunk_size)
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            return int(self._n_cached)
+        if self._curr_chunk_idx == self._prev_chunk_idx:
+            return int(self._n_cached - self.chunk_size)
+        raise RuntimeError(
+            f"Unexpected cache state: _curr_chunk_idx={self._curr_chunk_idx} "
+            f"vs _prev_chunk_idx={self._prev_chunk_idx}"
+        )
+
+    def _compute_valid_len_now(self) -> int:
+        """Post-update valid-token count from current cursor state."""
+        if self.is_steady_state():
+            return int(self.total_size)
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            return int(self._n_cached + self.chunk_size)
+        if self._curr_chunk_idx == self._prev_chunk_idx:
+            return int(self._n_cached)
+        raise RuntimeError(
+            f"Unexpected cache state: _curr_chunk_idx={self._curr_chunk_idx} "
+            f"vs _prev_chunk_idx={self._prev_chunk_idx}"
+        )
+
     def _roll_local_window_left(self) -> None:
-        """Shift the local window left by chunk_size tokens (steady-state only)."""
+        """Shift the local window left by chunk_size tokens (steady-state only).
+
+        Called by :meth:`before_update` on a steady-state advance; rolls only
+        this cache's private K/V buffer.
+        """
         total_size = self._k.shape[self.seq_dim]
         assert total_size == self._n_cached, (
             f"Expected full cache: {total_size=} != {self._n_cached=}"
@@ -188,190 +360,72 @@ class BlockKVCache:
             self._k[dst_slice] = self._k[src_slice].clone()
             self._v[dst_slice] = self._v[src_slice].clone()
 
-    def _overwrite_rightmost_steady(self, k: Tensor, v: Tensor) -> None:
-        """Write the new chunk into the rightmost positions (steady-state, after roll)."""
-        total_size = self._k.shape[self.seq_dim]
-        assert total_size == self._n_cached, (
-            f"Expected full cache: {total_size=} != {self._n_cached=}"
-        )
-        write_end = total_size
-        write_start = write_end - self.chunk_size
-        if write_start > self.sink_size:
-            sl_write = self._seq_slice(write_start, write_end)
-            self._k[sl_write] = k
-            self._v[sl_write] = v
-        else:
-            # The input token overlaps with the sink tokens, so we only keep partial of it.
-            # Note: here we assume the sink tokens have already been written to the cache.
-            # It is safe to assume this because this function will never be called for the
-            # first chunk, and we assume the first chunk should be enough to cover the sink tokens.
-            write_start = self.sink_size
-            keep_size = write_end - write_start
-            read_end = self.chunk_size
-            read_start = read_end - keep_size
-            sl_read = self._seq_slice(read_start, read_end)
-            sl_write = self._seq_slice(write_start, write_end)
-            self._k[sl_write] = k[sl_read]
-            self._v[sl_write] = v[sl_read]
+    # ---- branchless write API ----
+    #
+    # All data-dependent control flow lives in :meth:`before_update` (Python,
+    # outside the compiled forward). The traced region only sees the
+    # ``write_start`` int, keeping the graph ``_n_cached``-agnostic so Dynamo
+    # never guards on (or recompiles because of) the filling/steady-state phase.
 
-    def _overwrite_rightmost_filling(self, k: Tensor, v: Tensor) -> None:
-        """Write the new chunk into the rightmost positions (filling phase)."""
-        write_end = self._n_cached
-        write_start = write_end - self.chunk_size
-        assert write_start >= 0, (
-            f"write [{write_start}:{write_end}) out of bounds for buffer size {self.sink_size + self.window_size}"
-        )
-        sl = self._seq_slice(write_start, write_end)
-        self._k[sl] = k
-        self._v[sl] = v
+    def update_at(self, k: Tensor, v: Tensor, write_start: int) -> None:
+        """Branchless in-place write at ``[write_start, write_start + chunk_size)``.
 
-    def _append_to_end(self, k: Tensor, v: Tensor) -> None:
-        """Append the new chunk to the end of the cache (filling phase)."""
-        write_start = self._n_cached
-        write_end = write_start + self.chunk_size
-        assert write_end <= self.sink_size + self.window_size, (
-            f"write [{write_start}:{write_end}) out of bounds for buffer size {self.sink_size + self.window_size}"
-        )
-        sl = self._seq_slice(write_start, write_end)
-        self._k[sl] = k
-        self._v[sl] = v
-
-    def is_steady_state(self) -> bool:
-        """Return True if the cache is full (steady-state phase)."""
-        assert self._curr_chunk_idx is not None, (
-            "Must call before_update() before is_steady_state()"
-        )
-        total_size = self._k.shape[self.seq_dim]
-        is_full = total_size == self._n_cached
-        is_overlapping_with_sink = (
-            self.sink_size > 0
-            and self._curr_chunk_idx * self.chunk_size
-            < self.sink_size  # start < sink_size
-        )
-        return is_full and not is_overlapping_with_sink
-
-    def before_update(self, chunk_idx: int) -> None:
+        ``write_start`` is precomputed by :meth:`before_update` (read via
+        :attr:`write_start`). No asserts and no ``is_steady_state`` branches, so
+        Dynamo never derives an ``_n_cached`` upper bound from this path.
+        ``seq_dim`` / ``chunk_size`` are rollout-constants.
         """
-        Prepare the cache before writing new tokens.
+        seq_dim = self.seq_dim
+        chunk_size = self.chunk_size
+        self._k.narrow(seq_dim, write_start, chunk_size).copy_(k)
+        self._v.narrow(seq_dim, write_start, chunk_size).copy_(v)
 
-        If ``chunk_idx`` equals the previous chunk index, this is a no-op. Otherwise,
-        we expect the ``chunk_idx`` to be +1 from the previous chunk index. In this case,
-        we will roll the local window left if the cache is in steady-state, or no op
-        if the cache is in filling phase.
 
-        Args:
-            chunk_idx: Chunk index of the new chunk in the full sequence.
+@dataclass(kw_only=True)
+class PrefixBlockKVCache(BlockKVCache):
+    """Immutable one-shot prefix cache (cross-attention text / image embeddings).
+
+    Filled once from a tensor via :meth:`from_tensor`; the whole input is the
+    valid region. There is no cursor and no rolling: readers use :attr:`valid_len`
+    (== the input length along ``seq_dim``) or the constant :attr:`range`.
+    """
+
+    @property
+    def valid_len(self) -> int:
+        """Number of valid cached tokens: the full prefix length along ``seq_dim``."""
+        return self.k_shape[self.seq_dim]
+
+    @property
+    def range(self) -> KVRange:
+        """Constant branchless read pair for the whole prefix (``write_start=0``).
+
+        Lets cross-attention reuse the same ``apply_kv(..., kv_range=...)`` API
+        as self-attention; only ``valid_len`` is consumed there.
         """
-        assert self._curr_chunk_idx is None, (
-            "Must call after_update() before before_update()"
+        return KVRange(write_start=0, valid_len=self.valid_len)
+
+    @classmethod
+    def from_tensor(cls, k: Tensor, v: Tensor, seq_dim: int) -> Self:
+        """Build a prefix cache filled with ``k`` / ``v`` along ``seq_dim``.
+
+        Used for immutable cross-attention prefix caches (text / image
+        embeddings). ``seq_dim`` is normalized against ``k.ndim`` here (the cache
+        stores a non-negative index). After construction, callers read via
+        :meth:`cached_k_at` / :meth:`cached_v_at` using :attr:`valid_len` (which
+        equals the input length).
+        """
+        tensor_dim = k.ndim
+        assert -tensor_dim <= seq_dim < tensor_dim, (
+            f"seq_dim must be in [-{tensor_dim}, {tensor_dim}), got {seq_dim}"
         )
-        self._curr_chunk_idx = chunk_idx
-
-        if chunk_idx == self._prev_chunk_idx:
-            return
-
-        assert chunk_idx == self._prev_chunk_idx + 1, (
-            "Expected the new chunk_idx to be +1 from the previous chunk_idx, "
-            f"got {chunk_idx} != {self._prev_chunk_idx} + 1"
+        norm_seq_dim = seq_dim if seq_dim >= 0 else seq_dim + tensor_dim
+        cache = cls(
+            k_shape=tuple(k.shape),
+            v_shape=tuple(v.shape),
+            seq_dim=norm_seq_dim,
+            device=k.device,
+            dtype=k.dtype,
         )
-        if self.is_steady_state():
-            self._roll_local_window_left()
-
-    def update(self, k: Tensor, v: Tensor) -> None:
-        """
-        Write the new chunk's keys and values into the cache.
-
-        Must be called after ``before_update()`` and before ``after_update()``.
-
-        Args:
-            k: Keys; shape must match cached keys except at seq_dim, where length must be chunk_size.
-            v: Values; shape must match cached values except at seq_dim, where length must be chunk_size.
-        """
-        assert self._curr_chunk_idx is not None, (
-            "Must call before_update() before update()"
-        )
-
-        chunk_size_k = k.shape[self.seq_dim]
-        chunk_size_v = v.shape[self.seq_dim]
-        assert chunk_size_k == self.chunk_size, (
-            f"Expected input k to have chunk_size ({chunk_size_k}) at seq_dim ({self.seq_dim}), "
-            f"got {chunk_size_k} != {self.chunk_size}"
-        )
-        assert chunk_size_v == self.chunk_size, (
-            f"Expected input v to have chunk_size ({chunk_size_v}) at seq_dim ({self.seq_dim}), "
-            f"got {chunk_size_v} != {self.chunk_size}"
-        )
-        if self.is_steady_state():
-            self._overwrite_rightmost_steady(k, v)
-        else:
-            if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-                self._append_to_end(k, v)
-            elif self._curr_chunk_idx == self._prev_chunk_idx:
-                self._overwrite_rightmost_filling(k, v)
-            else:
-                raise ValueError(
-                    f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-                )
-
-    def after_update(self, chunk_idx: int) -> None:
-        """
-        Finalize bookkeeping after writing new tokens.
-
-        Updates ``_prev_chunk_idx`` and, in filling phase, ``_n_cached``.
-
-        Args:
-            chunk_idx: The index of the new chunk in the full sequence.
-        """
-        assert chunk_idx == self._curr_chunk_idx, (
-            f"Expected chunk_idx to be {self._curr_chunk_idx}, got {chunk_idx}"
-        )
-
-        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            if self.is_steady_state():
-                pass
-            else:
-                self._n_cached += self.chunk_size
-            self._prev_chunk_idx += 1
-        elif self._curr_chunk_idx == self._prev_chunk_idx:
-            pass
-        else:
-            raise ValueError(
-                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-            )
-
-        self._curr_chunk_idx = None
-
-    def cached_k(self) -> Tensor:
-        """
-        Return cached keys for attention (valid prefix in filling phase, full buffer in steady-state).
-        """
-        if self.is_steady_state():
-            return self._k
-        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._k[self._seq_slice(0, self._n_cached + self.chunk_size)]
-        elif self._curr_chunk_idx == self._prev_chunk_idx:
-            return self._k[self._seq_slice(0, self._n_cached)]
-        else:
-            raise ValueError(
-                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-            )
-
-    def cached_v(self) -> Tensor:
-        """
-        Return cached values for attention (valid prefix in filling phase, full buffer in steady-state).
-        """
-        if self.is_steady_state():
-            return self._v
-        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._v[self._seq_slice(0, self._n_cached + self.chunk_size)]
-        elif self._curr_chunk_idx == self._prev_chunk_idx:
-            return self._v[self._seq_slice(0, self._n_cached)]
-        else:
-            raise ValueError(
-                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-            )
-
-    def reset(self) -> None:
-        """Reset the cache to its initial empty state."""
-        self._prev_chunk_idx = -1
-        self._n_cached = 0
+        cache._k.copy_(k)
+        cache._v.copy_(v)
+        return cache

--- a/flashdreams/flashdreams/core/attention/legacy_kvcache.py
+++ b/flashdreams/flashdreams/core/attention/legacy_kvcache.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Legacy (pre-split) self-contained block KV cache.
+
+Frozen copy of the pre-refactor ``BlockKVCache`` (cf0eb1dd), kept only for
+flashvsr / hy_worldplay via :mod:`flashdreams.recipes.wan.transformer.legacy`.
+New code uses :mod:`flashdreams.core.attention.kvcache`
+(``RollingBlockKVCache`` / ``PrefixBlockKVCache`` + ``KVCacheLifecycle``).
+Do not extend this module.
+"""
+
+from dataclasses import dataclass, field
+
+import torch
+from torch import Tensor
+from typing_extensions import Self
+
+
+@dataclass
+class BlockKVCache:
+    """
+    KV cache for causal attention with a fixed-size local window and CUDA-graph support.
+
+    Keys and values can have arbitrary shape ``[..., total_size, ...]``; the sequence
+    (rolling) dimension is given by ``seq_dim`` (dimension index, can be negative).
+    Layout along that dimension: [sink tokens | local window tokens]. Sink tokens are
+    never evicted; the local window rolls left as new chunks are added if full. Chunks are
+    non-overlapping: each update adds one chunk of ``chunk_size`` tokens at the
+    next logical position in the full sequence.
+
+    Note: Currently only supports ``total_size`` (``sink_size + window_size``) divisible by ``chunk_size``.
+
+    Phases:
+        - Filling: cache not yet full; tokens are written contiguously;
+          ``cached_k()`` / ``cached_v()`` return only the valid prefix.
+        - Steady-state: cache full; each new chunk triggers a left-roll of the
+          local window and overwrites the rightmost positions;
+          ``cached_k()`` / ``cached_v()`` return the full buffer.
+
+    The argument ``chunk_idx`` (0, 1, 2, ...) is the index of the new chunk in the full
+    sequence (not an index into the cache). If ``chunk_idx`` is greater than
+    the previous one, the chunk is appended (or, in steady-state, written after
+    the roll). If ``chunk_idx`` equals the previous one, the same cache positions
+    are overwritten.
+
+    Per-step usage:
+        1. before_update(chunk_idx) — prepare (roll local window if steady-state).
+        2. update(k, v) — write the new chunk's keys/values into the cache.
+        3. cached_k() / cached_v() — get cached keys/values for attention.
+        4. after_update(chunk_idx) — update internal bookkeeping.
+    """
+
+    k_shape: tuple[int, ...]
+    """Shape of the keys. Must be the same as the values shape except for the last dimension."""
+
+    v_shape: tuple[int, ...]
+    """Shape of the values. Must be the same as the keys shape except for the last dimension."""
+
+    seq_dim: int
+    """Sequence dimension that will be rolled. Can be negative."""
+
+    chunk_size: int
+    """Number of tokens processed each time."""
+
+    window_size: int
+    """Size of the local attention window (excluding sink tokens)."""
+
+    sink_size: int = 0
+    """Number of sink tokens at the start of the cache that are never evicted. Defaults to 0."""
+
+    device: torch.device | str = torch.device("cuda")
+    """Device to store the cache on."""
+
+    dtype: torch.dtype = torch.float16
+    """Data type to store the cache in."""
+
+    _prev_chunk_idx: int = -1
+    """Chunk index of the last written chunk; -1 when empty."""
+
+    _curr_chunk_idx: int | None = None
+    """The index of the current chunk that is being processed. None when empty."""
+
+    _n_cached: int = 0
+    """Number of valid tokens currently in the cache."""
+
+    _k: Tensor = field(init=False)
+    """Cached keys. shape ``[..., total_size, ..., Dk]``, where the ``total_size`` is the length of the cache buffer at ``seq_dim`` dimension."""
+
+    _v: Tensor = field(init=False)
+    """Cached values. shape ``[..., total_size, ..., Dv]``, where the ``total_size`` is the length of the cache buffer at ``seq_dim`` dimension."""
+
+    @property
+    def size(self) -> int:
+        """Number of valid cached tokens visible to attention."""
+        if self._curr_chunk_idx is None:
+            return self._n_cached
+        if self.is_steady_state():
+            return self._k.shape[self.seq_dim]
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            return self._n_cached + self.chunk_size
+        if self._curr_chunk_idx == self._prev_chunk_idx:
+            return self._n_cached
+        raise ValueError(
+            f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+        )
+
+    @property
+    def write_end(self) -> int:
+        """Right edge of the current chunk in the physical cache layout."""
+        assert self._curr_chunk_idx is not None, (
+            "Must call before_update() before write_end"
+        )
+        return self.size
+
+    @classmethod
+    def from_tensor(cls, k: Tensor, v: Tensor, seq_dim: int) -> Self:
+        cache = cls(
+            k_shape=k.shape,
+            v_shape=v.shape,
+            seq_dim=seq_dim,
+            chunk_size=k.shape[seq_dim],
+            window_size=k.shape[seq_dim],
+            device=k.device,
+            dtype=k.dtype,
+        )
+        cache.before_update(0)
+        cache.update(k, v)
+        cache.after_update(0)
+        cache._curr_chunk_idx = 0
+        return cache
+
+    def __post_init__(self) -> None:
+        assert self.k_shape[:-1] == self.v_shape[:-1], (
+            "k and v must have the same shape except for the last dimension"
+        )
+
+        tensor_dim = len(self.k_shape)
+        assert -tensor_dim <= self.seq_dim < tensor_dim, (
+            f"seq_dim must be in [-{tensor_dim}, {tensor_dim}), got {self.seq_dim}"
+        )
+        # Normalize seq_dim to a non-negative index so downstream
+        # indexing math doesn't have to special-case negatives.
+        self.seq_dim = self.seq_dim if self.seq_dim >= 0 else self.seq_dim + tensor_dim
+
+        assert self.sink_size >= 0, "sink_size must be non-negative"
+
+        expected_length = self.sink_size + self.window_size
+        assert self.k_shape[self.seq_dim] == expected_length, (
+            f"k_shape[seq_dim] ({self.k_shape[self.seq_dim]}) must equal sink_size + window_size ({expected_length})"
+        )
+
+        assert (self.window_size + self.sink_size) % self.chunk_size == 0, (
+            f"window_size + sink_size ({self.window_size + self.sink_size}) must be divisible by chunk_size ({self.chunk_size})"
+        )
+
+        self._k = torch.empty(self.k_shape, device=self.device, dtype=self.dtype)
+        self._v = torch.empty(self.v_shape, device=self.device, dtype=self.dtype)
+
+    def _seq_slice(self, start: int | None, end: int | None) -> tuple[slice | int, ...]:
+        """Return an index tuple selecting ``[start:end]`` on ``seq_dim`` and all elements elsewhere."""
+        idx: list[slice | int] = [slice(None)] * len(self.k_shape)
+        idx[self.seq_dim] = slice(start, end)
+        return tuple(idx)
+
+    def _roll_local_window_left(self) -> None:
+        """Shift the local window left by chunk_size tokens (steady-state only)."""
+        total_size = self._k.shape[self.seq_dim]
+        assert total_size == self._n_cached, (
+            f"Expected full cache: {total_size=} != {self._n_cached=}"
+        )
+        tokens_to_keep = self.window_size - self.chunk_size
+
+        if tokens_to_keep > 0:
+            src_start = self.sink_size + self.chunk_size
+            src_end = total_size
+            dst_start = self.sink_size
+            dst_end = self.sink_size + tokens_to_keep
+
+            dst_slice = self._seq_slice(dst_start, dst_end)
+            src_slice = self._seq_slice(src_start, src_end)
+            self._k[dst_slice] = self._k[src_slice].clone()
+            self._v[dst_slice] = self._v[src_slice].clone()
+
+    def _overwrite_rightmost_steady(self, k: Tensor, v: Tensor) -> None:
+        """Write the new chunk into the rightmost positions (steady-state, after roll)."""
+        total_size = self._k.shape[self.seq_dim]
+        assert total_size == self._n_cached, (
+            f"Expected full cache: {total_size=} != {self._n_cached=}"
+        )
+        write_end = total_size
+        write_start = write_end - self.chunk_size
+        if write_start > self.sink_size:
+            sl_write = self._seq_slice(write_start, write_end)
+            self._k[sl_write] = k
+            self._v[sl_write] = v
+        else:
+            # The input token overlaps with the sink tokens, so we only keep partial of it.
+            # Note: here we assume the sink tokens have already been written to the cache.
+            # It is safe to assume this because this function will never be called for the
+            # first chunk, and we assume the first chunk should be enough to cover the sink tokens.
+            write_start = self.sink_size
+            keep_size = write_end - write_start
+            read_end = self.chunk_size
+            read_start = read_end - keep_size
+            sl_read = self._seq_slice(read_start, read_end)
+            sl_write = self._seq_slice(write_start, write_end)
+            self._k[sl_write] = k[sl_read]
+            self._v[sl_write] = v[sl_read]
+
+    def _overwrite_rightmost_filling(self, k: Tensor, v: Tensor) -> None:
+        """Write the new chunk into the rightmost positions (filling phase)."""
+        write_end = self._n_cached
+        write_start = write_end - self.chunk_size
+        assert write_start >= 0, (
+            f"write [{write_start}:{write_end}) out of bounds for buffer size {self.sink_size + self.window_size}"
+        )
+        sl = self._seq_slice(write_start, write_end)
+        self._k[sl] = k
+        self._v[sl] = v
+
+    def _append_to_end(self, k: Tensor, v: Tensor) -> None:
+        """Append the new chunk to the end of the cache (filling phase)."""
+        write_start = self._n_cached
+        write_end = write_start + self.chunk_size
+        assert write_end <= self.sink_size + self.window_size, (
+            f"write [{write_start}:{write_end}) out of bounds for buffer size {self.sink_size + self.window_size}"
+        )
+        sl = self._seq_slice(write_start, write_end)
+        self._k[sl] = k
+        self._v[sl] = v
+
+    def is_steady_state(self) -> bool:
+        """Return True if the cache is full (steady-state phase)."""
+        assert self._curr_chunk_idx is not None, (
+            "Must call before_update() before is_steady_state()"
+        )
+        total_size = self._k.shape[self.seq_dim]
+        is_full = total_size == self._n_cached
+        is_overlapping_with_sink = (
+            self.sink_size > 0
+            and self._curr_chunk_idx * self.chunk_size
+            < self.sink_size  # start < sink_size
+        )
+        return is_full and not is_overlapping_with_sink
+
+    def before_update(self, chunk_idx: int) -> None:
+        """
+        Prepare the cache before writing new tokens.
+
+        If ``chunk_idx`` equals the previous chunk index, this is a no-op. Otherwise,
+        we expect the ``chunk_idx`` to be +1 from the previous chunk index. In this case,
+        we will roll the local window left if the cache is in steady-state, or no op
+        if the cache is in filling phase.
+
+        Args:
+            chunk_idx: Chunk index of the new chunk in the full sequence.
+        """
+        assert self._curr_chunk_idx is None, (
+            "Must call after_update() before before_update()"
+        )
+        self._curr_chunk_idx = chunk_idx
+
+        if chunk_idx == self._prev_chunk_idx:
+            return
+
+        assert chunk_idx == self._prev_chunk_idx + 1, (
+            "Expected the new chunk_idx to be +1 from the previous chunk_idx, "
+            f"got {chunk_idx} != {self._prev_chunk_idx} + 1"
+        )
+        if self.is_steady_state():
+            self._roll_local_window_left()
+
+    def update(self, k: Tensor, v: Tensor) -> None:
+        """
+        Write the new chunk's keys and values into the cache.
+
+        Must be called after ``before_update()`` and before ``after_update()``.
+
+        Args:
+            k: Keys; shape must match cached keys except at seq_dim, where length must be chunk_size.
+            v: Values; shape must match cached values except at seq_dim, where length must be chunk_size.
+        """
+        assert self._curr_chunk_idx is not None, (
+            "Must call before_update() before update()"
+        )
+
+        chunk_size_k = k.shape[self.seq_dim]
+        chunk_size_v = v.shape[self.seq_dim]
+        assert chunk_size_k == self.chunk_size, (
+            f"Expected input k to have chunk_size ({chunk_size_k}) at seq_dim ({self.seq_dim}), "
+            f"got {chunk_size_k} != {self.chunk_size}"
+        )
+        assert chunk_size_v == self.chunk_size, (
+            f"Expected input v to have chunk_size ({chunk_size_v}) at seq_dim ({self.seq_dim}), "
+            f"got {chunk_size_v} != {self.chunk_size}"
+        )
+        if self.is_steady_state():
+            self._overwrite_rightmost_steady(k, v)
+        else:
+            if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+                self._append_to_end(k, v)
+            elif self._curr_chunk_idx == self._prev_chunk_idx:
+                self._overwrite_rightmost_filling(k, v)
+            else:
+                raise ValueError(
+                    f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+                )
+
+    def after_update(self, chunk_idx: int) -> None:
+        """
+        Finalize bookkeeping after writing new tokens.
+
+        Updates ``_prev_chunk_idx`` and, in filling phase, ``_n_cached``.
+
+        Args:
+            chunk_idx: The index of the new chunk in the full sequence.
+        """
+        assert chunk_idx == self._curr_chunk_idx, (
+            f"Expected chunk_idx to be {self._curr_chunk_idx}, got {chunk_idx}"
+        )
+
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            if self.is_steady_state():
+                pass
+            else:
+                self._n_cached += self.chunk_size
+            self._prev_chunk_idx += 1
+        elif self._curr_chunk_idx == self._prev_chunk_idx:
+            pass
+        else:
+            raise ValueError(
+                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+            )
+
+        self._curr_chunk_idx = None
+
+    def cached_k(self) -> Tensor:
+        """
+        Return cached keys for attention (valid prefix in filling phase, full buffer in steady-state).
+        """
+        if self.is_steady_state():
+            return self._k
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            return self._k[self._seq_slice(0, self._n_cached + self.chunk_size)]
+        elif self._curr_chunk_idx == self._prev_chunk_idx:
+            return self._k[self._seq_slice(0, self._n_cached)]
+        else:
+            raise ValueError(
+                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+            )
+
+    def cached_v(self) -> Tensor:
+        """
+        Return cached values for attention (valid prefix in filling phase, full buffer in steady-state).
+        """
+        if self.is_steady_state():
+            return self._v
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            return self._v[self._seq_slice(0, self._n_cached + self.chunk_size)]
+        elif self._curr_chunk_idx == self._prev_chunk_idx:
+            return self._v[self._seq_slice(0, self._n_cached)]
+        else:
+            raise ValueError(
+                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+            )
+
+    def reset(self) -> None:
+        """Reset the cache to its initial empty state."""
+        self._prev_chunk_idx = -1
+        self._n_cached = 0

--- a/flashdreams/flashdreams/recipes/cosmos/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/cosmos/transformer/__init__.py
@@ -487,6 +487,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             timesteps=timesteps,
             rope_freqs=cache.rope_freqs,
             cache=network_cache,
+            self_attn_range=network_cache.block_caches[0].self_attn.range,
             current_chunk_idx=ar_idx,
             eager_mode=False,
         )

--- a/flashdreams/flashdreams/recipes/cosmos/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/cosmos/transformer/impl/modules.py
@@ -24,7 +24,13 @@ import torch.nn as nn
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from flashdreams.core.attention import BlockKVCache, ContextParallelAttention
+from flashdreams.core.attention import (
+    BlockKVCache,
+    ContextParallelAttention,
+    KVRange,
+    PrefixBlockKVCache,
+    RollingBlockKVCache,
+)
 from flashdreams.core.attention.rope import apply_rope_freqs
 
 
@@ -280,21 +286,15 @@ class MultiHeadAttention(nn.Module):
         """World size of the context-parallel group (1 if disabled)."""
         return self.attn_op.context_parallel_size()
 
-    def _compute_or_update_kv_cache(
+    def _project_kv(
         self,
         context: Tensor,
-        kv_cache: BlockKVCache | None = None,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Compute K/V from ``context`` and optionally merge into ``kv_cache``.
+    ) -> tuple[Tensor, Tensor]:
+        """Project ``context`` into cache-shaped K/V ``[batch, L, n, d]``.
 
-        Args:
-            context: Source for K/V projections, shape ``[..., L, n * d]``.
-            kv_cache: Existing cache to update; ``None`` allocates a new one.
-            rope_freqs: RoPE frequencies, shape ``[L, 1, 1, d // 2]``.
-
-        Returns:
-            Cache containing the merged keys and values.
+        Single source for the K/V projection shared by :meth:`compute_kv`
+        (prefix fill) and :meth:`update_kv` (rolling in-place write).
         """
         batch_shape = context.shape[:-2]
         batch_size = math.prod(batch_shape)
@@ -305,34 +305,34 @@ class MultiHeadAttention(nn.Module):
         v = self.v_proj(context).reshape(batch_size, L, n, d)
         if rope_freqs is not None:
             k = apply_rope_freqs(k, rope_freqs)
-
-        if kv_cache is None:
-            kv_cache = BlockKVCache.from_tensor(k, v, seq_dim=-3)
-        else:
-            kv_cache.update(k, v)
-        return kv_cache
+        return k, v
 
     def compute_kv(
         self,
         x: Tensor,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Build a new KV cache from ``x``."""
-        return self._compute_or_update_kv_cache(x, None, rope_freqs)
+    ) -> PrefixBlockKVCache:
+        """Build a one-shot prefix KV cache from ``x`` (cross-attn prefix fill)."""
+        k, v = self._project_kv(x, rope_freqs)
+        return PrefixBlockKVCache.from_tensor(k, v, seq_dim=-3)
 
     def update_kv(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Append K/V computed from ``x`` into an existing ``kv_cache``."""
-        return self._compute_or_update_kv_cache(x, kv_cache, rope_freqs)
+    ) -> RollingBlockKVCache:
+        """Branchlessly write K/V computed from ``x`` into ``kv_cache`` at ``write_start``."""
+        k, v = self._project_kv(x, rope_freqs)
+        kv_cache.update_at(k, v, kv_range.write_start)
+        return kv_cache
 
     def apply_kv(
         self,
         x: Tensor,
         kv_cache: BlockKVCache,
+        kv_range: KVRange,
         rope_freqs: Tensor | None = None,
     ) -> Tensor:
         """Run attention using ``x`` as queries and ``kv_cache`` as K/V source.
@@ -340,6 +340,8 @@ class MultiHeadAttention(nn.Module):
         Args:
             x: Query tensor of shape [..., L, n * d].
             kv_cache: KV cache for inference.
+            kv_range: Branchless write/read pair supplied by the caller; only
+                ``valid_len`` (the read length) is consumed here.
             rope_freqs: RoPE frequencies, shape [L, 1, 1, d // 2].
 
         Returns:
@@ -355,34 +357,12 @@ class MultiHeadAttention(nn.Module):
         if rope_freqs is not None:
             q = apply_rope_freqs(q, rope_freqs)
 
-        cached_k = kv_cache.cached_k()
-        cached_v = kv_cache.cached_v()
+        cached_k = kv_cache.cached_k_at(kv_range.valid_len)
+        cached_v = kv_cache.cached_v_at(kv_range.valid_len)
 
         out = self.attn_op(q, cached_k, cached_v)
         out = out.reshape(batch_shape + (L, n * d))
         return self.output_proj(out)
-
-    def forward(
-        self,
-        x: Tensor,
-        kv_cache: BlockKVCache,
-        rope_freqs: Tensor | None = None,
-        update_kv_cache: bool = True,
-    ) -> Tensor:
-        """Optionally refresh cache from ``x`` and run attention.
-
-        Args:
-            x: Query tensor and, when updating, the source for new K/V ([..., L, n * d]).
-            kv_cache: Cache read by attention; written when ``update_kv_cache`` is True.
-            rope_freqs: Optional RoPE frequencies for Q and (when updating) K.
-            update_kv_cache: If False, only run attention against the existing cache.
-
-        Returns:
-            Projected output tensor of shape [..., L, query_dim].
-        """
-        if update_kv_cache:
-            kv_cache = self.update_kv(x, kv_cache, rope_freqs)
-        return self.apply_kv(x, kv_cache, rope_freqs)
 
 
 class SelfAttention(MultiHeadAttention):
@@ -396,7 +376,7 @@ class SelfAttention(MultiHeadAttention):
         sink_size: int,
         device: torch.device,
         dtype: torch.dtype,
-    ) -> BlockKVCache:
+    ) -> RollingBlockKVCache:
         """Initialize KV cache for streaming self-attention.
 
         Args:
@@ -408,10 +388,10 @@ class SelfAttention(MultiHeadAttention):
             dtype: Data type for cache tensors.
 
         Returns:
-            An initialized ``BlockKVCache``.
+            An initialized ``RollingBlockKVCache``.
         """
         total_size = sink_size + window_size
-        return BlockKVCache(
+        return RollingBlockKVCache(
             k_shape=(batch_size, total_size, self.n_heads, self.head_dim),
             v_shape=(batch_size, total_size, self.n_heads, self.head_dim),
             seq_dim=-3,
@@ -425,11 +405,16 @@ class SelfAttention(MultiHeadAttention):
     def forward(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
         rope_freqs: Tensor,
     ) -> Tensor:
-        """Same as base ``forward`` with ``update_kv_cache=True``."""
-        return super().forward(x, kv_cache, rope_freqs=rope_freqs, update_kv_cache=True)
+        """Refresh the cache from ``x`` (``update_kv``) and run attention (``apply_kv``).
+
+        ``kv_range`` carries the branchless write offset and read length.
+        """
+        self.update_kv(x, kv_cache, kv_range, rope_freqs)
+        return self.apply_kv(x, kv_cache, kv_range, rope_freqs)
 
 
 class CrossAttention(MultiHeadAttention):
@@ -438,7 +423,7 @@ class CrossAttention(MultiHeadAttention):
     def initialize_cache(
         self,
         context: Tensor,  # [..., L, D]
-    ) -> BlockKVCache:
+    ) -> PrefixBlockKVCache:
         """Initialize cross-attention cache from the provided context."""
         cache = self.compute_kv(context)
         return cache
@@ -446,18 +431,22 @@ class CrossAttention(MultiHeadAttention):
     def forward(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
+        kv_cache: PrefixBlockKVCache,
     ) -> Tensor:
-        """Attend with queries from ``x``; populate or roll ``kv_cache`` outside this call."""
-        return super().forward(x, kv_cache, rope_freqs=None, update_kv_cache=False)
+        """Attend with queries from ``x`` against the prefix ``kv_cache``.
+
+        The prefix cache is filled once via :meth:`compute_kv` and never updated,
+        so its :attr:`PrefixBlockKVCache.range` is constant.
+        """
+        return self.apply_kv(x, kv_cache, kv_range=kv_cache.range)
 
 
 @dataclass
 class BlockCache:
     """Per-block cache container for self-attention and cross-attention."""
 
-    self_attn: BlockKVCache
-    cross_attn: BlockKVCache
+    self_attn: RollingBlockKVCache
+    cross_attn: PrefixBlockKVCache
 
     def before_update(self, chunk_idx: int) -> None:
         """Run cache pre-update hook for the current chunk."""
@@ -582,6 +571,7 @@ class Block(nn.Module):
         emb: Tensor,
         cache: BlockCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
         adaln_lora: Tensor | None = None,
     ) -> Tensor:
         """Run the full block update for one denoising step.
@@ -591,6 +581,8 @@ class Block(nn.Module):
             emb: Timestep embedding with shape ``[..., L or 1, D]``.
             cache: KV cache container for this block.
             rope_freqs: RoPE frequencies with shape ``[L, 1, 1, D]``.
+            self_attn_range: Branchless self-attn cache write/read pair,
+                unpacked at :meth:`SelfAttention.forward`.
             adaln_lora: Optional AdaLN LoRA embedding with shape
                 ``[..., L or 1, 3 * D]``.
 
@@ -628,6 +620,7 @@ class Block(nn.Module):
             normed_x,
             rope_freqs=rope_freqs,
             kv_cache=cache.self_attn,
+            kv_range=self_attn_range,
         )
         x = x + gate_self * attn_out
 

--- a/flashdreams/flashdreams/recipes/cosmos/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/cosmos/transformer/impl/network.py
@@ -25,6 +25,7 @@ from einops import rearrange
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
+from flashdreams.core.attention import KVRange
 from flashdreams.core.checkpoint.remap import remap_checkpoint_keys
 from flashdreams.core.distributed.context_parallel import (
     cat_outputs_cp,
@@ -433,6 +434,7 @@ class CosmosDiTNetwork(nn.Module):
         timesteps: Tensor,
         cache: CosmosDiTNetworkCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
         current_chunk_idx: int = 0,
         eager_mode: bool = True,
     ) -> Tensor:
@@ -446,6 +448,8 @@ class CosmosDiTNetwork(nn.Module):
                 ``[L, 1, 1, head_dim // 2]``.
             cache: Per-block autoregressive cache produced by
                 :meth:`initialize_cache`.
+            self_attn_range: Branchless self-attn cache write/read pair (see
+                :class:`Block.forward`); used when ``eager_mode=False``.
             current_chunk_idx: Current chunk index in autoregressive inference.
             eager_mode: ``True`` runs cache pre/post-update inside the forward;
                 ``False`` expects the caller to drive ``before_update`` /
@@ -486,6 +490,8 @@ class CosmosDiTNetwork(nn.Module):
         # outside the (graph-captured) network forward.
         if eager_mode:
             cache.before_update(current_chunk_idx)
+            self_attn_range = cache.block_caches[0].self_attn.range
+
         for block_idx, block in enumerate(self.blocks):
             assert isinstance(block, Block)
             x = block(
@@ -494,6 +500,7 @@ class CosmosDiTNetwork(nn.Module):
                 rope_freqs=rope_freqs,
                 adaln_lora=adaln_lora,
                 cache=cache[block_idx],
+                self_attn_range=self_attn_range,
             )
         if eager_mode:
             cache.after_update(current_chunk_idx)

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -87,21 +87,21 @@ class MemBlock(nn.Module):
     def cache_step(
         self, x: torch.Tensor, state: Dict[int, torch.Tensor], batch: int
     ) -> torch.Tensor:
-        """Apply with streaming left-context drawn from ``state``.
+        """Apply with streaming left-context: prepend the previous chunk's
+        last frame to ``x``, run the conv stack, save the new last frame.
 
-        Rolls ``x`` right one step and pads with the previous chunk's last
-        frame (or zeros on the first chunk). Bit-for-bit compatible with the
-        legacy ``cache_mem[i] = _x; ... prev_mem[:, -1:]`` pattern.
+        ``state[id(self)]`` must already exist; :meth:`Decoder.initialize_state`
+        pre-allocates it as a ``[batch, 1, C, H, W]`` zero tensor on the
+        first chunk (bit-equivalent to the legacy ``F.pad`` zero-pad path).
+        Keeping the dict-state lookup branchless lets the compiled decoder
+        be one ``torch.compile``-stable graph across the AR0 -> AR1 transition.
         """
         key = id(self)
         bt, c, h, w = x.shape
         t = bt // batch
         x5 = x.view(batch, t, c, h, w)
-        prev = state.get(key)
-        if prev is None:
-            past = F.pad(x5, (0, 0, 0, 0, 0, 0, 1, 0))[:, :t]
-        else:
-            past = torch.cat([prev, x5[:, :-1]], dim=1)
+        prev = state[key]
+        past = torch.cat([prev, x5[:, :-1]], dim=1)
         out = self.forward(x, past.reshape(bt, c, h, w))
         set_or_copy(state, key, x5[:, -1:])
         return out
@@ -179,6 +179,49 @@ class Decoder(nn.Module):
                 x = blk(x)
         bt, c_out, h_out, w_out = x.shape
         return x.reshape(b, bt // b, c_out, h_out, w_out)
+
+    @torch.no_grad()
+    def initialize_state(
+        self,
+        z_shape: tuple[int, int, int, int, int],
+        dtype: torch.dtype,
+        device: torch.device,
+        state: Dict[int, torch.Tensor],
+    ) -> None:
+        """Populate ``state`` with one zero ``[B, 1, C_i, H_i, W_i]`` tensor per
+        :class:`MemBlock`.
+
+        Walks ``self.blocks`` once eagerly with a synthetic zero input to
+        derive each ``MemBlock``'s input shape; the conv outputs are
+        discarded. After this call every ``MemBlock``'s ``id()`` key is in
+        ``state`` so :meth:`MemBlock.cache_step` never raises and Dynamo's
+        first compiled trace already sees the populated branch (no AR0 -> AR1
+        recompile).
+
+        Zero ``prev`` makes ``cat([zeros, x5[:, :-1]], dim=1)`` in
+        ``cache_step`` bit-equivalent to the legacy
+        ``F.pad(x5, (.., 1, 0))[:, :t]`` first-chunk path, so AR0 outputs
+        are unchanged.
+        """
+        batch, t, c_z, h_z, w_z = z_shape
+        x = torch.zeros(batch * t, c_z, h_z, w_z, dtype=dtype, device=device)
+        for blk in self.blocks:
+            if isinstance(blk, MemBlock):
+                bt_x, c_x, h_x, w_x = x.shape
+                t_x = bt_x // batch
+                state[id(blk)] = torch.zeros(
+                    batch, 1, c_x, h_x, w_x, dtype=dtype, device=device
+                )
+                # Advance x's shape by running the block with a zero past;
+                # output values are discarded.
+                past = (
+                    state[id(blk)]
+                    .expand(-1, t_x, -1, -1, -1)
+                    .reshape(bt_x, c_x, h_x, w_x)
+                )
+                x = blk.forward(x, past)
+            else:
+                x = blk(x)
 
 
 class TAEHV(nn.Module):
@@ -394,6 +437,14 @@ class TAEHV(nn.Module):
             cache = self.prepare_cache()
         state = cache.dec_state
         first_decode = not state
+        if first_decode:
+            # Pre-populate state with zeros so Dynamo's first decoder trace
+            # already sees ``state[key]`` as Tensor; without this, AR1 would
+            # recompile when the dict transitions from empty to populated.
+            b, t, c_z, h_z, w_z = z.shape
+            self.decoder.initialize_state(
+                (b, t, c_z, h_z, w_z), z.dtype, z.device, state
+            )
         # Bind decoder before the first call so steady-state goes through the
         # wrapper while the autotune-during-capture shape stays on the eager
         # path.

--- a/flashdreams/flashdreams/recipes/template/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/template/transformer/__init__.py
@@ -471,6 +471,7 @@ class TemplateTransformer(Transformer[TemplateTransformerCache]):
             cache=network_cache,
             rope_freqs=cache.rope_freqs,
             control=control,
+            self_attn_range=network_cache.kv_cache.range,
         )
 
     def predict_flow(

--- a/flashdreams/flashdreams/recipes/template/transformer/network.py
+++ b/flashdreams/flashdreams/recipes/template/transformer/network.py
@@ -25,8 +25,11 @@ import torch.nn as nn
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from flashdreams.core.attention import ContextParallelAttention
-from flashdreams.core.attention.kvcache import BlockKVCache
+from flashdreams.core.attention import (
+    ContextParallelAttention,
+    KVRange,
+)
+from flashdreams.core.attention.kvcache import RollingBlockKVCache
 from flashdreams.core.attention.rope import apply_rope_freqs
 from flashdreams.infra.config import InstantiateConfig
 
@@ -37,10 +40,10 @@ class TemplateDiTCache:
 
     Holds the block's KV cache plus the one-shot context embedding
     injected as an additive bias every forward. Forwards the
-    ``before_update`` / ``after_update`` protocol to :class:`BlockKVCache`.
+    ``before_update`` / ``after_update`` protocol to :class:`RollingBlockKVCache`.
     """
 
-    kv_cache: BlockKVCache
+    kv_cache: RollingBlockKVCache
     """Self-attention KV cache; shape ``[B, total_size, H, d_h]``."""
 
     context: Tensor
@@ -177,7 +180,7 @@ class TemplateDiT(nn.Module):
         total = sink_size + window_size
         k_shape = (batch_size, total, self._num_heads, self._head_dim)
         v_shape = (batch_size, total, self._num_heads, self._head_dim)
-        kv_cache = BlockKVCache(
+        kv_cache = RollingBlockKVCache(
             k_shape=k_shape,
             v_shape=v_shape,
             seq_dim=1,
@@ -197,6 +200,7 @@ class TemplateDiT(nn.Module):
         timesteps: Tensor,
         cache: TemplateDiTCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
         control: Tensor | None = None,
     ) -> Tensor:
         """Predict flow for one per-rank AR chunk.
@@ -208,6 +212,8 @@ class TemplateDiT(nn.Module):
             cache: Per-rollout cache. AR-step bookkeeping is hoisted
                 to :class:`TemplateTransformerCache`.
             rope_freqs: Self attn rope freqs. Shape [L/cp, 1, 1, d // 2].
+            self_attn_range: Branchless self-attn cache write/read pair,
+                unpacked at the leaf :meth:`_self_attn_block`.
             control: Per-AR-step control latent, same shape as
                 ``noisy_latent``; ``None`` skips the control bias.
 
@@ -225,17 +231,30 @@ class TemplateDiT(nn.Module):
         ctx_bias = cache.context.mean(dim=1)  # [B, D]
         x = x + t_emb.view(1, 1, D) + ctx_bias.view(B, 1, D)
 
-        x = self._self_attn_block(x, rope_freqs, kv_cache=cache.kv_cache)
+        x = self._self_attn_block(
+            x,
+            rope_freqs,
+            kv_cache=cache.kv_cache,
+            kv_range=self_attn_range,
+        )
         return self.output_proj(x)
 
     def _self_attn_block(
-        self, x: Tensor, rope_freqs: Tensor, *, kv_cache: BlockKVCache
+        self,
+        x: Tensor,
+        rope_freqs: Tensor,
+        *,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
     ) -> Tensor:
         """Run one pre-norm self-attention + FFN residual block.
 
         Q is this rank's current chunk; K/V come from ``kv_cache``
         (filling or steady view). :class:`ContextParallelAttention` fuses the
-        cross-rank KV gather with the SDPA call.
+        cross-rank KV gather with the SDPA call. ``kv_range`` is a pair of
+        precomputed branchless ints, unpacked here at the leaf since the leaf
+        APIs (``update_at`` / ``cached_*_at``) each consume one of the two
+        values.
         """
         B, L_local, D = x.shape
 
@@ -247,9 +266,9 @@ class TemplateDiT(nn.Module):
         q = apply_rope_freqs(q, rope_freqs)
         k = apply_rope_freqs(k, rope_freqs)
 
-        kv_cache.update(k, v)
-        k_local = kv_cache.cached_k()  # [B, S_local, H, d_h]
-        v_local = kv_cache.cached_v()
+        kv_cache.update_at(k, v, kv_range.write_start)
+        k_local = kv_cache.cached_k_at(kv_range.valid_len)
+        v_local = kv_cache.cached_v_at(kv_range.valid_len)
 
         attn = self.attn(q, k_local, v_local).reshape(B, L_local, D)
         x = x + self.attn_out(attn)

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -810,6 +810,40 @@ class Encoder3d(nn.Module):
         assert isinstance(conv, CausalConv3d)
         return conv.cache_step(act(norm(x)), state)
 
+    @torch.no_grad()
+    def normalize_state_for_body(self, state: Dict[int, torch.Tensor]) -> None:
+        """Pad every CausalConv3d's seed-shaped state entry up to ``CACHE_T`` frames.
+
+        After ``WanVAE.encode``'s 1-frame seed call, each ``CausalConv3d`` has
+        stored ``state[id(cc3d)]`` as the last-CACHE_T-frames slice of a 1-frame
+        input -- so the stored tensor has T=1 rather than T=CACHE_T. This
+        triggers a whole-graph recompile on the first body chunk (T=4) of the
+        NEXT AR step because Dynamo specialized on the AR0 body's T=1 prev
+        state and AR1 body's prev state is T=CACHE_T=2.
+
+        Prepending zeros to make every entry T=CACHE_T is bit-equivalent to the
+        ``F.pad`` zero-prepad ``CausalConv3d.forward`` would have done if
+        ``prev`` had been shorter than ``time_pad`` -- verified by tracing the
+        conv input in both code paths. ``Resample._upsample3d_step`` /
+        ``_downsample3d_step`` already store T=CACHE_T (the upsample's 1-frame
+        branch explicitly allocates ``x.new_zeros(..., CACHE_T, ...)``, the
+        downsample stores a fixed T=1 tail), so this only touches CausalConv3d
+        entries.
+        """
+        for module in self.modules():
+            if not isinstance(module, CausalConv3d):
+                continue
+            key = id(module)
+            if key not in state:
+                continue
+            prev = state[key]
+            if prev.shape[2] >= CACHE_T:
+                continue
+            pad = CACHE_T - prev.shape[2]
+            b, c, _, h, w = prev.shape
+            zeros = prev.new_zeros(b, c, pad, h, w)
+            state[key] = torch.cat([zeros, prev], dim=2)
+
 
 class Decoder3d(nn.Module):
     def __init__(
@@ -1170,6 +1204,12 @@ class WanVAE(nn.Module):
         if not state:
             outs.append(self.encoder(x[:, :, :1], state))
             x = x[:, :, 1:]
+            # Pad CausalConv3d states from T=1 (seed) to T=CACHE_T so the
+            # AR0 body chunk and every AR1+ body chunk see identical state
+            # shapes -- this kills the ~68 s whole-graph encoder recompile
+            # at AR1. ``normalize_state_for_body`` is an eager ``Encoder3d``
+            # helper; the ``torch.compile`` proxy forwards the call to it.
+            self.encoder.normalize_state_for_body(state)
         else:
             assert x.shape[2] % TEMPORAL_WINDOW == 0, (
                 f"Streaming encode after the first chunk requires T % "

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
@@ -29,7 +29,10 @@ from torch.distributed import ProcessGroup
 from flashdreams.core.attention import (
     BlockKVCache,
     ContextParallelAttention,
+    KVRange,
     NativeAttention,
+    PrefixBlockKVCache,
+    RollingBlockKVCache,
 )
 from flashdreams.core.attention.rope import apply_rope_freqs
 
@@ -202,22 +205,15 @@ class MultiHeadAttention(nn.Module):
         """World size of the context-parallel group (1 if disabled)."""
         return self.attn_op.context_parallel_size()
 
-    def _compute_or_update_kv_cache(
+    def _project_kv(
         self,
         context: Tensor,
-        kv_cache: BlockKVCache | None = None,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Project ``context`` into K/V and optionally append to ``kv_cache``.
+    ) -> tuple[Tensor, Tensor]:
+        """Project ``context`` into cache-shaped K/V ``[batch, L, n, d]``.
 
-        Args:
-            context: Context tensor of shape [..., L, context_dim].
-            kv_cache: Existing cache to update, or ``None`` to create a new cache.
-            rope_freqs: Optional RoPE frequencies for K before
-                K cache write, shape ``[L, 1, 1, d]``.
-
-        Returns:
-            Updated ``BlockKVCache`` containing keys and values.
+        Single source for the K/V projection shared by :meth:`compute_kv`
+        (prefix fill) and :meth:`update_kv` (rolling in-place write).
         """
         batch_shape = context.shape[:-2]
         batch_size = math.prod(batch_shape)
@@ -228,34 +224,34 @@ class MultiHeadAttention(nn.Module):
         v = self.v(context).reshape(batch_size, L, n, d)
         if rope_freqs is not None and self.apply_rope_before_kvcache:
             k = apply_rope_freqs(k, rope_freqs, interleaved=True)
-
-        if kv_cache is None:
-            kv_cache = BlockKVCache.from_tensor(k, v, seq_dim=-3)
-        else:
-            kv_cache.update(k, v)
-        return kv_cache
+        return k, v
 
     def compute_kv(
         self,
         x: Tensor,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Build a new KV cache from ``x``."""
-        return self._compute_or_update_kv_cache(x, None, rope_freqs)
+    ) -> PrefixBlockKVCache:
+        """Build a one-shot prefix KV cache from ``x`` (cross-attn prefix fill)."""
+        k, v = self._project_kv(x, rope_freqs)
+        return PrefixBlockKVCache.from_tensor(k, v, seq_dim=-3)
 
     def update_kv(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Append K/V computed from ``x`` into an existing ``kv_cache``."""
-        return self._compute_or_update_kv_cache(x, kv_cache, rope_freqs)
+    ) -> RollingBlockKVCache:
+        """Branchlessly write K/V computed from ``x`` into ``kv_cache`` at ``write_start``."""
+        k, v = self._project_kv(x, rope_freqs)
+        kv_cache.update_at(k, v, kv_range.write_start)
+        return kv_cache
 
     def apply_kv(
         self,
         x: Tensor,
         kv_cache: BlockKVCache,
+        kv_range: KVRange,
         rope_freqs_q: Tensor | None = None,
         rope_freqs_k: Tensor | None = None,
     ) -> Tensor:
@@ -264,6 +260,8 @@ class MultiHeadAttention(nn.Module):
         Args:
             x: Query tokens, shape ``[..., L, query_dim]``.
             kv_cache: KV cache used as attention context.
+            kv_range: Branchless write/read pair supplied by the caller; only
+                ``valid_len`` (the read length) is consumed here.
             rope_freqs_q: Optional RoPE frequencies for Q, shape
                 ``[L, 1, 1, d]``.
             rope_freqs_k: Optional KV-cache-relative RoPE frequencies for
@@ -280,7 +278,7 @@ class MultiHeadAttention(nn.Module):
         assert n * d == D, "n * d must be equal to D"
 
         q = self.norm_q(self.q(x)).reshape(batch_size, L, n, d)
-        cached_k = kv_cache.cached_k()
+        cached_k = kv_cache.cached_k_at(kv_range.valid_len)
         if rope_freqs_q is not None:
             q = apply_rope_freqs(q, rope_freqs_q, interleaved=True)
         if not self.apply_rope_before_kvcache:
@@ -290,7 +288,7 @@ class MultiHeadAttention(nn.Module):
             cached_k = cached_k.clone()
             cached_k = apply_rope_freqs(cached_k, rope_freqs_k, interleaved=True)
 
-        cached_v = kv_cache.cached_v()
+        cached_v = kv_cache.cached_v_at(kv_range.valid_len)
 
         out = self.attn_op(q, cached_k, cached_v)
         out = out.reshape(batch_shape + (L, n * d))
@@ -299,44 +297,23 @@ class MultiHeadAttention(nn.Module):
     def _slice_rope_freqs(
         self,
         rope_freqs: Tensor | None,
-        kv_cache: BlockKVCache,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
     ) -> tuple[Tensor | None, Tensor | None]:
-        """Select Q/K RoPE frequencies for standard or cache-relative mode."""
+        """Select Q/K RoPE frequencies for standard or cache-relative mode.
+
+        Uses the branchless ``kv_range`` rather than the cache's mutable cursor,
+        keeping the traced graph ``_n_cached``-agnostic.
+        """
         if rope_freqs is None:
             return None, None
         if self.apply_rope_before_kvcache:
             return rope_freqs, rope_freqs
 
-        write_end = kv_cache.write_end
-        write_start = write_end - kv_cache.chunk_size
-        rope_freqs_q = rope_freqs[write_start:write_end]
-        rope_freqs_k = rope_freqs[: kv_cache.size]
+        we = kv_range.write_start + kv_cache.chunk_size
+        rope_freqs_q = rope_freqs[kv_range.write_start : we]
+        rope_freqs_k = rope_freqs[: kv_range.valid_len]
         return rope_freqs_q, rope_freqs_k
-
-    def forward(
-        self,
-        x: Tensor,
-        kv_cache: BlockKVCache,
-        rope_freqs: Tensor | None = None,
-        update_kv_cache: bool = True,
-    ) -> Tensor:
-        """Optionally refresh cache from ``x`` and run attention.
-
-        Args:
-            x: Query tensor and, when updating, the source for new K/V ([..., L, n * d]).
-            kv_cache: Cache read by attention; written when ``update_kv_cache`` is True.
-            rope_freqs: Optional RoPE frequencies. Standard mode receives current-chunk
-                frequencies. KV-cache-relative mode receives frequencies relative to the KV cache
-                and applies the K slice on cache read.
-            update_kv_cache: If False, only run attention against the existing cache.
-
-        Returns:
-            Projected output tensor of shape [..., L, query_dim].
-        """
-        rope_freqs_q, rope_freqs_k = self._slice_rope_freqs(rope_freqs, kv_cache)
-        if update_kv_cache:
-            kv_cache = self.update_kv(x, kv_cache, rope_freqs_k)
-        return self.apply_kv(x, kv_cache, rope_freqs_q, rope_freqs_k)
 
 
 class SelfAttention(MultiHeadAttention):
@@ -350,22 +327,24 @@ class SelfAttention(MultiHeadAttention):
         sink_size: int,
         device: torch.device,
         dtype: torch.dtype,
-    ) -> BlockKVCache:
+    ) -> RollingBlockKVCache:
         """Initialize KV cache for streaming self-attention.
 
         Args:
             batch_size: Flattened batch size used by attention.
-            chunk_size: Number of tokens appended per update step.
+            chunk_size: Tokens appended per AR step.
             window_size: Rolling-window capacity in tokens.
             sink_size: Sink-token capacity retained permanently.
             device: Device for cache tensors.
             dtype: Data type for cache tensors.
 
         Returns:
-            An initialized ``BlockKVCache``.
+            An initialized ``RollingBlockKVCache`` (self-contained cursor; the
+            owning ``*TransformerCache`` advances every block's cache in
+            lock-step).
         """
         total_size = sink_size + window_size
-        return BlockKVCache(
+        return RollingBlockKVCache(
             k_shape=(batch_size, total_size, self.n_heads, self.head_dim),
             v_shape=(batch_size, total_size, self.n_heads, self.head_dim),
             seq_dim=-3,
@@ -379,19 +358,30 @@ class SelfAttention(MultiHeadAttention):
     def forward(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
-        rope_freqs: Tensor,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
+        rope_freqs: Tensor | None = None,
     ) -> Tensor:
-        """Update cache from ``x`` and return self-attention output."""
-        return super().forward(x, kv_cache, rope_freqs=rope_freqs, update_kv_cache=True)
+        """Update cache from ``x`` and return self-attention output.
+
+        ``kv_range`` is precomputed by :meth:`RollingBlockKVCache.before_update`
+        (read via :attr:`RollingBlockKVCache.range`) and threaded through
+        the cross-layer plumbing. Branchless throughout to keep the
+        traced ``torch.compile`` graph ``_n_cached``-agnostic.
+        """
+        rope_freqs_q, rope_freqs_k = self._slice_rope_freqs(
+            rope_freqs, kv_cache, kv_range=kv_range
+        )
+        self.update_kv(x, kv_cache, kv_range, rope_freqs_k)
+        return self.apply_kv(x, kv_cache, kv_range, rope_freqs_q, rope_freqs_k)
 
 
 @dataclass
 class CrossAttnCache:
     """Cache container for cross-attention."""
 
-    text: BlockKVCache
-    img: BlockKVCache | None = None  # Optional image cache (I2V).
+    text: PrefixBlockKVCache
+    img: PrefixBlockKVCache | None = None  # Optional image cache (I2V).
 
 
 class CrossAttention(MultiHeadAttention):
@@ -414,14 +404,14 @@ class CrossAttention(MultiHeadAttention):
                 qkv_format="bshd", backend="cudnn", method=cp_method
             )
 
-    def compute_kv_image(self, context: Tensor) -> BlockKVCache:
+    def compute_kv_image(self, context: Tensor) -> PrefixBlockKVCache:
         """Compute K/V from image ``context``.
 
         Args:
             context: Image context, shape ``[..., L, context_dim]``.
 
         Returns:
-            Cache with projected image keys and values.
+            Prefix cache with projected image keys and values.
         """
         batch_shape = context.shape[:-2]
         batch_size = math.prod(batch_shape)
@@ -430,7 +420,7 @@ class CrossAttention(MultiHeadAttention):
 
         k = self.norm_k_img(self.k_img(context)).reshape(batch_size, L, n, d)
         v = self.v_img(context).reshape(batch_size, L, n, d)
-        return BlockKVCache.from_tensor(k, v, seq_dim=-3)
+        return PrefixBlockKVCache.from_tensor(k, v, seq_dim=-3)
 
     def initialize_cache(
         self,
@@ -461,7 +451,13 @@ class CrossAttention(MultiHeadAttention):
         x: Tensor,
         kv_cache: CrossAttnCache,
     ) -> Tensor:
-        """Run cross-attention with queries from ``x`` and cached context."""
+        """Run cross-attention with queries from ``x`` and cached context.
+
+        Text/image prefix caches are filled once and never updated, so each
+        cache's ``valid_len`` is the constant full prefix length, read directly
+        here -- safe inside the compiled forward because it never changes (no
+        ``kv_range`` threading needed, unlike self-attn).
+        """
         batch_shape = x.shape[:-2]
         batch_size = math.prod(batch_shape)
         L, D = x.shape[-2:]
@@ -469,13 +465,21 @@ class CrossAttention(MultiHeadAttention):
         assert n * d == D, "n * d must be equal to D"
 
         q = self.norm_q(self.q(x)).reshape(batch_size, L, n, d)
-        out = self.attn_op(q, kv_cache.text.cached_k(), kv_cache.text.cached_v())
+        text = kv_cache.text
+        out = self.attn_op(
+            q,
+            text.cached_k_at(text.valid_len),
+            text.cached_v_at(text.valid_len),
+        )
         if self.i2v:
             assert kv_cache.img is not None, (
                 "kv_cache_img is expected to be provided for I2V cross-attention"
             )
+            img = kv_cache.img
             out_img = self.attn_op_image(
-                q, kv_cache.img.cached_k(), kv_cache.img.cached_v()
+                q,
+                img.cached_k_at(img.valid_len),
+                img.cached_v_at(img.valid_len),
             )
             out = out + out_img
         out = out.reshape(batch_shape + (L, n * d))
@@ -486,7 +490,7 @@ class CrossAttention(MultiHeadAttention):
 class BlockCache:
     """Per-block cache container for self-attention and cross-attention."""
 
-    self_attn: BlockKVCache
+    self_attn: RollingBlockKVCache
     cross_attn: CrossAttnCache
 
     def before_update(self, chunk_idx: int) -> None:
@@ -615,6 +619,7 @@ class Block(nn.Module):
         e: Tensor,
         cache: BlockCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
     ) -> Tensor:
         """Run one transformer block update.
 
@@ -629,6 +634,8 @@ class Block(nn.Module):
             rope_freqs: Full-width RoPE frequencies. Standard mode passes
                 current-chunk frequencies with shape ``[L, 1, 1, head_dim]``;
                 KV-cache-relative mode passes cache-layout frequencies.
+            self_attn_range: Branchless self-attn cache write/read pair,
+                unpacked at :meth:`SelfAttention.forward`.
 
         Returns:
             Updated hidden states with shape [..., L, D].
@@ -650,6 +657,7 @@ class Block(nn.Module):
             y,
             rope_freqs=rope_freqs,
             kv_cache=cache.self_attn,
+            kv_range=self_attn_range,
         )
         x = x + (y * e_chunks[2])  # [..., L, D]
 

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
@@ -26,6 +26,7 @@ from einops import rearrange
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
+from flashdreams.core.attention import KVRange
 from flashdreams.core.distributed.context_parallel import (
     cat_outputs_cp,
     split_inputs_cp,
@@ -423,6 +424,7 @@ class WanDiTNetwork(nn.Module):
         timesteps: Tensor,
         cache: WanDiTNetworkCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
         current_chunk_idx: int = 0,
         eager_mode: bool = True,
         block_extra_kwargs: dict[str, Any] = {},
@@ -448,8 +450,14 @@ class WanDiTNetwork(nn.Module):
             rope_freqs: Full-width RoPE frequencies after CP. Standard mode
                 uses current-chunk frequencies with shape ``[L, 1, 1, d]``;
                 KV-cache-relative mode uses frequencies relative to the KV cache.
-            current_chunk_idx: Current chunk index for streaming cache update.
-            eager_mode: If ``True``, run cache before/after update hooks.
+            self_attn_range: Branchless self-attn cache write/read pair (see
+                :class:`Block.forward`); used when ``eager_mode=False``.
+            current_chunk_idx: Chunk index for the streaming cache update;
+                consulted only when ``eager_mode=True``.
+            eager_mode: ``True`` drives the cache ``before_update`` /
+                ``after_update`` inside this forward; ``False`` expects the
+                caller to drive them. Slated for removal (see
+                ``eager-mode-removal-HANDOFF.md``); production uses ``False``.
             block_extra_kwargs: Extra kwargs forwarded to each block.
 
         Returns:
@@ -510,9 +518,14 @@ class WanDiTNetwork(nn.Module):
             )  # [..., 1, D]
         block_e = torch.broadcast_to(e0, block_e_shape)
 
-        # Transformer blocks
+        # In non-eager mode the caller drives ``before_update`` /
+        # ``after_update`` outside the (graph-captured) network forward and
+        # passes the precomputed ``self_attn_range`` in.
         if eager_mode:
             cache.before_update(current_chunk_idx)
+            self_attn_range = cache.block_caches[0].self_attn.range
+
+        # Transformer blocks
         for block_idx, block in enumerate(self.blocks):
             assert isinstance(block, Block)
             x = block(
@@ -520,6 +533,7 @@ class WanDiTNetwork(nn.Module):
                 e=block_e,
                 rope_freqs=rope_freqs,
                 cache=cache[block_idx],
+                self_attn_range=self_attn_range,
                 **block_extra_kwargs,
             )
         if eager_mode:

--- a/flashdreams/flashdreams/recipes/wan/transformer/legacy.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/legacy.py
@@ -1,0 +1,796 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Legacy (pre-split) wan-transformer cache layer for flashvsr / hy_worldplay.
+
+Those two integrations were written against the **pre-refactor** self-contained
+``BlockKVCache`` (``before_update`` / ``update`` / ``cached_k`` with an internal
+cursor) and the old cache-construction chain. The core split
+(:class:`RollingBlockKVCache` / :class:`PrefixBlockKVCache` +
+:class:`KVCacheLifecycle`) changed that contract. Rather than migrate their
+bespoke block-sparse / dual-branch-PRoPE forwards, this module provides
+**same-named thin subclasses** of the live wan transformer that restore ONLY the
+old self-attention *rolling* cache plus its construction + cascade.
+
+What is reused unchanged from the live recipe (inherited, never copied):
+
+- all model math: ``MultiHeadAttention`` projections / attention op, ``MLP``,
+  RoPE, patchify / unpatchify, embeddings, ``Head``;
+- the **cross-attention** prefix cache (it is immutable and already works on the
+  new ``PrefixBlockKVCache`` / ``CrossAttnCache``).
+
+flashvsr / hy_worldplay repoint their imports here -- import lines only; their
+class bodies are unchanged. Bodies below are frozen copies of the pre-refactor
+recipe (``cf0eb1dd``); do not add features here -- migrate the consumers instead.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import torch
+from torch import Tensor
+
+from flashdreams.core.attention.legacy_kvcache import BlockKVCache
+from flashdreams.core.attention.rope import (
+    KVCacheRelativeRotaryPositionEmbedding3D,
+    RotaryPositionEmbedding3D,
+    apply_rope_freqs,
+)
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper
+from flashdreams.infra.diffusion.transformer import TransformerAutoregressiveCache
+from flashdreams.recipes.wan.autoencoder.i2v import I2VCtrl
+
+# Unchanged symbols re-exported so consumers can import everything from here.
+from flashdreams.recipes.wan.transformer.impl.modules import (
+    Block as _NewBlock,
+)
+from flashdreams.recipes.wan.transformer.impl.modules import (
+    CrossAttention,
+    CrossAttnCache,
+    sinusoidal_embedding_1d,
+)
+from flashdreams.recipes.wan.transformer.impl.modules import (
+    MultiHeadAttention as _NewMultiHeadAttention,
+)
+from flashdreams.recipes.wan.transformer.impl.network import (
+    WanDiTNetwork as _NewWanDiTNetwork,
+)
+from flashdreams.recipes.wan.transformer.impl.network import (
+    WanDiTNetwork1pt3BConfig,
+    WanDiTNetwork14BConfig,
+    WanDiTNetworkConfig,
+    WanDiTNetworkTI2V5BConfig,
+)
+from flashdreams.recipes.wan.transformer.wan21 import (
+    Wan21Transformer as _NewWan21Transformer,
+)
+from flashdreams.recipes.wan.transformer.wan21 import (
+    Wan21TransformerConfig,
+)
+
+__all__ = [
+    "BlockKVCache",
+    "SelfAttention",
+    "BlockCache",
+    "Block",
+    "CrossAttention",
+    "CrossAttnCache",
+    "MultiHeadAttention",
+    "sinusoidal_embedding_1d",
+    "WanDiTNetworkCache",
+    "WanDiTNetwork",
+    "WanDiTNetworkConfig",
+    "WanDiTNetwork1pt3BConfig",
+    "WanDiTNetwork14BConfig",
+    "WanDiTNetworkTI2V5BConfig",
+    "Wan21TransformerCache",
+    "Wan21Transformer",
+    "Wan21TransformerConfig",
+]
+
+
+class MultiHeadAttention(_NewMultiHeadAttention):
+    """Legacy multi-head attention: pre-split self-contained ``BlockKVCache`` contract.
+
+    Frozen copy (69e173c1) of the cache-facing methods the live
+    :class:`MultiHeadAttention` replaced when it moved to the branchless
+    ``RollingBlockKVCache`` + :class:`KVRange` API. The projections, attention
+    op, RoPE and ``__init__`` are inherited from the live module unchanged; only
+    the cursor-based cache read/write path (``before_update`` / ``update`` /
+    ``cached_k`` / ``size`` / ``write_end``) is restored here verbatim.
+    """
+
+    def _compute_or_update_kv_cache(
+        self,
+        context: Tensor,
+        kv_cache: BlockKVCache | None = None,
+        rope_freqs: Tensor | None = None,
+    ) -> BlockKVCache:
+        """Project ``context`` into K/V and optionally append to ``kv_cache``.
+
+        Args:
+            context: Context tensor of shape [..., L, context_dim].
+            kv_cache: Existing cache to update, or ``None`` to create a new cache.
+            rope_freqs: Optional RoPE frequencies for K before
+                K cache write, shape ``[L, 1, 1, d]``.
+
+        Returns:
+            Updated ``BlockKVCache`` containing keys and values.
+        """
+        batch_shape = context.shape[:-2]
+        batch_size = math.prod(batch_shape)
+        L, D = context.shape[-2:]
+        n, d = self.n_heads, self.head_dim
+
+        k = self.norm_k(self.k(context)).reshape(batch_size, L, n, d)
+        v = self.v(context).reshape(batch_size, L, n, d)
+        if rope_freqs is not None and self.apply_rope_before_kvcache:
+            k = apply_rope_freqs(k, rope_freqs, interleaved=True)
+
+        if kv_cache is None:
+            kv_cache = BlockKVCache.from_tensor(k, v, seq_dim=-3)
+        else:
+            kv_cache.update(k, v)
+        return kv_cache
+
+    def compute_kv(  # type: ignore[override]
+        self,
+        x: Tensor,
+        rope_freqs: Tensor | None = None,
+    ) -> BlockKVCache:
+        """Build a new KV cache from ``x``."""
+        return self._compute_or_update_kv_cache(x, None, rope_freqs)
+
+    def update_kv(  # type: ignore[override]
+        self,
+        x: Tensor,
+        kv_cache: BlockKVCache,
+        rope_freqs: Tensor | None = None,
+    ) -> BlockKVCache:
+        """Append K/V computed from ``x`` into an existing ``kv_cache``."""
+        return self._compute_or_update_kv_cache(x, kv_cache, rope_freqs)
+
+    def apply_kv(  # type: ignore[override]
+        self,
+        x: Tensor,
+        kv_cache: BlockKVCache,
+        rope_freqs_q: Tensor | None = None,
+        rope_freqs_k: Tensor | None = None,
+    ) -> Tensor:
+        """Run attention with queries from ``x`` against cached K/V.
+
+        Args:
+            x: Query tokens, shape ``[..., L, query_dim]``.
+            kv_cache: KV cache used as attention context.
+            rope_freqs_q: Optional RoPE frequencies for Q, shape
+                ``[L, 1, 1, d]``.
+            rope_freqs_k: Optional KV-cache-relative RoPE frequencies for
+                cached K, shape ``[S_cache, 1, 1, d]``. Only used when
+                K is stored without standard RoPE before the KV cache write.
+
+        Returns:
+            Output-projected attention, shape ``[..., L, query_dim]``.
+        """
+        batch_shape = x.shape[:-2]
+        batch_size = math.prod(batch_shape)
+        L, D = x.shape[-2:]
+        n, d = self.n_heads, self.head_dim
+        assert n * d == D, "n * d must be equal to D"
+
+        q = self.norm_q(self.q(x)).reshape(batch_size, L, n, d)
+        cached_k = kv_cache.cached_k()
+        if rope_freqs_q is not None:
+            q = apply_rope_freqs(q, rope_freqs_q, interleaved=True)
+        if not self.apply_rope_before_kvcache:
+            assert rope_freqs_k is not None, (
+                "KV-cache-relative RoPE requires rope_freqs_k for cached K"
+            )
+            cached_k = cached_k.clone()
+            cached_k = apply_rope_freqs(cached_k, rope_freqs_k, interleaved=True)
+
+        cached_v = kv_cache.cached_v()
+
+        out = self.attn_op(q, cached_k, cached_v)
+        out = out.reshape(batch_shape + (L, n * d))
+        return self.o(out)
+
+    def _slice_rope_freqs(  # type: ignore[override]
+        self,
+        rope_freqs: Tensor | None,
+        kv_cache: BlockKVCache,
+    ) -> tuple[Tensor | None, Tensor | None]:
+        """Select Q/K RoPE frequencies for standard or cache-relative mode."""
+        if rope_freqs is None:
+            return None, None
+        if self.apply_rope_before_kvcache:
+            return rope_freqs, rope_freqs
+
+        write_end = kv_cache.write_end
+        write_start = write_end - kv_cache.chunk_size
+        rope_freqs_q = rope_freqs[write_start:write_end]
+        rope_freqs_k = rope_freqs[: kv_cache.size]
+        return rope_freqs_q, rope_freqs_k
+
+    def forward(  # type: ignore[override]
+        self,
+        x: Tensor,
+        kv_cache: BlockKVCache,
+        rope_freqs: Tensor | None = None,
+        update_kv_cache: bool = True,
+    ) -> Tensor:
+        """Optionally refresh cache from ``x`` and run attention.
+
+        Args:
+            x: Query tensor and, when updating, the source for new K/V ([..., L, n * d]).
+            kv_cache: Cache read by attention; written when ``update_kv_cache`` is True.
+            rope_freqs: Optional RoPE frequencies. Standard mode receives current-chunk
+                frequencies. KV-cache-relative mode receives frequencies relative to the KV cache
+                and applies the K slice on cache read.
+            update_kv_cache: If False, only run attention against the existing cache.
+
+        Returns:
+            Projected output tensor of shape [..., L, query_dim].
+        """
+        rope_freqs_q, rope_freqs_k = self._slice_rope_freqs(rope_freqs, kv_cache)
+        if update_kv_cache:
+            kv_cache = self.update_kv(x, kv_cache, rope_freqs_k)
+        return self.apply_kv(x, kv_cache, rope_freqs_q, rope_freqs_k)
+
+
+class SelfAttention(MultiHeadAttention):
+    """Self-attention that always refreshes K/V cache from current ``x`` (pre-split)."""
+
+    def initialize_cache(
+        self,
+        batch_size: int,
+        chunk_size: int,
+        window_size: int,
+        sink_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> BlockKVCache:
+        """Initialize KV cache for streaming self-attention.
+
+        Args:
+            batch_size: Flattened batch size used by attention.
+            chunk_size: Number of tokens appended per update step.
+            window_size: Rolling-window capacity in tokens.
+            sink_size: Sink-token capacity retained permanently.
+            device: Device for cache tensors.
+            dtype: Data type for cache tensors.
+
+        Returns:
+            An initialized ``BlockKVCache``.
+        """
+        total_size = sink_size + window_size
+        return BlockKVCache(
+            k_shape=(batch_size, total_size, self.n_heads, self.head_dim),
+            v_shape=(batch_size, total_size, self.n_heads, self.head_dim),
+            seq_dim=-3,
+            chunk_size=chunk_size,
+            window_size=window_size,
+            sink_size=sink_size,
+            device=device,
+            dtype=dtype,
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        kv_cache: BlockKVCache,
+        rope_freqs: Tensor,
+    ) -> Tensor:
+        """Update cache from ``x`` and return self-attention output."""
+        return super().forward(x, kv_cache, rope_freqs=rope_freqs, update_kv_cache=True)
+
+
+@dataclass
+class BlockCache:
+    """Per-block cache: legacy rolling self-attn + (new) immutable prefix cross-attn."""
+
+    self_attn: BlockKVCache
+    cross_attn: CrossAttnCache
+
+    def before_update(self, chunk_idx: int) -> None:
+        """Run pre-update hook for the self-attention cache."""
+        self.self_attn.before_update(chunk_idx)
+
+    def after_update(self, chunk_idx: int) -> None:
+        """Run post-update hook for the self-attention cache."""
+        self.self_attn.after_update(chunk_idx)
+
+
+class Block(_NewBlock):
+    """Legacy block: old-signature ``initialize_cache`` / ``forward``; cross-attn stays new.
+
+    Self-attn cache construction goes through ``self.self_attn.initialize_cache``
+    so consumer subclasses that swap in their own self-attn (flashvsr's
+    ``SparseSelfAttention``, hy's PRoPE self-attn) keep their side-effect setup.
+    """
+
+    self_attn: SelfAttention  # type: ignore[assignment]
+    """Legacy cursor-based self-attention (the live base builds a
+    ``RollingBlockKVCache`` variant; we install the pre-split one below)."""
+
+    def __init__(
+        self,
+        dim: int,
+        ffn_dim: int,
+        num_heads: int,
+        cross_attn_norm: bool = True,
+        eps: float = 1e-6,
+        i2v: bool = False,
+        apply_rope_before_kvcache: bool = True,
+        cp_method: Literal["ring", "ulysses"] = "ring",
+    ) -> None:
+        super().__init__(
+            dim=dim,
+            ffn_dim=ffn_dim,
+            num_heads=num_heads,
+            cross_attn_norm=cross_attn_norm,
+            eps=eps,
+            i2v=i2v,
+            apply_rope_before_kvcache=apply_rope_before_kvcache,
+            cp_method=cp_method,
+        )
+        # Replace the live RollingBlockKVCache self-attn with the legacy
+        # cursor-based one so this block's initialize_cache / forward speak
+        # the pre-split BlockKVCache contract. Parameter names are identical
+        # (``self_attn.{q,k,v,o,norm_q,norm_k}``) so checkpoints load drop-in.
+        self.self_attn = SelfAttention(
+            query_dim=dim,
+            n_heads=num_heads,
+            head_dim=dim // num_heads,
+            eps=eps,
+            apply_rope_before_kvcache=apply_rope_before_kvcache,
+            cp_method=cp_method,
+        )
+
+    def initialize_cache(  # type: ignore[override]
+        self,
+        chunk_size: int,
+        window_size: int,
+        sink_size: int,
+        context_text: Tensor,
+        context_img: Tensor | None = None,
+    ) -> BlockCache:
+        """Initialize per-branch caches for this transformer block."""
+        batch_shape = context_text.shape[:-2]
+        batch_size = math.prod(batch_shape)
+        device = context_text.device
+        dtype = context_text.dtype
+
+        return BlockCache(
+            self_attn=self.self_attn.initialize_cache(
+                batch_size,
+                chunk_size,
+                window_size,
+                sink_size,
+                device=device,
+                dtype=dtype,
+            ),
+            cross_attn=self.cross_attn.initialize_cache(context_text, context_img),
+        )
+
+    def forward(  # type: ignore[override]
+        self,
+        x: Tensor,
+        e: Tensor,
+        cache: BlockCache,
+        rope_freqs: Tensor,
+    ) -> Tensor:
+        """Run one transformer block update (pre-split, no ``self_attn_range``)."""
+        assert self._parameters_updated_after_loading_checkpoint, (
+            "We expect to have called update_parameters_after_loading_checkpoint() "
+            "before running the forward pass"
+        )
+        e_chunks = [c.squeeze(-2) for c in (self.modulation + e).chunk(6, dim=-2)]
+
+        y = self.norm1(x) * (1 + e_chunks[1]) + e_chunks[0]  # [..., L, D]
+        y = self.self_attn(
+            y,
+            rope_freqs=rope_freqs,
+            kv_cache=cache.self_attn,
+        )
+        x = x + (y * e_chunks[2])  # [..., L, D]
+
+        x = x + self.cross_attn(
+            self.norm3(x),
+            kv_cache=cache.cross_attn,
+        )
+        y = self.norm2(x) * (1 + e_chunks[4]) + e_chunks[3]  # [..., L, D]
+        y = self.ffn(y)
+        x = x + (y * e_chunks[5])  # [..., L, D]
+        return x
+
+
+@dataclass
+class WanDiTNetworkCache:
+    """Cache container for all transformer blocks (legacy cascade)."""
+
+    block_caches: list[BlockCache]
+    """Per-transformer-block KV cache, indexed by block position."""
+
+    def __getitem__(self, index: int) -> BlockCache:
+        """Get cache for a specific block."""
+        return self.block_caches[index]
+
+    def before_update(self, chunk_idx: int) -> None:
+        """Run pre-update hooks for all block caches."""
+        for block_cache in self.block_caches:
+            block_cache.before_update(chunk_idx)
+
+    def after_update(self, chunk_idx: int) -> None:
+        """Run post-update hooks for all block caches."""
+        for block_cache in self.block_caches:
+            block_cache.after_update(chunk_idx)
+
+
+class WanDiTNetwork(_NewWanDiTNetwork):
+    """Legacy network: builds legacy blocks, old-signature ``initialize_cache`` / ``forward``."""
+
+    def _build_block(self, layer_idx: int) -> Block:
+        """Construct one legacy (cursor-based self-attn) transformer block."""
+        return Block(
+            dim=self.dim,
+            ffn_dim=self.ffn_dim,
+            num_heads=self.num_heads,
+            cross_attn_norm=self.cross_attn_norm,
+            eps=self.eps,
+            i2v=self.cross_attn_enable_img,
+            apply_rope_before_kvcache=self.apply_rope_before_kvcache,
+            cp_method=self.cp_method,
+        )
+
+    def initialize_cache(  # type: ignore[override]
+        self,
+        chunk_size: int,
+        window_size: int,
+        sink_size: int,
+        text_embeddings: Tensor,
+        img_embeddings: Tensor | None = None,
+    ) -> WanDiTNetworkCache:
+        """Initialize block caches from text/image context embeddings."""
+        assert text_embeddings.shape[-2] == self.text_len
+        context_text = self.text_embedding(text_embeddings)
+        if self.cross_attn_enable_img:
+            assert img_embeddings is not None, (
+                "img_embeddings is required when cross_attn_enable_img=True"
+            )
+            context_img = self.img_emb(img_embeddings)
+        else:
+            context_img = None
+
+        block_caches: list[BlockCache] = []
+        for block in self.blocks:
+            assert isinstance(block, Block)
+            block_caches.append(
+                block.initialize_cache(
+                    chunk_size, window_size, sink_size, context_text, context_img
+                )
+            )
+        return WanDiTNetworkCache(block_caches=block_caches)
+
+    def forward(  # type: ignore[override]
+        self,
+        x: Tensor,
+        timesteps: Tensor,
+        cache: WanDiTNetworkCache,
+        rope_freqs: Tensor,
+        current_chunk_idx: int = 0,
+        eager_mode: bool = True,
+        block_extra_kwargs: dict[str, Any] = {},
+    ) -> Tensor:
+        """Run one denoising forward pass (pre-split eager cache cascade)."""
+        assert self._parameters_updated_after_loading_checkpoint, (
+            "We expect to have called update_parameters_after_loading_checkpoint() "
+            "after loading the checkpoint"
+        )
+        batch_shape = x.shape[:-2]
+        L = x.shape[-2]
+
+        # Patch embedding
+        if self.patch_embedding_type == "linear":
+            x = self.patch_embedding(x)  # (..., L, D)
+        elif self.patch_embedding_type == "conv3d":
+            _weight = self.patch_embedding.weight.reshape(self.dim, -1)
+            _bias = self.patch_embedding.bias
+            x = torch.nn.functional.linear(x, _weight, _bias)
+        else:
+            raise ValueError(
+                f"Invalid patch embedding type: {self.patch_embedding_type}"
+            )
+
+        per_token_timestep = (
+            timesteps.ndim > len(batch_shape) and timesteps.shape[-1] == L
+        )
+        e = self.time_embedding(
+            sinusoidal_embedding_1d(self.freq_dim, timesteps).type_as(x)
+        )
+        e0 = self.time_projection(e).unflatten(-1, (6, self.dim))
+
+        if per_token_timestep:
+            block_e_shape = batch_shape + (L, 6, self.dim)
+            head_e = torch.broadcast_to(e, batch_shape + (L, self.dim)).unsqueeze(-2)
+        else:
+            block_e_shape = batch_shape + (6, self.dim)
+            head_e = torch.broadcast_to(e, batch_shape + (self.dim,)).unsqueeze(-2)
+        block_e = torch.broadcast_to(e0, block_e_shape)
+
+        # Transformer blocks. The cache carries its own cursor, so eager mode
+        # drives before_update / after_update here (the owning cache also does
+        # so via its start / finalize cascade when eager_mode=False).
+        if eager_mode:
+            cache.before_update(current_chunk_idx)
+        for block_idx, block in enumerate(self.blocks):
+            assert isinstance(block, Block)
+            x = block(
+                x=x,
+                e=block_e,
+                rope_freqs=rope_freqs,
+                cache=cache[block_idx],
+                **block_extra_kwargs,
+            )
+        if eager_mode:
+            cache.after_update(current_chunk_idx)
+
+        # Final head
+        x = self.head(x, head_e)  # (..., L, D)
+        return x
+
+
+@dataclass(kw_only=True)
+class Wan21TransformerCache(TransformerAutoregressiveCache):
+    """Per-rollout AR cache for the Wan 2.1 transformer (legacy, no lifecycle).
+
+    Holds an always-present conditional network cache and an optional
+    unconditional one for classifier-free guidance (``None`` disables CFG).
+    The shared cursor lives per-cache (old ``before_update`` / ``after_update``
+    cascade) rather than on a :class:`KVCacheLifecycle`.
+    """
+
+    network_cache: WanDiTNetworkCache
+    """Conditional per-block KV / cross-attention caches."""
+
+    network_cache_uncond: WanDiTNetworkCache | None = None
+    """Unconditional caches; ``None`` disables CFG."""
+
+    rope_adapter: RotaryPositionEmbedding3D | KVCacheRelativeRotaryPositionEmbedding3D
+    """3D RoPE adapter for self-attention position frequencies."""
+
+    rope_freqs: Tensor | None = None
+    """Self-attention RoPE frequencies for the current AR step (recomputed in
+    :meth:`start`, reused across cond/uncond and scheduler steps)."""
+
+    autoregressive_index: int = -1
+    """Current AR step index, set by :meth:`start`."""
+
+    def start(self, autoregressive_index: int) -> None:
+        self.rope_freqs = self.rope_adapter.shift_t(autoregressive_index)
+        self.autoregressive_index = autoregressive_index
+        self.network_cache.before_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.before_update(autoregressive_index)
+
+    def finalize(self, autoregressive_index: int) -> None:
+        self.network_cache.after_update(autoregressive_index)
+        if self.network_cache_uncond is not None:
+            self.network_cache_uncond.after_update(autoregressive_index)
+
+
+class Wan21Transformer(_NewWan21Transformer):
+    """Legacy transformer: old cache-construction chain (no lifecycle / self_attn_range)."""
+
+    network: WanDiTNetwork  # type: ignore[assignment]
+    """Legacy DiT network (the live base types this as the post-split network)."""
+
+    @torch.no_grad()
+    def _build_network_cache(  # type: ignore[override]
+        self,
+        *,
+        text_embeddings: Tensor,
+        image_embeddings: Tensor | None = None,
+    ) -> WanDiTNetworkCache:
+        """Build one network cache (cond or uncond branch)."""
+        assert self._output_height is not None and self._output_width is not None, (
+            "_build_network_cache called before height/width were stashed."
+        )
+        cfg = self.config
+        kt, kh, kw = cfg.network.patch_size
+        pHW = (self._output_height // kh) * (self._output_width // kw)
+        cp_size = self._cp_size
+        chunk_size = self.latent_shape[-2]  # already CP-divided
+        window_size_t = cfg.window_size_t // kt
+        sink_size_t = cfg.sink_size_t // kt
+        assert (window_size_t * pHW) % cp_size == 0, (
+            f"window_size_t * frame_token_count ({window_size_t * pHW}) must be "
+            f"divisible by cp_size ({cp_size})"
+        )
+        assert (sink_size_t * pHW) % cp_size == 0, (
+            f"sink_size_t * frame_token_count ({sink_size_t * pHW}) must be "
+            f"divisible by cp_size ({cp_size})"
+        )
+        window_size = (window_size_t * pHW) // cp_size
+        sink_size = (sink_size_t * pHW) // cp_size
+        return self.network.initialize_cache(
+            chunk_size=chunk_size,
+            window_size=window_size,
+            sink_size=sink_size,
+            text_embeddings=text_embeddings,
+            img_embeddings=image_embeddings,
+        )
+
+    @torch.no_grad()
+    def initialize_autoregressive_cache(  # type: ignore[override]
+        self,
+        *,
+        height: int,
+        width: int,
+        text_embeddings: Tensor,
+        image_embeddings: Tensor | None = None,
+        negative_text_embeddings: Tensor | None = None,
+        **_unused: Any,
+    ) -> Wan21TransformerCache:
+        """Build a seeded transformer cache for a new rollout (legacy, no lifecycle)."""
+        cfg = self.config
+        kt, kh, kw = cfg.network.patch_size
+        assert height % kh == 0 and width % kw == 0, (
+            f"(height, width) = ({height}, {width}) must be divisible by "
+            f"patch_size={cfg.network.patch_size[1:]}."
+        )
+        self._output_height = height
+        self._output_width = width
+        total_tokens = (cfg.len_t // kt) * (height // kh) * (width // kw)
+        assert total_tokens % self._cp_size == 0, (
+            f"Wan token length ({total_tokens} from len_t={cfg.len_t}, "
+            f"height={height}, width={width}, "
+            f"patch_size={cfg.network.patch_size}) must be divisible by "
+            f"cp_size={self._cp_size}"
+        )
+
+        network_cache = self._build_network_cache(
+            text_embeddings=text_embeddings,
+            image_embeddings=image_embeddings,
+        )
+        network_cache_uncond: WanDiTNetworkCache | None = None
+        if self.config.guidance_scale > 1.0:
+            assert negative_text_embeddings is not None, (
+                f"WanTransformerConfig.guidance_scale="
+                f"{self.config.guidance_scale} > 1.0 requires "
+                f"negative_text_embeddings."
+            )
+            network_cache_uncond = self._build_network_cache(
+                text_embeddings=negative_text_embeddings,
+                image_embeddings=image_embeddings,
+            )
+
+        head_dim = self.config.network.dim // self.config.network.num_heads
+        rope_kwargs: dict[str, Any] = {
+            "len_t": cfg.len_t // kt,
+            "len_h": height // kh,
+            "len_w": width // kw,
+            "head_dim": head_dim,
+            "h_extrapolation_ratio": self.config.h_extrapolation_ratio,
+            "w_extrapolation_ratio": self.config.w_extrapolation_ratio,
+            "interleaved": True,
+            "device": self.device,
+        }
+        if cfg.network.apply_rope_before_kvcache:
+            rope_adapter = RotaryPositionEmbedding3D(**rope_kwargs)
+        else:
+            rope_kwargs["sink_size_t"] = cfg.sink_size_t // kt
+            rope_kwargs["window_size_t"] = cfg.window_size_t // kt
+            rope_adapter = KVCacheRelativeRotaryPositionEmbedding3D(**rope_kwargs)
+        rope_adapter.set_context_parallel_group(cp_group=self._cp_group)
+
+        # Reset any prior CUDA graph: it refers to slot pointers from the
+        # previous cache, which the new cache invalidates.
+        if self._use_cuda_graph:
+            assert isinstance(self._network_call, CUDAGraphWrapper)
+            self._network_call.reset()
+            assert isinstance(self._network_call_uncond, CUDAGraphWrapper)
+            self._network_call_uncond.reset()
+
+        return Wan21TransformerCache(
+            network_cache=network_cache,
+            network_cache_uncond=network_cache_uncond,
+            rope_adapter=rope_adapter,
+        )
+
+    def _predict_flow(  # type: ignore[override]
+        self,
+        network_input: Tensor,
+        timestep: Tensor,
+        cache: Wan21TransformerCache,
+        autoregressive_index: int,
+        network_extra_kwargs: dict[str, Any],
+        *,
+        uncond: bool,
+    ) -> Tensor:
+        network_cache = cache.network_cache_uncond if uncond else cache.network_cache
+        assert network_cache is not None, (
+            "uncond=True requires cache.network_cache_uncond, but it is None "
+            "(CFG was not enabled at cache build time)."
+        )
+        assert cache.rope_freqs is not None, (
+            "Wan21TransformerCache.start() must populate rope_freqs before predict_flow"
+        )
+        return self._select_network(autoregressive_index, uncond=uncond)(
+            x=network_input,
+            timesteps=timestep,
+            cache=network_cache,
+            rope_freqs=cache.rope_freqs,
+            current_chunk_idx=autoregressive_index,
+            eager_mode=False,
+            **network_extra_kwargs,
+        )
+
+    def predict_flow(  # type: ignore[override]
+        self,
+        noisy_latent: Tensor,
+        timestep: Tensor,
+        cache: Wan21TransformerCache,
+        input: I2VCtrl | None = None,
+        network_extra_kwargs: dict[str, Any] | None = None,
+    ) -> Tensor:
+        """Predict the flow for one denoising step (legacy cache type).
+
+        Mirrors :meth:`Wan21Transformer.predict_flow` but is typed against the
+        legacy :class:`Wan21TransformerCache` so consumers (hy_worldplay) can
+        thread their own legacy-derived cache through ``super().predict_flow``.
+        """
+        ar_idx = cache.autoregressive_index
+        assert ar_idx >= 0, (
+            "Wan21TransformerCache.start(autoregressive_index) must be called "
+            "before predict_flow (DiffusionModel.generate handles this)."
+        )
+        network_extra_kwargs = network_extra_kwargs or {}
+        network_input = self._build_network_input(noisy_latent, input)
+        timestep = self._maybe_build_per_token_timestep(
+            timestep=timestep, input=input, autoregressive_index=ar_idx
+        )
+
+        flow_cond = self._predict_flow(
+            network_input=network_input,
+            timestep=timestep,
+            cache=cache,
+            autoregressive_index=ar_idx,
+            network_extra_kwargs=network_extra_kwargs,
+            uncond=False,
+        )
+        if cache.network_cache_uncond is None:
+            return flow_cond
+        flow_uncond = self._predict_flow(
+            network_input=network_input,
+            timestep=timestep,
+            cache=cache,
+            autoregressive_index=ar_idx,
+            network_extra_kwargs=network_extra_kwargs,
+            uncond=True,
+        )
+        return flow_uncond + self.config.guidance_scale * (flow_cond - flow_uncond)
+
+    def finalize_kv_cache(  # type: ignore[override]
+        self,
+        noisy_latent: Tensor,
+        timestep: Tensor,
+        cache: Wan21TransformerCache,
+        input: Any = None,
+    ) -> None:
+        """Advance the legacy AR cache via a single discarded ``predict_flow``."""
+        _ = self.predict_flow(noisy_latent, timestep, cache, input)

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
@@ -54,7 +54,10 @@ class Wan21TransformerCache(TransformerAutoregressiveCache):
     Holds an always-present conditional network cache and an optional
     unconditional one for classifier-free guidance (``None`` disables CFG).
     Both branches own independent per-block self-attention KV buffers since
-    the residual stream diverges after the first cross-attention layer.
+    the residual stream diverges after the first cross-attention layer. Every
+    self-attn cache is a self-contained :class:`RollingBlockKVCache`; all blocks
+    (and both branches) share geometry + chunk sequence, so they advance in
+    lock-step.
     """
 
     network_cache: WanDiTNetworkCache
@@ -78,14 +81,18 @@ class Wan21TransformerCache(TransformerAutoregressiveCache):
     """Current AR step index, set by ``start``."""
 
     def start(self, autoregressive_index: int) -> None:
-        # Hoist per-block KV pre-update out of the (graph-captured) network
-        # forward; predict_flow runs with eager_mode=False so the network
-        # itself does not call before_update. Same for shift_t: tying the
-        # AR index into the captured graph as a Python int would re-trigger
+        # Hoist the KV pre-update + RoPE shift out of the (graph-captured)
+        # network forward; the network never advances the caches itself, so we
+        # drive before_update here (and after_update in finalize). Tying the AR
+        # index into the captured graph as a Python int would re-trigger
         # cat/repeat on every cond/uncond pass.
         self.rope_freqs = self.rope_adapter.shift_t(autoregressive_index)
 
         self.autoregressive_index = autoregressive_index
+        # Advance + roll every block's self-attn cache (cond + uncond) for this
+        # chunk; they march in lock-step (same geometry + chunk sequence).
+        # Readers fetch the branchless pair from the first cache
+        # (``network_cache.block_caches[0].self_attn.range``).
         self.network_cache.before_update(autoregressive_index)
         if self.network_cache_uncond is not None:
             self.network_cache_uncond.before_update(autoregressive_index)
@@ -325,9 +332,11 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
     ) -> WanDiTNetworkCache:
         """Build one network cache (cond or uncond branch).
 
-        Caller must have populated ``self._output_height/_output_width``
-        (done by :meth:`initialize_autoregressive_cache`) before invoking
-        this.
+        Caller must have populated ``self._output_height/_output_width`` (done
+        by :meth:`initialize_autoregressive_cache`) before invoking this. Every
+        block's self-attn cache is sized identically so the cond and uncond
+        branches march in lock-step. ``seq_dim`` is fixed at 1 (the sequence
+        axis of the per-block ``[B, total, n_heads, head_dim]`` K/V tensor).
         """
         assert self._output_height is not None and self._output_width is not None, (
             "_build_network_cache called before height/width were stashed."
@@ -581,6 +590,7 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
             timesteps=timestep,
             cache=network_cache,
             rope_freqs=cache.rope_freqs,
+            self_attn_range=network_cache.block_caches[0].self_attn.range,
             current_chunk_idx=autoregressive_index,
             eager_mode=False,
             **network_extra_kwargs,

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Unit tests for BlockKVCache.
+Unit tests for RollingBlockKVCache.
 """
 
 from typing import Any, cast
@@ -22,7 +22,9 @@ from typing import Any, cast
 import pytest
 import torch
 
-from flashdreams.core.attention.kvcache import BlockKVCache
+from flashdreams.core.attention.kvcache import (
+    RollingBlockKVCache,
+)
 from flashdreams.core.attention.rope import (
     KVCacheRelativeRotaryPositionEmbedding3D,
     RotaryPositionEmbedding3D,
@@ -58,29 +60,12 @@ class _NaiveKVCache:
 
         length = k.shape[1]
         if chunk_idx == self._prev_chunk_idx:
-            overlaps_sink = self.sink_size > 0 and chunk_idx * length < self.sink_size
-            if self._cache_k.shape[1] == self.total_size and not overlaps_sink:
-                if length <= self.window_size:
-                    self._cache_k[:, -length:] = k
-                    self._cache_v[:, -length:] = v
-                else:
-                    self._cache_k = torch.cat(
-                        [
-                            self._cache_k[:, : self.sink_size],
-                            k[:, -self.window_size :],
-                        ],
-                        dim=1,
-                    )
-                    self._cache_v = torch.cat(
-                        [
-                            self._cache_v[:, : self.sink_size],
-                            v[:, -self.window_size :],
-                        ],
-                        dim=1,
-                    )
-            else:
-                self._cache_k[:, -length:] = k
-                self._cache_v[:, -length:] = v
+            # Reuse (same chunk_idx): overwrite the rightmost ``length``
+            # tokens in place. ``chunk_size <= window_size`` is enforced by
+            # ``RollingBlockKVCache.__post_init__``, so the chunk always fits the
+            # window and there is no partial-keep (``length > window_size``) case.
+            self._cache_k[:, -length:] = k
+            self._cache_v[:, -length:] = v
             return
 
         if self._cache_k.shape[1] == self.total_size:
@@ -128,6 +113,57 @@ class _FakeDeviceMesh:
         return self._world_size
 
 
+def _new_cache(
+    *,
+    chunk_size: int,
+    window_size: int,
+    sink_size: int,
+    k_shape: tuple[int, ...],
+    v_shape: tuple[int, ...],
+    device: torch.device | str = "cpu",
+    dtype: torch.dtype = torch.float32,
+) -> RollingBlockKVCache:
+    """Build a self-contained :class:`RollingBlockKVCache` from sizes (``seq_dim=1``)."""
+    return RollingBlockKVCache(
+        k_shape=k_shape,
+        v_shape=v_shape,
+        seq_dim=1,
+        chunk_size=chunk_size,
+        window_size=window_size,
+        sink_size=sink_size,
+        device=device,
+        dtype=dtype,
+    )
+
+
+def _cursor_cache(
+    *, chunk_size: int = 2, window_size: int = 6, sink_size: int = 0
+) -> RollingBlockKVCache:
+    """A minimal-buffer cache for driving the inlined cursor in isolation."""
+    total = sink_size + window_size
+    return _new_cache(
+        chunk_size=chunk_size,
+        window_size=window_size,
+        sink_size=sink_size,
+        k_shape=(1, total, 1, 1),
+        v_shape=(1, total, 1, 1),
+    )
+
+
+def _cascade_before(caches: list[RollingBlockKVCache], chunk_idx: int) -> None:
+    """Owner-style step (mirrors ``*TransformerCache.start``): advance + roll
+    every cache's own cursor for ``chunk_idx``. The caches share geometry +
+    chunk sequence, so they march in lock-step."""
+    for c in caches:
+        c.before_update(chunk_idx)
+
+
+def _cascade_after(caches: list[RollingBlockKVCache], chunk_idx: int) -> None:
+    """Owner-style finalize: ``after_update`` every cache's own cursor."""
+    for c in caches:
+        c.after_update(chunk_idx)
+
+
 @pytest.fixture
 def device() -> torch.device:
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -139,14 +175,27 @@ def dtype() -> torch.dtype:
 
 
 @pytest.mark.ci_cpu
-@pytest.mark.parametrize("sink_size,window_size", [(0, 8), (0, 24), (3, 5), (3, 21)])
-def test_block_kvcache_matches_baseline(
+@pytest.mark.parametrize("sink_size,window_size", [(0, 8), (0, 24), (3, 21)])
+def test_block_kvcache_branchless_api_matches_baseline(
     device: torch.device,
     dtype: torch.dtype,
     sink_size: int,
     window_size: int,
 ) -> None:
-    """Compare cache API with baseline."""
+    """``update_at`` / ``cached_{k,v}_at`` must be numerically equivalent to
+    the naive baseline for the same chunk sequence.
+
+    This pins the contract the torch.compile path relies on: all
+    data-dependent control flow lives in
+    :meth:`RollingBlockKVCache.before_update`, which precomputes
+    ``write_start`` / ``valid_len`` in Python before the compiled forward,
+    and ``update_at`` / ``cached_{k,v}_at`` are the only traced cache ops.
+
+    Parametrization deliberately excludes ``chunk_size > window_size``
+    (e.g. ``sink_size=3, window_size=5``); the precondition is asserted
+    once in :meth:`RollingBlockKVCache.__post_init__`. Real configs
+    (single-view ``window_size_t=6, len_t=2``) satisfy ``chunk_size <= window_size``.
+    """
     batch, n_heads = 2, 4
     dim_k, dim_v = 8, 16
     chunk_size = 8
@@ -155,13 +204,12 @@ def test_block_kvcache_matches_baseline(
     k_shape = (batch, buffer_size, n_heads, dim_k)
     v_shape = (batch, buffer_size, n_heads, dim_v)
 
-    cache = BlockKVCache(
-        k_shape=k_shape,
-        v_shape=v_shape,
-        seq_dim=1,
+    cache = _new_cache(
         chunk_size=chunk_size,
         window_size=window_size,
         sink_size=sink_size,
+        k_shape=k_shape,
+        v_shape=v_shape,
         device=device,
         dtype=dtype,
     )
@@ -185,16 +233,16 @@ def test_block_kvcache_matches_baseline(
         k_baseline = naive.cached_k()
         v_baseline = naive.cached_v()
 
-        # test basic API
         cache.before_update(chunk_idx)
-        cache.update(new_k, new_v)
-        k_api = cache.cached_k()
-        v_api = cache.cached_v()
+        cache.update_at(new_k, new_v, cache.write_start)
+        k_api = cache.cached_k_at(cache.valid_len)
+        v_api = cache.cached_v_at(cache.valid_len)
         cache.after_update(chunk_idx)
         torch.testing.assert_close(k_api, k_baseline)
         torch.testing.assert_close(v_api, v_baseline)
 
-        # now test that passing in the same index again, should only update the cache at the same positions
+        # Overwrite same chunk (filling-same-chunk / steady-state-replay):
+        # write_start should rewind onto the just-written slot, not append.
         new_k = torch.randn(
             batch, chunk_size, n_heads, dim_k, device=device, dtype=dtype
         )
@@ -207,44 +255,37 @@ def test_block_kvcache_matches_baseline(
         v_baseline = naive.cached_v()
 
         cache.before_update(chunk_idx)
-        cache.update(new_k, new_v)
-        k_api = cache.cached_k()
-        v_api = cache.cached_v()
+        cache.update_at(new_k, new_v, cache.write_start)
+        k_api = cache.cached_k_at(cache.valid_len)
+        v_api = cache.cached_v_at(cache.valid_len)
         cache.after_update(chunk_idx)
         torch.testing.assert_close(k_api, k_baseline)
         torch.testing.assert_close(v_api, v_baseline)
 
 
 @pytest.mark.ci_cpu
-def test_block_kvcache_size_and_write_end_track_current_update() -> None:
-    """Attention can slice RoPE using the cache target write region."""
-    cache = BlockKVCache(
-        k_shape=(1, 6, 1, 1),
-        v_shape=(1, 6, 1, 1),
-        seq_dim=1,
-        chunk_size=2,
-        window_size=6,
-        device="cpu",
-        dtype=torch.float32,
-    )
-    assert cache.size == 0
+def test_cache_size_tracks_current_update() -> None:
+    """``cache.size()`` follows the branchless ``valid_len`` precompute
+    across the fill -> steady -> reuse sequence. Pure introspection test."""
+    cache = _cursor_cache(chunk_size=2, window_size=6, sink_size=0)
+    assert cache.size() == 0
 
     for chunk_idx, expected_end in [(0, 2), (1, 4), (2, 6), (3, 6)]:
         cache.before_update(chunk_idx)
-        assert cache.write_end == expected_end
-        assert cache.size == expected_end
+        assert cache.size() == expected_end
         values = torch.full((1, 2, 1, 1), float(chunk_idx))
-        cache.update(values, values)
+        cache.update_at(values, values, cache.write_start)
         cache.after_update(chunk_idx)
-        assert cache.size == expected_end
+        assert cache.size() == expected_end
 
+    # Multi-step reuse path: re-running chunk 3 keeps size at the
+    # steady-state total_size.
     cache.before_update(3)
-    assert cache.write_end == 6
-    assert cache.size == 6
+    assert cache.size() == 6
     values = torch.full((1, 2, 1, 1), 30.0)
-    cache.update(values, values)
+    cache.update_at(values, values, cache.write_start)
     cache.after_update(3)
-    assert cache.size == 6
+    assert cache.size() == 6
 
 
 @pytest.mark.ci_cpu
@@ -313,13 +354,20 @@ def test_kvcache_relative_rope_cp_freqs_match_cache_chunks() -> None:
     not torch.cuda.is_available(), reason="CUDA required for cudagraph test"
 )
 @pytest.mark.ci_gpu
-@pytest.mark.parametrize("sink_size,window_size", [(0, 8), (0, 24), (3, 5), (3, 21)])
+@pytest.mark.parametrize("sink_size,window_size", [(0, 8), (0, 24), (3, 21)])
 def test_block_kvcache_cudagraph_matches_baseline(
     dtype: torch.dtype,
     sink_size: int,
     window_size: int,
 ) -> None:
-    """BlockKVCache with CUDA graph (steady-state path) should match baseline."""
+    """Branchless ``update_at`` / ``cached_*_at`` inside a CUDA graph
+    (steady-state path) matches the naive baseline.
+
+    Static ``write_start`` / ``valid_len`` (both ``int`` precomputed by
+    :meth:`RollingBlockKVCache.before_update`) flow into the captured
+    region as Python ints, matching the production ``torch.compile``
+    branchless-int contract.
+    """
     device = torch.device("cuda")
     batch, n_heads = 2, 4
     dim_k, dim_v = 8, 16
@@ -329,13 +377,12 @@ def test_block_kvcache_cudagraph_matches_baseline(
     k_shape = (batch, buffer_size, n_heads, dim_k)
     v_shape = (batch, buffer_size, n_heads, dim_v)
 
-    cache = BlockKVCache(
-        k_shape=k_shape,
-        v_shape=v_shape,
-        seq_dim=1,
+    cache = _new_cache(
         chunk_size=chunk_size,
         window_size=window_size,
         sink_size=sink_size,
+        k_shape=k_shape,
+        v_shape=v_shape,
         device=device,
         dtype=dtype,
     )
@@ -357,11 +404,11 @@ def test_block_kvcache_cudagraph_matches_baseline(
     graph: torch.cuda.CUDAGraph | None = None
     warmup_iters = 3
 
-    def fn(k: torch.Tensor, v: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        cache.update(k, v)
-        k_output = cache.cached_k()
-        v_output = cache.cached_v()
-        return k_output, v_output
+    def fn(
+        k: torch.Tensor, v: torch.Tensor, write_start: int, valid_len: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cache.update_at(k, v, write_start)
+        return cache.cached_k_at(valid_len), cache.cached_v_at(valid_len)
 
     for chunk_idx in range(num_chunks):
         new_k = torch.randn(
@@ -376,6 +423,7 @@ def test_block_kvcache_cudagraph_matches_baseline(
         v_baseline = naive.cached_v()
 
         cache.before_update(chunk_idx)
+        rng = cache.range
         if cache.is_steady_state():
             steady_k.copy_(new_k)
             steady_v.copy_(new_v)
@@ -385,21 +433,23 @@ def test_block_kvcache_cudagraph_matches_baseline(
                 s.wait_stream(torch.cuda.current_stream())
                 with torch.cuda.stream(s):
                     for _ in range(warmup_iters):
-                        fn(steady_k, steady_v)
+                        fn(steady_k, steady_v, rng.write_start, rng.valid_len)
                 torch.cuda.current_stream().wait_stream(s)
                 graph = torch.cuda.CUDAGraph()
                 with torch.cuda.graph(graph):
-                    k_api, v_api = fn(steady_k, steady_v)
+                    k_api, v_api = fn(
+                        steady_k, steady_v, rng.write_start, rng.valid_len
+                    )
             else:
                 graph.replay()
         else:
-            k_api, v_api = fn(new_k, new_v)
+            k_api, v_api = fn(new_k, new_v, rng.write_start, rng.valid_len)
         cache.after_update(chunk_idx)
 
         torch.testing.assert_close(k_api, k_baseline)
         torch.testing.assert_close(v_api, v_baseline)
 
-        # Overwrite same chunk (same as baseline test)
+        # Overwrite same chunk: write_start rewinds onto the just-written slot.
         new_k = torch.randn(
             batch, chunk_size, n_heads, dim_k, device=device, dtype=dtype
         )
@@ -412,13 +462,14 @@ def test_block_kvcache_cudagraph_matches_baseline(
         v_baseline = naive.cached_v()
 
         cache.before_update(chunk_idx)
+        rng = cache.range
         if graph is not None:
             assert cache.is_steady_state()
             steady_k.copy_(new_k)
             steady_v.copy_(new_v)
             graph.replay()
         else:
-            k_api, v_api = fn(new_k, new_v)
+            k_api, v_api = fn(new_k, new_v, rng.write_start, rng.valid_len)
         cache.after_update(chunk_idx)
 
         torch.testing.assert_close(k_api, k_baseline)
@@ -426,3 +477,392 @@ def test_block_kvcache_cudagraph_matches_baseline(
 
     # make sure the graph is captured.
     assert graph is not None
+
+
+# ---- inlined rolling-cursor + lock-step tests ----
+
+
+@pytest.mark.ci_cpu
+def test_cursor_advances_through_filling_and_steady() -> None:
+    """The inlined cursor on a RollingBlockKVCache reproduces the state machine."""
+    cache = _cursor_cache(chunk_size=2, window_size=6, sink_size=0)
+
+    assert cache._n_cached == 0
+    assert cache._curr_chunk_idx is None
+    assert cache._prev_chunk_idx == -1
+
+    for chunk_idx, expected_size in [(0, 2), (1, 4), (2, 6), (3, 6), (4, 6)]:
+        cache.before_update(chunk_idx)
+        assert cache._curr_chunk_idx == chunk_idx
+        assert cache.size() == expected_size
+        assert cache.valid_len == expected_size
+        cache.after_update(chunk_idx)
+        assert cache._curr_chunk_idx is None
+        assert cache._prev_chunk_idx == chunk_idx
+
+
+@pytest.mark.ci_cpu
+def test_before_update_is_idempotent() -> None:
+    """Re-entrant before_update(chunk_idx) calls within an AR step are no-ops."""
+    cache = _cursor_cache(chunk_size=2, window_size=6, sink_size=0)
+
+    # AR 0: first call advances, repeated calls do nothing.
+    cache.before_update(0)
+    n0 = cache._n_cached
+    needs_roll0 = cache._needs_buffer_roll
+    for _ in range(10):
+        cache.before_update(0)
+        assert cache._n_cached == n0
+        assert cache._needs_buffer_roll == needs_roll0
+        assert cache._curr_chunk_idx == 0
+    cache.after_update(0)
+
+    # Fill to steady state, then verify the steady-state transition sets the
+    # roll flag and idempotent re-entries observe it.
+    for chunk_idx in [1, 2]:
+        cache.before_update(chunk_idx)
+        cache.after_update(chunk_idx)
+    cache.before_update(3)
+    assert cache._needs_buffer_roll is True
+    for _ in range(5):
+        cache.before_update(3)
+        assert cache._needs_buffer_roll is True
+
+
+@pytest.mark.ci_cpu
+def test_after_update_is_idempotent() -> None:
+    """Re-entrant after_update(chunk_idx) calls are no-ops."""
+    cache = _cursor_cache(chunk_size=2, window_size=6, sink_size=0)
+
+    cache.before_update(0)
+    cache.after_update(0)
+    # Re-entry within the same AR step sees _curr_chunk_idx already None.
+    for _ in range(10):
+        cache.after_update(0)
+        assert cache._curr_chunk_idx is None
+        assert cache._prev_chunk_idx == 0
+        assert cache._n_cached == 2
+
+
+@pytest.mark.ci_cpu
+def test_write_start_matches_branchy_logic() -> None:
+    """write_start covers steady, filling-advance, filling-same."""
+    cache = _cursor_cache(chunk_size=2, window_size=6, sink_size=0)
+
+    # Filling, advancing.
+    cache.before_update(0)
+    assert cache.write_start == 0
+    cache.after_update(0)
+    cache.before_update(1)
+    assert cache.write_start == 2
+    cache.after_update(1)
+    cache.before_update(2)
+    assert cache.write_start == 4
+    cache.after_update(2)
+
+    # Steady state: rightmost slot, total_size - chunk_size = 6 - 2 = 4.
+    cache.before_update(3)
+    assert cache.is_steady_state()
+    assert cache.write_start == 4
+    cache.after_update(3)
+
+    # Filling-same in steady state: chunk_idx repeats, _curr == _prev.
+    cache.before_update(3)
+    assert cache.write_start == 4
+    cache.after_update(3)
+
+
+@pytest.mark.ci_cpu
+def test_precomputes_write_start_and_valid_len_in_before_update() -> None:
+    """``write_start`` / ``valid_len`` are populated by ``before_update`` itself
+    (no separate compute step), and 10 idempotent re-entries within the same AR
+    step don't drift either field."""
+    cache = _cursor_cache(chunk_size=2, window_size=6, sink_size=0)
+
+    # Zero-init before any before_update.
+    assert cache.write_start == 0
+    assert cache.valid_len == 0
+
+    # AR 0: first call populates both fields; 10 idempotent re-entries leave
+    # them untouched.
+    cache.before_update(0)
+    assert cache.write_start == 0
+    assert cache.valid_len == 2
+    for _ in range(10):
+        cache.before_update(0)
+        assert cache.write_start == 0
+        assert cache.valid_len == 2
+    cache.after_update(0)
+
+    # AR 1, AR 2: filling continues, both fields advance lock-step with cursor.
+    for chunk_idx, expected_ws, expected_vl in [(1, 2, 4), (2, 4, 6)]:
+        cache.before_update(chunk_idx)
+        assert cache.write_start == expected_ws
+        assert cache.valid_len == expected_vl
+        cache.after_update(chunk_idx)
+
+    # AR 3 hits steady state: rightmost slot at total_size - chunk_size = 4,
+    # full valid_len = total_size = 6.
+    cache.before_update(3)
+    assert cache.is_steady_state()
+    assert cache.write_start == 4
+    assert cache.valid_len == 6
+    for _ in range(10):
+        cache.before_update(3)
+        assert cache.write_start == 4
+        assert cache.valid_len == 6
+    cache.after_update(3)
+
+
+@pytest.mark.ci_cpu
+def test_precomputes_for_multi_step_reuse_path() -> None:
+    """An advance -> reuse -> advance sequence (multi-step scheduler reusing
+    the same chunk) must re-precompute write_start / valid_len for the reuse
+    step, not leave stale values from the prior advance.
+
+    Specifically guards against an early-return regression in
+    ``RollingBlockKVCache.before_update``: the reuse path (`chunk_idx ==
+    _prev_chunk_idx`) must reach the precompute block at the bottom so
+    ``write_start`` rewinds onto the just-written slot
+    (``_n_cached - chunk_size``) instead of holding the previous-step's
+    append offset.
+    """
+    cache = _cursor_cache(chunk_size=2, window_size=6, sink_size=0)
+
+    # Advance: AR 0 appends at 0, valid_len = 2.
+    cache.before_update(0)
+    assert cache.write_start == 0
+    assert cache.valid_len == 2
+    cache.after_update(0)
+
+    # Reuse: scheduler re-runs chunk 0 on the same slot. The reuse-slot
+    # semantics rewind write_start to ``_n_cached - chunk_size = 2 - 2 = 0``
+    # and keep valid_len at the same 2 (no new tokens become visible).
+    cache.before_update(0)
+    assert cache.write_start == 0
+    assert cache.valid_len == 2
+    cache.after_update(0)
+
+    # Advance to AR 1: now appending fresh tokens at ``_n_cached = 2``,
+    # valid_len grows to 4. Verifies the reuse cycle didn't poison _n_cached.
+    cache.before_update(1)
+    assert cache.write_start == 2
+    assert cache.valid_len == 4
+    cache.after_update(1)
+
+    # Fill to steady state, then exercise the steady-state reuse path:
+    # write_start must rewind to total_size - chunk_size on reuse, not
+    # stay at the previous append offset.
+    cache.before_update(2)
+    assert cache.write_start == 4
+    assert cache.valid_len == 6
+    cache.after_update(2)
+    cache.before_update(3)
+    assert cache.is_steady_state()
+    assert cache.write_start == 4
+    assert cache.valid_len == 6
+    cache.after_update(3)
+    # Steady-state reuse of chunk 3 must keep write_start at the rightmost
+    # slot (still 4) and valid_len at the full total_size (still 6).
+    cache.before_update(3)
+    assert cache.write_start == 4
+    assert cache.valid_len == 6
+    cache.after_update(3)
+
+
+@pytest.mark.ci_cpu
+def test_lockstep_caches_advance_equally() -> None:
+    """N independent RollingBlockKVCaches sharing geometry + chunk sequence
+    advance in lock-step: the per-cache before/after_update cascade gives every
+    cache identical branchless params and advances each cursor exactly once."""
+    num_caches = 4
+    caches = [
+        _new_cache(
+            chunk_size=2,
+            window_size=6,
+            sink_size=0,
+            k_shape=(1, 6, 1, 4),
+            v_shape=(1, 6, 1, 4),
+        )
+        for _ in range(num_caches)
+    ]
+
+    for chunk_idx in [0, 1, 2, 3, 4]:
+        # Per-cache cascade: each cache advances + rolls its own cursor/buffer.
+        _cascade_before(caches, chunk_idx)
+        # Lock-step geometry => each cache sees the same window-relative state.
+        write_starts = [c.write_start for c in caches]
+        valid_lens = [c.valid_len for c in caches]
+        assert all(ws == write_starts[0] for ws in write_starts)
+        assert all(vl == valid_lens[0] for vl in valid_lens)
+
+        # Each cache writes (per-buffer) at the same write_start.
+        write_start = write_starts[0]
+        for idx, c in enumerate(caches):
+            payload = torch.full((1, 2, 1, 4), float(10 * idx + chunk_idx))
+            c.update_at(payload, payload, write_start)
+
+        _cascade_after(caches, chunk_idx)
+
+        # Each cache advanced exactly once per AR step (``_n_cached`` increments
+        # by chunk_size, not chunk_size * num_caches).
+        assert caches[0]._n_cached == min((chunk_idx + 1) * 2, caches[0].total_size)
+
+
+@pytest.mark.ci_cpu
+def test_lockstep_caches_cond_uncond_pattern() -> None:
+    """Mimic the cond/uncond CFG pattern: two independent groups of caches with
+    physically-distinct K/V tensors advance in lock-step. The per-cache cascade
+    across both branches advances every cursor once and rolls every buffer.
+
+    Models call cache.start() -> network_cache(_uncond).before_update(idx) on
+    each branch, run predict_flow, then cache.finalize() ->
+    network_cache(_uncond).after_update(idx).
+    """
+
+    def _make_group() -> list[RollingBlockKVCache]:
+        return [
+            _new_cache(
+                chunk_size=2,
+                window_size=6,
+                sink_size=0,
+                k_shape=(1, 6, 1, 4),
+                v_shape=(1, 6, 1, 4),
+            )
+            for _ in range(3)
+        ]
+
+    cond_caches = _make_group()
+    uncond_caches = _make_group()
+    all_caches = cond_caches + uncond_caches
+
+    # Distinct buffer identities.
+    assert cond_caches[0]._k.data_ptr() != uncond_caches[0]._k.data_ptr()
+
+    for chunk_idx in [0, 1, 2, 3, 4]:
+        # Per-cache cascade across both branches advances each cursor once and
+        # rolls every member buffer (cond + uncond).
+        _cascade_before(all_caches, chunk_idx)
+        # Every cache sees identical branchless params.
+        write_starts = [bc.write_start for bc in all_caches]
+        assert all(ws == write_starts[0] for ws in write_starts)
+        valid_lens = [bc.valid_len for bc in all_caches]
+        assert all(vl == valid_lens[0] for vl in valid_lens)
+
+        # Writes.
+        write_start = write_starts[0]
+        for branch_idx, branch in enumerate([cond_caches, uncond_caches]):
+            for bc_idx, bc in enumerate(branch):
+                payload = torch.full(
+                    (1, 2, 1, 4), float(100 * branch_idx + 10 * bc_idx + chunk_idx)
+                )
+                bc.update_at(payload, payload, write_start)
+
+        # Finalize across BOTH branches; each cursor advances once.
+        _cascade_after(all_caches, chunk_idx)
+        # _n_cached advanced by chunk_size, not by chunk_size * 2 branches.
+        assert all_caches[0]._n_cached == min(
+            (chunk_idx + 1) * 2, all_caches[0].total_size
+        )
+
+
+@pytest.mark.ci_cpu
+def test_lockstep_buffer_roll_propagates_to_every_cache() -> None:
+    """When the lock-step caches enter steady-state, each member's own
+    before_update rolls its private buffer left (not just one cache)."""
+    caches = [
+        _new_cache(
+            chunk_size=2,
+            window_size=6,
+            sink_size=0,
+            k_shape=(1, 6, 1, 4),
+            v_shape=(1, 6, 1, 4),
+        )
+        for _ in range(3)
+    ]
+
+    # Fill the cache to steady-state. Each AR step writes a per-cache
+    # distinct value so we can verify the roll moved each cache's buffer.
+    for chunk_idx in [0, 1, 2]:
+        _cascade_before(caches, chunk_idx)
+        write_start = caches[0].write_start
+        for cache_idx, c in enumerate(caches):
+            payload = torch.full(
+                (1, 2, 1, 4), float(100 * cache_idx + 10 * chunk_idx + 1)
+            )
+            c.update_at(payload, payload, write_start)
+        _cascade_after(caches, chunk_idx)
+
+    # Cache state before steady-state roll: each cache's buffer = [chunk0, chunk1, chunk2].
+    pre_roll_snapshots = [c._k.clone() for c in caches]
+    for cache_idx, snap in enumerate(pre_roll_snapshots):
+        # Each cache's chunk 0 entries should be 100*cache_idx + 1 (the value we wrote for chunk 0).
+        expected_chunk0 = float(100 * cache_idx + 1)
+        assert snap[0, 0, 0, 0].item() == expected_chunk0
+
+    # Now AR step 3 enters steady-state: each cache's before_update rolls its
+    # own buffer left by chunk_size=2, so what was at position [2:6] now lives
+    # at [0:4]. The new position 0 holds the chunk written at chunk_idx=1,
+    # i.e. value 100*cache_idx + 11.
+    _cascade_before(caches, 3)
+
+    for cache_idx, c in enumerate(caches):
+        expected_after_roll = float(100 * cache_idx + 11)
+        assert c._k[0, 0, 0, 0].item() == expected_after_roll, (
+            f"cache {cache_idx} buffer was not rolled correctly"
+        )
+
+
+@pytest.mark.ci_cpu
+def test_rolling_cache_exposes_geometry_fields() -> None:
+    """A RollingBlockKVCache exposes its inlined geometry (chunk/window/sink)
+    and derives ``total_size = sink_size + window_size``."""
+    cache = _new_cache(
+        chunk_size=2,
+        window_size=6,
+        sink_size=2,
+        k_shape=(1, 8, 1, 4),
+        v_shape=(1, 8, 1, 4),
+    )
+    assert (cache.chunk_size, cache.window_size, cache.sink_size, cache.seq_dim) == (
+        2,
+        6,
+        2,
+        1,
+    )
+    assert cache.total_size == 8
+
+
+@pytest.mark.ci_cpu
+def test_rolling_cache_k_shape_must_match_total_size() -> None:
+    """Passing ``k_shape[seq_dim]`` that disagrees with ``sink_size + window_size``
+    raises in ``__post_init__``."""
+    # total_size == 8; k_shape[seq_dim=1] == 6 disagrees.
+    with pytest.raises(AssertionError):
+        _new_cache(
+            chunk_size=4,
+            window_size=8,
+            sink_size=0,
+            k_shape=(1, 6, 1, 4),
+            v_shape=(1, 6, 1, 4),
+        )
+
+
+@pytest.mark.ci_cpu
+def test_rolling_cache_constructor_requires_size_fields() -> None:
+    """Omitting a required size field (``chunk_size``) raises ``TypeError`` --
+    the inlined geometry fields have no defaults.
+    """
+    # Cast through ``Any`` so static type checkers (mypy, pyright, ty)
+    # don't flag the deliberately-missing required kwarg.
+    ctor = cast(Any, RollingBlockKVCache)
+    with pytest.raises(TypeError, match="chunk_size"):
+        ctor(
+            k_shape=(1, 6, 1, 4),
+            v_shape=(1, 6, 1, 4),
+            seq_dim=1,
+            window_size=6,
+            sink_size=0,
+            device="cpu",
+            dtype=torch.float32,
+        )

--- a/flashdreams/tests/test_wan_context_parallel.py
+++ b/flashdreams/tests/test_wan_context_parallel.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import pytest
 import torch
 
-from flashdreams.core.attention.kvcache import BlockKVCache
+from flashdreams.core.attention.kvcache import PrefixBlockKVCache
 from flashdreams.recipes.wan.transformer.impl import modules as wan_modules
 from flashdreams.recipes.wan.transformer.impl.network import WanDiTNetworkConfig
 from flashdreams.recipes.wan.transformer.wan21 import (
@@ -107,7 +107,7 @@ def test_kvcache_relative_rope_does_not_mutate_cached_keys(monkeypatch) -> None:
 
     cache_k = torch.randn(1, 3, 1, 4)
     cache_v = torch.randn(1, 3, 1, 4)
-    cache = BlockKVCache.from_tensor(cache_k.clone(), cache_v, seq_dim=1)
+    cache = PrefixBlockKVCache.from_tensor(cache_k.clone(), cache_v, seq_dim=1)
     before = cache._k.clone()
 
     def _fake_apply_rope_freqs(x, freqs, interleaved=False):
@@ -119,6 +119,7 @@ def test_kvcache_relative_rope_does_not_mutate_cached_keys(monkeypatch) -> None:
         cache,
         rope_freqs_q=torch.zeros(3, 1, 1, 4),
         rope_freqs_k=torch.zeros(3, 1, 1, 4),
+        kv_range=cache.range,
     )
 
     torch.testing.assert_close(cache._k, before)

--- a/integrations/flashvsr/flashvsr/pipeline.py
+++ b/integrations/flashvsr/flashvsr/pipeline.py
@@ -34,7 +34,7 @@ from flashdreams.infra.pipeline import (
     StreamInferencePipelineConfig,
 )
 from flashdreams.infra.profiler import EventProfiler, record_event
-from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerCache
+from flashdreams.recipes.wan.transformer.legacy import Wan21TransformerCache
 from flashvsr.decoder import (
     FlashVSRDecoder,
     FlashVSRDecoderCache,

--- a/integrations/flashvsr/flashvsr/transformer/__init__.py
+++ b/integrations/flashvsr/flashvsr/transformer/__init__.py
@@ -40,11 +40,11 @@ from torch import Tensor
 
 from flashdreams.core.distributed.context_parallel import split_inputs_cp
 from flashdreams.infra.cuda_graph import CUDAGraphWrapper
-from flashdreams.recipes.wan.transformer.impl.network import WanDiTNetworkConfig
-from flashdreams.recipes.wan.transformer.wan21 import (
+from flashdreams.recipes.wan.transformer.legacy import (
     Wan21Transformer,
     Wan21TransformerCache,
     Wan21TransformerConfig,
+    WanDiTNetworkConfig,
 )
 from flashvsr.transformer.network import (
     _SELF_ATTN_WINDOW,

--- a/integrations/flashvsr/flashvsr/transformer/network.py
+++ b/integrations/flashvsr/flashvsr/transformer/network.py
@@ -65,19 +65,21 @@ import torch.nn as nn
 from einops import rearrange
 from torch import Tensor
 
-from flashdreams.core.attention import BlockKVCache
+from flashdreams.core.attention.legacy_kvcache import BlockKVCache
 from flashdreams.core.attention.rope import apply_rope_freqs
-from flashdreams.recipes.wan.transformer.impl.modules import (
+
+# Legacy (pre-split) wan transformer: flashvsr's sparse self-attn uses the old
+# rolling-cache API (update / cached_k / before_update). See
+# flashdreams.recipes.wan.transformer.legacy.
+from flashdreams.recipes.wan.transformer.legacy import (
     Block,
     BlockCache,
     CrossAttention,
     MultiHeadAttention,
     SelfAttention,
-    sinusoidal_embedding_1d,
-)
-from flashdreams.recipes.wan.transformer.impl.network import (
     WanDiTNetwork,
     WanDiTNetworkConfig,
+    sinusoidal_embedding_1d,
 )
 
 __all__ = [

--- a/integrations/hy_worldplay/hy_worldplay/_action.py
+++ b/integrations/hy_worldplay/hy_worldplay/_action.py
@@ -31,19 +31,17 @@ from flashdreams.recipes.wan.autoencoder.i2v import (
     I2VCtrlEncoderCache,
     WanI2VCtrlEncoderConfig,
 )
-from flashdreams.recipes.wan.transformer.impl.modules import (
-    sinusoidal_embedding_1d,
-)
-from flashdreams.recipes.wan.transformer.impl.network import (
+# Legacy (pre-split) wan transformer: hy_worldplay uses the old rolling-cache
+# API + cascade. See flashdreams.recipes.wan.transformer.legacy.
+from flashdreams.recipes.wan.transformer.legacy import (
     Block,
-    WanDiTNetwork,
-    WanDiTNetworkCache,
-    WanDiTNetworkTI2V5BConfig,
-)
-from flashdreams.recipes.wan.transformer.wan21 import (
     Wan21Transformer,
     Wan21TransformerCache,
     Wan21TransformerConfig,
+    WanDiTNetwork,
+    WanDiTNetworkCache,
+    WanDiTNetworkTI2V5BConfig,
+    sinusoidal_embedding_1d,
 )
 
 _HY_STABILIZATION_TIMESTEP: int = 14

--- a/integrations/hy_worldplay/hy_worldplay/_action.py
+++ b/integrations/hy_worldplay/hy_worldplay/_action.py
@@ -31,6 +31,7 @@ from flashdreams.recipes.wan.autoencoder.i2v import (
     I2VCtrlEncoderCache,
     WanI2VCtrlEncoderConfig,
 )
+
 # Legacy (pre-split) wan transformer: hy_worldplay uses the old rolling-cache
 # API + cascade. See flashdreams.recipes.wan.transformer.legacy.
 from flashdreams.recipes.wan.transformer.legacy import (

--- a/integrations/hy_worldplay/hy_worldplay/_camera.py
+++ b/integrations/hy_worldplay/hy_worldplay/_camera.py
@@ -27,9 +27,13 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from flashdreams.core.attention import BlockKVCache, ContextParallelAttention
+from flashdreams.core.attention import ContextParallelAttention
+from flashdreams.core.attention.legacy_kvcache import BlockKVCache
 from flashdreams.core.attention.rope import apply_rope_freqs
-from flashdreams.recipes.wan.transformer.impl.modules import (
+
+# Legacy (pre-split) wan transformer: hy_worldplay's PRoPE self-attn uses the
+# old rolling-cache API. See flashdreams.recipes.wan.transformer.legacy.
+from flashdreams.recipes.wan.transformer.legacy import (
     Block,
     BlockCache,
     SelfAttention,

--- a/integrations/hy_worldplay/tests/test_action.py
+++ b/integrations/hy_worldplay/tests/test_action.py
@@ -241,7 +241,7 @@ def test_patchify_override_is_declared_on_subclass() -> None:
     """
     from hy_worldplay._action import HyWorldPlayWan21Transformer
 
-    from flashdreams.recipes.wan.transformer.wan21 import Wan21Transformer
+    from flashdreams.recipes.wan.transformer.legacy import Wan21Transformer
 
     assert (
         HyWorldPlayWan21Transformer.patchify_and_maybe_split_cp
@@ -288,7 +288,7 @@ def test_predict_flow_threads_action_via_network_extra_kwargs() -> None:
     import torch
     from hy_worldplay._action import HyWorldPlayCtrl, HyWorldPlayWan21Transformer
 
-    from flashdreams.recipes.wan.transformer.wan21 import Wan21Transformer
+    from flashdreams.recipes.wan.transformer.legacy import Wan21Transformer
 
     captured: dict[str, dict] = {}
 

--- a/integrations/hy_worldplay/tests/test_camera.py
+++ b/integrations/hy_worldplay/tests/test_camera.py
@@ -201,7 +201,7 @@ def test_hyworldplay_dit_network_use_prope_blocks_swaps_block_class() -> None:
     )
     from hy_worldplay._camera import HyWorldPlayPRoPEBlock
 
-    from flashdreams.recipes.wan.transformer.impl.network import Block
+    from flashdreams.recipes.wan.transformer.legacy import Block
 
     # Tiny but valid network config -- mirrors what
     # :class:`Wan21Transformer` would otherwise build at setup time.

--- a/integrations/hy_worldplay/tests/test_prefill.py
+++ b/integrations/hy_worldplay/tests/test_prefill.py
@@ -310,7 +310,7 @@ def test_transformer_cache_history_defaults_to_empty() -> None:
     """
     from hy_worldplay._action import HyWorldPlayWan21TransformerCache
 
-    from flashdreams.recipes.wan.transformer.impl.network import (
+    from flashdreams.recipes.wan.transformer.legacy import (
         WanDiTNetworkCache,
     )
 
@@ -485,7 +485,7 @@ def test_is_first_step_of_chunk_uses_prefill_latch() -> None:
         HyWorldPlayWan21TransformerCache,
     )
 
-    from flashdreams.recipes.wan.transformer.impl.network import (
+    from flashdreams.recipes.wan.transformer.legacy import (
         WanDiTNetworkCache,
     )
 
@@ -520,7 +520,7 @@ def test_transformer_cache_start_resets_rolling_caches_on_new_chunk() -> None:
     """
     from hy_worldplay._action import HyWorldPlayWan21TransformerCache
 
-    from flashdreams.recipes.wan.transformer.impl.network import (
+    from flashdreams.recipes.wan.transformer.legacy import (
         WanDiTNetworkCache,
     )
 
@@ -562,7 +562,7 @@ def test_transformer_cache_start_keeps_chunk_0_intact() -> None:
     """
     from hy_worldplay._action import HyWorldPlayWan21TransformerCache
 
-    from flashdreams.recipes.wan.transformer.impl.network import (
+    from flashdreams.recipes.wan.transformer.legacy import (
         WanDiTNetworkCache,
     )
 

--- a/integrations/lingbot/lingbot/transformer/impl/modules.py
+++ b/integrations/lingbot/lingbot/transformer/impl/modules.py
@@ -23,6 +23,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
+from flashdreams.core.attention import KVRange
 from flashdreams.recipes.wan.transformer.impl.modules import (
     Block,
     BlockCache,
@@ -60,6 +61,7 @@ class CamCtrlBlock(Block):
         e: Tensor,
         cache: BlockCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
         plucker_embedding: Tensor,
     ) -> Tensor:
         """Run one transformer block update.
@@ -70,6 +72,8 @@ class CamCtrlBlock(Block):
             cache: KV cache container for this block.
             rope_freqs: RoPE frequencies of shape
                 ``[L, 1, 1, head_dim // 2]``.
+            self_attn_range: Branchless self-attn cache write/read pair,
+                threaded through to :meth:`SelfAttention.forward`.
             plucker_embedding: Optional camera-control Plücker embedding
                 of shape ``[..., L, D]``. ``None`` disables the camera
                 modulation (pass-through).
@@ -84,6 +88,7 @@ class CamCtrlBlock(Block):
             y,
             rope_freqs=rope_freqs,
             kv_cache=cache.self_attn,
+            kv_range=self_attn_range,
         )
         x = x + (y * e_chunks[2])
 

--- a/integrations/lingbot/lingbot/transformer/impl/network.py
+++ b/integrations/lingbot/lingbot/transformer/impl/network.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
+from flashdreams.core.attention import KVRange
 from flashdreams.recipes.wan.transformer.impl.network import (
     WanDiTNetwork,
     WanDiTNetworkCache,
@@ -108,6 +109,7 @@ class LingbotWorldDiTNetwork(WanDiTNetwork):
         timesteps: Tensor,
         cache: LingbotWorldDiTNetworkCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
         current_chunk_idx: int = 0,
         eager_mode: bool = True,
     ) -> Tensor:
@@ -122,6 +124,8 @@ class LingbotWorldDiTNetwork(WanDiTNetwork):
             cache: Per-block KV caches.
             rope_freqs: RoPE frequencies of shape
                 ``[L, 1, 1, head_dim // 2]`` after CP.
+            self_attn_range: Branchless self-attn cache write/read pair,
+                threaded through to each block's self-attention.
             current_chunk_idx: Current chunk index for streaming cache update.
             eager_mode: If True, run cache before/after update hooks.
 
@@ -143,6 +147,7 @@ class LingbotWorldDiTNetwork(WanDiTNetwork):
             timesteps=timesteps,
             cache=cache,
             rope_freqs=rope_freqs,
+            self_attn_range=self_attn_range,
             current_chunk_idx=current_chunk_idx,
             eager_mode=eager_mode,
             block_extra_kwargs={"plucker_embedding": plucker_embedding},

--- a/integrations/omnidreams/omnidreams/transformer/__init__.py
+++ b/integrations/omnidreams/omnidreams/transformer/__init__.py
@@ -79,7 +79,9 @@ class CosmosTransformerCache(TransformerAutoregressiveCache):
     """Long-lived AR cache for the Cosmos transformer."""
 
     network_cache: CosmosDiTNetworkCache
-    """Per-block self-attn KV + (text-only) cross-attn KV."""
+    """Per-block self-attn KV + (text-only) cross-attn KV. Each self-attn cache
+    is a self-contained :class:`RollingBlockKVCache`; all blocks (and the
+    cond/uncond branches) advance in lock-step."""
 
     network_cache_uncond: CosmosDiTNetworkCache | None = None
     """Unconditional cache for CFG; ``None`` disables CFG."""
@@ -113,11 +115,15 @@ class CosmosTransformerCache(TransformerAutoregressiveCache):
 
     def start(self, autoregressive_index: int) -> None:
         # Hoist per-block KV pre-update and the RoPE shift out of the
-        # (graph-captured) network forward. ``predict_flow`` runs with
-        # ``eager_mode=False``; the cond/uncond passes share ``rope_freqs``.
+        # (graph-captured) network forward: the network never advances the
+        # caches itself, so we drive ``before_update`` here (and
+        # ``after_update`` in ``finalize``). Cond/uncond share ``rope_freqs``.
         self.rope_freqs = self.rope_adapter.shift_t(autoregressive_index)
 
         self.autoregressive_index = autoregressive_index
+        # Advance + roll every block's self-attn cache (cond + uncond) for this
+        # chunk; they march in lock-step. Readers fetch the branchless pair from
+        # the first cache (``network_cache.block_caches[0].self_attn.range``).
         self.network_cache.before_update(autoregressive_index)
         if self.network_cache_uncond is not None:
             self.network_cache_uncond.before_update(autoregressive_index)
@@ -690,6 +696,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             current_chunk_idx=ar_idx,
             hdmap_condition=input,
             view_indices=cache.view_indices,
+            self_attn_range=network_cache.block_caches[0].self_attn.range,
             eager_mode=False,
         )
 

--- a/integrations/omnidreams/omnidreams/transformer/impl/modules.py
+++ b/integrations/omnidreams/omnidreams/transformer/impl/modules.py
@@ -25,7 +25,13 @@ from einops import rearrange, repeat
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
-from flashdreams.core.attention import BlockKVCache, ContextParallelAttention
+from flashdreams.core.attention import (
+    BlockKVCache,
+    ContextParallelAttention,
+    KVRange,
+    PrefixBlockKVCache,
+    RollingBlockKVCache,
+)
 from flashdreams.core.attention.rope import apply_rope_freqs
 
 
@@ -291,21 +297,15 @@ class MultiHeadAttention(nn.Module):
         """World size of the context-parallel group (1 if disabled)."""
         return self.attn_op.context_parallel_size()
 
-    def _compute_or_update_kv_cache(
+    def _project_kv(
         self,
         context: Tensor,
-        kv_cache: BlockKVCache | None = None,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Compute K/V from ``context`` and optionally merge into ``kv_cache``.
+    ) -> tuple[Tensor, Tensor]:
+        """Project ``context`` into cache-shaped K/V ``[batch, L, n, d]``.
 
-        Args:
-            context: Source for K/V projections, shape ``[..., L, n * d]``.
-            kv_cache: Existing cache to update; ``None`` allocates a new one.
-            rope_freqs: RoPE frequencies, shape ``[L, 1, 1, d // 2]``.
-
-        Returns:
-            Cache containing the merged keys and values.
+        Single source for the K/V projection shared by :meth:`compute_kv`
+        (prefix fill) and :meth:`update_kv` (rolling in-place write).
         """
         batch_shape = context.shape[:-2]
         batch_size = math.prod(batch_shape)
@@ -316,34 +316,34 @@ class MultiHeadAttention(nn.Module):
         v = self.v_proj(context).reshape(batch_size, L, n, d)
         if rope_freqs is not None:
             k = apply_rope_freqs(k, rope_freqs)
-
-        if kv_cache is None:
-            kv_cache = BlockKVCache.from_tensor(k, v, seq_dim=-3)
-        else:
-            kv_cache.update(k, v)
-        return kv_cache
+        return k, v
 
     def compute_kv(
         self,
         x: Tensor,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Build a new KV cache from ``x``."""
-        return self._compute_or_update_kv_cache(x, None, rope_freqs)
+    ) -> PrefixBlockKVCache:
+        """Build a one-shot prefix KV cache from ``x`` (cross-attn prefix fill)."""
+        k, v = self._project_kv(x, rope_freqs)
+        return PrefixBlockKVCache.from_tensor(k, v, seq_dim=-3)
 
     def update_kv(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
         rope_freqs: Tensor | None = None,
-    ) -> BlockKVCache:
-        """Append K/V computed from ``x`` into an existing ``kv_cache``."""
-        return self._compute_or_update_kv_cache(x, kv_cache, rope_freqs)
+    ) -> RollingBlockKVCache:
+        """Branchlessly write K/V computed from ``x`` into ``kv_cache`` at ``write_start``."""
+        k, v = self._project_kv(x, rope_freqs)
+        kv_cache.update_at(k, v, kv_range.write_start)
+        return kv_cache
 
     def apply_kv(
         self,
         x: Tensor,
         kv_cache: BlockKVCache,
+        kv_range: KVRange,
         rope_freqs: Tensor | None = None,
     ) -> Tensor:
         """Run attention using ``x`` as queries and ``kv_cache`` as K/V source.
@@ -351,6 +351,14 @@ class MultiHeadAttention(nn.Module):
         Args:
             x: Query tensor of shape [..., L, n * d].
             kv_cache: KV cache for inference.
+            kv_range: Branchless write/read pair, **supplied by the caller** so
+                ``apply_kv`` never reads the cache's cursor itself -- that
+                keeps this (torch.compile'd / CUDA-graph-captured) forward
+                decoupled from the cache's mutable cursor. Self-attn threads the
+                precomputed range in from outside the graph; cross-attn passes
+                its prefix cache's constant range at the call site (see
+                :meth:`CrossAttention.forward`). Only ``valid_len`` (the read
+                length) is consumed here; ``write_start`` is unused.
             rope_freqs: RoPE frequencies, shape [L, 1, 1, d // 2].
 
         Returns:
@@ -366,34 +374,12 @@ class MultiHeadAttention(nn.Module):
         if rope_freqs is not None:
             q = apply_rope_freqs(q, rope_freqs)
 
-        cached_k = kv_cache.cached_k()
-        cached_v = kv_cache.cached_v()
+        cached_k = kv_cache.cached_k_at(kv_range.valid_len)
+        cached_v = kv_cache.cached_v_at(kv_range.valid_len)
 
         out = self.attn_op(q, cached_k, cached_v)
         out = out.reshape(batch_shape + (L, n * d))
         return self.output_proj(out)
-
-    def forward(
-        self,
-        x: Tensor,
-        kv_cache: BlockKVCache,
-        rope_freqs: Tensor | None = None,
-        update_kv_cache: bool = True,
-    ) -> Tensor:
-        """Optionally refresh cache from ``x`` and run attention.
-
-        Args:
-            x: Query tensor and, when updating, the source for new K/V ([..., L, n * d]).
-            kv_cache: Cache read by attention; written when ``update_kv_cache`` is True.
-            rope_freqs: Optional RoPE frequencies for Q and (when updating) K.
-            update_kv_cache: If False, only run attention against the existing cache.
-
-        Returns:
-            Projected output tensor of shape [..., L, query_dim].
-        """
-        if update_kv_cache:
-            kv_cache = self.update_kv(x, kv_cache, rope_freqs)
-        return self.apply_kv(x, kv_cache, rope_freqs)
 
 
 class SelfAttention(MultiHeadAttention):
@@ -407,22 +393,24 @@ class SelfAttention(MultiHeadAttention):
         sink_size: int,
         device: torch.device,
         dtype: torch.dtype,
-    ) -> BlockKVCache:
+    ) -> RollingBlockKVCache:
         """Initialize KV cache for streaming self-attention.
 
         Args:
             batch_size: Flattened batch size used by attention.
-            chunk_size: Number of tokens appended per update step.
+            chunk_size: Tokens appended per AR step.
             window_size: Rolling-window capacity in tokens.
             sink_size: Sink-token capacity retained permanently.
             device: Device for cache tensors.
             dtype: Data type for cache tensors.
 
         Returns:
-            An initialized ``BlockKVCache``.
+            An initialized ``RollingBlockKVCache`` (self-contained cursor; the
+            owning ``*TransformerCache`` advances every block's cache in
+            lock-step).
         """
         total_size = sink_size + window_size
-        return BlockKVCache(
+        return RollingBlockKVCache(
             k_shape=(batch_size, total_size, self.n_heads, self.head_dim),
             v_shape=(batch_size, total_size, self.n_heads, self.head_dim),
             seq_dim=-3,
@@ -436,11 +424,20 @@ class SelfAttention(MultiHeadAttention):
     def forward(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
-        rope_freqs: Tensor,
+        kv_cache: RollingBlockKVCache,
+        kv_range: KVRange,
+        rope_freqs: Tensor | None = None,
     ) -> Tensor:
-        """Same as base ``forward`` with ``update_kv_cache=True``."""
-        return super().forward(x, kv_cache, rope_freqs=rope_freqs, update_kv_cache=True)
+        """Refresh the cache from ``x`` and run attention.
+
+        ``kv_range`` is precomputed by :meth:`RollingBlockKVCache.before_update`
+        (read via :attr:`RollingBlockKVCache.range`) and threaded through the
+        cross-layer plumbing so the traced ``torch.compile`` graph stays
+        ``_n_cached``-agnostic. ``update_kv`` consumes the write offset;
+        ``apply_kv`` takes the bundle and reads ``valid_len``.
+        """
+        self.update_kv(x, kv_cache, kv_range, rope_freqs)
+        return self.apply_kv(x, kv_cache, kv_range, rope_freqs)
 
 
 class CrossAttention(MultiHeadAttention):
@@ -449,26 +446,37 @@ class CrossAttention(MultiHeadAttention):
     def initialize_cache(
         self,
         context: Tensor,  # [B, V, L, D]
-    ) -> BlockKVCache:
-        """Initialize cross-attention cache from the provided context."""
-        cache = self.compute_kv(context)
-        return cache
+    ) -> PrefixBlockKVCache:
+        """Initialize cross-attention cache from the provided context.
+
+        Returns a one-shot prefix cache via
+        :meth:`PrefixBlockKVCache.from_tensor`.
+        """
+        return self.compute_kv(context)
 
     def forward(
         self,
         x: Tensor,
-        kv_cache: BlockKVCache,
+        kv_cache: PrefixBlockKVCache,
     ) -> Tensor:
-        """Attend with queries from ``x``; populate or roll ``kv_cache`` outside this call."""
-        return super().forward(x, kv_cache, rope_freqs=None, update_kv_cache=False)
+        """Attend with queries from ``x`` against the prefix ``kv_cache``.
+
+        Prefix caches are filled once via :meth:`compute_kv` and never updated,
+        so their :attr:`PrefixBlockKVCache.range` is constant. ``apply_kv`` keeps
+        ``kv_range`` required (it never reads the cache's state itself), so we
+        pass that constant range here -- safe to read inside the compiled
+        forward precisely because it never changes (unlike self-attn's per-step
+        range, which is threaded in from outside the graph).
+        """
+        return self.apply_kv(x, kv_cache, kv_range=kv_cache.range)
 
 
 @dataclass
 class BlockCache:
     """Per-block cache container for self-attention and cross-attention."""
 
-    self_attn: BlockKVCache
-    cross_attn: BlockKVCache
+    self_attn: RollingBlockKVCache
+    cross_attn: PrefixBlockKVCache
 
     def before_update(self, chunk_idx: int) -> None:
         """Run cache pre-update hook for the current chunk."""
@@ -596,7 +604,14 @@ class Block(nn.Module):
         # cross-attention
         context: Tensor,  # [B, V, L, D]
     ) -> BlockCache:
-        """Initialize per-branch caches for this transformer block."""
+        """Initialize per-branch caches for this transformer block.
+
+        Self-attention gets a self-contained :class:`RollingBlockKVCache` sized
+        from ``chunk_size`` / ``window_size`` / ``sink_size``; every block (and
+        the cond/uncond branches) is sized identically so the caches advance in
+        lock-step. Cross-attention caches are immutable prefix caches (built by
+        :meth:`PrefixBlockKVCache.from_tensor`).
+        """
         device = context.device
         dtype = context.dtype
         batch_size = context.shape[0]
@@ -620,6 +635,7 @@ class Block(nn.Module):
         emb: Tensor,
         cache: BlockCache,
         rope_freqs: Tensor,
+        self_attn_range: KVRange,
         adaln_lora: Tensor | None = None,
         view_embedding_proj: Tensor | None = None,
     ) -> Tensor:
@@ -632,6 +648,13 @@ class Block(nn.Module):
             rope_freqs: RoPE frequencies with shape [L, 1, 1, D].
             adaln_lora: Optional AdaLN LoRA embedding with shape [B, 3D].
             view_embedding_proj: Optional per-view modulation tensor [B, V, 9D].
+            self_attn_range: Branchless self-attn cache write offset +
+                read length, precomputed in
+                :meth:`RollingBlockKVCache.before_update` and exposed as
+                :attr:`RollingBlockKVCache.range`. All blocks share the
+                same value because their per-block self-attn caches
+                have identical geometry; unpacked at
+                :meth:`SelfAttention.forward`.
 
         Returns:
             Updated hidden states with the same shape as ``x``.
@@ -710,6 +733,7 @@ class Block(nn.Module):
             normed_x,
             rope_freqs=rope_freqs,
             kv_cache=cache.self_attn,
+            kv_range=self_attn_range,
         ).reshape_as(normed_x)
         x = x + gate_self * attn_out
 

--- a/integrations/omnidreams/omnidreams/transformer/impl/network.py
+++ b/integrations/omnidreams/omnidreams/transformer/impl/network.py
@@ -24,6 +24,7 @@ from einops import rearrange
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
+from flashdreams.core.attention import KVRange
 from flashdreams.core.distributed.context_parallel import (
     cat_outputs_cp,
     split_inputs_cp,
@@ -51,10 +52,12 @@ class CosmosDiTNetworkCache:
         return self.block_caches[index]
 
     def before_update(self, chunk_idx: int) -> None:
+        """Advance + roll every block's self-attn cache for ``chunk_idx``."""
         for block_cache in self.block_caches:
             block_cache.before_update(chunk_idx)
 
     def after_update(self, chunk_idx: int) -> None:
+        """Finalize every block's self-attn cursor for ``chunk_idx``."""
         for block_cache in self.block_caches:
             block_cache.after_update(chunk_idx)
 
@@ -422,7 +425,14 @@ class CosmosDiTNetwork(nn.Module):
         # cross attn
         context: Tensor,
     ) -> CosmosDiTNetworkCache:
-        """Build a fresh autoregressive cache for the DiT given the chunk geometry."""
+        """Build a fresh autoregressive cache for the DiT.
+
+        Every block's self-attn :class:`RollingBlockKVCache` is sized from
+        ``chunk_size`` / ``window_size`` / ``sink_size`` and is self-contained;
+        all blocks (and the cond/uncond CFG branches) are built identically so
+        they advance in lock-step. The threaded ``self_attn_range`` is read from
+        the first block (``block_caches[0].self_attn``).
+        """
         if self.config.use_crossattn_projection:
             context = self.crossattn_proj(context)
 
@@ -441,6 +451,7 @@ class CosmosDiTNetwork(nn.Module):
         rope_freqs: Tensor,  # [L, 1, 1, D]
         cache: CosmosDiTNetworkCache,
         condition_video_input_mask: Tensor,
+        self_attn_range: KVRange,
         current_chunk_idx: int = 0,
         hdmap_condition: Tensor | None = None,
         view_indices: Tensor | None = None,
@@ -454,12 +465,27 @@ class CosmosDiTNetwork(nn.Module):
             rope_freqs: RoPE cosine/sine embeddings of shape ``[L, 1, 1, D]``.
             cache: Per-block autoregressive cache produced by :meth:`initialize_cache`.
             condition_video_input_mask: Patchified condition mask, same shape as ``x``.
-            current_chunk_idx: Current chunk index in autoregressive inference.
+            self_attn_range: Branchless self-attn cache write/read pair
+                (see :class:`Block.forward`). Precomputed in
+                :meth:`RollingBlockKVCache.before_update` and read via
+                :attr:`RollingBlockKVCache.range`. All blocks share the
+                same value because their per-block self-attention
+                caches have identical geometry; threaded through the
+                traced graph as a fixed-arity tuple of two Python ints.
+                The per-block caches' cursors (``before_update`` /
+                ``after_update``) are advanced by the owning
+                ``CosmosTransformerCache`` at the AR-step boundary, outside this
+                graph-captured forward.
+            current_chunk_idx: Chunk index for the streaming cache update;
+                consulted only when ``eager_mode=True``.
             hdmap_condition: Optional HDMap tokens of shape ``[B, V, T, HW, D]`` or ``[B, V, L, D]``.
             view_indices: Optional view indices of shape ``[B, V]``.
-            eager_mode: ``True`` runs cache pre/post-update inside the forward;
-                ``False`` expects the caller to drive ``before_update`` / ``after_update``
-                outside the (graph-captured) network.
+            eager_mode: ``True`` drives ``before_update`` / ``after_update``
+                on the cache inside this forward; ``False`` expects the caller
+                to drive them outside the (graph-captured) network. NOTE:
+                slated for removal in a follow-up PR (see
+                ``eager-mode-removal-HANDOFF.md``); production uses
+                ``eager_mode=False``.
         """
         assert self._parameters_updated_after_loading_checkpoint, (
             "We expect to have called update_parameters_after_loading_checkpoint() after loading the checkpoint"
@@ -504,10 +530,13 @@ class CosmosDiTNetwork(nn.Module):
         else:
             view_embedding_proj = None
 
-        # In non-eager mode the caller drives ``before_update``/``after_update``
-        # outside the (graph-captured) network forward.
+        # In non-eager mode the caller drives ``before_update`` /
+        # ``after_update`` outside the (graph-captured) network forward and
+        # passes the precomputed ``self_attn_range`` in.
         if eager_mode:
             cache.before_update(current_chunk_idx)
+            self_attn_range = cache.block_caches[0].self_attn.range
+
         for block_idx, block in enumerate(self.blocks):
             assert isinstance(block, Block)
             x = block(
@@ -517,6 +546,7 @@ class CosmosDiTNetwork(nn.Module):
                 adaln_lora=adaln_lora,
                 cache=cache[block_idx],
                 view_embedding_proj=view_embedding_proj,
+                self_attn_range=self_attn_range,
             )
         if eager_mode:
             cache.after_update(current_chunk_idx)

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -13,19 +13,19 @@ the diffusion infra and stay unchanged.
 
 Streaming-cache lifecycle. ``native_extension.optimized_dit_forward``
 writes per-layer self-attn K/V in-place at ``self_attn_write_start``
-but does NOT call the cache's ``before_update`` / ``after_update``
-(the upstream ``net.forward(eager_mode=True)`` does). We wrap the C++
-call so the ``BlockKVCache`` state machine evolves the same way:
-
-  * before_update(chunk_idx) -> compute write_start -> C++ call ->
-    after_update(chunk_idx)
+but does NOT call the cache's ``before_update`` / ``after_update``.
+Neither does this shim: like the upstream PyTorch network forward, it
+leaves the ``RollingBlockKVCache`` state machine untouched. The cursor is
+advanced once per AR step at the boundary by
+``CosmosTransformerCache.start`` / ``.finalize``; ``predict_flow`` just
+reads the precomputed ``self_attn.write_start`` (from the first block's
+self-attn cache) and hands it to the C++ launcher.
 
 For the multi-step scheduler loop (one call per denoising step plus
-one finalize call) this is correct because
-``BlockKVCache.before_update`` is a no-op when
-``chunk_idx == _prev_chunk_idx``: only the first call per AR step
-advances the cursor; subsequent calls overwrite the rightmost slot
-with refined K/V from a less-noisy x0.
+one finalize call) this is correct because the boundary
+``before_update`` is a no-op when ``chunk_idx == _prev_chunk_idx``:
+only the first call per AR step advances the cursor; subsequent calls
+overwrite the rightmost slot with refined K/V from a less-noisy x0.
 
 Memory. We snapshot ``self.network.state_dict()`` lazily on the first
 ``predict_flow`` call to hand to the C++ side. Lazy because
@@ -103,7 +103,14 @@ class _CosmosCacheTensorLists:
     v_self: list[Tensor]
 
 
-def _clone_block_kv_cache(cache: Any) -> Any:
+def _clone_rolling_kv_cache(cache: Any) -> Any:
+    """Clone a self-contained :class:`RollingBlockKVCache` (geometry + cursor + buffers).
+
+    The clone is fully decoupled from ``cache`` (its own cursor) but starts at
+    the same cursor position, so a captured template reproduces the source
+    state. ``before_update`` / ``after_update`` then advance the clone's own
+    cursor; ``predict_flow`` reads ``block_caches[0].self_attn.range``.
+    """
     cloned = type(cache)(
         k_shape=tuple(cache.k_shape),
         v_shape=tuple(cache.v_shape),
@@ -117,17 +124,33 @@ def _clone_block_kv_cache(cache: Any) -> Any:
     cloned._prev_chunk_idx = cache._prev_chunk_idx
     cloned._curr_chunk_idx = cache._curr_chunk_idx
     cloned._n_cached = cache._n_cached
+    cloned._needs_buffer_roll = cache._needs_buffer_roll
+    cloned.write_start = cache.write_start
+    cloned.valid_len = cache.valid_len
     cloned._k.copy_(cache._k)
     cloned._v.copy_(cache._v)
     return cloned
 
 
+def _clone_prefix_kv_cache(cache: Any) -> Any:
+    """Clone an immutable :class:`PrefixBlockKVCache` (independent per block).
+
+    Prefix caches have no cursor, so the clone is just a fresh tensor copy
+    (``from_tensor`` allocates a new buffer and copies the K/V into it).
+    """
+    return type(cache).from_tensor(cache._k, cache._v, seq_dim=cache.seq_dim)
+
+
 def _clone_network_cache(cache: CosmosDiTNetworkCache) -> CosmosDiTNetworkCache:
+    # Each self-attn cache is self-contained (its own cursor); the clone copies
+    # its geometry + cursor + buffers. Cross-attn (prefix) caches are
+    # independent tensor copies. The clones advance in lock-step with the live
+    # caches because they share geometry + chunk sequence.
     return CosmosDiTNetworkCache(
         block_caches=[
             type(block)(
-                self_attn=_clone_block_kv_cache(block.self_attn),
-                cross_attn=_clone_block_kv_cache(block.cross_attn),
+                self_attn=_clone_rolling_kv_cache(block.self_attn),
+                cross_attn=_clone_prefix_kv_cache(block.cross_attn),
             )
             for block in cache.block_caches
         ]
@@ -596,33 +619,6 @@ def _roll_fp8_cache_left_like_block_cache(
     dst_end = int(block_cache.sink_size + tokens_to_keep)
     tensor[_seq_slice(tensor.ndim, actual_seq_dim, dst_start, dst_end)].copy_(
         tensor[_seq_slice(tensor.ndim, actual_seq_dim, src_start, src_end)].clone()
-    )
-
-
-def compute_self_attn_write_start(self_attn_cache: Any) -> int:
-    """The cursor optimized_dit_forward writes K/V at. Three cases
-    (matching ``BlockKVCache.update``):
-
-      * steady-state: write at the rightmost slot, after the left-roll;
-      * filling, advancing chunk: append at ``_n_cached``;
-      * filling, same chunk: overwrite the just-written rightmost slot.
-        This last case fires when ``predict_flow`` runs multiple times
-        per AR step (once per scheduler step).
-
-    Must be called AFTER ``before_update(chunk_idx)`` so
-    ``_curr_chunk_idx`` is set and any steady-state roll has already
-    happened.
-    """
-    if self_attn_cache.is_steady_state():
-        total_size = self_attn_cache._k.shape[self_attn_cache.seq_dim]
-        return int(total_size - self_attn_cache.chunk_size)
-    if self_attn_cache._curr_chunk_idx == self_attn_cache._prev_chunk_idx + 1:
-        return int(self_attn_cache._n_cached)
-    if self_attn_cache._curr_chunk_idx == self_attn_cache._prev_chunk_idx:
-        return int(self_attn_cache._n_cached - self_attn_cache.chunk_size)
-    raise RuntimeError(
-        f"Unexpected cache state: _curr_chunk_idx={self_attn_cache._curr_chunk_idx} "
-        f"vs _prev_chunk_idx={self_attn_cache._prev_chunk_idx}"
     )
 
 
@@ -1650,19 +1646,18 @@ class OptimizedDiTExecutor:
         # which ``DiffusionModel.generate`` invokes around the scheduler
         # loop. ``predict_flow`` is called MULTIPLE times per AR step
         # (one per scheduler timestep) and the inner network just
-        # overwrites the rightmost slot each call (see the
-        # ``filling-same-chunk`` and ``steady-state`` branches in
-        # ``compute_self_attn_write_start``). An older revision of this
-        # shim wrapped the ``optimized_dit_forward`` call in
-        # ``before_update`` / ``after_update`` and tripped
-        # ``BlockKVCache.before_update``'s "Must call after_update()
-        # before before_update()" assert on the second scheduler
-        # timestep of every AR step. We just consume the post-
-        # ``before_update`` state directly here -- the C++ launcher
-        # writes K/V in place at ``write_start``, and the boundary
-        # ``finalize`` advances the state machine once.
-        net_cache = cache.network_cache
-        write_start = compute_self_attn_write_start(net_cache.block_caches[0].self_attn)
+        # overwrites the rightmost slot each call (the per-cache branchless
+        # ``write_start`` was precomputed once per AR step by ``before_update``
+        # in ``CosmosTransformerCache.start``, identical across blocks since
+        # they share geometry + chunk sequence). An older revision of this shim
+        # wrapped the ``optimized_dit_forward`` call in ``before_update`` /
+        # ``after_update`` and tripped ``RollingBlockKVCache.before_update``'s
+        # "Must call after_update() before before_update()" assert on the second
+        # scheduler timestep of every AR step. We just read the precomputed
+        # ``write_start`` from the first self-attn cache here -- the C++ launcher
+        # writes K/V in place at that offset, and the boundary ``finalize``
+        # advances the cursors once.
+        write_start = cache.network_cache.block_caches[0].self_attn.write_start
         kv_lists = self._ensure_kv_tensor_lists(cache=cache)
 
         # Upstream single-view CosmosTransformer flattens THW to [B, V, L, D].
@@ -1773,6 +1768,5 @@ class OptimizedDiTExecutor:
 
 __all__ = [
     "OptimizedDiTExecutor",
-    "compute_self_attn_write_start",
     "prepare_cosmos_streaming_weights",
 ]

--- a/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
@@ -612,6 +612,93 @@ def test_optimized_dit_shape_ops_preserves_configured_dtype() -> None:
 
 
 @pytest.mark.ci_cpu
+def test_optimized_dit_initialize_cache_clones_self_contained_caches() -> None:
+    """``_CosmosNetworkShapeOps.initialize_cache`` clones the captured template
+    into independent, self-contained self-attn caches whose geometry matches the
+    requested rollout sizes; cross-attn caches are independent prefix copies.
+
+    Regression: the optimized FP8 path must reproduce the template's cursor in
+    each clone (so ``start()`` / ``finalize()`` advance a cursor the forward
+    reads ``write_start`` from) without sharing buffers across rollouts, and
+    must reject a rollout geometry that disagrees with the template.
+    """
+    from omnidreams.transformer.impl.modules import BlockCache
+    from omnidreams.transformer.impl.network import CosmosDiTNetworkCache
+
+    from flashdreams.core.attention import (
+        PrefixBlockKVCache,
+        RollingBlockKVCache,
+    )
+
+    optimized_dit = native.load_python_module("optimized_dit")
+
+    chunk_size, window_size, sink_size = 2, 6, 0
+    total_size = sink_size + window_size
+    n_heads, head_dim = 2, 4
+
+    def _make_block_cache() -> Any:
+        self_attn = RollingBlockKVCache(
+            k_shape=(1, total_size, n_heads, head_dim),
+            v_shape=(1, total_size, n_heads, head_dim),
+            seq_dim=1,
+            chunk_size=chunk_size,
+            window_size=window_size,
+            sink_size=sink_size,
+            device=torch.device("cpu"),
+            dtype=torch.float16,
+        )
+        cross_attn = PrefixBlockKVCache.from_tensor(
+            torch.zeros(1, chunk_size, n_heads, head_dim, dtype=torch.float16),
+            torch.zeros(1, chunk_size, n_heads, head_dim, dtype=torch.float16),
+            seq_dim=1,
+        )
+        return BlockCache(self_attn=self_attn, cross_attn=cross_attn)
+
+    def _make_shape_ops() -> Any:
+        template = CosmosDiTNetworkCache(
+            block_caches=[_make_block_cache() for _ in range(2)]
+        )
+        return optimized_dit._CosmosNetworkShapeOps(
+            SimpleNamespace(patch_temporal=1, patch_spatial=2),
+            device=torch.device("cpu"),
+            dtype=torch.bfloat16,
+            cache_templates=(template,),
+        ), template
+
+    shape_ops, template = _make_shape_ops()
+    network_cache = shape_ops.initialize_cache(
+        context=torch.zeros(1, dtype=torch.float16),
+        chunk_size=chunk_size,
+        window_size=window_size,
+        sink_size=sink_size,
+    )
+
+    assert network_cache.block_caches, "expected at least one cloned block"
+    for tmpl_block, block in zip(template.block_caches, network_cache.block_caches):
+        sa = block.self_attn
+        # Self-contained clone: matching inlined geometry + an independent buffer.
+        assert (sa.chunk_size, sa.window_size, sa.sink_size, sa.seq_dim) == (
+            chunk_size,
+            window_size,
+            sink_size,
+            1,
+        )
+        assert sa._k.data_ptr() != tmpl_block.self_attn._k.data_ptr()
+        # Cross-attn caches are immutable prefix caches (independent copies).
+        assert isinstance(block.cross_attn, PrefixBlockKVCache)
+
+    # A rollout geometry that disagrees with the captured template is rejected.
+    mismatch_ops, _ = _make_shape_ops()
+    with pytest.raises(RuntimeError, match="geometry"):
+        mismatch_ops.initialize_cache(
+            context=torch.zeros(1, dtype=torch.float16),
+            chunk_size=chunk_size,
+            window_size=window_size + 2,
+            sink_size=sink_size,
+        )
+
+
+@pytest.mark.ci_cpu
 def test_cosmos_transformer_config_defaults_to_auto_native_attention() -> None:
     from omnidreams.transformer import CosmosTransformerConfig
 


### PR DESCRIPTION
```
root@a05-p01-dgx-03-c01:/workspace/flashdreams# TORCHINDUCTOR_CACHE_DIR="$(mktemp -d)" TRITON_CACHE_DIR="$(mktemp -d)" uv run flashdreams-run self-forcing-wan2.1-t2v-1.3b --total-blocks 7 &> log_self_forcing_2.txt
root@a05-p01-dgx-03-c03:/workspace/flashdreams# grep "flashdreams.infra.pipeline.base:finalize:334" log_self_forcing_2.txt 
2026-05-29 04:03:17.214 | INFO     | flashdreams.infra.pipeline.base:finalize:334 - AR 0 encode 0.052 ms diffuse 37174.969 ms decode 422.605 ms finalize 34.829 ms | total(w/o finalize) 37597.625 ms total 37632.454 ms | GPU mem alloc 10.328 GiB reserved 16.096 GiB peak 19.133 GiB
2026-05-29 04:03:17.971 | INFO     | flashdreams.infra.pipeline.base:finalize:334 - AR 1 encode 0.020 ms diffuse 581.096 ms decode 139.183 ms finalize 35.915 ms | total(w/o finalize) 720.299 ms total 756.214 ms | GPU mem alloc 10.334 GiB reserved 20.535 GiB peak 19.133 GiB
2026-05-29 04:03:18.330 | INFO     | flashdreams.infra.pipeline.base:finalize:334 - AR 2 encode 0.020 ms diffuse 188.438 ms decode 132.816 ms finalize 35.384 ms | total(w/o finalize) 321.275 ms total 356.659 ms | GPU mem alloc 10.335 GiB reserved 20.535 GiB peak 19.133 GiB
2026-05-29 04:03:18.738 | INFO     | flashdreams.infra.pipeline.base:finalize:334 - AR 3 encode 0.018 ms diffuse 186.884 ms decode 183.161 ms finalize 36.114 ms | total(w/o finalize) 370.062 ms total 406.177 ms | GPU mem alloc 10.361 GiB reserved 22.676 GiB peak 19.133 GiB
2026-05-29 04:03:19.093 | INFO     | flashdreams.infra.pipeline.base:finalize:334 - AR 4 encode 0.019 ms diffuse 186.296 ms decode 132.292 ms finalize 34.903 ms | total(w/o finalize) 318.607 ms total 353.510 ms | GPU mem alloc 10.362 GiB reserved 22.678 GiB peak 19.133 GiB
2026-05-29 04:03:19.447 | INFO     | flashdreams.infra.pipeline.base:finalize:334 - AR 5 encode 0.016 ms diffuse 184.996 ms decode 132.116 ms finalize 35.035 ms | total(w/o finalize) 317.128 ms total 352.163 ms | GPU mem alloc 10.361 GiB reserved 22.678 GiB peak 19.133 GiB
2026-05-29 04:03:19.795 | INFO     | flashdreams.infra.pipeline.base:finalize:334 - AR 6 encode 0.017 ms diffuse 179.466 ms decode 132.302 ms finalize 34.805 ms | total(w/o finalize) 311.785 ms total 346.589 ms | GPU mem alloc 10.362 GiB reserved 22.678 GiB peak 19.133 GiB
```


```
TORCHINDUCTOR_CACHE_DIR="$(mktemp -d)"  TRITON_CACHE_DIR="$(mktemp -d)"  uv run flashdreams-run omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf --example-data True --total-blocks 20
qiwu@a09-u06-p01-slurm-01:~/work/flashsim$ grep "flashdreams.infra.pipeline.base:finalize:332 - " log_flashdreams_perf_18.txt
2026-05-28 23:27:20.569 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 0 encode 138566.656 ms diffuse 44666.816 ms decode 45296.246 ms finalize 183.578 ms | total(w/o finalize) 228529.719 ms total 228713.296 ms | GPU mem alloc 34.030 GiB reserved 40.379 GiB peak 37.557 GiB
2026-05-28 23:27:21.003 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 1 encode 27.146 ms diffuse 359.506 ms decode 5.393 ms finalize 39.948 ms | total(w/o finalize) 392.044 ms total 431.992 ms | GPU mem alloc 34.030 GiB reserved 40.379 GiB peak 37.557 GiB
2026-05-28 23:27:21.206 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 2 encode 45.808 ms diffuse 106.920 ms decode 8.062 ms finalize 40.885 ms | total(w/o finalize) 160.790 ms total 201.676 ms | GPU mem alloc 34.031 GiB reserved 38.859 GiB peak 37.557 GiB
2026-05-28 23:27:21.410 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 3 encode 27.684 ms diffuse 80.600 ms decode 18.793 ms finalize 76.261 ms | total(w/o finalize) 127.077 ms total 203.339 ms | GPU mem alloc 34.080 GiB reserved 39.670 GiB peak 37.557 GiB
2026-05-28 23:27:21.564 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 4 encode 28.027 ms diffuse 79.765 ms decode 4.766 ms finalize 39.955 ms | total(w/o finalize) 112.559 ms total 152.514 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:21.718 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 5 encode 27.711 ms diffuse 80.064 ms decode 4.806 ms finalize 40.310 ms | total(w/o finalize) 112.581 ms total 152.891 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:21.871 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 6 encode 27.610 ms diffuse 78.709 ms decode 4.911 ms finalize 40.771 ms | total(w/o finalize) 111.230 ms total 152.001 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:22.025 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 7 encode 28.304 ms diffuse 79.908 ms decode 4.800 ms finalize 39.553 ms | total(w/o finalize) 113.013 ms total 152.566 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:22.179 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 8 encode 27.935 ms diffuse 79.680 ms decode 4.817 ms finalize 40.352 ms | total(w/o finalize) 112.431 ms total 152.783 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:22.399 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 9 encode 26.173 ms diffuse 80.733 ms decode 4.851 ms finalize 40.516 ms | total(w/o finalize) 111.757 ms total 152.273 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:22.555 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 10 encode 28.443 ms diffuse 80.121 ms decode 4.811 ms finalize 40.841 ms | total(w/o finalize) 113.374 ms total 154.215 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:22.711 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 11 encode 28.790 ms diffuse 79.261 ms decode 4.751 ms finalize 40.480 ms | total(w/o finalize) 112.802 ms total 153.283 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:22.867 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 12 encode 29.161 ms diffuse 78.315 ms decode 4.809 ms finalize 40.115 ms | total(w/o finalize) 112.284 ms total 152.399 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:23.023 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 13 encode 28.695 ms diffuse 79.272 ms decode 4.837 ms finalize 40.720 ms | total(w/o finalize) 112.805 ms total 153.525 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:23.176 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 14 encode 27.175 ms diffuse 78.964 ms decode 4.729 ms finalize 40.017 ms | total(w/o finalize) 110.868 ms total 150.885 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:23.334 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 15 encode 28.543 ms diffuse 80.989 ms decode 4.749 ms finalize 40.712 ms | total(w/o finalize) 114.282 ms total 154.993 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:23.489 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 16 encode 28.537 ms diffuse 79.736 ms decode 4.806 ms finalize 39.822 ms | total(w/o finalize) 113.079 ms total 152.901 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:23.644 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 17 encode 28.767 ms diffuse 78.914 ms decode 4.739 ms finalize 39.498 ms | total(w/o finalize) 112.420 ms total 151.918 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:23.798 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 18 encode 27.203 ms diffuse 80.136 ms decode 4.768 ms finalize 40.123 ms | total(w/o finalize) 112.107 ms total 152.230 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
2026-05-28 23:27:23.953 | INFO     | flashdreams.infra.pipeline.base:finalize:332 - AR 19 encode 28.559 ms diffuse 78.970 ms decode 4.749 ms finalize 39.975 ms | total(w/o finalize) 112.278 ms total 152.253 ms | GPU mem alloc 34.080 GiB reserved 39.674 GiB peak 37.557 GiB
```