### PR TITLE
integrations/omnidreams: rename distribution to flashdreams-omnidream…

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -79,7 +79,7 @@ uv pip install "flashdreams-wan21 @ git+https://github.com/NVIDIA/flashdreams.gi
 | flashdreams-self-forcing | git only | synced |
 | flashdreams-causal-forcing | git only | synced |
 | flashdreams-fastvideo-causal-wan22 | git only | synced |
-| flash-omnidreams | git only | synced |
+| flashdreams-omnidreams | git only | synced |
 | flashdreams-lingbot | git only | synced |
 | ludus-renderer | git only | independent (0.9.0) |
 

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -133,7 +133,7 @@ Spin up the interactive single-view OmniDreams server via WebRTC:
 .. code-block:: bash
 
    # from the repo root
-   uv run --package flash-omnidreams torchrun --nproc_per_node 1 \
+   uv run --package flashdreams-omnidreams torchrun --nproc_per_node 1 \
        -m omnidreams.webrtc.server \
        --host 0.0.0.0 --port 8089 \
        --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf \

--- a/integrations/flashvsr/tests/parity_check/README.md
+++ b/integrations/flashvsr/tests/parity_check/README.md
@@ -157,7 +157,7 @@ parity-check uv calls. `data_local/docker_interactive.sh` pins
 `UV_PROJECT_ENVIRONMENT=/tmp/venv/flashdreams` on the docker session so
 every workspace `uv sync` lands in one shared venv; without the
 override, `uv sync` from here would manage the shared venv and
