### PR TITLE
Move from stdlib logging to loguru

### DIFF
--- a/flashdreams/flashdreams/serving/webrtc/server.py
+++ b/flashdreams/flashdreams/serving/webrtc/server.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Any, Protocol
 
 from aiohttp import web
-
-LOGGER = logging.getLogger(__name__)
+from loguru import logger
 
 
 class SessionBusyError(RuntimeError):
@@ -71,7 +69,7 @@ def create_webrtc_app(
         except SessionBusyError as exc:
             raise web.HTTPConflict(reason=str(exc)) from exc
         except Exception as exc:
-            LOGGER.exception("Failed to process WebRTC offer.")
+            logger.exception("Failed to process WebRTC offer.")
             raise web.HTTPInternalServerError(reason=str(exc)) from exc
 
         return web.json_response(answer_payload)
@@ -88,13 +86,13 @@ def create_webrtc_app(
 
     async def on_startup(app: web.Application) -> None:
         manager = app[SESSION_MANAGER_KEY]
-        LOGGER.info("Preloading %s runtime on startup.", preload_name)
+        logger.info("Preloading {} runtime on startup.", preload_name)
         await manager.preload_runtime()
-        LOGGER.info("%s runtime preload complete.", preload_name)
+        logger.info("{} runtime preload complete.", preload_name)
 
     async def on_shutdown(app: web.Application) -> None:
         manager = app[SESSION_MANAGER_KEY]
-        LOGGER.info("Shutting down %s runtime.", preload_name)
+        logger.info("Shutting down {} runtime.", preload_name)
         await manager.shutdown()
 
     app.router.add_get("/request_session", request_session_page)

--- a/integrations/flashvsr/flashvsr/grpc/streaming_view.py
+++ b/integrations/flashvsr/flashvsr/grpc/streaming_view.py
@@ -16,7 +16,6 @@
 """HTTP MJPEG viewer support for the FlashVSR gRPC server."""
 
 import io
-import logging
 import queue
 import threading
 import time
@@ -26,8 +25,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import numpy as np
 import torch
-
-log = logging.getLogger(__name__)
+from loguru import logger
 
 DEFAULT_VIEWER_CHUNK_QUEUE_DEPTH = 8
 DEFAULT_VIEWER_JPEG_QUALITY = 90
@@ -189,7 +187,7 @@ class StreamingViewer:
 
         class Handler(BaseHTTPRequestHandler):
             def log_message(self, format: str, *args) -> None:
-                log.debug("viewer: " + format, *args)
+                logger.debug("viewer: {}", format % args)
 
             def do_GET(self) -> None:
                 if self.path in ("", "/"):
@@ -361,7 +359,7 @@ class StreamingViewer:
         ]
         for thread in self._playback_threads:
             thread.start()
-        log.info("Viewer listening on %s", self.url)
+        logger.info("Viewer listening on {}", self.url)
 
     def _playback_loop(self, channel: str, hub: _MjpegFrameHub) -> None:
         playback_queue = self._playback_queues[channel]
@@ -442,8 +440,8 @@ class StreamingViewer:
             except queue.Full:
                 try:
                     playback_queue.get_nowait()
-                    log.warning(
-                        "Viewer %s playback queue full; dropped oldest completed chunk",
+                    logger.warning(
+                        "Viewer {} playback queue full; dropped oldest completed chunk",
                         channel,
                     )
                 except queue.Empty:

--- a/integrations/flashvsr/flashvsr/grpc/uplift_server.py
+++ b/integrations/flashvsr/flashvsr/grpc/uplift_server.py
@@ -33,7 +33,6 @@ Usage (from repo root):
 
 import argparse
 import importlib
-import logging
 import os
 import queue
 import signal
@@ -49,6 +48,7 @@ from typing import Literal
 import grpc
 import numpy as np
 import torch
+from loguru import logger
 
 from flashvsr.config import build_flashvsr_v1_1
 from flashvsr.grpc.protos import flashvsr_pb2 as pb2
@@ -64,13 +64,6 @@ from flashvsr.grpc.streaming_view import (
     encode_jpeg_cuda_tensor,
 )
 from flashvsr.pipeline import FlashVSRPipeline, FlashVSRPipelineCache
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(message)s",
-    datefmt="%H:%M:%S",
-)
-log = logging.getLogger(__name__)
 
 DEFAULT_PORT = 50051
 DEFAULT_MAX_MESSAGE_MB = 512
@@ -119,7 +112,7 @@ def _resolve_attention_mode(attention_mode: RequestedAttentionMode) -> Attention
     if _block_sparse_attn_available():
         return "sparse"
     if attention_mode == "auto":
-        log.warning(
+        logger.warning(
             "block_sparse_attn is unavailable; falling back to attention_mode=full"
         )
         return "full"
@@ -225,8 +218,8 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
         # Serialize GPU ops so multiple concurrent gRPC calls don't fight.
         self._gpu_lock = threading.Lock()
 
-        log.info(
-            "Warming up model at (%d×%d) scale=%d attention_mode=%s ...",
+        logger.info(
+            "Warming up model at ({}×{}) scale={} attention_mode={} ...",
             default_H,
             default_W,
             default_scale,
@@ -234,7 +227,7 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
         )
         self._get_upsampler(default_H, default_W, default_scale, default_sparse_ratio)
         self._warm_up_viewer_jpeg()
-        log.info("Model ready.")
+        logger.info("Model ready.")
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -253,15 +246,14 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                 frame_stride=1,
             )
             _synchronize_device(self._device)
-            log.info("Viewer CUDA JPEG encoder ready.")
+            logger.info("Viewer CUDA JPEG encoder ready.")
         except Exception:
             if self._viewer.jpeg_backend == "cuda":
                 raise
             if not self._warned_cuda_jpeg_fallback:
-                log.warning(
+                logger.opt(exception=True).warning(
                     "CUDA viewer JPEG encode unavailable; falling back to "
-                    "CPU/Pillow encoding",
-                    exc_info=True,
+                    "CPU/Pillow encoding"
                 )
                 self._warned_cuda_jpeg_fallback = True
 
@@ -272,9 +264,9 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
         key = (H, W, resolved_scale, float(sparse_ratio), self._attention_mode)
         with self._pool_lock:
             if key not in self._upsampler_pool:
-                log.info(
-                    "Loading upsampler for (%d×%d) scale=%d sparse_ratio=%.3g "
-                    "attention_mode=%s compile=%s cuda_graph=%s ...",
+                logger.info(
+                    "Loading upsampler for ({}×{}) scale={} sparse_ratio={:.3g} "
+                    "attention_mode={} compile={} cuda_graph={} ...",
                     H,
                     W,
                     resolved_scale,
@@ -400,10 +392,9 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                     if backend == "cuda":
                         raise
                     if not self._warned_cuda_jpeg_fallback:
-                        log.warning(
+                        logger.opt(exception=True).warning(
                             "CUDA viewer JPEG encode unavailable; falling back "
-                            "to CPU/Pillow encoding",
-                            exc_info=True,
+                            "to CPU/Pillow encoding"
                         )
                         self._warned_cuda_jpeg_fallback = True
             if viewer_jpegs is None:
@@ -437,9 +428,10 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                     viewer_frames,
                     elapsed_ms=viewer_elapsed_ms,
                 )
-        log.info(
-            "  chunk %d timing:  decode_in=%.0f ms  infer=%.0f ms  encode_out=%.0f ms  total=%.0f ms"
-            "  critical=%.0f ms  (out %d×%d)",
+        logger.info(
+            "  chunk {} timing:  decode_in={:.0f} ms  infer={:.0f} ms  "
+            "encode_out={:.0f} ms  total={:.0f} ms  critical={:.0f} ms  "
+            "(out {}×{})",
             chunk_index,
             decode_ms,
             infer_ms,
@@ -521,8 +513,8 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                     key=(H, W, scale, sparse_ratio, self._attention_mode),
                     cache=cache,
                 )
-            log.info(
-                "start_session %s (%d×%d scale=%d sparse_ratio=%.3g attention_mode=%s)",
+            logger.info(
+                "start_session {} ({}×{} scale={} sparse_ratio={:.3g} attention_mode={})",
                 session_id,
                 H,
                 W,
@@ -532,14 +524,14 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
             )
             return pb2.StartSessionResponse(session_id=session_id, success=True)
         except Exception as exc:
-            log.exception("start_session failed")
+            logger.exception("start_session failed")
             return pb2.StartSessionResponse(success=False, error=str(exc))
 
     def end_session(self, request, context):
         with self._sessions_lock:
             removed = self._sessions.pop(request.session_id, None)
         if removed:
-            log.info("end_session %s", request.session_id)
+            logger.info("end_session {}", request.session_id)
             # FlashVSRPipelineCache holds GPU buffers via its sub-caches;
             # dropping the reference is enough — the next initialize_cache
             # call rebuilds them. No explicit free() needed.
@@ -566,8 +558,8 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                 request.chunk_index,
                 return_frames=not omit_frames,
             )
-            log.info(
-                "upscale_chunk %s chunk=%d T=%d → %.0f ms",
+            logger.info(
+                "upscale_chunk {} chunk={} T={} -> {:.0f} ms",
                 request.session_id,
                 request.chunk_index,
                 request.num_frames,
@@ -584,7 +576,7 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                 frames_omitted=omit_frames,
             )
         except Exception as exc:
-            log.exception("upscale_chunk failed")
+            logger.exception("upscale_chunk failed")
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(str(exc))
             return pb2.UpscaleChunkResponse(error=str(exc))
@@ -656,15 +648,15 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                         counts["rx"] += 1
             except grpc.RpcError as exc:
                 if abort.is_set() or not context.is_active():
-                    log.info("upscale_video: client stream closed")
+                    logger.info("upscale_video: client stream closed")
                 else:
-                    log.warning(
-                        "upscale_video: receive loop ended with gRPC error: %s",
+                    logger.warning(
+                        "upscale_video: receive loop ended with gRPC error: {}",
                         exc,
                     )
                     reader_err = _UpscaleVideoReaderError(exc)
             except BaseException as exc:
-                log.exception("upscale_video: receive loop failed")
+                logger.exception("upscale_video: receive loop failed")
                 reader_err = _UpscaleVideoReaderError(exc)
             finally:
                 if reader_err is not None:
@@ -695,9 +687,9 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                 upsampler_local = self._get_upsampler(H, W, scale, sparse_ratio)
                 cache_local = upsampler_local.initialize_cache()
                 cache_holder[0] = cache_local
-                log.info(
-                    "upscale_video stream %s (%d×%d scale=%d) pipelined "
-                    "inbound_depth=%d outbound_depth=%d combine_8_frame_chunks=%s",
+                logger.info(
+                    "upscale_video stream {} ({}×{} scale={}) pipelined "
+                    "inbound_depth={} outbound_depth={} combine_8_frame_chunks={}",
                     sid,
                     H,
                     W,
@@ -763,7 +755,7 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                 try:
                     ensure_stream(reqs[0])
                 except Exception as exc:
-                    log.exception("upscale_video: model init failed")
+                    logger.exception("upscale_video: model init failed")
                     put_outbound(pb2.UpscaleChunkResponse(error=str(exc)))
                     put_outbound(_OUTBOUND_END)
                     return False
@@ -776,9 +768,9 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                         cum_rx = counts["rx"]
                         cum_gpu = counts["gpu_done"]
                         cum_sent = counts["sent"]
-                    log.info(
-                        "  model chunk %d pipeline: buf_inbound=%d buf_outbound=%d "
-                        "cum_rx_chunks=%d cum_model_done=%d cum_sent=%d",
+                    logger.info(
+                        "  model chunk {} pipeline: buf_inbound={} buf_outbound={} "
+                        "cum_rx_chunks={} cum_model_done={} cum_sent={}",
                         ci,
                         inbound.qsize(),
                         outbound.qsize(),
@@ -818,11 +810,11 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                         cum_rx = counts["rx"]
                         cum_gpu = counts["gpu_done"]
                         cum_sent = counts["sent"]
-                    log.info(
-                        "upscale_video %s model_chunk=%d source_chunks=%s "
-                        "source_frames=%s model_T=%d infer=%.0f ms wall=%.0f ms "
-                        "(grpc_overhead=%.0f ms) buf_inbound=%d buf_outbound=%d "
-                        "cum_rx_chunks=%d cum_model_done=%d cum_sent=%d",
+                    logger.info(
+                        "upscale_video {} model_chunk={} source_chunks={} "
+                        "source_frames={} model_T={} infer={:.0f} ms wall={:.0f} ms "
+                        "(grpc_overhead={:.0f} ms) buf_inbound={} buf_outbound={} "
+                        "cum_rx_chunks={} cum_model_done={} cum_sent={}",
                         sid,
                         model_chunk_index,
                         source_indexes,
@@ -840,8 +832,8 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                     model_chunk_index += 1
                     return True
                 except Exception as exc:
-                    log.exception(
-                        "upscale_video: model chunk %d failed for source chunks %s",
+                    logger.exception(
+                        "upscale_video: model chunk {} failed for source chunks {}",
                         model_chunk_index,
                         source_indexes,
                     )
@@ -930,11 +922,11 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                         cum_rx = counts["rx"]
                         cum_gpu = counts["gpu_done"]
                         cum_sent = counts["sent"]
-                    log.info(
-                        "  coalesced model chunk %d pipeline: "
-                        "buf_frames=%d buf_requests=%d buf_inbound=%d "
-                        "buf_outbound=%d cum_rx_chunks=%d cum_model_done=%d "
-                        "cum_sent=%d",
+                    logger.info(
+                        "  coalesced model chunk {} pipeline: "
+                        "buf_frames={} buf_requests={} buf_inbound={} "
+                        "buf_outbound={} cum_rx_chunks={} cum_model_done={} "
+                        "cum_sent={}",
                         ci,
                         len(frame_buffer),
                         len(request_buffer),
@@ -982,13 +974,13 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                         cum_rx = counts["rx"]
                         cum_gpu = counts["gpu_done"]
                         cum_sent = counts["sent"]
-                    log.info(
-                        "upscale_video %s coalesced_model_chunk=%d "
-                        "source_chunks=%s source_request_frames=%s model_T=%d "
-                        "infer=%.0f ms wall=%.0f ms (grpc_overhead=%.0f ms) "
-                        "buf_frames=%d buf_requests=%d buf_inbound=%d "
-                        "buf_outbound=%d cum_rx_chunks=%d cum_model_done=%d "
-                        "cum_sent=%d",
+                    logger.info(
+                        "upscale_video {} coalesced_model_chunk={} "
+                        "source_chunks={} source_request_frames={} model_T={} "
+                        "infer={:.0f} ms wall={:.0f} ms (grpc_overhead={:.0f} ms) "
+                        "buf_frames={} buf_requests={} buf_inbound={} "
+                        "buf_outbound={} cum_rx_chunks={} cum_model_done={} "
+                        "cum_sent={}",
                         sid,
                         model_chunk_index,
                         source_indexes,
@@ -1008,9 +1000,9 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                     model_chunk_index += 1
                     return True
                 except Exception as exc:
-                    log.exception(
-                        "upscale_video: coalesced model chunk %d failed for "
-                        "source chunks %s",
+                    logger.exception(
+                        "upscale_video: coalesced model chunk {} failed for "
+                        "source chunks {}",
                         model_chunk_index,
                         source_indexes,
                     )
@@ -1031,8 +1023,8 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                 if final:
                     if frame_buffer:
                         dropped = len(frame_buffer)
-                        log.warning(
-                            "upscale_video stream %s: dropping %d trailing "
+                        logger.warning(
+                            "upscale_video stream {}: dropping {} trailing "
                             "frame(s) that do not form a supported FlashVSR "
                             "final chunk",
                             sid,
@@ -1052,7 +1044,7 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                     frames = item.frames
                     coalesced_decode_ms += item.decode_ms
                 except Exception as exc:
-                    log.exception("upscale_video: coalesced request prepare failed")
+                    logger.exception("upscale_video: coalesced request prepare failed")
                     put_outbound(pb2.UpscaleChunkResponse(error=str(exc)))
                     put_outbound(_OUTBOUND_END)
                     return False
@@ -1104,7 +1096,7 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
                     if not process_requests([item]):
                         return
             except Exception:
-                log.exception("upscale_video: GPU worker crashed")
+                logger.exception("upscale_video: GPU worker crashed")
                 try:
                     put_outbound(
                         pb2.UpscaleChunkResponse(error="internal GPU worker error")
@@ -1136,7 +1128,7 @@ class FlashVSR(pb2_grpc.FlashVSRServicer):
             gx.join(timeout=120.0)
             rx.join(timeout=5.0)
             cache_holder[0] = None
-            log.info("upscale_video stream %s: cache released", session_id_box[0])
+            logger.info("upscale_video stream {}: cache released", session_id_box[0])
 
 
 def _add_flash_vsr_servicer_to_server(servicer: FlashVSR, server: grpc.Server) -> None:
@@ -1317,7 +1309,7 @@ def main():
 
     compile_network = bool(args.compile or args.cuda_graph)
     if args.cuda_graph and not args.compile:
-        log.info("--cuda_graph implies --compile; enabling compile too.")
+        logger.info("--cuda_graph implies --compile; enabling compile too.")
 
     dtype_map = {
         "bfloat16": torch.bfloat16,
@@ -1381,8 +1373,8 @@ def main():
 
     _add_flash_vsr_servicer_to_server(servicer, server)
     server.start()
-    log.info(
-        "Server listening on [::]:%d (max msg %d MB)",
+    logger.info(
+        "Server listening on [::]:{} (max msg {} MB)",
         bound_port,
         args.max_message_mb,
     )
@@ -1391,9 +1383,9 @@ def main():
 
     def _on_signal(signum: int, _frame: object) -> None:
         if stop_requested.is_set():
-            log.warning("Second signal %d received; forcing exit.", signum)
+            logger.warning("Second signal {} received; forcing exit.", signum)
             os._exit(130)
-        log.info("Signal %d received; requesting shutdown.", signum)
+        logger.info("Signal {} received; requesting shutdown.", signum)
         stop_requested.set()
 
     signal.signal(signal.SIGINT, _on_signal)
@@ -1403,15 +1395,17 @@ def main():
         while not stop_requested.wait(timeout=0.5):
             pass
     finally:
-        log.info("Shutting down ...")
+        logger.info("Shutting down ...")
         stopped = server.stop(grace=5)
         if not stopped.wait(timeout=10):
-            log.warning("gRPC server.stop did not complete within 10s; exiting anyway.")
+            logger.warning(
+                "gRPC server.stop did not complete within 10s; exiting anyway."
+            )
         if viewer is not None:
             try:
                 viewer.stop()
             except Exception:
-                log.exception("viewer.stop() raised; continuing shutdown")
+                logger.exception("viewer.stop() raised; continuing shutdown")
         sys.exit(0)
 
 

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
@@ -15,11 +15,12 @@
 
 """JIT compilation of the C++/CUDA plugin for Ludus renderer."""
 
-import logging
 import os
+import time
 
 import torch
 import torch.utils.cpp_extension
+from loguru import logger
 
 _cached_plugin = None
 
@@ -103,16 +104,23 @@ def _get_plugin():
 
     # Check for stale lock files
     plugin_name = "ludus_renderer_plugin"
+    build_directory = None
     try:
-        lock_fn = os.path.join(
-            torch.utils.cpp_extension._get_build_directory(plugin_name, False), "lock"
+        build_directory = torch.utils.cpp_extension._get_build_directory(plugin_name, False)
+        lock_fn = os.path.join(build_directory, "lock")
+        logger.info(
+            "Loading Ludus renderer extension {}; build_directory={}.",
+            plugin_name,
+            build_directory,
         )
         if os.path.exists(lock_fn):
-            logging.getLogger("ludus_renderer").warning(
-                "Lock file exists in build directory: '%s'" % lock_fn
+            logger.warning(
+                "Ludus renderer extension lock file exists: {}. "
+                "If no compiler process is active, this may be a stale PyTorch JIT lock.",
+                lock_fn,
             )
-    except:
-        pass
+    except Exception as exc:
+        logger.debug("Could not inspect Ludus renderer extension build directory: {}", exc)
 
     # Speed up compilation on Windows
     if os.name == "nt":
@@ -129,6 +137,7 @@ def _get_plugin():
             pass
 
     # Compile and cache
+    compile_started_at = time.perf_counter()
     source_paths = [os.path.join(os.path.dirname(__file__), fn) for fn in source_files]
     extra_include_paths = [
         os.path.join(os.path.dirname(__file__), "../_cpp/cudaraster/framework"),
@@ -142,6 +151,12 @@ def _get_plugin():
         extra_ldflags=ldflags,
         with_cuda=True,
         verbose=True,
+    )
+    logger.info(
+        "Loaded Ludus renderer extension {} in {:.1f}s{}.",
+        plugin_name,
+        time.perf_counter() - compile_started_at,
+        f"; build_directory={build_directory}" if build_directory else "",
     )
 
     return _cached_plugin

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/clipgt.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/clipgt.py
@@ -47,6 +47,7 @@ import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 import torch
+from loguru import logger
 from scipy.spatial.transform import Rotation as R
 from torch import Tensor
 
@@ -1429,12 +1430,43 @@ def _get_camera_cpp_ext():
     global _camera_cpp_ext
     if _camera_cpp_ext is not None:
         return _camera_cpp_ext
-    from torch.utils.cpp_extension import load
+
+    import torch.utils.cpp_extension
+
+    extension_name = "camera_convert_cpp"
+    build_directory = None
+    try:
+        build_directory = torch.utils.cpp_extension._get_build_directory(
+            extension_name,
+            False,
+        )
+        lock_fn = os.path.join(build_directory, "lock")
+        logger.info(
+            "Loading camera converter extension {}; build_directory={}.",
+            extension_name,
+            build_directory,
+        )
+        if os.path.exists(lock_fn):
+            logger.warning(
+                "Camera converter extension lock file exists: {}. "
+                "If no compiler process is active, this may be a stale PyTorch JIT lock.",
+                lock_fn,
+            )
+    except Exception as exc:
+        logger.debug("Could not inspect camera converter extension build directory: {}", exc)
+
     csrc = os.path.join(os.path.dirname(__file__), "_cpp", "loader")
-    _camera_cpp_ext = load(
-        name="camera_convert_cpp",
+    load_started_at = time.perf_counter()
+    _camera_cpp_ext = torch.utils.cpp_extension.load(
+        name=extension_name,
         sources=[os.path.join(csrc, "camera_convert.cpp")],
         verbose=False,
+    )
+    logger.info(
+        "Loaded camera converter extension {} in {:.1f}s{}.",
+        extension_name,
+        time.perf_counter() - load_started_at,
+        f"; build_directory={build_directory}" if build_directory else "",
     )
     return _camera_cpp_ext
 
@@ -1583,7 +1615,14 @@ def _cameras_to_ftheta(
         - camera_name -> id mapping
         - camera_name -> sensor_to_rig mapping
     """
+    started_at = time.perf_counter()
     n = len(cameras)
+    logger.debug(
+        "Converting {} ClipGT cameras to FTheta on {}; target_resolution={}.",
+        n,
+        device,
+        target_resolution,
+    )
 
     max_poly_len = max(len(cam.poly) for cam in cameras)
     poly_coeffs = np.zeros((n, max_poly_len), dtype=np.float64)
@@ -1641,6 +1680,8 @@ def _cameras_to_ftheta(
         cam_names.append(cam.name)
 
     ext = _get_camera_cpp_ext()
+    compute_started_at = time.perf_counter()
+    logger.debug("Computing ClipGT camera parameters with camera converter extension.")
     fw_t_cpu, mra_t_cpu = ext.compute_camera_params(
         torch.from_numpy(poly_coeffs),
         torch.from_numpy(poly_lengths),
@@ -1651,13 +1692,23 @@ def _cameras_to_ftheta(
         torch.from_numpy(w_sc), torch.from_numpy(h_sc),
         torch.from_numpy(pscale),
     )
+    logger.debug(
+        "Computed ClipGT camera parameters in {:.1f}s.",
+        time.perf_counter() - compute_started_at,
+    )
 
+    transfer_started_at = time.perf_counter()
     pp_t = torch.from_numpy(pp_np).to(device)
     sz_t = torch.from_numpy(sz_np).to(device)
     fw_t = fw_t_cpu.to(device)
     ld_t = torch.from_numpy(ld_np).to(device)
     s2r_t = torch.from_numpy(s2r_np).to(device)
     mra_np = mra_t_cpu.numpy()
+    logger.debug(
+        "Moved ClipGT camera tensors to {} in {:.1f}s.",
+        device,
+        time.perf_counter() - transfer_started_at,
+    )
 
     camera_list = []
     sensor_to_rig_map = {}
@@ -1673,6 +1724,12 @@ def _cameras_to_ftheta(
         camera_list.append(ftheta)
         sensor_to_rig_map[cam_names[i]] = s2r_t[i]
 
+    logger.debug(
+        "Converted {} ClipGT cameras to FTheta in {:.1f}s: {}.",
+        len(camera_list),
+        time.perf_counter() - started_at,
+        cam_names,
+    )
     return camera_list, camera_name_to_id, sensor_to_rig_map
 
 
@@ -1820,10 +1877,22 @@ def load_clipgt_scene(
     Returns:
         ClipgtGpuScene ready for GPU rendering
     """
+    started_at = time.perf_counter()
     if isinstance(device, str):
         device = torch.device(device)
 
     scene_dir = Path(scene_dir)
+    logger.debug(
+        "Loading ClipGT scene from {} on {}; target_resolution={}, "
+        "include_ego_trajectory={}, include_ego_obstacle={}, "
+        "simplify_dual_lane_lines={}.",
+        scene_dir,
+        device,
+        target_resolution,
+        include_ego_trajectory,
+        include_ego_obstacle,
+        simplify_dual_lane_lines,
+    )
     
     # Use default exclusions if not specified
     if exclude_elements is None:
@@ -1839,31 +1908,104 @@ def load_clipgt_scene(
             return matches[0]
         return simple_path
 
+    def read_input(label: str, path: Path, read_fn):
+        input_started_at = time.perf_counter()
+        logger.debug("Reading ClipGT {} parquet: {}.", label, path)
+        value = read_fn(path)
+        try:
+            item_count = len(value)
+        except TypeError:
+            item_count = "unknown"
+        logger.debug(
+            "Read ClipGT {} parquet in {:.1f}s; items={}.",
+            label,
+            time.perf_counter() - input_started_at,
+            item_count,
+        )
+        return value
+
     # Read all parquet files
     if verbose:
         print(f"Loading clipgt scene from: {scene_dir}")
         if exclude_elements:
             print(f"  Excluding: {exclude_elements}")
-    
-    road_boundary = read_road_boundary(get_parquet_path("road_boundary"))
-    lane_boundary = read_lane(get_parquet_path("lane")) if 'lane_boundary' not in exclude_elements else []
-    lane_line_data = read_lane_line(
-        get_parquet_path("lane_line"),
-        simplify_dual_lines=simplify_dual_lane_lines,
+    if exclude_elements:
+        logger.debug("Excluding ClipGT scene elements: {}.", sorted(exclude_elements))
+
+    inputs_started_at = time.perf_counter()
+    road_boundary = read_input(
+        "road_boundary",
+        get_parquet_path("road_boundary"),
+        read_road_boundary,
     )
-    crosswalk = read_crosswalk(get_parquet_path("crosswalk"))
-    road_marking = read_road_marking(get_parquet_path("road_marking"))
-    wait_line = read_wait_line(get_parquet_path("wait_line"))
-    pole = read_pole(get_parquet_path("pole"))
-    intersection_area = read_intersection_area(get_parquet_path("intersection_area")) if 'intersection_area' not in exclude_elements else []
-    road_island = read_road_island(get_parquet_path("road_island")) if 'road_island' not in exclude_elements else []
-    traffic_light = read_traffic_light(get_parquet_path("traffic_light"))
-    traffic_sign = read_traffic_sign(get_parquet_path("traffic_sign"))
-    obstacles = read_obstacles(get_parquet_path("obstacle"))
-    ego_track = read_egomotion_estimate(get_parquet_path("egomotion_estimate"))
-    cameras = read_calibration_estimate(get_parquet_path("calibration_estimate"))
+    if 'lane_boundary' not in exclude_elements:
+        lane_boundary = read_input("lane", get_parquet_path("lane"), read_lane)
+    else:
+        logger.debug("Skipping ClipGT lane_boundary due to exclusion.")
+        lane_boundary = []
+    lane_line_data = read_input(
+        "lane_line",
+        get_parquet_path("lane_line"),
+        lambda path: read_lane_line(
+            path,
+            simplify_dual_lines=simplify_dual_lane_lines,
+        ),
+    )
+    crosswalk = read_input("crosswalk", get_parquet_path("crosswalk"), read_crosswalk)
+    road_marking = read_input(
+        "road_marking",
+        get_parquet_path("road_marking"),
+        read_road_marking,
+    )
+    wait_line = read_input("wait_line", get_parquet_path("wait_line"), read_wait_line)
+    pole = read_input("pole", get_parquet_path("pole"), read_pole)
+    if 'intersection_area' not in exclude_elements:
+        intersection_area = read_input(
+            "intersection_area",
+            get_parquet_path("intersection_area"),
+            read_intersection_area,
+        )
+    else:
+        logger.debug("Skipping ClipGT intersection_area due to exclusion.")
+        intersection_area = []
+    if 'road_island' not in exclude_elements:
+        road_island = read_input(
+            "road_island",
+            get_parquet_path("road_island"),
+            read_road_island,
+        )
+    else:
+        logger.debug("Skipping ClipGT road_island due to exclusion.")
+        road_island = []
+    traffic_light = read_input(
+        "traffic_light",
+        get_parquet_path("traffic_light"),
+        read_traffic_light,
+    )
+    traffic_sign = read_input(
+        "traffic_sign",
+        get_parquet_path("traffic_sign"),
+        read_traffic_sign,
+    )
+    obstacles = read_input("obstacle", get_parquet_path("obstacle"), read_obstacles)
+    ego_track = read_input(
+        "egomotion_estimate",
+        get_parquet_path("egomotion_estimate"),
+        read_egomotion_estimate,
+    )
+    cameras = read_input(
+        "calibration_estimate",
+        get_parquet_path("calibration_estimate"),
+        read_calibration_estimate,
+    )
+    logger.debug(
+        "Read all ClipGT parquet inputs in {:.1f}s.",
+        time.perf_counter() - inputs_started_at,
+    )
 
     # Convert to GPU pools
+    pools_started_at = time.perf_counter()
+    logger.debug("Converting ClipGT scene primitives to GPU pools on {}.", device)
     polyline_pools = []
 
     # Road boundary
@@ -1961,14 +2103,34 @@ def load_clipgt_scene(
         cube_pools.append(pool)
 
     # Convert cameras
+    logger.debug(
+        "Converted ClipGT scene primitives to GPU pools in {:.1f}s; "
+        "polyline_pools={}, polygon_pools={}, cube_pools={}.",
+        time.perf_counter() - pools_started_at,
+        len(polyline_pools),
+        len(polygon_pools),
+        len(cube_pools),
+    )
+    cameras_started_at = time.perf_counter()
     camera_list, camera_name_to_id, sensor_to_rig = _cameras_to_ftheta(
         cameras, device, target_resolution
     )
+    logger.debug(
+        "Converted ClipGT cameras in {:.1f}s.",
+        time.perf_counter() - cameras_started_at,
+    )
 
     # Move ego track to device
+    ego_started_at = time.perf_counter()
     ego_track = EgoTrackData(
         timestamps=ego_track.timestamps.to(device),
         poses_tquat=ego_track.poses_tquat.to(device),
+    )
+    logger.debug(
+        "Moved ClipGT ego track to {} in {:.1f}s; frames={}.",
+        device,
+        time.perf_counter() - ego_started_at,
+        len(ego_track.timestamps),
     )
 
     # Build scene
@@ -1983,6 +2145,16 @@ def load_clipgt_scene(
         print(f"  Cameras: {list(camera_name_to_id.keys())}")
         print(f"  Ego timestamps: {len(ego_track.timestamps)} frames")
 
+    logger.info(
+        "Built ClipGT GPU scene in {:.1f}s; polyline_pools={}, "
+        "polygon_pools={}, cube_pools={}, cameras={}, ego_frames={}.",
+        time.perf_counter() - started_at,
+        len(polyline_pools),
+        len(polygon_pools),
+        len(cube_pools),
+        len(camera_list),
+        len(ego_track.timestamps),
+    )
     return ClipgtGpuScene(
         timestamped_scene=timestamped_scene,
         cameras=camera_list,
@@ -3219,5 +3391,3 @@ def _read_av2_calibration(loader) -> List[CameraData]:
     """Read calibration from AV2 format via file loader."""
     fh = loader.open("calibration_estimate.parquet")
     return _read_av2_calibration_from_fh(fh)
-
-

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/scene_cache.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/scene_cache.py
@@ -50,7 +50,6 @@ from __future__ import annotations
 
 import hashlib
 import io
-import logging
 import os
 import threading
 import time
@@ -64,8 +63,6 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-
-_log = logging.getLogger(__name__)
 
 try:
     import lmdb as _lmdb  # ty:ignore[unresolved-import]

--- a/integrations/omnidreams/omnidreams/conditioning/renderer.py
+++ b/integrations/omnidreams/omnidreams/conditioning/renderer.py
@@ -21,11 +21,13 @@ library to render HD map scenes for conditioning video generation.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Literal
 
 import ludus_renderer
 import torch
+from loguru import logger
 from ludus_renderer import (
     load_clipgt_scene,
     mirror_augment_scene,
@@ -251,6 +253,8 @@ def load_and_attach_ludus_scene(
     lookahead_m: float = 50.0,
 ) -> SceneData:
     """Load HDMap scene from path and attach it to scene data."""
+    started_at = time.perf_counter()
+    logger.info("Loading Ludus scene from {} on {}.", scene_data_path, device)
     ludus_scene = load_clipgt_scene(
         scene_data_path,
         device=torch.device(device),
@@ -258,11 +262,27 @@ def load_and_attach_ludus_scene(
         include_ego_obstacle=include_ego_obstacle,
         simplify_dual_lane_lines=simplify_dual_lane_lines,
     )
+    logger.info(
+        "Loaded Ludus ClipGT scene in {:.1f}s; mirror_augment={}.",
+        time.perf_counter() - started_at,
+        perform_mirror_augment,
+    )
     if perform_mirror_augment:
+        augment_started_at = time.perf_counter()
         augmented_scene = mirror_augment_scene(
             ludus_scene, n_mirrors=n_mirrors, lookahead_m=lookahead_m
         )
+        logger.info(
+            "Mirror-augmented Ludus scene in {:.1f}s.",
+            time.perf_counter() - augment_started_at,
+        )
     else:
         augmented_scene = ludus_scene
+    adapter_started_at = time.perf_counter()
     scene_data.metadata["ludus_scene"] = SceneAdapter(augmented_scene)
+    logger.info(
+        "Attached Ludus scene adapter in {:.1f}s; total attach time {:.1f}s.",
+        time.perf_counter() - adapter_started_at,
+        time.perf_counter() - started_at,
+    )
     return scene_data

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -60,7 +60,7 @@ def parse_args() -> argparse.Namespace:
         / "assets"
         / "example_data"
         / "omnidreams-webrtc"
-        / "0d404ff7-2b66-498c-b047-1ed8cded60d4",
+        / "0b10bce8-61f1-4350-8577-cf3c9493ffc3",
     )
     parser.add_argument("--device", type=str, default="cuda:0")
     parser.add_argument("--seed", type=int, default=42)

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -8,6 +8,7 @@ import contextlib
 import json
 import os
 import tempfile
+import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -313,11 +314,22 @@ class OmnidreamsInferenceRuntime:
         if self._wrapper is not None:
             return
 
+        init_t0 = time.perf_counter()
         cfg = self.config
         scene_dir = cfg.scene_dir
         clipgt_dir = scene_dir / cfg.clipgt_dirname
         first_frame_path = scene_dir / cfg.first_frame_filename
         prompt_path = scene_dir / cfg.prompt_filename
+        logger.info(
+            "Initializing Omnidreams runtime: config={} scene_dir={} device={} "
+            "camera={} resolution={}x{}",
+            cfg.pipeline_config_name,
+            scene_dir,
+            cfg.device,
+            cfg.camera_name,
+            cfg.video_width,
+            cfg.video_height,
+        )
         missing_paths = [
             str(path)
             for path in (clipgt_dir, first_frame_path, prompt_path)
@@ -350,6 +362,7 @@ class OmnidreamsInferenceRuntime:
         if self._device.type == "cuda" and not torch.cuda.is_available():
             raise RuntimeError("CUDA is required for Omnidreams WebRTC runtime.")
 
+        logger.info("Loading Omnidreams first frame from {}", first_frame_path)
         image_bgr = cv2.imread(str(first_frame_path), cv2.IMREAD_COLOR)
         if image_bgr is None:
             raise RuntimeError(f"Failed to read first frame from {first_frame_path}")
@@ -372,6 +385,8 @@ class OmnidreamsInferenceRuntime:
         self._text_prompts = [TextPrompt(positive=prompt)]
 
         loadable_clipgt_dir = self._prepare_clipgt_dir(clipgt_dir)
+        logger.info("Loading Omnidreams scene data from {}", loadable_clipgt_dir)
+        scene_t0 = time.perf_counter()
         scene_data = load_scene(
             loadable_clipgt_dir,
             camera_names=[cfg.camera_name],
@@ -379,10 +394,19 @@ class OmnidreamsInferenceRuntime:
             input_pose_fps=SETTINGS["INPUT_POSE_FPS"],
             resize_resolution_hw=(cfg.video_height, cfg.video_width),
         )
+        logger.info(
+            "Loaded Omnidreams scene data in {:.1f}s; attaching Ludus scene.",
+            time.perf_counter() - scene_t0,
+        )
+        ludus_t0 = time.perf_counter()
         scene_data = load_and_attach_ludus_scene(
             loadable_clipgt_dir,
             scene_data,
             device=self._device,
+        )
+        logger.info(
+            "Attached Omnidreams Ludus scene in {:.1f}s.",
+            time.perf_counter() - ludus_t0,
         )
         if not scene_data.ego_poses:
             raise ValueError(f"Scene {loadable_clipgt_dir} has no ego poses.")
@@ -395,14 +419,31 @@ class OmnidreamsInferenceRuntime:
                 f"Camera {cfg.camera_name!r} has no extrinsics in {loadable_clipgt_dir}."
             )
 
+        logger.info(
+            "Setting up Omnidreams pipeline {} on {}. This may load checkpoints, "
+            "compile modules, and initialize CUDA graphs.",
+            cfg.pipeline_config_name,
+            self._device,
+        )
+        pipeline_t0 = time.perf_counter()
         self._wrapper = OmnidreamsConditioningWrapper(
             pipeline_config_name=cfg.pipeline_config_name,
             resolution_wh=(cfg.video_width, cfg.video_height),
             seed_for_every_rollout=cfg.seed,
             device=self._device,
         )
+        logger.info(
+            "Omnidreams pipeline setup complete in {:.1f}s.",
+            time.perf_counter() - pipeline_t0,
+        )
         self._scene_data = scene_data
+        logger.info("Creating Omnidreams renderer for camera {}", cfg.camera_name)
+        renderer_t0 = time.perf_counter()
         self._renderer = self._wrapper.create_renderer(scene_data, [cfg.camera_name])
+        logger.info(
+            "Omnidreams renderer ready in {:.1f}s.",
+            time.perf_counter() - renderer_t0,
+        )
         self._camera_to_rig = torch.as_tensor(
             scene_data.camera_extrinsics[cfg.camera_name],
             device=self._device,
@@ -411,6 +452,10 @@ class OmnidreamsInferenceRuntime:
         self._initial_ego_pose = scene_data.ego_poses[0].transformation_matrix
         self._next_timestamp_us = int(scene_data.ego_poses[0].timestamp)
         self._reset_rollout_sync()
+        logger.info(
+            "Omnidreams runtime initialization complete in {:.1f}s.",
+            time.perf_counter() - init_t0,
+        )
 
     def _prepare_clipgt_dir(self, clipgt_dir: Path) -> Path:
         if list(clipgt_dir.glob("*.calibration_estimate.parquet")):
@@ -632,13 +677,29 @@ class OmnidreamsWebRTCSessionManager:
     async def preload_runtime(self) -> None:
         async with self._preload_lock:
             if not self._runtime_ready:
+                logger.info("Omnidreams runtime preload: initializing model runtime.")
+                preload_t0 = time.perf_counter()
                 await self._runtime.initialize()
                 self._runtime_ready = True
+                logger.info(
+                    "Omnidreams runtime preload: model runtime ready in {:.1f}s.",
+                    time.perf_counter() - preload_t0,
+                )
             if not self._warmup_complete:
+                logger.info(
+                    "Omnidreams runtime preload: starting loopback warmup with {} "
+                    "chunk(s).",
+                    self.runtime_config.warmup_chunks,
+                )
+                warmup_t0 = time.perf_counter()
                 await self._run_loopback_warmup_session(
                     num_chunks=self.runtime_config.warmup_chunks
                 )
                 self._warmup_complete = True
+                logger.info(
+                    "Omnidreams runtime preload: warmup complete in {:.1f}s.",
+                    time.perf_counter() - warmup_t0,
+                )
 
     async def create_answer(self, *, offer_sdp: str, offer_type: str) -> dict[str, str]:
         if not self._runtime_ready or not self._warmup_complete:


### PR DESCRIPTION
Standardizes on using `loguru` over `stdlib` (`loguru` is configured to emit only on rank0 when in multiprocess contexts, which is helpful). Additionally expands some diagnostics in omnidreams webrtc path.