-uninstall every workspace integration (`flash-omnidreams`,
+uninstall every workspace integration (`flashdreams-omnidreams`,
 `flashdreams-flashvsr`, …) that this directory's `pyproject.toml`
 doesn't declare.
 

--- a/integrations/flashvsr/tests/parity_check/run.sh
+++ b/integrations/flashvsr/tests/parity_check/run.sh
@@ -40,8 +40,8 @@ INPUT_PATH="${INPUT_PATH:-${REPO_DIR}/examples/WanVSR/inputs/example4.mp4}"
 # every workspace ``uv sync`` lands in one shared venv. The parity-check
 # is the opposite shape -- an isolated venv pinned to upstream FlashVSR's
 # deps -- and running ``uv sync`` from here against the shared venv
-# uninstalls every workspace integration (flash-omnidreams,
-# flash-lingbot, ..., flashdreams-flashvsr) that this directory's
+# uninstalls every workspace integration (flashdreams-omnidreams,
+# flashdreams-lingbot, ..., flashdreams-flashvsr) that this directory's
 # pyproject.toml doesn't declare. Override the inherited variable to the
 # default ``${SCRIPT_DIR}/.venv`` path so:
 #   - ``uv sync`` / ``uv run`` here manage ${SCRIPT_DIR}/.venv, leaving

--- a/integrations/omnidreams/README.md
+++ b/integrations/omnidreams/README.md
@@ -45,7 +45,7 @@ switches checkpoint and example-data URLs back to `s3://flashdreams`.
 From the workspace root, run:
 
 ```bash
-uv run --package flash-omnidreams torchrun --nproc_per_node 1 -m omnidreams.webrtc.server --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf --scene-uuid 065dcac9-ee67-4434-a835-c6b816c88e48 --port 8089
+uv run --package flashdreams-omnidreams torchrun --nproc_per_node 1 -m omnidreams.webrtc.server --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf --scene-uuid 065dcac9-ee67-4434-a835-c6b816c88e48 --port 8089
 ```
 
 When `--scene_dir` is omitted, the server downloads the selected scene from the

--- a/integrations/omnidreams/compile_protos.sh
+++ b/integrations/omnidreams/compile_protos.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 cd "$SCRIPT_DIR"
 
-uv run --package flash-omnidreams python -m grpc_tools.protoc \
+uv run --package flashdreams-omnidreams python -m grpc_tools.protoc \
     -I. \
     --python_out=. \
     --grpc_python_out=. \

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -18,7 +18,7 @@ requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "flash-omnidreams"
+name = "flashdreams-omnidreams"
 version = "0.1.0a2"
 description = "Omnidreams inference with flashdreams"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,13 @@ resolution-markers = [
 
 [manifest]
 members = [
-    "flash-omnidreams",
     "flashdreams",
     "flashdreams-causal-forcing",
     "flashdreams-cosmos-predict2",
     "flashdreams-fastvideo-causal-wan22",
     "flashdreams-flashvsr",
     "flashdreams-lingbot",
+    "flashdreams-omnidreams",
     "flashdreams-self-forcing",
     "flashdreams-wan21",
     "ludus-renderer",
@@ -584,44 +584,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flash-omnidreams"
-version = "0.1.0a2"
-source = { editable = "integrations/omnidreams" }
-dependencies = [
-    { name = "flashdreams", extra = ["serving"] },
-    { name = "grpcio" },
-    { name = "grpcio-tools" },
-    { name = "imageio" },
-    { name = "ludus-renderer" },
-    { name = "mediapy" },
-    { name = "nvidia-cudnn-frontend" },
-    { name = "opencv-python-headless" },
-    { name = "shapely" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-manual-marker" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "flashdreams", extras = ["serving"], editable = "flashdreams" },
-    { name = "grpcio" },
-    { name = "grpcio-tools" },
-    { name = "imageio" },
-    { name = "ludus-renderer", editable = "integrations/omnidreams/ludus-renderer" },
-    { name = "mediapy", specifier = ">=1.1" },
-    { name = "nvidia-cudnn-frontend", specifier = "==1.22.1" },
-    { name = "opencv-python-headless" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-manual-marker", marker = "extra == 'dev'" },
-    { name = "shapely" },
-]
-provides-extras = ["dev"]
-
-[[package]]
 name = "flashdreams"
 source = { editable = "flashdreams" }
 dependencies = [
@@ -837,6 +799,44 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "scipy", specifier = ">=1.11" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "flashdreams-omnidreams"
+version = "0.1.0a2"
+source = { editable = "integrations/omnidreams" }
+dependencies = [
+    { name = "flashdreams", extra = ["serving"] },
+    { name = "grpcio" },
+    { name = "grpcio-tools" },
+    { name = "imageio" },
+    { name = "ludus-renderer" },
+    { name = "mediapy" },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "opencv-python-headless" },
+    { name = "shapely" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-manual-marker" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "flashdreams", extras = ["serving"], editable = "flashdreams" },
+    { name = "grpcio" },
+    { name = "grpcio-tools" },
+    { name = "imageio" },
+    { name = "ludus-renderer", editable = "integrations/omnidreams/ludus-renderer" },
+    { name = "mediapy", specifier = ">=1.1" },
+    { name = "nvidia-cudnn-frontend", specifier = "==1.22.1" },
+    { name = "opencv-python-headless" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-manual-marker", marker = "extra == 'dev'" },
+    { name = "shapely" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION

The OmniDreams plugin was published as ``flash-omnidreams`` while every other workspace integration uses the ``flashdreams-<name>`` prefix (``flashdreams-causal-forcing``, ``flashdreams-cosmos-predict2``, ``flashdreams-fastvideo-causal-wan22``, ``flashdreams-flashvsr``, ``flashdreams-lingbot``, ``flashdreams-self-forcing``, ``flashdreams-wan21``). Rename it for uniformity.

- Set ``[project].name = "flashdreams-omnidreams"`` in ``integrations/omnidreams/pyproject.toml``. No version bump: the distribution stays at ``0.1.0a2`` like the other unreleased integrations, and ``[tool.setuptools.packages.find]`` already targets the on-disk ``omnidreams`` package, so the import path ``import omnidreams`` is unchanged (the dist name was the only thing that needed fixing).
- Update every ``--package flash-omnidreams`` CLI invocation and prose reference in ``integrations/omnidreams/README.md``, ``integrations/omnidreams/compile_protos.sh``, ``docs/source/models/omnidreams.rst``, ``DEV.md``, and the FlashVSR parity-check ``run.sh`` / ``README.md`` comment block (which also carried a stale ``flash-lingbot`` typo, fixed to ``flashdreams-lingbot`` in the same comment).
- Regenerate ``uv.lock`` with ``uv lock`` so the manifest member and the editable package entry pick up the new dist name. Verified with ``uv sync --dry-run`` from the repo root: every workspace member now resolves as ``flashdreams-* @ file:///...`` (``flashdreams``, ``flashdreams-causal-forcing``, ``flashdreams-cosmos-predict2``, ``flashdreams-fastvideo-causal-wan22``, ``flashdreams-flashvsr``, ``flashdreams-lingbot``, ``flashdreams-omnidreams``, ``flashdreams-self-forcing``, ``flashdreams-wan21``, ``ludus-renderer``).
- No other ``flash-*`` distribution names remain under ``integrations/`` -- ``omnidreams`` was the only outlier. The nested ``integrations/flashvsr/tests/parity_check/pyproject.toml`` declares ``flashvsr-parity-check``, but that is an internal test scaffold (not a published integration), so it is intentionally left alone.

Refs #161