### PR TITLE
Port optimized OmniDreams DiT native path

### DIFF
--- a/integrations/omnidreams/README.md
+++ b/integrations/omnidreams/README.md
@@ -57,6 +57,21 @@ windowing runtime); server users running only `omnidreams.webrtc` or
 `omnidreams-prepare` for explicit staging of arbitrary scene UUIDs
 or to pre-warm the ~14 GB Cosmos-Reason1 text encoder.
 
+## Native DiT defaults
+
+OmniDreams native DiT acceleration remains gated by the pipeline config's
+`native_dit_acceleration` policy (`disabled`, `auto`, or `required`). When that
+native path is enabled, the default compute profile is the FP8 KV-cache backend
+with cuDNN attention:
+
+- `native_dit_backend="fp8_kvcache_cudnn"`
+- `native_dit_attention_backend="auto"` (currently resolves to cuDNN)
+
+Set `native_dit_attention_backend="sparge"`, `"sage3"`, or `"sage3_fp8"`
+explicitly to opt into Sparge/SageAttention-3 experiments. Use
+`native_dit_sparge_hybrid_period > 1` with `"sparge"` to enable the FP8
+Sparge/SageAttention-3 hybrid schedule when the extension and GPU support it.
+
 ## Run WebRTC server
 
 From the workspace root, run:

--- a/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
+++ b/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
@@ -103,7 +103,9 @@ def load_python_module(name: str) -> ModuleType:
     """Load a helper module shipped with the single-view native sources."""
 
     if not name.isidentifier():
-        raise ValueError(f"Native helper module name must be an identifier, got {name!r}")
+        raise ValueError(
+            f"Native helper module name must be an identifier, got {name!r}"
+        )
     path = _PYTHON_DIR / f"{name}.py"
     if not path.is_file():
         raise ImportError(f"Unknown OmniDreams single-view native helper {name!r}")
@@ -112,7 +114,9 @@ def load_python_module(name: str) -> ModuleType:
         return sys.modules[module_name]
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
-        raise ImportError(f"Cannot import OmniDreams single-view native helper from {path}")
+        raise ImportError(
+            f"Cannot import OmniDreams single-view native helper from {path}"
+        )
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     python_dir = str(_PYTHON_DIR)
@@ -166,6 +170,7 @@ def _extension_sources() -> list[Path]:
         _DIT_STREAMING_KERNEL_DIR / "cosmos_modulate.cu",
         _DIT_STREAMING_KERNEL_DIR / "ops.cu",
         _DIT_STREAMING_KERNEL_DIR / "sage3_attention.cu",
+        _DIT_STREAMING_KERNEL_DIR / "sparge_attention_sm89_inst.cu",
         _DIT_STREAMING_KERNEL_DIR / "transformer_block.cu",
     ]
 
@@ -308,6 +313,8 @@ def load_extension(
             cutlass_dir = Path(thirdparty_info["cutlass"]["path"])
             cutlass_include = cutlass_dir / "include"
             sage_attention_dir = Path(thirdparty_info["SageAttention"]["path"])
+            sparge_attn_dir = Path(thirdparty_info["SpargeAttn"]["path"])
+            sparge_attn_csrc = sparge_attn_dir / "csrc"
             cudnn_frontend_include = (
                 Path(thirdparty_info["cudnn-frontend"]["path"]) / "include"
             )
@@ -371,6 +378,9 @@ def load_extension(
                             / "sageattn3"
                             / "quantization"
                         ),
+                        str(sparge_attn_csrc),
+                        str(sparge_attn_csrc / "qattn"),
+                        str(sparge_attn_csrc / "fused"),
                         str(cudnn_frontend_include),
                         *([] if cudnn_include is None else [str(cudnn_include)]),
                     ],
@@ -380,6 +390,7 @@ def load_extension(
                         "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA",
                         "-DOMNIDREAMS_SINGLEVIEW_USE_CUTLASS",
                         "-DOMNIDREAMS_SINGLEVIEW_HAS_SAGE3=1",
+                        "-DOMNIDREAMS_SINGLEVIEW_HAS_SPARGE=1",
                         "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_SHA="
                         f'\\"{thirdparty_info["cutlass"]["commit"]}\\"',
                         "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_SOURCE_SHA="
@@ -404,18 +415,25 @@ def load_extension(
                         "-std=c++20",
                         "--expt-relaxed-constexpr",
                         "--expt-extended-lambda",
+                        "-lineinfo",
+                        "--use_fast_math",
                         "-U__CUDA_NO_HALF_OPERATORS__",
                         "-U__CUDA_NO_HALF_CONVERSIONS__",
+                        "-U__CUDA_NO_BFLOAT16_OPERATORS__",
                         "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+                        "-U__CUDA_NO_BFLOAT162_OPERATORS__",
+                        "-U__CUDA_NO_BFLOAT162_CONVERSIONS__",
                         "-DQBLKSIZE=128",
                         "-DKBLKSIZE=128",
                         "-DCTA256",
                         "-DDQINRMEM",
                         "-DEXECMODE=0",
                         "-DNDEBUG",
+                        "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1",
                         "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA",
                         "-DOMNIDREAMS_SINGLEVIEW_USE_CUTLASS",
                         "-DOMNIDREAMS_SINGLEVIEW_HAS_SAGE3=1",
+                        "-DOMNIDREAMS_SINGLEVIEW_HAS_SPARGE=1",
                     ],
                     extra_ldflags=[
                         "-lcublas",

--- a/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
+++ b/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
@@ -38,10 +38,15 @@ from omnidreams.native.acceleration import (
 _ROOT = Path(__file__).resolve().parents[2] / "omnidreams_singleview"
 _NATIVE_BUILD_PATH = _ROOT / "tools" / "native_build.py"
 _SOURCE_DIR = _ROOT / "src"
+_PYTHON_DIR = _ROOT / "python"
 _EXTENSION_SOURCE = _SOURCE_DIR / "omnidreams_singleview_ext.cpp"
 _NATIVE_PRIMITIVES_SOURCE = _SOURCE_DIR / "native_primitives.cpp"
 _NATIVE_PRIMITIVES_CUDA_SOURCE = _SOURCE_DIR / "native_primitives_cuda.cu"
 _NATIVE_COMMON_HEADER_DIR = _SOURCE_DIR / "native_common"
+_DIT_STREAMING_DIR = _SOURCE_DIR / "dit_streaming"
+_DIT_STREAMING_KERNEL_DIR = _DIT_STREAMING_DIR / "kernels"
+_DIT_STREAMING_PYEXT_DIR = _DIT_STREAMING_DIR / "pyext"
+_DIT_STREAMING_COMMON_DIR = _DIT_STREAMING_DIR / "common"
 _PYTORCH_MAX_JOBS_ENV = "MAX_JOBS"
 _DEFAULT_MAX_JOBS_CAP = 8
 _NATIVE_CUDA_ARCH_LIST_ENV = "OMNIDREAMS_SINGLEVIEW_CUDA_ARCH_LIST"
@@ -94,6 +99,36 @@ def sync_thirdparty(*, force: bool = False) -> dict[str, Any]:
     }
 
 
+def load_python_module(name: str) -> ModuleType:
+    """Load a helper module shipped with the single-view native sources."""
+
+    if not name.isidentifier():
+        raise ValueError(f"Native helper module name must be an identifier, got {name!r}")
+    path = _PYTHON_DIR / f"{name}.py"
+    if not path.is_file():
+        raise ImportError(f"Unknown OmniDreams single-view native helper {name!r}")
+    module_name = f"omnidreams_singleview_native_{name}"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot import OmniDreams single-view native helper from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    python_dir = str(_PYTHON_DIR)
+    if python_dir not in sys.path:
+        sys.path.insert(0, python_dir)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _first_library_dir(library_name: str, candidates: tuple[Path, ...]) -> Path | None:
+    for directory in candidates:
+        if (directory / library_name).is_file():
+            return directory
+    return None
+
+
 def build_info(
     build_root: Path | str | None = None,
 ) -> dict[str, Any]:
@@ -115,6 +150,23 @@ def _extension_sources() -> list[Path]:
         _EXTENSION_SOURCE,
         _NATIVE_PRIMITIVES_SOURCE,
         _NATIVE_PRIMITIVES_CUDA_SOURCE,
+        _DIT_STREAMING_DIR / "streaming_dit_bindings.cpp",
+        _DIT_STREAMING_PYEXT_DIR / "streaming_dit_bridge.cu",
+        _DIT_STREAMING_PYEXT_DIR / "sage3_blackwell_api_shim.cu",
+        _DIT_STREAMING_PYEXT_DIR / "sage3_fp4_quant_shim.cu",
+        _DIT_STREAMING_KERNEL_DIR / "attention.cu",
+        _DIT_STREAMING_KERNEL_DIR / "block_quant.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_adaln_lora.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_block.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_fp8_flash.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_fp8_flash_tc.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_fp8_tc_probe.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_fp8_two_gemm.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_gemm_bf16.cu",
+        _DIT_STREAMING_KERNEL_DIR / "cosmos_modulate.cu",
+        _DIT_STREAMING_KERNEL_DIR / "ops.cu",
+        _DIT_STREAMING_KERNEL_DIR / "sage3_attention.cu",
+        _DIT_STREAMING_KERNEL_DIR / "transformer_block.cu",
     ]
 
 
@@ -122,6 +174,10 @@ def _extension_fingerprint_sources() -> list[Path]:
     return [
         *_extension_sources(),
         *sorted(_NATIVE_COMMON_HEADER_DIR.glob("*.h")),
+        *sorted(_DIT_STREAMING_DIR.rglob("*.h")),
+        *sorted(_DIT_STREAMING_DIR.rglob("*.cuh")),
+        *sorted(_DIT_STREAMING_DIR.rglob("*.hpp")),
+        *sorted(_PYTHON_DIR.glob("*.py")),
     ]
 
 
@@ -174,6 +230,16 @@ def _effective_cuda_arch_list() -> str:
         _PYTORCH_CUDA_ARCH_LIST_ENV,
         os.environ.get(_NATIVE_CUDA_ARCH_LIST_ENV, _DEFAULT_CUDA_ARCH_LIST),
     )
+
+
+def _python_package_dir(package: str) -> Path | None:
+    spec = importlib.util.find_spec(package)
+    if spec is None or spec.submodule_search_locations is None:
+        return None
+    locations = list(spec.submodule_search_locations)
+    if not locations:
+        return None
+    return Path(locations[0])
 
 
 @contextlib.contextmanager
@@ -239,7 +305,33 @@ def load_extension(
 
             thirdparty_info = validate_thirdparty()
             extension_name = _extension_name(thirdparty_info)
-            cutlass_include = Path(thirdparty_info["cutlass"]["path"]) / "include"
+            cutlass_dir = Path(thirdparty_info["cutlass"]["path"])
+            cutlass_include = cutlass_dir / "include"
+            sage_attention_dir = Path(thirdparty_info["SageAttention"]["path"])
+            cudnn_frontend_include = (
+                Path(thirdparty_info["cudnn-frontend"]["path"]) / "include"
+            )
+            cudnn_package_dir = _python_package_dir("nvidia.cudnn")
+            cudnn_include = (
+                cudnn_package_dir / "include"
+                if cudnn_package_dir is not None
+                and (cudnn_package_dir / "include" / "cudnn.h").is_file()
+                else None
+            )
+            cudnn_lib = (
+                cudnn_package_dir / "lib"
+                if cudnn_package_dir is not None
+                and (cudnn_package_dir / "lib" / "libcudnn.so.9").is_file()
+                else None
+            )
+            cuda_driver_lib = _first_library_dir(
+                "libcuda.so",
+                (
+                    Path("/usr/lib/wsl/lib"),
+                    Path("/usr/lib/x86_64-linux-gnu"),
+                    Path("/usr/local/cuda/lib64"),
+                ),
+            )
             extension_build_dir = _native_build().torch_extension_build_dir(
                 extension_name,
                 build_root=build_root,
@@ -251,10 +343,43 @@ def load_extension(
                     name=extension_name,
                     sources=[str(source) for source in _extension_sources()],
                     build_directory=str(extension_build_dir),
-                    extra_include_paths=[str(_SOURCE_DIR), str(cutlass_include)],
+                    extra_include_paths=[
+                        str(_SOURCE_DIR),
+                        str(_DIT_STREAMING_DIR),
+                        str(_DIT_STREAMING_KERNEL_DIR),
+                        str(_DIT_STREAMING_PYEXT_DIR),
+                        str(_DIT_STREAMING_COMMON_DIR),
+                        str(cutlass_include),
+                        str(cutlass_dir / "tools" / "util" / "include"),
+                        str(cutlass_dir / "examples" / "common"),
+                        str(cutlass_dir / "examples" / "41_fused_multi_head_attention"),
+                        str(sage_attention_dir),
+                        str(
+                            sage_attention_dir
+                            / "sageattention3_blackwell"
+                            / "sageattn3"
+                        ),
+                        str(
+                            sage_attention_dir
+                            / "sageattention3_blackwell"
+                            / "sageattn3"
+                            / "blackwell"
+                        ),
+                        str(
+                            sage_attention_dir
+                            / "sageattention3_blackwell"
+                            / "sageattn3"
+                            / "quantization"
+                        ),
+                        str(cudnn_frontend_include),
+                        *([] if cudnn_include is None else [str(cudnn_include)]),
+                    ],
                     extra_cflags=[
                         "-O3",
+                        "-std=c++20",
                         "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA",
+                        "-DOMNIDREAMS_SINGLEVIEW_USE_CUTLASS",
+                        "-DOMNIDREAMS_SINGLEVIEW_HAS_SAGE3=1",
                         "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_SHA="
                         f'\\"{thirdparty_info["cutlass"]["commit"]}\\"',
                         "-DOMNIDREAMS_SINGLEVIEW_CUTLASS_SOURCE_SHA="
@@ -276,7 +401,30 @@ def load_extension(
                     ],
                     extra_cuda_cflags=[
                         "-O3",
+                        "-std=c++20",
+                        "--expt-relaxed-constexpr",
+                        "--expt-extended-lambda",
+                        "-U__CUDA_NO_HALF_OPERATORS__",
+                        "-U__CUDA_NO_HALF_CONVERSIONS__",
+                        "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+                        "-DQBLKSIZE=128",
+                        "-DKBLKSIZE=128",
+                        "-DCTA256",
+                        "-DDQINRMEM",
+                        "-DEXECMODE=0",
+                        "-DNDEBUG",
                         "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA",
+                        "-DOMNIDREAMS_SINGLEVIEW_USE_CUTLASS",
+                        "-DOMNIDREAMS_SINGLEVIEW_HAS_SAGE3=1",
+                    ],
+                    extra_ldflags=[
+                        "-lcublas",
+                        "-lcublasLt",
+                        *([] if cudnn_lib is None else [f"-L{cudnn_lib}"]),
+                        "-lcudnn" if cudnn_lib is None else "-l:libcudnn.so.9",
+                        *([] if cuda_driver_lib is None else [f"-L{cuda_driver_lib}"]),
+                        "-lcuda",
+                        "-lnvrtc",
                     ],
                     with_cuda=True,
                     verbose=verbose,

--- a/integrations/omnidreams/omnidreams/transformer/__init__.py
+++ b/integrations/omnidreams/omnidreams/transformer/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import torch.nn.functional as F
@@ -36,6 +36,12 @@ from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
     TransformerConfig,
+)
+from omnidreams.native.acceleration import (
+    NativeAccelerationConfig,
+    NativeAccelerationMode,
+    NativeBackendSelection,
+    require_extension_symbols,
 )
 
 from .impl.context_parallel import (
@@ -197,6 +203,24 @@ class CosmosTransformerConfig(TransformerConfig):
     skip_finalize_kv_cache: bool = False
     """Skip the KV cache finalize step."""
 
+    native_dit_acceleration: NativeAccelerationMode = "disabled"
+    """Native optimized DiT policy: ``disabled``, ``auto``, or ``required``."""
+
+    native_dit_build_root: str | None = None
+    """Optional native extension build/cache root."""
+
+    native_dit_max_jobs: int | str | None = None
+    """Optional PyTorch/Ninja job cap for the native DiT build."""
+
+    native_dit_verbose_build: bool = False
+    """Forward verbose build output from the native extension loader."""
+
+    native_dit_backend: Literal["fp8_kvcache_cudnn", "bf16"] = "fp8_kvcache_cudnn"
+    """Optimized native DiT compute backend."""
+
+    native_dit_attention_backend: str = "auto"
+    """Optimized native attention backend. ``auto`` selects the best built backend."""
+
     guidance_scale: float = 1.0
     """CFG scale. ``1.0`` disables CFG; ``> 1.0`` requires negative text embeddings."""
 
@@ -267,7 +291,12 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             self.network.load_state_dict(state_dict)
         self.network.update_parameters_after_loading_checkpoint()
 
-        if config.compile_network:
+        self._optimized_dit_executor: Any | None = None
+        self._optimized_dit_selection: NativeBackendSelection | None = None
+        if config.native_dit_acceleration != "disabled":
+            self._configure_optimized_dit_from_config()
+
+        if config.compile_network and self._optimized_dit_executor is None:
             self.network = compile_module(self.network)
 
         # Per-rollout dispatch when use_cuda_graph=True:
@@ -302,6 +331,31 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         # For multi-view, we keep the original 5D [B, V, T, HW, D] shape so we can apply
         # dedicated hierarchical CP groups.
         self.flatten_thw = config.num_views == 1
+
+    def _configure_optimized_dit_from_config(self) -> None:
+        from omnidreams.native import omnidreams_singleview
+
+        helper = omnidreams_singleview.load_python_module("optimized_dit")
+        native_config = NativeAccelerationConfig(
+            mode=self.config.native_dit_acceleration,
+            build_root=self.config.native_dit_build_root,
+            max_jobs=self.config.native_dit_max_jobs,
+            verbose_build=self.config.native_dit_verbose_build,
+        )
+        selection = omnidreams_singleview.select_backend(
+            "optimized_dit",
+            native_config,
+            availability_check=require_extension_symbols("optimized_dit_forward"),
+        )
+        self._optimized_dit_selection = selection
+        if not selection.enabled:
+            return
+        self._optimized_dit_executor = helper.OptimizedDiTExecutor(
+            self,
+            selection.require_extension(),
+            dit_backend=self.config.native_dit_backend,
+            attention_backend=self.config.native_dit_attention_backend,
+        )
 
     ## Patchify / CP plumbing
 
@@ -530,7 +584,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             assert isinstance(self._network_call_uncond, CUDAGraphWrapper)
             self._network_call_uncond.reset()
 
-        return CosmosTransformerCache(
+        cache = CosmosTransformerCache(
             network_cache=network_cache,
             network_cache_uncond=network_cache_uncond,
             rope_adapter=rope_adapter,
@@ -539,6 +593,9 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             mask_other_blocks=mask_other_patched,
             view_indices=view_indices,
         )
+        if self._optimized_dit_executor is not None:
+            self._optimized_dit_executor.after_initialize_autoregressive_cache(cache)
+        return cache
 
     ## Mask-injection helpers
 
@@ -611,6 +668,13 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         cache: CosmosTransformerCache,
         input: Tensor | None = None,
     ) -> Tensor:
+        if self._optimized_dit_executor is not None:
+            return self._optimized_dit_executor.predict_flow(
+                noisy_latent=noisy_latent,
+                timestep=timestep,
+                cache=cache,
+                input=input,
+            )
         flow_cond = self._predict_branch(
             noisy_latent=noisy_latent,
             timestep=timestep,
@@ -644,6 +708,9 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if self.config.skip_finalize_kv_cache:
-            return
-        super().finalize_kv_cache(*args, **kwargs)
+        try:
+            if not self.config.skip_finalize_kv_cache:
+                super().finalize_kv_cache(*args, **kwargs)
+        finally:
+            if self._optimized_dit_executor is not None:
+                self._optimized_dit_executor.after_finalize_kv_cache()

--- a/integrations/omnidreams/omnidreams/transformer/__init__.py
+++ b/integrations/omnidreams/omnidreams/transformer/__init__.py
@@ -221,21 +221,22 @@ class CosmosTransformerConfig(TransformerConfig):
     native_dit_attention_backend: str = "auto"
     """Optimized native attention backend.
 
-    ``auto`` uses the FP8 Sparge/SageAttention-3 hybrid when both native
-    backends are available; otherwise it selects the best built backend.
+    ``auto`` selects the current default, which resolves to the portable cuDNN
+    FP8 SDPA path. Set ``sparge``, ``sage3``, or ``sage3_fp8`` explicitly to
+    opt into Sparge/SageAttention-3 experiments.
     """
 
     native_dit_sparge_topk: float | None = None
     """Optional Sparge self-attention top-k ratio.
 
-    ``None`` uses ``0.25`` for both the FP8 ``auto`` hybrid schedule and pure
-    Sparge.
+    ``None`` uses ``0.25`` for Sparge and Sparge/SageAttention-3 hybrid runs.
     """
 
     native_dit_sparge_hybrid_period: int | None = None
     """Optional Sparge/SageAttention-3 hybrid period.
 
-    ``None`` uses period ``2`` for FP8 ``auto`` and ``0`` otherwise.
+    ``None`` uses ``0``. Set a value greater than ``1`` with
+    ``native_dit_attention_backend="sparge"`` to enable the hybrid schedule.
     """
 
     native_dit_sparge_hybrid_phase: int | None = None

--- a/integrations/omnidreams/omnidreams/transformer/__init__.py
+++ b/integrations/omnidreams/omnidreams/transformer/__init__.py
@@ -219,7 +219,27 @@ class CosmosTransformerConfig(TransformerConfig):
     """Optimized native DiT compute backend."""
 
     native_dit_attention_backend: str = "auto"
-    """Optimized native attention backend. ``auto`` selects the best built backend."""
+    """Optimized native attention backend.
+
+    ``auto`` uses the FP8 Sparge/SageAttention-3 hybrid when both native
+    backends are available; otherwise it selects the best built backend.
+    """
+
+    native_dit_sparge_topk: float | None = None
+    """Optional Sparge self-attention top-k ratio.
+
+    ``None`` uses ``0.10`` for the FP8 ``auto`` hybrid schedule and ``0.25``
+    for pure Sparge.
+    """
+
+    native_dit_sparge_hybrid_period: int | None = None
+    """Optional Sparge/SageAttention-3 hybrid period.
+
+    ``None`` uses period ``2`` for FP8 ``auto`` and ``0`` otherwise.
+    """
+
+    native_dit_sparge_hybrid_phase: int | None = None
+    """Optional Sparge hybrid phase. ``None`` uses backend defaults."""
 
     guidance_scale: float = 1.0
     """CFG scale. ``1.0`` disables CFG; ``> 1.0`` requires negative text embeddings."""
@@ -355,6 +375,9 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
             selection.require_extension(),
             dit_backend=self.config.native_dit_backend,
             attention_backend=self.config.native_dit_attention_backend,
+            sparge_topk=self.config.native_dit_sparge_topk,
+            sparge_hybrid_period=self.config.native_dit_sparge_hybrid_period,
+            sparge_hybrid_phase=self.config.native_dit_sparge_hybrid_phase,
         )
 
     ## Patchify / CP plumbing

--- a/integrations/omnidreams/omnidreams/transformer/__init__.py
+++ b/integrations/omnidreams/omnidreams/transformer/__init__.py
@@ -23,6 +23,12 @@ from typing import Any, Literal
 
 import torch
 import torch.nn.functional as F
+from omnidreams.native.acceleration import (
+    NativeAccelerationConfig,
+    NativeAccelerationMode,
+    NativeBackendSelection,
+    require_extension_symbols,
+)
 from torch import Tensor
 
 from flashdreams.core.attention.rope import (
@@ -36,12 +42,6 @@ from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
     TransformerConfig,
-)
-from omnidreams.native.acceleration import (
-    NativeAccelerationConfig,
-    NativeAccelerationMode,
-    NativeBackendSelection,
-    require_extension_symbols,
 )
 
 from .impl.context_parallel import (
@@ -228,8 +228,8 @@ class CosmosTransformerConfig(TransformerConfig):
     native_dit_sparge_topk: float | None = None
     """Optional Sparge self-attention top-k ratio.
 
-    ``None`` uses ``0.10`` for the FP8 ``auto`` hybrid schedule and ``0.25``
-    for pure Sparge.
+    ``None`` uses ``0.25`` for both the FP8 ``auto`` hybrid schedule and pure
+    Sparge.
     """
 
     native_dit_sparge_hybrid_period: int | None = None

--- a/integrations/omnidreams/omnidreams_singleview/python/cosmos_fp8_utils.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/cosmos_fp8_utils.py
@@ -1,0 +1,754 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import torch
+
+
+FP8_MAX_E4M3 = 448.0
+FP8_SCALE_EPS = 1.0e-12
+COSMOS_FP8_ACTIVATION_SCALE_SITES: Tuple[str, ...] = (
+    "sa_normed",
+    "sa_q",
+    "sa_k",
+    "sa_v",
+    "sa_attn_out",
+    "ca_normed",
+    "ca_q",
+    "ca_attn_out",
+    "ffn_normed",
+    "ffn1_gelu",
+)
+
+
+_COSMOS_BLOCK_FP8_LINEAR_KEYS: Tuple[str, ...] = (
+    "self_attn.q_proj.weight",
+    "self_attn.k_proj.weight",
+    "self_attn.v_proj.weight",
+    "self_attn.output_proj.weight",
+    "cross_attn.q_proj.weight",
+    "cross_attn.output_proj.weight",
+    "mlp.layer1.weight",
+    "mlp.layer2.weight",
+)
+
+_COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS: Tuple[str, ...] = (
+    "self_attn.q_proj.weight",
+    "self_attn.k_proj.weight",
+    "self_attn.v_proj.weight",
+)
+
+_COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY = "self_attn.qkv_proj.weight"
+_COSMOS_FP8_PREPARED_WEIGHT_SUFFIX = "_fp8_prepared"
+_COSMOS_FP8_PREPARED_SCALE_SUFFIX = "_fp8_prepared_scale"
+
+_COSMOS_FP8_LINEAR_POLICY_GROUPS: Mapping[str, Tuple[str, ...]] = {
+    "sa_qkv": _COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS,
+    "sa_out": ("self_attn.output_proj.weight",),
+    "ca_q": ("cross_attn.q_proj.weight",),
+    "ca_out": ("cross_attn.output_proj.weight",),
+    "ffn1": ("mlp.layer1.weight",),
+    "ffn2": ("mlp.layer2.weight",),
+}
+
+_COSMOS_FP8_LINEAR_POLICIES: Mapping[str, Tuple[str, ...]] = {
+    "all": tuple(_COSMOS_FP8_LINEAR_POLICY_GROUPS.keys()),
+    "attn_only": ("sa_qkv", "sa_out", "ca_q", "ca_out"),
+    "mlp_only": ("ffn1", "ffn2"),
+    "no_ffn2": ("sa_qkv", "sa_out", "ca_q", "ca_out", "ffn1"),
+    "no_out_proj": ("sa_qkv", "ca_q", "ffn1"),
+}
+
+
+def cosmos_block_fp8_linear_keys(num_blocks: int) -> Tuple[str, ...]:
+    if num_blocks <= 0:
+        raise ValueError(f"num_blocks must be positive, got {num_blocks}")
+    return tuple(
+        f"blocks.{block_idx}.{rel_key}"
+        for block_idx in range(num_blocks)
+        for rel_key in _COSMOS_BLOCK_FP8_LINEAR_KEYS
+    )
+
+
+def cosmos_block_fp8_fused_qkv_keys(num_blocks: int) -> Tuple[str, ...]:
+    if num_blocks <= 0:
+        raise ValueError(f"num_blocks must be positive, got {num_blocks}")
+    return tuple(
+        f"blocks.{block_idx}.{_COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY}"
+        for block_idx in range(num_blocks)
+    )
+
+
+def scale_key_for_weight(weight_key: str) -> str:
+    if not weight_key.endswith(".weight"):
+        raise ValueError(f"expected a .weight key, got {weight_key!r}")
+    return f"{weight_key}_scale"
+
+
+def fp8_prepared_weight_key(weight_key: str) -> str:
+    if not weight_key.endswith(".weight"):
+        raise ValueError(f"expected a .weight key, got {weight_key!r}")
+    return f"{weight_key}{_COSMOS_FP8_PREPARED_WEIGHT_SUFFIX}"
+
+
+def fp8_prepared_scale_key(weight_key: str) -> str:
+    if not weight_key.endswith(".weight"):
+        raise ValueError(f"expected a .weight key, got {weight_key!r}")
+    return f"{weight_key}{_COSMOS_FP8_PREPARED_SCALE_SUFFIX}"
+
+
+def cosmos_fp8_linear_policy_groups() -> Tuple[str, ...]:
+    return tuple(_COSMOS_FP8_LINEAR_POLICY_GROUPS.keys())
+
+
+def cosmos_fp8_linear_policies() -> Tuple[str, ...]:
+    return tuple((*_COSMOS_FP8_LINEAR_POLICIES.keys(), "custom"))
+
+
+def _normalize_group_names(groups: Optional[Sequence[str] | str]) -> Tuple[str, ...]:
+    if groups is None:
+        return ()
+    if isinstance(groups, str):
+        raw = groups.replace(";", ",").split(",")
+    else:
+        raw = list(groups)
+    normalized = tuple(group.strip().lower() for group in raw if group.strip())
+    unknown = tuple(group for group in normalized if group not in _COSMOS_FP8_LINEAR_POLICY_GROUPS)
+    if unknown:
+        valid = ", ".join(cosmos_fp8_linear_policy_groups())
+        raise ValueError(f"unknown Cosmos FP8 linear policy group {unknown[0]!r}; expected one of: {valid}")
+    return normalized
+
+
+def resolve_cosmos_fp8_linear_policy(
+    policy: str = "all",
+    *,
+    custom_groups: Optional[Sequence[str] | str] = None,
+) -> Tuple[str, ...]:
+    """Return relative Cosmos block linear keys selected for FP8 quantization."""
+
+    normalized = policy.strip().lower()
+    if normalized == "custom":
+        groups = _normalize_group_names(custom_groups)
+        if not groups:
+            raise ValueError("custom Cosmos FP8 linear policy requires at least one group")
+    elif normalized in _COSMOS_FP8_LINEAR_POLICIES:
+        if custom_groups is not None:
+            raise ValueError("custom_groups is only valid when policy='custom'")
+        groups = _COSMOS_FP8_LINEAR_POLICIES[normalized]
+    else:
+        valid = ", ".join(cosmos_fp8_linear_policies())
+        raise ValueError(f"unknown Cosmos FP8 linear policy {policy!r}; expected one of: {valid}")
+
+    selected: list[str] = []
+    for group in groups:
+        for rel_key in _COSMOS_FP8_LINEAR_POLICY_GROUPS[group]:
+            if rel_key not in selected:
+                selected.append(rel_key)
+    return tuple(selected)
+
+
+def quantize_fp8_per_out_channel(
+    weight: torch.Tensor,
+    *,
+    scale_dtype: torch.dtype = torch.float16,
+    eps: float = FP8_SCALE_EPS,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a PyTorch Linear weight [out_features, in_features] to E4M3 bytes.
+
+    The returned byte tensor intentionally keeps the original row-major
+    [out, in] shape. Cosmos CUTLASS RCR GEMMs consume that exact memory as a
+    column-major [in, out] matrix, matching ``input @ weight.T``.
+    """
+
+    if weight.dim() != 2:
+        raise ValueError(f"linear weight must be 2D [out, in], got {tuple(weight.shape)}")
+    if not hasattr(torch, "float8_e4m3fn"):
+        raise RuntimeError("torch.float8_e4m3fn is required for Cosmos FP8 quantization")
+
+    weight_f32 = weight.detach().to(torch.float32)
+    amax = weight_f32.abs().amax(dim=1)
+    scale_f32 = torch.clamp(amax / FP8_MAX_E4M3, min=eps)
+    q_f32 = torch.clamp(weight_f32 / scale_f32[:, None], -FP8_MAX_E4M3, FP8_MAX_E4M3)
+    q_u8 = q_f32.to(torch.float8_e4m3fn).view(torch.uint8).contiguous()
+    return q_u8, scale_f32.to(device=weight.device, dtype=scale_dtype).contiguous()
+
+
+def fp8_activation_scale(
+    activation: torch.Tensor,
+    *,
+    mode: str = "dynamic",
+    static_scale: Optional[torch.Tensor | float] = None,
+    calibrated_amax: Optional[torch.Tensor | float] = None,
+    scale_dtype: torch.dtype = torch.float32,
+    eps: float = FP8_SCALE_EPS,
+) -> torch.Tensor:
+    """Return a finite per-tensor E4M3 activation scale.
+
+    Supported modes are explicit because the kernel ABI must not hide how Q/K/V
+    ranges were chosen:
+
+    - ``dynamic``: scale from the runtime tensor amax.
+    - ``calibrated``: scale from a caller-provided calibration amax.
+    - ``static``: use a caller-provided scale directly.
+    """
+
+    mode = mode.lower()
+    device = activation.device
+    if mode == "dynamic":
+        scale = activation.detach().to(torch.float32).abs().amax() / FP8_MAX_E4M3
+    elif mode == "calibrated":
+        if calibrated_amax is None:
+            raise ValueError("calibrated mode requires calibrated_amax")
+        scale = torch.as_tensor(calibrated_amax, device=device, dtype=torch.float32) / FP8_MAX_E4M3
+    elif mode == "static":
+        if static_scale is None:
+            raise ValueError("static mode requires static_scale")
+        scale = torch.as_tensor(static_scale, device=device, dtype=torch.float32)
+    else:
+        raise ValueError(f"unknown FP8 activation scale mode {mode!r}")
+
+    scale = torch.clamp(scale, min=eps)
+    if not torch.isfinite(scale).all():
+        raise ValueError("FP8 activation scale must be finite")
+    return scale.to(dtype=scale_dtype).contiguous()
+
+
+def quantize_fp8_activation_per_tensor(
+    activation: torch.Tensor,
+    *,
+    mode: str = "dynamic",
+    static_scale: Optional[torch.Tensor | float] = None,
+    calibrated_amax: Optional[torch.Tensor | float] = None,
+    scale_dtype: torch.dtype = torch.float32,
+    eps: float = FP8_SCALE_EPS,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize an activation tensor to raw E4M3 bytes with one tensor scale."""
+
+    if not hasattr(torch, "float8_e4m3fn"):
+        raise RuntimeError("torch.float8_e4m3fn is required for Cosmos FP8 quantization")
+    scale = fp8_activation_scale(
+        activation,
+        mode=mode,
+        static_scale=static_scale,
+        calibrated_amax=calibrated_amax,
+        scale_dtype=scale_dtype,
+        eps=eps,
+    )
+    q_f32 = torch.clamp(
+        activation.detach().to(torch.float32) / scale.to(torch.float32),
+        -FP8_MAX_E4M3,
+        FP8_MAX_E4M3,
+    )
+    q_u8 = q_f32.to(torch.float8_e4m3fn).view(torch.uint8).contiguous()
+    return q_u8, scale
+
+
+def assert_fp8_scale_shape(scale: torch.Tensor, expected_shape: Tuple[int, ...], *, name: str) -> None:
+    if tuple(scale.shape) != tuple(expected_shape):
+        raise ValueError(f"{name} must have shape {expected_shape}, got {tuple(scale.shape)}")
+    if not scale.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    if not torch.isfinite(scale.float()).all():
+        raise ValueError(f"{name} must contain only finite values")
+
+
+def validate_cosmos_fp8_activation_calibration(
+    calibration: Mapping[str, object],
+    *,
+    num_blocks: int,
+) -> Dict[str, torch.Tensor]:
+    """Validate and normalize a per-layer activation calibration artifact.
+
+    The accepted Python representation is intentionally simple:
+    ``{"amax": {site: sequence_of_num_blocks_values}}``.
+    """
+
+    if num_blocks <= 0:
+        raise ValueError(f"num_blocks must be positive, got {num_blocks}")
+    raw_amax = calibration.get("amax")
+    if not isinstance(raw_amax, Mapping):
+        raise ValueError("Cosmos FP8 activation calibration requires an 'amax' mapping")
+
+    normalized: Dict[str, torch.Tensor] = {}
+    for site in COSMOS_FP8_ACTIVATION_SCALE_SITES:
+        if site not in raw_amax:
+            raise ValueError(f"Cosmos FP8 activation calibration is missing site {site!r}")
+        tensor = torch.as_tensor(raw_amax[site], dtype=torch.float32)
+        if tensor.shape != (num_blocks,):
+            raise ValueError(
+                f"Cosmos FP8 activation calibration site {site!r} must have shape "
+                f"({num_blocks},), got {tuple(tensor.shape)}"
+            )
+        if not torch.isfinite(tensor).all():
+            raise ValueError(f"Cosmos FP8 activation calibration site {site!r} must be finite")
+        if (tensor <= 0).any():
+            raise ValueError(f"Cosmos FP8 activation calibration site {site!r} must be positive")
+        normalized[site] = tensor.contiguous()
+    return normalized
+
+
+def cosmos_fp8_activation_scale_tensor(
+    calibration: Mapping[str, object],
+    *,
+    num_blocks: int,
+    device: Optional[torch.device | str] = None,
+    scale_dtype: torch.dtype = torch.float32,
+    eps: float = FP8_SCALE_EPS,
+) -> torch.Tensor:
+    """Return runtime `[num_blocks, num_sites]` activation scales.
+
+    The C++ streaming path consumes scales, not raw amax values. Columns follow
+    ``COSMOS_FP8_ACTIVATION_SCALE_SITES`` exactly.
+    """
+
+    normalized = validate_cosmos_fp8_activation_calibration(
+        calibration,
+        num_blocks=num_blocks,
+    )
+    stacked_amax = torch.stack([normalized[site] for site in COSMOS_FP8_ACTIVATION_SCALE_SITES], dim=1)
+    scales = torch.clamp(stacked_amax / FP8_MAX_E4M3, min=eps)
+    if device is not None:
+        scales = scales.to(device=device)
+    return scales.to(dtype=scale_dtype).contiguous()
+
+
+def fuse_cosmos_self_attn_qkv_fp8_weights(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    drop_split_self_attn_qkv: bool = False,
+    include_missing: bool = False,
+) -> Dict[str, torch.Tensor]:
+    """Add optional fused self-attention QKV FP8 weights.
+
+    Cosmos checkpoints store Q/K/V projections as separate Linear weights.
+    The FP8 runtime can avoid three small GEMMs when a caller provides a
+    pre-concatenated ``self_attn.qkv_proj.weight`` with per-output scales.
+    Split tensors are kept by default so existing callers retain the fallback.
+    """
+
+    out: Dict[str, torch.Tensor] = dict(weights)
+    for block_idx in range(num_blocks):
+        prefix = f"blocks.{block_idx}."
+        split_keys = tuple(prefix + rel_key for rel_key in _COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS)
+        split_scale_keys = tuple(scale_key_for_weight(key) for key in split_keys)
+        fused_key = prefix + _COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY
+        fused_scale_key = scale_key_for_weight(fused_key)
+
+        missing = [key for key in (*split_keys, *split_scale_keys) if key not in out]
+        if missing:
+            if include_missing:
+                continue
+            raise KeyError(f"missing Cosmos split QKV FP8 tensors for fusion: {missing[0]!r}")
+
+        q_weight, k_weight, v_weight = (out[key] for key in split_keys)
+        q_scale, k_scale, v_scale = (out[key] for key in split_scale_keys)
+        out[fused_key] = torch.cat((q_weight, k_weight, v_weight), dim=0).contiguous()
+        out[fused_scale_key] = torch.cat((q_scale, k_scale, v_scale), dim=0).contiguous()
+
+        if drop_split_self_attn_qkv:
+            for key in (*split_keys, *split_scale_keys):
+                out.pop(key, None)
+
+    return out
+
+
+def quantize_cosmos_fp8_weights(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    device: Optional[torch.device | str] = None,
+    include_missing: bool = False,
+    fuse_self_attn_qkv: bool = True,
+    drop_split_self_attn_qkv: bool = False,
+    linear_policy: str = "all",
+    custom_linear_groups: Optional[Sequence[str] | str] = None,
+) -> Dict[str, torch.Tensor]:
+    """Return a shallow-copied weights dict with Cosmos block linears in FP8.
+
+    For each quantized weight key ``K``, the output dict contains:
+
+    - ``K``: raw E4M3 bytes as ``torch.uint8`` in the original [out, in] layout
+    - ``f"{K}_scale"``: per-output-channel dequantization scale
+
+    Non-quantized tensors are carried through unchanged.
+    """
+
+    out: Dict[str, torch.Tensor] = dict(weights)
+    target_device = torch.device(device) if device is not None else None
+    selected_rel_keys = set(
+        resolve_cosmos_fp8_linear_policy(
+            linear_policy,
+            custom_groups=custom_linear_groups,
+        )
+    )
+
+    for block_idx in range(num_blocks):
+        prefix = f"blocks.{block_idx}."
+        for rel_key in selected_rel_keys:
+            key = prefix + rel_key
+            if key not in weights:
+                if include_missing:
+                    continue
+                raise KeyError(f"missing Cosmos FP8 linear weight {key!r}")
+            weight = weights[key]
+            if target_device is not None:
+                weight = weight.to(target_device)
+            q_u8, scale = quantize_fp8_per_out_channel(weight)
+            out[key] = q_u8
+            out[scale_key_for_weight(key)] = scale
+
+    for key in cosmos_block_fp8_linear_keys(num_blocks):
+        if key not in weights:
+            if include_missing:
+                continue
+            raise KeyError(f"missing Cosmos FP8 linear weight {key!r}")
+        if key not in out:
+            continue
+
+    has_all_self_qkv = all(rel_key in selected_rel_keys for rel_key in _COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS)
+    if fuse_self_attn_qkv and has_all_self_qkv:
+        out = fuse_cosmos_self_attn_qkv_fp8_weights(
+            out,
+            num_blocks=num_blocks,
+            drop_split_self_attn_qkv=drop_split_self_attn_qkv,
+            include_missing=include_missing,
+        )
+
+    elif drop_split_self_attn_qkv:
+        raise ValueError("drop_split_self_attn_qkv=True requires a policy that quantizes all self-attention Q/K/V weights")
+
+    return out
+
+
+def add_cosmos_fp8_prepared_aliases(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    include_missing: bool = False,
+    linear_policy: str = "all",
+    custom_linear_groups: Optional[Sequence[str] | str] = None,
+) -> Dict[str, torch.Tensor]:
+    """Add explicit prepared FP8 aliases for the streaming runtime.
+
+    The aliases deliberately do not use the BF16 ``.weight_prepared`` suffix:
+    BF16 prepared tensors are transposed for the prepared BF16 GEMM path, while
+    Cosmos FP8 kernels consume raw E4M3 bytes in the original [out, in] layout.
+    """
+
+    out: Dict[str, torch.Tensor] = dict(weights)
+    selected_rel_keys = set(
+        resolve_cosmos_fp8_linear_policy(
+            linear_policy,
+            custom_groups=custom_linear_groups,
+        )
+    )
+    qkv_rel_keys = set(_COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS)
+    has_all_self_qkv = qkv_rel_keys.issubset(selected_rel_keys)
+
+    for block_idx in range(num_blocks):
+        prefix = f"blocks.{block_idx}."
+        fused_key = prefix + _COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY
+        fused_ready = (
+            isinstance(out.get(fused_key), torch.Tensor)
+            and out[fused_key].dtype == torch.uint8
+            and isinstance(out.get(scale_key_for_weight(fused_key)), torch.Tensor)
+        )
+        rel_keys: list[str] = [
+            rel_key
+            for rel_key in _COSMOS_BLOCK_FP8_LINEAR_KEYS
+            if rel_key in selected_rel_keys
+        ]
+        if has_all_self_qkv and fused_key in out:
+            rel_keys.append(_COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY)
+
+        for rel_key in rel_keys:
+            key = prefix + rel_key
+            if rel_key in qkv_rel_keys and key not in out and fused_ready:
+                continue
+            scale_key = scale_key_for_weight(key)
+            if key not in out or scale_key not in out:
+                if include_missing:
+                    continue
+                missing = key if key not in out else scale_key
+                raise KeyError(f"missing Cosmos FP8 tensor for prepared alias: {missing!r}")
+
+            weight = out[key]
+            scale = out[scale_key]
+            if not isinstance(weight, torch.Tensor) or weight.dtype != torch.uint8:
+                raise ValueError(f"{key} must be torch.uint8 raw E4M3 bytes for FP8 prepared aliases")
+            if not isinstance(scale, torch.Tensor):
+                raise ValueError(f"{scale_key} must be a tensor for FP8 prepared aliases")
+            if scale.dim() != 1 or scale.numel() != weight.shape[0]:
+                raise ValueError(
+                    f"{scale_key} must have shape [{weight.shape[0]}], got {tuple(scale.shape)}"
+                )
+
+            out[fp8_prepared_weight_key(key)] = weight.contiguous()
+            out[fp8_prepared_scale_key(key)] = scale.contiguous()
+
+    return out
+
+
+def prepare_cosmos_quantized_streaming_weights(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    device: Optional[torch.device | str] = None,
+    include_missing: bool = False,
+    fuse_self_attn_qkv: bool = True,
+    drop_split_self_attn_qkv: Optional[bool] = None,
+    linear_policy: str = "all",
+    custom_linear_groups: Optional[Sequence[str] | str] = None,
+    add_fp8_prepared: bool = True,
+    validate: bool = True,
+) -> Dict[str, torch.Tensor]:
+    """Prepare Cosmos streaming weights and quantized FP8 artifacts together.
+
+    This composes the BF16 streaming preparation from ``common.cosmos_weights``
+    with the FP8 quantization contract in this module. The result contains the
+    existing BF16 ``.weight_prepared`` tensors plus opt-in FP8 prepared aliases
+    that can be selected by ``cosmos_quantized_prepared=True`` at runtime.
+
+    By default, the prepared artifact drops split self-attention Q/K/V FP8
+    tensors whenever fused self-QKV is available. The streaming runtime consumes
+    the fused tensor directly, so keeping both layouts only increases artifact
+    size. Pass ``drop_split_self_attn_qkv=False`` to retain split FP8 Q/K/V
+    fallback tensors.
+    """
+
+    from cosmos_weights import prepare_cosmos_streaming_weights
+
+    selected_rel_keys = set(
+        resolve_cosmos_fp8_linear_policy(
+            linear_policy,
+            custom_groups=custom_linear_groups,
+        )
+    )
+    has_all_self_qkv = set(_COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS).issubset(selected_rel_keys)
+    if drop_split_self_attn_qkv is None:
+        drop_split_self_attn_qkv = fuse_self_attn_qkv and has_all_self_qkv
+
+    prepared_bf16 = prepare_cosmos_streaming_weights(weights)
+    quantized = quantize_cosmos_fp8_weights(
+        prepared_bf16,
+        num_blocks=num_blocks,
+        device=device,
+        include_missing=include_missing,
+        fuse_self_attn_qkv=fuse_self_attn_qkv,
+        drop_split_self_attn_qkv=drop_split_self_attn_qkv,
+        linear_policy=linear_policy,
+        custom_linear_groups=custom_linear_groups,
+    )
+    if add_fp8_prepared:
+        quantized = add_cosmos_fp8_prepared_aliases(
+            quantized,
+            num_blocks=num_blocks,
+            include_missing=include_missing,
+            linear_policy=linear_policy,
+            custom_linear_groups=custom_linear_groups,
+        )
+    if device is not None:
+        target_device = torch.device(device)
+        quantized = {
+            key: value.to(device=target_device).contiguous()
+            if isinstance(value, torch.Tensor)
+            else value
+            for key, value in quantized.items()
+        }
+    else:
+        quantized = {
+            key: value.contiguous() if isinstance(value, torch.Tensor) else value
+            for key, value in quantized.items()
+        }
+    if validate:
+        assert_cosmos_fp8_ready(
+            quantized,
+            num_blocks=num_blocks,
+            linear_policy=linear_policy,
+            custom_linear_groups=custom_linear_groups,
+        )
+        if add_fp8_prepared:
+            assert_cosmos_fp8_prepared_ready(
+                quantized,
+                num_blocks=num_blocks,
+                linear_policy=linear_policy,
+                custom_linear_groups=custom_linear_groups,
+            )
+    return quantized
+
+
+def missing_cosmos_fp8_keys(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    linear_policy: str = "all",
+    custom_linear_groups: Optional[Sequence[str] | str] = None,
+) -> Tuple[str, ...]:
+    missing = []
+    selected_rel_keys = set(
+        resolve_cosmos_fp8_linear_policy(
+            linear_policy,
+            custom_groups=custom_linear_groups,
+        )
+    )
+    split_qkv_rel_keys = set(_COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS)
+    has_all_self_qkv = split_qkv_rel_keys.issubset(selected_rel_keys)
+    for block_idx in range(num_blocks):
+        prefix = f"blocks.{block_idx}."
+        fused_key = prefix + _COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY
+        fused_scale_key = scale_key_for_weight(fused_key)
+        fused_weight = weights.get(fused_key)
+        fused_scale = weights.get(fused_scale_key)
+        fused_qkv_ready = (
+            isinstance(fused_weight, torch.Tensor)
+            and fused_weight.dtype == torch.uint8
+            and isinstance(fused_scale, torch.Tensor)
+        )
+        if has_all_self_qkv and fused_key in weights and not fused_qkv_ready:
+            if not isinstance(fused_weight, torch.Tensor) or fused_weight.dtype != torch.uint8:
+                missing.append(fused_key)
+            if not isinstance(fused_scale, torch.Tensor):
+                missing.append(fused_scale_key)
+        for rel_key in _COSMOS_BLOCK_FP8_LINEAR_KEYS:
+            if rel_key not in selected_rel_keys:
+                continue
+            if rel_key in split_qkv_rel_keys and fused_qkv_ready:
+                continue
+            key = prefix + rel_key
+            scale_key = scale_key_for_weight(key)
+            if key not in weights:
+                missing.append(key)
+            elif weights[key].dtype != torch.uint8:
+                missing.append(key)
+            if scale_key not in weights:
+                missing.append(scale_key)
+    return tuple(missing)
+
+
+def missing_cosmos_fp8_prepared_keys(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    linear_policy: str = "all",
+    custom_linear_groups: Optional[Sequence[str] | str] = None,
+) -> Tuple[str, ...]:
+    missing = list(
+        missing_cosmos_fp8_keys(
+            weights,
+            num_blocks=num_blocks,
+            linear_policy=linear_policy,
+            custom_linear_groups=custom_linear_groups,
+        )
+    )
+    selected_rel_keys = set(
+        resolve_cosmos_fp8_linear_policy(
+            linear_policy,
+            custom_groups=custom_linear_groups,
+        )
+    )
+    qkv_rel_keys = set(_COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS)
+    has_all_self_qkv = qkv_rel_keys.issubset(selected_rel_keys)
+
+    for block_idx in range(num_blocks):
+        prefix = f"blocks.{block_idx}."
+        fused_key = prefix + _COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY
+        fused_prepared_weight_key = fp8_prepared_weight_key(fused_key)
+        fused_prepared_scale_key = fp8_prepared_scale_key(fused_key)
+        fused_prepared_ready = (
+            isinstance(weights.get(fused_key), torch.Tensor)
+            and weights[fused_key].dtype == torch.uint8
+            and isinstance(weights.get(scale_key_for_weight(fused_key)), torch.Tensor)
+            and isinstance(weights.get(fused_prepared_weight_key), torch.Tensor)
+            and weights[fused_prepared_weight_key].dtype == torch.uint8
+            and isinstance(weights.get(fused_prepared_scale_key), torch.Tensor)
+        )
+
+        rel_keys: list[str] = [
+            rel_key
+            for rel_key in _COSMOS_BLOCK_FP8_LINEAR_KEYS
+            if rel_key in selected_rel_keys
+        ]
+        if has_all_self_qkv and fused_key in weights:
+            rel_keys.append(_COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY)
+
+        for rel_key in rel_keys:
+            key = prefix + rel_key
+            if rel_key in qkv_rel_keys and key not in weights and fused_prepared_ready:
+                continue
+            weight = weights.get(key)
+            if not isinstance(weight, torch.Tensor) or weight.dtype != torch.uint8:
+                continue
+
+            prepared_weight_key = fp8_prepared_weight_key(key)
+            prepared_scale_key = fp8_prepared_scale_key(key)
+            prepared_weight = weights.get(prepared_weight_key)
+            prepared_scale = weights.get(prepared_scale_key)
+            if not isinstance(prepared_weight, torch.Tensor) or prepared_weight.dtype != torch.uint8:
+                missing.append(prepared_weight_key)
+            elif prepared_weight.shape != weight.shape or not prepared_weight.is_contiguous():
+                missing.append(prepared_weight_key)
+            if not isinstance(prepared_scale, torch.Tensor):
+                missing.append(prepared_scale_key)
+            else:
+                scale_key = scale_key_for_weight(key)
+                scale = weights.get(scale_key)
+                if isinstance(scale, torch.Tensor) and (
+                    prepared_scale.shape != scale.shape or not prepared_scale.is_contiguous()
+                ):
+                    missing.append(prepared_scale_key)
+
+    return tuple(dict.fromkeys(missing))
+
+
+def assert_cosmos_fp8_ready(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    linear_policy: str = "all",
+    custom_linear_groups: Optional[Sequence[str] | str] = None,
+) -> None:
+    missing = missing_cosmos_fp8_keys(
+        weights,
+        num_blocks=num_blocks,
+        linear_policy=linear_policy,
+        custom_linear_groups=custom_linear_groups,
+    )
+    if missing:
+        preview = ", ".join(missing[:8])
+        suffix = "" if len(missing) <= 8 else f", ... +{len(missing) - 8} more"
+        raise ValueError(f"Cosmos FP8 weights are incomplete: {preview}{suffix}")
+
+
+def assert_cosmos_fp8_prepared_ready(
+    weights: Mapping[str, torch.Tensor],
+    *,
+    num_blocks: int,
+    linear_policy: str = "all",
+    custom_linear_groups: Optional[Sequence[str] | str] = None,
+) -> None:
+    missing = missing_cosmos_fp8_prepared_keys(
+        weights,
+        num_blocks=num_blocks,
+        linear_policy=linear_policy,
+        custom_linear_groups=custom_linear_groups,
+    )
+    if missing:
+        preview = ", ".join(missing[:8])
+        suffix = "" if len(missing) <= 8 else f", ... +{len(missing) - 8} more"
+        raise ValueError(f"Cosmos FP8 prepared weights are incomplete: {preview}{suffix}")
+
+
+def move_cosmos_fp8_weights_(
+    weights: MutableMapping[str, torch.Tensor],
+    *,
+    device: torch.device | str,
+    keys: Optional[Iterable[str]] = None,
+) -> None:
+    selected = tuple(keys) if keys is not None else tuple(weights.keys())
+    target = torch.device(device)
+    for key in selected:
+        value = weights.get(key)
+        if isinstance(value, torch.Tensor):
+            weights[key] = value.to(device=target).contiguous()

--- a/integrations/omnidreams/omnidreams_singleview/python/cosmos_fp8_utils.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/cosmos_fp8_utils.py
@@ -1,9 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 import torch
-
 
 FP8_MAX_E4M3 = 448.0
 FP8_SCALE_EPS = 1.0e-12
@@ -113,10 +115,14 @@ def _normalize_group_names(groups: Optional[Sequence[str] | str]) -> Tuple[str, 
     else:
         raw = list(groups)
     normalized = tuple(group.strip().lower() for group in raw if group.strip())
-    unknown = tuple(group for group in normalized if group not in _COSMOS_FP8_LINEAR_POLICY_GROUPS)
+    unknown = tuple(
+        group for group in normalized if group not in _COSMOS_FP8_LINEAR_POLICY_GROUPS
+    )
     if unknown:
         valid = ", ".join(cosmos_fp8_linear_policy_groups())
-        raise ValueError(f"unknown Cosmos FP8 linear policy group {unknown[0]!r}; expected one of: {valid}")
+        raise ValueError(
+            f"unknown Cosmos FP8 linear policy group {unknown[0]!r}; expected one of: {valid}"
+        )
     return normalized
 
 
@@ -131,14 +137,18 @@ def resolve_cosmos_fp8_linear_policy(
     if normalized == "custom":
         groups = _normalize_group_names(custom_groups)
         if not groups:
-            raise ValueError("custom Cosmos FP8 linear policy requires at least one group")
+            raise ValueError(
+                "custom Cosmos FP8 linear policy requires at least one group"
+            )
     elif normalized in _COSMOS_FP8_LINEAR_POLICIES:
         if custom_groups is not None:
             raise ValueError("custom_groups is only valid when policy='custom'")
         groups = _COSMOS_FP8_LINEAR_POLICIES[normalized]
     else:
         valid = ", ".join(cosmos_fp8_linear_policies())
-        raise ValueError(f"unknown Cosmos FP8 linear policy {policy!r}; expected one of: {valid}")
+        raise ValueError(
+            f"unknown Cosmos FP8 linear policy {policy!r}; expected one of: {valid}"
+        )
 
     selected: list[str] = []
     for group in groups:
@@ -162,9 +172,13 @@ def quantize_fp8_per_out_channel(
     """
 
     if weight.dim() != 2:
-        raise ValueError(f"linear weight must be 2D [out, in], got {tuple(weight.shape)}")
+        raise ValueError(
+            f"linear weight must be 2D [out, in], got {tuple(weight.shape)}"
+        )
     if not hasattr(torch, "float8_e4m3fn"):
-        raise RuntimeError("torch.float8_e4m3fn is required for Cosmos FP8 quantization")
+        raise RuntimeError(
+            "torch.float8_e4m3fn is required for Cosmos FP8 quantization"
+        )
 
     weight_f32 = weight.detach().to(torch.float32)
     amax = weight_f32.abs().amax(dim=1)
@@ -200,7 +214,10 @@ def fp8_activation_scale(
     elif mode == "calibrated":
         if calibrated_amax is None:
             raise ValueError("calibrated mode requires calibrated_amax")
-        scale = torch.as_tensor(calibrated_amax, device=device, dtype=torch.float32) / FP8_MAX_E4M3
+        scale = (
+            torch.as_tensor(calibrated_amax, device=device, dtype=torch.float32)
+            / FP8_MAX_E4M3
+        )
     elif mode == "static":
         if static_scale is None:
             raise ValueError("static mode requires static_scale")
@@ -226,7 +243,9 @@ def quantize_fp8_activation_per_tensor(
     """Quantize an activation tensor to raw E4M3 bytes with one tensor scale."""
 
     if not hasattr(torch, "float8_e4m3fn"):
-        raise RuntimeError("torch.float8_e4m3fn is required for Cosmos FP8 quantization")
+        raise RuntimeError(
+            "torch.float8_e4m3fn is required for Cosmos FP8 quantization"
+        )
     scale = fp8_activation_scale(
         activation,
         mode=mode,
@@ -244,9 +263,13 @@ def quantize_fp8_activation_per_tensor(
     return q_u8, scale
 
 
-def assert_fp8_scale_shape(scale: torch.Tensor, expected_shape: Tuple[int, ...], *, name: str) -> None:
+def assert_fp8_scale_shape(
+    scale: torch.Tensor, expected_shape: Tuple[int, ...], *, name: str
+) -> None:
     if tuple(scale.shape) != tuple(expected_shape):
-        raise ValueError(f"{name} must have shape {expected_shape}, got {tuple(scale.shape)}")
+        raise ValueError(
+            f"{name} must have shape {expected_shape}, got {tuple(scale.shape)}"
+        )
     if not scale.is_contiguous():
         raise ValueError(f"{name} must be contiguous")
     if not torch.isfinite(scale.float()).all():
@@ -273,7 +296,9 @@ def validate_cosmos_fp8_activation_calibration(
     normalized: Dict[str, torch.Tensor] = {}
     for site in COSMOS_FP8_ACTIVATION_SCALE_SITES:
         if site not in raw_amax:
-            raise ValueError(f"Cosmos FP8 activation calibration is missing site {site!r}")
+            raise ValueError(
+                f"Cosmos FP8 activation calibration is missing site {site!r}"
+            )
         tensor = torch.as_tensor(raw_amax[site], dtype=torch.float32)
         if tensor.shape != (num_blocks,):
             raise ValueError(
@@ -281,9 +306,13 @@ def validate_cosmos_fp8_activation_calibration(
                 f"({num_blocks},), got {tuple(tensor.shape)}"
             )
         if not torch.isfinite(tensor).all():
-            raise ValueError(f"Cosmos FP8 activation calibration site {site!r} must be finite")
+            raise ValueError(
+                f"Cosmos FP8 activation calibration site {site!r} must be finite"
+            )
         if (tensor <= 0).any():
-            raise ValueError(f"Cosmos FP8 activation calibration site {site!r} must be positive")
+            raise ValueError(
+                f"Cosmos FP8 activation calibration site {site!r} must be positive"
+            )
         normalized[site] = tensor.contiguous()
     return normalized
 
@@ -306,7 +335,9 @@ def cosmos_fp8_activation_scale_tensor(
         calibration,
         num_blocks=num_blocks,
     )
-    stacked_amax = torch.stack([normalized[site] for site in COSMOS_FP8_ACTIVATION_SCALE_SITES], dim=1)
+    stacked_amax = torch.stack(
+        [normalized[site] for site in COSMOS_FP8_ACTIVATION_SCALE_SITES], dim=1
+    )
     scales = torch.clamp(stacked_amax / FP8_MAX_E4M3, min=eps)
     if device is not None:
         scales = scales.to(device=device)
@@ -331,7 +362,9 @@ def fuse_cosmos_self_attn_qkv_fp8_weights(
     out: Dict[str, torch.Tensor] = dict(weights)
     for block_idx in range(num_blocks):
         prefix = f"blocks.{block_idx}."
-        split_keys = tuple(prefix + rel_key for rel_key in _COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS)
+        split_keys = tuple(
+            prefix + rel_key for rel_key in _COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS
+        )
         split_scale_keys = tuple(scale_key_for_weight(key) for key in split_keys)
         fused_key = prefix + _COSMOS_BLOCK_FP8_FUSED_SELF_ATTN_QKV_KEY
         fused_scale_key = scale_key_for_weight(fused_key)
@@ -340,12 +373,16 @@ def fuse_cosmos_self_attn_qkv_fp8_weights(
         if missing:
             if include_missing:
                 continue
-            raise KeyError(f"missing Cosmos split QKV FP8 tensors for fusion: {missing[0]!r}")
+            raise KeyError(
+                f"missing Cosmos split QKV FP8 tensors for fusion: {missing[0]!r}"
+            )
 
         q_weight, k_weight, v_weight = (out[key] for key in split_keys)
         q_scale, k_scale, v_scale = (out[key] for key in split_scale_keys)
         out[fused_key] = torch.cat((q_weight, k_weight, v_weight), dim=0).contiguous()
-        out[fused_scale_key] = torch.cat((q_scale, k_scale, v_scale), dim=0).contiguous()
+        out[fused_scale_key] = torch.cat(
+            (q_scale, k_scale, v_scale), dim=0
+        ).contiguous()
 
         if drop_split_self_attn_qkv:
             for key in (*split_keys, *split_scale_keys):
@@ -407,7 +444,9 @@ def quantize_cosmos_fp8_weights(
         if key not in out:
             continue
 
-    has_all_self_qkv = all(rel_key in selected_rel_keys for rel_key in _COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS)
+    has_all_self_qkv = all(
+        rel_key in selected_rel_keys for rel_key in _COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS
+    )
     if fuse_self_attn_qkv and has_all_self_qkv:
         out = fuse_cosmos_self_attn_qkv_fp8_weights(
             out,
@@ -417,7 +456,9 @@ def quantize_cosmos_fp8_weights(
         )
 
     elif drop_split_self_attn_qkv:
-        raise ValueError("drop_split_self_attn_qkv=True requires a policy that quantizes all self-attention Q/K/V weights")
+        raise ValueError(
+            "drop_split_self_attn_qkv=True requires a policy that quantizes all self-attention Q/K/V weights"
+        )
 
     return out
 
@@ -472,14 +513,20 @@ def add_cosmos_fp8_prepared_aliases(
                 if include_missing:
                     continue
                 missing = key if key not in out else scale_key
-                raise KeyError(f"missing Cosmos FP8 tensor for prepared alias: {missing!r}")
+                raise KeyError(
+                    f"missing Cosmos FP8 tensor for prepared alias: {missing!r}"
+                )
 
             weight = out[key]
             scale = out[scale_key]
             if not isinstance(weight, torch.Tensor) or weight.dtype != torch.uint8:
-                raise ValueError(f"{key} must be torch.uint8 raw E4M3 bytes for FP8 prepared aliases")
+                raise ValueError(
+                    f"{key} must be torch.uint8 raw E4M3 bytes for FP8 prepared aliases"
+                )
             if not isinstance(scale, torch.Tensor):
-                raise ValueError(f"{scale_key} must be a tensor for FP8 prepared aliases")
+                raise ValueError(
+                    f"{scale_key} must be a tensor for FP8 prepared aliases"
+                )
             if scale.dim() != 1 or scale.numel() != weight.shape[0]:
                 raise ValueError(
                     f"{scale_key} must have shape [{weight.shape[0]}], got {tuple(scale.shape)}"
@@ -526,7 +573,9 @@ def prepare_cosmos_quantized_streaming_weights(
             custom_groups=custom_linear_groups,
         )
     )
-    has_all_self_qkv = set(_COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS).issubset(selected_rel_keys)
+    has_all_self_qkv = set(_COSMOS_BLOCK_FP8_SELF_ATTN_QKV_KEYS).issubset(
+        selected_rel_keys
+    )
     if drop_split_self_attn_qkv is None:
         drop_split_self_attn_qkv = fuse_self_attn_qkv and has_all_self_qkv
 
@@ -607,7 +656,10 @@ def missing_cosmos_fp8_keys(
             and isinstance(fused_scale, torch.Tensor)
         )
         if has_all_self_qkv and fused_key in weights and not fused_qkv_ready:
-            if not isinstance(fused_weight, torch.Tensor) or fused_weight.dtype != torch.uint8:
+            if (
+                not isinstance(fused_weight, torch.Tensor)
+                or fused_weight.dtype != torch.uint8
+            ):
                 missing.append(fused_key)
             if not isinstance(fused_scale, torch.Tensor):
                 missing.append(fused_scale_key)
@@ -685,9 +737,15 @@ def missing_cosmos_fp8_prepared_keys(
             prepared_scale_key = fp8_prepared_scale_key(key)
             prepared_weight = weights.get(prepared_weight_key)
             prepared_scale = weights.get(prepared_scale_key)
-            if not isinstance(prepared_weight, torch.Tensor) or prepared_weight.dtype != torch.uint8:
+            if (
+                not isinstance(prepared_weight, torch.Tensor)
+                or prepared_weight.dtype != torch.uint8
+            ):
                 missing.append(prepared_weight_key)
-            elif prepared_weight.shape != weight.shape or not prepared_weight.is_contiguous():
+            elif (
+                prepared_weight.shape != weight.shape
+                or not prepared_weight.is_contiguous()
+            ):
                 missing.append(prepared_weight_key)
             if not isinstance(prepared_scale, torch.Tensor):
                 missing.append(prepared_scale_key)
@@ -695,7 +753,8 @@ def missing_cosmos_fp8_prepared_keys(
                 scale_key = scale_key_for_weight(key)
                 scale = weights.get(scale_key)
                 if isinstance(scale, torch.Tensor) and (
-                    prepared_scale.shape != scale.shape or not prepared_scale.is_contiguous()
+                    prepared_scale.shape != scale.shape
+                    or not prepared_scale.is_contiguous()
                 ):
                     missing.append(prepared_scale_key)
 
@@ -737,7 +796,9 @@ def assert_cosmos_fp8_prepared_ready(
     if missing:
         preview = ", ".join(missing[:8])
         suffix = "" if len(missing) <= 8 else f", ... +{len(missing) - 8} more"
-        raise ValueError(f"Cosmos FP8 prepared weights are incomplete: {preview}{suffix}")
+        raise ValueError(
+            f"Cosmos FP8 prepared weights are incomplete: {preview}{suffix}"
+        )
 
 
 def move_cosmos_fp8_weights_(

--- a/integrations/omnidreams/omnidreams_singleview/python/cosmos_fp8_utils.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/cosmos_fp8_utils.py
@@ -3,7 +3,16 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import (
+    Dict,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 import torch
 
@@ -292,14 +301,15 @@ def validate_cosmos_fp8_activation_calibration(
     raw_amax = calibration.get("amax")
     if not isinstance(raw_amax, Mapping):
         raise ValueError("Cosmos FP8 activation calibration requires an 'amax' mapping")
+    raw_amax_map = cast(Mapping[str, object], raw_amax)
 
     normalized: Dict[str, torch.Tensor] = {}
     for site in COSMOS_FP8_ACTIVATION_SCALE_SITES:
-        if site not in raw_amax:
+        if site not in raw_amax_map:
             raise ValueError(
                 f"Cosmos FP8 activation calibration is missing site {site!r}"
             )
-        tensor = torch.as_tensor(raw_amax[site], dtype=torch.float32)
+        tensor = torch.as_tensor(raw_amax_map[site], dtype=torch.float32)
         if tensor.shape != (num_blocks,):
             raise ValueError(
                 f"Cosmos FP8 activation calibration site {site!r} must have shape "

--- a/integrations/omnidreams/omnidreams_singleview/python/cosmos_weights.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/cosmos_weights.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Cosmos streaming weight preparation helpers."""
 
 from __future__ import annotations
@@ -6,7 +9,6 @@ from collections.abc import Mapping
 
 import torch
 from torch import Tensor
-
 
 _PREPARED_SUFFIXES = (
     "self_attn.qkv_proj.weight",
@@ -18,7 +20,9 @@ _PREPARED_SUFFIXES = (
 )
 
 
-def prepare_cosmos_streaming_weights(state_dict: Mapping[str, Tensor]) -> dict[str, Tensor]:
+def prepare_cosmos_streaming_weights(
+    state_dict: Mapping[str, Tensor],
+) -> dict[str, Tensor]:
     """Augment a Cosmos state dict with per-block fused self-attention QKV weights.
 
     Adds ``blocks.{i}.self_attn.qkv_proj.weight`` as

--- a/integrations/omnidreams/omnidreams_singleview/python/cosmos_weights.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/cosmos_weights.py
@@ -1,0 +1,56 @@
+"""Cosmos streaming weight preparation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+from torch import Tensor
+
+
+_PREPARED_SUFFIXES = (
+    "self_attn.qkv_proj.weight",
+    "self_attn.output_proj.weight",
+    "cross_attn.q_proj.weight",
+    "cross_attn.output_proj.weight",
+    "mlp.layer1.weight",
+    "mlp.layer2.weight",
+)
+
+
+def prepare_cosmos_streaming_weights(state_dict: Mapping[str, Tensor]) -> dict[str, Tensor]:
+    """Augment a Cosmos state dict with per-block fused self-attention QKV weights.
+
+    Adds ``blocks.{i}.self_attn.qkv_proj.weight`` as
+    ``cat([q_proj, k_proj, v_proj], dim=0)`` while preserving the original
+    separate Q/K/V keys used by other paths.
+    """
+    weights = dict(state_dict)
+    q_suffix = "self_attn.q_proj.weight"
+    for q_key, q_weight in list(weights.items()):
+        if not q_key.endswith(q_suffix):
+            continue
+
+        prefix = q_key[: -len(q_suffix)]
+        fused_key = prefix + "self_attn.qkv_proj.weight"
+        if fused_key in weights:
+            weights[fused_key] = weights[fused_key].contiguous()
+            continue
+
+        k_key = prefix + "self_attn.k_proj.weight"
+        v_key = prefix + "self_attn.v_proj.weight"
+        if k_key not in weights or v_key not in weights:
+            raise KeyError(f"Missing K/V weights for fused QKV key {fused_key!r}")
+
+        weights[fused_key] = torch.cat(
+            [q_weight, weights[k_key], weights[v_key]], dim=0
+        ).contiguous()
+
+    for key, weight in list(weights.items()):
+        if key.endswith(".weight_prepared"):
+            weights[key] = weight.contiguous()
+            continue
+        if key.endswith(_PREPARED_SUFFIXES):
+            weights[f"{key}_prepared"] = weight.t().contiguous()
+
+    return {k: v.contiguous() for k, v in weights.items()}

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -68,6 +68,11 @@ from torch import Tensor
 
 _LOGGER = logging.getLogger(__name__)
 
+_DEFAULT_SPARGE_TOPK = 0.25
+_DEFAULT_SPARGE_HYBRID_TOPK = 0.10
+_DEFAULT_SPARGE_HYBRID_PERIOD = 2
+_DEFAULT_SPARGE_HYBRID_PHASE = 0
+
 _COSMOS_PREPARED_SUFFIXES = (
     "self_attn.qkv_proj.weight",
     "self_attn.output_proj.weight",
@@ -272,6 +277,8 @@ def _make_cosmos_streaming_workspace(
     device: torch.device | str,
     dtype: torch.dtype = torch.bfloat16,
     use_sage3_fp8_attention: bool = False,
+    use_sparge_attention: bool = False,
+    sparge_topk_ratio: float = 0.25,
 ) -> dict[str, Tensor]:
     """Allocate the caller-owned scratch tensors expected by native_extension.
 
@@ -282,6 +289,10 @@ def _make_cosmos_streaming_workspace(
         raise ValueError("model_channels must be divisible by heads")
     if batch <= 0 or tokens <= 0 or max_attn_tokens <= 0 or num_blocks <= 0:
         raise ValueError("batch, tokens, max_attn_tokens, and num_blocks must be positive")
+    if not 0.0 < sparge_topk_ratio <= 1.0:
+        raise ValueError(
+            f"sparge_topk_ratio must be in (0, 1], got {sparge_topk_ratio}"
+        )
 
     head_dim = model_channels // heads
     linear_scratch_features = max(model_channels, ff, 3 * model_channels)
@@ -321,6 +332,39 @@ def _make_cosmos_streaming_workspace(
         "attn_v_bhdm_fp8": (batch, heads, head_dim, max_attn_tokens),
         "attn_probs_fp8": singleton,
     }
+    if use_sparge_attention:
+        if head_dim != 128:
+            raise ValueError(f"Sparge requires head_dim=128, got {head_dim}")
+        blkq, blkk = 128, 64
+        num_q_blocks = (tokens + blkq - 1) // blkq
+        num_k_blocks = (max_attn_tokens + blkk - 1) // blkk
+        topk = max(1, min(num_k_blocks, int(sparge_topk_ratio * num_k_blocks)))
+        padded_q_len = num_q_blocks * blkq
+        padded_k_len = num_k_blocks * blkk
+        padded_kv_len = ((max_attn_tokens + 127) // 128) * 128
+        sparge_workspace_bytes = 0
+        sparge_workspace_bytes += heads * num_q_blocks * head_dim * 2
+        sparge_workspace_bytes += heads * num_k_blocks * head_dim * 2
+        sparge_workspace_bytes += heads * num_q_blocks * num_k_blocks * 4
+        sparge_workspace_bytes += heads * num_q_blocks * num_k_blocks * 4
+        sparge_workspace_bytes += heads * num_q_blocks * num_k_blocks * 4
+        sparge_workspace_bytes += heads * num_q_blocks * 4
+        sparge_workspace_bytes += heads * num_q_blocks * topk * 4
+        sparge_workspace_bytes += heads * padded_q_len * head_dim
+        sparge_workspace_bytes += heads * padded_k_len * head_dim
+        sparge_workspace_bytes += heads * num_q_blocks * 4
+        sparge_workspace_bytes += heads * num_k_blocks * 4
+        sparge_workspace_bytes += heads * head_dim * padded_kv_len
+        sparge_workspace_bytes += heads * head_dim * 4
+        sparge_workspace_bytes += heads * padded_q_len * head_dim * 2
+        sparge_workspace_bytes += heads * tokens * head_dim * 2
+        sparge_workspace_bytes += heads * max_attn_tokens * head_dim * 2
+        sparge_workspace_bytes += heads * head_dim * head_dim * 2
+        sparge_workspace_bytes += heads * head_dim * 2
+        sparge_workspace_bytes += heads * tokens * head_dim * 2
+        sparge_workspace_bytes += heads * tokens * head_dim * 2
+        u8_specs = dict(u8_specs)
+        u8_specs["sparge_workspace"] = (sparge_workspace_bytes,)
     fp8_specs: Mapping[str, tuple[int, ...]] = {}
     if use_sage3_fp8_attention:
         sage3_q_tokens = ((tokens + 127) // 128) * 128
@@ -569,6 +613,9 @@ class OptimizedDiTExecutor:
         *,
         dit_backend: str = "fp8_kvcache_cudnn",
         attention_backend: str = "auto",
+        sparge_topk: float | None = None,
+        sparge_hybrid_period: int | None = None,
+        sparge_hybrid_phase: int | None = None,
     ) -> None:
         self.transformer = transformer
         self.config = transformer.config
@@ -619,14 +666,40 @@ class OptimizedDiTExecutor:
             "adaln_lora_dim": net_cfg.adaln_lora_dim,
             "timestep_scale": float(net_cfg.timestep_scale),
         }
-        requested_attention_backend = (attention_backend or "auto").strip().lower()
-        self._attention_backend = self._resolve_attention_backend(
-            requested_attention_backend
-        )
+        self._requested_attention_backend = (attention_backend or "auto").strip().lower()
+        if self._requested_attention_backend not in {"auto", "cudnn", "sparge", "sage3", "sage3_fp8"}:
+            raise ValueError(
+                "--native-attention-backend must be 'auto', 'cudnn', "
+                f"'sparge', 'sage3', or 'sage3_fp8' (got {self._requested_attention_backend!r})"
+            )
+        self._requested_sparge_topk = sparge_topk
+        self._requested_sparge_hybrid_period = sparge_hybrid_period
+        self._requested_sparge_hybrid_phase = sparge_hybrid_phase
+        if sparge_topk is not None and not 0.0 < float(sparge_topk) <= 1.0:
+            raise ValueError(
+                f"native_dit_sparge_topk must be in (0, 1], got {float(sparge_topk)}"
+            )
+        if sparge_hybrid_period is not None and int(sparge_hybrid_period) < 0:
+            raise ValueError(
+                "native_dit_sparge_hybrid_period must be non-negative, "
+                f"got {int(sparge_hybrid_period)}"
+            )
+        if sparge_hybrid_phase is not None and int(sparge_hybrid_phase) < 0:
+            raise ValueError(
+                "native_dit_sparge_hybrid_phase must be non-negative, "
+                f"got {int(sparge_hybrid_phase)}"
+            )
+        self._attention_backend = "cudnn"
+        self._attention_backend_device: torch.device | None = None
+        self._sparge_topk = _DEFAULT_SPARGE_TOPK
+        self._sparge_hybrid_period = 0
+        self._sparge_hybrid_phase = 0
 
         self._optimized_weights: dict[str, Tensor] | None = None
         self._bf16_runtime: dict[str, Any] | None = None
         self._fp8_runtime: dict[str, Any] | None = None
+        self._bf16_runtime_device: torch.device | None = None
+        self._fp8_runtime_device: torch.device | None = None
         self._optimized_invariant_cache: dict[tuple[Any, ...], _CosmosInvariantTensors] = {}
         self._optimized_rope_cache: dict[tuple[Any, ...], tuple[Tensor, Tensor]] = {}
         self._optimized_rope_freqs_cache: dict[tuple[Any, ...], Tensor] = {}
@@ -666,7 +739,27 @@ class OptimizedDiTExecutor:
     def _select_mask(self, cache: CosmosTransformerCache) -> Tensor:
         return self.transformer._select_mask(cache)
 
-    def _sage3_status(self) -> tuple[bool, str]:
+    def _cuda_device_index(self, device: torch.device | int | None) -> tuple[int | None, str]:
+        if not torch.cuda.is_available():
+            return None, "CUDA is unavailable"
+        if isinstance(device, int):
+            return device, ""
+        if device is None:
+            try:
+                return int(torch.cuda.current_device()), ""
+            except Exception as e:
+                return None, f"torch.cuda.current_device() failed: {e}"
+        device = torch.device(device)
+        if device.type != "cuda":
+            return None, f"device {device} is not a CUDA device"
+        if device.index is None:
+            try:
+                return int(torch.cuda.current_device()), ""
+            except Exception as e:
+                return None, f"torch.cuda.current_device() failed: {e}"
+        return int(device.index), ""
+
+    def _sage3_status(self, device: torch.device | int | None = None) -> tuple[bool, str]:
         if sys.platform == "win32":
             return False, "Sage3 is not supported on Windows"
         built_fn = getattr(self._native_extension, "sage3_is_built", None)
@@ -678,35 +771,93 @@ class OptimizedDiTExecutor:
                 return False, "native_extension was built with Sage3 stubs"
         except Exception as e:
             return False, f"native_extension.sage3_is_built() failed: {e}"
-        if not torch.cuda.is_available():
-            return False, "CUDA is unavailable"
+        device_index, reason = self._cuda_device_index(device)
+        if device_index is None:
+            return False, reason
         try:
-            device = torch.cuda.current_device()
-        except Exception as e:
-            return False, f"torch.cuda.current_device() failed: {e}"
-        try:
-            if not bool(supported_fn(device)):
-                return False, "the active CUDA device is not enabled for Sage3"
+            if not bool(supported_fn(device_index)):
+                return False, f"CUDA device {device_index} is not enabled for Sage3"
         except Exception as e:
             return False, f"native_extension.sage3_is_runtime_supported() failed: {e}"
         return True, ""
 
+    def _sparge_status(self, device: torch.device | int | None = None) -> tuple[bool, str]:
+        if sys.platform == "win32":
+            return False, "Sparge is not supported on Windows"
+        built_fn = getattr(self._native_extension, "sparge_is_built", None)
+        supported_fn = getattr(self._native_extension, "sparge_is_runtime_supported", None)
+        if built_fn is None or supported_fn is None:
+            return False, "native_extension does not expose Sparge availability probes"
+        try:
+            if not bool(built_fn()):
+                return False, "native_extension was built without Sparge"
+        except Exception as e:
+            return False, f"native_extension.sparge_is_built() failed: {e}"
+        device_index, reason = self._cuda_device_index(device)
+        if device_index is None:
+            return False, reason
+        try:
+            if not bool(supported_fn(device_index)):
+                return False, f"CUDA device {device_index} is not enabled for Sparge"
+        except Exception as e:
+            return False, f"native_extension.sparge_is_runtime_supported() failed: {e}"
+        return True, ""
+
+    def _resolve_sparge_options(self) -> tuple[float, int, int]:
+        hybrid_default = (
+            self._uses_fp8_dit and self._requested_attention_backend == "auto"
+        )
+        period = (
+            _DEFAULT_SPARGE_HYBRID_PERIOD
+            if self._requested_sparge_hybrid_period is None and hybrid_default
+            else int(self._requested_sparge_hybrid_period or 0)
+        )
+        if 0 < period <= 1:
+            period = 0
+        topk = (
+            (_DEFAULT_SPARGE_HYBRID_TOPK if period > 0 else _DEFAULT_SPARGE_TOPK)
+            if self._requested_sparge_topk is None
+            else float(self._requested_sparge_topk)
+        )
+        phase = (
+            _DEFAULT_SPARGE_HYBRID_PHASE
+            if self._requested_sparge_hybrid_phase is None
+            else int(self._requested_sparge_hybrid_phase)
+        )
+        return topk, period, phase
+
     def _resolve_attention_backend(
         self,
         requested: str,
-    ) -> str:
+        *,
+        sparge_hybrid_period: int = 0,
+        device: torch.device | int | None = None,
+    ) -> tuple[str, bool]:
         requested = (requested or "auto").strip().lower()
-        if requested not in {"auto", "cudnn", "sage3", "sage3_fp8"}:
+        if requested not in {"auto", "cudnn", "sparge", "sage3", "sage3_fp8"}:
             raise ValueError(
                 "--native-attention-backend must be 'auto', 'cudnn', "
-                f"'sage3', or 'sage3_fp8' (got {requested!r})"
+                f"'sparge', 'sage3', or 'sage3_fp8' (got {requested!r})"
             )
 
-        sage3_available, sage3_reason = self._sage3_status()
+        sage3_available, sage3_reason = self._sage3_status(device)
+        sparge_available, sparge_reason = self._sparge_status(device)
+        head_dim = self.config.network.model_channels // self.config.network.num_heads
+        sparge_supported = head_dim == 128
         if requested == "auto":
+            if self._uses_fp8_dit and sparge_hybrid_period > 0:
+                if sage3_available and sparge_available and sparge_supported:
+                    return "sparge", True
+                if sage3_available:
+                    return "sage3_fp8", False
+                if sparge_available and sparge_supported:
+                    return "sparge", False
+                return "cudnn", False
+            if sparge_available and sparge_supported:
+                return "sparge", False
             if sage3_available:
-                return "sage3_fp8" if self._uses_fp8_dit else "sage3"
-            return "cudnn"
+                return ("sage3_fp8" if self._uses_fp8_dit else "sage3"), False
+            return "cudnn", False
 
         if requested == "sage3_fp8" and not self._uses_fp8_dit:
             raise ValueError(
@@ -724,7 +875,57 @@ class OptimizedDiTExecutor:
                 f"but {sage3_reason}. Use --native-attention-backend=cudnn "
                 "for the portable cuDNN attention path."
             )
-        return requested
+        if requested == "sparge" and not sparge_available:
+            raise ValueError(
+                f"--native-attention-backend=sparge requested Sparge, "
+                f"but {sparge_reason}. Use --native-attention-backend=cudnn "
+                "for the portable cuDNN attention path."
+            )
+        if requested == "sparge" and not sparge_supported:
+            raise ValueError(
+                "--native-attention-backend=sparge requires head_dim=128, "
+                f"got {head_dim}"
+            )
+        if requested == "sparge" and sparge_hybrid_period > 1 and not sage3_available:
+            raise ValueError(
+                "Sparge hybrid scheduling requires SageAttention-3 for the "
+                f"non-Sparge blocks, but {sage3_reason}. Set "
+                "native_dit_sparge_hybrid_period=0 for pure Sparge or use "
+                "--native-attention-backend=cudnn for the portable cuDNN "
+                "attention path."
+            )
+        return requested, requested == "sparge" and sparge_hybrid_period > 1
+
+    def _resolve_runtime_attention_backend(self, device: torch.device | int) -> None:
+        device_key = torch.device(device)
+        if self._attention_backend_device == device_key:
+            return
+        sparge_topk, sparge_hybrid_period, sparge_hybrid_phase = self._resolve_sparge_options()
+        attention_backend, sparge_hybrid_enabled = self._resolve_attention_backend(
+            self._requested_attention_backend,
+            sparge_hybrid_period=sparge_hybrid_period,
+            device=device_key,
+        )
+        if self._requested_attention_backend == "auto" and not sparge_hybrid_enabled:
+            sparge_hybrid_period = 0
+            if self._requested_sparge_topk is None and attention_backend == "sparge":
+                sparge_topk = _DEFAULT_SPARGE_TOPK
+        if sparge_hybrid_period and (
+            attention_backend != "sparge" or not self._uses_fp8_dit
+        ):
+            raise ValueError(
+                "Sparge hybrid scheduling requires attention_backend='sparge' "
+                "with the fp8_kvcache_cudnn optimized native DiT backend"
+            )
+        self._attention_backend = attention_backend
+        self._attention_backend_device = device_key
+        self._sparge_topk = sparge_topk
+        self._sparge_hybrid_period = sparge_hybrid_period
+        self._sparge_hybrid_phase = (
+            sparge_hybrid_phase % sparge_hybrid_period
+            if sparge_hybrid_period
+            else 0
+        )
 
     def after_initialize_autoregressive_cache(
         self,
@@ -736,6 +937,9 @@ class OptimizedDiTExecutor:
         self._capture_network_cache_templates(cache)
         self._bf16_runtime = None
         self._fp8_runtime = None
+        self._bf16_runtime_device = None
+        self._fp8_runtime_device = None
+        self._attention_backend_device = None
         self._optimized_invariant_cache.clear()
         self._optimized_rope_cache.clear()
         self._optimized_rope_freqs_cache.clear()
@@ -846,8 +1050,12 @@ class OptimizedDiTExecutor:
     ) -> dict[str, Any]:
         if not self._uses_fp8_dit:
             return {}
-        if self._fp8_runtime is not None:
+        device = k_self[0].device
+        self._resolve_runtime_attention_backend(device)
+        if self._fp8_runtime is not None and self._fp8_runtime_device == device:
             return self._fp8_runtime
+        self._fp8_runtime = None
+        self._fp8_runtime_device = None
         if not hasattr(torch, "float8_e4m3fn"):
             raise RuntimeError("torch.float8_e4m3fn is required for fp8_kvcache_cudnn")
 
@@ -860,8 +1068,14 @@ class OptimizedDiTExecutor:
             *(int(t.size(1)) for t in k_cross),
             *(int(t.size(1)) for t in k_self),
         )
-        device = k_self[0].device
-        use_sage3_fp8_attention = self._attention_backend == "sage3_fp8"
+        use_sparge_hybrid = (
+            self._attention_backend == "sparge"
+            and self._sparge_hybrid_period > 0
+        )
+        use_sage3_fp8_attention = (
+            self._attention_backend == "sage3_fp8" or use_sparge_hybrid
+        )
+        use_sparge_attention = self._attention_backend == "sparge"
         workspace = _make_cosmos_streaming_workspace(
             batch=int(k_self[0].size(0)),
             tokens=tokens,
@@ -874,16 +1088,22 @@ class OptimizedDiTExecutor:
             device=device,
             dtype=torch.bfloat16,
             use_sage3_fp8_attention=use_sage3_fp8_attention,
+            use_sparge_attention=use_sparge_attention,
+            sparge_topk_ratio=self._sparge_topk,
         )
 
         cfg: dict[str, Any] = {
             "cosmos_linear_backend": "fp8",
             "cosmos_attention_backend": (
-                self._attention_backend if use_sage3_fp8_attention
+                self._attention_backend if (use_sage3_fp8_attention or use_sparge_attention)
                 else "fp8_cudnn"
             ),
             "cosmos_kv_cache_backend": "fp8",
-            "cosmos_write_bf16_kv_cache": False,
+            "cosmos_write_bf16_kv_cache": use_sparge_attention,
+            "cosmos_sparge_topk_ratio": self._sparge_topk,
+            "cosmos_sparge_hybrid_period": self._sparge_hybrid_period,
+            "cosmos_sparge_hybrid_phase": self._sparge_hybrid_phase,
+            "cosmos_sparge_attention_sink": True,
             "cosmos_quantized_prepared": True,
             "cosmos_quantized_prepared_strict": True,
             "cosmos_workspace": workspace,
@@ -964,6 +1184,7 @@ class OptimizedDiTExecutor:
                 ],
             })
         self._fp8_runtime = cfg
+        self._fp8_runtime_device = device
         self._release_network_after_fp8_snapshot()
         return cfg
 
@@ -976,8 +1197,12 @@ class OptimizedDiTExecutor:
     ) -> dict[str, Any]:
         if self._uses_fp8_dit:
             return {}
-        if self._bf16_runtime is not None:
+        device = k_self[0].device
+        self._resolve_runtime_attention_backend(device)
+        if self._bf16_runtime is not None and self._bf16_runtime_device == device:
             return self._bf16_runtime
+        self._bf16_runtime = None
+        self._bf16_runtime_device = None
 
         heads = self.config.network.num_heads
         model_channels = self.config.network.model_channels
@@ -988,7 +1213,6 @@ class OptimizedDiTExecutor:
             *(int(t.size(1)) for t in k_cross),
             *(int(t.size(1)) for t in k_self),
         )
-        device = k_self[0].device
         workspace = _make_cosmos_streaming_workspace(
             batch=int(k_self[0].size(0)),
             tokens=tokens,
@@ -1000,13 +1224,19 @@ class OptimizedDiTExecutor:
             lora_dim=lora_dim,
             device=device,
             dtype=torch.bfloat16,
+            use_sparge_attention=self._attention_backend == "sparge",
+            sparge_topk_ratio=self._sparge_topk,
         )
         self._bf16_runtime = {
             "cosmos_workspace": workspace,
             "cosmos_attn_tc_scale_is_ones": True,
         }
-        if self._attention_backend == "sage3":
+        if self._attention_backend in {"sage3", "sparge"}:
             self._bf16_runtime["cosmos_attention_backend"] = self._attention_backend
+        if self._attention_backend == "sparge":
+            self._bf16_runtime["cosmos_sparge_topk_ratio"] = self._sparge_topk
+            self._bf16_runtime["cosmos_sparge_attention_sink"] = True
+        self._bf16_runtime_device = device
         return self._bf16_runtime
 
     def _roll_fp8_self_caches_if_needed(

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -1,0 +1,1497 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""native-accelerated drop-in for ``CosmosTransformer``.
+
+Subclasses ``CosmosTransformer`` and overrides ``predict_flow`` to run
+the per-step DiT forward through ``native_extension.optimized_dit_forward``
+(C++/CUDA) instead of the upstream PyTorch network. The mask
+injection (first-frame image latent at AR step 0) and the AR cache
+state machine are inherited from the parent. The scheduler loop
+(``FlowMatchScheduler.sample``) and noise/denoise math are owned by
+the diffusion infra and stay unchanged.
+
+Streaming-cache lifecycle. ``native_extension.optimized_dit_forward``
+writes per-layer self-attn K/V in-place at ``self_attn_write_start``
+but does NOT call the cache's ``before_update`` / ``after_update``
+(the upstream ``net.forward(eager_mode=True)`` does). We wrap the C++
+call so the ``BlockKVCache`` state machine evolves the same way:
+
+  * before_update(chunk_idx) -> compute write_start -> C++ call ->
+    after_update(chunk_idx)
+
+For the multi-step scheduler loop (one call per denoising step plus
+one finalize call) this is correct because
+``BlockKVCache.before_update`` is a no-op when
+``chunk_idx == _prev_chunk_idx``: only the first call per AR step
+advances the cursor; subsequent calls overwrite the rightmost slot
+with refined K/V from a less-noisy x0.
+
+Memory. We snapshot ``self.network.state_dict()`` lazily on the first
+``predict_flow`` call to hand to the C++ side. Lazy because
+``nn.Module.to(device)`` (called by the framework AFTER ``__init__``)
+replaces parameter storage; snapshotting earlier would capture stale
+CPU references. The dict holds parameter references (not copies), so
+memory cost is negligible above what the parent already holds.
+``update_parameters_after_loading_checkpoint`` (the fuse ops -- bake
+the padding-mask channel out of ``x_embedder`` and reshape
+``final_layer.linear.weight`` into the post-shuffle layout) has
+already run by then (parent's __init__ calls it before returning).
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import math
+import os
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from flashdreams.core.distributed.context_parallel import (
+    cat_outputs_cp,
+    split_inputs_cp,
+)
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper
+from omnidreams.transformer import (
+    CosmosTransformer,
+    CosmosTransformerCache,
+    CosmosTransformerConfig,
+)
+from omnidreams.transformer.impl.network import CosmosDiTNetworkCache
+from torch import Tensor
+
+_LOGGER = logging.getLogger(__name__)
+
+_COSMOS_PREPARED_SUFFIXES = (
+    "self_attn.qkv_proj.weight",
+    "self_attn.output_proj.weight",
+    "cross_attn.q_proj.weight",
+    "cross_attn.output_proj.weight",
+    "mlp.layer1.weight",
+    "mlp.layer2.weight",
+)
+
+
+@dataclass
+class _CosmosInvariantTensors:
+    t_emb: Tensor
+    t_emb_silu: Tensor
+    adaln_lora: Tensor
+    final_shift: Tensor
+    final_scale: Tensor
+    block_mods_sa: Tensor
+    block_mods_ca: Tensor
+    block_mods_mlp: Tensor
+
+
+@dataclass
+class _CosmosCacheTensorLists:
+    k_cross: list[Tensor]
+    v_cross: list[Tensor]
+    k_self: list[Tensor]
+    v_self: list[Tensor]
+
+
+def _clone_block_kv_cache(cache: Any) -> Any:
+    cloned = type(cache)(
+        k_shape=tuple(cache.k_shape),
+        v_shape=tuple(cache.v_shape),
+        seq_dim=cache.seq_dim,
+        chunk_size=cache.chunk_size,
+        window_size=cache.window_size,
+        sink_size=cache.sink_size,
+        device=cache._k.device,
+        dtype=cache._k.dtype,
+    )
+    cloned._prev_chunk_idx = cache._prev_chunk_idx
+    cloned._curr_chunk_idx = cache._curr_chunk_idx
+    cloned._n_cached = cache._n_cached
+    cloned._k.copy_(cache._k)
+    cloned._v.copy_(cache._v)
+    return cloned
+
+
+def _clone_network_cache(cache: CosmosDiTNetworkCache) -> CosmosDiTNetworkCache:
+    return CosmosDiTNetworkCache(
+        block_caches=[
+            type(block)(
+                self_attn=_clone_block_kv_cache(block.self_attn),
+                cross_attn=_clone_block_kv_cache(block.cross_attn),
+            )
+            for block in cache.block_caches
+        ]
+    )
+
+
+def _cosmos_sinusoidal_emb(ts: Tensor, num_channels: int) -> Tensor:
+    half = num_channels // 2
+    freqs = torch.exp(
+        -math.log(10000.0)
+        * torch.arange(half, dtype=torch.float32, device=ts.device)
+        / float(half)
+    )
+    angles = ts.to(torch.float32).reshape(-1, 1) * freqs.reshape(1, -1)
+    return torch.cat((torch.cos(angles), torch.sin(angles)), dim=-1)
+
+
+def _make_cosmos_timestep_cache(
+    timesteps: Tensor,
+    weights: Mapping[str, Tensor],
+    *,
+    model_channels: int,
+    timestep_scale: float,
+    dtype: torch.dtype,
+) -> tuple[Tensor, Tensor, Tensor]:
+    t_sin = _cosmos_sinusoidal_emb(
+        timesteps.to(torch.float32) * timestep_scale,
+        model_channels,
+    ).to(dtype)
+    w_t1 = weights["t_embedder.1.linear_1.weight"].to(
+        device=timesteps.device, dtype=dtype
+    )
+    w_t2 = weights["t_embedder.1.linear_2.weight"].to(
+        device=timesteps.device, dtype=dtype
+    )
+    t_h = F.silu(t_sin @ w_t1.t())
+    adaln_lora = (t_h @ w_t2.t()).contiguous()
+
+    gamma = weights["t_embedding_norm.weight"].to(
+        device=timesteps.device, dtype=torch.float32
+    )
+    xf = t_sin.to(torch.float32)
+    inv = torch.rsqrt(xf.pow(2).mean(dim=-1, keepdim=True) + 1.0e-6)
+    t_emb = (xf * inv * gamma).to(dtype).contiguous()
+    t_emb_silu = F.silu(t_emb).to(dtype).contiguous()
+    return t_emb, t_emb_silu, adaln_lora
+
+
+def _make_cosmos_final_mod_cache(
+    t_emb: Tensor,
+    adaln_lora: Tensor,
+    weights: Mapping[str, Tensor],
+    *,
+    model_channels: int,
+    dtype: torch.dtype,
+) -> tuple[Tensor, Tensor]:
+    fl_down = weights["final_layer.adaln_modulation.1.weight"].to(
+        device=t_emb.device, dtype=dtype
+    )
+    fl_up = weights["final_layer.adaln_modulation.2.weight"].to(
+        device=t_emb.device, dtype=dtype
+    )
+    fl_mods = (F.silu(t_emb).to(dtype) @ fl_down.t()) @ fl_up.t()
+    fl_mods = fl_mods + adaln_lora[:, : 2 * model_channels]
+    shift, scale = fl_mods.split(model_channels, dim=-1)
+    return shift.contiguous(), scale.contiguous()
+
+
+def _make_cosmos_block_mod_cache(
+    t_emb_silu: Tensor,
+    adaln_lora: Tensor,
+    weights: Mapping[str, Tensor],
+    *,
+    num_blocks: int,
+    model_channels: int,
+    dtype: torch.dtype,
+) -> tuple[Tensor, Tensor, Tensor]:
+    device = t_emb_silu.device
+    t = t_emb_silu.to(dtype=dtype)
+    lora = adaln_lora.to(device=device, dtype=dtype)
+
+    def build(rel: str) -> Tensor:
+        per_block: list[Tensor] = []
+        for block_idx in range(num_blocks):
+            prefix = f"blocks.{block_idx}.{rel}"
+            down = weights[f"{prefix}.1.weight"].to(device=device, dtype=dtype)
+            up = weights[f"{prefix}.2.weight"].to(device=device, dtype=dtype)
+            per_block.append((((t @ down.t()) @ up.t()) + lora).contiguous())
+        return torch.stack(per_block, dim=0).contiguous()
+
+    return (
+        build("adaln_modulation_self_attn"),
+        build("adaln_modulation_cross_attn"),
+        build("adaln_modulation_mlp"),
+    )
+
+
+def _make_cosmos_rope_cache(
+    rope_emb: Tensor,
+    *,
+    dtype: torch.dtype,
+) -> tuple[Tensor, Tensor]:
+    rope_view = rope_emb.permute(1, 0, 2, 3).reshape(
+        rope_emb.shape[0], rope_emb.shape[-1]
+    )
+    return (
+        torch.cos(rope_view).to(dtype).contiguous(),
+        torch.sin(rope_view).to(dtype).contiguous(),
+    )
+
+
+def _make_cosmos_hdmap_cache(
+    hdmap_patched: Tensor,
+    weights: Mapping[str, Tensor],
+    *,
+    model_channels: int,
+    dtype: torch.dtype,
+) -> Tensor:
+    batch, views, frames, tokens, _ = hdmap_patched.shape
+    hdmap_flat = hdmap_patched.to(dtype=dtype).reshape(
+        batch,
+        views * frames * tokens,
+        -1,
+    ).contiguous()
+    w_hd = weights["additional_patch_embedding.proj.1.weight"].to(
+        device=hdmap_patched.device,
+        dtype=dtype,
+    )
+    if w_hd.shape[0] != model_channels:
+        raise RuntimeError(
+            "additional_patch_embedding.proj.1.weight output dimension "
+            f"{w_hd.shape[0]} does not match model_channels={model_channels}"
+        )
+    return (hdmap_flat @ w_hd.t()).contiguous()
+
+
+def _make_cosmos_streaming_workspace(
+    *,
+    batch: int,
+    tokens: int,
+    max_attn_tokens: int,
+    num_blocks: int,
+    model_channels: int,
+    heads: int,
+    ff: int,
+    lora_dim: int,
+    device: torch.device | str,
+    dtype: torch.dtype = torch.bfloat16,
+    use_sage3_fp8_attention: bool = False,
+) -> dict[str, Tensor]:
+    """Allocate the caller-owned scratch tensors expected by native_extension.
+
+    Keep this local to the FlashDreams shim: the bundled extension path only
+    guarantees the built `.pyd` and may not include optimized native's Python helpers.
+    """
+    if model_channels % heads != 0:
+        raise ValueError("model_channels must be divisible by heads")
+    if batch <= 0 or tokens <= 0 or max_attn_tokens <= 0 or num_blocks <= 0:
+        raise ValueError("batch, tokens, max_attn_tokens, and num_blocks must be positive")
+
+    head_dim = model_channels // heads
+    linear_scratch_features = max(model_channels, ff, 3 * model_channels)
+    singleton = (1,)
+
+    bf16_specs: Mapping[str, tuple[int, ...]] = {
+        "qkv_row": (tokens, 3 * model_channels),
+        "q_row": (tokens, model_channels),
+        "k_row": (tokens, model_channels),
+        "v_row": (tokens, model_channels),
+        "q_bmhk": (tokens, heads, head_dim),
+        "k_bmhk": (tokens, heads, head_dim),
+        "o_bmhk": (tokens, heads, head_dim),
+        "normed": (tokens, model_channels),
+        "ffn_intermediate": (tokens, ff),
+        "lora_hidden_sa": (batch, lora_dim),
+        "lora_hidden_ca": (batch, lora_dim),
+        "lora_hidden_mlp": (batch, lora_dim),
+        "lora_hidden_all": (num_blocks * 3, batch, lora_dim),
+        "mods_sa": (batch, 3 * model_channels),
+        "mods_ca": (batch, 3 * model_channels),
+        "mods_mlp": (batch, 3 * model_channels),
+        "mods_all": (num_blocks * 3, batch, 3 * model_channels),
+        "attn_scores_bf16": singleton,
+        "attn_score_c_bf16": singleton,
+        "attn_o_bhmd_bf16": (batch, heads, tokens, head_dim),
+        "attn_o_c_bf16": (batch, heads, tokens, head_dim),
+    }
+    u8_specs: Mapping[str, tuple[int, ...]] = {
+        "linear_fp8_scratch": (tokens, linear_scratch_features),
+        "attn_q_fp8": (batch, tokens, heads, head_dim),
+        "attn_k_fp8": (batch, max_attn_tokens, heads, head_dim),
+        "attn_v_fp8": (batch, max_attn_tokens, heads, head_dim),
+        "attn_q_bhmd_fp8": (batch, heads, tokens, head_dim),
+        "attn_k_bhmd_fp8": (batch, heads, max_attn_tokens, head_dim),
+        "attn_v_bhmd_fp8": (batch, heads, max_attn_tokens, head_dim),
+        "attn_v_bhdm_fp8": (batch, heads, head_dim, max_attn_tokens),
+        "attn_probs_fp8": singleton,
+    }
+    fp8_specs: Mapping[str, tuple[int, ...]] = {}
+    if use_sage3_fp8_attention:
+        sage3_q_tokens = ((tokens + 127) // 128) * 128
+        u8_specs = dict(u8_specs)
+        u8_specs["attn_q_sage3_fp4"] = (batch, heads, sage3_q_tokens, head_dim // 2)
+        fp8_specs = {
+            "attn_q_sage3_sf": (batch, heads, sage3_q_tokens, head_dim // 16),
+        }
+    fp16_specs: Mapping[str, tuple[int, ...]] = {
+        "linear_half_scratch": (tokens, linear_scratch_features),
+        "attn_scores_half": singleton,
+        "attn_o_bhmd_half": (batch, heads, tokens, head_dim),
+        "attn_o_half": (batch, tokens, heads, head_dim),
+    }
+
+    workspace: dict[str, Tensor] = {}
+    workspace.update({name: torch.empty(shape, device=device, dtype=dtype) for name, shape in bf16_specs.items()})
+    workspace.update({name: torch.empty(shape, device=device, dtype=torch.uint8) for name, shape in u8_specs.items()})
+    workspace.update({name: torch.empty(shape, device=device, dtype=torch.float8_e4m3fn) for name, shape in fp8_specs.items()})
+    workspace.update({name: torch.empty(shape, device=device, dtype=torch.float16) for name, shape in fp16_specs.items()})
+    workspace["attn_tc_scale"] = torch.ones((12,), device=device, dtype=torch.float32)
+    return workspace
+
+
+class _CosmosNetworkShapeOps(torch.nn.Module):
+    """Weightless replacement for CosmosDiTNetwork patch/unpatch helpers."""
+
+    def __init__(
+        self,
+        config: Any,
+        *,
+        device: torch.device,
+        cache_templates: tuple[CosmosDiTNetworkCache, ...] = (),
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self._cache_templates = cache_templates
+        self._cache_template_index = 0
+        self._device_anchor = torch.nn.Parameter(
+            torch.empty(0, device=device),
+            requires_grad=False,
+        )
+
+    def set_cache_templates(
+        self,
+        cache_templates: tuple[CosmosDiTNetworkCache, ...],
+    ) -> None:
+        self._cache_templates = cache_templates
+        self._cache_template_index = 0
+
+    def reset_cache_template_cursor(self) -> None:
+        self._cache_template_index = 0
+
+    def initialize_cache(
+        self,
+        chunk_size: int,
+        window_size: int,
+        sink_size: int,
+        context: Tensor,
+    ) -> CosmosDiTNetworkCache:
+        """Clone the pre-release cache template for a new FP8 rollout."""
+        del context
+        if self._cache_template_index >= len(self._cache_templates):
+            raise RuntimeError(
+                "optimized native FP8 DiT released the upstream network before a "
+                "cache template was captured. Start one rollout before "
+                "resetting; keep at least one captured cache template per rollout."
+            )
+        template = self._cache_templates[self._cache_template_index]
+        self._cache_template_index += 1
+        first_self_attn = template.block_caches[0].self_attn
+        if (
+            first_self_attn.chunk_size != chunk_size
+            or first_self_attn.window_size != window_size
+            or first_self_attn.sink_size != sink_size
+        ):
+            raise RuntimeError(
+                "optimized native FP8 DiT cache template geometry does not match "
+                "the requested rollout reset geometry."
+            )
+        return _clone_network_cache(template)
+
+    def patchify_and_maybe_split_cp(
+        self,
+        x: Tensor,
+        process_groups: list[Any | None] | None = None,
+        cp_dims: list[int | None] | None = None,
+        flatten_thw: bool = False,
+    ) -> Tensor:
+        assert x.ndim == 6, f"x must be a 6D tensor, but got shape {x.shape}"
+        pattern = (
+            "... v (t kt) c (h kh) (w kw) -> ... v (t h w) (c kt kh kw)"
+            if flatten_thw
+            else "... v (t kt) c (h kh) (w kw) -> ... v t (h w) (c kt kh kw)"
+        )
+        x = rearrange(
+            x,
+            pattern,
+            kt=self.config.patch_temporal,
+            kh=self.config.patch_spatial,
+            kw=self.config.patch_spatial,
+        )
+        if process_groups is not None:
+            assert cp_dims is not None and len(cp_dims) == len(process_groups)
+            for cp_dim, process_group in zip(cp_dims, process_groups, strict=True):
+                if process_group is not None:
+                    assert cp_dim is not None
+                    x = split_inputs_cp(x, seq_dim=cp_dim, cp_group=process_group)
+        return x
+
+    def unpatchify_and_maybe_gather_cp(
+        self,
+        pH: int,
+        pW: int,
+        x: Tensor,
+        process_groups: list[Any | None] | None = None,
+        cp_dims: list[int | None] | None = None,
+        flatten_thw: bool = False,
+    ) -> Tensor:
+        if flatten_thw:
+            pattern = "b v (t h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
+            assert x.ndim == 4, f"x must be a 4D tensor, but got shape {x.shape}"
+        else:
+            pattern = "b v t (h w) (c kt kh kw) -> b v (t kt) c (h kh) (w kw)"
+            assert x.ndim == 5, f"x must be a 5D tensor, but got shape {x.shape}"
+        if process_groups is not None:
+            assert cp_dims is not None and len(cp_dims) == len(process_groups)
+            for cp_dim, process_group in zip(cp_dims, process_groups, strict=True):
+                if process_group is not None:
+                    assert cp_dim is not None
+                    x = cat_outputs_cp(x, seq_dim=cp_dim, cp_group=process_group)
+        return rearrange(
+            x,
+            pattern,
+            h=pH,
+            w=pW,
+            kt=self.config.patch_temporal,
+            kh=self.config.patch_spatial,
+            kw=self.config.patch_spatial,
+        )
+
+
+def prepare_cosmos_streaming_weights(state_dict: Mapping[str, Tensor]) -> dict[str, Tensor]:
+    """Add per-block fused self-attention QKV weights for native_extension.
+
+    This lives alongside the public native helper so deployment only needs the
+    built ``native_extension`` binary and this source tree.
+    """
+    weights = dict(state_dict)
+    q_suffix = "self_attn.q_proj.weight"
+    for q_key, q_weight in list(weights.items()):
+        if not q_key.endswith(q_suffix):
+            continue
+
+        prefix = q_key[: -len(q_suffix)]
+        fused_key = prefix + "self_attn.qkv_proj.weight"
+        if fused_key in weights:
+            weights[fused_key] = weights[fused_key].contiguous()
+            continue
+
+        k_key = prefix + "self_attn.k_proj.weight"
+        v_key = prefix + "self_attn.v_proj.weight"
+        if k_key not in weights or v_key not in weights:
+            raise KeyError(f"Missing K/V weights for fused QKV key {fused_key!r}")
+
+        weights[fused_key] = torch.cat(
+            [q_weight, weights[k_key], weights[v_key]], dim=0
+        ).contiguous()
+
+    for key, weight in list(weights.items()):
+        if key.endswith(".weight_prepared"):
+            weights[key] = weight.contiguous()
+            continue
+        if key.endswith(_COSMOS_PREPARED_SUFFIXES):
+            weights[f"{key}_prepared"] = weight.t().contiguous()
+
+    return {k: v.contiguous() for k, v in weights.items()}
+
+
+def _seq_slice(ndim: int, seq_dim: int, start: int, end: int) -> tuple[slice, ...]:
+    idx = [slice(None)] * ndim
+    idx[seq_dim] = slice(start, end)
+    return tuple(idx)
+
+
+def _roll_fp8_cache_left_like_block_cache(
+    tensor: Tensor,
+    block_cache: Any,
+    *,
+    seq_dim: int | None = None,
+) -> None:
+    actual_seq_dim = block_cache.seq_dim if seq_dim is None else seq_dim
+    total_size = tensor.shape[actual_seq_dim]
+    tokens_to_keep = int(block_cache.window_size - block_cache.chunk_size)
+    if tokens_to_keep <= 0:
+        return
+    src_start = int(block_cache.sink_size + block_cache.chunk_size)
+    src_end = total_size
+    dst_start = int(block_cache.sink_size)
+    dst_end = int(block_cache.sink_size + tokens_to_keep)
+    tensor[_seq_slice(tensor.ndim, actual_seq_dim, dst_start, dst_end)].copy_(
+        tensor[_seq_slice(tensor.ndim, actual_seq_dim, src_start, src_end)].clone()
+    )
+
+
+def compute_self_attn_write_start(self_attn_cache: Any) -> int:
+    """The cursor optimized_dit_forward writes K/V at. Three cases
+    (matching ``BlockKVCache.update``):
+
+      * steady-state: write at the rightmost slot, after the left-roll;
+      * filling, advancing chunk: append at ``_n_cached``;
+      * filling, same chunk: overwrite the just-written rightmost slot.
+        This last case fires when ``predict_flow`` runs multiple times
+        per AR step (once per scheduler step).
+
+    Must be called AFTER ``before_update(chunk_idx)`` so
+    ``_curr_chunk_idx`` is set and any steady-state roll has already
+    happened.
+    """
+    if self_attn_cache.is_steady_state():
+        total_size = self_attn_cache._k.shape[self_attn_cache.seq_dim]
+        return int(total_size - self_attn_cache.chunk_size)
+    if self_attn_cache._curr_chunk_idx == self_attn_cache._prev_chunk_idx + 1:
+        return int(self_attn_cache._n_cached)
+    if self_attn_cache._curr_chunk_idx == self_attn_cache._prev_chunk_idx:
+        return int(self_attn_cache._n_cached - self_attn_cache.chunk_size)
+    raise RuntimeError(
+        f"Unexpected cache state: _curr_chunk_idx={self_attn_cache._curr_chunk_idx} "
+        f"vs _prev_chunk_idx={self_attn_cache._prev_chunk_idx}"
+    )
+
+
+class OptimizedDiTExecutor:
+    """Runs the single-view DiT hot path through the native streaming extension.
+
+    The public transformer keeps ownership of patch/unpatch, masks, CFG,
+    scheduler state, and the standard cache lifecycle. This object owns the
+    optimized native call, quantized runtime state, and precomputed invariants.
+    """
+
+    def __init__(
+        self,
+        transformer: CosmosTransformer,
+        extension: Any,
+        *,
+        dit_backend: str = "fp8_kvcache_cudnn",
+        attention_backend: str = "auto",
+    ) -> None:
+        self.transformer = transformer
+        self.config = transformer.config
+        self._native_extension = extension
+
+        config = self.config
+        if not hasattr(extension, "optimized_dit_forward"):
+            raise RuntimeError(
+                "native extension has no optimized_dit_forward entry point"
+            )
+        if config.num_views > 1:
+            raise NotImplementedError(
+                "optimized native DiT supports num_views=1 only "
+                f"(got {config.num_views}); optimized_dit_forward has "
+                "not been validated against the cross-view-attn path."
+            )
+        supports_block_mod_cache = getattr(
+            extension,
+            "optimized_dit_supports_block_mod_cache",
+            None,
+        )
+        self._supports_block_mod_cache = (
+            bool(supports_block_mod_cache())
+            if supports_block_mod_cache is not None
+            else False
+        )
+        supports_hdmap_cache = getattr(
+            extension,
+            "optimized_dit_supports_hdmap_cache",
+            None,
+        )
+        self._supports_hdmap_cache = (
+            bool(supports_hdmap_cache()) if supports_hdmap_cache is not None else False
+        )
+        self._dit_backend = dit_backend
+        if self._dit_backend not in {"bf16", "fp8_kvcache_cudnn"}:
+            raise ValueError(
+                f"Unsupported optimized native DiT backend {self._dit_backend!r}; "
+                "expected 'bf16' or 'fp8_kvcache_cudnn'."
+            )
+        self._uses_fp8_dit = self._dit_backend == "fp8_kvcache_cudnn"
+
+        net_cfg = config.network
+        self._optimized_streaming_config = {
+            "num_blocks": net_cfg.num_blocks,
+            "num_heads": net_cfg.num_heads,
+            "model_channels": net_cfg.model_channels,
+            "adaln_lora_dim": net_cfg.adaln_lora_dim,
+            "timestep_scale": float(net_cfg.timestep_scale),
+        }
+        requested_attention_backend = (attention_backend or "auto").strip().lower()
+        self._attention_backend = self._resolve_attention_backend(
+            requested_attention_backend
+        )
+
+        self._optimized_weights: dict[str, Tensor] | None = None
+        self._bf16_runtime: dict[str, Any] | None = None
+        self._fp8_runtime: dict[str, Any] | None = None
+        self._optimized_invariant_cache: dict[tuple[Any, ...], _CosmosInvariantTensors] = {}
+        self._optimized_rope_cache: dict[tuple[Any, ...], tuple[Tensor, Tensor]] = {}
+        self._optimized_rope_freqs_cache: dict[tuple[Any, ...], Tensor] = {}
+        self._optimized_hdmap_cache: dict[tuple[Any, ...], Tensor] = {}
+        self._optimized_empty_hdmap_cache: dict[tuple[Any, ...], Tensor] = {}
+        self._optimized_kv_tensor_lists: dict[int, _CosmosCacheTensorLists] = {}
+        self._optimized_runtime_config_id: int | None = None
+        self._optimized_last_ar_idx: int | None = None
+        self._optimized_scheduler_call_idx = 0
+        self._optimized_scheduler_timestep_keys: dict[int, tuple[Any, ...]] = {}
+        self._released_network_for_fp8 = False
+        self._optimized_network_cache_templates: tuple[CosmosDiTNetworkCache, ...] = ()
+        self._optimized_call: CUDAGraphWrapper | None = (
+            CUDAGraphWrapper(
+                self._predict_flow_ext_impl,
+                warmup_iters=config.cuda_graph_warmup_iters,
+            )
+            if config.use_cuda_graph
+            else None
+        )
+
+    @property
+    def network(self) -> torch.nn.Module:
+        return self.transformer.network
+
+    @network.setter
+    def network(self, value: torch.nn.Module) -> None:
+        self.transformer.network = value  # type: ignore[assignment]
+
+    def _maybe_inject_image(
+        self,
+        latent: Tensor,
+        cache: CosmosTransformerCache,
+    ) -> Tensor:
+        return self.transformer._maybe_inject_image(latent, cache)
+
+    def _select_mask(self, cache: CosmosTransformerCache) -> Tensor:
+        return self.transformer._select_mask(cache)
+
+    def _sage3_status(self) -> tuple[bool, str]:
+        if sys.platform == "win32":
+            return False, "Sage3 is not supported on Windows"
+        built_fn = getattr(self._native_extension, "sage3_is_built", None)
+        supported_fn = getattr(self._native_extension, "sage3_is_runtime_supported", None)
+        if built_fn is None or supported_fn is None:
+            return False, "native_extension does not expose Sage3 availability probes"
+        try:
+            if not bool(built_fn()):
+                return False, "native_extension was built with Sage3 stubs"
+        except Exception as e:
+            return False, f"native_extension.sage3_is_built() failed: {e}"
+        if not torch.cuda.is_available():
+            return False, "CUDA is unavailable"
+        try:
+            device = torch.cuda.current_device()
+        except Exception as e:
+            return False, f"torch.cuda.current_device() failed: {e}"
+        try:
+            if not bool(supported_fn(device)):
+                return False, "the active CUDA device is not enabled for Sage3"
+        except Exception as e:
+            return False, f"native_extension.sage3_is_runtime_supported() failed: {e}"
+        return True, ""
+
+    def _resolve_attention_backend(
+        self,
+        requested: str,
+    ) -> str:
+        requested = (requested or "auto").strip().lower()
+        if requested not in {"auto", "cudnn", "sage3", "sage3_fp8"}:
+            raise ValueError(
+                "--native-attention-backend must be 'auto', 'cudnn', "
+                f"'sage3', or 'sage3_fp8' (got {requested!r})"
+            )
+
+        sage3_available, sage3_reason = self._sage3_status()
+        if requested == "auto":
+            if sage3_available:
+                return "sage3_fp8" if self._uses_fp8_dit else "sage3"
+            return "cudnn"
+
+        if requested == "sage3_fp8" and not self._uses_fp8_dit:
+            raise ValueError(
+                f"--native-attention-backend={requested} requires "
+                "the 'fp8_kvcache_cudnn' optimized native DiT backend."
+            )
+        if requested == "sage3" and self._uses_fp8_dit:
+            raise ValueError(
+                "--native-attention-backend=sage3 is not supported with "
+                "the fp8 DiT backend; use 'sage3_fp8' or 'auto' instead."
+            )
+        if requested in {"sage3", "sage3_fp8"} and not sage3_available:
+            raise ValueError(
+                f"--native-attention-backend={requested} requested Sage3, "
+                f"but {sage3_reason}. Use --native-attention-backend=cudnn "
+                "for the portable cuDNN attention path."
+            )
+        return requested
+
+    def after_initialize_autoregressive_cache(
+        self,
+        cache: CosmosTransformerCache,
+    ) -> None:
+        reset_template_cursor = getattr(self.network, "reset_cache_template_cursor", None)
+        if callable(reset_template_cursor):
+            reset_template_cursor()
+        self._capture_network_cache_templates(cache)
+        self._bf16_runtime = None
+        self._fp8_runtime = None
+        self._optimized_invariant_cache.clear()
+        self._optimized_rope_cache.clear()
+        self._optimized_rope_freqs_cache.clear()
+        self._optimized_hdmap_cache.clear()
+        self._optimized_empty_hdmap_cache.clear()
+        self._optimized_kv_tensor_lists.clear()
+        self._optimized_runtime_config_id = None
+        self._optimized_last_ar_idx = None
+        self._optimized_scheduler_call_idx = 0
+        self._optimized_scheduler_timestep_keys.clear()
+        if self._optimized_call is not None:
+            self._optimized_call.reset()
+
+    def _capture_network_cache_templates(self, cache: CosmosTransformerCache) -> None:
+        templates = [_clone_network_cache(cache.network_cache)]
+        if cache.network_cache_uncond is not None:
+            templates.append(_clone_network_cache(cache.network_cache_uncond))
+        self._optimized_network_cache_templates = tuple(templates)
+        set_cache_templates = getattr(self.network, "set_cache_templates", None)
+        if callable(set_cache_templates):
+            set_cache_templates(self._optimized_network_cache_templates)
+
+    def _ensure_weights_snapshot(self) -> dict[str, Tensor]:
+        """Snapshot ``self.network.state_dict()`` once. Idempotent."""
+        if self._optimized_weights is None:
+            state_dict = self.network.state_dict()
+            if self._uses_fp8_dit:
+                from cosmos_fp8_utils import (
+                    prepare_cosmos_quantized_streaming_weights,
+                )
+
+                device = next(self.network.parameters()).device
+                # Quantize from CPU so one-time FP32/FP8 conversion temporaries
+                # do not coexist on the GPU with the full BF16 DiT, VAE, TAE,
+                # and CUDA graph pools during block 0.
+                cpu_state = {
+                    key: value.detach().cpu()
+                    for key, value in state_dict.items()
+                }
+                # Do not keep the GPU state_dict view alive across the later
+                # network release; its tensor refs would mask the freed memory.
+                del state_dict
+                self._optimized_weights = prepare_cosmos_quantized_streaming_weights(
+                    cpu_state,
+                    num_blocks=self.config.network.num_blocks,
+                    device=None,
+                    linear_policy="all",
+                )
+                self._drop_redundant_bf16_prepared_weights()
+                self._optimized_weights = {
+                    key: value.to(device=device).contiguous()
+                    if isinstance(value, torch.Tensor)
+                    else value
+                    for key, value in self._optimized_weights.items()
+                }
+                del cpu_state
+                self._release_network_after_fp8_snapshot()
+            else:
+                self._optimized_weights = prepare_cosmos_streaming_weights(state_dict)
+        return self._optimized_weights
+
+    def _drop_redundant_bf16_prepared_weights(self) -> None:
+        """Remove BF16 prepared aliases superseded by FP8 prepared weights."""
+        if self._optimized_weights is None:
+            return
+        for key in list(self._optimized_weights):
+            if key.endswith(".weight_prepared"):
+                self._optimized_weights.pop(key, None)
+
+    def _release_network_after_fp8_snapshot(self) -> None:
+        """Free the upstream BF16 DiT once FP8 weights/caches are ready.
+
+        The inherited network is needed to load the checkpoint, patchify cache
+        inputs, and initialize the FlashDreams KV caches. After the first FP8
+        predict_flow call, native_extension consumes only `_optimized_weights` plus the
+        cache tensors, so keeping the full PyTorch DiT resident just duplicates
+        several GiB of parameters and graph-wrapper state.
+        """
+        if not self._uses_fp8_dit or self._released_network_for_fp8:
+            return
+        shape_ops = _CosmosNetworkShapeOps(
+            self.network.config,
+            device=next(self.network.parameters()).device,
+            cache_templates=self._optimized_network_cache_templates,
+        )
+        # After release, optimized native's own _optimized_call owns CUDA graph capture.
+        # The parent graph wrappers point at the freed PyTorch network and
+        # must stay disabled when a reset initializes a fresh cache.
+        self.transformer._use_cuda_graph = False
+        self.transformer._network_call = None  # type: ignore[assignment]
+        self.transformer._network_call_uncond = None  # type: ignore[assignment]
+        self.network = shape_ops  # type: ignore[assignment]
+        self._released_network_for_fp8 = True
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def _ensure_fp8_runtime(
+        self,
+        *,
+        k_cross: list[Tensor],
+        v_cross: list[Tensor],
+        k_self: list[Tensor],
+        v_self: list[Tensor],
+        tokens: int,
+        cache: CosmosTransformerCache,
+    ) -> dict[str, Any]:
+        if not self._uses_fp8_dit:
+            return {}
+        if self._fp8_runtime is not None:
+            return self._fp8_runtime
+        if not hasattr(torch, "float8_e4m3fn"):
+            raise RuntimeError("torch.float8_e4m3fn is required for fp8_kvcache_cudnn")
+
+        heads = self.config.network.num_heads
+        model_channels = self.config.network.model_channels
+        ff = int(4 * model_channels)
+        lora_dim = self.config.network.adaln_lora_dim
+        max_attn_tokens = max(
+            tokens,
+            *(int(t.size(1)) for t in k_cross),
+            *(int(t.size(1)) for t in k_self),
+        )
+        device = k_self[0].device
+        use_sage3_fp8_attention = self._attention_backend == "sage3_fp8"
+        workspace = _make_cosmos_streaming_workspace(
+            batch=int(k_self[0].size(0)),
+            tokens=tokens,
+            max_attn_tokens=max_attn_tokens,
+            num_blocks=self.config.network.num_blocks,
+            model_channels=model_channels,
+            heads=heads,
+            ff=ff,
+            lora_dim=lora_dim,
+            device=device,
+            dtype=torch.bfloat16,
+            use_sage3_fp8_attention=use_sage3_fp8_attention,
+        )
+
+        cfg: dict[str, Any] = {
+            "cosmos_linear_backend": "fp8",
+            "cosmos_attention_backend": (
+                self._attention_backend if use_sage3_fp8_attention
+                else "fp8_cudnn"
+            ),
+            "cosmos_kv_cache_backend": "fp8",
+            "cosmos_write_bf16_kv_cache": False,
+            "cosmos_quantized_prepared": True,
+            "cosmos_quantized_prepared_strict": True,
+            "cosmos_workspace": workspace,
+            "cosmos_attn_tc_scale_is_ones": True,
+        }
+
+        if use_sage3_fp8_attention:
+            sage3_cross = [
+                self._native_extension.sage3_quantize_cross_kv_bf16(k, v)
+                for k, v in zip(k_cross, v_cross, strict=True)
+            ]
+            k_cross_sage3_fp4 = [tensors[0] for tensors in sage3_cross]
+            v_cross_sage3_fp4 = [tensors[1] for tensors in sage3_cross]
+            k_cross_sage3_sf = [tensors[2] for tensors in sage3_cross]
+            v_cross_sage3_sf = [tensors[3] for tensors in sage3_cross]
+            k_cross_fp8: list[Tensor] = []
+            v_cross_fp8: list[Tensor] = []
+        else:
+            k_cross_fp8 = [
+                t.to(torch.float8_e4m3fn).view(torch.uint8).contiguous()
+                for t in k_cross
+            ]
+            v_cross_fp8 = [
+                t.to(torch.float8_e4m3fn).view(torch.uint8).contiguous()
+                for t in v_cross
+            ]
+            k_cross_sage3_fp4 = []
+            v_cross_sage3_fp4 = []
+            k_cross_sage3_sf = []
+            v_cross_sage3_sf = []
+
+        k_self_fp8 = [torch.zeros_like(t, dtype=torch.uint8) for t in k_self]
+        v_self_fp8 = [torch.zeros_like(t, dtype=torch.uint8) for t in v_self]
+        cfg.update(
+            {
+                "k_cross_fp8_caches": k_cross_fp8,
+                "v_cross_fp8_caches": v_cross_fp8,
+                "k_self_fp8_caches": k_self_fp8,
+                "v_self_fp8_caches": v_self_fp8,
+                "_last_rolled": {},
+            }
+        )
+        if use_sage3_fp8_attention:
+            cfg.update(
+                {
+                    "k_cross_sage3_fp4_caches": k_cross_sage3_fp4,
+                    "v_cross_sage3_fp4_caches": v_cross_sage3_fp4,
+                    "k_cross_sage3_sf_caches": k_cross_sage3_sf,
+                    "v_cross_sage3_sf_caches": v_cross_sage3_sf,
+                }
+            )
+        fp8_sdpa_layout = os.environ.get(
+            "OMNIDREAMS_DIT_FP8_SDPA_LAYOUT", ""
+        ).strip().lower()
+        if use_sage3_fp8_attention and fp8_sdpa_layout == "bhmd":
+            _LOGGER.warning(
+                "OMNIDREAMS_DIT_FP8_SDPA_LAYOUT=bhmd is ignored for the "
+                "SageAttention-3 path with FP8 DiT state; sage3_fp8 uses "
+                "Sage3 FP4 cross-attention KV cache layout."
+            )
+        if not use_sage3_fp8_attention and fp8_sdpa_layout == "bhmd":
+            cfg.update({
+                "k_cross_fp8_bhmd_caches": [
+                    t.view(torch.float8_e4m3fn).permute(0, 2, 1, 3).contiguous().view(torch.uint8)
+                    for t in cfg["k_cross_fp8_caches"]
+                ],
+                "v_cross_fp8_bhmd_caches": [
+                    t.view(torch.float8_e4m3fn).permute(0, 2, 1, 3).contiguous().view(torch.uint8)
+                    for t in cfg["v_cross_fp8_caches"]
+                ],
+                "k_self_fp8_bhmd_caches": [
+                    torch.zeros((t.size(0), t.size(2), t.size(1), t.size(3)), device=t.device, dtype=torch.uint8)
+                    for t in k_self
+                ],
+                "v_self_fp8_bhmd_caches": [
+                    torch.zeros((t.size(0), t.size(2), t.size(1), t.size(3)), device=t.device, dtype=torch.uint8)
+                    for t in v_self
+                ],
+            })
+        self._fp8_runtime = cfg
+        self._release_network_after_fp8_snapshot()
+        return cfg
+
+    def _ensure_bf16_runtime(
+        self,
+        *,
+        k_cross: list[Tensor],
+        k_self: list[Tensor],
+        tokens: int,
+    ) -> dict[str, Any]:
+        if self._uses_fp8_dit:
+            return {}
+        if self._bf16_runtime is not None:
+            return self._bf16_runtime
+
+        heads = self.config.network.num_heads
+        model_channels = self.config.network.model_channels
+        ff = int(4 * model_channels)
+        lora_dim = self.config.network.adaln_lora_dim
+        max_attn_tokens = max(
+            tokens,
+            *(int(t.size(1)) for t in k_cross),
+            *(int(t.size(1)) for t in k_self),
+        )
+        device = k_self[0].device
+        workspace = _make_cosmos_streaming_workspace(
+            batch=int(k_self[0].size(0)),
+            tokens=tokens,
+            max_attn_tokens=max_attn_tokens,
+            num_blocks=self.config.network.num_blocks,
+            model_channels=model_channels,
+            heads=heads,
+            ff=ff,
+            lora_dim=lora_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        self._bf16_runtime = {
+            "cosmos_workspace": workspace,
+            "cosmos_attn_tc_scale_is_ones": True,
+        }
+        if self._attention_backend == "sage3":
+            self._bf16_runtime["cosmos_attention_backend"] = self._attention_backend
+        return self._bf16_runtime
+
+    def _roll_fp8_self_caches_if_needed(
+        self,
+        runtime: dict[str, Any],
+        cache: CosmosTransformerCache,
+    ) -> None:
+        if not runtime or "k_self_fp8_caches" not in runtime:
+            return
+        last_rolled: dict[int, int] = runtime["_last_rolled"]
+        block_caches = cache.network_cache.block_caches
+        for block_idx, block in enumerate(block_caches):
+            self_attn = block.self_attn
+            curr = self_attn._curr_chunk_idx
+            if curr is None or curr == self_attn._prev_chunk_idx:
+                continue
+            if last_rolled.get(block_idx) == curr:
+                continue
+            if not self_attn.is_steady_state():
+                continue
+            _roll_fp8_cache_left_like_block_cache(runtime["k_self_fp8_caches"][block_idx], self_attn)
+            _roll_fp8_cache_left_like_block_cache(runtime["v_self_fp8_caches"][block_idx], self_attn)
+            if "k_self_fp8_bhmd_caches" in runtime:
+                _roll_fp8_cache_left_like_block_cache(
+                    runtime["k_self_fp8_bhmd_caches"][block_idx], self_attn, seq_dim=2
+                )
+                _roll_fp8_cache_left_like_block_cache(
+                    runtime["v_self_fp8_bhmd_caches"][block_idx], self_attn, seq_dim=2
+                )
+            last_rolled[block_idx] = curr
+
+    @staticmethod
+    def _timesteps_key(timesteps: Tensor) -> tuple[Any, ...]:
+        values = timesteps.detach().to(device="cpu", dtype=torch.float32).reshape(-1)
+        return (
+            str(timesteps.device),
+            timesteps.dtype,
+            tuple(float(v) for v in values.tolist()),
+        )
+
+    def _next_timestep_cache_key(
+        self,
+        *,
+        ar_idx: int,
+        timesteps: Tensor,
+    ) -> tuple[Any, ...]:
+        if self._optimized_last_ar_idx != int(ar_idx):
+            self._optimized_last_ar_idx = int(ar_idx)
+            self._optimized_scheduler_call_idx = 0
+
+        call_idx = self._optimized_scheduler_call_idx
+        self._optimized_scheduler_call_idx += 1
+
+        timestep_key = self._optimized_scheduler_timestep_keys.get(call_idx)
+        if timestep_key is None:
+            timestep_key = self._timesteps_key(timesteps)
+            self._optimized_scheduler_timestep_keys[call_idx] = timestep_key
+        return ("scheduler_call", call_idx, timestep_key)
+
+    def _ensure_invariant_tensors(
+        self,
+        *,
+        ar_idx: int,
+        timesteps: Tensor,
+    ) -> _CosmosInvariantTensors | None:
+        if not self._supports_block_mod_cache:
+            return None
+
+        weights = self._ensure_weights_snapshot()
+        net_cfg = self.config.network
+        dtype = self.config.dtype
+        key = (
+            id(weights),
+            net_cfg.num_blocks,
+            net_cfg.model_channels,
+            net_cfg.adaln_lora_dim,
+            dtype,
+            self._next_timestep_cache_key(ar_idx=ar_idx, timesteps=timesteps),
+        )
+        cached = self._optimized_invariant_cache.get(key)
+        if cached is not None:
+            return cached
+
+        t_emb, t_emb_silu, adaln_lora = _make_cosmos_timestep_cache(
+            timesteps,
+            weights,
+            model_channels=net_cfg.model_channels,
+            timestep_scale=float(net_cfg.timestep_scale),
+            dtype=dtype,
+        )
+        final_shift, final_scale = _make_cosmos_final_mod_cache(
+            t_emb,
+            adaln_lora,
+            weights,
+            model_channels=net_cfg.model_channels,
+            dtype=dtype,
+        )
+        block_mods_sa, block_mods_ca, block_mods_mlp = _make_cosmos_block_mod_cache(
+            t_emb_silu,
+            adaln_lora,
+            weights,
+            num_blocks=net_cfg.num_blocks,
+            model_channels=net_cfg.model_channels,
+            dtype=dtype,
+        )
+        cached = _CosmosInvariantTensors(
+            t_emb=t_emb,
+            t_emb_silu=t_emb_silu,
+            adaln_lora=adaln_lora,
+            final_shift=final_shift,
+            final_scale=final_scale,
+            block_mods_sa=block_mods_sa,
+            block_mods_ca=block_mods_ca,
+            block_mods_mlp=block_mods_mlp,
+        )
+        self._optimized_invariant_cache[key] = cached
+        return cached
+
+    def _ensure_rope_tensors(
+        self,
+        *,
+        ar_idx: int,
+        rope_freqs: Tensor,
+    ) -> tuple[Tensor, Tensor] | tuple[None, None]:
+        if not self._supports_block_mod_cache:
+            return None, None
+
+        key = (
+            int(ar_idx),
+            tuple(int(v) for v in rope_freqs.shape),
+            str(rope_freqs.device),
+            self.config.dtype,
+        )
+        cached = self._optimized_rope_cache.get(key)
+        if cached is None:
+            cached = _make_cosmos_rope_cache(
+                rope_freqs,
+                dtype=self.config.dtype,
+            )
+            self._optimized_rope_cache[key] = cached
+        return cached
+
+    def _ensure_rope_freqs(
+        self,
+        *,
+        ar_idx: int,
+        cache: CosmosTransformerCache,
+    ) -> Tensor:
+        del ar_idx
+        assert cache.rope_freqs is not None, (
+            "Cache.start(autoregressive_index) must populate rope_freqs before "
+            "predict_flow."
+        )
+        return cache.rope_freqs
+
+    def _ensure_hdmap_tensor(
+        self,
+        *,
+        ar_idx: int,
+        input_for_ext: Tensor | None,
+    ) -> Tensor | None:
+        if (
+            not self._supports_hdmap_cache
+            or input_for_ext is None
+            or input_for_ext.numel() == 0
+        ):
+            return None
+
+        weights = self._ensure_weights_snapshot()
+        net_cfg = self.config.network
+        key = (
+            id(weights),
+            int(ar_idx),
+            tuple(int(v) for v in input_for_ext.shape),
+            str(input_for_ext.device),
+            self.config.dtype,
+        )
+        cached = self._optimized_hdmap_cache.get(key)
+        if cached is None:
+            cached = _make_cosmos_hdmap_cache(
+                input_for_ext,
+                weights,
+                model_channels=net_cfg.model_channels,
+                dtype=self.config.dtype,
+            )
+            self._optimized_hdmap_cache[key] = cached
+        return cached
+
+    def _empty_hdmap_tensor(self, *, device: torch.device, dtype: torch.dtype) -> Tensor:
+        key = (str(device), dtype)
+        cached = self._optimized_empty_hdmap_cache.get(key)
+        if cached is None:
+            cached = torch.empty((0,), device=device, dtype=dtype)
+            self._optimized_empty_hdmap_cache[key] = cached
+        return cached
+
+    def _ensure_kv_tensor_lists(
+        self,
+        *,
+        cache: CosmosTransformerCache,
+    ) -> _CosmosCacheTensorLists:
+        net_cache = cache.network_cache
+        key = id(net_cache)
+        cached = self._optimized_kv_tensor_lists.get(key)
+        if cached is None:
+            block_caches = net_cache.block_caches
+            cached = _CosmosCacheTensorLists(
+                k_self=[block.self_attn._k for block in block_caches],
+                v_self=[block.self_attn._v for block in block_caches],
+                k_cross=[block.cross_attn._k for block in block_caches],
+                v_cross=[block.cross_attn._v for block in block_caches],
+            )
+            self._optimized_kv_tensor_lists[key] = cached
+        return cached
+
+    def _apply_runtime_config(self, runtime_cfg: dict[str, Any]) -> None:
+        if not runtime_cfg:
+            return
+        cfg_id = id(runtime_cfg)
+        if self._optimized_runtime_config_id == cfg_id:
+            return
+        self._optimized_streaming_config.update(runtime_cfg)
+        self._optimized_runtime_config_id = cfg_id
+
+    def _clear_transient_ar_caches(self) -> None:
+        """Drop per-AR-step tensors that are only useful within one step."""
+        self._optimized_rope_cache.clear()
+        self._optimized_rope_freqs_cache.clear()
+        self._optimized_hdmap_cache.clear()
+
+    def after_finalize_kv_cache(self) -> None:
+        self._clear_transient_ar_caches()
+
+    def _select_optimized_call(self, cache: CosmosTransformerCache) -> Any:
+        if self._optimized_call is None:
+            return self._predict_flow_ext_impl
+        return (
+            self._optimized_call.drain
+            if cache.autoregressive_index < self.transformer._cuda_graph_capture_ar_idx
+            else self._optimized_call
+        )
+
+    def _predict_flow_ext_impl(
+        self,
+        noisy_for_ext: Tensor,
+        mask_for_ext: Tensor,
+        input_for_ext: Tensor | None,
+        hdmap_embed: Tensor | None,
+        timestep_b: Tensor,
+        rope_freqs: Tensor,
+        t_emb: Tensor | None,
+        t_emb_silu: Tensor | None,
+        adaln_lora: Tensor | None,
+        final_shift: Tensor | None,
+        final_scale: Tensor | None,
+        rope_cos: Tensor | None,
+        rope_sin: Tensor | None,
+        block_mods_sa: Tensor | None,
+        block_mods_ca: Tensor | None,
+        block_mods_mlp: Tensor | None,
+        k_cross: list[Tensor],
+        v_cross: list[Tensor],
+        k_self: list[Tensor],
+        v_self: list[Tensor],
+        write_start: int,
+    ) -> Tensor:
+        config = dict(self._optimized_streaming_config)
+        if hdmap_embed is not None:
+            config["cosmos_hdmap_embed"] = hdmap_embed
+        if t_emb is not None:
+            assert t_emb_silu is not None
+            assert adaln_lora is not None
+            assert final_shift is not None
+            assert final_scale is not None
+            assert rope_cos is not None
+            assert rope_sin is not None
+            assert block_mods_sa is not None
+            assert block_mods_ca is not None
+            assert block_mods_mlp is not None
+            config.update(
+                {
+                    "cosmos_t_emb": t_emb,
+                    "cosmos_t_emb_silu": t_emb_silu,
+                    "cosmos_adaln_lora": adaln_lora,
+                    "cosmos_final_shift": final_shift,
+                    "cosmos_final_scale": final_scale,
+                    "cosmos_rope_cos": rope_cos,
+                    "cosmos_rope_sin": rope_sin,
+                    "cosmos_block_mods_sa": block_mods_sa,
+                    "cosmos_block_mods_ca": block_mods_ca,
+                    "cosmos_block_mods_mlp": block_mods_mlp,
+                }
+            )
+        return self._native_extension.optimized_dit_forward(
+            x_new=noisy_for_ext,
+            condition_mask_patched=mask_for_ext,
+            hdmap_patched=input_for_ext,
+            timesteps=timestep_b,
+            rope_emb=rope_freqs,
+            k_cross_caches=k_cross,
+            v_cross_caches=v_cross,
+            k_self_caches=k_self,
+            v_self_caches=v_self,
+            self_attn_write_start=int(write_start),
+            weights=self._ensure_weights_snapshot(),
+            config=config,
+        )
+
+    def predict_flow(
+        self,
+        noisy_latent: Tensor,
+        timestep: Tensor,
+        cache: CosmosTransformerCache,
+        input: Tensor | None = None,
+    ) -> Tensor:
+        """One scheduler step. Identical to the parent except the inner
+        network forward runs through ``native_extension.optimized_dit_forward``.
+        """
+        ar_idx = cache.autoregressive_index
+        assert ar_idx >= 0, (
+            "CosmosTransformerCache.start(autoregressive_index) must be called "
+            "before predict_flow (DiffusionModel.generate handles this)."
+        )
+        return_dtype = noisy_latent.dtype
+
+        rope_freqs = self._ensure_rope_freqs(ar_idx=ar_idx, cache=cache)
+
+        # AR step 0: inject the encoded first-frame latent into the
+        # noisy input (parent's helper).
+        noisy_latent = self._maybe_inject_image(noisy_latent, cache)
+        condition_video_input_mask = self._select_mask(cache)
+
+        self._ensure_weights_snapshot()
+
+        # ---- C++/CUDA forward through native_extension.optimized_dit_forward ----
+        # The C++ entry point doesn't drive cache.before_update /
+        # after_update; we wrap it so the BlockKVCache state machine
+        # evolves the same way the upstream eager path does.
+        # The scheduler hands us a 0-D scalar timestep; native_extension's
+        # bridge wants ``[B]`` (the upstream PyTorch network is fine
+        # with the scalar because its first op is a broadcast multiply).
+        # Repeat to ``[B]`` to match the bridge's contract.
+        batch_size = noisy_latent.shape[0]
+        timestep_b = timestep.reshape(1).expand(batch_size).contiguous()
+        invariant_tensors = self._ensure_invariant_tensors(
+            ar_idx=ar_idx,
+            timesteps=timestep_b,
+        )
+        rope_cos, rope_sin = self._ensure_rope_tensors(
+            ar_idx=ar_idx,
+            rope_freqs=rope_freqs,
+        )
+
+        # NOTE: upstream's ``CosmosTransformer.predict_flow`` does NOT
+        # drive ``network_cache.before_update`` / ``after_update`` -- the
+        # cache state machine is advanced once per AR step at the
+        # boundary by ``CosmosTransformerCache.start`` / ``.finalize``,
+        # which ``DiffusionModel.generate`` invokes around the scheduler
+        # loop. ``predict_flow`` is called MULTIPLE times per AR step
+        # (one per scheduler timestep) and the inner network just
+        # overwrites the rightmost slot each call (see the
+        # ``filling-same-chunk`` and ``steady-state`` branches in
+        # ``compute_self_attn_write_start``). An older revision of this
+        # shim wrapped the ``optimized_dit_forward`` call in
+        # ``before_update`` / ``after_update`` and tripped
+        # ``BlockKVCache.before_update``'s "Must call after_update()
+        # before before_update()" assert on the second scheduler
+        # timestep of every AR step. We just consume the post-
+        # ``before_update`` state directly here -- the C++ launcher
+        # writes K/V in place at ``write_start``, and the boundary
+        # ``finalize`` advances the state machine once.
+        net_cache = cache.network_cache
+        write_start = compute_self_attn_write_start(
+            net_cache.block_caches[0].self_attn
+        )
+        kv_lists = self._ensure_kv_tensor_lists(cache=cache)
+
+        # Upstream single-view CosmosTransformer flattens THW to [B, V, L, D].
+        # native_extension still consumes the unflattened patch layout [B, V, T, HW, D].
+        return_flattened = noisy_latent.ndim == 4
+        if return_flattened:
+            B, V, L, D = noisy_latent.shape
+            cfg = self.config
+            transformer = self.transformer
+            assert (
+                transformer._output_height is not None
+                and transformer._output_width is not None
+            ), "optimized DiT requires an initialized rollout spatial shape"
+            T = cfg.len_t // cfg.network.patch_temporal
+            HW = (
+                transformer._output_height
+                // cfg.network.patch_spatial
+                * transformer._output_width
+                // cfg.network.patch_spatial
+            )
+            assert L == T * HW, (
+                f"Flattened latent length {L} does not match T*HW={T * HW}"
+            )
+            noisy_for_ext = noisy_latent.reshape(B, V, T, HW, D)
+            mask_for_ext = condition_video_input_mask.reshape(
+                B, V, T, HW, condition_video_input_mask.shape[-1]
+            )
+            input_for_ext = (
+                None
+                if input is None
+                else input.reshape(B, V, T, HW, input.shape[-1])
+            )
+        else:
+            noisy_for_ext = noisy_latent
+            mask_for_ext = condition_video_input_mask
+            input_for_ext = input
+
+        ext_dtype = self.config.dtype
+        noisy_for_ext = noisy_for_ext.to(dtype=ext_dtype)
+        mask_for_ext = mask_for_ext.to(dtype=ext_dtype)
+        if input_for_ext is not None:
+            input_for_ext = input_for_ext.to(dtype=ext_dtype)
+        hdmap_embed = self._ensure_hdmap_tensor(
+            ar_idx=ar_idx,
+            input_for_ext=input_for_ext,
+        )
+        hdmap_for_ext = (
+            input_for_ext
+            if hdmap_embed is None
+            else self._empty_hdmap_tensor(
+                device=noisy_for_ext.device,
+                dtype=ext_dtype,
+            )
+        )
+
+        runtime_cfg = self._ensure_fp8_runtime(
+            k_cross=kv_lists.k_cross,
+            v_cross=kv_lists.v_cross,
+            k_self=kv_lists.k_self,
+            v_self=kv_lists.v_self,
+            tokens=int(noisy_for_ext.shape[2] * noisy_for_ext.shape[3]),
+            cache=cache,
+        )
+        if not runtime_cfg:
+            runtime_cfg = self._ensure_bf16_runtime(
+                k_cross=kv_lists.k_cross,
+                k_self=kv_lists.k_self,
+                tokens=int(noisy_for_ext.shape[2] * noisy_for_ext.shape[3]),
+            )
+        if self._uses_fp8_dit:
+            self._roll_fp8_self_caches_if_needed(runtime_cfg, cache)
+        self._apply_runtime_config(runtime_cfg)
+
+        predicted_flow = self._select_optimized_call(cache)(
+            noisy_for_ext,
+            mask_for_ext,
+            hdmap_for_ext,
+            hdmap_embed,
+            timestep_b,
+            rope_freqs,
+            None if invariant_tensors is None else invariant_tensors.t_emb,
+            None if invariant_tensors is None else invariant_tensors.t_emb_silu,
+            None if invariant_tensors is None else invariant_tensors.adaln_lora,
+            None if invariant_tensors is None else invariant_tensors.final_shift,
+            None if invariant_tensors is None else invariant_tensors.final_scale,
+            rope_cos,
+            rope_sin,
+            None if invariant_tensors is None else invariant_tensors.block_mods_sa,
+            None if invariant_tensors is None else invariant_tensors.block_mods_ca,
+            None if invariant_tensors is None else invariant_tensors.block_mods_mlp,
+            kv_lists.k_cross,
+            kv_lists.v_cross,
+            kv_lists.k_self,
+            kv_lists.v_self,
+            int(write_start),
+        )
+        # ----------------------------------------------------------------------
+
+        if return_flattened:
+            predicted_flow = predicted_flow.reshape(
+                noisy_latent.shape[0],
+                noisy_latent.shape[1],
+                noisy_latent.shape[2],
+                predicted_flow.shape[-1],
+            )
+        if predicted_flow.dtype != return_dtype:
+            predicted_flow = predicted_flow.to(dtype=return_dtype)
+        return predicted_flow
+
+
+__all__ = [
+    "OptimizedDiTExecutor",
+    "compute_self_attn_write_start",
+    "prepare_cosmos_streaming_weights",
+]

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -53,11 +53,6 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 from einops import rearrange
-from flashdreams.core.distributed.context_parallel import (
-    cat_outputs_cp,
-    split_inputs_cp,
-)
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from omnidreams.transformer import (
     CosmosTransformer,
     CosmosTransformerCache,
@@ -66,10 +61,16 @@ from omnidreams.transformer import (
 from omnidreams.transformer.impl.network import CosmosDiTNetworkCache
 from torch import Tensor
 
+from flashdreams.core.distributed.context_parallel import (
+    cat_outputs_cp,
+    split_inputs_cp,
+)
+from flashdreams.infra.cuda_graph import CUDAGraphWrapper
+
 _LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_SPARGE_TOPK = 0.25
-_DEFAULT_SPARGE_HYBRID_TOPK = 0.10
+_DEFAULT_SPARGE_HYBRID_TOPK = _DEFAULT_SPARGE_TOPK
 _DEFAULT_SPARGE_HYBRID_PERIOD = 2
 _DEFAULT_SPARGE_HYBRID_PHASE = 0
 
@@ -247,11 +248,15 @@ def _make_cosmos_hdmap_cache(
     dtype: torch.dtype,
 ) -> Tensor:
     batch, views, frames, tokens, _ = hdmap_patched.shape
-    hdmap_flat = hdmap_patched.to(dtype=dtype).reshape(
-        batch,
-        views * frames * tokens,
-        -1,
-    ).contiguous()
+    hdmap_flat = (
+        hdmap_patched.to(dtype=dtype)
+        .reshape(
+            batch,
+            views * frames * tokens,
+            -1,
+        )
+        .contiguous()
+    )
     w_hd = weights["additional_patch_embedding.proj.1.weight"].to(
         device=hdmap_patched.device,
         dtype=dtype,
@@ -288,7 +293,9 @@ def _make_cosmos_streaming_workspace(
     if model_channels % heads != 0:
         raise ValueError("model_channels must be divisible by heads")
     if batch <= 0 or tokens <= 0 or max_attn_tokens <= 0 or num_blocks <= 0:
-        raise ValueError("batch, tokens, max_attn_tokens, and num_blocks must be positive")
+        raise ValueError(
+            "batch, tokens, max_attn_tokens, and num_blocks must be positive"
+        )
     if not 0.0 < sparge_topk_ratio <= 1.0:
         raise ValueError(
             f"sparge_topk_ratio must be in (0, 1], got {sparge_topk_ratio}"
@@ -381,10 +388,30 @@ def _make_cosmos_streaming_workspace(
     }
 
     workspace: dict[str, Tensor] = {}
-    workspace.update({name: torch.empty(shape, device=device, dtype=dtype) for name, shape in bf16_specs.items()})
-    workspace.update({name: torch.empty(shape, device=device, dtype=torch.uint8) for name, shape in u8_specs.items()})
-    workspace.update({name: torch.empty(shape, device=device, dtype=torch.float8_e4m3fn) for name, shape in fp8_specs.items()})
-    workspace.update({name: torch.empty(shape, device=device, dtype=torch.float16) for name, shape in fp16_specs.items()})
+    workspace.update(
+        {
+            name: torch.empty(shape, device=device, dtype=dtype)
+            for name, shape in bf16_specs.items()
+        }
+    )
+    workspace.update(
+        {
+            name: torch.empty(shape, device=device, dtype=torch.uint8)
+            for name, shape in u8_specs.items()
+        }
+    )
+    workspace.update(
+        {
+            name: torch.empty(shape, device=device, dtype=torch.float8_e4m3fn)
+            for name, shape in fp8_specs.items()
+        }
+    )
+    workspace.update(
+        {
+            name: torch.empty(shape, device=device, dtype=torch.float16)
+            for name, shape in fp16_specs.items()
+        }
+    )
     workspace["attn_tc_scale"] = torch.ones((12,), device=device, dtype=torch.float32)
     return workspace
 
@@ -508,7 +535,9 @@ class _CosmosNetworkShapeOps(torch.nn.Module):
         )
 
 
-def prepare_cosmos_streaming_weights(state_dict: Mapping[str, Tensor]) -> dict[str, Tensor]:
+def prepare_cosmos_streaming_weights(
+    state_dict: Mapping[str, Tensor],
+) -> dict[str, Tensor]:
     """Add per-block fused self-attention QKV weights for native_extension.
 
     This lives alongside the public native helper so deployment only needs the
@@ -666,8 +695,16 @@ class OptimizedDiTExecutor:
             "adaln_lora_dim": net_cfg.adaln_lora_dim,
             "timestep_scale": float(net_cfg.timestep_scale),
         }
-        self._requested_attention_backend = (attention_backend or "auto").strip().lower()
-        if self._requested_attention_backend not in {"auto", "cudnn", "sparge", "sage3", "sage3_fp8"}:
+        self._requested_attention_backend = (
+            (attention_backend or "auto").strip().lower()
+        )
+        if self._requested_attention_backend not in {
+            "auto",
+            "cudnn",
+            "sparge",
+            "sage3",
+            "sage3_fp8",
+        }:
             raise ValueError(
                 "--native-attention-backend must be 'auto', 'cudnn', "
                 f"'sparge', 'sage3', or 'sage3_fp8' (got {self._requested_attention_backend!r})"
@@ -700,7 +737,9 @@ class OptimizedDiTExecutor:
         self._fp8_runtime: dict[str, Any] | None = None
         self._bf16_runtime_device: torch.device | None = None
         self._fp8_runtime_device: torch.device | None = None
-        self._optimized_invariant_cache: dict[tuple[Any, ...], _CosmosInvariantTensors] = {}
+        self._optimized_invariant_cache: dict[
+            tuple[Any, ...], _CosmosInvariantTensors
+        ] = {}
         self._optimized_rope_cache: dict[tuple[Any, ...], tuple[Tensor, Tensor]] = {}
         self._optimized_rope_freqs_cache: dict[tuple[Any, ...], Tensor] = {}
         self._optimized_hdmap_cache: dict[tuple[Any, ...], Tensor] = {}
@@ -739,7 +778,9 @@ class OptimizedDiTExecutor:
     def _select_mask(self, cache: CosmosTransformerCache) -> Tensor:
         return self.transformer._select_mask(cache)
 
-    def _cuda_device_index(self, device: torch.device | int | None) -> tuple[int | None, str]:
+    def _cuda_device_index(
+        self, device: torch.device | int | None
+    ) -> tuple[int | None, str]:
         if not torch.cuda.is_available():
             return None, "CUDA is unavailable"
         if isinstance(device, int):
@@ -759,11 +800,15 @@ class OptimizedDiTExecutor:
                 return None, f"torch.cuda.current_device() failed: {e}"
         return int(device.index), ""
 
-    def _sage3_status(self, device: torch.device | int | None = None) -> tuple[bool, str]:
+    def _sage3_status(
+        self, device: torch.device | int | None = None
+    ) -> tuple[bool, str]:
         if sys.platform == "win32":
             return False, "Sage3 is not supported on Windows"
         built_fn = getattr(self._native_extension, "sage3_is_built", None)
-        supported_fn = getattr(self._native_extension, "sage3_is_runtime_supported", None)
+        supported_fn = getattr(
+            self._native_extension, "sage3_is_runtime_supported", None
+        )
         if built_fn is None or supported_fn is None:
             return False, "native_extension does not expose Sage3 availability probes"
         try:
@@ -781,11 +826,15 @@ class OptimizedDiTExecutor:
             return False, f"native_extension.sage3_is_runtime_supported() failed: {e}"
         return True, ""
 
-    def _sparge_status(self, device: torch.device | int | None = None) -> tuple[bool, str]:
+    def _sparge_status(
+        self, device: torch.device | int | None = None
+    ) -> tuple[bool, str]:
         if sys.platform == "win32":
             return False, "Sparge is not supported on Windows"
         built_fn = getattr(self._native_extension, "sparge_is_built", None)
-        supported_fn = getattr(self._native_extension, "sparge_is_runtime_supported", None)
+        supported_fn = getattr(
+            self._native_extension, "sparge_is_runtime_supported", None
+        )
         if built_fn is None or supported_fn is None:
             return False, "native_extension does not expose Sparge availability probes"
         try:
@@ -900,7 +949,9 @@ class OptimizedDiTExecutor:
         device_key = torch.device(device)
         if self._attention_backend_device == device_key:
             return
-        sparge_topk, sparge_hybrid_period, sparge_hybrid_phase = self._resolve_sparge_options()
+        sparge_topk, sparge_hybrid_period, sparge_hybrid_phase = (
+            self._resolve_sparge_options()
+        )
         attention_backend, sparge_hybrid_enabled = self._resolve_attention_backend(
             self._requested_attention_backend,
             sparge_hybrid_period=sparge_hybrid_period,
@@ -922,16 +973,16 @@ class OptimizedDiTExecutor:
         self._sparge_topk = sparge_topk
         self._sparge_hybrid_period = sparge_hybrid_period
         self._sparge_hybrid_phase = (
-            sparge_hybrid_phase % sparge_hybrid_period
-            if sparge_hybrid_period
-            else 0
+            sparge_hybrid_phase % sparge_hybrid_period if sparge_hybrid_period else 0
         )
 
     def after_initialize_autoregressive_cache(
         self,
         cache: CosmosTransformerCache,
     ) -> None:
-        reset_template_cursor = getattr(self.network, "reset_cache_template_cursor", None)
+        reset_template_cursor = getattr(
+            self.network, "reset_cache_template_cursor", None
+        )
         if callable(reset_template_cursor):
             reset_template_cursor()
         self._capture_network_cache_templates(cache)
@@ -976,8 +1027,7 @@ class OptimizedDiTExecutor:
                 # do not coexist on the GPU with the full BF16 DiT, VAE, TAE,
                 # and CUDA graph pools during block 0.
                 cpu_state = {
-                    key: value.detach().cpu()
-                    for key, value in state_dict.items()
+                    key: value.detach().cpu() for key, value in state_dict.items()
                 }
                 # Do not keep the GPU state_dict view alive across the later
                 # network release; its tensor refs would mask the freed memory.
@@ -1069,8 +1119,7 @@ class OptimizedDiTExecutor:
             *(int(t.size(1)) for t in k_self),
         )
         use_sparge_hybrid = (
-            self._attention_backend == "sparge"
-            and self._sparge_hybrid_period > 0
+            self._attention_backend == "sparge" and self._sparge_hybrid_period > 0
         )
         use_sage3_fp8_attention = (
             self._attention_backend == "sage3_fp8" or use_sparge_hybrid
@@ -1095,13 +1144,15 @@ class OptimizedDiTExecutor:
         cfg: dict[str, Any] = {
             "cosmos_linear_backend": "fp8",
             "cosmos_attention_backend": (
-                self._attention_backend if (use_sage3_fp8_attention or use_sparge_attention)
+                self._attention_backend
+                if (use_sage3_fp8_attention or use_sparge_attention)
                 else "fp8_cudnn"
             ),
             "cosmos_kv_cache_backend": "fp8",
             # Hybrid schedules need BF16 self-KV only on Sparge blocks; the
             # bridge forces those per block while leaving Sage3 blocks FP8-only.
-            "cosmos_write_bf16_kv_cache": use_sparge_attention and not use_sparge_hybrid,
+            "cosmos_write_bf16_kv_cache": use_sparge_attention
+            and not use_sparge_hybrid,
             "cosmos_sparge_topk_ratio": self._sparge_topk,
             "cosmos_sparge_hybrid_period": self._sparge_hybrid_period,
             "cosmos_sparge_hybrid_phase": self._sparge_hybrid_phase,
@@ -1157,9 +1208,9 @@ class OptimizedDiTExecutor:
                     "v_cross_sage3_sf_caches": v_cross_sage3_sf,
                 }
             )
-        fp8_sdpa_layout = os.environ.get(
-            "OMNIDREAMS_DIT_FP8_SDPA_LAYOUT", ""
-        ).strip().lower()
+        fp8_sdpa_layout = (
+            os.environ.get("OMNIDREAMS_DIT_FP8_SDPA_LAYOUT", "").strip().lower()
+        )
         if use_sage3_fp8_attention and fp8_sdpa_layout == "bhmd":
             _LOGGER.warning(
                 "OMNIDREAMS_DIT_FP8_SDPA_LAYOUT=bhmd is ignored for the "
@@ -1167,24 +1218,40 @@ class OptimizedDiTExecutor:
                 "Sage3 FP4 cross-attention KV cache layout."
             )
         if not use_sage3_fp8_attention and fp8_sdpa_layout == "bhmd":
-            cfg.update({
-                "k_cross_fp8_bhmd_caches": [
-                    t.view(torch.float8_e4m3fn).permute(0, 2, 1, 3).contiguous().view(torch.uint8)
-                    for t in cfg["k_cross_fp8_caches"]
-                ],
-                "v_cross_fp8_bhmd_caches": [
-                    t.view(torch.float8_e4m3fn).permute(0, 2, 1, 3).contiguous().view(torch.uint8)
-                    for t in cfg["v_cross_fp8_caches"]
-                ],
-                "k_self_fp8_bhmd_caches": [
-                    torch.zeros((t.size(0), t.size(2), t.size(1), t.size(3)), device=t.device, dtype=torch.uint8)
-                    for t in k_self
-                ],
-                "v_self_fp8_bhmd_caches": [
-                    torch.zeros((t.size(0), t.size(2), t.size(1), t.size(3)), device=t.device, dtype=torch.uint8)
-                    for t in v_self
-                ],
-            })
+            cfg.update(
+                {
+                    "k_cross_fp8_bhmd_caches": [
+                        t.view(torch.float8_e4m3fn)
+                        .permute(0, 2, 1, 3)
+                        .contiguous()
+                        .view(torch.uint8)
+                        for t in cfg["k_cross_fp8_caches"]
+                    ],
+                    "v_cross_fp8_bhmd_caches": [
+                        t.view(torch.float8_e4m3fn)
+                        .permute(0, 2, 1, 3)
+                        .contiguous()
+                        .view(torch.uint8)
+                        for t in cfg["v_cross_fp8_caches"]
+                    ],
+                    "k_self_fp8_bhmd_caches": [
+                        torch.zeros(
+                            (t.size(0), t.size(2), t.size(1), t.size(3)),
+                            device=t.device,
+                            dtype=torch.uint8,
+                        )
+                        for t in k_self
+                    ],
+                    "v_self_fp8_bhmd_caches": [
+                        torch.zeros(
+                            (t.size(0), t.size(2), t.size(1), t.size(3)),
+                            device=t.device,
+                            dtype=torch.uint8,
+                        )
+                        for t in v_self
+                    ],
+                }
+            )
         self._fp8_runtime = cfg
         self._fp8_runtime_device = device
         self._release_network_after_fp8_snapshot()
@@ -1259,8 +1326,12 @@ class OptimizedDiTExecutor:
                 continue
             if not self_attn.is_steady_state():
                 continue
-            _roll_fp8_cache_left_like_block_cache(runtime["k_self_fp8_caches"][block_idx], self_attn)
-            _roll_fp8_cache_left_like_block_cache(runtime["v_self_fp8_caches"][block_idx], self_attn)
+            _roll_fp8_cache_left_like_block_cache(
+                runtime["k_self_fp8_caches"][block_idx], self_attn
+            )
+            _roll_fp8_cache_left_like_block_cache(
+                runtime["v_self_fp8_caches"][block_idx], self_attn
+            )
             if "k_self_fp8_bhmd_caches" in runtime:
                 _roll_fp8_cache_left_like_block_cache(
                     runtime["k_self_fp8_bhmd_caches"][block_idx], self_attn, seq_dim=2
@@ -1427,7 +1498,9 @@ class OptimizedDiTExecutor:
             self._optimized_hdmap_cache[key] = cached
         return cached
 
-    def _empty_hdmap_tensor(self, *, device: torch.device, dtype: torch.dtype) -> Tensor:
+    def _empty_hdmap_tensor(
+        self, *, device: torch.device, dtype: torch.dtype
+    ) -> Tensor:
         key = (str(device), dtype)
         cached = self._optimized_empty_hdmap_cache.get(key)
         if cached is None:
@@ -1611,9 +1684,7 @@ class OptimizedDiTExecutor:
         # writes K/V in place at ``write_start``, and the boundary
         # ``finalize`` advances the state machine once.
         net_cache = cache.network_cache
-        write_start = compute_self_attn_write_start(
-            net_cache.block_caches[0].self_attn
-        )
+        write_start = compute_self_attn_write_start(net_cache.block_caches[0].self_attn)
         kv_lists = self._ensure_kv_tensor_lists(cache=cache)
 
         # Upstream single-view CosmosTransformer flattens THW to [B, V, L, D].
@@ -1642,9 +1713,7 @@ class OptimizedDiTExecutor:
                 B, V, T, HW, condition_video_input_mask.shape[-1]
             )
             input_for_ext = (
-                None
-                if input is None
-                else input.reshape(B, V, T, HW, input.shape[-1])
+                None if input is None else input.reshape(B, V, T, HW, input.shape[-1])
             )
         else:
             noisy_for_ext = noisy_latent

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -353,6 +353,7 @@ class _CosmosNetworkShapeOps(torch.nn.Module):
         config: Any,
         *,
         device: torch.device,
+        dtype: torch.dtype,
         cache_templates: tuple[CosmosDiTNetworkCache, ...] = (),
     ) -> None:
         super().__init__()
@@ -360,7 +361,7 @@ class _CosmosNetworkShapeOps(torch.nn.Module):
         self._cache_templates = cache_templates
         self._cache_template_index = 0
         self._device_anchor = torch.nn.Parameter(
-            torch.empty(0, device=device),
+            torch.empty(0, device=device, dtype=dtype),
             requires_grad=False,
         )
 
@@ -818,6 +819,7 @@ class OptimizedDiTExecutor:
         shape_ops = _CosmosNetworkShapeOps(
             self.network.config,
             device=next(self.network.parameters()).device,
+            dtype=self.config.dtype,
             cache_templates=self._optimized_network_cache_templates,
         )
         # After release, optimized native's own _optimized_call owns CUDA graph capture.

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -1099,7 +1099,9 @@ class OptimizedDiTExecutor:
                 else "fp8_cudnn"
             ),
             "cosmos_kv_cache_backend": "fp8",
-            "cosmos_write_bf16_kv_cache": use_sparge_attention,
+            # Hybrid schedules need BF16 self-KV only on Sparge blocks; the
+            # bridge forces those per block while leaving Sage3 blocks FP8-only.
+            "cosmos_write_bf16_kv_cache": use_sparge_attention and not use_sparge_hybrid,
             "cosmos_sparge_topk_ratio": self._sparge_topk,
             "cosmos_sparge_hybrid_period": self._sparge_hybrid_period,
             "cosmos_sparge_hybrid_phase": self._sparge_hybrid_phase,

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -48,7 +48,7 @@ import os
 import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.nn.functional as F
@@ -765,7 +765,7 @@ class OptimizedDiTExecutor:
 
     @network.setter
     def network(self, value: torch.nn.Module) -> None:
-        self.transformer.network = value  # type: ignore[assignment]
+        cast(Any, self.transformer).network = value
 
     def _maybe_inject_image(
         self,
@@ -1058,9 +1058,9 @@ class OptimizedDiTExecutor:
         # The parent graph wrappers point at the freed PyTorch network and
         # must stay disabled when a reset initializes a fresh cache.
         self.transformer._use_cuda_graph = False
-        self.transformer._network_call = None  # type: ignore[assignment]
-        self.transformer._network_call_uncond = None  # type: ignore[assignment]
-        self.network = shape_ops  # type: ignore[assignment]
+        cast(Any, self.transformer)._network_call = None
+        cast(Any, self.transformer)._network_call_uncond = None
+        self.network = shape_ops
         self._released_network_for_fp8 = True
         gc.collect()
         if torch.cuda.is_available():
@@ -1556,7 +1556,7 @@ class OptimizedDiTExecutor:
         v_self: list[Tensor],
         write_start: int,
     ) -> Tensor:
-        config = dict(self._optimized_streaming_config)
+        config: dict[str, Any] = dict(self._optimized_streaming_config)
         if hdmap_embed is not None:
             config["cosmos_hdmap_embed"] = hdmap_embed
         if t_emb is not None:

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -56,7 +56,6 @@ from einops import rearrange
 from omnidreams.transformer import (
     CosmosTransformer,
     CosmosTransformerCache,
-    CosmosTransformerConfig,
 )
 from omnidreams.transformer.impl.network import CosmosDiTNetworkCache
 from torch import Tensor
@@ -853,14 +852,7 @@ class OptimizedDiTExecutor:
         return True, ""
 
     def _resolve_sparge_options(self) -> tuple[float, int, int]:
-        hybrid_default = (
-            self._uses_fp8_dit and self._requested_attention_backend == "auto"
-        )
-        period = (
-            _DEFAULT_SPARGE_HYBRID_PERIOD
-            if self._requested_sparge_hybrid_period is None and hybrid_default
-            else int(self._requested_sparge_hybrid_period or 0)
-        )
+        period = int(self._requested_sparge_hybrid_period or 0)
         if 0 < period <= 1:
             period = 0
         topk = (
@@ -889,24 +881,13 @@ class OptimizedDiTExecutor:
                 f"'sparge', 'sage3', or 'sage3_fp8' (got {requested!r})"
             )
 
+        if requested == "auto":
+            return "cudnn", False
+
         sage3_available, sage3_reason = self._sage3_status(device)
         sparge_available, sparge_reason = self._sparge_status(device)
         head_dim = self.config.network.model_channels // self.config.network.num_heads
         sparge_supported = head_dim == 128
-        if requested == "auto":
-            if self._uses_fp8_dit and sparge_hybrid_period > 0:
-                if sage3_available and sparge_available and sparge_supported:
-                    return "sparge", True
-                if sage3_available:
-                    return "sage3_fp8", False
-                if sparge_available and sparge_supported:
-                    return "sparge", False
-                return "cudnn", False
-            if sparge_available and sparge_supported:
-                return "sparge", False
-            if sage3_available:
-                return ("sage3_fp8" if self._uses_fp8_dit else "sage3"), False
-            return "cudnn", False
 
         if requested == "sage3_fp8" and not self._uses_fp8_dit:
             raise ValueError(
@@ -916,7 +897,8 @@ class OptimizedDiTExecutor:
         if requested == "sage3" and self._uses_fp8_dit:
             raise ValueError(
                 "--native-attention-backend=sage3 is not supported with "
-                "the fp8 DiT backend; use 'sage3_fp8' or 'auto' instead."
+                "the fp8 DiT backend; use 'sage3_fp8' or 'auto' for the "
+                "default cuDNN path instead."
             )
         if requested in {"sage3", "sage3_fp8"} and not sage3_available:
             raise ValueError(
@@ -952,15 +934,11 @@ class OptimizedDiTExecutor:
         sparge_topk, sparge_hybrid_period, sparge_hybrid_phase = (
             self._resolve_sparge_options()
         )
-        attention_backend, sparge_hybrid_enabled = self._resolve_attention_backend(
+        attention_backend, _ = self._resolve_attention_backend(
             self._requested_attention_backend,
             sparge_hybrid_period=sparge_hybrid_period,
             device=device_key,
         )
-        if self._requested_attention_backend == "auto" and not sparge_hybrid_enabled:
-            sparge_hybrid_period = 0
-            if self._requested_sparge_topk is None and attention_backend == "sparge":
-                sparge_topk = _DEFAULT_SPARGE_TOPK
         if sparge_hybrid_period and (
             attention_backend != "sparge" or not self._uses_fp8_dit
         ):

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/attn_backend.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/attn_backend.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 // Backend selector for native CUDA kernels

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/attn_backend.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/attn_backend.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// Backend selector for native CUDA kernels
+// Usage:
+// - Define OMNIDREAMS_SINGLEVIEW_BACKEND at compile time to switch implementations.
+// - Defaults to CUTLASS to preserve existing behavior.
+
+// Backend constants
+#define OMNIDREAMS_SINGLEVIEW_BACKEND_CUTLASS 1
+#define OMNIDREAMS_SINGLEVIEW_BACKEND_TIN     2
+
+// Default backend: CUTLASS
+#ifndef OMNIDREAMS_SINGLEVIEW_BACKEND
+#define OMNIDREAMS_SINGLEVIEW_BACKEND OMNIDREAMS_SINGLEVIEW_BACKEND_CUTLASS
+#endif
+
+// Convenience feature macros
+#if OMNIDREAMS_SINGLEVIEW_BACKEND == OMNIDREAMS_SINGLEVIEW_BACKEND_CUTLASS
+#ifndef OMNIDREAMS_SINGLEVIEW_USE_CUTLASS
+#define OMNIDREAMS_SINGLEVIEW_USE_CUTLASS
+#endif
+#endif
+
+// When using PyTorch extensions, these macros are often defined to disable half operators.
+// We re-enable them project-wide before including any CUDA half headers or third-party libs.
+#ifdef __CUDA_NO_HALF_OPERATORS__
+#undef __CUDA_NO_HALF_OPERATORS__
+#endif
+#ifdef __CUDA_NO_HALF_CONVERSIONS__
+#undef __CUDA_NO_HALF_CONVERSIONS__
+#endif
+#ifdef __CUDA_NO_HALF2_OPERATORS__
+#undef __CUDA_NO_HALF2_OPERATORS__
+#endif
+#ifdef __CUDA_NO_BFLOAT16_CONVERSIONS__
+#undef __CUDA_NO_BFLOAT16_CONVERSIONS__
+#endif

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/cuda_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/cuda_utils.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cuda.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/cuda_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/cuda_utils.cuh
@@ -1,0 +1,320 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <stdint.h>
+#include <assert.h>
+#include <math.h>
+
+// Signal to backends that common provides build_past_shifted helpers
+#ifndef OMNIDREAMS_SINGLEVIEW_BUILD_PAST_IN_COMMON
+#define OMNIDREAMS_SINGLEVIEW_BUILD_PAST_IN_COMMON 1
+#endif
+
+// Forward declaration for trim kernel (defined later in this header)
+__global__ void ntchw_trim_front_half_kernel(
+    const half* __restrict__ in,
+    half* __restrict__ out,
+    int N_, int T_, int C_, int H_, int W_, int K_);
+
+namespace omnidreams_singleview {
+
+// Debug/assert helpers
+#if !defined(OMNIDREAMS_SINGLEVIEW_DEBUG)
+#define OMNIDREAMS_SINGLEVIEW_DEBUG 0
+#endif
+
+// Variadic macro to support both OMNIDREAMS_SINGLEVIEW_CUDA_CHECK() and OMNIDREAMS_SINGLEVIEW_CUDA_CHECK(cudaCall())
+#if OMNIDREAMS_SINGLEVIEW_DEBUG
+#define OMNIDREAMS_SINGLEVIEW_ASSERT(cond) do { if (!(cond)) { fprintf(stderr, "[OMNIDREAMS_SINGLEVIEW_ASSERT] %s:%d: assertion failed: %s\n", __FILE__, __LINE__, #cond); throw std::runtime_error("OMNIDREAMS_SINGLEVIEW_ASSERT failed"); } } while (0)
+#define OMNIDREAMS_SINGLEVIEW_CUDA_CHECK(...) do { \
+    __VA_ARGS__; \
+    cudaError_t _e_sync = cudaDeviceSynchronize(); \
+    if (_e_sync != cudaSuccess) { \
+        fprintf(stderr, "[OMNIDREAMS_SINGLEVIEW_CUDA_CHECK] %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(_e_sync)); \
+        throw std::runtime_error("CUDA kernel error"); \
+    } \
+} while (0)
+#else
+#define OMNIDREAMS_SINGLEVIEW_ASSERT(cond) ((void)0)
+#define OMNIDREAMS_SINGLEVIEW_CUDA_CHECK(...) do { __VA_ARGS__; } while (0)
+#endif
+
+// Activations
+enum class Activation : uint32_t {
+    None = 0,
+    ReLU = 1,
+    ClampTanh3 = 2
+};
+
+// Helpers
+__device__ __forceinline__ float clamp_tanh3(float x) {
+    return tanhf(x * (1.0f / 3.0f)) * 3.0f;
+}
+
+// Shape helpers
+inline int conv3x3_out_dim(int in, int stride, int pad) {
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in > 0 && stride > 0);
+    return (int)((in + 2 * pad - 3) / stride) + 1;
+}
+
+// Transpose kernels declarations (defined inline here for reuse)
+__global__ void transpose_hwc_to_nchw_half_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int N, int H, int W, int C)
+{
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+    int n = blockIdx.z;
+    if (x >= W || y >= H || n >= N) return;
+    int hwc_base = ((n * H + y) * W + x) * C;
+    for (int c = 0; c < C; ++c) {
+        output[((n * C + c) * H + y) * W + x] = input[hwc_base + c];
+    }
+}
+
+__global__ void transpose_nchw_to_hwc_half_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int N, int H, int W, int C)
+{
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+    int n = blockIdx.z;
+    if (x >= W || y >= H || n >= N) return;
+    int hwc_base = ((n * H + y) * W + x) * C;
+    for (int c = 0; c < C; ++c) {
+        output[hwc_base + c] = input[((n * C + c) * H + y) * W + x];
+    }
+}
+
+__global__ void transpose_nthwc_to_ntchw_half_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int N, int T, int H, int W, int C)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * T * H * W * C;
+    if (idx >= total) return;
+    int c = idx % C; idx /= C;
+    int w = idx % W; idx /= W;
+    int h = idx % H; idx /= H;
+    int t = idx % T; idx /= T;
+    int n = (int)idx;
+    long long in_idx  = (((((long long)n * T + t) * H + h) * W + w) * C + c);
+    long long out_idx = (((((long long)(n * T + t) * C + c) * H + h) * W + w));
+    output[out_idx] = input[in_idx];
+}
+
+__global__ void transpose_ntchw_to_nthwc_half_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int N, int T, int H, int W, int C)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * T * H * W * C;
+    if (idx >= total) return;
+    int c = idx % C; idx /= C;
+    int w = idx % W; idx /= W;
+    int h = idx % H; idx /= H;
+    int t = idx % T; idx /= T;
+    int n = (int)idx;
+    long long out_idx = (((((long long)n * T + t) * H + h) * W + w) * C + c);
+    long long in_idx  = (((((long long)(n * T + t) * C + c) * H + h) * W + w));
+    output[out_idx] = input[in_idx];
+}
+
+__global__ void reorder_mn_to_nchw_half_kernel(
+    const half* __restrict__ src_mn,
+    half* __restrict__ dst_nchw,
+    long long M, int N, int C, int H, int W)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = M * C;
+    if (idx >= total) return;
+    int oc = (int)(idx % C);
+    long long row = idx / C;
+    int n = (int)(row / (H * W));
+    int hw = (int)(row % (H * W));
+    long long out_index = (long long)n * (C * H * W) + (long long)oc * (H * W) + hw;
+    dst_nchw[out_index] = src_mn[row * C + oc];
+}
+
+// Build past by shifting time in flattened NT batches: for each (n, t), past(n,t)=x(n,t-1), and zero for t=0
+__global__ void build_past_shifted_nchw_half_kernel(
+    const half* __restrict__ x, half* __restrict__ past,
+    int N, int T, int C, int H, int W)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * T * C * H * W;
+    if (idx >= total) return;
+    int w = idx % W; idx /= W;
+    int h = idx % H; idx /= H;
+    int c = idx % C; idx /= C;
+    int t = idx % T; idx /= T;
+    int n = (int)idx;
+    long long base = (((((long long)n * T + t) * C + c) * H + h) * W + w);
+    if (t == 0) {
+        past[base] = __float2half(0.0f);
+    } else {
+        int t_prev = t - 1;
+        long long base_prev = (((((long long)n * T + t_prev) * C + c) * H + h) * W + w);
+        past[base] = x[base_prev];
+    }
+}
+
+inline void build_past_shifted_nchw(const half* x, half* past, int N, int T, int C, int H, int W, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x != nullptr && past != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > 0 && C > 0 && H > 0 && W > 0);
+    long long total = (long long)N * T * C * H * W;
+    int blk = 256;
+    int grd = (int)((total + blk - 1) / blk);
+    build_past_shifted_nchw_half_kernel<<<grd, blk, 0, stream>>>(x, past, N, T, C, H, W);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// Build past by shifting time in flattened NT batches for NHWC layout: past(n,t,y,x,c)=x(n,t-1,y,x,c), zero for t=0
+__global__ void build_past_shifted_nhwc_half_kernel(
+    const half* __restrict__ x, half* __restrict__ past,
+    int N, int T, int H, int W, int C)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * T * H * W * C;
+    if (idx >= total) return;
+    int c = (int)(idx % C); idx /= C;
+    int w = (int)(idx % W); idx /= W;
+    int h = (int)(idx % H); idx /= H;
+    int t = (int)(idx % T); idx /= T;
+    int n = (int)idx;
+    long long base = (((((long long)n * T + t) * H + h) * W + w) * C + c);
+    if (t == 0) {
+        past[base] = __float2half(0.0f);
+    } else {
+        int t_prev = t - 1;
+        long long base_prev = (((((long long)n * T + t_prev) * H + h) * W + w) * C + c);
+        past[base] = x[base_prev];
+    }
+}
+
+inline void build_past_shifted_nhwc(const half* x, half* past, int N, int T, int H, int W, int C, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x != nullptr && past != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > 0 && H > 0 && W > 0 && C > 0);
+    long long total = (long long)N * T * H * W * C;
+    int blk = 256;
+    int grd = (int)((total + blk - 1) / blk);
+    build_past_shifted_nhwc_half_kernel<<<grd, blk, 0, stream>>>(x, past, N, T, H, W, C);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// Trim first K frames from NTHWC buffer: in [N*T, H, W, C] with known N and T.
+__global__ void nthwc_trim_front_half_kernel(
+    const half* __restrict__ in, half* __restrict__ out,
+    int N, int T, int H, int W, int C, int K)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * (T - K) * H * W * C;
+    if (idx >= total) return;
+    int c = idx % C; idx /= C;
+    int w = idx % W; idx /= W;
+    int h = idx % H; idx /= H;
+    int t = idx % (T - K); idx /= (T - K);
+    int n = (int)idx;
+    long long in_base  = (((((long long)n * T + (t + K)) * H + h) * W + w) * C + c);
+    long long out_base = (((((long long)n * (T - K) + t) * H + h) * W + w) * C + c);
+    out[out_base] = in[in_base];
+}
+
+inline void nthwc_trim_front_half(
+    const half* in, half* out,
+    int N, int T, int H, int W, int C, int K,
+    cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in != nullptr && out != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > 0 && H > 0 && W > 0 && C > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(K >= 0 && K < T);
+    long long total = (long long)N * (T - K) * H * W * C;
+    int blk = 256;
+    int grd = (int)((total + blk - 1) / blk);
+    nthwc_trim_front_half_kernel<<<grd, blk, 0, stream>>>(in, out, N, T, H, W, C, K);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// Wrappers
+inline void hwc_to_nchw_half(const half* in_hwc, half* out_nchw, int N, int H, int W, int C, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in_hwc != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(out_nchw != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && H > 0 && W > 0 && C > 0);
+    dim3 block(16, 16, 1);
+    dim3 grid((W + block.x - 1) / block.x, (H + block.y - 1) / block.y, N);
+    transpose_hwc_to_nchw_half_kernel<<<grid, block, 0, stream>>>(in_hwc, out_nchw, N, H, W, C);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+inline void nchw_to_hwc_half(const half* in_nchw, half* out_hwc, int N, int H, int W, int C, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in_nchw != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(out_hwc != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && H > 0 && W > 0 && C > 0);
+    dim3 block(16, 16, 1);
+    dim3 grid((W + block.x - 1) / block.x, (H + block.y - 1) / block.y, N);
+    transpose_nchw_to_hwc_half_kernel<<<grid, block, 0, stream>>>(in_nchw, out_hwc, N, H, W, C);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+inline void nthwc_to_ntchw_half(const half* in_nthwc, half* out_ntchw, int N, int T, int H, int W, int C, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in_nthwc != nullptr && out_ntchw != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > 0 && H > 0 && W > 0 && C > 0);
+    long long total = (long long)N * T * H * W * C;
+    int blk = 256;
+    int grd = (int)((total + blk - 1) / blk);
+    transpose_nthwc_to_ntchw_half_kernel<<<grd, blk, 0, stream>>>(in_nthwc, out_ntchw, N, T, H, W, C);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+inline void ntchw_to_nthwc_half(const half* in_ntchw, half* out_nthwc, int N, int T, int H, int W, int C, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in_ntchw != nullptr && out_nthwc != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > 0 && H > 0 && W > 0 && C > 0);
+    long long total = (long long)N * T * H * W * C;
+    int blk = 256;
+    int grd = (int)((total + blk - 1) / blk);
+    transpose_ntchw_to_nthwc_half_kernel<<<grd, blk, 0, stream>>>(in_ntchw, out_nthwc, N, T, H, W, C);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+inline void ntchw_trim_front_half(const half* in_ntchw, half* out_ntchw, int N, int T, int C, int H, int W, int K, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in_ntchw != nullptr && out_ntchw != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > K && C > 0 && H > 0 && W > 0);
+    long long total = (long long)N * (T - K) * C * H * W;
+    int blk = 256;
+    int grd = (int)((total + blk - 1) / blk);
+    ::ntchw_trim_front_half_kernel<<<grd, blk, 0, stream>>>(in_ntchw, out_ntchw, N, T, C, H, W, K);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+} // namespace omnidreams_singleview
+
+// Define the trim kernel after the namespace to avoid accidental internal linkage issues
+__global__ void ntchw_trim_front_half_kernel(
+    const half* __restrict__ in,
+    half* __restrict__ out,
+    int N_, int T_, int C_, int H_, int W_, int K_)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total2 = (long long)N_ * (T_ - K_) * C_ * H_ * W_;
+    if (idx >= total2) return;
+    int w = idx % W_; idx /= W_;
+    int h = idx % H_; idx /= H_;
+    int c = idx % C_; idx /= C_;
+    int t = idx % (T_ - K_); idx /= (T_ - K_);
+    int n = (int)idx;
+    long long in_base  = (((((long long)n * T_ + (t + K_)) * C_ + c) * H_ + h) * W_ + w);
+    long long out_base = (((((long long)n * (T_ - K_) + t) * C_ + c) * H_ + h) * W_ + w);
+    out[out_base] = in[in_base];
+}

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/math_compat.hpp
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/math_compat.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cmath>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/math_compat.hpp
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/math_compat.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cmath>
+#include <math.h>
+
+// This header re-introduces the C99 single-precision math symbols inside std::
+// so that third-party headers that expect std::xxx f() continue to compile
+// under C++20/libstdc++ where those aliases were removed.
+
+#if defined(__cplusplus)
+namespace std {
+using ::ceilf;
+using ::cosf;
+using ::expf;
+using ::exp2f;
+using ::floorf;
+using ::logf;
+using ::log10f;
+using ::log2f;
+using ::powf;
+using ::rintf;
+using ::sinf;
+using ::sqrtf;
+using ::tanhf;
+using ::truncf;
+} // namespace std
+#endif

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profile_config.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profile_config.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <atomic>
+
+namespace omnidreams_singleview {
+
+// Profiling levels:
+//  0: off
+//  1: coarse per-forward CUDA-event breakdown (transformer_forward phases)
+//  2+: reserved for finer-grained breakdowns (e.g. per-block sections)
+inline std::atomic<int> g_wan_profile_level{0};
+
+// Print every N forward calls (each CFG step calls forward twice).
+inline std::atomic<int> g_wan_profile_print_every{1};
+
+// Internal call counter for rate limiting.
+inline std::atomic<long long> g_wan_profile_call_idx{0};
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profile_config.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profile_config.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <atomic>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profiler.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profiler.h
@@ -1,0 +1,229 @@
+#pragma once
+
+// profiler.h -- Structured performance profiling accumulator for native.
+//
+// Collects named timing entries across multiple iterations, computes statistics,
+// and serializes to JSON for baseline comparison. Header-only, zero external
+// dependencies beyond the C++ standard library.
+//
+// Compile-time gating: all accumulator calls are no-ops unless OMNIDREAMS_SINGLEVIEW_PROFILE
+// is defined. The standalone profiler (CMake build) always defines it; the Python
+// extension build does not, ensuring zero overhead in production.
+//
+// This header is independent of profile_config.h, which provides the runtime
+// g_wan_profile_level mechanism for the existing printf-based profiling path.
+// Both can coexist: the printf path is controlled at runtime, while this
+// accumulator path is controlled at compile time.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace omnidreams_singleview {
+
+struct ProfileStats {
+    float min_ms;
+    float max_ms;
+    float mean_ms;
+    float median_ms;
+    float p95_ms;
+    float stddev_ms;
+    int   count;
+};
+
+inline ProfileStats compute_stats(std::vector<float> vals) {
+    ProfileStats s{};
+    if (vals.empty()) return s;
+    s.count = static_cast<int>(vals.size());
+    std::sort(vals.begin(), vals.end());
+    s.min_ms = vals.front();
+    s.max_ms = vals.back();
+    double sum = 0.0;
+    for (float v : vals) sum += v;
+    s.mean_ms = static_cast<float>(sum / vals.size());
+    s.median_ms = (vals.size() % 2 == 1)
+        ? vals[vals.size() / 2]
+        : (vals[vals.size() / 2 - 1] + vals[vals.size() / 2]) * 0.5f;
+    size_t p95_idx = static_cast<size_t>(std::ceil(vals.size() * 0.95)) - 1;
+    if (p95_idx >= vals.size()) p95_idx = vals.size() - 1;
+    s.p95_ms = vals[p95_idx];
+    double var = 0.0;
+    for (float v : vals) {
+        double d = v - s.mean_ms;
+        var += d * d;
+    }
+    s.stddev_ms = static_cast<float>(std::sqrt(var / vals.size()));
+    return s;
+}
+
+// Category -> Component -> per-iteration ms values.
+using TimingMap = std::map<std::string, std::map<std::string, std::vector<float>>>;
+
+class ProfileAccumulator {
+public:
+    static ProfileAccumulator& instance() {
+        static ProfileAccumulator inst;
+        return inst;
+    }
+
+    void record(const std::string& category, const std::string& component, float ms) {
+        std::lock_guard<std::mutex> lock(mu_);
+        data_[category][component].push_back(ms);
+    }
+
+    void new_iteration() {
+        std::lock_guard<std::mutex> lock(mu_);
+        iteration_count_++;
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(mu_);
+        data_.clear();
+        iteration_count_ = 0;
+    }
+
+    int iteration_count() const {
+        std::lock_guard<std::mutex> lock(mu_);
+        return iteration_count_;
+    }
+
+    TimingMap data() const {
+        std::lock_guard<std::mutex> lock(mu_);
+        return data_;
+    }
+
+    // Metadata fields -- set by the harness before dump.
+    struct Metadata {
+        std::string gpu_name;
+        std::string cuda_version;
+        int warmup_iters = 0;
+        int timing_iters = 0;
+        int profile_level = 0;
+    };
+    Metadata metadata;
+
+    struct ModelConfig {
+        std::string preset;
+        int N = 0, T = 0, H = 0, W = 0;
+        int M = 0, K = 0, H_heads = 0, D = 0, FF = 0;
+        int num_layers = 0;
+    };
+    ModelConfig model_config;
+
+    bool dump_json(const std::string& path) const {
+        TimingMap data_snapshot = data();
+        FILE* f = fopen(path.c_str(), "w");
+        if (!f) return false;
+
+        auto timestamp_str = [] {
+            auto now = std::chrono::system_clock::now();
+            auto t = std::chrono::system_clock::to_time_t(now);
+            char buf[64];
+            std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&t));
+            return std::string(buf);
+        };
+
+        fprintf(f, "{\n");
+
+        // Metadata
+        fprintf(f, "  \"metadata\": {\n");
+        fprintf(f, "    \"gpu\": \"%s\",\n", metadata.gpu_name.c_str());
+        fprintf(f, "    \"cuda_version\": \"%s\",\n", metadata.cuda_version.c_str());
+        fprintf(f, "    \"timestamp\": \"%s\",\n", timestamp_str().c_str());
+        fprintf(f, "    \"warmup_iters\": %d,\n", metadata.warmup_iters);
+        fprintf(f, "    \"timing_iters\": %d,\n", metadata.timing_iters);
+        fprintf(f, "    \"profile_level\": %d\n", metadata.profile_level);
+        fprintf(f, "  },\n");
+
+        // Model config
+        fprintf(f, "  \"model_config\": {\n");
+        fprintf(f, "    \"preset\": \"%s\",\n", model_config.preset.c_str());
+        fprintf(f, "    \"N\": %d, \"T\": %d, \"H\": %d, \"W\": %d,\n",
+                model_config.N, model_config.T, model_config.H, model_config.W);
+        fprintf(f, "    \"M\": %d, \"K\": %d, \"H_heads\": %d, \"D\": %d, \"FF\": %d,\n",
+                model_config.M, model_config.K, model_config.H_heads, model_config.D, model_config.FF);
+        fprintf(f, "    \"num_layers\": %d\n", model_config.num_layers);
+        fprintf(f, "  },\n");
+
+        // Timings
+        fprintf(f, "  \"timings\": {\n");
+        size_t cat_i = 0;
+        for (auto& [cat, components] : data_snapshot) {
+            fprintf(f, "    \"%s\": {\n", cat.c_str());
+            size_t comp_i = 0;
+            for (auto& [comp, vals] : components) {
+                ProfileStats s = compute_stats(vals);
+                fprintf(f, "      \"%s\": {\"mean\": %.4f, \"min\": %.4f, \"max\": %.4f, "
+                        "\"median\": %.4f, \"p95\": %.4f, \"stddev\": %.4f, \"count\": %d}",
+                        comp.c_str(), s.mean_ms, s.min_ms, s.max_ms,
+                        s.median_ms, s.p95_ms, s.stddev_ms, s.count);
+                fprintf(f, "%s\n", (++comp_i < components.size()) ? "," : "");
+            }
+            fprintf(f, "    }%s\n", (++cat_i < data_snapshot.size()) ? "," : "");
+        }
+        fprintf(f, "  }\n");
+
+        fprintf(f, "}\n");
+        fclose(f);
+        return true;
+    }
+
+    void print_summary() const {
+        TimingMap data_snapshot = data();
+        std::printf("\n===== native Performance Summary =====\n");
+        std::printf("GPU: %s | CUDA: %s | Warmup: %d | Iters: %d | Profile Level: %d\n",
+                    metadata.gpu_name.c_str(), metadata.cuda_version.c_str(),
+                    metadata.warmup_iters, metadata.timing_iters, metadata.profile_level);
+        std::printf("Config: %s  N=%d T=%d H=%d W=%d  M=%d K=%d H=%d D=%d FF=%d  layers=%d\n",
+                    model_config.preset.c_str(),
+                    model_config.N, model_config.T, model_config.H, model_config.W,
+                    model_config.M, model_config.K, model_config.H_heads, model_config.D,
+                    model_config.FF, model_config.num_layers);
+        std::printf("-----------------------------------------\n");
+        for (auto& [cat, components] : data_snapshot) {
+            std::printf("[%s]\n", cat.c_str());
+            for (auto& [comp, vals] : components) {
+                ProfileStats s = compute_stats(vals);
+                std::printf("  %-24s  mean=%8.3f  min=%8.3f  max=%8.3f  median=%8.3f  p95=%8.3f  stddev=%6.3f ms  (n=%d)\n",
+                            comp.c_str(), s.mean_ms, s.min_ms, s.max_ms,
+                            s.median_ms, s.p95_ms, s.stddev_ms, s.count);
+            }
+        }
+        std::printf("=========================================\n\n");
+    }
+
+private:
+    ProfileAccumulator() = default;
+    mutable std::mutex mu_;
+    TimingMap data_;
+    int iteration_count_ = 0;
+};
+
+// Compile-time gated macros. No-ops when OMNIDREAMS_SINGLEVIEW_PROFILE is not defined.
+#ifdef OMNIDREAMS_SINGLEVIEW_PROFILE
+
+#define OMNIDREAMS_SINGLEVIEW_PROF_RECORD(category, component, ms_val) \
+    omnidreams_singleview::ProfileAccumulator::instance().record(category, component, ms_val)
+
+#define OMNIDREAMS_SINGLEVIEW_PROF_NEW_ITER() \
+    omnidreams_singleview::ProfileAccumulator::instance().new_iteration()
+
+#define OMNIDREAMS_SINGLEVIEW_PROF_CLEAR() \
+    omnidreams_singleview::ProfileAccumulator::instance().clear()
+
+#else
+
+#define OMNIDREAMS_SINGLEVIEW_PROF_RECORD(category, component, ms_val) ((void)0)
+#define OMNIDREAMS_SINGLEVIEW_PROF_NEW_ITER()                          ((void)0)
+#define OMNIDREAMS_SINGLEVIEW_PROF_CLEAR()                             ((void)0)
+
+#endif
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profiler.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/profiler.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 // profiler.h -- Structured performance profiling accumulator for native.

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/workspace_alloc.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/workspace_alloc.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <algorithm>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/workspace_alloc.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/common/workspace_alloc.h
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+
+namespace ts {
+
+// ============================================================================
+// WorkspaceAllocator — bounds-checked linear allocator for GPU workspace memory
+// ============================================================================
+//
+// Replaces raw pointer arithmetic (ptr += N * K * sizeof(half)) with a typed,
+// bounds-checked bump allocator. Every alloc() call verifies that the request
+// fits within the pre-allocated memory pool, catching overflow/overlap bugs at
+// initialization time rather than at kernel crash time.
+//
+// Usage:
+//   WorkspaceAllocator ws(pool_ptr, pool_bytes, "model_workspace");
+//   auto* hidden  = ws.alloc<half>(N * M * K);        // aligned, bounds-checked
+//   auto* scratch = ws.alloc<float>(N * M * K);       // auto-aligned to alignof(float)
+//   ws.align_to(256);                                  // explicit alignment bump
+//   auto* int8_buf = ws.alloc<int8_t>(N * M * FF);
+//
+// Debug mode (compile with -DOMNIDREAMS_SINGLEVIEW_DEBUG_WORKSPACE):
+//   Prints every allocation with label, offset, size, and remaining capacity.
+//
+class WorkspaceAllocator {
+public:
+    WorkspaceAllocator() : base_(nullptr), total_(0), used_(0), label_("") {}
+
+    WorkspaceAllocator(void* base, size_t total_bytes, const char* label = "workspace")
+        : base_(static_cast<uint8_t*>(base))
+        , total_(total_bytes)
+        , used_(0)
+        , label_(label) {}
+
+    // Allocate `count` elements of type T, with optional alignment (defaults to alignof(T)).
+    // Returns a typed device pointer. Aborts on overflow in debug builds.
+    template <typename T>
+    T* alloc(size_t count, size_t align = 0) {
+        if (align == 0) align = alignof(T);
+        align_to(align);
+
+        if (count > std::numeric_limits<size_t>::max() / sizeof(T)) {
+            std::fprintf(stderr,
+                "[FATAL] WorkspaceAllocator '%s' size overflow: requested %zu elements of %zu bytes\n",
+                label_, count, sizeof(T));
+#ifndef OMNIDREAMS_SINGLEVIEW_WORKSPACE_NO_ABORT
+            std::abort();
+#else
+            return nullptr;
+#endif
+        }
+        size_t bytes = count * sizeof(T);
+
+#ifdef OMNIDREAMS_SINGLEVIEW_DEBUG_WORKSPACE
+        const size_t remaining = used_ <= total_ ? total_ - used_ : 0;
+        std::printf("[WorkspaceAlloc][%s] +%zu bytes (%zu x %zu) at offset %zu / %zu (%.1f%% used)\n",
+                    label_, bytes, count, sizeof(T), used_, total_,
+                    total_ > 0 ? 100.0 * (total_ - remaining + std::min(bytes, remaining)) / total_ : 0.0);
+#endif
+
+        if (used_ > total_ || bytes > (total_ - used_)) {
+            const size_t remaining = used_ <= total_ ? total_ - used_ : 0;
+            const size_t shortfall = bytes > remaining ? bytes - remaining : bytes;
+            std::fprintf(stderr,
+                "[FATAL] WorkspaceAllocator '%s' overflow: requested %zu bytes at offset %zu, "
+                "but total capacity is %zu bytes (%zu bytes short)\n",
+                label_, bytes, used_, total_, shortfall);
+#ifndef OMNIDREAMS_SINGLEVIEW_WORKSPACE_NO_ABORT
+            std::abort();
+#else
+            return nullptr;
+#endif
+        }
+
+        T* ptr = reinterpret_cast<T*>(base_ + used_);
+        used_ += bytes;
+        return ptr;
+    }
+
+    // Advance the internal pointer to satisfy the given alignment.
+    void align_to(size_t alignment) {
+        if (alignment <= 1) return;
+        if ((alignment & (alignment - 1)) != 0 ||
+            used_ > total_ ||
+            reinterpret_cast<uintptr_t>(base_) > std::numeric_limits<uintptr_t>::max() - used_) {
+            std::fprintf(stderr,
+                "[FATAL] WorkspaceAllocator '%s' invalid alignment request: align=%zu, offset=%zu, total=%zu\n",
+                label_, alignment, used_, total_);
+#ifndef OMNIDREAMS_SINGLEVIEW_WORKSPACE_NO_ABORT
+            std::abort();
+#else
+            return;
+#endif
+        }
+        uintptr_t addr = reinterpret_cast<uintptr_t>(base_) + used_;
+        uintptr_t mask = alignment - 1;
+        if (addr > std::numeric_limits<uintptr_t>::max() - mask) {
+            std::fprintf(stderr,
+                "[FATAL] WorkspaceAllocator '%s' alignment address overflow: align=%zu, offset=%zu\n",
+                label_, alignment, used_);
+#ifndef OMNIDREAMS_SINGLEVIEW_WORKSPACE_NO_ABORT
+            std::abort();
+#else
+            return;
+#endif
+        }
+        uintptr_t aligned = (addr + mask) & ~mask;
+        size_t padding = aligned - addr;
+        if (padding > total_ - used_) {
+            std::fprintf(stderr,
+                "[FATAL] WorkspaceAllocator '%s' alignment overflow: requested %zu bytes at offset %zu, "
+                "but total capacity is %zu bytes\n",
+                label_, padding, used_, total_);
+#ifndef OMNIDREAMS_SINGLEVIEW_WORKSPACE_NO_ABORT
+            std::abort();
+#else
+            return;
+#endif
+        }
+        used_ += padding;
+    }
+
+    // Reset used counter to zero (reuse the same memory pool from the start).
+    void reset() { used_ = 0; }
+
+    // Current write position (raw byte pointer).
+    uint8_t* current() const { return base_ + used_; }
+
+    size_t used() const { return used_; }
+    size_t remaining() const { return total_ > used_ ? total_ - used_ : 0; }
+    size_t total() const { return total_; }
+
+    // Create a sub-allocator from the current position with a fixed byte budget.
+    // Advances this allocator by `budget_bytes` (bounds-checked).
+    WorkspaceAllocator sub(size_t budget_bytes, const char* sub_label = "sub") {
+        if (used_ > total_ || budget_bytes > (total_ - used_)) {
+            std::fprintf(stderr,
+                "[FATAL] WorkspaceAllocator '%s' sub-alloc overflow: requested %zu bytes at offset %zu, "
+                "but total capacity is %zu bytes\n",
+                label_, budget_bytes, used_, total_);
+#ifndef OMNIDREAMS_SINGLEVIEW_WORKSPACE_NO_ABORT
+            std::abort();
+#else
+            return WorkspaceAllocator(nullptr, 0, sub_label);
+#endif
+        }
+        WorkspaceAllocator child(base_ + used_, budget_bytes, sub_label);
+        used_ += budget_bytes;
+        return child;
+    }
+
+private:
+    uint8_t* base_;
+    size_t total_;
+    size_t used_;
+    const char* label_;
+};
+
+} // namespace ts

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/arch_traits.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/arch_traits.h
@@ -1,0 +1,67 @@
+#pragma once
+
+namespace omnidreams_singleview {
+
+// ============================================================================
+// Architecture Traits for Multi-Model Extensibility
+// ============================================================================
+//
+// ArchTraits encode the architectural decisions that differ between transformer
+// model families (Wan, Flux, Hunyuan, etc.). The transformer block
+// (run_transformer_block) and model forward (transformer_forward) are templated
+// on an ArchTraits type so that new models can be supported by defining a new
+// traits struct and instantiating the templates, without modifying core logic.
+//
+// Each traits struct must provide the following static constexpr members:
+//   NormType  kSelfAttnNorm    - normalization before self-attention
+//   NormType  kCrossAttnNorm   - normalization before cross-attention
+//   ActType   kFFNActivation   - FFN hidden-layer activation function
+//   bool      kHasImageCrossAttn - whether I2V image cross-attention is supported
+//   int       kFFNGateStyle    - 0 = no gate, 1 = gated residual from scale_shift_table
+//   int       kScaleShiftSlots - number of entries in per-block scale_shift_table (e.g. 6)
+
+enum class NormType {
+    RMSNorm,    // x / sqrt(mean(x^2) + eps)  -- no learnable affine (Wan)
+    LayerNorm,  // (x - mean) / sqrt(var + eps) * gamma + beta (standard)
+};
+
+enum class ActType {
+    GELU,       // Gaussian Error Linear Unit (Wan FFN)
+    SiLU,       // Sigmoid Linear Unit / Swish (Flux, Hunyuan)
+    GELUTanh,   // GELU with tanh approximation
+};
+
+// ---------------------------------------------------------------------------
+// WanArchTraits -- Wan 2.1 (T2V-1.3B, I2V-14B) architecture
+// ---------------------------------------------------------------------------
+struct WanArchTraits {
+    static constexpr NormType kSelfAttnNorm    = NormType::RMSNorm;
+    static constexpr NormType kCrossAttnNorm   = NormType::LayerNorm;
+    static constexpr ActType  kFFNActivation   = ActType::GELU;
+    static constexpr bool     kHasImageCrossAttn = true;
+    static constexpr int      kFFNGateStyle    = 1;  // gated residual
+    static constexpr int      kScaleShiftSlots = 6;  // [scale1, shift1, gate1, shift2, scale2, gate2]
+};
+
+// ---------------------------------------------------------------------------
+// Future model traits (not yet implemented -- placeholders for extensibility)
+// ---------------------------------------------------------------------------
+// struct FluxArchTraits {
+//     static constexpr NormType kSelfAttnNorm    = NormType::LayerNorm;
+//     static constexpr NormType kCrossAttnNorm   = NormType::LayerNorm;
+//     static constexpr ActType  kFFNActivation   = ActType::SiLU;
+//     static constexpr bool     kHasImageCrossAttn = false;
+//     static constexpr int      kFFNGateStyle    = 0;
+//     static constexpr int      kScaleShiftSlots = 2;
+// };
+//
+// struct HunyuanArchTraits {
+//     static constexpr NormType kSelfAttnNorm    = NormType::RMSNorm;
+//     static constexpr NormType kCrossAttnNorm   = NormType::RMSNorm;
+//     static constexpr ActType  kFFNActivation   = ActType::SiLU;
+//     static constexpr bool     kHasImageCrossAttn = false;
+//     static constexpr int      kFFNGateStyle    = 1;
+//     static constexpr int      kScaleShiftSlots = 6;
+// };
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/arch_traits.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/arch_traits.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 namespace omnidreams_singleview {

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cu
@@ -1,0 +1,2257 @@
+#include "attention.cuh"
+#include "workspace.cuh"
+#include "linear_utils.cuh"
+#include "helper.h"
+#include "kernel_forward.h"
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/device/gemm.h"
+#include "cutlass/gemm/device/gemm_batched.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+
+#include "cutlass/layout/matrix.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/bfloat16.h"
+#include "ops.cuh"
+#include "dtype_utils.cuh"
+#include "common/profile_config.h"
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cudnn_frontend.h>
+#include <chrono>
+#include <cmath>
+#include <algorithm>
+#include <cstdlib>
+#include <cctype>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <cstdint>
+
+// Debug helper: check for NaN/Inf in a half buffer on device
+// Uncomment `#define FP8_NAN_DEBUG 1` to enable
+// #define FP8_NAN_DEBUG 1
+#ifdef FP8_NAN_DEBUG
+static __global__ void ca_nan_check_kernel(const half* data, int64_t n, int* found_nan, int* found_inf) {
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  float v = __half2float(data[idx]);
+  if (isnan(v)) atomicAdd(found_nan, 1);
+  if (isinf(v)) atomicAdd(found_inf, 1);
+}
+static bool ca_check_nan_inf(const cutlass::half_t* buf, int64_t count, const char* label, cudaStream_t stream) {
+  int h_nan = 0, h_inf = 0;
+  int *d_nan, *d_inf;
+  cudaMallocAsync(&d_nan, sizeof(int), stream);
+  cudaMallocAsync(&d_inf, sizeof(int), stream);
+  cudaMemsetAsync(d_nan, 0, sizeof(int), stream);
+  cudaMemsetAsync(d_inf, 0, sizeof(int), stream);
+  int threads = 256;
+  int blocks = (int)((count + threads - 1) / threads);
+  ca_nan_check_kernel<<<blocks, threads, 0, stream>>>(
+    reinterpret_cast<const half*>(buf), count, d_nan, d_inf);
+  cudaMemcpyAsync(&h_nan, d_nan, sizeof(int), cudaMemcpyDeviceToHost, stream);
+  cudaMemcpyAsync(&h_inf, d_inf, sizeof(int), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+  cudaFreeAsync(d_nan, stream);
+  cudaFreeAsync(d_inf, stream);
+  if (h_nan > 0 || h_inf > 0) {
+    printf("[NAN_DEBUG] %s: %d NaN, %d Inf out of %lld elements\n", label, h_nan, h_inf, (long long)count);
+    return true;
+  }
+  return false;
+}
+#define CA_NAN_CHECK(buf, count, label) ca_check_nan_inf(buf, count, label, stream)
+#else
+#define CA_NAN_CHECK(buf, count, label) false
+#endif
+
+namespace fe = cudnn_frontend;
+
+namespace omnidreams_singleview {
+
+// ============================================================================
+// Optional fine-grained profiling helpers (level >= 3)
+// ============================================================================
+
+static inline bool wan_profile_detail_enabled(long long* out_call_idx) {
+  int prof_lvl = g_wan_profile_level.load(std::memory_order_relaxed);
+  if (prof_lvl < 3) return false;
+
+  int print_every = g_wan_profile_print_every.load(std::memory_order_relaxed);
+  if (print_every < 1) print_every = 1;
+
+  // g_wan_profile_call_idx is incremented in the transformer block before calling attention.
+  // We want the "current" call index, i.e. the last value returned by fetch_add.
+  long long cur = g_wan_profile_call_idx.load(std::memory_order_relaxed);
+  long long call_idx = (cur > 0) ? (cur - 1) : 0;
+  if ((call_idx % print_every) != 0) return false;
+
+  if (out_call_idx) *out_call_idx = call_idx;
+  return true;
+}
+
+// ============================================================================
+// Cosmos FP8 cuDNN SDPA engine/layout selection
+// ============================================================================
+
+namespace {
+
+std::string cosmos_lower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return value;
+}
+
+bool cosmos_env_is_set(const char* value) {
+  return value && value[0] != '\0';
+}
+
+bool cosmos_valid_fp8_sdpa_layout(const std::string& layout) {
+  return layout == "bmhd" || layout == "bhmd";
+}
+
+bool cosmos_valid_fp8_sdpa_heuristics(const std::string& heuristics) {
+  return heuristics == "a" ||
+         heuristics == "b" ||
+         heuristics == "fallback" ||
+         heuristics == "a_b" ||
+         heuristics == "a_b_fallback" ||
+         heuristics == "b_fallback";
+}
+
+bool cosmos_valid_fp8_sdpa_plan(const std::string& plan) {
+  return plan == "heuristic" || plan == "all" || plan == "autotune";
+}
+
+std::vector<fe::HeurMode_t> cosmos_fp8_sdpa_heur_modes(const std::string& heuristics) {
+  if (heuristics == "b") return {fe::HeurMode_t::B};
+  if (heuristics == "fallback") return {fe::HeurMode_t::FALLBACK};
+  if (heuristics == "a_b") return {fe::HeurMode_t::A, fe::HeurMode_t::B};
+  if (heuristics == "a_b_fallback") {
+    return {fe::HeurMode_t::A, fe::HeurMode_t::B, fe::HeurMode_t::FALLBACK};
+  }
+  if (heuristics == "b_fallback") {
+    return {fe::HeurMode_t::B, fe::HeurMode_t::FALLBACK};
+  }
+  return {fe::HeurMode_t::A};
+}
+
+fe::BuildPlanPolicy_t cosmos_fp8_sdpa_build_policy(const std::string& plan) {
+  return plan == "all" || plan == "autotune"
+      ? fe::BuildPlanPolicy_t::ALL
+      : fe::BuildPlanPolicy_t::HEURISTICS_CHOICE;
+}
+
+}  // namespace
+
+CosmosFp8SdpaSelection select_cosmos_fp8_sdpa(
+    int B, int Mq, int Mk,
+    int H, int D) {
+  (void)B;
+  (void)Mq;
+  (void)Mk;
+  (void)H;
+  (void)D;
+
+  CosmosFp8SdpaSelection selection;
+  const char* preset_env = std::getenv("OMNIDREAMS_DIT_FP8_SDPA_PRESET");
+  selection.preset = cosmos_env_is_set(preset_env) ? cosmos_lower(preset_env) : "540p";
+
+  const char* layout_env = std::getenv("OMNIDREAMS_DIT_FP8_SDPA_LAYOUT");
+  const char* heur_env = std::getenv("OMNIDREAMS_DIT_FP8_SDPA_HEUR");
+  const char* plan_env = std::getenv("OMNIDREAMS_DIT_FP8_SDPA_PLAN");
+
+  if (cosmos_env_is_set(layout_env)) {
+    std::string requested = cosmos_lower(layout_env);
+    if (cosmos_valid_fp8_sdpa_layout(requested)) {
+      selection.layout = requested;
+      selection.layout_env_override = true;
+      selection.reason = "OMNIDREAMS_DIT_FP8_SDPA_LAYOUT_override";
+    } else {
+      selection.reason = "ignored_invalid_OMNIDREAMS_DIT_FP8_SDPA_LAYOUT";
+    }
+  }
+
+  if (cosmos_env_is_set(heur_env)) {
+    std::string requested = cosmos_lower(heur_env);
+    if (cosmos_valid_fp8_sdpa_heuristics(requested)) {
+      selection.heuristics = requested;
+      selection.heuristics_env_override = true;
+      if (selection.reason.empty()) {
+        selection.reason = "OMNIDREAMS_DIT_FP8_SDPA_HEUR_override";
+      }
+    } else if (selection.reason.empty() || selection.reason == "540p_preset") {
+      selection.reason = "ignored_invalid_OMNIDREAMS_DIT_FP8_SDPA_HEUR";
+    }
+  }
+
+  if (cosmos_env_is_set(plan_env)) {
+    std::string requested = cosmos_lower(plan_env);
+    if (cosmos_valid_fp8_sdpa_plan(requested)) {
+      selection.plan = requested;
+      selection.plan_env_override = true;
+      if (selection.reason.empty()) {
+        selection.reason = "OMNIDREAMS_DIT_FP8_SDPA_PLAN_override";
+      }
+    } else if (selection.reason.empty() || selection.reason == "540p_preset") {
+      selection.reason = "ignored_invalid_OMNIDREAMS_DIT_FP8_SDPA_PLAN";
+    }
+  }
+
+  if (selection.layout.empty() || selection.heuristics.empty() || selection.plan.empty()) {
+    if (selection.preset == "legacy" || selection.preset == "env") {
+      if (selection.layout.empty()) selection.layout = "bmhd";
+      if (selection.heuristics.empty()) selection.heuristics = "a";
+      if (selection.plan.empty()) selection.plan = "heuristic";
+      if (selection.reason.empty()) {
+        selection.reason = selection.preset == "env"
+            ? "env_missing_fields_legacy_fallback"
+            : "legacy";
+      }
+    } else {
+      // 540p preset, retained until a measured autotune winner beats it:
+      // BMHD input avoids extra transposes; A+B heuristics with all successful
+      // plans was the 2026-05-06 540p E2E winner in
+      // profiles/cosmos_fp8_attention/autotune_sdpa_540p_20260506_184914_summary.json.
+      if (selection.layout.empty()) selection.layout = "bmhd";
+      if (selection.heuristics.empty()) selection.heuristics = "a_b";
+      if (selection.plan.empty()) selection.plan = "all";
+      if (selection.reason.empty()) {
+        selection.reason = selection.preset == "540p"
+            ? "540p_preset"
+            : "unknown_preset_540p_fallback";
+      }
+    }
+  }
+
+  return selection;
+}
+
+// ============================================================================
+// Attention Backend Selection
+// ============================================================================
+
+namespace {
+    AttnBackend g_attention_backend = AttnBackend::CUTLASS_FLASH;
+}
+
+void set_attention_backend(AttnBackend backend) {
+    g_attention_backend = backend;
+}
+
+AttnBackend get_attention_backend() {
+    return g_attention_backend;
+}
+
+static GemmBackend g_gemm_backend = GemmBackend::FP16;
+void set_gemm_backend(GemmBackend b) { g_gemm_backend = b; }
+GemmBackend get_gemm_backend() { return g_gemm_backend; }
+
+// ============================================================================
+// Backend Implementations
+// ============================================================================
+
+// RowMajor fused variant: RMSNorm+pack BMHK and apply RoPE for Q,K in one pass
+__global__ void rmsnorm_pack_bmhk_rope_from_row_kernel(
+    const half* __restrict__ Drow, int M, int K,
+    int H, int Dh,
+    int M_rope,  // RoPE table length (per-sample sequence length, i.e. Mq)
+    const cutlass::half_t* __restrict__ gamma_q, const cutlass::half_t* __restrict__ gamma_k, float eps,
+    const float* __restrict__ cos_tbl, // [M, D] row-major
+    const float* __restrict__ sin_tbl, // [M, D] row-major
+    cutlass::half_t* __restrict__ Q_bmhk,
+    cutlass::half_t* __restrict__ K_bmhk,
+    cutlass::half_t* __restrict__ V_bmhk) {
+  int row = blockIdx.x; if (row >= M) return;
+  int tid = threadIdx.x;
+  extern __shared__ float ssum[];
+  float* ssum_q = ssum;
+  float* ssum_k = ssum + blockDim.x;
+  // base pointer for this row
+  const half* row_ptr = Drow + size_t(row) * (3 * K);
+  // Accumulate sums for RMSNorm of Q and K
+  float sq = 0.f, sk = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float qv = __half2float(row_ptr[j]);
+    float kv = __half2float(row_ptr[K + j]);
+    sq += qv * qv;
+    sk += kv * kv;
+  }
+  ssum_q[tid] = sq;
+  ssum_k[tid] = sk;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) {
+      ssum_q[tid] += ssum_q[tid + off];
+      ssum_k[tid] += ssum_k[tid + off];
+    }
+    __syncthreads();
+  }
+  float inv_q = rsqrtf(ssum_q[0] / float(K) + eps);
+  float inv_k = rsqrtf(ssum_k[0] / float(K) + eps);
+
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+
+  // Pointers to RoPE rows for this sequence position.
+  // For batched inputs, tokens are flattened as [B*Mq, ...] and share a single RoPE table [Mq, Dh].
+  // So we index RoPE by m = row % M_rope, where M_rope == Mq.
+  int rope_m = (cos_tbl && sin_tbl) ? (row % M_rope) : 0;
+  const float* cos_row = cos_tbl ? (cos_tbl + size_t(rope_m) * Dh) : nullptr;
+  const float* sin_row = sin_tbl ? (sin_tbl + size_t(rope_m) * Dh) : nullptr;
+
+  // Write BMHK with RoPE applied to Q and K. Process pairs (even, odd) per head.
+  // Iterate over K with step 2 per thread to avoid write races between pair elements.
+  for (int j = tid * 2; j + 1 < K; j += blockDim.x * 2) {
+    int p = j % Dh; // position within head
+    // Load and normalize Q pair
+    float q_even = __half2float(row_ptr[j]);
+    float q_odd  = __half2float(row_ptr[j + 1]);
+    float q_ne = (q_even * inv_q) * to_f32(gamma_q[j]);
+    float q_no = (q_odd  * inv_q) * to_f32(gamma_q[j + 1]);
+    // Load and normalize K pair
+    float k_even = __half2float(row_ptr[K + j]);
+    float k_odd  = __half2float(row_ptr[K + j + 1]);
+    float k_ne = (k_even * inv_k) * to_f32(gamma_k[j]);
+    float k_no = (k_odd  * inv_k) * to_f32(gamma_k[j + 1]);
+
+    if (cos_row && sin_row) {
+      // Apply RoPE rotation using per-dimension cos/sin
+      float c = cos_row[p];
+      float s = sin_row[p + 1];
+      // Q rotation
+      float q_rot_e = q_ne * c - q_no * s;
+      float q_rot_o = q_ne * s + q_no * c;
+      q_ne = q_rot_e; q_no = q_rot_o;
+      // K rotation
+      float k_rot_e = k_ne * c - k_no * s;
+      float k_rot_o = k_ne * s + k_no * c;
+      k_ne = k_rot_e; k_no = k_rot_o;
+    }
+
+    size_t base = size_t(row) * K;
+    // Write Q
+    Q_bmhk[base + j]     = to_f16(q_ne);
+    Q_bmhk[base + j + 1] = to_f16(q_no);
+    // Write K
+    K_bmhk[base + j]     = to_f16(k_ne);
+    K_bmhk[base + j + 1] = to_f16(k_no);
+    // Write V (no RMSNorm, no RoPE)
+    float v0 = __half2float(row_ptr[2 * K + j]);
+    float v1 = __half2float(row_ptr[2 * K + j + 1]);
+    V_bmhk[base + j]     = to_f16(v0);
+    V_bmhk[base + j + 1] = to_f16(v1);
+  }
+
+  // If Dh is odd (unlikely), handle the last lane without RoPE pairwise rotation
+  if ((Dh & 1) && (tid == 0)) {
+    // Process indices j where (j % Dh) == Dh-1
+    for (int h = 0; h < H; ++h) {
+      int j = h * Dh + (Dh - 1);
+      if (j < K) {
+        float qv = __half2float(row_ptr[j]);
+        float kv = __half2float(row_ptr[K + j]);
+        float vv = __half2float(row_ptr[2 * K + j]);
+        float qn = (qv * inv_q) * to_f32(gamma_q[j]);
+        float kn = (kv * inv_k) * to_f32(gamma_k[j]);
+        Q_bmhk[size_t(row) * K + j] = to_f16(qn);
+        K_bmhk[size_t(row) * K + j] = to_f16(kn);
+        V_bmhk[size_t(row) * K + j] = to_f16(vv);
+      }
+    }
+  }
+}
+
+
+// Pack one matrix with RMSNorm (half input), add bias and gamma
+__global__ void rmsnorm_pack_single_from_half_kernel(
+    const cutlass::half_t* __restrict__ Dcol_h, int ld, int rows, int K,
+    int H, int Dh,
+    const cutlass::half_t* __restrict__ gamma,
+    float eps,
+    cutlass::half_t* __restrict__ Out_bmhk) {
+  int row = blockIdx.x; if (row >= rows) return;
+  int tid = threadIdx.x;
+  extern __shared__ float ssum[];
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float acc = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = to_f32(Dcol_h[row + j * ld]);
+    acc += v * v;
+  }
+  ssum[tid] = acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) { if (tid < off) ssum[tid] += ssum[tid + off]; __syncthreads(); }
+  float inv = rsqrtf(ssum[0] / float(K) + eps);
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  size_t row_base = size_t(row) * K;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float vn = (to_f32(Dcol_h[row + j * ld])) * inv * to_f32(gamma[j]);
+    Out_bmhk[row_base + j] = to_f16(vn);
+  }
+}
+
+// Pack K with RMSNorm (gamma_k) and V as-is from concatenated [rows, 2K] half into BMHK half
+__global__ void rmsnorm_pack_kv_from_half_kernel(
+    const cutlass::half_t* __restrict__ Dcol_h, int ld, int rows, int K,
+    int H, int Dh,
+    const cutlass::half_t* __restrict__ gamma_k,
+    float eps,
+    cutlass::half_t* __restrict__ K_bmhk,
+    cutlass::half_t* __restrict__ V_bmhk) {
+  int row = blockIdx.x; if (row >= rows) return;
+  int tid = threadIdx.x;
+  extern __shared__ float ssum[];
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float acc = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = to_f32(Dcol_h[row + j * ld]);
+    acc += v * v;
+  }
+  ssum[tid] = acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) { if (tid < off) ssum[tid] += ssum[tid + off]; __syncthreads(); }
+  float inv = rsqrtf(ssum[0] / float(K) + eps);
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  size_t row_base = size_t(row) * K;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float kn = (to_f32(Dcol_h[row + j * ld])) * inv * to_f32(gamma_k[j]);
+    K_bmhk[row_base + j] = to_f16(kn);
+    float vv = to_f32(Dcol_h[row + (K + j) * ld]);
+    V_bmhk[row_base + j] = to_f16(vv);
+  }
+}
+
+// RowMajor variant: Pack one matrix with RMSNorm (row-major input)
+__global__ void rmsnorm_pack_single_from_row_kernel(
+    const half* __restrict__ Drow, int rows, int K,
+    int H, int Dh,
+    const cutlass::half_t* __restrict__ gamma,
+    float eps,
+    cutlass::half_t* __restrict__ Out_bmhk) {
+  int row = blockIdx.x; if (row >= rows) return;
+  int tid = threadIdx.x;
+  extern __shared__ float ssum[];
+  float acc = 0.f;
+  const half* row_ptr = Drow + size_t(row) * K;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = __half2float(row_ptr[j]);
+    acc += v * v;
+  }
+  ssum[tid] = acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) { if (tid < off) ssum[tid] += ssum[tid + off]; __syncthreads(); }
+  float inv = rsqrtf(ssum[0] / float(K) + eps);
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  size_t row_base = size_t(row) * K;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float vn = (__half2float(row_ptr[j])) * inv * to_f32(gamma[j]);
+    Out_bmhk[row_base + j] = to_f16(vn);
+  }
+}
+
+// RowMajor variant: Pack K with RMSNorm (gamma_k) and V as-is from concatenated [rows, 2K] row-major into BMHK half
+__global__ void rmsnorm_pack_kv_from_row_kernel(
+    const half* __restrict__ Drow, int rows, int K,
+    int H, int Dh,
+    const cutlass::half_t* __restrict__ gamma_k,
+    float eps,
+    cutlass::half_t* __restrict__ K_bmhk,
+    cutlass::half_t* __restrict__ V_bmhk) {
+  int row = blockIdx.x; if (row >= rows) return;
+  int tid = threadIdx.x;
+  extern __shared__ float ssum[];
+  float acc = 0.f;
+  const half* row_ptr = Drow + size_t(row) * (2 * K);
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = __half2float(row_ptr[j]);
+    acc += v * v;
+  }
+  ssum[tid] = acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) { if (tid < off) ssum[tid] += ssum[tid + off]; __syncthreads(); }
+  float inv = rsqrtf(ssum[0] / float(K) + eps);
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  size_t row_base = size_t(row) * K;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float kn = (__half2float(row_ptr[j])) * inv * to_f32(gamma_k[j]);
+    K_bmhk[row_base + j] = to_f16(kn);
+    float vv = __half2float(row_ptr[K + j]);
+    V_bmhk[row_base + j] = to_f16(vv);
+  }
+}
+
+// Apply RoPE in-place on Q and K packed as BMHK (half precision)
+__global__ void apply_rope_bmhk_kernel(
+    cutlass::half_t* __restrict__ Q_bmhk,
+    cutlass::half_t* __restrict__ K_bmhk,
+    int M, int H, int D,
+    const float* __restrict__ cos_tbl, // [M, D] row-major
+    const float* __restrict__ sin_tbl  // [M, D] row-major
+    ) {
+  int i = blockIdx.y; // sequence position
+  int h = blockIdx.x; // head
+  if (i >= M || h >= H) return;
+  int t = threadIdx.x;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  size_t base = size_t(i) * (H * D) + size_t(h) * D;
+  const float* cos_row = cos_tbl + size_t(i) * D;
+  const float* sin_row = sin_tbl + size_t(i) * D;
+  // process pairs (even, odd)
+  for (int p = t * 2; p + 1 < D; p += blockDim.x * 2) {
+    float c = cos_row[p];
+    float s = sin_row[p + 1];
+    // Q
+    float q_even = to_f32(Q_bmhk[base + p]);
+    float q_odd  = to_f32(Q_bmhk[base + p + 1]);
+    float q_ne = q_even * c - q_odd * s;
+    float q_no = q_even * s + q_odd * c;
+    Q_bmhk[base + p] = to_f16(q_ne);
+    Q_bmhk[base + p + 1] = to_f16(q_no);
+    // K
+    float k_even = to_f32(K_bmhk[base + p]);
+    float k_odd  = to_f32(K_bmhk[base + p + 1]);
+    float k_ne = k_even * c - k_odd * s;
+    float k_no = k_even * s + k_odd * c;
+    K_bmhk[base + p] = to_f16(k_ne);
+    K_bmhk[base + p + 1] = to_f16(k_no);
+  }
+}
+
+// CUTLASS Flash Attention implementation
+static cudaError_t run_self_attention_cutlass(const AttentionDeviceParamsT<cutlass::half_t>& p, cudaStream_t stream) {
+  int B = p.B;
+  int Mq = p.Mq;
+  if (Mq <= 0) { return cudaErrorInvalidValue; }
+  int M = B * Mq;
+  int K = p.K, H = p.H, D = p.D;
+
+  // Optional fine-grained profiling (GPU time via CUDA events).
+  long long prof_call_idx = 0;
+  bool prof_detail = wan_profile_detail_enabled(&prof_call_idx);
+  enum {
+    EV_START = 0,
+    EV_AFTER_QKV_PROJ,
+    EV_AFTER_PACK_ROPE,
+    EV_AFTER_FMHA,
+    EV_AFTER_OUT,
+    EV_COUNT
+  };
+  cudaEvent_t ev[EV_COUNT];
+  auto rec = [&](int idx) {
+    if (prof_detail) cudaEventRecord(ev[idx], stream);
+  };
+  if (prof_detail) {
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventCreate(&ev[i]);
+    rec(EV_START);
+  }
+
+  // Use workspace (always provided)
+  cutlass::half_t* qkv_row = p.workspace->cutlass_flash.sa_qkv_row;
+  cutlass::half_t* dQh_bmhk = p.workspace->cutlass_flash.sa_q_bmhk;
+  cutlass::half_t* dKh_bmhk = p.workspace->cutlass_flash.sa_k_bmhk;
+  cutlass::half_t* dVh_bmhk = p.workspace->cutlass_flash.sa_v_bmhk;
+  cutlass::half_t* dOh_bmhk = p.workspace->cutlass_flash.sa_o_bmhk;  // Reuses sa_q_bmhk
+
+  // 1) QKV projection via cutlass_linear_layer (weights pre-transposed in Python to [K,3K])
+  // Expect hidden_states to be RowMajor [M,K] already (avoid extra transpose)
+  // RowMajor GEMM with stride-trick bias to compute QKV into RowMajor buffer
+  {
+    auto* fp8_scratch = reinterpret_cast<cutlass::half_t*>(dQh_bmhk); // scratch for potential FP8 path
+    cudaError_t err = apply_linear_row<cutlass::half_t>(
+        reinterpret_cast<const cutlass::half_t*>(p.hidden_states),
+        reinterpret_cast<const cutlass::half_t*>(p.w_qkv),
+        reinterpret_cast<const cutlass::half_t*>(p.b_qkv),
+        reinterpret_cast<cutlass::half_t*>(qkv_row),
+        M, K, 3 * K, stream,
+        fp8_scratch);
+    if (err != cudaSuccess) { return err; }
+  }
+  rec(EV_AFTER_QKV_PROJ);
+
+  // Fused RMSNorm+pack+RoPE
+  rmsnorm_pack_bmhk_rope_from_row_kernel<<<M, 256, 2*256*sizeof(float), stream>>>(
+    reinterpret_cast<const half*>(qkv_row), M, K, H, D, Mq,
+    p.norm_q_gamma, p.norm_k_gamma, 1e-6f,
+    p.rotary_cos, p.rotary_sin,
+    dQh_bmhk, dKh_bmhk, dVh_bmhk);
+  CUDA_CHECK(cudaGetLastError());
+  rec(EV_AFTER_PACK_ROPE);
+
+  // 3) FMHA using CUTLASS example kernel (half precision) directly on packed tensors
+  using Attention = AttentionKernel<cutlass::half_t, cutlass::arch::Sm80, true, 128, 128, 128, false, false>;
+  typename Attention::Params ap{};
+  ap.query_ptr = dQh_bmhk; ap.key_ptr = dKh_bmhk; ap.value_ptr = dVh_bmhk;
+  ap.logsumexp_ptr = nullptr; ap.output_accum_ptr = nullptr; ap.output_ptr = dOh_bmhk;
+  ap.scale = 1.0f / sqrtf(float(D)); ap.num_heads = H; ap.num_batches = B; ap.head_dim = D; ap.head_dim_value = D; ap.num_queries = Mq; ap.num_keys = Mq;
+  ap.q_strideH = D; ap.k_strideH = D; ap.v_strideH = D; ap.q_strideM = H * D; ap.k_strideM = H * D; ap.v_strideM = H * D; ap.q_strideB = ap.q_strideM * ap.num_queries; ap.k_strideB = ap.k_strideM * ap.num_keys; ap.v_strideB = ap.v_strideM * ap.num_keys; ap.o_strideM = ap.head_dim_value * ap.num_heads;
+  ap.custom_mask_type = p.is_causal ? Attention::CausalFromTopLeft : Attention::NoCustomMask;
+  constexpr auto kernel_fn = attention_kernel_batched_impl<Attention>;
+  int smem_bytes = sizeof(typename Attention::SharedStorage);
+  if (smem_bytes > 0xc000) { cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes); }
+  if (!Attention::check_supported(ap)) return cudaErrorNotSupported;
+  kernel_fn<<<ap.getBlocksGrid(), ap.getThreadsGrid(), smem_bytes, stream>>>(ap);
+  CUDA_CHECK(cudaGetLastError());
+  rec(EV_AFTER_FMHA);
+
+  // 4) Output projection via shared helper (consume BMHK as row-major [M,K])
+  {
+    auto* fp8_scratch = reinterpret_cast<cutlass::half_t*>(dQh_bmhk); // safe scratch
+    cudaError_t err = apply_linear_row<cutlass::half_t>(
+        reinterpret_cast<const cutlass::half_t*>(dOh_bmhk),
+        reinterpret_cast<const cutlass::half_t*>(p.w_out),
+        reinterpret_cast<const cutlass::half_t*>(p.b_out),
+        reinterpret_cast<cutlass::half_t*>(p.out_after_linear),
+        M, K, K, stream,
+        fp8_scratch);
+    if (err != cudaSuccess) { return err; }
+
+    rec(EV_AFTER_OUT);
+    if (prof_detail) {
+      cudaEventSynchronize(ev[EV_AFTER_OUT]);
+      auto ms = [&](int a, int b) -> float {
+        float out = 0.f;
+        cudaEventElapsedTime(&out, ev[a], ev[b]);
+        return out;
+      };
+      float t_qkv  = ms(EV_START, EV_AFTER_QKV_PROJ);
+      float t_pack = ms(EV_AFTER_QKV_PROJ, EV_AFTER_PACK_ROPE);
+      float t_fmha = ms(EV_AFTER_PACK_ROPE, EV_AFTER_FMHA);
+      float t_out  = ms(EV_AFTER_FMHA, EV_AFTER_OUT);
+      float t_tot  = ms(EV_START, EV_AFTER_OUT);
+      std::printf(
+        "[sa_cutlass][call=%lld] M=%d K=%d H=%d D=%d | "
+        "qkv=%.3f pack_rope=%.3f fmha=%.3f out=%.3f total=%.3f ms\n",
+        prof_call_idx, M, K, H, D, t_qkv, t_pack, t_fmha, t_out, t_tot
+      );
+      for (int i = 0; i < EV_COUNT; ++i) cudaEventDestroy(ev[i]);
+    }
+  }
+  return cudaSuccess;
+}
+
+// CUTLASS Flash Attention implementation
+static cudaError_t run_cross_attention_cutlass(const AttentionDeviceParamsT<cutlass::half_t>& p, bool fuse_residual, cudaStream_t stream) {
+  int B = p.B;
+  int Mq = p.Mq;
+  if (Mq <= 0) { return cudaErrorInvalidValue; }
+  int M = B * Mq;
+  int K = p.K, H = p.H, D = p.D;
+  bool use_image_branch = (p.w_kv == nullptr) && (p.w_add_k != nullptr) && (p.w_add_v != nullptr);
+  int Mk = use_image_branch ? (p.Mk_img ? p.Mk_img : Mq) : (p.Mk ? p.Mk : Mq);
+
+  // Determine encoder batch size for KV projection (shared KV optimization for CFG)
+  // If encoder_batch_size=0, use B (standard behavior). If encoder_batch_size=1 and B>1,
+  // project KV once and broadcast to all batch items.
+  int enc_B = (p.encoder_batch_size > 0) ? p.encoder_batch_size : B;
+  bool shared_kv = (enc_B < B);
+  int kv_rows = enc_B * Mk;
+
+  cutlass::half_t* dQh_bmhk = p.workspace->cutlass_flash.ca_q_bmhk;
+  cutlass::half_t* dKh_bmhk = p.workspace->cutlass_flash.ca_k_bmhk;
+  cutlass::half_t* dVh_bmhk = p.workspace->cutlass_flash.ca_v_bmhk;
+  cutlass::half_t* dOh_bmhk = p.workspace->cutlass_flash.ca_o_bmhk;  // Reuses ca_q_bmhk
+  cutlass::half_t* dQrow = p.workspace->cutlass_flash.ca_q_row;       // Reuses portion of sa_qkv_row
+  cutlass::half_t* dKVrow = p.workspace->cutlass_flash.ca_kv_row;
+
+  // 1a) Q projection with row-major linear (stride-trick bias)
+  {
+    cudaError_t err = cutlass_linear_layer_rrr(
+        reinterpret_cast<const half*>(p.hidden_states),
+        reinterpret_cast<const half*>(p.w_q),
+        reinterpret_cast<const half*>(p.b_q),
+        reinterpret_cast<half*>(dQrow),
+        M, K, K, stream);
+    if (err != cudaSuccess) { return err; }
+    // Pack Q directly from row-major
+    rmsnorm_pack_single_from_row_kernel<<<M, 256, 256*sizeof(float), stream>>>(
+      reinterpret_cast<const half*>(dQrow), M, K, H, D,
+      p.norm_q_gamma, 1.0e-6f,
+      dQh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  // 1b) KV projection with row-major linear (stride-trick bias)
+  // When shared_kv=true, project only enc_B*Mk tokens instead of B*Mk.
+  if (!use_image_branch) {
+    cudaError_t err = cutlass_linear_layer_rrr(
+        reinterpret_cast<const half*>(p.encoder_hidden_states),
+        reinterpret_cast<const half*>(p.w_kv),
+        reinterpret_cast<const half*>(p.b_kv),
+        reinterpret_cast<half*>(dKVrow),
+        kv_rows, K, 2 * K, stream);
+    if (err != cudaSuccess) { return err; }
+    // Pack K and V directly from row-major
+    rmsnorm_pack_kv_from_row_kernel<<<kv_rows, 256, 256*sizeof(float), stream>>>(
+      reinterpret_cast<const half*>(dKVrow), kv_rows, K, H, D,
+      p.norm_k_gamma, 1.0e-6f,
+      dKh_bmhk, dVh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+  } else {
+    // Image added-KV path: separate K/V projections
+    CUDA_CHECK(p.added_kv_proj_dim > 0 ? cudaSuccess : cudaErrorInvalidValue);
+    // IMPORTANT: dKVrow is a [kv_rows, 2K] row-major buffer. We must write K and V
+    // into it with row stride = 2K, otherwise rows get scrambled.
+    cudaError_t err_k = cutlass_linear_layer_rrr_strided(
+        reinterpret_cast<const half*>(p.encoder_hidden_states),
+        reinterpret_cast<const half*>(p.w_add_k),
+        reinterpret_cast<const half*>(p.b_add_k),
+        reinterpret_cast<half*>(dKVrow),
+        kv_rows, p.added_kv_proj_dim, K, 2 * K, stream);
+    if (err_k != cudaSuccess) { return err_k; }
+    cudaError_t err_v = cutlass_linear_layer_rrr_strided(
+        reinterpret_cast<const half*>(p.encoder_hidden_states),
+        reinterpret_cast<const half*>(p.w_add_v),
+        reinterpret_cast<const half*>(p.b_add_v),
+        reinterpret_cast<half*>(dKVrow) + K,
+        kv_rows, p.added_kv_proj_dim, K, 2 * K, stream);
+    if (err_v != cudaSuccess) { return err_v; }
+    rmsnorm_pack_kv_from_row_kernel<<<kv_rows, 256, 256*sizeof(float), stream>>>(
+      reinterpret_cast<const half*>(dKVrow), kv_rows, K, H, D,
+      p.norm_added_k_gamma, 1.0e-6f,
+      dKh_bmhk, dVh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+  }
+
+  // 2) Pack Q, K, V into BMHK half (already packed above)
+
+  // 3) FMHA
+  using Attention = AttentionKernel<cutlass::half_t, cutlass::arch::Sm80, true, 128, 128, 128, false, false>;
+  typename Attention::Params ap{};
+  ap.query_ptr = dQh_bmhk; ap.key_ptr = dKh_bmhk; ap.value_ptr = dVh_bmhk;
+  ap.logsumexp_ptr = nullptr; ap.output_accum_ptr = nullptr; ap.output_ptr = dOh_bmhk;
+  ap.scale = 1.0f / sqrtf(float(D)); ap.num_heads = H; ap.num_batches = B; ap.head_dim = D; ap.head_dim_value = D; ap.num_queries = Mq; ap.num_keys = Mk;
+  ap.q_strideH = D; ap.k_strideH = D; ap.v_strideH = D; ap.q_strideM = H * D; ap.k_strideM = H * D; ap.v_strideM = H * D; ap.q_strideB = ap.q_strideM * ap.num_queries;
+  // When shared_kv=true, set K/V batch stride to 0 to broadcast the single KV set to all batch items
+  ap.k_strideB = shared_kv ? 0 : (ap.k_strideM * ap.num_keys);
+  ap.v_strideB = shared_kv ? 0 : (ap.v_strideM * ap.num_keys);
+  ap.o_strideM = ap.head_dim_value * ap.num_heads;
+  constexpr auto kernel_fn = attention_kernel_batched_impl<Attention>;
+  int smem_bytes = sizeof(typename Attention::SharedStorage);
+  if (smem_bytes > 0xc000) { cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes); }
+  if (!Attention::check_supported(ap)) return cudaErrorNotSupported;
+  kernel_fn<<<ap.getBlocksGrid(), ap.getThreadsGrid(), smem_bytes, stream>>>(ap);
+  CUDA_CHECK(cudaGetLastError());
+
+  // 4) Output projection (optionally fused with residual)
+  // Flash attention outputs in row-major [M, K] format already (o_strideM = H*D = K)
+  cudaError_t ca_err = cudaSuccess;
+  if (fuse_residual) {
+    ca_err = cutlass_linear_layer_rrr_fused_residual(
+        reinterpret_cast<const half*>(dOh_bmhk),
+        reinterpret_cast<const half*>(p.w_out),
+        reinterpret_cast<const half*>(p.b_out),
+        reinterpret_cast<half*>(p.out_after_linear),  // residual inout
+        M, K, K, stream);
+  } else {
+    ca_err = cutlass_linear_layer_rrr(
+        reinterpret_cast<const half*>(dOh_bmhk),
+        reinterpret_cast<const half*>(p.w_out),
+        reinterpret_cast<const half*>(p.b_out),
+        reinterpret_cast<half*>(p.out_after_linear),
+        M, K, K, stream);
+  }
+  if (ca_err != cudaSuccess) { return ca_err; }
+  return cudaSuccess;
+}
+
+// ============================================================================
+// I2V fused cross-attention (CUTLASS backend): share Q across text + image branches
+// ============================================================================
+
+__global__ void add_inplace_half_kernel_1d(half* __restrict__ dst, const half* __restrict__ src, int64_t n) {
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t stride = int64_t(blockDim.x) * gridDim.x;
+  for (int64_t i = idx; i < n; i += stride) {
+    dst[i] = __hadd(dst[i], src[i]);
+  }
+}
+
+static cudaError_t run_cross_attention_i2v_cutlass(
+    const CrossAttentionI2VParamsT<cutlass::half_t>& p,
+    bool fuse_residual,
+    cudaStream_t stream) {
+  // CUTLASS fused I2V path currently supports only B=1.
+  if (p.B != 1) return cudaErrorNotSupported;
+
+  int M = p.M, K = p.K, H = p.H, D = p.D;
+  int Mk_text = p.Mk_text ? p.Mk_text : p.M;
+
+  // Image branch enabled only when all required pointers are present.
+  bool do_img = (p.Mk_img > 0) &&
+                (p.encoder_hidden_states_img != nullptr) &&
+                (p.w_add_k != nullptr) && (p.w_add_v != nullptr) &&
+                (p.norm_added_k_gamma != nullptr);
+  int Mk_img = do_img ? p.Mk_img : 0;
+  int Mk_total = Mk_text + Mk_img;  // fused KV length when image branch is present
+
+  // Optional fine-grained profiling (GPU time via CUDA events).
+  long long prof_call_idx = 0;
+  bool prof_detail = wan_profile_detail_enabled(&prof_call_idx);
+  enum {
+    EV_START = 0,
+    EV_AFTER_Q_PROJ,
+    EV_AFTER_Q_PACK,
+    EV_AFTER_TEXT_KV_PROJ,
+    EV_AFTER_TEXT_KV_PACK,
+    EV_AFTER_IMG_K_PROJ,
+    EV_AFTER_IMG_V_PROJ,
+    EV_AFTER_IMG_KV_PACK,
+    EV_AFTER_FMHA,
+    EV_AFTER_OUT_PROJ,
+    EV_COUNT
+  };
+  cudaEvent_t ev[EV_COUNT];
+  auto rec = [&](int idx) {
+    if (prof_detail) cudaEventRecord(ev[idx], stream);
+  };
+  if (prof_detail) {
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventCreate(&ev[i]);
+    rec(EV_START);
+  }
+
+  // Workspace pointers
+  cutlass::half_t* dQh_bmhk = p.workspace->cutlass_flash.ca_q_bmhk;   // [M,K]
+  cutlass::half_t* dKh_bmhk = p.workspace->cutlass_flash.ca_k_bmhk;   // [Mk_max,K]
+  cutlass::half_t* dVh_bmhk = p.workspace->cutlass_flash.ca_v_bmhk;   // [Mk_max,K]
+  cutlass::half_t* dQrow    = p.workspace->cutlass_flash.ca_q_row;    // [M,K]
+  cutlass::half_t* dKVrow   = p.workspace->cutlass_flash.ca_kv_row;   // [Mk_max,2K]
+
+  // Accumulator for attention outputs (row-major [M,K])
+  // NOTE: Reuse block scratch (previously out_text).
+  half* out_acc = reinterpret_cast<half*>(p.workspace->scratch_mk_b);
+
+  // 1) Q projection (once) + RMSNorm/pack
+  {
+    cudaError_t err = cutlass_linear_layer_rrr(
+        reinterpret_cast<const half*>(p.hidden_states),
+        reinterpret_cast<const half*>(p.w_q),
+        reinterpret_cast<const half*>(p.b_q),
+        reinterpret_cast<half*>(dQrow),
+        M, K, K, stream);
+    if (err != cudaSuccess) { return err; }
+    rec(EV_AFTER_Q_PROJ);
+
+    rmsnorm_pack_single_from_row_kernel<<<M, 256, 256 * sizeof(float), stream>>>(
+        reinterpret_cast<const half*>(dQrow), M, K, H, D,
+        p.norm_q_gamma, 1.0e-6f,
+        dQh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+    rec(EV_AFTER_Q_PACK);
+  }
+
+  // Helper: run FMHA for a given KV length using the shared packed Q.
+  auto run_fmha = [&](int Mk, cutlass::half_t* out_ptr) -> cudaError_t {
+    using Attention = AttentionKernel<cutlass::half_t, cutlass::arch::Sm80, true, 128, 128, 128, false, false>;
+    typename Attention::Params ap{};
+    ap.query_ptr = dQh_bmhk; ap.key_ptr = dKh_bmhk; ap.value_ptr = dVh_bmhk;
+    ap.logsumexp_ptr = nullptr; ap.output_accum_ptr = nullptr; ap.output_ptr = out_ptr;
+    ap.scale = 1.0f / sqrtf(float(D));
+    ap.num_heads = H; ap.num_batches = 1;
+    ap.head_dim = D; ap.head_dim_value = D;
+    ap.num_queries = M; ap.num_keys = Mk;
+    ap.q_strideH = D; ap.k_strideH = D; ap.v_strideH = D;
+    ap.q_strideM = H * D; ap.k_strideM = H * D; ap.v_strideM = H * D;
+    ap.q_strideB = ap.q_strideM * ap.num_queries;
+    ap.k_strideB = ap.k_strideM * ap.num_keys;
+    ap.v_strideB = ap.v_strideM * ap.num_keys;
+    ap.o_strideM = ap.head_dim_value * ap.num_heads;
+    constexpr auto kernel_fn = attention_kernel_batched_impl<Attention>;
+    int smem_bytes = sizeof(typename Attention::SharedStorage);
+    if (smem_bytes > 0xc000) { cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes); }
+    if (!Attention::check_supported(ap)) return cudaErrorNotSupported;
+    kernel_fn<<<ap.getBlocksGrid(), ap.getThreadsGrid(), smem_bytes, stream>>>(ap);
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+  };
+
+  // 2) Text KV -> pack
+  {
+    cudaError_t err = cutlass_linear_layer_rrr(
+        reinterpret_cast<const half*>(p.encoder_hidden_states_text),
+        reinterpret_cast<const half*>(p.w_kv),
+        reinterpret_cast<const half*>(p.b_kv),
+        reinterpret_cast<half*>(dKVrow),
+        Mk_text, K, 2 * K, stream);
+    if (err != cudaSuccess) { return err; }
+    rec(EV_AFTER_TEXT_KV_PROJ);
+
+    rmsnorm_pack_kv_from_row_kernel<<<Mk_text, 256, 256 * sizeof(float), stream>>>(
+        reinterpret_cast<const half*>(dKVrow), Mk_text, K, H, D,
+        p.norm_k_gamma, 1.0e-6f,
+        dKh_bmhk, dVh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+    rec(EV_AFTER_TEXT_KV_PACK);
+  }
+
+  // 3) Image KV -> pack into the contiguous tail after text, then run a single FMHA over [text; image]
+  if (do_img) {
+    CUDA_CHECK(p.added_kv_proj_dim > 0 ? cudaSuccess : cudaErrorInvalidValue);
+
+    // IMPORTANT: dKVrow is [Mk_img, 2K] row-major. Write K and V with row stride=2K.
+    half* kv_row_img = reinterpret_cast<half*>(dKVrow + size_t(Mk_text) * 2 * K);
+    cudaError_t err_k = cutlass_linear_layer_rrr_strided(
+        reinterpret_cast<const half*>(p.encoder_hidden_states_img),
+        reinterpret_cast<const half*>(p.w_add_k),
+        reinterpret_cast<const half*>(p.b_add_k),
+        kv_row_img,
+        Mk_img, p.added_kv_proj_dim, K, 2 * K, stream);
+    if (err_k != cudaSuccess) { return err_k; }
+    rec(EV_AFTER_IMG_K_PROJ);
+
+    cudaError_t err_v = cutlass_linear_layer_rrr_strided(
+        reinterpret_cast<const half*>(p.encoder_hidden_states_img),
+        reinterpret_cast<const half*>(p.w_add_v),
+        reinterpret_cast<const half*>(p.b_add_v),
+        kv_row_img + K,
+        Mk_img, p.added_kv_proj_dim, K, 2 * K, stream);
+    if (err_v != cudaSuccess) { return err_v; }
+    rec(EV_AFTER_IMG_V_PROJ);
+
+    // Pack image KV into the tail of dKh_bmhk / dVh_bmhk
+    cutlass::half_t* dKh_img = dKh_bmhk + size_t(Mk_text) * H * D;
+    cutlass::half_t* dVh_img = dVh_bmhk + size_t(Mk_text) * H * D;
+    rmsnorm_pack_kv_from_row_kernel<<<Mk_img, 256, 256 * sizeof(float), stream>>>(
+        reinterpret_cast<const half*>(kv_row_img), Mk_img, K, H, D,
+        p.norm_added_k_gamma, 1.0e-6f,
+        dKh_img, dVh_img);
+    CUDA_CHECK(cudaGetLastError());
+    rec(EV_AFTER_IMG_KV_PACK);
+  }
+  if (prof_detail && !do_img) {
+    // Keep event timeline consistent so printing logic is simple.
+    rec(EV_AFTER_IMG_K_PROJ);
+    rec(EV_AFTER_IMG_V_PROJ);
+    rec(EV_AFTER_IMG_KV_PACK);
+  }
+
+  // 4) Single FMHA over concatenated [text; image] KV
+  cudaError_t fmha_err = run_fmha(Mk_total, reinterpret_cast<cutlass::half_t*>(out_acc));
+  if (fmha_err != cudaSuccess) { return fmha_err; }
+  rec(EV_AFTER_FMHA);
+
+  // 5) Output projection (optionally fused with residual)
+  cudaError_t out_err;
+  if (fuse_residual) {
+    out_err = cutlass_linear_layer_rrr_fused_residual(
+        reinterpret_cast<const half*>(out_acc),
+        reinterpret_cast<const half*>(p.w_out),
+        reinterpret_cast<const half*>(p.b_out),
+        reinterpret_cast<half*>(p.out_after_linear),
+        M, K, K, stream);
+  } else {
+    out_err = cutlass_linear_layer_rrr(
+        reinterpret_cast<const half*>(out_acc),
+        reinterpret_cast<const half*>(p.w_out),
+        reinterpret_cast<const half*>(p.b_out),
+        reinterpret_cast<half*>(p.out_after_linear),
+        M, K, K, stream);
+  }
+  if (out_err != cudaSuccess) { return out_err; }
+  rec(EV_AFTER_OUT_PROJ);
+
+  if (prof_detail) {
+    cudaEventSynchronize(ev[EV_AFTER_OUT_PROJ]);
+    auto ms = [&](int a, int b) -> float {
+      float out = 0.f;
+      cudaEventElapsedTime(&out, ev[a], ev[b]);
+      return out;
+    };
+    float t_q_proj   = ms(EV_START, EV_AFTER_Q_PROJ);
+    float t_q_pack   = ms(EV_AFTER_Q_PROJ, EV_AFTER_Q_PACK);
+    float t_kv_text  = ms(EV_AFTER_Q_PACK, EV_AFTER_TEXT_KV_PROJ);
+    float t_pack_txt = ms(EV_AFTER_TEXT_KV_PROJ, EV_AFTER_TEXT_KV_PACK);
+    float t_k_img    = ms(EV_AFTER_TEXT_KV_PACK, EV_AFTER_IMG_K_PROJ);
+    float t_v_img    = ms(EV_AFTER_IMG_K_PROJ, EV_AFTER_IMG_V_PROJ);
+    float t_pack_img = ms(EV_AFTER_IMG_V_PROJ, EV_AFTER_IMG_KV_PACK);
+    float t_fmha     = ms(EV_AFTER_IMG_KV_PACK, EV_AFTER_FMHA);
+    float t_out      = ms(EV_AFTER_FMHA, EV_AFTER_OUT_PROJ);
+    float t_total    = ms(EV_START, EV_AFTER_OUT_PROJ);
+
+    std::printf(
+      "[wan_ca_i2v_cutlass][call=%lld] M=%d K=%d H=%d D=%d Mk_text=%d Mk_img=%d | "
+      "q_proj=%.3f q_pack=%.3f kv_text=%.3f pack_text=%.3f "
+      "k_img=%.3f v_img=%.3f pack_img=%.3f fmha=%.3f out=%.3f total=%.3f ms\n",
+      prof_call_idx, M, K, H, D, Mk_text, Mk_img,
+      t_q_proj, t_q_pack, t_kv_text, t_pack_txt,
+      t_k_img, t_v_img, t_pack_img, t_fmha, t_out, t_total
+    );
+
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventDestroy(ev[i]);
+  }
+
+  return cudaSuccess;
+}
+
+// ============================================================================
+// cuDNN Backend Implementation
+// ============================================================================
+
+// cuDNN handle and graph cache management (thread-local for safety)
+namespace {
+  thread_local cudnnHandle_t g_cudnn_handle = nullptr;
+
+  cudnnHandle_t get_cudnn_handle() {
+    if (!g_cudnn_handle) {
+      cudnnCreate(&g_cudnn_handle);
+    }
+    return g_cudnn_handle;
+  }
+
+  // Cache for cuDNN graphs (key: B_Mq_H_D_Mk)
+  struct GraphCacheKey {
+    int B, Mq, H, D, Mk;
+    bool operator==(const GraphCacheKey& other) const {
+      return B == other.B && Mq == other.Mq && H == other.H && D == other.D && Mk == other.Mk;
+    }
+  };
+
+  struct GraphCacheKeyHash {
+    std::size_t operator()(const GraphCacheKey& k) const {
+      size_t h = std::hash<int>()(k.B);
+      h ^= (std::hash<int>()(k.Mq) << 1);
+      h ^= (std::hash<int>()(k.H) << 2);
+      h ^= (std::hash<int>()(k.D) << 3);
+      h ^= (std::hash<int>()(k.Mk) << 4);
+      return h;
+    }
+  };
+
+  thread_local std::unordered_map<GraphCacheKey, std::shared_ptr<fe::graph::Graph>, GraphCacheKeyHash> g_sdpa_graph_cache;
+
+  // Cache for packed-QKV bf16 cuDNN graphs (key: B_Mq_Mk_H_D_causal)
+  struct PackedFmhaCacheKey {
+    int B, Mq, Mk, H, D;
+    bool causal;
+    bool operator==(const PackedFmhaCacheKey& o) const {
+      return B == o.B && Mq == o.Mq && Mk == o.Mk && H == o.H && D == o.D && causal == o.causal;
+    }
+  };
+
+  struct PackedFmhaCacheKeyHash {
+    std::size_t operator()(const PackedFmhaCacheKey& k) const {
+      size_t h = std::hash<int>()(k.B);
+      h ^= (std::hash<int>()(k.Mq)    << 1);
+      h ^= (std::hash<int>()(k.Mk)    << 2);
+      h ^= (std::hash<int>()(k.H)     << 3);
+      h ^= (std::hash<int>()(k.D)     << 4);
+      h ^= (std::hash<bool>()(k.causal) << 5);
+      return h;
+    }
+  };
+
+  struct PackedFp8FmhaCacheKey {
+    int B, Mq, Mk, H, D;
+    bool causal;
+    std::string layout;
+    std::string heuristics;
+    std::string plan;
+    bool operator==(const PackedFp8FmhaCacheKey& o) const {
+      return B == o.B && Mq == o.Mq && Mk == o.Mk && H == o.H && D == o.D &&
+             causal == o.causal && layout == o.layout &&
+             heuristics == o.heuristics && plan == o.plan;
+    }
+  };
+
+  struct PackedFp8FmhaCacheKeyHash {
+    std::size_t operator()(const PackedFp8FmhaCacheKey& k) const {
+      size_t h = std::hash<int>()(k.B);
+      h ^= (std::hash<int>()(k.Mq) << 1);
+      h ^= (std::hash<int>()(k.Mk) << 2);
+      h ^= (std::hash<int>()(k.H) << 3);
+      h ^= (std::hash<int>()(k.D) << 4);
+      h ^= (std::hash<bool>()(k.causal) << 5);
+      h ^= (std::hash<std::string>()(k.layout) << 6);
+      h ^= (std::hash<std::string>()(k.heuristics) << 7);
+      h ^= (std::hash<std::string>()(k.plan) << 8);
+      return h;
+    }
+  };
+
+  thread_local std::unordered_map<PackedFmhaCacheKey,
+                                   std::shared_ptr<fe::graph::Graph>,
+                                   PackedFmhaCacheKeyHash>
+      g_packed_fmha_graph_cache;
+  thread_local std::unordered_map<PackedFp8FmhaCacheKey,
+                                   std::shared_ptr<fe::graph::Graph>,
+                                   PackedFp8FmhaCacheKeyHash>
+      g_packed_fp8_fmha_graph_cache;
+
+  // Growable device workspace for packed-QKV cuDNN SDPA
+  thread_local void*  g_packed_fmha_ws      = nullptr;
+  thread_local size_t g_packed_fmha_ws_size = 0;
+
+  static cudaError_t ensure_packed_fmha_ws(size_t needed) {
+    if (needed <= g_packed_fmha_ws_size) return cudaSuccess;
+    if (g_packed_fmha_ws) cudaFree(g_packed_fmha_ws);
+    g_packed_fmha_ws = nullptr;
+    cudaError_t err = cudaMalloc(&g_packed_fmha_ws, needed);
+    if (err != cudaSuccess) return err;
+    g_packed_fmha_ws_size = needed;
+    return cudaSuccess;
+  }
+}
+
+// cuDNN FMHA helper: accepts pre-packed BMHK Q/K/V in bf16, skips QKV projection and RoPE.
+//
+// Inputs  Q     [B*Mq, H, D]  bfloat16, contiguous (BMHK — batch items concatenated along M)
+//         K, V  [B*Mk, H, D]  bfloat16, contiguous
+// Output  O     [B*Mq, H, D]  bfloat16, caller-allocated
+// Params  causal → top-left causal mask;  scale 0 → 1/sqrt(D)
+cudaError_t run_cudnn_fmha_packed_qkv(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* K,
+    const cutlass::bfloat16_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream) {
+  if (Mq <= 0 || Mk <= 0) return cudaErrorInvalidValue;
+
+  auto handle = get_cudnn_handle();
+  cudnnSetStream(handle, stream);
+
+  PackedFmhaCacheKey cache_key{B, Mq, Mk, H, D, causal};
+  auto it = g_packed_fmha_graph_cache.find(cache_key);
+
+  std::unordered_map<fe::graph::Tensor_attributes::uid_t, void*> variant_pack = {
+      {1, const_cast<cutlass::bfloat16_t*>(Q)},
+      {2, const_cast<cutlass::bfloat16_t*>(K)},
+      {3, const_cast<cutlass::bfloat16_t*>(V)},
+      {4, O}};
+
+  auto build_graph = [&](fe::HeurMode_t heur_mode) -> std::shared_ptr<fe::graph::Graph> {
+    auto graph = std::make_shared<fe::graph::Graph>();
+    graph->set_io_data_type(fe::DataType_t::BFLOAT16)
+         .set_intermediate_data_type(fe::DataType_t::FLOAT)
+         .set_compute_data_type(fe::DataType_t::FLOAT);
+
+    // Strides for [B*Mq, H, D] packed layout viewed as [B, H, Mq, D]:
+    //   batch stride = Mq*H*D,  head stride = D,  seq stride = H*D,  dim stride = 1
+    int64_t K_total = int64_t(H) * D;
+    auto tQ = graph->tensor(fe::graph::Tensor_attributes()
+                                .set_name("Q").set_uid(1)
+                                .set_dim   ({B, H, Mq, D})
+                                .set_stride({int64_t(Mq) * K_total, D, K_total, 1}));
+    auto tK = graph->tensor(fe::graph::Tensor_attributes()
+                                .set_name("K").set_uid(2)
+                                .set_dim   ({B, H, Mk, D})
+                                .set_stride({int64_t(Mk) * K_total, D, K_total, 1}));
+    auto tV = graph->tensor(fe::graph::Tensor_attributes()
+                                .set_name("V").set_uid(3)
+                                .set_dim   ({B, H, Mk, D})
+                                .set_stride({int64_t(Mk) * K_total, D, K_total, 1}));
+
+    float attn_scale = (scale > 0.f) ? scale : (1.0f / sqrtf(float(D)));
+    auto sdpa_opts = fe::graph::SDPA_attributes()
+                         .set_name("packed_sdpa")
+                         .set_attn_scale(attn_scale)
+                         .set_causal_mask(causal);
+
+    auto [tO, tStats] = graph->sdpa(tQ, tK, tV, sdpa_opts);
+    tO->set_output(true)
+        .set_dim   ({B, H, Mq, D})
+        .set_stride({int64_t(Mq) * K_total, D, K_total, 1})
+        .set_uid(4);
+
+    if (!graph->build(handle, {heur_mode}).is_good()) {
+      return nullptr;
+    }
+    return graph;
+  };
+
+  auto execute_graph = [&](const std::shared_ptr<fe::graph::Graph>& graph) -> cudaError_t {
+    int64_t workspace_size = 0;
+    if (!graph->get_workspace_size(workspace_size).is_good()) {
+      return cudaErrorUnknown;
+    }
+    if (cudaError_t ws_err = ensure_packed_fmha_ws((size_t)workspace_size); ws_err != cudaSuccess) {
+      return ws_err;
+    }
+
+    if (!graph->execute(handle, variant_pack, g_packed_fmha_ws).is_good()) {
+      return cudaErrorUnknown;
+    }
+    return cudaSuccess;
+  };
+
+  if (it != g_packed_fmha_graph_cache.end()) {
+    cudaError_t cached_err = execute_graph(it->second);
+    if (cached_err == cudaSuccess) {
+      return cudaSuccess;
+    }
+    g_packed_fmha_graph_cache.erase(it);
+    if (cached_err != cudaErrorUnknown) {
+      return cached_err;
+    }
+  }
+
+  const fe::HeurMode_t heur_modes[] = {
+      fe::HeurMode_t::A,
+      fe::HeurMode_t::B,
+      fe::HeurMode_t::FALLBACK};
+  for (fe::HeurMode_t heur_mode : heur_modes) {
+    auto graph = build_graph(heur_mode);
+    if (!graph) {
+      continue;
+    }
+    cudaError_t err = execute_graph(graph);
+    if (err == cudaSuccess) {
+      g_packed_fmha_graph_cache[cache_key] = graph;
+      return cudaSuccess;
+    }
+    if (err != cudaErrorUnknown) {
+      return err;
+    }
+  }
+  return cudaErrorUnknown;
+}
+
+cudaError_t run_cudnn_fmha_packed_qkv_fp8(
+    const cutlass::float_e4m3_t* Q,
+    const cutlass::float_e4m3_t* K,
+    const cutlass::float_e4m3_t* V,
+    cutlass::float_e4m3_t* O,
+    const float* descale_q,
+    const float* descale_k,
+    const float* descale_v,
+    const float* descale_s,
+    const float* scale_s,
+    const float* scale_o,
+    float* amax_s,
+    float* amax_o,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream) {
+  if (!Q || !K || !V || !O || !descale_q || !descale_k || !descale_v ||
+      !descale_s || !scale_s || !scale_o || !amax_s || !amax_o ||
+      B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0 || D <= 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  auto handle = get_cudnn_handle();
+  cudnnSetStream(handle, stream);
+
+  const auto selection = select_cosmos_fp8_sdpa(B, Mq, Mk, H, D);
+  PackedFp8FmhaCacheKey cache_key{
+      B, Mq, Mk, H, D, causal,
+      selection.layout, selection.heuristics, selection.plan};
+  auto it = g_packed_fp8_fmha_graph_cache.find(cache_key);
+  std::shared_ptr<fe::graph::Graph> graph;
+  bool needs_autotune = false;
+  bool cache_miss = false;
+
+  if (it != g_packed_fp8_fmha_graph_cache.end()) {
+    graph = it->second;
+  } else {
+    cache_miss = true;
+    graph = std::make_shared<fe::graph::Graph>();
+    graph->set_io_data_type(fe::DataType_t::FP8_E4M3)
+         .set_intermediate_data_type(fe::DataType_t::FLOAT)
+         .set_compute_data_type(fe::DataType_t::FLOAT);
+
+    const int64_t hidden_stride = int64_t(H) * D;
+    const bool input_bhmd = selection.layout == "bhmd";
+    const int64_t q_batch_stride = input_bhmd ? int64_t(H) * Mq * D : int64_t(Mq) * hidden_stride;
+    const int64_t k_batch_stride = input_bhmd ? int64_t(H) * Mk * D : int64_t(Mk) * hidden_stride;
+    const int64_t q_head_stride = input_bhmd ? int64_t(Mq) * D : D;
+    const int64_t k_head_stride = input_bhmd ? int64_t(Mk) * D : D;
+    const int64_t q_seq_stride = input_bhmd ? D : hidden_stride;
+    const int64_t k_seq_stride = input_bhmd ? D : hidden_stride;
+    auto tQ = graph->tensor(fe::graph::Tensor_attributes()
+                                .set_name("Q").set_uid(1)
+                                .set_dim({B, H, Mq, D})
+                                .set_stride({q_batch_stride, q_head_stride, q_seq_stride, 1})
+                                .set_data_type(fe::DataType_t::FP8_E4M3));
+    auto tK = graph->tensor(fe::graph::Tensor_attributes()
+                                .set_name("K").set_uid(2)
+                                .set_dim({B, H, Mk, D})
+                                .set_stride({k_batch_stride, k_head_stride, k_seq_stride, 1})
+                                .set_data_type(fe::DataType_t::FP8_E4M3));
+    auto tV = graph->tensor(fe::graph::Tensor_attributes()
+                                .set_name("V").set_uid(3)
+                                .set_dim({B, H, Mk, D})
+                                .set_stride({k_batch_stride, k_head_stride, k_seq_stride, 1})
+                                .set_data_type(fe::DataType_t::FP8_E4M3));
+
+    auto descale_q_t = graph->tensor(fe::graph::Tensor_attributes()
+                                         .set_name("Descale_Q").set_uid(5)
+                                         .set_dim({1, 1, 1, 1})
+                                         .set_stride({1, 1, 1, 1})
+                                         .set_data_type(fe::DataType_t::FLOAT));
+    auto descale_k_t = graph->tensor_like(descale_q_t, "Descale_K");
+    descale_k_t->set_uid(6);
+    auto descale_v_t = graph->tensor_like(descale_q_t, "Descale_V");
+    descale_v_t->set_uid(7);
+    auto descale_s_t = graph->tensor_like(descale_q_t, "Descale_S");
+    descale_s_t->set_uid(8);
+    auto scale_s_t = graph->tensor_like(descale_q_t, "Scale_S");
+    scale_s_t->set_uid(9);
+    auto scale_o_t = graph->tensor_like(descale_q_t, "Scale_O");
+    scale_o_t->set_uid(10);
+
+    float attn_scale = (scale > 0.f) ? scale : (1.0f / sqrtf(float(D)));
+    auto sdpa_fp8_options = fe::graph::SDPA_fp8_attributes()
+                                .set_name("packed_sdpa_fp8_probe")
+                                .set_generate_stats(false)
+                                .set_causal_mask(causal)
+                                .set_attn_scale(attn_scale);
+
+    auto [tO, tStats, tAmaxS, tAmaxO] = graph->sdpa_fp8(
+        tQ, tK, tV,
+        descale_q_t, descale_k_t, descale_v_t, descale_s_t,
+        scale_s_t, scale_o_t,
+        sdpa_fp8_options);
+    if (tStats != nullptr) {
+      return cudaErrorNotSupported;
+    }
+
+    tO->set_output(true)
+        .set_dim({B, H, Mq, D})
+        .set_stride({int64_t(Mq) * hidden_stride, D, hidden_stride, 1})
+        .set_data_type(fe::DataType_t::FP8_E4M3)
+        .set_uid(4);
+    tAmaxS->set_output(true)
+        .set_dim({1, 1, 1, 1})
+        .set_stride({1, 1, 1, 1})
+        .set_data_type(fe::DataType_t::FLOAT)
+        .set_uid(11);
+    tAmaxO->set_output(true)
+        .set_dim({1, 1, 1, 1})
+        .set_stride({1, 1, 1, 1})
+        .set_data_type(fe::DataType_t::FLOAT)
+        .set_uid(12);
+
+    if (!graph->build(
+             handle,
+             cosmos_fp8_sdpa_heur_modes(selection.heuristics),
+             cosmos_fp8_sdpa_build_policy(selection.plan)).is_good()) {
+      return cudaErrorNotSupported;
+    }
+    needs_autotune = selection.plan == "autotune";
+  }
+
+  int64_t workspace_size = 0;
+  if (!graph->get_workspace_size(workspace_size).is_good()) {
+    return cudaErrorUnknown;
+  }
+  if (needs_autotune) {
+    workspace_size = std::max<int64_t>(workspace_size, graph->get_autotune_workspace_size());
+  }
+  if (cudaError_t ws_err = ensure_packed_fmha_ws((size_t)workspace_size); ws_err != cudaSuccess) {
+    return ws_err;
+  }
+
+  std::unordered_map<fe::graph::Tensor_attributes::uid_t, void*> variant_pack = {
+      {1, const_cast<cutlass::float_e4m3_t*>(Q)},
+      {2, const_cast<cutlass::float_e4m3_t*>(K)},
+      {3, const_cast<cutlass::float_e4m3_t*>(V)},
+      {4, O},
+      {5, const_cast<float*>(descale_q)},
+      {6, const_cast<float*>(descale_k)},
+      {7, const_cast<float*>(descale_v)},
+      {8, const_cast<float*>(descale_s)},
+      {9, const_cast<float*>(scale_s)},
+      {10, const_cast<float*>(scale_o)},
+      {11, amax_s},
+      {12, amax_o}};
+
+  if (needs_autotune) {
+    if (!graph->autotune(handle, variant_pack, g_packed_fmha_ws).is_good()) {
+      return cudaErrorUnknown;
+    }
+  }
+  if (cache_miss) {
+    g_packed_fp8_fmha_graph_cache[cache_key] = graph;
+  }
+
+  if (!graph->execute(handle, variant_pack, g_packed_fmha_ws).is_good()) {
+    return cudaErrorUnknown;
+  }
+  return cudaSuccess;
+}
+
+// cuDNN self-attention implementation using cudnn-frontend SDPA
+template <typename WeightT>
+static cudaError_t run_self_attention_cudnn_impl(
+    const AttentionDeviceParamsT<WeightT>& p,
+    cudaStream_t stream,
+    cutlass::half_t* qkv_capture = nullptr,
+    float* act_scale_capture = nullptr) {
+  int B = p.B;
+  int Mq = p.Mq;
+  if (Mq <= 0) { return cudaErrorInvalidValue; }
+  int M = B * Mq;
+  int K = p.K, H = p.H, D = p.D;
+
+  // Optional fine-grained profiling:
+  // - GPU time via CUDA events for qkv/pack/sdpa/out
+  // - CPU wall time for cuDNN graph build (first-call overhead)
+  long long prof_call_idx = 0;
+  bool prof_detail = wan_profile_detail_enabled(&prof_call_idx);
+  enum {
+    EV_START = 0,
+    EV_AFTER_QKV_PROJ,
+    EV_AFTER_PACK_ROPE,
+    EV_BEFORE_SDPA_EXEC,
+    EV_AFTER_SDPA_EXEC,
+    EV_AFTER_OUT,
+    EV_COUNT
+  };
+  cudaEvent_t ev[EV_COUNT];
+  auto rec = [&](int idx) {
+    if (prof_detail) cudaEventRecord(ev[idx], stream);
+  };
+  if (prof_detail) {
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventCreate(&ev[i]);
+    rec(EV_START);
+  }
+  double graph_build_ms_cpu = 0.0;
+  bool graph_built_now = false;
+
+  // Use cuDNN workspace buffers
+  cutlass::half_t* qkv_row = p.workspace->cudnn.sa_qkv_row;
+  cutlass::half_t* dQh_bmhk = p.workspace->cudnn.sa_q_bmhk;
+  cutlass::half_t* dKh_bmhk = p.workspace->cudnn.sa_k_bmhk;
+  cutlass::half_t* dVh_bmhk = p.workspace->cudnn.sa_v_bmhk;
+  cutlass::half_t* dOh_bmhk = p.workspace->cudnn.sa_o_bmhk;
+
+  // 1) QKV projection via CUTLASS linear layer
+  {
+    // Use dQh_bmhk as fp8_scratch (will be overwritten in the next step)
+    cudaError_t err = apply_linear_row<WeightT>(
+        p.hidden_states,
+        p.w_qkv,
+        p.b_qkv,
+        qkv_row,
+        M, K, 3 * K, stream,
+        dQh_bmhk,  // fp8_scratch
+        p.w_qkv_scale,  // weight_scale (FP8)
+        p.workspace->int8_scratch,  // int8_scratch
+        p.workspace->int8_act_block_scales,  // int8_act_block_scales (INT8)
+        p.w_qkv_block_scale);  // weight_block_scale (INT8)
+    if (err != cudaSuccess) { return err; }
+  }
+  if (qkv_capture) {
+    auto err = cudaMemcpyAsync(qkv_capture, qkv_row, sizeof(cutlass::half_t) * size_t(M) * 3 * K, cudaMemcpyDeviceToDevice, stream);
+    if (err != cudaSuccess) { return err; }
+  }
+  if (act_scale_capture && std::is_same<WeightT, int8_t>::value) {
+    float act_scale = 1.0f;
+    cudaError_t act = compute_activation_scale(
+      reinterpret_cast<const cutlass::half_t*>(p.hidden_states),
+      int64_t(M) * K,
+      &act_scale,
+      stream);
+    if (act != cudaSuccess) return act;
+    auto err = cudaMemcpyAsync(act_scale_capture, &act_scale, sizeof(float), cudaMemcpyHostToDevice, stream);
+    if (err != cudaSuccess) return err;
+  }
+  rec(EV_AFTER_QKV_PROJ);
+
+  // 2) Pack and normalize Q, K, V + apply RoPE
+  {
+    rmsnorm_pack_bmhk_rope_from_row_kernel<<<M, 256, 2*256*sizeof(float), stream>>>(
+      reinterpret_cast<const half*>(qkv_row), M, K, H, D, Mq,
+      p.norm_q_gamma, p.norm_k_gamma, 1.0e-6f,
+      p.rotary_cos, p.rotary_sin,
+      dQh_bmhk, dKh_bmhk, dVh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+  }
+  rec(EV_AFTER_PACK_ROPE);
+
+  // 3) Run cuDNN SDPA
+  {
+    auto handle = get_cudnn_handle();
+    cudnnSetStream(handle, stream);
+
+    // Check graph cache or create new graph
+    GraphCacheKey cache_key{B, Mq, H, D, Mq};  // Mk = Mq for self-attention
+    auto it = g_sdpa_graph_cache.find(cache_key);
+    std::shared_ptr<fe::graph::Graph> graph;
+
+    if (it != g_sdpa_graph_cache.end()) {
+      graph = it->second;
+    } else {
+      auto t0 = std::chrono::high_resolution_clock::now();
+      graph_built_now = true;
+      // Create cuDNN graph for SDPA
+      graph = std::make_shared<fe::graph::Graph>();
+      graph->set_io_data_type(fe::DataType_t::HALF)
+          .set_intermediate_data_type(fe::DataType_t::FLOAT)
+          .set_compute_data_type(fe::DataType_t::FLOAT);
+
+    // Define Q, K, V tensors in BHSD format (batch=B, heads=H, seq=Mq, dim=D)
+    // Note: The packing kernel outputs row-major [M, K] where K=H*D
+    // So strides are [batch_stride (unused), D, H*D, 1] to match row-major layout
+    int64_t b = B;
+    int64_t K_total = H * D;  // Total hidden dimension
+    auto Q = graph->tensor(fe::graph::Tensor_attributes()
+                               .set_name("Q")
+                               .set_uid(1)
+                               .set_dim({b, H, Mq, D})
+                               .set_stride({int64_t(Mq) * K_total, D, K_total, 1}));
+
+    auto K = graph->tensor(fe::graph::Tensor_attributes()
+                               .set_name("K")
+                               .set_uid(2)
+                               .set_dim({b, H, Mq, D})
+                               .set_stride({int64_t(Mq) * K_total, D, K_total, 1}));
+
+    auto V = graph->tensor(fe::graph::Tensor_attributes()
+                               .set_name("V")
+                               .set_uid(3)
+                               .set_dim({b, H, Mq, D})
+                               .set_stride({int64_t(Mq) * K_total, D, K_total, 1}));
+
+    // SDPA options with attention scale
+    float attn_scale = 1.0f / sqrtf(static_cast<float>(D));
+
+    auto sdpa_options = fe::graph::SDPA_attributes()
+                            .set_name("sdpa_self_attention")
+                            .set_attn_scale(attn_scale);
+
+    // Create SDPA operation
+    auto [O, Stats] = graph->sdpa(Q, K, V, sdpa_options);
+
+      // Set output tensor properties with row-major [M, K] layout to match input format
+      O->set_output(true).set_dim({b, H, Mq, D}).set_stride({int64_t(Mq) * K_total, D, K_total, 1}).set_uid(4);
+
+      // Build the graph
+      if (!graph->build(handle, {fe::HeurMode_t::A}).is_good()) {
+        return cudaErrorUnknown;
+      }
+
+      // Cache the graph
+      g_sdpa_graph_cache[cache_key] = graph;
+      auto t1 = std::chrono::high_resolution_clock::now();
+      graph_build_ms_cpu = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    }
+
+    // Prepare variant pack
+    std::unordered_map<fe::graph::Tensor_attributes::uid_t, void*> variant_pack = {
+        {1, dQh_bmhk}, {2, dKh_bmhk}, {3, dVh_bmhk}, {4, dOh_bmhk}};
+
+    // Get workspace size and validate
+    int64_t workspace_size = 0;
+    if (!graph->get_workspace_size(workspace_size).is_good()) {
+      return cudaErrorUnknown;
+    }
+
+    // Ensure cuDNN SDPA workspace exists with sufficient capacity
+    p.workspace->ensure_cudnn_workspace((size_t)workspace_size);
+    void* workspace = p.workspace->cudnn.cudnn_workspace;
+    rec(EV_BEFORE_SDPA_EXEC);
+    if (!graph->execute(handle, variant_pack, workspace).is_good()) {
+      return cudaErrorUnknown;
+    }
+    rec(EV_AFTER_SDPA_EXEC);
+  }
+
+  // 4) Output projection - dOh_bmhk is already in row-major [M, K] format due to stride config
+  {
+    // INT8 fused gated residual path: GEMM + gate*output + residual in one kernel
+    if constexpr (std::is_same_v<WeightT, int8_t>) {
+      if (p.gate_sst != nullptr) {
+        // Copy residual source into output buffer before GEMM overwrites it
+        cudaMemcpyAsync(p.out_after_linear, p.residual_src,
+            size_t(M) * K * sizeof(cutlass::half_t),
+            cudaMemcpyDeviceToDevice, stream);
+        // Quantize activations
+        cudaError_t q = quantize_per_block_128(
+            reinterpret_cast<const half*>(dOh_bmhk),
+            p.workspace->int8_scratch,
+            p.workspace->int8_act_block_scales,
+            M, K, stream, false);
+        if (q != cudaSuccess) return q;
+        // Fused GEMM + gated residual
+        cudaError_t err = int8_gemm_gated_residual(
+            p.workspace->int8_scratch,
+            p.workspace->int8_act_block_scales,
+            reinterpret_cast<const int8_t*>(p.w_out),
+            p.w_out_block_scale,
+            reinterpret_cast<half*>(p.out_after_linear),
+            reinterpret_cast<const half*>(p.b_out),
+            reinterpret_cast<const half*>(p.gate_sst),
+            reinterpret_cast<const half*>(p.gate_temb),
+            p.gate_temb_row_stride,
+            p.gate_idx,
+            M, K, K, stream);
+        if (err != cudaSuccess) return err;
+        return cudaSuccess;
+      }
+    }
+    // Fallback: existing apply_linear_row path (FP16/FP8, or INT8 without gate fusion)
+    cudaError_t err = apply_linear_row<WeightT>(
+        dOh_bmhk,
+        p.w_out,
+        p.b_out,
+        p.out_after_linear,
+        M, K, K, stream,
+        dQh_bmhk,  // fp8_scratch
+        p.w_out_scale,  // weight_scale (FP8)
+        p.workspace->int8_scratch,  // int8_scratch
+        p.workspace->int8_act_block_scales,  // int8_act_block_scales (INT8)
+        p.w_out_block_scale);  // weight_block_scale (INT8)
+    if (err != cudaSuccess) { return err; }
+  }
+  rec(EV_AFTER_OUT);
+
+  if (prof_detail) {
+    cudaEventSynchronize(ev[EV_AFTER_OUT]);
+    auto ms = [&](int a, int b) -> float {
+      float out = 0.f;
+      cudaEventElapsedTime(&out, ev[a], ev[b]);
+      return out;
+    };
+    float t_qkv  = ms(EV_START, EV_AFTER_QKV_PROJ);
+    float t_pack = ms(EV_AFTER_QKV_PROJ, EV_AFTER_PACK_ROPE);
+    float t_sdpa = ms(EV_BEFORE_SDPA_EXEC, EV_AFTER_SDPA_EXEC);
+    float t_out  = ms(EV_AFTER_SDPA_EXEC, EV_AFTER_OUT);
+    float t_tot  = ms(EV_START, EV_AFTER_OUT);
+    std::printf(
+      "[wan_sa_cudnn][call=%lld] M=%d K=%d H=%d D=%d | "
+      "qkv=%.3f pack_rope=%.3f sdpa=%.3f out=%.3f total=%.3f ms",
+      prof_call_idx, M, K, H, D, t_qkv, t_pack, t_sdpa, t_out, t_tot
+    );
+    if (graph_built_now) {
+      std::printf(" | graph_build_cpu=%.3f ms", graph_build_ms_cpu);
+    }
+    std::printf("\n");
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventDestroy(ev[i]);
+  }
+
+  return cudaSuccess;
+}
+// cuDNN cross-attention implementation using cudnn-frontend SDPA
+template <typename WeightT>
+static cudaError_t run_cross_attention_cudnn(const AttentionDeviceParamsT<WeightT>& p, bool fuse_residual, cudaStream_t stream) {
+  int B = p.B;
+  int Mq = p.Mq;
+  if (Mq <= 0) { return cudaErrorInvalidValue; }
+  int M = B * Mq;
+  int K = p.K, H = p.H, D = p.D;
+  int Mk = p.Mk ? p.Mk : Mq;
+
+  // Determine encoder batch size for KV projection (shared KV optimization for CFG)
+  int enc_B = (p.encoder_batch_size > 0) ? p.encoder_batch_size : B;
+  bool shared_kv = (enc_B < B);
+
+  // Use cuDNN workspace buffers
+  cutlass::half_t* dQh_bmhk = p.workspace->cudnn.ca_q_bmhk;
+  cutlass::half_t* dKh_bmhk = p.workspace->cudnn.ca_k_bmhk;
+  cutlass::half_t* dVh_bmhk = p.workspace->cudnn.ca_v_bmhk;
+  cutlass::half_t* dOh_bmhk = p.workspace->cudnn.ca_o_bmhk;
+  cutlass::half_t* dQrow = p.workspace->cudnn.ca_q_row;
+  cutlass::half_t* dKVrow = p.workspace->cudnn.ca_kv_row;
+
+  CA_NAN_CHECK(p.hidden_states, int64_t(M)*K, "CA_input_hidden_states");
+  CA_NAN_CHECK(p.encoder_hidden_states, int64_t(enc_B)*Mk*K, "CA_input_encoder_hidden_states");
+
+  // 1a) Q projection
+  {
+    // Use dQh_bmhk as fp8_scratch (will be overwritten in packing step)
+    cudaError_t err = apply_linear_row<WeightT>(
+        p.hidden_states,
+        p.w_q,
+        p.b_q,
+        dQrow,
+        M, K, K, stream,
+        dQh_bmhk,  // fp8_scratch
+        p.w_q_scale,  // weight_scale (FP8)
+        p.workspace->int8_scratch,  // int8_scratch
+        p.workspace->int8_act_block_scales,  // int8_act_block_scales (INT8)
+        p.w_q_block_scale);  // weight_block_scale (INT8)
+    if (err != cudaSuccess) { return err; }
+    CA_NAN_CHECK(dQrow, int64_t(M)*K, "CA_after_Q_gemm");
+    rmsnorm_pack_single_from_row_kernel<<<M, 256, 256*sizeof(float), stream>>>(
+      reinterpret_cast<const half*>(dQrow), M, K, H, D,
+      p.norm_q_gamma, 1.0e-6f,
+      dQh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+    CA_NAN_CHECK(dQh_bmhk, int64_t(M)*K, "CA_after_Q_rmsnorm_pack");
+  }
+
+  // 1b) KV projection - project only enc_B*Mk tokens when shared_kv=true
+  {
+    // Use dKh_bmhk as fp8_scratch (will be overwritten in packing step)
+    int kv_rows = enc_B * Mk;
+    cudaError_t err = apply_linear_row<WeightT>(
+        p.encoder_hidden_states,
+        p.w_kv,
+        p.b_kv,
+        dKVrow,
+        kv_rows, K, 2 * K, stream,
+        dKh_bmhk,  // fp8_scratch
+        p.w_kv_scale,  // weight_scale (FP8)
+        p.workspace->int8_scratch,  // int8_scratch
+        p.workspace->int8_act_block_scales,  // int8_act_block_scales (INT8)
+        p.w_kv_block_scale);  // weight_block_scale (INT8)
+    if (err != cudaSuccess) { return err; }
+    CA_NAN_CHECK(dKVrow, int64_t(kv_rows)*2*K, "CA_after_KV_gemm");
+
+    rmsnorm_pack_kv_from_row_kernel<<<kv_rows, 256, 256*sizeof(float), stream>>>(
+      reinterpret_cast<const half*>(dKVrow), kv_rows, K, H, D,
+      p.norm_k_gamma, 1.0e-6f,
+      dKh_bmhk, dVh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+    CA_NAN_CHECK(dKh_bmhk, int64_t(kv_rows)*K, "CA_after_K_rmsnorm_pack");
+    CA_NAN_CHECK(dVh_bmhk, int64_t(kv_rows)*K, "CA_after_V_pack");
+  }
+
+  // 2) Run cuDNN cross-attention SDPA
+  {
+    auto handle = get_cudnn_handle();
+    cudnnSetStream(handle, stream);
+
+    // Check graph cache or create new graph
+    // Include shared_kv in cache key since stride patterns differ
+    GraphCacheKey cache_key{B, Mq, H, D, shared_kv ? -Mk : Mk};  // Negative Mk signals shared KV mode
+    auto it = g_sdpa_graph_cache.find(cache_key);
+    std::shared_ptr<fe::graph::Graph> graph;
+
+    if (it != g_sdpa_graph_cache.end()) {
+      graph = it->second;
+    } else {
+      // Create cuDNN graph for cross-attention SDPA
+      graph = std::make_shared<fe::graph::Graph>();
+      graph->set_io_data_type(fe::DataType_t::HALF)
+          .set_intermediate_data_type(fe::DataType_t::FLOAT)
+          .set_compute_data_type(fe::DataType_t::FLOAT);
+
+    // Define Q, K, V tensors in BHSD format
+    // Note: Packing kernels output row-major [M, K] or [Mk, K] where K=H*D
+    // Q: batch=B, heads=H, seq=Mq, dim=D
+    // K, V: batch=B (logical), heads=H, seq=Mk (encoder sequence), dim=D
+    //       When shared_kv=true, K/V batch stride=0 to broadcast single KV set
+    int64_t b = B;
+    int64_t K_total = H * D;  // Total hidden dimension
+    int64_t kv_batch_stride = shared_kv ? 0 : (int64_t(Mk) * K_total);
+    auto Q = graph->tensor(fe::graph::Tensor_attributes()
+                               .set_name("Q")
+                               .set_uid(1)
+                               .set_dim({b, H, Mq, D})
+                               .set_stride({int64_t(Mq) * K_total, D, K_total, 1}));
+
+    auto K = graph->tensor(fe::graph::Tensor_attributes()
+                               .set_name("K")
+                               .set_uid(2)
+                               .set_dim({b, H, Mk, D})
+                               .set_stride({kv_batch_stride, D, K_total, 1}));
+
+    auto V = graph->tensor(fe::graph::Tensor_attributes()
+                               .set_name("V")
+                               .set_uid(3)
+                               .set_dim({b, H, Mk, D})
+                               .set_stride({kv_batch_stride, D, K_total, 1}));
+
+    // SDPA options with attention scale
+    float attn_scale = 1.0f / sqrtf(static_cast<float>(D));
+    auto sdpa_options = fe::graph::SDPA_attributes()
+                            .set_name("sdpa_cross_attention")
+                            .set_attn_scale(attn_scale);
+
+    // Create SDPA operation
+    auto [O, Stats] = graph->sdpa(Q, K, V, sdpa_options);
+
+      // Set output tensor properties with row-major [M, K] layout to match Q input format
+      O->set_output(true).set_dim({b, H, Mq, D}).set_stride({int64_t(Mq) * K_total, D, K_total, 1}).set_uid(4);
+
+      // Build the graph
+      if (!graph->build(handle, {fe::HeurMode_t::A}).is_good()) {
+        return cudaErrorUnknown;
+      }
+
+      // Cache the graph
+      g_sdpa_graph_cache[cache_key] = graph;
+    }
+
+    // Prepare variant pack
+    std::unordered_map<fe::graph::Tensor_attributes::uid_t, void*> variant_pack = {
+        {1, dQh_bmhk}, {2, dKh_bmhk}, {3, dVh_bmhk}, {4, dOh_bmhk}};
+
+    // Get workspace size and validate
+    int64_t workspace_size = 0;
+    if (!graph->get_workspace_size(workspace_size).is_good()) {
+      return cudaErrorUnknown;
+    }
+
+    // Ensure cuDNN SDPA workspace exists with sufficient capacity
+    p.workspace->ensure_cudnn_workspace((size_t)workspace_size);
+    void* workspace = p.workspace->cudnn.cudnn_workspace;
+    if (!graph->execute(handle, variant_pack, workspace).is_good()) {
+      return cudaErrorUnknown;
+    }
+  }
+  CA_NAN_CHECK(dOh_bmhk, int64_t(M)*K, "CA_after_cuDNN_SDPA");
+
+  // 3) Output projection - dOh_bmhk is already in row-major [M, K] format due to stride config
+  {
+    // Use dQh_bmhk as fp8_scratch.
+    // For temp_out (FP8 scaled path): need M*K halves, but dKVrow is only Mk*2K which is
+    // too small when M >> Mk. Use sa_qkv_row (M*3K halves, self-attention is done).
+    cutlass::half_t* out_temp = p.workspace->cudnn.sa_qkv_row;  // M*3K >= M*K
+    cudaError_t err = cudaSuccess;
+    if (fuse_residual) {
+      err = apply_linear_row_fused_residual<WeightT>(
+          dOh_bmhk,
+          p.w_out,
+          p.b_out,
+          p.out_after_linear,  // residual_inout
+          M, K, K, stream,
+          dQh_bmhk,  // fp8_scratch
+          p.w_out_scale,  // weight_scale (FP8)
+          out_temp,  // temp_out (M*K GEMM output, needs M*K halves)
+          p.workspace->int8_scratch,  // int8_scratch
+          p.workspace->int8_act_block_scales,  // int8_act_block_scales (INT8)
+          p.w_out_block_scale);  // weight_block_scale (INT8)
+    } else {
+      err = apply_linear_row<WeightT>(
+          dOh_bmhk,
+          p.w_out,
+          p.b_out,
+          p.out_after_linear,
+          M, K, K, stream,
+          dQh_bmhk,  // fp8_scratch
+          p.w_out_scale,  // weight_scale (FP8)
+          p.workspace->int8_scratch,  // int8_scratch
+          p.workspace->int8_act_block_scales,  // int8_act_block_scales (INT8)
+          p.w_out_block_scale);  // weight_block_scale (INT8)
+    }
+    if (err != cudaSuccess) { return err; }
+  }
+  CA_NAN_CHECK(p.out_after_linear, int64_t(M)*K, "CA_after_out_proj_fused_residual");
+
+  return cudaSuccess;
+}
+
+
+// cuDNN cross-attention implementation for fused text+image (I2V) path
+template <typename WeightT>
+static cudaError_t run_cross_attention_i2v_cudnn(const CrossAttentionI2VParamsT<WeightT>& p, bool fuse_residual, cudaStream_t stream) {
+  int B = p.B;
+  int Mq = p.M;                // query length per batch item
+  int M_total = B * Mq;        // total query rows in flattened [B*Mq, K]
+  int K = p.K, H = p.H, D = p.D;
+  int Mk_text = p.Mk_text ? p.Mk_text : Mq;  // text KV length per batch item
+
+  // Image branch enabled only when all required pointers are present.
+  bool do_img = (p.Mk_img > 0) &&
+                (p.encoder_hidden_states_img != nullptr) &&
+                (p.w_add_k != nullptr) && (p.w_add_v != nullptr) &&
+                (p.norm_added_k_gamma != nullptr);
+  int Mk_img = do_img ? p.Mk_img : 0;
+  int Mk_total = Mk_text + Mk_img;  // KV length per batch item (text + image)
+  int Mk_text_total = B * Mk_text;
+  int Mk_img_total = B * Mk_img;
+
+  // Optional fine-grained profiling:
+  // - GPU time via CUDA events around key kernels and SDPA execute
+  // - CPU wall time for cuDNN graph build (first-call overhead)
+  long long prof_call_idx = 0;
+  bool prof_detail = wan_profile_detail_enabled(&prof_call_idx);
+  enum {
+    EV_START = 0,
+    EV_AFTER_Q_PROJ,
+    EV_AFTER_Q_PACK,
+    EV_AFTER_TEXT_KV_PROJ,
+    EV_AFTER_TEXT_KV_PACK,
+    EV_AFTER_IMG_K_PROJ,
+    EV_AFTER_IMG_V_PROJ,
+    EV_AFTER_IMG_KV_PACK,
+    EV_BEFORE_SDPA_EXEC,
+    EV_AFTER_SDPA_EXEC,
+    EV_AFTER_OUT_PROJ,
+    EV_COUNT
+  };
+  cudaEvent_t ev[EV_COUNT];
+  auto rec = [&](int idx) {
+    if (prof_detail) cudaEventRecord(ev[idx], stream);
+  };
+  if (prof_detail) {
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventCreate(&ev[i]);
+    rec(EV_START);
+  }
+  double graph_build_ms_cpu = 0.0;
+  bool graph_built_now = false;
+
+  // Workspace pointers (cuDNN layout)
+  cutlass::half_t* dQh_bmhk = p.workspace->cudnn.ca_q_bmhk;   // [B*Mq, K]
+  cutlass::half_t* dKh_bmhk = p.workspace->cudnn.ca_k_bmhk;   // [Mk_max, K] (Mk_max >= B*(Mk_text+Mk_img))
+  cutlass::half_t* dVh_bmhk = p.workspace->cudnn.ca_v_bmhk;   // [Mk_max, K]
+  cutlass::half_t* dOh_bmhk = p.workspace->cudnn.ca_o_bmhk;   // [B*Mq, K]
+  cutlass::half_t* dQrow    = p.workspace->cudnn.ca_q_row;    // [B*Mq, K]
+  cutlass::half_t* dKVrow   = p.workspace->cudnn.ca_kv_row;   // [Mk_max, 2K]
+
+  // 1) Q projection + RMSNorm/pack
+  {
+    auto* fp8_scratch = reinterpret_cast<cutlass::half_t*>(dQh_bmhk); // safe scratch
+    cudaError_t err = apply_linear_row<WeightT>(
+        reinterpret_cast<const cutlass::half_t*>(p.hidden_states),
+        reinterpret_cast<const WeightT*>(p.w_q),
+        reinterpret_cast<const cutlass::half_t*>(p.b_q),
+        reinterpret_cast<cutlass::half_t*>(dQrow),
+        M_total, K, K, stream,
+        fp8_scratch,
+        reinterpret_cast<const cutlass::half_t*>(p.w_q_scale));
+    if (err != cudaSuccess) { return err; }
+    rec(EV_AFTER_Q_PROJ);
+    rmsnorm_pack_single_from_row_kernel<<<M_total, 256, 256*sizeof(float), stream>>>(
+      reinterpret_cast<const half*>(dQrow), M_total, K, H, D,
+      p.norm_q_gamma, 1.0e-6f,
+      dQh_bmhk);
+    CUDA_CHECK(cudaGetLastError());
+    rec(EV_AFTER_Q_PACK);
+  }
+
+  // 2) Text KV projection -> pack (for all batches)
+  {
+    auto* fp8_scratch = reinterpret_cast<cutlass::half_t*>(dKh_bmhk); // safe scratch
+    cudaError_t err = apply_linear_row<WeightT>(
+        reinterpret_cast<const cutlass::half_t*>(p.encoder_hidden_states_text),
+        reinterpret_cast<const WeightT*>(p.w_kv),
+        reinterpret_cast<const cutlass::half_t*>(p.b_kv),
+        reinterpret_cast<cutlass::half_t*>(dKVrow),
+        Mk_text_total, K, 2 * K, stream,
+        fp8_scratch,
+        reinterpret_cast<const cutlass::half_t*>(p.w_kv_scale));
+    if (err != cudaSuccess) { return err; }
+    rec(EV_AFTER_TEXT_KV_PROJ);
+
+    // Pack into [B, Mk_total, K] layout in the shared buffer:
+    // For each batch b: write text tokens into rows [b*Mk_total + 0 : b*Mk_total + Mk_text)
+    for (int b = 0; b < B; ++b) {
+      const half* kv_row_b = reinterpret_cast<const half*>(dKVrow) + size_t(b) * Mk_text * 2 * K;
+      cutlass::half_t* dKh_b = dKh_bmhk + size_t(b) * Mk_total * K;
+      cutlass::half_t* dVh_b = dVh_bmhk + size_t(b) * Mk_total * K;
+      rmsnorm_pack_kv_from_row_kernel<<<Mk_text, 256, 256*sizeof(float), stream>>>(
+        kv_row_b, Mk_text, K, H, D,
+        p.norm_k_gamma, 1.0e-6f,
+        dKh_b, dVh_b);
+      CUDA_CHECK(cudaGetLastError());
+    }
+    rec(EV_AFTER_TEXT_KV_PACK);
+  }
+
+  // 3) Image KV projection -> pack into the tail after text (optional)
+  if (do_img) {
+    CUDA_CHECK(p.added_kv_proj_dim > 0 ? cudaSuccess : cudaErrorInvalidValue);
+
+    // Store image KV rows in a contiguous region after the text KV rows:
+    // kv_row_img_all is [B*Mk_img, 2K] row-major, arranged batch-major.
+    half* kv_row_img_all = reinterpret_cast<half*>(dKVrow + size_t(Mk_text_total) * 2 * K);
+    // Use a contiguous temp buffer for scaled K/V, then scatter into strided [B*Mk_img, 2K].
+    auto* fp8_scratch = reinterpret_cast<cutlass::half_t*>(p.workspace->scratch_mk_b);
+    auto* tmp_row = reinterpret_cast<cutlass::half_t*>(dQrow);
+    cudaError_t errk = apply_linear_row<WeightT>(
+        reinterpret_cast<const cutlass::half_t*>(p.encoder_hidden_states_img),
+        reinterpret_cast<const WeightT*>(p.w_add_k),
+        reinterpret_cast<const cutlass::half_t*>(p.b_add_k),
+        reinterpret_cast<cutlass::half_t*>(tmp_row),
+        Mk_img_total, p.added_kv_proj_dim, K, stream,
+        fp8_scratch,
+        reinterpret_cast<const cutlass::half_t*>(p.w_add_k_scale));
+    if (errk != cudaSuccess) { return errk; }
+    rec(EV_AFTER_IMG_K_PROJ);
+    cudaError_t cpy_k = cudaMemcpy2DAsync(
+        kv_row_img_all, size_t(2 * K) * sizeof(half),
+        tmp_row, size_t(K) * sizeof(half),
+        size_t(K) * sizeof(half), Mk_img_total,
+        cudaMemcpyDeviceToDevice, stream);
+    if (cpy_k != cudaSuccess) { return cpy_k; }
+
+    cudaError_t errv = apply_linear_row<WeightT>(
+        reinterpret_cast<const cutlass::half_t*>(p.encoder_hidden_states_img),
+        reinterpret_cast<const WeightT*>(p.w_add_v),
+        reinterpret_cast<const cutlass::half_t*>(p.b_add_v),
+        reinterpret_cast<cutlass::half_t*>(tmp_row),
+        Mk_img_total, p.added_kv_proj_dim, K, stream,
+        fp8_scratch,
+        reinterpret_cast<const cutlass::half_t*>(p.w_add_v_scale));
+    if (errv != cudaSuccess) { return errv; }
+    rec(EV_AFTER_IMG_V_PROJ);
+    cudaError_t cpy_v = cudaMemcpy2DAsync(
+        kv_row_img_all + K, size_t(2 * K) * sizeof(half),
+        tmp_row, size_t(K) * sizeof(half),
+        size_t(K) * sizeof(half), Mk_img_total,
+        cudaMemcpyDeviceToDevice, stream);
+    if (cpy_v != cudaSuccess) { return cpy_v; }
+
+    // Pack into [B, Mk_total, K] layout:
+    // For each batch b: write image tokens into rows [b*Mk_total + Mk_text : b*Mk_total + Mk_total)
+    for (int b = 0; b < B; ++b) {
+      const half* kv_row_img_b = kv_row_img_all + size_t(b) * Mk_img * 2 * K;
+      cutlass::half_t* dKh_img_b = dKh_bmhk + (size_t(b) * Mk_total + Mk_text) * K;
+      cutlass::half_t* dVh_img_b = dVh_bmhk + (size_t(b) * Mk_total + Mk_text) * K;
+      rmsnorm_pack_kv_from_row_kernel<<<Mk_img, 256, 256*sizeof(float), stream>>>(
+          kv_row_img_b, Mk_img, K, H, D,
+          p.norm_added_k_gamma, 1.0e-6f,
+          dKh_img_b, dVh_img_b);
+      CUDA_CHECK(cudaGetLastError());
+    }
+    rec(EV_AFTER_IMG_KV_PACK);
+  }
+  if (prof_detail && !do_img) {
+    rec(EV_AFTER_IMG_K_PROJ);
+    rec(EV_AFTER_IMG_V_PROJ);
+    rec(EV_AFTER_IMG_KV_PACK);
+  }
+
+  // 4) Run cuDNN cross-attention SDPA over concatenated [text; image]
+  {
+    auto handle = get_cudnn_handle();
+    cudnnSetStream(handle, stream);
+
+    GraphCacheKey cache_key{B, Mq, H, D, Mk_total};
+    auto it = g_sdpa_graph_cache.find(cache_key);
+    std::shared_ptr<fe::graph::Graph> graph;
+
+    if (it != g_sdpa_graph_cache.end()) {
+      graph = it->second;
+    } else {
+      auto t0 = std::chrono::high_resolution_clock::now();
+      graph_built_now = true;
+      graph = std::make_shared<fe::graph::Graph>();
+      graph->set_io_data_type(fe::DataType_t::HALF)
+          .set_intermediate_data_type(fe::DataType_t::FLOAT)
+          .set_compute_data_type(fe::DataType_t::FLOAT);
+
+      int64_t b = B;
+      int64_t K_total = H * D;
+      auto Q = graph->tensor(fe::graph::Tensor_attributes()
+                                 .set_name("Q")
+                                 .set_uid(1)
+                                 .set_dim({b, H, Mq, D})
+                                 .set_stride({int64_t(Mq) * K_total, D, K_total, 1}));
+
+      auto K_t = graph->tensor(fe::graph::Tensor_attributes()
+                                   .set_name("K")
+                                   .set_uid(2)
+                                   .set_dim({b, H, Mk_total, D})
+                                   .set_stride({int64_t(Mk_total) * K_total, D, K_total, 1}));
+
+      auto V_t = graph->tensor(fe::graph::Tensor_attributes()
+                                   .set_name("V")
+                                   .set_uid(3)
+                                   .set_dim({b, H, Mk_total, D})
+                                   .set_stride({int64_t(Mk_total) * K_total, D, K_total, 1}));
+
+      float attn_scale = 1.0f / sqrtf(static_cast<float>(D));
+      auto sdpa_options = fe::graph::SDPA_attributes()
+                              .set_name("sdpa_cross_attention_i2v")
+                              .set_attn_scale(attn_scale);
+
+      auto [O, Stats] = graph->sdpa(Q, K_t, V_t, sdpa_options);
+
+      O->set_output(true).set_dim({b, H, Mq, D}).set_stride({int64_t(Mq) * K_total, D, K_total, 1}).set_uid(4);
+
+      if (!graph->build(handle, {fe::HeurMode_t::A}).is_good()) {
+        return cudaErrorUnknown;
+      }
+
+      g_sdpa_graph_cache[cache_key] = graph;
+      auto t1 = std::chrono::high_resolution_clock::now();
+      graph_build_ms_cpu = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    }
+
+    std::unordered_map<fe::graph::Tensor_attributes::uid_t, void*> variant_pack = {
+        {1, dQh_bmhk}, {2, dKh_bmhk}, {3, dVh_bmhk}, {4, dOh_bmhk}};
+
+    int64_t workspace_size = 0;
+    if (!graph->get_workspace_size(workspace_size).is_good()) {
+      return cudaErrorUnknown;
+    }
+
+    // Ensure cuDNN SDPA workspace exists with sufficient capacity.
+    // Note: This is allocated separately from the monolithic workspace pool, so it can grow
+    // without invalidating other pointers.
+    p.workspace->ensure_cudnn_workspace((size_t)workspace_size);
+    void* workspace = p.workspace->cudnn.cudnn_workspace;
+
+    rec(EV_BEFORE_SDPA_EXEC);
+    if (!graph->execute(handle, variant_pack, workspace).is_good()) {
+      return cudaErrorUnknown;
+    }
+    rec(EV_AFTER_SDPA_EXEC);
+  }
+
+  // 5) Output projection (optionally fused with residual)
+  {
+    auto* fp8_scratch = reinterpret_cast<cutlass::half_t*>(dQh_bmhk); // safe scratch
+    cudaError_t err = cudaSuccess;
+    if (fuse_residual) {
+      err = apply_linear_row_fused_residual<WeightT>(
+        reinterpret_cast<const cutlass::half_t*>(dOh_bmhk),
+        reinterpret_cast<const WeightT*>(p.w_out),
+        reinterpret_cast<const cutlass::half_t*>(p.b_out),
+        reinterpret_cast<cutlass::half_t*>(p.out_after_linear),
+        M_total, K, K, stream,
+        fp8_scratch,
+        reinterpret_cast<const cutlass::half_t*>(p.w_out_scale),
+        reinterpret_cast<cutlass::half_t*>(dQrow));
+    } else {
+      err = apply_linear_row<WeightT>(
+        reinterpret_cast<const cutlass::half_t*>(dOh_bmhk),
+        reinterpret_cast<const WeightT*>(p.w_out),
+        reinterpret_cast<const cutlass::half_t*>(p.b_out),
+        reinterpret_cast<cutlass::half_t*>(p.out_after_linear),
+        M_total, K, K, stream,
+        fp8_scratch,
+        reinterpret_cast<const cutlass::half_t*>(p.w_out_scale));
+    }
+    if (err != cudaSuccess) { return err; }
+  }
+  rec(EV_AFTER_OUT_PROJ);
+
+  if (prof_detail) {
+    cudaEventSynchronize(ev[EV_AFTER_OUT_PROJ]);
+    auto ms = [&](int a, int b) -> float {
+      float out = 0.f;
+      cudaEventElapsedTime(&out, ev[a], ev[b]);
+      return out;
+    };
+    float t_q_proj   = ms(EV_START, EV_AFTER_Q_PROJ);
+    float t_q_pack   = ms(EV_AFTER_Q_PROJ, EV_AFTER_Q_PACK);
+    float t_kv_text  = ms(EV_AFTER_Q_PACK, EV_AFTER_TEXT_KV_PROJ);
+    float t_pack_txt = ms(EV_AFTER_TEXT_KV_PROJ, EV_AFTER_TEXT_KV_PACK);
+    float t_k_img    = ms(EV_AFTER_TEXT_KV_PACK, EV_AFTER_IMG_K_PROJ);
+    float t_v_img    = ms(EV_AFTER_IMG_K_PROJ, EV_AFTER_IMG_V_PROJ);
+    float t_pack_img = ms(EV_AFTER_IMG_V_PROJ, EV_AFTER_IMG_KV_PACK);
+    float t_sdpa     = ms(EV_BEFORE_SDPA_EXEC, EV_AFTER_SDPA_EXEC);
+    float t_out      = ms(EV_AFTER_SDPA_EXEC, EV_AFTER_OUT_PROJ);
+    float t_total    = ms(EV_START, EV_AFTER_OUT_PROJ);
+
+    std::printf(
+      "[wan_ca_i2v_cudnn][call=%lld] B=%d Mq=%d K=%d H=%d D=%d Mk_text=%d Mk_img=%d | "
+      "q_proj=%.3f q_pack=%.3f kv_text=%.3f pack_text=%.3f "
+      "k_img=%.3f v_img=%.3f pack_img=%.3f sdpa=%.3f out=%.3f total=%.3f ms",
+      prof_call_idx, B, Mq, K, H, D, Mk_text, Mk_img,
+      t_q_proj, t_q_pack, t_kv_text, t_pack_txt,
+      t_k_img, t_v_img, t_pack_img, t_sdpa, t_out, t_total
+    );
+    if (graph_built_now) {
+      std::printf(" | graph_build_cpu=%.3f ms", graph_build_ms_cpu);
+    }
+    std::printf("\n");
+
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventDestroy(ev[i]);
+  }
+
+  return cudaSuccess;
+}
+
+template <typename WeightT>
+static cudaError_t run_self_attention_cudnn(const AttentionDeviceParamsT<WeightT>& p, cudaStream_t stream) {
+  return run_self_attention_cudnn_impl<WeightT>(p, stream, nullptr, nullptr);
+}
+
+// ============================================================================
+// Public API - Backend Dispatcher
+// ============================================================================
+
+template <typename WeightT>
+cudaError_t run_self_attention(const AttentionDeviceParamsT<WeightT>& p, cudaStream_t stream) {
+    switch (g_attention_backend) {
+        case AttnBackend::CUTLASS_FLASH:
+            if constexpr (std::is_same<WeightT, cutlass::half_t>::value) {
+              return run_self_attention_cutlass(p, stream);
+            }
+            else {
+              return cudaErrorNotSupported;
+            }
+        case AttnBackend::CUDNN:
+            return run_self_attention_cudnn_impl<WeightT>(p, stream, nullptr, nullptr);
+        default:
+            return cudaErrorNotSupported;
+    }
+}
+
+template <typename WeightT>
+cudaError_t run_cross_attention(const AttentionDeviceParamsT<WeightT>& p, bool fuse_residual, cudaStream_t stream) {
+    switch (g_attention_backend) {
+        case AttnBackend::CUTLASS_FLASH:
+            if constexpr (std::is_same<WeightT, cutlass::half_t>::value) {
+              return run_cross_attention_cutlass(p, fuse_residual, stream);
+            }
+            else {
+              return cudaErrorNotSupported;
+            }
+        case AttnBackend::CUDNN:
+            return run_cross_attention_cudnn<WeightT>(p, fuse_residual, stream);
+        default:
+            return cudaErrorNotSupported;
+    }
+}
+
+template <typename WeightT>
+cudaError_t run_cross_attention_i2v(const CrossAttentionI2VParamsT<WeightT>& p, bool fuse_residual, cudaStream_t stream) {
+    switch (g_attention_backend) {
+    case AttnBackend::CUTLASS_FLASH:
+        if constexpr (std::is_same<WeightT, cutlass::half_t>::value) {
+            return run_cross_attention_i2v_cutlass(p, fuse_residual, stream);
+        } else {
+            return cudaErrorNotSupported;
+        }
+    case AttnBackend::CUDNN:
+        return run_cross_attention_i2v_cudnn<WeightT>(p, fuse_residual, stream);
+    default:
+        return cudaErrorNotSupported;
+    }
+}
+
+// Explicit template instantiations for linkage (mirrors run_cross_attention)
+template cudaError_t run_cross_attention_i2v<cutlass::half_t>(
+    const CrossAttentionI2VParamsT<cutlass::half_t>& p,
+    bool fuse_residual,
+    cudaStream_t stream
+);
+template cudaError_t run_cross_attention_i2v<cutlass::float_e4m3_t>(
+    const CrossAttentionI2VParamsT<cutlass::float_e4m3_t>& p,
+    bool fuse_residual,
+    cudaStream_t stream
+);
+template cudaError_t run_cross_attention_i2v<int8_t>(
+    const CrossAttentionI2VParamsT<int8_t>& p,
+    bool fuse_residual,
+    cudaStream_t stream
+);
+// Explicit template instantiations to ensure linkage across translation units
+template cudaError_t run_self_attention<cutlass::half_t>(
+  const AttentionDeviceParamsT<cutlass::half_t>& p,
+  cudaStream_t stream
+);
+template cudaError_t run_cross_attention<cutlass::half_t>(
+  const AttentionDeviceParamsT<cutlass::half_t>& p,
+  bool fuse_residual,
+  cudaStream_t stream
+);
+template cudaError_t run_self_attention<cutlass::float_e4m3_t>(
+  const AttentionDeviceParamsT<cutlass::float_e4m3_t>& p,
+  cudaStream_t stream
+);
+template cudaError_t run_cross_attention<cutlass::float_e4m3_t>(
+  const AttentionDeviceParamsT<cutlass::float_e4m3_t>& p,
+  bool fuse_residual,
+  cudaStream_t stream
+);
+template cudaError_t run_self_attention<int8_t>(
+  const AttentionDeviceParamsT<int8_t>& p,
+  cudaStream_t stream
+);
+template cudaError_t run_cross_attention<int8_t>(
+  const AttentionDeviceParamsT<int8_t>& p,
+  bool fuse_residual,
+  cudaStream_t stream
+);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cu
@@ -3,6 +3,9 @@
 #include "linear_utils.cuh"
 #include "helper.h"
 #include "kernel_forward.h"
+#ifdef OMNIDREAMS_SINGLEVIEW_HAS_SPARGE
+#include "sparge_attention_kernels.cuh"
+#endif
 
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/device/gemm.h"
@@ -24,6 +27,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cctype>
+#include <cstdio>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -2154,6 +2158,923 @@ template <typename WeightT>
 static cudaError_t run_self_attention_cudnn(const AttentionDeviceParamsT<WeightT>& p, cudaStream_t stream) {
   return run_self_attention_cudnn_impl<WeightT>(p, stream, nullptr, nullptr);
 }
+
+// Sparge Attention Implementation
+// ============================================================================
+
+// Smooth-K support has been removed; K is used as-is without mean subtraction.
+
+constexpr int kSpargeSm89CtaQ = 128;
+constexpr int kSpargeSm89CtaK = 64;
+
+// Helper: Convert cutlass::half_t to float
+__device__ __forceinline__ float half_to_float(cutlass::half_t val) {
+  return __half2float(*reinterpret_cast<const half*>(&val));
+}
+
+// Helper: Convert float to cutlass::half_t
+__device__ __forceinline__ cutlass::half_t float_to_half(float val) {
+  half h = __float2half(val);
+  return *reinterpret_cast<cutlass::half_t*>(&h);
+}
+
+// Kernel: Mean pool blocks for block map computation (optimized with vectorized loads)
+// Grid: (num_blocks, H), Block: (D/2) - each thread handles 2 elements via half2
+// NOTE: Input X is in [M, H, D] layout (output of rmsnorm_pack_bmhk_rope_from_row_kernel)
+//       Output X_pooled is in [num_blocks, H, D] layout (MHD-consistent, eliminates transpose)
+// When subtract_mean=true, subtracts X_mean from each element before pooling
+__global__ void sparge_mean_pool_kernel(
+    const cutlass::half_t* __restrict__ X,       // [M, H, D] - stride [H*D, D, 1]
+    const cutlass::half_t* __restrict__ X_mean,  // [H, D] - optional mean to subtract (nullptr if not used)
+    cutlass::half_t* __restrict__ X_pooled,      // [num_blocks, H, D] - MHD layout
+    int M, int H, int D, int BLOCK_SIZE,
+    bool subtract_mean) {
+  int block_idx = blockIdx.x;
+  int h = blockIdx.y;
+  int tid = threadIdx.x;
+
+  int start = block_idx * BLOCK_SIZE;
+  int end = min(start + BLOCK_SIZE, M);
+  int count = end - start;
+  if (count <= 0) return;
+
+  // Use half2 for vectorized access (2 elements per thread)
+  const half2* X_h2 = reinterpret_cast<const half2*>(X);
+  half2* out_h2 = reinterpret_cast<half2*>(X_pooled);
+  int D2 = D / 2;
+  int K2 = H * D2;  // Stride in half2 units for [*, H, D] layout
+
+  // Load mean if needed (X_mean is [H, D], stored contiguously)
+  float2 mean_val = make_float2(0.f, 0.f);
+  if (subtract_mean && X_mean != nullptr && tid < D2) {
+    const half2* mean_h2 = reinterpret_cast<const half2*>(X_mean);
+    half2 m = mean_h2[h * D2 + tid];
+    mean_val.x = __half2float(m.x);
+    mean_val.y = __half2float(m.y);
+  }
+
+  if (tid < D2) {
+    float2 sum = make_float2(0.f, 0.f);
+
+    #pragma unroll 4
+    for (int i = start; i < end; i++) {
+      // [M, H, D] layout: X[m, h, d] at index m * H * D + h * D + d
+      // In half2: X_h2[m * H * D2 + h * D2 + tid]
+      half2 val = X_h2[i * K2 + h * D2 + tid];
+      float2 fval;
+      fval.x = __half2float(val.x) - mean_val.x;
+      fval.y = __half2float(val.y) - mean_val.y;
+      sum.x += fval.x;
+      sum.y += fval.y;
+    }
+
+    float inv_count = 1.f / float(count);
+    half2 result;
+    result.x = __float2half(sum.x * inv_count);
+    result.y = __float2half(sum.y * inv_count);
+
+    // Output [num_blocks, H, D] layout: X_pooled[block_idx, h, d] at index block_idx * H * D + h * D + d
+    // In half2: out_h2[block_idx * K2 + h * D2 + tid]
+    out_h2[block_idx * K2 + h * D2 + tid] = result;
+  }
+}
+
+__global__ void sparge_mean_pool_bf16_kernel(
+    const cutlass::bfloat16_t* __restrict__ X,
+    const cutlass::bfloat16_t* __restrict__ X_mean,
+    cutlass::half_t* __restrict__ X_pooled,
+    int M, int H, int D, int BLOCK_SIZE,
+    bool subtract_mean) {
+  int block_idx = blockIdx.x;
+  int h = blockIdx.y;
+  int tid = threadIdx.x;
+
+  int start = block_idx * BLOCK_SIZE;
+  int end = min(start + BLOCK_SIZE, M);
+  int count = end - start;
+  if (count <= 0) return;
+
+  const int K = H * D;
+  const int pair_count = D / 2;
+  if (tid < pair_count) {
+    int d = tid * 2;
+
+    float2 mean_val = make_float2(0.f, 0.f);
+    if (subtract_mean && X_mean != nullptr) {
+      mean_val = omnidreams_singleview::load_vec2_as_float2(X_mean + h * D + d);
+    }
+
+    float2 sum = make_float2(0.f, 0.f);
+    for (int m = start; m < end; ++m) {
+      float2 val = omnidreams_singleview::load_vec2_as_float2(X + size_t(m) * K + h * D + d);
+      sum.x += val.x - mean_val.x;
+      sum.y += val.y - mean_val.y;
+    }
+
+    float inv_count = 1.f / float(count);
+    omnidreams_singleview::store_float2_as_vec2<cutlass::half_t>(
+        X_pooled + (block_idx * H + h) * D + d,
+        make_float2(sum.x * inv_count, sum.y * inv_count));
+    return;
+  }
+
+  if ((D & 1) == 0 || tid != pair_count) return;
+
+  int d = D - 1;
+  float mean_val = 0.f;
+  if (subtract_mean && X_mean != nullptr) {
+    mean_val = omnidreams_singleview::to_float(X_mean[h * D + d]);
+  }
+
+  float sum = 0.f;
+  for (int m = start; m < end; ++m) {
+    sum += omnidreams_singleview::to_float(X[size_t(m) * K + h * D + d]) - mean_val;
+  }
+
+  X_pooled[(block_idx * H + h) * D + d] =
+      omnidreams_singleview::from_float<cutlass::half_t>(sum / float(count));
+}
+
+// (Removed) K-mean kernel; smooth-K no longer used.
+
+// Kernel: Compute pooled scores (Q_pooled @ K_pooled^T) - tiled for high throughput
+// Grid: (num_q_blocks, H), Block: (128) - 4 warps independently process k_blocks
+// Each warp computes full D-dimensional dot products using vectorized float2 loads.
+// Q[q_blk, h, :] is loaded once into registers and reused across all k_blocks.
+// Requires D == 128 (32 lanes x 4 elements per lane via float2 loads).
+// NOTE: Inputs Q_pooled and K_pooled are in MHD layout [num_blocks, H, D]
+//       Output scores is in [num_q_blocks, num_k_blocks, H] layout (MHD-consistent)
+__global__ void sparge_pooled_score_kernel(
+    const cutlass::half_t* __restrict__ Q_pooled,  // [num_q_blocks, H, D] - MHD layout
+    const cutlass::half_t* __restrict__ K_pooled,  // [num_k_blocks, H, D] - MHD layout
+    float* __restrict__ scores,                     // [num_q_blocks, num_k_blocks, H] - MHD-consistent
+    int num_q_blocks, int num_k_blocks, int H, int D, float scale) {
+  const int q_blk = blockIdx.x;
+  const int h = blockIdx.y;
+  const int warp_id = threadIdx.x / 32;
+  const int lane_id = threadIdx.x % 32;
+  const int num_warps = blockDim.x / 32;
+
+  // D=128: each lane loads 4 halfs as one float2 (8 bytes), 32 lanes cover all 128 elements
+  const int D_f2 = D / 4;  // stride in float2 units (=32 for D=128)
+  const float2* Q_f2 = reinterpret_cast<const float2*>(Q_pooled);
+  const float2* K_f2 = reinterpret_cast<const float2*>(K_pooled);
+
+  // Load Q[q_blk, h, :] into registers once - reused across all k_blocks
+  const int q_off = (q_blk * H + h) * D_f2;
+  float2 q_vec = Q_f2[q_off + lane_id];
+  const half* qh = reinterpret_cast<const half*>(&q_vec);
+  const float q0 = __half2float(qh[0]);
+  const float q1 = __half2float(qh[1]);
+  const float q2 = __half2float(qh[2]);
+  const float q3 = __half2float(qh[3]);
+
+  // Output base offset for this (q_blk, h): scores[q_blk, k, h]
+  const int score_base = q_blk * num_k_blocks * H + h;
+
+  // Each warp independently processes k_blocks in round-robin
+  for (int k = warp_id; k < num_k_blocks; k += num_warps) {
+    const int k_off = (k * H + h) * D_f2;
+    float2 k_vec = K_f2[k_off + lane_id];
+    const half* kh = reinterpret_cast<const half*>(&k_vec);
+
+    float sum = q0 * __half2float(kh[0])
+              + q1 * __half2float(kh[1])
+              + q2 * __half2float(kh[2])
+              + q3 * __half2float(kh[3]);
+
+    // Warp-level reduction (5 steps for 32 lanes)
+    for (int offset = 16; offset > 0; offset >>= 1)
+      sum += __shfl_down_sync(0xffffffff, sum, offset);
+
+    if (lane_id == 0)
+      scores[score_base + k * H] = sum * scale;
+  }
+}
+
+// Kernel: TopK selection and sparse map creation - parallel version
+// Grid: (num_q_blocks, H), Block: (256)
+// Uses parallel reduction for finding max, then marks and repeats
+// Shared memory layout: float[256] s_max, int[256] s_idx, int8_t[num_k_blocks] s_used
+// NOTE: scores is in [num_q_blocks, num_k_blocks, H] layout (MHD-consistent)
+//       sparse_map and topk_indices outputs are in HMD layout for SpargeAttn
+__global__ void sparge_topk_sparse_map_kernel(
+    const float* __restrict__ scores,     // [num_q_blocks, num_k_blocks, H] - MHD-consistent
+    int32_t* __restrict__ sparse_map,     // [H, num_q_blocks, num_k_blocks] - HMD layout for SpargeAttn
+    int32_t* __restrict__ topk_indices,   // [H, num_q_blocks, topk] - HMD layout for SpargeAttn
+    int32_t* __restrict__ lut,             // [H, num_q_blocks, num_k_blocks] - HMD for SpargeAttn (merged from build_lut)
+    int32_t* __restrict__ valid_block_num, // [H, num_q_blocks] - HMD for SpargeAttn (merged from build_lut)
+    int num_q_blocks, int num_k_blocks, int H, int topk,
+    int q_to_k_token_offset,
+    bool attention_sink) {
+  int q_blk = blockIdx.x;
+  int h = blockIdx.y;
+  int tid = threadIdx.x;
+
+  // Scores input: [num_q_blocks, num_k_blocks, H] -> stride = [num_k_blocks * H, H, 1]
+  int score_base = q_blk * num_k_blocks * H + h;
+  int score_stride = H;  // k_blk stride in scores
+
+  // Sparse map output: [H, num_q_blocks, num_k_blocks] -> offset = h * num_q_blocks * num_k_blocks + q_blk * num_k_blocks
+  // NOTE: HMD layout required for SpargeAttn compatibility
+  int sparse_offset = h * num_q_blocks * num_k_blocks + q_blk * num_k_blocks;
+
+  // TopK output: [H, num_q_blocks, topk] -> offset = h * num_q_blocks * topk + q_blk * topk
+  int topk_offset = h * num_q_blocks * topk + q_blk * topk;
+
+  // Dynamic shared memory layout
+  extern __shared__ char smem_raw[];
+  float* s_max = reinterpret_cast<float*>(smem_raw);
+  int* s_idx = reinterpret_cast<int*>(smem_raw + 256 * sizeof(float));
+  int8_t* s_used = reinterpret_cast<int8_t*>(smem_raw + 256 * sizeof(float) + 256 * sizeof(int));
+
+  // Initialize sparse map to 0 and copy to shared
+  for (int k = tid; k < num_k_blocks; k += blockDim.x) {
+    sparse_map[sparse_offset + k] = 0;
+    s_used[k] = 0;
+  }
+  __syncthreads();
+
+  // Iterate topk times to find top-k elements
+  for (int t = 0; t < topk && t < num_k_blocks; t++) {
+    // Each thread finds max in its assigned elements
+    float thread_max = -1e30f;
+    int thread_idx = -1;
+
+    for (int k = tid; k < num_k_blocks; k += blockDim.x) {
+      if (s_used[k] == 0) {
+        // Score at [q_blk, k, h] = score_base + k * score_stride
+        float val = scores[score_base + k * score_stride];
+        if (val > thread_max) {
+          thread_max = val;
+          thread_idx = k;
+        }
+      }
+    }
+
+    s_max[tid] = thread_max;
+    s_idx[tid] = thread_idx;
+    __syncthreads();
+
+    // Parallel reduction to find global max
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+      if (tid < s) {
+        if (s_max[tid + s] > s_max[tid]) {
+          s_max[tid] = s_max[tid + s];
+          s_idx[tid] = s_idx[tid + s];
+        }
+      }
+      __syncthreads();
+    }
+
+    // Thread 0 records the result
+    if (tid == 0) {
+      int best_idx = s_idx[0];
+      if (best_idx >= 0) {
+        sparse_map[sparse_offset + best_idx] = 1;
+        topk_indices[topk_offset + t] = best_idx;
+        s_used[best_idx] = 1;  // Mark as used for next iteration
+      }
+    }
+    __syncthreads();
+  }
+
+  // Build delta-encoded LUT (merged from sparge_build_lut_kernel)
+  // Thread 0 scans sparse_map and writes delta-encoded block indices
+  if (tid == 0) {
+    if (attention_sink && num_k_blocks > 0) {
+      sparse_map[sparse_offset] = 1;
+    }
+    if (q_to_k_token_offset >= 0 && num_k_blocks > 0) {
+      int q_token_start = q_blk * kSpargeSm89CtaQ;
+      int q_token_end = q_token_start + kSpargeSm89CtaQ;
+      int k_token_start = q_to_k_token_offset + q_token_start;
+      int k_token_end = q_to_k_token_offset + q_token_end - 1;
+      int local_k_start = max(0, min(num_k_blocks - 1, k_token_start / kSpargeSm89CtaK));
+      int local_k_end = max(0, min(num_k_blocks - 1, k_token_end / kSpargeSm89CtaK));
+      for (int k = local_k_start; k <= local_k_end; ++k) {
+        sparse_map[sparse_offset + k] = 1;
+      }
+    }
+    if (lut != nullptr && valid_block_num != nullptr) {
+      int lut_offset = sparse_offset;  // same HMD layout
+      int valid_offset = h * num_q_blocks + q_blk;
+      int count = 0;
+      int prev_block = 0;
+      for (int k = 0; k < num_k_blocks; k++) {
+        if (sparse_map[sparse_offset + k]) {
+          lut[lut_offset + count] = k - prev_block;
+          prev_block = k;
+          count++;
+        }
+      }
+      valid_block_num[valid_offset] = count;
+    }
+  }
+}
+
+// Dense Sparge map for topk=100% coverage.
+//
+// The SpargeAttn kernel consumes a delta-encoded LUT in HMD layout. For the
+// dense Sparge path every K block is valid, so the LUT is simply [0, 1, 1, ...]
+// for each (head, q_block). This avoids the Sparge pooled-score/top-k prep
+// launches when the caller requested dense coverage.
+__global__ void sparge_dense_lut_kernel(
+    int32_t* __restrict__ lut,
+    int32_t* __restrict__ valid_block_num,
+    int num_q_blocks,
+    int num_k_blocks,
+    int H) {
+  int q_blk = blockIdx.x;
+  int h = blockIdx.y;
+  int tid = threadIdx.x;
+  if (q_blk >= num_q_blocks || h >= H) return;
+
+  int lut_offset = h * num_q_blocks * num_k_blocks + q_blk * num_k_blocks;
+  for (int k = tid; k < num_k_blocks; k += blockDim.x) {
+    lut[lut_offset + k] = (k == 0) ? 0 : 1;
+  }
+  if (tid == 0) {
+    valid_block_num[h * num_q_blocks + q_blk] = num_k_blocks;
+  }
+}
+
+// Kernel: Convert sparse map to delta-encoded LUT
+// Grid: (num_q_blocks, H), Block: (1)
+// NOTE: sparse_map is in [H, num_q_blocks, num_k_blocks] layout (HMD)
+//       lut output is in [H, num_q_blocks, num_k_blocks] layout (HMD)
+//       valid_block_num is in [H, num_q_blocks] layout (HMD)
+__global__ void sparge_build_lut_kernel(
+    const int32_t* __restrict__ sparse_map,  // [H, num_q_blocks, num_k_blocks] - HMD for SpargeAttn
+    int32_t* __restrict__ lut,               // [H, num_q_blocks, num_k_blocks] - HMD for SpargeAttn
+    int32_t* __restrict__ valid_block_num,   // [H, num_q_blocks] - HMD for SpargeAttn
+    int num_q_blocks, int H, int num_k_blocks, int topk) {
+  int q_blk = blockIdx.x;
+  int h = blockIdx.y;
+
+  // HMD layout: [H, num_q_blocks, num_k_blocks] -> offset = h * num_q_blocks * num_k_blocks + q_blk * num_k_blocks
+  // NOTE: HMD layout required for SpargeAttn compatibility
+  int offset = h * num_q_blocks * num_k_blocks + q_blk * num_k_blocks;
+  int lut_offset = offset;
+  // valid_block_num: [H, num_q_blocks] -> offset = h * num_q_blocks + q_blk
+  int valid_offset = h * num_q_blocks + q_blk;
+
+  int count = 0;
+  int prev_block = 0;
+
+  for (int k = 0; k < num_k_blocks && count < topk; k++) {
+    if (sparse_map[offset + k]) {
+      lut[lut_offset + count] = k - prev_block;
+      prev_block = k;
+      count++;
+    }
+  }
+  valid_block_num[valid_offset] = count;
+}
+
+// Kernel: Per-block quantization of Q/K to int8 with zero-padding
+// Grid: (num_blocks, H), Block: (BLOCK_SIZE)
+// NOTE: Input X is in [M, H, D] layout (output of rmsnorm_pack_bmhk_rope_from_row_kernel)
+//       Output X_int8 is also in [M, H, D] layout (for SpargeAttn compatibility)
+//       For the last block, positions beyond M are zero-padded to avoid out-of-bounds reads
+__global__ void sparge_quantize_kernel(
+    const cutlass::half_t* __restrict__ X,  // [M, H, D] - stride [H*D, D, 1]
+    const cutlass::half_t* __restrict__ X_mean,  // [H, D] or nullptr
+    int8_t* __restrict__ X_int8,             // [padded_M, H, D] - stride [H*D, D, 1]
+    float* __restrict__ X_scale,             // [H, num_blocks]
+    int M, int H, int D, int BLOCK_SIZE, bool subtract_mean) {
+  int block_idx = blockIdx.x;
+  int h = blockIdx.y;
+  int tid = threadIdx.x;
+
+  int start = block_idx * BLOCK_SIZE;
+  int block_end = start + BLOCK_SIZE;  // End of this block (may exceed M)
+  int valid_end = min(block_end, M);   // End of valid data
+  if (start >= M) {
+    // Block is entirely in padding region - write zeros
+    for (int i = start + (tid / D); i < block_end; i += (blockDim.x / D)) {
+      int d = tid % D;
+      if (d < D) {
+        X_int8[i * H * D + h * D + d] = 0;
+      }
+    }
+    return;
+  }
+
+  extern __shared__ float smem[];
+  float* smax = smem;
+
+  // Compute stride for [M, H, D] layout
+  int K = H * D;  // Total hidden dimension
+
+  // Find max abs value in valid portion of block
+  float local_max = 0.f;
+  for (int i = start + (tid / D); i < valid_end; i += (blockDim.x / D)) {
+    int d = tid % D;
+    if (d < D && i < valid_end) {
+      // [M, H, D] layout: X[m, h, d] = X[m * H * D + h * D + d]
+      float val = half_to_float(X[i * K + h * D + d]);
+      if (subtract_mean && X_mean != nullptr) {
+        val -= half_to_float(X_mean[h * D + d]);
+      }
+      local_max = fmaxf(local_max, fabsf(val));
+    }
+  }
+
+  // Block reduce to find max
+  smax[tid] = local_max;
+  __syncthreads();
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      smax[tid] = fmaxf(smax[tid], smax[tid + s]);
+    }
+    __syncthreads();
+  }
+
+  float scale = smax[0] / 127.f + 1e-7f;
+  if (tid == 0) {
+    X_scale[h * ((M + BLOCK_SIZE - 1) / BLOCK_SIZE) + block_idx] = scale;
+  }
+  __syncthreads();
+
+  // Quantize valid data
+  for (int i = start + (tid / D); i < valid_end; i += (blockDim.x / D)) {
+    int d = tid % D;
+    if (d < D && i < valid_end) {
+      // [M, H, D] layout: X[m, h, d] = X[m * H * D + h * D + d]
+      float val = half_to_float(X[i * K + h * D + d]);
+      if (subtract_mean && X_mean != nullptr) {
+        val -= half_to_float(X_mean[h * D + d]);
+      }
+      int q = __float2int_rn(val / scale);
+      q = max(-127, min(127, q));
+      X_int8[i * K + h * D + d] = static_cast<int8_t>(q);
+    }
+  }
+
+  // Zero-pad positions beyond M (last block only)
+  for (int i = valid_end + (tid / D); i < block_end; i += (blockDim.x / D)) {
+    int d = tid % D;
+    if (d < D) {
+      X_int8[i * K + h * D + d] = 0;
+    }
+  }
+}
+
+__global__ void sparge_quantize_bf16_kernel(
+    const cutlass::bfloat16_t* __restrict__ X,
+    const cutlass::bfloat16_t* __restrict__ X_mean,
+    int8_t* __restrict__ X_int8,
+    float* __restrict__ X_scale,
+    int M, int H, int D, int BLOCK_SIZE, bool subtract_mean) {
+  int block_idx = blockIdx.x;
+  int h = blockIdx.y;
+  int tid = threadIdx.x;
+
+  int start = block_idx * BLOCK_SIZE;
+  int block_end = start + BLOCK_SIZE;
+  int valid_end = min(block_end, M);
+  if (start >= M) {
+    for (int i = start + (tid / D); i < block_end; i += (blockDim.x / D)) {
+      int d = tid % D;
+      if (d < D) {
+        X_int8[i * H * D + h * D + d] = 0;
+      }
+    }
+    return;
+  }
+
+  extern __shared__ float smem[];
+  float* smax = smem;
+  int K = H * D;
+
+  float local_max = 0.f;
+  for (int i = start + (tid / D); i < valid_end; i += (blockDim.x / D)) {
+    int d = tid % D;
+    if (d < D && i < valid_end) {
+      float val = omnidreams_singleview::to_float(X[i * K + h * D + d]);
+      if (subtract_mean && X_mean != nullptr) {
+        val -= omnidreams_singleview::to_float(X_mean[h * D + d]);
+      }
+      local_max = fmaxf(local_max, fabsf(val));
+    }
+  }
+
+  smax[tid] = local_max;
+  __syncthreads();
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (tid < s) {
+      smax[tid] = fmaxf(smax[tid], smax[tid + s]);
+    }
+    __syncthreads();
+  }
+
+  float scale = smax[0] / 127.f + 1e-7f;
+  if (tid == 0) {
+    X_scale[h * ((M + BLOCK_SIZE - 1) / BLOCK_SIZE) + block_idx] = scale;
+  }
+  __syncthreads();
+
+  for (int i = start + (tid / D); i < valid_end; i += (blockDim.x / D)) {
+    int d = tid % D;
+    if (d < D && i < valid_end) {
+      float val = omnidreams_singleview::to_float(X[i * K + h * D + d]);
+      if (subtract_mean && X_mean != nullptr) {
+        val -= omnidreams_singleview::to_float(X_mean[h * D + d]);
+      }
+      int q = __float2int_rn(val / scale);
+      q = max(-127, min(127, q));
+      X_int8[i * K + h * D + d] = static_cast<int8_t>(q);
+    }
+  }
+
+  for (int i = valid_end + (tid / D); i < block_end; i += (blockDim.x / D)) {
+    int d = tid % D;
+    if (d < D) {
+      X_int8[i * K + h * D + d] = 0;
+    }
+  }
+}
+
+// Helper: Compute SpargeAttn permutation for V tensor
+// This permutes elements within 16-element blocks for optimized fp8 matmul access
+// Pattern: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] -> [0,1,4,5,8,9,12,13,2,3,6,7,10,11,14,15]
+__device__ __forceinline__ int sparge_v_permute(int m) {
+  int base = (m / 16) * 16;
+  int mod = m % 16;
+  // Formula from SpargeAttn's TransposePadPermuteKernel
+  return base + (mod / 8) * 2 + ((mod / 2) % 4) * 4 + (mod % 2);
+}
+
+// Kernel A: Compute per-(h,d) absmax of V for FP8 quantization
+// Grid: (H, num_tiles), Block: (D) where D=128
+// Each block handles one head, one tile of V_ABSMAX_TILE_M rows.
+// Threads map 1:1 to D values -> coalesced reads within each row.
+// Uses atomicMax on positive floats to accumulate across tiles.
+// V_scale must be zeroed before launch.
+constexpr int V_ABSMAX_TILE_M = 256;
+
+__global__ void sparge_v_absmax_kernel(
+    const cutlass::half_t* __restrict__ V,  // [M, H, D] - stride [H*D, D, 1]
+    float* __restrict__ V_scale,            // [H, D] - must be zeroed before launch
+    int M, int H, int D) {
+  int h = blockIdx.x;
+  int tile = blockIdx.y;
+  int d = threadIdx.x;  // 0..D-1, coalesced along D
+  if (d >= D) return;
+  int K = H * D;
+
+  int m_start = tile * V_ABSMAX_TILE_M;
+  int m_end = min(m_start + V_ABSMAX_TILE_M, M);
+
+  // Accumulate per-d absmax over this tile
+  float local_max = 0.f;
+  for (int m = m_start; m < m_end; m++) {
+    float val = fabsf(half_to_float(V[m * K + h * D + d]));
+    local_max = fmaxf(local_max, val);
+  }
+
+  // Atomic max into global V_scale (positive floats sort like unsigned ints)
+  atomicMax(reinterpret_cast<int*>(&V_scale[h * D + d]), __float_as_int(local_max));
+}
+
+__global__ void sparge_v_absmax_bf16_kernel(
+    const cutlass::bfloat16_t* __restrict__ V,
+    float* __restrict__ V_scale,
+    int M, int H, int D) {
+  int h = blockIdx.x;
+  int tile = blockIdx.y;
+  int d = threadIdx.x;
+  if (d >= D) return;
+  int K = H * D;
+
+  int m_start = tile * V_ABSMAX_TILE_M;
+  int m_end = min(m_start + V_ABSMAX_TILE_M, M);
+
+  float local_max = 0.f;
+  for (int m = m_start; m < m_end; m++) {
+    float val = fabsf(omnidreams_singleview::to_float(V[m * K + h * D + d]));
+    local_max = fmaxf(local_max, val);
+  }
+
+  atomicMax(reinterpret_cast<int*>(&V_scale[h * D + d]), __float_as_int(local_max));
+}
+
+// Kernel A': Finalize V_scale: apply headroom factor
+// Grid: ceil(total/256), Block: 256
+__global__ void sparge_v_scale_finalize_kernel(
+    float* __restrict__ V_scale, int total) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < total) {
+    V_scale[idx] = V_scale[idx] / 2.25f + 1e-7f;
+  }
+}
+
+// Kernel B: Quantize V to FP8 with transposition via shared memory
+// Grid: (H, ceil(padded_M / TILE_M)), Block: (256)
+// Uses smem to transpose V[M,H,D] -> V_fp8[H,D,padded_M] with SpargeAttn permutation.
+// TILE_M=128: each block processes a 128xD tile of V for one head.
+// Shared memory: half smem[TILE_M][D+2] = 128*130*2 = 33,280 bytes (pad to avoid bank conflicts).
+constexpr int V_QUANT_TILE_M = 128;
+constexpr int V_QUANT_SMEM_PAD = 2;  // padding to avoid bank conflicts
+
+__global__ void sparge_v_quantize_permute_kernel(
+    const cutlass::half_t* __restrict__ V,     // [M, H, D] - stride [H*D, D, 1]
+    const float* __restrict__ V_scale,         // [H, D]
+    cutlass::float_e4m3_t* __restrict__ V_fp8, // [H, D, padded_M]
+    int M, int H, int D, int padded_M) {
+  int h = blockIdx.x;
+  int tile_idx = blockIdx.y;
+  int tid = threadIdx.x;
+  int K = H * D;
+  int m_base = tile_idx * V_QUANT_TILE_M;
+
+  // Shared memory for the tile: [TILE_M][D + pad]
+  extern __shared__ cutlass::half_t v_smem[];
+  int smem_stride = D + V_QUANT_SMEM_PAD;
+
+  // Phase 1: Load V tile into smem (coalesced reads along D dimension)
+  // 256 threads, D=128: 2 rows per iteration, need TILE_M/2 = 64 iterations
+  int rows_per_iter = 256 / D;  // = 2 for D=128
+  for (int iter = 0; iter < (V_QUANT_TILE_M + rows_per_iter - 1) / rows_per_iter; iter++) {
+    int local_row = iter * rows_per_iter + tid / D;
+    int d = tid % D;
+    int m = m_base + local_row;
+    cutlass::half_t val;
+    if (local_row < V_QUANT_TILE_M && m < M) {
+      val = V[m * K + h * D + d];
+    } else {
+      val = cutlass::half_t(0);  // pad with zero
+    }
+    if (local_row < V_QUANT_TILE_M) {
+      v_smem[local_row * smem_stride + d] = val;
+    }
+  }
+  __syncthreads();
+
+  // Phase 2: Quantize + permute + write V_fp8 (coalesced writes along M dimension)
+  // Remap threads: tid % TILE_M gives m_local, tid / TILE_M gives d_offset (0 or 1)
+  // 256 threads / 128 TILE_M = 2 d-values per iteration
+  int m_local = tid % V_QUANT_TILE_M;
+  int d_off = tid / V_QUANT_TILE_M;  // 0 or 1
+  int m_global = m_base + m_local;
+  int permuted_m = sparge_v_permute(m_global);
+
+  // Iterate over D dimension: 2 d-values per iteration, D/2 = 64 iterations
+  for (int iter = 0; iter < (D + 1) / 2; iter++) {
+    int d = iter * 2 + d_off;
+    if (d < D) {
+      float scale = V_scale[h * D + d];
+      float val = half_to_float(v_smem[m_local * smem_stride + d]);
+      val = fmaxf(-448.f, fminf(448.f, val / scale));
+      V_fp8[h * D * padded_M + d * padded_M + permuted_m] =
+          cutlass::float_e4m3_t(val);
+    }
+  }
+}
+
+__global__ void sparge_v_quantize_permute_bf16_kernel(
+    const cutlass::bfloat16_t* __restrict__ V,
+    const float* __restrict__ V_scale,
+    cutlass::float_e4m3_t* __restrict__ V_fp8,
+    int M, int H, int D, int padded_M) {
+  int h = blockIdx.x;
+  int tile_idx = blockIdx.y;
+  int tid = threadIdx.x;
+  int lane = tid & 31;
+  int warp = tid >> 5;
+  int K = H * D;
+  int m_base = tile_idx * V_QUANT_TILE_M;
+
+  constexpr int kWarps = 8;
+  for (int m_off = 0; m_off < V_QUANT_TILE_M; m_off += 32) {
+    int m = m_base + m_off + lane;
+    int permuted_m = sparge_v_permute(m);
+    for (int d_base = 0; d_base < D; d_base += kWarps) {
+      int d = d_base + warp;
+      if (d < D) {
+        float val = 0.0f;
+        if (m < M) {
+          val = omnidreams_singleview::to_float(V[m * K + h * D + d]);
+        }
+        float scale = V_scale[h * D + d];
+        val = fmaxf(-448.f, fminf(448.f, val / scale));
+        V_fp8[h * D * padded_M + d * padded_M + permuted_m] =
+            cutlass::float_e4m3_t(val);
+      }
+    }
+  }
+}
+
+__global__ void cosmos_sparge_bf16_to_half_kernel(
+    const cutlass::bfloat16_t* __restrict__ src,
+    cutlass::half_t* __restrict__ dst,
+    int64_t n) {
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  dst[idx] = omnidreams_singleview::from_float<cutlass::half_t>(omnidreams_singleview::to_float(src[idx]));
+}
+
+__global__ void cosmos_sparge_half_to_bf16_kernel(
+    const cutlass::half_t* __restrict__ src,
+    cutlass::bfloat16_t* __restrict__ dst,
+    int64_t n) {
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  dst[idx] = omnidreams_singleview::from_float<cutlass::bfloat16_t>(half_to_float(src[idx]));
+}
+
+__global__ void cosmos_sparge_fill_one_float_kernel(float* dst, float value) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    dst[0] = value;
+  }
+}
+
+__global__ void cosmos_sparge_fill_float_kernel(float* dst, float value, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    dst[idx] = value;
+  }
+}
+
+static cudaError_t cosmos_sparge_convert_bf16_to_half(
+    const cutlass::bfloat16_t* src,
+    cutlass::half_t* dst,
+    int64_t n,
+    cudaStream_t stream) {
+  if (!src || !dst || n <= 0) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  cosmos_sparge_bf16_to_half_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      src, dst, n);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_sparge_convert_half_to_bf16(
+    const cutlass::half_t* src,
+    cutlass::bfloat16_t* dst,
+    int64_t n,
+    cudaStream_t stream) {
+  if (!src || !dst || n <= 0) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  cosmos_sparge_half_to_bf16_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      src, dst, n);
+  return cudaGetLastError();
+}
+
+cudaError_t run_cosmos_sparge_attention_bf16(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* K,
+    const cutlass::bfloat16_t* V,
+    cutlass::bfloat16_t* O,
+    ts::SpargeAttentionWorkspace* workspace,
+    cutlass::half_t* qkv_half_scratch,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    float topk_ratio,
+    bool attention_sink,
+    cudaStream_t stream) {
+#ifndef OMNIDREAMS_SINGLEVIEW_HAS_SPARGE
+  (void)Q;
+  (void)K;
+  (void)V;
+  (void)O;
+  (void)workspace;
+  (void)qkv_half_scratch;
+  (void)Mq;
+  (void)Mk;
+  (void)H;
+  (void)D;
+  (void)topk_ratio;
+  (void)attention_sink;
+  (void)stream;
+  return cudaErrorNotSupported;
+#else
+  if (!Q || !K || !V || !O || !workspace || !qkv_half_scratch) {
+    return cudaErrorInvalidValue;
+  }
+  if (Mq <= 0 || Mk <= 0 || H <= 0 || D != 128) {
+    return cudaErrorNotSupported;
+  }
+  if (!(topk_ratio > 0.0f && topk_ratio <= 1.0f)) {
+    return cudaErrorInvalidValue;
+  }
+  const int K_total = H * D;
+  const int64_t q_elems = int64_t(Mq) * K_total;
+  cutlass::half_t* qh = qkv_half_scratch;
+  ts::SpargeAttentionWorkspace& ws = *workspace;
+
+  cudaError_t err = cosmos_sparge_convert_bf16_to_half(Q, qh, q_elems, stream);
+  if (err != cudaSuccess) return err;
+
+  const int BLKQ = ws.BLKQ;
+  const int BLKK = ws.BLKK;
+  if (BLKQ != kSpargeSm89CtaQ || BLKK != kSpargeSm89CtaK) {
+    return cudaErrorNotSupported;
+  }
+  const int num_q_blocks = (Mq + BLKQ - 1) / BLKQ;
+  const int num_k_blocks = (Mk + BLKK - 1) / BLKK;
+  const int num_q_scale_blocks = num_q_blocks;
+  const int num_k_scale_blocks = num_k_blocks;
+  const int topk_raw = static_cast<int>(topk_ratio * static_cast<float>(num_k_blocks));
+  const int topk = max(1, min(num_k_blocks, topk_raw));
+  const int allocated_topk_raw =
+      static_cast<int>(ws.topk_ratio * static_cast<float>(num_k_blocks));
+  const int allocated_topk = max(1, min(num_k_blocks, allocated_topk_raw));
+  if (topk > allocated_topk) {
+    return cudaErrorInvalidValue;
+  }
+  const bool dense_sparge_map = topk >= num_k_blocks;
+  const int padded_kv_len = ((Mk + 127) / 128) * 128;
+
+  const float scale = 1.0f / sqrtf(static_cast<float>(D));
+  if (dense_sparge_map) {
+    sparge_dense_lut_kernel<<<dim3(num_q_blocks, H), 128, 0, stream>>>(
+        ws.lut, ws.valid_block_num, num_q_blocks, num_k_blocks, H);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) return err;
+  } else {
+    sparge_mean_pool_kernel<<<dim3(num_q_blocks, H), D / 2, 0, stream>>>(
+        qh, nullptr, ws.pooled_q, Mq, H, D, BLKQ, false);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) return err;
+
+    int k_pool_threads = (D + 1) / 2;
+    sparge_mean_pool_bf16_kernel<<<dim3(num_k_blocks, H), k_pool_threads, 0, stream>>>(
+        K, nullptr, ws.pooled_k, Mk, H, D, BLKK, false);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) return err;
+
+    sparge_pooled_score_kernel<<<dim3(num_q_blocks, H), 128, 0, stream>>>(
+        ws.pooled_q, ws.pooled_k, ws.pooled_scores,
+        num_q_blocks, num_k_blocks, H, D, scale);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) return err;
+
+    size_t smem_topk = 256 * sizeof(float) + 256 * sizeof(int) +
+                       size_t(num_k_blocks) * sizeof(int8_t);
+    sparge_topk_sparse_map_kernel<<<dim3(num_q_blocks, H), 256, smem_topk, stream>>>(
+        ws.pooled_scores, ws.sparse_map, ws.topk_indices,
+        ws.lut, ws.valid_block_num,
+        num_q_blocks, num_k_blocks, H, topk, max(0, Mk - Mq), attention_sink);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) return err;
+  }
+
+  int q_block_threads = min(256, BLKQ * D);
+  sparge_quantize_kernel<<<dim3(num_q_scale_blocks, H), q_block_threads,
+      q_block_threads * sizeof(float), stream>>>(
+      qh, nullptr, ws.q_int8, ws.q_scale, Mq, H, D, BLKQ, false);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  int k_block_threads = min(256, BLKK * D);
+  sparge_quantize_bf16_kernel<<<dim3(num_k_scale_blocks, H), k_block_threads,
+      k_block_threads * sizeof(float), stream>>>(
+      K, nullptr, ws.k_int8, ws.k_scale, Mk, H, D, BLKK, false);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  err = cudaMemsetAsync(ws.v_scale, 0, size_t(H) * D * sizeof(float), stream);
+  if (err != cudaSuccess) return err;
+  int absmax_tiles = (Mk + V_ABSMAX_TILE_M - 1) / V_ABSMAX_TILE_M;
+  sparge_v_absmax_bf16_kernel<<<dim3(H, absmax_tiles), D, 0, stream>>>(
+      V, ws.v_scale, Mk, H, D);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+  sparge_v_scale_finalize_kernel<<<(H * D + 255) / 256, 256, 0, stream>>>(
+      ws.v_scale, H * D);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  int num_tiles = (padded_kv_len + V_QUANT_TILE_M - 1) / V_QUANT_TILE_M;
+  sparge_v_quantize_permute_bf16_kernel<<<dim3(H, num_tiles), 256, 0, stream>>>(
+      V, ws.v_scale, ws.v_fp8, Mk, H, D, padded_kv_len);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  cosmos_sparge_fill_float_kernel<<<(H + 255) / 256, 256, 0, stream>>>(
+      ws.pooled_scores, 1.0e6f, H);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+  err = sparge_attention::run_sparge_attention_sm89_hd128(
+      ws.q_int8, ws.k_int8,
+      reinterpret_cast<__nv_fp8_e4m3*>(ws.v_fp8),
+      reinterpret_cast<half*>(ws.o_sparse),
+      ws.lut, ws.valid_block_num, ws.pooled_scores,
+      ws.q_scale, ws.k_scale, ws.v_scale,
+      1, Mq, Mk, H, H, padded_kv_len, scale, stream);
+  if (err != cudaSuccess) return err;
+
+  err = cosmos_sparge_convert_half_to_bf16(ws.o_sparse, O, q_elems, stream);
+  if (err != cudaSuccess) return err;
+  return cudaSuccess;
+#endif
+}
+
 
 // ============================================================================
 // Public API - Backend Dispatcher

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "attention.cuh"
 #include "workspace.cuh"
 #include "linear_utils.cuh"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cuh
@@ -1,0 +1,403 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include "cutlass/numeric_types.h"
+#include "arch_traits.h"
+
+namespace ts {
+// Forward declaration
+struct Workspace;
+}
+
+namespace omnidreams_singleview {
+
+// Attention backend selection
+enum class AttnBackend {
+    CUTLASS_FLASH,  // Default: fused Flash Attention implementation
+    CUDNN,          // cuDNN Flash Attention implementation
+    // Future backends can be added here (e.g., PYTORCH_REFERENCE, TRITON, etc.)
+};
+
+// Set the attention backend to use for subsequent attention operations
+void set_attention_backend(AttnBackend backend);
+
+// Get the currently selected attention backend
+AttnBackend get_attention_backend();
+
+// GEMM backend selection (FP16, FP8, or INT8 linear layers)
+enum class GemmBackend { FP16, FP8, INT8 };
+void set_gemm_backend(GemmBackend backend);
+GemmBackend get_gemm_backend();
+
+template <typename WeightT>
+struct AttentionDeviceParamsT {
+  // Dimensions
+  // Batched attention contract:
+  // - Query tokens are logically shaped [B, Mq, K] but are passed as a flattened
+  //   contiguous row-major buffer [B*Mq, K].
+  // - For self-attention: keys/values are the same sequence as queries (Mk ignored).
+  // - For cross-attention: encoder tokens are [B, Mk, K] flattened to [B*Mk, K].
+  //   When encoder_batch_size=1 and B>1, encoder KV is projected once and broadcast
+  //   to all batch items (useful for CFG with shared/empty negative prompt).
+  int B = 1;   // batch size
+  int Mq = 0;  // query length per batch item
+  int K; // embed dim (heads * head_dim)
+  int H; // heads
+  int D; // head_dim
+  int Mk = 0;      // key/value length per batch item (text cross-attn); if 0, defaults to Mq
+  int Mk_img = 0;  // key/value length for image added-KV branch (optional)
+  int added_kv_proj_dim = 0; // dim of image encoder tokens before add_k/add_v
+  int encoder_batch_size = 0; // 0 = same as B, else project KV for this many batches and broadcast
+
+  // Input pointers (device)
+  const cutlass::half_t* hidden_states;   // [B*Mq, K] RowMajor
+  const WeightT* w_qkv;                   // [3K,K] row-major (PyTorch)
+  const cutlass::half_t* w_qkv_scale = nullptr; // [3K] per-channel scale (for FP8/INT8) or nullptr
+  const cutlass::half_t* b_qkv;           // [3K]
+  // Cross-attention variants (optional): separate Q and KV
+  const WeightT* w_q = nullptr;           // [K,K]
+  const cutlass::half_t* w_q_scale = nullptr; // [K] or nullptr
+  const cutlass::half_t* b_q = nullptr;   // [K]
+  const WeightT* w_kv = nullptr;          // [2K,K] (text KV)
+  const cutlass::half_t* b_kv = nullptr;  // [2K]    (text KV)
+  const WeightT* w_add_k = nullptr;       // [K, added_kv_proj_dim] (image K)
+  const cutlass::half_t* b_add_k = nullptr;  // [K] (image K)
+  const cutlass::half_t* w_add_k_scale = nullptr; // [K] or nullptr
+  const WeightT* w_add_v = nullptr;       // [K, added_kv_proj_dim] (image V)
+  const cutlass::half_t* b_add_v = nullptr;  // [K] (image V)
+  const cutlass::half_t* w_add_v_scale = nullptr; // [K] or nullptr
+  const cutlass::half_t* norm_added_k_gamma = nullptr; // [K] RMSNorm for image K
+  const cutlass::half_t* w_kv_scale = nullptr; // [2K] or nullptr
+  // Cross-attn: [enc_B*Mk, K] RowMajor (text); for image add-KV, [enc_B*Mk_img, added_kv_proj_dim].
+  const cutlass::half_t* encoder_hidden_states = nullptr;
+  const cutlass::half_t* norm_q_gamma;    // [K]
+  const cutlass::half_t* norm_k_gamma;    // [K]
+  const WeightT* w_out;                   // [K,K] row-major
+  const cutlass::half_t* w_out_scale = nullptr; // [K] or nullptr
+  const cutlass::half_t* b_out;           // [K] (can be nullptr when bias applied externally)
+  const float* rotary_cos;                // [Mq,D] row-major (shared across batch)
+  const float* rotary_sin;                // [Mq,D] row-major (shared across batch)
+
+  // Per-block INT8 weight scales (for per-block quantization mode)
+  // Shape: [in_features/128, out_features/128] float32
+  const float* w_qkv_block_scale = nullptr;   // [K/128, 3K/128] for self-attn
+  const float* w_q_block_scale = nullptr;     // [K/128, K/128] for cross-attn Q
+  const float* w_kv_block_scale = nullptr;    // [K/128, 2K/128] for cross-attn KV
+  const float* w_out_block_scale = nullptr;   // [K/128, K/128] for output projection
+  bool use_perblock_quant = false;            // Flag to enable per-block quantization
+
+  // Fused gated residual params (optional, INT8 only)
+  // When gate_sst != nullptr, the output projection GEMM fuses gate*bias + residual
+  const cutlass::half_t* gate_sst = nullptr;        // scale_shift_table [6, K]
+  const cutlass::half_t* gate_temb = nullptr;        // temporal embedding
+  int gate_temb_row_stride = 0;                      // temb row stride (0 = broadcast)
+  int gate_idx = -1;                                 // gate index in sst (-1 = disabled)
+  const cutlass::half_t* residual_src = nullptr;     // source for residual add
+
+  // Output pointer (device)
+  // For cross-attn, treated as input/output residual when fuse_residual=true.
+  cutlass::half_t* out_after_linear;      // [B*Mq, K] row-major (fp16)
+
+  // Causal masking (self-attention only; ignored for cross-attention)
+  bool is_causal = false;
+
+  // Workspace
+  ts::Workspace* workspace;
+};
+
+// Split orchestrators for cleaner flow
+template <typename WeightT>
+cudaError_t run_self_attention(const AttentionDeviceParamsT<WeightT>& p, cudaStream_t stream);
+template <typename WeightT>
+cudaError_t run_cross_attention(const AttentionDeviceParamsT<WeightT>& p,
+                                    bool fuse_residual,
+                                    cudaStream_t stream);
+
+// FMHA-only helper: takes pre-packed Q/K/V in BMHK bfloat16 format, returns FMHA output.
+// Useful when QKV projection and RoPE are computed externally (e.g. with a different
+// RoPE convention from the built-in rmsnorm_pack_bmhk_rope_from_row_kernel).
+// Uses cuDNN SDPA; preferred at large sequence lengths (≳8K tokens).
+//
+// Inputs  Q     [B*Mq, H, D]  bfloat16 (BMHK — batch items concatenated along M)
+//         K, V  [B*Mk, H, D]  bfloat16
+// Output  O     [B*Mq, H, D]  bfloat16 (caller-allocated)
+// Params  B, Mq, Mk, H, D, causal (top-left mask), scale (0 → 1/sqrt(D))
+cudaError_t run_cudnn_fmha_packed_qkv(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* K,
+    const cutlass::bfloat16_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream);
+
+struct CosmosFp8SdpaSelection {
+  std::string preset;
+  std::string layout;
+  std::string heuristics;
+  std::string plan;
+  std::string reason;
+  bool layout_env_override = false;
+  bool heuristics_env_override = false;
+  bool plan_env_override = false;
+};
+
+CosmosFp8SdpaSelection select_cosmos_fp8_sdpa(
+    int B, int Mq, int Mk,
+    int H, int D);
+
+// Standalone cuDNN FP8 SDPA probe: accepts pre-packed BMHK raw E4M3 Q/K/V and
+// returns BMHK raw E4M3 O. This is intentionally not wired into Cosmos
+// streaming until a local SM120 probe proves correctness and performance.
+cudaError_t run_cudnn_fmha_packed_qkv_fp8(
+    const cutlass::float_e4m3_t* Q,
+    const cutlass::float_e4m3_t* K,
+    const cutlass::float_e4m3_t* V,
+    cutlass::float_e4m3_t* O,
+    const float* descale_q,
+    const float* descale_k,
+    const float* descale_v,
+    const float* descale_s,
+    const float* scale_s,
+    const float* scale_o,
+    float* amax_s,
+    float* amax_o,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream);
+
+cudaError_t run_sage3_fmha_packed_qkv(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* K,
+    const cutlass::bfloat16_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream);
+
+cudaError_t run_sage3_fmha_packed_qkv_fp8(
+    const cutlass::float_e4m3_t* Q,
+    const cutlass::float_e4m3_t* K,
+    const cutlass::float_e4m3_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream);
+
+bool sage3_is_built();
+bool sage3_is_runtime_supported(int device);
+
+cudaError_t run_sage3_fmha_packed_qfp4_kvfp8(
+    const uint8_t* Q_fp4,
+    const cutlass::float_e4m3_t* Q_sf,
+    const cutlass::float_e4m3_t* K,
+    const cutlass::float_e4m3_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    int padded_mq,
+    cudaStream_t stream);
+
+cudaError_t run_sage3_fmha_packed_qkv_fp4(
+    const uint8_t* Q_fp4,
+    const uint8_t* K_fp4,
+    const uint8_t* V_fp4,
+    const cutlass::float_e4m3_t* Q_sf,
+    const cutlass::float_e4m3_t* K_sf,
+    const cutlass::float_e4m3_t* V_sf,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    int padded_mq,
+    int padded_mk,
+    cudaStream_t stream);
+
+cudaError_t sage3_quantize_q_bf16(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* gamma,
+    const cutlass::bfloat16_t* rope_cos,
+    const cutlass::bfloat16_t* rope_sin,
+    uint8_t* Q_fp4,
+    cutlass::float_e4m3_t* Q_sf,
+    int B, int Mq,
+    int H, int D,
+    int input_row_stride,
+    int input_head_offset,
+    bool apply_rope,
+    int padded_mq,
+    cudaStream_t stream);
+
+// ============================================================================
+// I2V fused cross-attention (text + image branches share Q)
+// ============================================================================
+//
+// HF I2V cross-attn does:
+//   q = to_q(x);  k,v = to_kv(text);  k_img,v_img = add_k/add_v(image)
+//   out = attn(q,k,v) + attn(q,k_img,v_img)
+//   out = to_out(out)
+//
+// The existing implementation ran text and image cross-attn as two separate calls,
+// which duplicates Q projection + Q RMSNorm/packing. This fused path computes Q once
+// and reuses it for both branches (CUTLASS backend).
+template <typename WeightT>
+struct CrossAttentionI2VParamsT {
+  // Dimensions
+  int B = 1; // batch size (B>1 supported for cuDNN backend)
+  int M; // query length
+  int K; // embed dim
+  int H; // heads
+  int D; // head dim
+  int Mk_text; // text KV length
+  int Mk_img;  // image KV length (0 disables image branch)
+  int added_kv_proj_dim; // dim of image tokens before add_k/add_v
+
+  // Inputs
+  const cutlass::half_t* hidden_states;            // [M,K] row-major
+  const cutlass::half_t* encoder_hidden_states_text; // [Mk_text, K] row-major
+  const cutlass::half_t* encoder_hidden_states_img;  // [Mk_img, added_kv_proj_dim] row-major (optional)
+
+  // Weights
+  const WeightT* w_q;                   // [K,K] row-major
+  const cutlass::half_t* b_q;           // [K]
+  const cutlass::half_t* w_q_scale = nullptr; // [K] or nullptr
+  const WeightT* w_kv;                  // [K,2K] row-major (text KV)
+  const cutlass::half_t* b_kv;          // [2K]
+  const cutlass::half_t* w_kv_scale = nullptr; // [2K] or nullptr
+  const WeightT* w_add_k;               // [added_kv_proj_dim, K] row-major (image K)
+  const cutlass::half_t* b_add_k;       // [K]
+  const cutlass::half_t* w_add_k_scale = nullptr; // [K] or nullptr
+  const WeightT* w_add_v;               // [added_kv_proj_dim, K] row-major (image V)
+  const cutlass::half_t* b_add_v;       // [K]
+  const cutlass::half_t* w_add_v_scale = nullptr; // [K] or nullptr
+  const cutlass::half_t* norm_q_gamma;  // [K]
+  const cutlass::half_t* norm_k_gamma;  // [K] (text K)
+  const cutlass::half_t* norm_added_k_gamma; // [K] (image K)
+  const WeightT* w_out;                 // [K,K] row-major
+  const cutlass::half_t* b_out;         // [K] (can be nullptr when bias applied externally)
+  const cutlass::half_t* w_out_scale = nullptr; // [K] or nullptr
+
+  // Output/residual
+  cutlass::half_t* out_after_linear;    // [M,K] row-major (if fuse_residual=true, this is residual_inout)
+
+  // Workspace
+  ts::Workspace* workspace;
+};
+
+template <typename WeightT>
+cudaError_t run_cross_attention_i2v(const CrossAttentionI2VParamsT<WeightT>& p,
+                                        bool fuse_residual,
+                                        cudaStream_t stream);
+
+
+
+// Transformer block orchestrator (T2V flavor)
+template <typename WeightT>
+struct TransformerBlockParamsT {
+  // Dimensions
+  int B = 1;   // batch size
+  int Mq = 0;  // token length per batch item (patch tokens)
+  int K; // model dim
+  int H; // heads
+  int D; // head dim
+  int layer_idx = -1; // optional: which block (for profiling output)
+  int Mk = 0; // encoder text seq len per batch item (if 0, defaults to Mq)
+  int Mk_img = 0;  // encoder image seq len per batch item (optional)
+  int added_kv_proj_dim = 0; // image encoder dim before add_k/add_v
+  int FF; // ffn inner dim
+  int encoder_batch_size = 0; // 0 = same as B, else project KV for this many batches and broadcast
+
+  // Inputs (device)
+  const cutlass::half_t* hidden_states;            // [B*Mq, K] RowMajor
+  const cutlass::half_t* encoder_hidden_states;    // [enc_B*Mk, K] RowMajor (text)
+  const cutlass::half_t* encoder_hidden_states_img; // [enc_B*Mk_img, added_kv_proj_dim] RowMajor (optional)
+  const float* rotary_cos;                         // [Mq, D] row-major (self-attn only)
+  const float* rotary_sin;                         // [Mq, D] row-major (self-attn only)
+  const cutlass::half_t* temb_scale_shift_table;   // [6,K] RowMajor
+  const cutlass::half_t* temb;                     // [N,6,K] or [1,6,K] RowMajor (broadcast via temb_row_stride)
+  int temb_row_stride = 0;                         // 0 = broadcast (all rows share temb[0]), 6*K = per-batch-item
+
+  // Self-attn weights
+  const WeightT* sa_w_qkv;   // [3K,K] row-major
+  const cutlass::half_t* sa_w_qkv_scale = nullptr; // [3K] per-channel scale or nullptr
+  const cutlass::half_t* sa_b_qkv;   // [3K]
+  const cutlass::half_t* sa_norm_q_gamma; // [K]
+  const cutlass::half_t* sa_norm_k_gamma; // [K]
+  const WeightT* sa_w_out;   // [K,K] row-major
+  const cutlass::half_t* sa_w_out_scale = nullptr; // [K] per-channel scale or nullptr
+  const cutlass::half_t* sa_b_out;   // [K]
+
+  // Cross-attn weights (separate Q and KV)
+  const WeightT* ca_w_q;     // [K,K] row-major
+  const cutlass::half_t* ca_w_q_scale = nullptr; // [K] per-channel scale or nullptr
+  const cutlass::half_t* ca_b_q;     // [K]
+  const WeightT* ca_w_kv;    // [2K,K] row-major
+  const cutlass::half_t* ca_w_kv_scale = nullptr; // [2K] per-channel scale or nullptr
+  const cutlass::half_t* ca_b_kv;    // [2K]
+  const cutlass::half_t* ca_norm_q_gamma; // [K]
+  const cutlass::half_t* ca_norm_k_gamma; // [K]
+  const WeightT* ca_w_add_k;   // [K, added_kv_proj_dim] (image)
+  const cutlass::half_t* ca_b_add_k;   // [K] (image)
+  const cutlass::half_t* ca_w_add_k_scale; // [K] or nullptr
+  const WeightT* ca_w_add_v;   // [K, added_kv_proj_dim] (image)
+  const cutlass::half_t* ca_b_add_v;   // [K] (image)
+  const cutlass::half_t* ca_w_add_v_scale; // [K] or nullptr
+  const cutlass::half_t* ca_norm_added_k_gamma; // [K] (image)
+  const WeightT* ca_w_out;   // [K,K] row-major
+  const cutlass::half_t* ca_w_out_scale = nullptr; // [K] per-channel scale or nullptr
+  const cutlass::half_t* ca_b_out;   // [K]
+
+  // Norms
+  const cutlass::half_t* ln1_gamma; // [K] (FP32LayerNorm elementwise_affine=False -> gamma only)
+  const cutlass::half_t* ln3_gamma; // [K]
+  const cutlass::half_t* ln2_gamma; // [K] optional if cross_attn_norm
+  const cutlass::half_t* ln2_bias;  // [K] optional
+
+  // FFN weights
+  const WeightT* ffn_w1; // [ffn_dim, K] row-major
+  const cutlass::half_t* ffn_w1_scale = nullptr; // [ffn_dim] per-channel scale or nullptr
+  const cutlass::half_t* ffn_b1; // [ffn_dim]
+  const WeightT* ffn_w2; // [K, ffn_dim] row-major
+  const cutlass::half_t* ffn_w2_scale = nullptr; // [K] per-channel scale or nullptr
+  const cutlass::half_t* ffn_b2; // [K]
+
+  // Per-block INT8 weight scales (for per-block quantization mode)
+  // These are used when use_perblock_quant=true
+  // Shape: [in_features/128, out_features/128] float32
+  const float* sa_w_qkv_block_scale = nullptr;   // [K/128, 3K/128]
+  const float* sa_w_out_block_scale = nullptr;   // [K/128, K/128]
+  const float* ca_w_q_block_scale = nullptr;     // [K/128, K/128]
+  const float* ca_w_kv_block_scale = nullptr;    // [K/128, 2K/128]
+  const float* ca_w_out_block_scale = nullptr;   // [K/128, K/128]
+  const float* ffn_w1_block_scale = nullptr;     // [K/128, FF/128]
+  const float* ffn_w2_block_scale = nullptr;     // [FF/128, K/128]
+
+  // Flag to enable per-block quantization mode
+  bool use_perblock_quant = false;
+
+  // Output
+  cutlass::half_t* out; // [B*Mq, K] RowMajor (half)
+
+  // Workspace
+  ts::Workspace* workspace;
+};
+
+// Runs the full transformer block forward pass.
+// Arch selects the model-specific compute pattern (norm type, activation, gate style).
+// Defaults to WanArchTraits; future models define their own traits struct.
+template <typename WeightT, typename Arch = WanArchTraits>
+cudaError_t run_transformer_block(const TransformerBlockParamsT<WeightT>& p, cudaStream_t stream);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cuh
@@ -8,6 +8,7 @@
 namespace ts {
 // Forward declaration
 struct Workspace;
+struct SpargeAttentionWorkspace;
 }
 
 namespace omnidreams_singleview {
@@ -238,6 +239,21 @@ cudaError_t sage3_quantize_q_bf16(
     int input_head_offset,
     bool apply_rope,
     int padded_mq,
+    cudaStream_t stream);
+
+cudaError_t run_cosmos_sparge_attention_bf16(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* K,
+    const cutlass::bfloat16_t* V,
+    cutlass::bfloat16_t* O,
+    ts::SpargeAttentionWorkspace* workspace,
+    cutlass::half_t* qkv_half_scratch,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    float topk_ratio,
+    bool attention_sink,
     cudaStream_t stream);
 
 // ============================================================================

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/attention.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cstdint>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Per-block INT8 quantization kernel implementations.
  *

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cu
@@ -1,0 +1,803 @@
+/**
+ * Per-block INT8 quantization kernel implementations.
+ *
+ * This file contains the CUDA kernel implementations for per-block quantization.
+ * The header file (wan_block_quant.cuh) contains only declarations.
+ */
+
+#include "block_quant.cuh"
+#include "int8_swizzle.cuh"
+
+namespace omnidreams_singleview {
+
+// =============================================================================
+// Per-Block Quantization Kernel
+// =============================================================================
+
+__global__ void quantize_per_block_128_kernel(
+    const half* __restrict__ src,
+    int8_t* __restrict__ dst,
+    float* __restrict__ block_scales,
+    int M, int K,
+    int num_m_blocks, int num_k_blocks
+) {
+    // Block coordinates
+    int k_blk = blockIdx.x;
+    int m_blk = blockIdx.y;
+
+    if (k_blk >= num_k_blocks || m_blk >= num_m_blocks) return;
+
+    // Thread index
+    int tid = threadIdx.x;
+
+    // Block boundaries (handle edge cases)
+    int m_start = m_blk * QUANT_BLOCK_SIZE;
+    int m_end = min(m_start + QUANT_BLOCK_SIZE, M);
+    int k_start = k_blk * QUANT_BLOCK_SIZE;
+    int k_end = min(k_start + QUANT_BLOCK_SIZE, K);
+
+    // Shared memory for parallel reduction
+    __shared__ float s_amax[128];
+
+    // Step 1: Each thread computes local amax for its column
+    float local_amax = 0.0f;
+    int k_col = k_start + tid;
+
+    if (k_col < k_end) {
+        for (int m_row = m_start; m_row < m_end; m_row++) {
+            float v = __half2float(src[m_row * K + k_col]);
+            local_amax = fmaxf(local_amax, fabsf(v));
+        }
+    }
+
+    // Step 2: Block-level reduction for amax
+    s_amax[tid] = local_amax;
+    __syncthreads();
+
+    // Parallel reduction
+    for (int stride = 64; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            s_amax[tid] = fmaxf(s_amax[tid], s_amax[tid + stride]);
+        }
+        __syncthreads();
+    }
+
+    // Block amax and scale
+    float block_amax = s_amax[0];
+    float scale = fmaxf(block_amax / 127.0f, 1e-8f);
+    float inv_scale = 1.0f / scale;
+
+    // Step 3: Store scale (one thread)
+    if (tid == 0) {
+        block_scales[m_blk * num_k_blocks + k_blk] = scale;
+    }
+
+    // Step 4: Quantize and store
+    if (k_col < k_end) {
+        for (int m_row = m_start; m_row < m_end; m_row++) {
+            float v = __half2float(src[m_row * K + k_col]);
+            float scaled = v * inv_scale;
+            int8_t quantized = static_cast<int8_t>(fmaxf(-127.0f, fminf(127.0f, roundf(scaled))));
+            dst[m_row * K + k_col] = quantized;
+        }
+    }
+}
+
+__global__ void quantize_per_block_128_tiled_kernel(
+    const half* __restrict__ src,
+    int8_t* __restrict__ dst,
+    float* __restrict__ block_scales,
+    int M, int K,
+    int num_m_blocks, int num_k_blocks
+) {
+    // Block coordinates
+    int k_blk = blockIdx.x;
+    int m_blk = blockIdx.y;
+
+    if (k_blk >= num_k_blocks || m_blk >= num_m_blocks) return;
+
+    // Thread indices
+    int tx = threadIdx.x;  // 0-31
+    int ty = threadIdx.y;  // 0-3
+    int tid = ty * 32 + tx; // 0-127
+
+    // Block boundaries
+    int m_start = m_blk * QUANT_BLOCK_SIZE;
+    int m_end = min(m_start + QUANT_BLOCK_SIZE, M);
+    int k_start = k_blk * QUANT_BLOCK_SIZE;
+    int k_end = min(k_start + QUANT_BLOCK_SIZE, K);
+
+    int block_m = m_end - m_start;
+    int block_k = k_end - k_start;
+
+    // Shared memory for reduction
+    __shared__ float s_amax[128];
+
+    // Step 1: Compute local amax
+    // Each thread handles multiple elements: 128*128/128 = 128 elements per thread
+    float local_amax = 0.0f;
+
+    for (int elem = tid; elem < QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE; elem += 128) {
+        int local_m = elem / QUANT_BLOCK_SIZE;
+        int local_k = elem % QUANT_BLOCK_SIZE;
+
+        if (local_m < block_m && local_k < block_k) {
+            int global_m = m_start + local_m;
+            int global_k = k_start + local_k;
+            float v = __half2float(src[global_m * K + global_k]);
+            local_amax = fmaxf(local_amax, fabsf(v));
+        }
+    }
+
+    // Step 2: Block-level reduction
+    s_amax[tid] = local_amax;
+    __syncthreads();
+
+    for (int stride = 64; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            s_amax[tid] = fmaxf(s_amax[tid], s_amax[tid + stride]);
+        }
+        __syncthreads();
+    }
+
+    float block_amax = s_amax[0];
+    float scale = fmaxf(block_amax / 127.0f, 1e-8f);
+    float inv_scale = 1.0f / scale;
+
+    // Step 3: Store scale
+    if (tid == 0) {
+        block_scales[m_blk * num_k_blocks + k_blk] = scale;
+    }
+
+    // Step 4: Quantize and store
+    for (int elem = tid; elem < QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE; elem += 128) {
+        int local_m = elem / QUANT_BLOCK_SIZE;
+        int local_k = elem % QUANT_BLOCK_SIZE;
+
+        if (local_m < block_m && local_k < block_k) {
+            int global_m = m_start + local_m;
+            int global_k = k_start + local_k;
+            float v = __half2float(src[global_m * K + global_k]);
+            float scaled = v * inv_scale;
+            int8_t quantized = static_cast<int8_t>(fmaxf(-127.0f, fminf(127.0f, roundf(scaled))));
+            dst[global_m * K + global_k] = quantized;
+        }
+    }
+}
+
+__global__ void dequantize_per_block_128_kernel(
+    const int8_t* __restrict__ src,
+    half* __restrict__ dst,
+    const float* __restrict__ block_scales,
+    int M, int K,
+    int num_m_blocks, int num_k_blocks
+) {
+    int k_blk = blockIdx.x;
+    int m_blk = blockIdx.y;
+
+    if (k_blk >= num_k_blocks || m_blk >= num_m_blocks) return;
+
+    int tid = threadIdx.x;
+
+    int m_start = m_blk * QUANT_BLOCK_SIZE;
+    int m_end = min(m_start + QUANT_BLOCK_SIZE, M);
+    int k_start = k_blk * QUANT_BLOCK_SIZE;
+    int k_end = min(k_start + QUANT_BLOCK_SIZE, K);
+
+    float scale = block_scales[m_blk * num_k_blocks + k_blk];
+
+    int k_col = k_start + tid;
+    if (k_col < k_end) {
+        for (int m_row = m_start; m_row < m_end; m_row++) {
+            float v = static_cast<float>(src[m_row * K + k_col]) * scale;
+            dst[m_row * K + k_col] = __float2half(v);
+        }
+    }
+}
+
+// =============================================================================
+// Fast Single-Pass Quantization Kernel
+// =============================================================================
+//
+// Single-pass, register-resident, vectorized quantization.
+// 256 threads per CTA, 2 threads per row, each handles 64 consecutive elements.
+// Loads FP16 once into float32 registers, computes amax via warp shuffle + atomic,
+// quantizes from registers, stores INT8 with vectorized int4 writes.
+// One DRAM read instead of two. ~2x faster than the tiled kernel above.
+//
+// Requires K to be a multiple of 128 (always true in our pipeline: K=1536, 4608, 8960).
+
+// Device function with compile-time IsEvenM specialization.
+// Two non-template __global__ wrappers below avoid MSVC __cudaLaunch macro issues
+// with template kernel launches.
+template<bool IsEvenM>
+__device__ __forceinline__ void quantize_block_fast_impl(
+    const half* __restrict__ src,
+    int8_t* __restrict__ dst,
+    float* __restrict__ block_scales,
+    int M, int K,
+    int num_m_blocks, int num_k_blocks)
+{
+    constexpr int BLOCK = 128;
+    constexpr int ELEMS = 64;
+
+    const int k_blk = blockIdx.x;
+    const int m_blk = blockIdx.y;
+    const int tid = threadIdx.x;
+
+    // 2 threads per row: thread handles cols [col_start, col_start+64)
+    const int row = tid >> 1;            // 0..127
+    const int col_half = tid & 1;        // 0 or 1
+    const int col_start = col_half << 6; // 0 or 64
+
+    const int global_m = m_blk * BLOCK + row;
+    const int global_k = k_blk * BLOCK + col_start;
+    const bool row_valid = IsEvenM || (global_m < M);
+
+    // ---- Phase 1: Load FP16 -> float32 registers (8 x int4 = 64 halfs) ----
+    float data[ELEMS];
+
+    if (row_valid) {
+        const int4* load_ptr = reinterpret_cast<const int4*>(
+            src + static_cast<int64_t>(global_m) * K + global_k);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            union { int4 vec; half h[8]; } u;
+            u.vec = load_ptr[i];
+            #pragma unroll
+            for (int j = 0; j < 8; j++)
+                data[i * 8 + j] = __half2float(u.h[j]);
+        }
+    } else {
+        #pragma unroll
+        for (int i = 0; i < ELEMS; i++) data[i] = 0.0f;
+    }
+
+    // ---- Phase 2: Block amax via warp shuffle + atomic ----
+    float amax = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < ELEMS; i++)
+        amax = fmaxf(amax, fabsf(data[i]));
+
+    // Warp-level butterfly reduction (all lanes get warp max)
+    #pragma unroll
+    for (int mask = 16; mask >= 1; mask >>= 1)
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, mask));
+
+    // CTA-level reduction: atomicMax on uint32 works for positive floats
+    // because IEEE 754 bit representation is monotonically increasing.
+    __shared__ unsigned int smem_amax;
+    if (tid == 0) smem_amax = 0u;
+    __syncthreads();
+
+    atomicMax(&smem_amax, __float_as_uint(amax));
+    __syncthreads();
+
+    const float block_amax = __uint_as_float(smem_amax);
+    const float scale = fmaxf(block_amax / 127.0f, 1e-8f);
+    const float inv_scale = 1.0f / scale;
+
+    if (tid == 0) {
+        block_scales[m_blk * num_k_blocks + k_blk] = scale;
+    }
+
+    // ---- Phase 3: Quantize from registers + vectorized store (4 x int4) ----
+    if (row_valid) {
+        int4* store_ptr = reinterpret_cast<int4*>(
+            dst + static_cast<int64_t>(global_m) * K + global_k);
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            // Pack 16 int8 values into one int4 (16 bytes) and store
+            union { int8_t b[16]; int4 vec; } pack;
+            #pragma unroll
+            for (int j = 0; j < 16; j++) {
+                int v = __float2int_rn(data[i * 16 + j] * inv_scale);
+                v = max(-127, min(127, v));
+                pack.b[j] = static_cast<int8_t>(v);
+            }
+            store_ptr[i] = pack.vec;
+        }
+    }
+}
+
+// M is a multiple of 128 -- no bounds checking on rows
+__global__ __launch_bounds__(256)
+void quantize_block_fast_even_kernel(
+    const half* __restrict__ src,
+    int8_t* __restrict__ dst,
+    float* __restrict__ block_scales,
+    int M, int K,
+    int num_m_blocks, int num_k_blocks)
+{
+    quantize_block_fast_impl<true>(src, dst, block_scales, M, K, num_m_blocks, num_k_blocks);
+}
+
+// M is NOT a multiple of 128 -- last block checks row bounds
+__global__ __launch_bounds__(256)
+void quantize_block_fast_partial_kernel(
+    const half* __restrict__ src,
+    int8_t* __restrict__ dst,
+    float* __restrict__ block_scales,
+    int M, int K,
+    int num_m_blocks, int num_k_blocks)
+{
+    quantize_block_fast_impl<false>(src, dst, block_scales, M, K, num_m_blocks, num_k_blocks);
+}
+
+// =============================================================================
+// Host API Functions
+// =============================================================================
+
+cudaError_t quantize_per_block_128(
+    const half* src,
+    int8_t* dst,
+    float* block_scales,
+    int M, int K,
+    cudaStream_t stream,
+    bool debug
+) {
+    int num_m_blocks = (M + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+    int num_k_blocks = (K + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+
+    dim3 grid(num_k_blocks, num_m_blocks);
+
+    if (K % QUANT_BLOCK_SIZE == 0) {
+        // Fast path: single-pass vectorized kernel (requires K aligned to 128)
+        dim3 block(256);
+        if (M % QUANT_BLOCK_SIZE == 0) {
+            quantize_block_fast_even_kernel<<<grid, block, 0, stream>>>(
+                src, dst, block_scales, M, K, num_m_blocks, num_k_blocks);
+        } else {
+            quantize_block_fast_partial_kernel<<<grid, block, 0, stream>>>(
+                src, dst, block_scales, M, K, num_m_blocks, num_k_blocks);
+        }
+    } else {
+        // Fallback: old tiled kernel for non-128-aligned K
+        dim3 block(32, 4);
+        quantize_per_block_128_tiled_kernel<<<grid, block, 0, stream>>>(
+            src, dst, block_scales, M, K, num_m_blocks, num_k_blocks);
+    }
+
+    if (debug) {
+        cudaStreamSynchronize(stream);
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            printf("[ERROR] quantize_per_block_128: %s\n", cudaGetErrorString(err));
+            return err;
+        }
+        printf("[DEBUG] quantize_per_block_128: M=%d, K=%d, blocks=(%d, %d)\n",
+               M, K, num_m_blocks, num_k_blocks);
+    }
+
+    return cudaSuccess;
+}
+
+cudaError_t dequantize_per_block_128(
+    const int8_t* src,
+    half* dst,
+    const float* block_scales,
+    int M, int K,
+    cudaStream_t stream
+) {
+    int num_m_blocks = (M + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+    int num_k_blocks = (K + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+
+    dim3 grid(num_k_blocks, num_m_blocks);
+    dim3 block(128);
+
+    dequantize_per_block_128_kernel<<<grid, block, 0, stream>>>(
+        src, dst, block_scales, M, K, num_m_blocks, num_k_blocks);
+
+    return cudaSuccess;
+}
+
+// =============================================================================
+// Swizzled Weight Quantization Kernels
+// =============================================================================
+
+/**
+ * Quantize weights with swizzle pattern for tensor core MMA.
+ *
+ * This kernel processes one 128x128 block of the output (N, K) tile.
+ * Input is [K, N] row-major, output is [N, K] with swizzle applied.
+ *
+ * Each CTA:
+ * 1. Loads a 128x128 tile from src[k_base:k_base+128, n_base:n_base+128]
+ * 2. Computes per-block amax and scale
+ * 3. Quantizes to INT8
+ * 4. Stores to dst with swizzle pattern applied
+ */
+__global__ void quantize_weights_swizzled_128_kernel(
+    const half* __restrict__ src,       // [K, N] row-major
+    int8_t* __restrict__ dst_swizzled,  // [N_padded, K_padded] swizzled
+    float* __restrict__ block_scales,   // [num_k_blocks, num_n_blocks]
+    int K, int N,
+    int K_padded, int N_padded,
+    int num_k_blocks, int num_n_blocks
+) {
+    // Block coordinates: processing output tile [n_blk*128:(n_blk+1)*128, k_blk*128:(k_blk+1)*128]
+    // which corresponds to input tile [k_blk*128:(k_blk+1)*128, n_blk*128:(n_blk+1)*128]
+    int n_blk = blockIdx.x;
+    int k_blk = blockIdx.y;
+
+    if (n_blk >= num_n_blocks || k_blk >= num_k_blocks) return;
+
+    int tid = threadIdx.x;
+
+    // Input boundaries
+    int k_start = k_blk * QUANT_BLOCK_SIZE;
+    int k_end = min(k_start + QUANT_BLOCK_SIZE, K);
+    int n_start = n_blk * QUANT_BLOCK_SIZE;
+    int n_end = min(n_start + QUANT_BLOCK_SIZE, N);
+
+    int block_k = k_end - k_start;
+    int block_n = n_end - n_start;
+
+    // Shared memory for reduction and temporary storage
+    __shared__ float s_amax[128];
+    __shared__ float s_scale;
+    __shared__ float s_inv_scale;
+
+    // Step 1: Compute local amax
+    // Each thread processes multiple elements: 128*128/128 = 128 elements
+    float local_amax = 0.0f;
+
+    for (int elem = tid; elem < QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE; elem += 128) {
+        int local_k = elem / QUANT_BLOCK_SIZE;
+        int local_n = elem % QUANT_BLOCK_SIZE;
+
+        if (local_k < block_k && local_n < block_n) {
+            int global_k = k_start + local_k;
+            int global_n = n_start + local_n;
+            float v = __half2float(src[global_k * N + global_n]);
+            local_amax = fmaxf(local_amax, fabsf(v));
+        }
+    }
+
+    // Step 2: Block-level reduction for amax
+    s_amax[tid] = local_amax;
+    __syncthreads();
+
+    for (int stride = 64; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            s_amax[tid] = fmaxf(s_amax[tid], s_amax[tid + stride]);
+        }
+        __syncthreads();
+    }
+
+    // Compute scale
+    if (tid == 0) {
+        float block_amax = s_amax[0];
+        s_scale = fmaxf(block_amax / 127.0f, 1e-8f);
+        s_inv_scale = 1.0f / s_scale;
+        // Store scale: scales are [num_k_blocks, num_n_blocks] row-major
+        block_scales[k_blk * num_n_blocks + n_blk] = s_scale;
+    }
+    __syncthreads();
+
+    float inv_scale = s_inv_scale;
+
+    // Step 3: Quantize and store with swizzle
+    // Output is [N_padded, K_padded] - each row corresponds to one N index
+    // Within each 128x128 output tile, we apply swizzle for bank-conflict-free access
+
+    for (int elem = tid; elem < QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE; elem += 128) {
+        int local_k = elem / QUANT_BLOCK_SIZE;
+        int local_n = elem % QUANT_BLOCK_SIZE;
+
+        int8_t quantized = 0;
+
+        if (local_k < block_k && local_n < block_n) {
+            int global_k = k_start + local_k;
+            int global_n = n_start + local_n;
+            float v = __half2float(src[global_k * N + global_n]);
+            float scaled = v * inv_scale;
+            quantized = static_cast<int8_t>(fmaxf(-127.0f, fminf(127.0f, roundf(scaled))));
+        }
+
+        // Output coordinates: [n_blk*128 + local_n, k_blk*128 + local_k]
+        // Apply swizzle within the 128x128 tile
+        int out_n = n_blk * QUANT_BLOCK_SIZE + local_n;
+        int out_k = k_blk * QUANT_BLOCK_SIZE + local_k;
+
+        if (out_n < N_padded && out_k < K_padded) {
+            // Apply swizzle: local_n is the "row" within this tile (N dimension)
+            // local_k is the "column" within this tile (K dimension)
+            int swizzled_offset = swizzle_smem_offset(local_n, local_k, kSwizzledStrideK);
+
+            // Base offset for this tile in global memory
+            // Tiles are stored contiguously, each tile is 128 * kSwizzledStrideK bytes
+            int tile_base = (n_blk * num_k_blocks + k_blk) * (QUANT_BLOCK_SIZE * kSwizzledStrideK);
+
+            dst_swizzled[tile_base + swizzled_offset] = quantized;
+        }
+    }
+}
+
+/**
+ * Alternative: Store swizzled weights in a more straightforward layout.
+ *
+ * This version stores the swizzled data as [N_padded][K_padded] with swizzle
+ * applied per-row, which is more natural for loading into shared memory.
+ */
+__global__ void quantize_weights_swizzled_128_v2_kernel(
+    const half* __restrict__ src,       // [K, N] row-major
+    int8_t* __restrict__ dst_swizzled,  // [N_padded][kSwizzledStrideK * num_k_blocks] with swizzle
+    float* __restrict__ block_scales,   // [num_k_blocks, num_n_blocks]
+    int K, int N,
+    int K_padded, int N_padded,
+    int num_k_blocks, int num_n_blocks
+) {
+    // Block processes one 128x128 quantization block
+    int n_blk = blockIdx.x;
+    int k_blk = blockIdx.y;
+
+    if (n_blk >= num_n_blocks || k_blk >= num_k_blocks) return;
+
+    int tid = threadIdx.x;
+
+    int k_start = k_blk * QUANT_BLOCK_SIZE;
+    int k_end = min(k_start + QUANT_BLOCK_SIZE, K);
+    int n_start = n_blk * QUANT_BLOCK_SIZE;
+    int n_end = min(n_start + QUANT_BLOCK_SIZE, N);
+
+    int block_k = k_end - k_start;
+    int block_n = n_end - n_start;
+
+    __shared__ float s_amax[128];
+
+    // Compute amax
+    float local_amax = 0.0f;
+    for (int elem = tid; elem < QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE; elem += 128) {
+        int local_k = elem / QUANT_BLOCK_SIZE;
+        int local_n = elem % QUANT_BLOCK_SIZE;
+        if (local_k < block_k && local_n < block_n) {
+            float v = __half2float(src[(k_start + local_k) * N + (n_start + local_n)]);
+            local_amax = fmaxf(local_amax, fabsf(v));
+        }
+    }
+
+    s_amax[tid] = local_amax;
+    __syncthreads();
+
+    for (int stride = 64; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            s_amax[tid] = fmaxf(s_amax[tid], s_amax[tid + stride]);
+        }
+        __syncthreads();
+    }
+
+    float scale = fmaxf(s_amax[0] / 127.0f, 1e-8f);
+    float inv_scale = 1.0f / scale;
+
+    if (tid == 0) {
+        block_scales[k_blk * num_n_blocks + n_blk] = scale;
+    }
+
+    // Global stride for swizzled output: each row (N) has K_padded bytes
+    // but stored with swizzle pattern applied per 128-column chunk
+    int global_k_stride = kSwizzledStrideK * num_k_blocks;
+
+    // Quantize and store with swizzle
+    for (int elem = tid; elem < QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE; elem += 128) {
+        int local_k = elem / QUANT_BLOCK_SIZE;
+        int local_n = elem % QUANT_BLOCK_SIZE;
+
+        int8_t quantized = 0;
+        if (local_k < block_k && local_n < block_n) {
+            float v = __half2float(src[(k_start + local_k) * N + (n_start + local_n)]);
+            quantized = static_cast<int8_t>(fmaxf(-127.0f, fminf(127.0f, roundf(v * inv_scale))));
+        }
+
+        int out_n = n_start + local_n;
+        if (out_n < N_padded && (k_start + local_k) < K_padded) {
+            // Row in output = out_n
+            // Column = k_blk * kSwizzledStrideK + swizzled local offset
+            int swizzled_local_k = swizzle_smem_offset(local_n, local_k, kSwizzledStrideK) -
+                                   local_n * kSwizzledStrideK;  // Just the column part
+
+            int out_offset = out_n * global_k_stride +
+                            k_blk * kSwizzledStrideK +
+                            swizzled_local_k;
+
+            dst_swizzled[out_offset] = quantized;
+        }
+    }
+}
+
+cudaError_t quantize_weights_swizzled_128(
+    const half* src,
+    int8_t* dst_swizzled,
+    float* block_scales,
+    int K, int N,
+    cudaStream_t stream
+) {
+    int K_padded = pad_to_128(K);
+    int N_padded = pad_to_128(N);
+    int num_k_blocks = K_padded / QUANT_BLOCK_SIZE;
+    int num_n_blocks = N_padded / QUANT_BLOCK_SIZE;
+
+    dim3 grid(num_n_blocks, num_k_blocks);
+    dim3 block(128);
+
+    quantize_weights_swizzled_128_kernel<<<grid, block, 0, stream>>>(
+        src, dst_swizzled, block_scales,
+        K, N, K_padded, N_padded,
+        num_k_blocks, num_n_blocks);
+
+    return cudaGetLastError();
+}
+
+// =============================================================================
+// Dequantize Swizzled Weights (for verification)
+// =============================================================================
+
+__global__ void dequantize_weights_swizzled_128_kernel(
+    const int8_t* __restrict__ src_swizzled,  // [N_padded][K_padded] swizzled
+    half* __restrict__ dst,                    // [K, N] row-major
+    const float* __restrict__ block_scales,    // [num_k_blocks, num_n_blocks]
+    int K, int N,
+    int K_padded, int N_padded,
+    int num_k_blocks, int num_n_blocks
+) {
+    int n_blk = blockIdx.x;
+    int k_blk = blockIdx.y;
+
+    if (n_blk >= num_n_blocks || k_blk >= num_k_blocks) return;
+
+    int tid = threadIdx.x;
+
+    int k_start = k_blk * QUANT_BLOCK_SIZE;
+    int k_end = min(k_start + QUANT_BLOCK_SIZE, K);
+    int n_start = n_blk * QUANT_BLOCK_SIZE;
+    int n_end = min(n_start + QUANT_BLOCK_SIZE, N);
+
+    int block_k = k_end - k_start;
+    int block_n = n_end - n_start;
+
+    float scale = block_scales[k_blk * num_n_blocks + n_blk];
+
+    // Tile base in swizzled storage
+    int tile_base = (n_blk * num_k_blocks + k_blk) * (QUANT_BLOCK_SIZE * kSwizzledStrideK);
+
+    for (int elem = tid; elem < QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE; elem += 128) {
+        int local_k = elem / QUANT_BLOCK_SIZE;
+        int local_n = elem % QUANT_BLOCK_SIZE;
+
+        if (local_k < block_k && local_n < block_n) {
+            // Read from swizzled location
+            int swizzled_offset = swizzle_smem_offset(local_n, local_k, kSwizzledStrideK);
+            int8_t quantized = src_swizzled[tile_base + swizzled_offset];
+
+            // Dequantize and store to original layout
+            float v = static_cast<float>(quantized) * scale;
+            int global_k = k_start + local_k;
+            int global_n = n_start + local_n;
+            dst[global_k * N + global_n] = __float2half(v);
+        }
+    }
+}
+
+cudaError_t dequantize_weights_swizzled_128(
+    const int8_t* src_swizzled,
+    half* dst,
+    const float* block_scales,
+    int K, int N,
+    cudaStream_t stream
+) {
+    int K_padded = pad_to_128(K);
+    int N_padded = pad_to_128(N);
+    int num_k_blocks = K_padded / QUANT_BLOCK_SIZE;
+    int num_n_blocks = N_padded / QUANT_BLOCK_SIZE;
+
+    dim3 grid(num_n_blocks, num_k_blocks);
+    dim3 block(128);
+
+    dequantize_weights_swizzled_128_kernel<<<grid, block, 0, stream>>>(
+        src_swizzled, dst, block_scales,
+        K, N, K_padded, N_padded,
+        num_k_blocks, num_n_blocks);
+
+    return cudaGetLastError();
+}
+
+// =============================================================================
+// Swizzle Pre-Quantized INT8 Weights (no re-quantization)
+// =============================================================================
+
+/**
+ * Swizzle already-quantized INT8 weights into the format expected by the GEMM kernel.
+ *
+ * This is for weights that are already quantized (e.g., from a checkpoint).
+ * It only applies the swizzle pattern without re-quantization.
+ *
+ * Input:  src [K, N] row-major INT8
+ * Output: dst [num_n_blocks * num_k_blocks, 128, 128] swizzled INT8
+ *
+ * The swizzle pattern is: swizzled_k = local_k ^ ((local_n & 7) << 4)
+ */
+__global__ void swizzle_int8_weights_kernel(
+    const int8_t* __restrict__ src,         // [K, N] row-major
+    int8_t* __restrict__ dst_swizzled,      // [num_tiles, 128, 128] swizzled
+    int K, int N,
+    int K_padded, int N_padded,
+    int num_k_blocks, int num_n_blocks
+) {
+    // Block coordinates: processing tile [n_blk, k_blk]
+    int n_blk = blockIdx.x;
+    int k_blk = blockIdx.y;
+
+    int n_start = n_blk * QUANT_BLOCK_SIZE;
+    int k_start = k_blk * QUANT_BLOCK_SIZE;
+
+    // Output tile index (n-major ordering to match kernel expectations)
+    int tile_idx = n_blk * num_k_blocks + k_blk;
+    int8_t* tile_out = dst_swizzled + tile_idx * QUANT_BLOCK_SIZE * kSwizzledStrideK;
+
+    // Each thread processes multiple elements
+    int tid = threadIdx.x;
+    int elements_per_thread = (QUANT_BLOCK_SIZE * QUANT_BLOCK_SIZE) / blockDim.x;
+
+    for (int i = 0; i < elements_per_thread; ++i) {
+        int linear_idx = tid + i * blockDim.x;
+        int local_n = linear_idx / QUANT_BLOCK_SIZE;  // Row in output tile (N dimension)
+        int local_k = linear_idx % QUANT_BLOCK_SIZE;  // Col in output tile (K dimension)
+
+        int global_n = n_start + local_n;
+        int global_k = k_start + local_k;
+
+        // Read from source (handle out-of-bounds)
+        int8_t val = 0;
+        if (global_k < K && global_n < N) {
+            val = src[global_k * N + global_n];
+        }
+
+        // Apply swizzle pattern: XOR row bits 0-2 into col bits 4-6
+        int swizzled_k = local_k ^ ((local_n & 7) << 4);
+        int out_offset = local_n * kSwizzledStrideK + swizzled_k;
+
+        tile_out[out_offset] = val;
+    }
+}
+
+cudaError_t swizzle_int8_weights(
+    const int8_t* src,
+    int8_t* dst_swizzled,
+    int K, int N,
+    cudaStream_t stream
+) {
+    int K_padded = pad_to_128(K);
+    int N_padded = pad_to_128(N);
+    int num_k_blocks = K_padded / QUANT_BLOCK_SIZE;
+    int num_n_blocks = N_padded / QUANT_BLOCK_SIZE;
+
+    dim3 grid(num_n_blocks, num_k_blocks);
+    dim3 block(128);
+
+    swizzle_int8_weights_kernel<<<grid, block, 0, stream>>>(
+        src, dst_swizzled,
+        K, N, K_padded, N_padded,
+        num_k_blocks, num_n_blocks);
+
+    return cudaGetLastError();
+}
+
+/**
+ * Check if weights are already in swizzled format.
+ *
+ * Swizzled format: [num_tiles, 128, 128] where num_tiles = (K/128) * (N/128)
+ * Non-swizzled:    [K, N]
+ *
+ * Returns true if the tensor shape matches swizzled format for given K, N.
+ */
+bool is_swizzled_format(int64_t dim0, int64_t dim1, int64_t dim2, int K, int N) {
+    int K_padded = pad_to_128(K);
+    int N_padded = pad_to_128(N);
+    int num_k_blocks = K_padded / QUANT_BLOCK_SIZE;
+    int num_n_blocks = N_padded / QUANT_BLOCK_SIZE;
+    int expected_tiles = num_n_blocks * num_k_blocks;
+
+    return (dim0 == expected_tiles && dim1 == 128 && dim2 == 128);
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cuh
@@ -1,0 +1,283 @@
+#pragma once
+
+/**
+ * Per-block INT8 quantization kernels.
+ *
+ * This implements 2D per-block (128x128) INT8 quantization for activations
+ * and weights. Per-block quantization adapts to local value distributions,
+ * preserving precision across heterogeneous tensors.
+ *
+ * Quantization scheme:
+ *   - Block size: 128x128
+ *   - Activations [M, K]: scales [M/128, K/128]
+ *   - Weights [K, N]: scales [K/128, N/128]
+ *
+ * For each block:
+ *   amax = max(|block|)
+ *   scale = amax / 127.0
+ *   quantized = round(block / scale).clamp(-127, 127)
+ *
+ * Swizzled weight format (for tensor core optimization):
+ *   - Input: [K, N] row-major (standard PyTorch layout)
+ *   - Output: [N_padded, K_padded] with swizzle pattern applied
+ *   - Stored as column-major for MMA B operand
+ *   - Swizzle pattern: Swizzle<2, 4, 3> for bank-conflict-free ldmatrix
+ */
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cutlass/numeric_types.h>
+#include <cstdint>
+
+namespace omnidreams_singleview {
+
+// Block size for per-block quantization
+constexpr int QUANT_BLOCK_SIZE = 128;
+
+// =============================================================================
+// Kernel Declarations (implementations in wan_block_quant.cu)
+// =============================================================================
+
+/**
+ * Per-block INT8 quantization kernel.
+ *
+ * Each CTA processes one 128x128 block:
+ * 1. Load 128x128 tile to shared memory
+ * 2. Compute block amax via parallel reduction
+ * 3. Scale and convert to int8
+ * 4. Store scale to scale tensor
+ *
+ * Grid: (num_k_blocks, num_m_blocks)
+ * Block: (128) - one thread per column, processes 128 rows
+ */
+__global__ void quantize_per_block_128_kernel(
+    const half* __restrict__ src,       // [M, K] input (row-major)
+    int8_t* __restrict__ dst,            // [M, K] output (row-major)
+    float* __restrict__ block_scales,    // [num_m_blocks, num_k_blocks] scales
+    int M, int K,
+    int num_m_blocks, int num_k_blocks);
+
+/**
+ * Optimized per-block quantization using shared memory tiling.
+ *
+ * This version loads the entire 128x128 block to shared memory for better
+ * memory access patterns and reduced global memory traffic.
+ *
+ * Grid: (num_k_blocks, num_m_blocks)
+ * Block: (32, 4) = 128 threads, each processes 32 elements
+ */
+__global__ void quantize_per_block_128_tiled_kernel(
+    const half* __restrict__ src,       // [M, K] input (row-major)
+    int8_t* __restrict__ dst,            // [M, K] output (row-major)
+    float* __restrict__ block_scales,    // [num_m_blocks, num_k_blocks] scales
+    int M, int K,
+    int num_m_blocks, int num_k_blocks);
+
+/**
+ * Per-block dequantization kernel.
+ *
+ * Reconstructs fp16 tensor from int8 + per-block scales.
+ *
+ * Grid: (num_k_blocks, num_m_blocks)
+ * Block: (128)
+ */
+__global__ void dequantize_per_block_128_kernel(
+    const int8_t* __restrict__ src,      // [M, K] input (row-major)
+    half* __restrict__ dst,               // [M, K] output (row-major)
+    const float* __restrict__ block_scales, // [num_m_blocks, num_k_blocks] scales
+    int M, int K,
+    int num_m_blocks, int num_k_blocks);
+
+// =============================================================================
+// Host API Functions (implementations in wan_block_quant.cu)
+// =============================================================================
+
+/**
+ * Quantize FP16 tensor to INT8 with per-128x128-block scales.
+ *
+ * @param src Input tensor [M, K] in fp16 (row-major)
+ * @param dst Output tensor [M, K] in int8 (row-major)
+ * @param block_scales Output scales [M/128, K/128] in float32 (row-major)
+ * @param M Number of rows
+ * @param K Number of columns
+ * @param stream CUDA stream
+ * @param debug Enable debug output
+ * @return cudaSuccess on success
+ */
+cudaError_t quantize_per_block_128(
+    const half* src,
+    int8_t* dst,
+    float* block_scales,
+    int M, int K,
+    cudaStream_t stream,
+    bool debug = false);
+
+/**
+ * Dequantize INT8 tensor to FP16 with per-128x128-block scales.
+ *
+ * @param src Input tensor [M, K] in int8 (row-major)
+ * @param dst Output tensor [M, K] in fp16 (row-major)
+ * @param block_scales Input scales [M/128, K/128] in float32 (row-major)
+ * @param M Number of rows
+ * @param K Number of columns
+ * @param stream CUDA stream
+ * @return cudaSuccess on success
+ */
+cudaError_t dequantize_per_block_128(
+    const int8_t* src,
+    half* dst,
+    const float* block_scales,
+    int M, int K,
+    cudaStream_t stream);
+
+// =============================================================================
+// Swizzled Weight Quantization (for Tensor Core optimization)
+// =============================================================================
+
+/**
+ * Quantize weights and store with swizzle pattern for MMA B operand.
+ *
+ * This kernel performs three operations:
+ * 1. Quantize FP16 weights to INT8 with per-block scales
+ * 2. Transpose from [K, N] to [N, K] for column-major MMA access
+ * 3. Apply swizzle pattern for bank-conflict-free ldmatrix loading
+ *
+ * The output format is optimized for the m16n8k32 INT8 tensor core MMA:
+ * - B operand expects column-major data (N-major, K-minor)
+ * - Swizzle ensures 32 threads can load without bank conflicts
+ *
+ * Grid: (num_n_tiles, num_k_tiles)
+ * Block: (128) - processes one 128x128 output tile
+ *
+ * @param src Input weights [K, N] row-major (standard PyTorch layout)
+ * @param dst_swizzled Output [N_padded, K_padded] swizzled for MMA
+ * @param block_scales Output scales [K/128, N/128] row-major
+ * @param K Input feature dimension (rows of weight matrix)
+ * @param N Output feature dimension (cols of weight matrix)
+ * @param K_padded Padded K dimension (multiple of 128)
+ * @param N_padded Padded N dimension (multiple of 128)
+ * @param num_k_blocks Number of K blocks
+ * @param num_n_blocks Number of N blocks
+ */
+__global__ void quantize_weights_swizzled_128_kernel(
+    const half* __restrict__ src,
+    int8_t* __restrict__ dst_swizzled,
+    float* __restrict__ block_scales,
+    int K, int N,
+    int K_padded, int N_padded,
+    int num_k_blocks, int num_n_blocks);
+
+/**
+ * Host API for swizzled weight quantization.
+ *
+ * Allocates padded dimensions automatically and applies swizzle pattern.
+ * The caller must provide output buffers of sufficient size:
+ * - dst_swizzled: N_padded * K_padded bytes
+ * - block_scales: (K/128) * (N/128) * sizeof(float) bytes
+ *
+ * Use get_swizzled_weight_dims() and get_swizzled_weight_size() from
+ * wan_int8_swizzle.cuh to calculate required buffer sizes.
+ *
+ * @param src Input weights [K, N] row-major fp16
+ * @param dst_swizzled Output [N_padded, K_padded] swizzled int8
+ * @param block_scales Output scales [K/128, N/128] float32
+ * @param K Input feature dimension
+ * @param N Output feature dimension
+ * @param stream CUDA stream
+ * @return cudaSuccess on success
+ */
+cudaError_t quantize_weights_swizzled_128(
+    const half* src,
+    int8_t* dst_swizzled,
+    float* block_scales,
+    int K, int N,
+    cudaStream_t stream);
+
+/**
+ * Dequantize swizzled weights back to FP16 for verification.
+ *
+ * This reverses the swizzle and transpose to produce [K, N] row-major output.
+ * Primarily used for debugging and accuracy verification.
+ *
+ * @param src_swizzled Input [N_padded, K_padded] swizzled int8
+ * @param dst Output [K, N] row-major fp16
+ * @param block_scales Input scales [K/128, N/128] float32
+ * @param K Output rows
+ * @param N Output cols
+ * @param stream CUDA stream
+ * @return cudaSuccess on success
+ */
+cudaError_t dequantize_weights_swizzled_128(
+    const int8_t* src_swizzled,
+    half* dst,
+    const float* block_scales,
+    int K, int N,
+    cudaStream_t stream);
+
+/**
+ * Swizzle pre-quantized INT8 weights (no re-quantization).
+ *
+ * This function takes already-quantized INT8 weights and applies only the
+ * swizzle pattern needed for efficient tensor core access. Use this when
+ * loading weights from a pre-quantized checkpoint.
+ *
+ * Input:  src [K, N] row-major INT8
+ * Output: dst_swizzled [num_tiles, 128, 128] where num_tiles = (N/128) * (K/128)
+ *
+ * @param src Source INT8 weights [K, N] row-major
+ * @param dst_swizzled Output swizzled weights [num_tiles, 128, 128]
+ * @param K Input rows (in_features)
+ * @param N Input cols (out_features)
+ * @param stream CUDA stream
+ * @return cudaSuccess on success
+ */
+cudaError_t swizzle_int8_weights(
+    const int8_t* src,
+    int8_t* dst_swizzled,
+    int K, int N,
+    cudaStream_t stream);
+
+/**
+ * Check if weights are already in swizzled format.
+ *
+ * Swizzled format: [num_tiles, 128, 128] where num_tiles = (K/128) * (N/128)
+ * Non-swizzled:    [K, N]
+ *
+ * @param dim0, dim1, dim2 Tensor dimensions (dim2 = -1 for 2D tensors)
+ * @param K Original K dimension
+ * @param N Original N dimension
+ * @return true if tensor is in swizzled format
+ */
+bool is_swizzled_format(int64_t dim0, int64_t dim1, int64_t dim2, int K, int N);
+
+// =============================================================================
+// Utility Functions (inline, safe to include in header)
+// =============================================================================
+
+/**
+ * Calculate the number of bytes needed for per-block scales.
+ *
+ * @param M Number of rows in the tensor
+ * @param K Number of columns in the tensor
+ * @return Size in bytes for the scale tensor
+ */
+inline size_t calculate_block_scales_size(int M, int K) {
+    int num_m_blocks = (M + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+    int num_k_blocks = (K + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+    return num_m_blocks * num_k_blocks * sizeof(float);
+}
+
+/**
+ * Get the shape of the scale tensor.
+ *
+ * @param M Number of rows in the tensor
+ * @param K Number of columns in the tensor
+ * @param num_m_blocks Output: number of M blocks
+ * @param num_k_blocks Output: number of K blocks
+ */
+inline void get_block_scales_shape(int M, int K, int* num_m_blocks, int* num_k_blocks) {
+    *num_m_blocks = (M + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+    *num_k_blocks = (K + QUANT_BLOCK_SIZE - 1) / QUANT_BLOCK_SIZE;
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/block_quant.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 /**

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_adaln_lora.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_adaln_lora.cu
@@ -1,0 +1,205 @@
+// cosmos_adaln_lora.cu — fused adaln-LoRA (down + up) projection helper.
+//
+// Cosmos has three adaln sub-layers per block (self_attn, cross_attn, mlp),
+// each backed by its own LoRA stack:
+//
+//     down: [lora_dim, K]
+//     up:   [3K, lora_dim]
+//
+// The math the bridge previously did per sub-layer was:
+//
+//     h    = SiLU(t_emb)               # [B, K]
+//     h2   = h @ down.T                # [B, lora_dim]   <- ATen matmul
+//     mods = h2 @ up.T + adaln_lora_3D # [B, 3K]         <- ATen matmul + add
+//     shift, scale, gate = mods.chunk(3, -1)
+//
+// That is FOUR ATen ops per sub-layer × 3 sub-layers × 28 blocks = 336
+// ATen launches per forward just for the adaln mods. We collapse this to:
+//
+//   silu_inplace_bf16(t_emb_silu_buf)
+//   GEMM (down)              -> lora_hidden  [B, lora_dim]
+//   GEMM (up) with bias=adaln_lora_3D row -> mods_out [B, 3K]
+//
+// We can use the bias path of the second GEMM to fold the
+// "+ adaln_lora_3D" add into the GEMM's own bias broadcast, BUT only when
+// `adaln_lora_3D` is a single row [1, 3K] -- which it is in the streaming
+// path (B=1 typically, or B=2 for CFG with the same lora component
+// broadcast). For B>1 we fall back to a separate add kernel.
+//
+// `mods_out` is then carved into (shift, scale, gate) views by the caller
+// using simple pointer arithmetic; no copy.
+
+#include "cosmos_block.cuh"
+#include "dtype_utils.cuh"
+
+#include <cuda_runtime.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/bfloat16.h>
+#include <cutlass/half.h>
+
+namespace omnidreams_singleview {
+
+// ---------------------------------------------------------------------------
+// In-place SiLU on bf16/fp16 buffer.
+// SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_silu_inplace_kernel(ElementT* __restrict__ data, int64_t numel) {
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= numel) return;
+  float v = omnidreams_singleview::to_float(data[idx]);
+  float s = v / (1.f + __expf(-v));
+  data[idx] = omnidreams_singleview::from_float<ElementT>(s);
+}
+
+// ---------------------------------------------------------------------------
+// Add adaln_lora_3D (the per-block bias-style component) into mods_out.
+// adaln_lora_3D is broadcast across rows of mods_out:
+//   - When adaln_lora_3D has stride 0 across batch (i.e. shape [1, 3K]),
+//     same row added to every output row.
+//   - When stride = 3K, per-row add.
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_add_lora_3d_kernel(
+    ElementT* __restrict__ mods,           // [B, 3K]
+    const ElementT* __restrict__ lora_3d,  // [B, 3K] or [1, 3K]
+    int B, int three_K,
+    int lora_row_stride)                   // 0 = broadcast, 3K = per-row
+{
+  int b = blockIdx.y;
+  int j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (b >= B || j >= three_K) return;
+  size_t pos_dst = size_t(b) * three_K + j;
+  size_t pos_src = size_t(b) * lora_row_stride + j;
+  float a = omnidreams_singleview::to_float(mods[pos_dst]);
+  float l = omnidreams_singleview::to_float(lora_3d[pos_src]);
+  mods[pos_dst] = omnidreams_singleview::from_float<ElementT>(a + l);
+}
+
+// ---------------------------------------------------------------------------
+// Host launcher
+//
+// Note: `down` and `up` are passed in PyTorch's row-major layout
+//   - down: [lora_dim, K]    PyTorch nn.Linear(K, lora_dim).weight
+//   - up:   [3K, lora_dim]   PyTorch nn.Linear(lora_dim, 3K).weight
+//
+// `cutlass_linear_layer_rrr_bf16` accepts these PyTorch-layout weights
+// directly because internally it uses CUTLASS's RCR layout (RowMajor input
+// × ColumnMajor weight × RowMajor output). PyTorch's `[out, in]` row-major
+// is byte-equivalent to CUTLASS's `[in, out]` column-major, so the GEMM
+// computes `output = input @ weight^T` -- matching PyTorch's nn.Linear
+// math directly. No pre-transpose pass needed (unlike WAN's path, which
+// does `weight.transpose(0, 1).contiguous()` offline in
+// `native/common/weight_utils.py`).
+//
+// Math expansion:
+//   h        [B, K]                      = SiLU(t_emb)            (caller-applied)
+//   lora_h   [B, lora_dim]               = h @ down^T
+//   mods_pre [B, 3K]                     = lora_h @ up^T
+//   mods_out [B, 3K]                     = mods_pre + adaln_lora_3D
+// ---------------------------------------------------------------------------
+
+template <typename ElementT>
+cudaError_t cosmos_adaln_lora_split(
+    const ElementT* t_emb,
+    const ElementT* down_weight,
+    const ElementT* up_weight,
+    const ElementT* adaln_lora_3D,
+    ElementT* lora_hidden_buf,
+    ElementT* mods_out,
+    int B, int K, int lora_dim,
+    cudaStream_t stream)
+{
+  if (B <= 0 || K <= 0 || lora_dim <= 0) return cudaSuccess;
+
+  // 1) Copy t_emb -> lora_hidden_buf (we apply SiLU into the buffer rather
+  //    than mutating t_emb in-place; t_emb is shared across all three
+  //    sub-layers in a block).
+  //
+  //    Optimization: we can SiLU directly into a temporary scratch we then
+  //    feed as the GEMM input. But to keep the helper allocation-free, we
+  //    SiLU-into the bottom of `lora_hidden_buf` (we have B*lora_dim of
+  //    space; we need B*K which is much larger... so this approach needs
+  //    a separate scratch).
+  //
+  //    Simpler: SiLU in-place on t_emb is NOT safe (shared). Instead we
+  //    fuse SiLU + GEMM by using cutlass_linear_layer_rrr_silu_bf16, which
+  //    computes `SiLU(A @ B + bias)` -- but that's SiLU AFTER the GEMM,
+  //    not before. The cosmos op order is SiLU(emb) THEN GEMM, so we need
+  //    SiLU-before-GEMM.
+  //
+  //    Solution: have the caller pre-compute SiLU(t_emb) once per forward
+  //    and pass that pre-silu'd buffer here. (One SiLU launch per forward,
+  //    not per sub-layer.) The bridge does this and passes the same
+  //    `t_emb_silu` to all three sub-layers within a block.
+
+  // 2) GEMM: lora_hidden = t_emb_silu @ down  (PyTorch row-major down ==
+  //    transposed-for-math: interpret as [K, lora_dim])
+  //    Shape: [B, K] x [K, lora_dim] -> [B, lora_dim]
+  cudaError_t err = cutlass_linear_layer_rrr_bf16(
+      reinterpret_cast<const cutlass::bfloat16_t*>(t_emb),
+      reinterpret_cast<const cutlass::bfloat16_t*>(down_weight),
+      /*bias=*/nullptr,
+      reinterpret_cast<cutlass::bfloat16_t*>(lora_hidden_buf),
+      B, K, lora_dim, stream);
+  if (err != cudaSuccess) return err;
+
+  // 3) GEMM: mods = lora_hidden @ up
+  //    Shape: [B, lora_dim] x [lora_dim, 3K] -> [B, 3K]
+  const ElementT* up_bias = (B == 1) ? adaln_lora_3D : nullptr;
+  err = cutlass_linear_layer_rrr_bf16(
+      reinterpret_cast<const cutlass::bfloat16_t*>(lora_hidden_buf),
+      reinterpret_cast<const cutlass::bfloat16_t*>(up_weight),
+      reinterpret_cast<const cutlass::bfloat16_t*>(up_bias),
+      reinterpret_cast<cutlass::bfloat16_t*>(mods_out),
+      B, lora_dim, 3 * K, stream);
+  if (err != cudaSuccess) return err;
+
+  // 4) Add adaln_lora_3D into mods_out.
+  //    Streaming path always has B small (1 or 2) and adaln_lora_3D has
+  //    shape [B, 3K] (per-batch). The add is cheap; one launch.
+  if (adaln_lora_3D != nullptr && B != 1) {
+    int three_K = 3 * K;
+    int lora_row_stride = three_K;  // per-row add (one row per batch)
+    dim3 block(256);
+    dim3 grid((three_K + block.x - 1) / block.x, B);
+    cosmos_add_lora_3d_kernel<ElementT><<<grid, block, 0, stream>>>(
+        mods_out, adaln_lora_3D, B, three_K, lora_row_stride);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) return err;
+  }
+
+  return cudaSuccess;
+}
+
+// In-place SiLU launcher (called once per forward by the bridge to compute
+// SiLU(t_emb) once and reuse across all sub-layers).
+template <typename ElementT>
+cudaError_t cosmos_silu_inplace(
+    ElementT* data,
+    int64_t numel,
+    cudaStream_t stream)
+{
+  if (numel <= 0) return cudaSuccess;
+  int threads = 256;
+  int64_t blocks = (numel + threads - 1) / threads;
+  cosmos_silu_inplace_kernel<ElementT><<<blocks, threads, 0, stream>>>(data, numel);
+  return cudaGetLastError();
+}
+
+// Explicit instantiations
+template cudaError_t cosmos_adaln_lora_split<cutlass::bfloat16_t>(
+    const cutlass::bfloat16_t*, const cutlass::bfloat16_t*, const cutlass::bfloat16_t*,
+    const cutlass::bfloat16_t*, cutlass::bfloat16_t*, cutlass::bfloat16_t*,
+    int, int, int, cudaStream_t);
+template cudaError_t cosmos_adaln_lora_split<cutlass::half_t>(
+    const cutlass::half_t*, const cutlass::half_t*, const cutlass::half_t*,
+    const cutlass::half_t*, cutlass::half_t*, cutlass::half_t*,
+    int, int, int, cudaStream_t);
+
+template cudaError_t cosmos_silu_inplace<cutlass::bfloat16_t>(
+    cutlass::bfloat16_t*, int64_t, cudaStream_t);
+template cudaError_t cosmos_silu_inplace<cutlass::half_t>(
+    cutlass::half_t*, int64_t, cudaStream_t);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_adaln_lora.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_adaln_lora.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // cosmos_adaln_lora.cu — fused adaln-LoRA (down + up) projection helper.
 //
 // Cosmos has three adaln sub-layers per block (self_attn, cross_attn, mlp),

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cu
@@ -1026,6 +1026,129 @@ static cudaError_t cosmos_linear_half_input_fp8_residual(
       N, in_features, out_features, stream);
 }
 
+static cudaError_t cosmos_attention_fp8_cudnn(
+    const CosmosBlockParams& p,
+    const cutlass::bfloat16_t* q,
+    const cutlass::bfloat16_t* k,
+    const cutlass::bfloat16_t* v,
+    const cutlass::float_e4m3_t* q_fp8,
+    const cutlass::float_e4m3_t* q_fp8_bhmd,
+    int q_fp8_bhmd_tokens,
+    const cutlass::float_e4m3_t* k_fp8,
+    const cutlass::float_e4m3_t* v_fp8,
+    const cutlass::float_e4m3_t* k_fp8_bhmd,
+    const cutlass::float_e4m3_t* v_fp8_bhmd,
+    int k_fp8_bhmd_tokens,
+    int v_fp8_bhmd_tokens,
+    const cutlass::float_e4m3_t* v_fp8_bhdm,
+    cutlass::bfloat16_t* out,
+    cutlass::float_e4m3_t* out_fp8,
+    int Mk,
+    bool write_bf16_output,
+    bool write_fp8_output,
+    cudaStream_t stream)
+{
+  if (!p.buf.attn_q_fp8 || !p.buf.attn_k_fp8 || !p.buf.attn_v_fp8) {
+    return cudaErrorInvalidValue;
+  }
+  const int64_t q_elems = int64_t(p.B) * p.M * p.H * p.D;
+  const int64_t kv_elems = int64_t(p.B) * Mk * p.H * p.D;
+  cudaError_t err = cudaSuccess;
+
+  const cutlass::float_e4m3_t* q_attn = q_fp8;
+  if (!q_attn) {
+    if (!q) return cudaErrorInvalidValue;
+    err = cosmos_bf16_to_fp8(q, p.buf.attn_q_fp8, q_elems, stream);
+    if (err != cudaSuccess) return err;
+    q_attn = p.buf.attn_q_fp8;
+  }
+  const cutlass::float_e4m3_t* k_attn = k_fp8;
+  const cutlass::float_e4m3_t* v_attn = v_fp8;
+  if (!k_attn || !v_attn) {
+    if (!k || !v) return cudaErrorInvalidValue;
+    err = cosmos_bf16_to_fp8(k, p.buf.attn_k_fp8, kv_elems, stream);
+    if (err != cudaSuccess) return err;
+    err = cosmos_bf16_to_fp8(v, p.buf.attn_v_fp8, kv_elems, stream);
+    if (err != cudaSuccess) return err;
+    k_attn = p.buf.attn_k_fp8;
+    v_attn = p.buf.attn_v_fp8;
+  }
+
+  if (write_fp8_output && !out_fp8) {
+    return cudaErrorInvalidValue;
+  }
+  constexpr int kScaleSlot = 0;
+  constexpr int kAmaxSSlot = 4;
+  constexpr int kAmaxOSlot = 8;
+  if (!p.buf.attn_tc_scale || p.buf.attn_tc_scale_elems <= kAmaxOSlot) {
+    return cudaErrorInvalidValue;
+  }
+  if (!p.buf.attn_tc_scale_is_ones) {
+    err = cosmos_fill_float(p.buf.attn_tc_scale + kScaleSlot, 1, 1.0f, stream);
+    if (err != cudaSuccess) return err;
+  }
+
+  cutlass::float_e4m3_t* fp8_out = out_fp8;
+  if (!fp8_out) {
+    if (!p.buf.linear_fp8_scratch) return cudaErrorInvalidValue;
+    fp8_out = p.buf.linear_fp8_scratch;
+  }
+  const auto sdpa_selection = select_cosmos_fp8_sdpa(p.B, p.M, Mk, p.H, p.D);
+  const bool input_bhmd = sdpa_selection.layout == "bhmd";
+  const cutlass::float_e4m3_t* q_cudnn = q_attn;
+  const cutlass::float_e4m3_t* k_cudnn = k_attn;
+  const cutlass::float_e4m3_t* v_cudnn = v_attn;
+  if (input_bhmd) {
+    if (!p.buf.attn_q_bhmd_fp8 || !p.buf.attn_k_bhmd_fp8 || !p.buf.attn_v_bhmd_fp8) {
+      return cudaErrorInvalidValue;
+    }
+    const bool q_bhmd_packed = q_fp8_bhmd && q_fp8_bhmd_tokens == p.M;
+    const bool k_bhmd_packed = k_fp8_bhmd && k_fp8_bhmd_tokens == Mk;
+    const bool v_bhmd_packed = v_fp8_bhmd && v_fp8_bhmd_tokens == Mk;
+    q_cudnn = q_bhmd_packed ? q_fp8_bhmd : p.buf.attn_q_bhmd_fp8;
+    k_cudnn = k_bhmd_packed ? k_fp8_bhmd : p.buf.attn_k_bhmd_fp8;
+    v_cudnn = v_bhmd_packed ? v_fp8_bhmd : p.buf.attn_v_bhmd_fp8;
+    if (!q_bhmd_packed) {
+      err = cosmos_fp8_bmhd_to_bhmd(q_attn, p.buf.attn_q_bhmd_fp8, p.B, p.M, p.H, p.D, stream);
+      if (err != cudaSuccess) return err;
+    }
+    if (!k_bhmd_packed) {
+      err = cosmos_fp8_bmhd_to_bhmd(k_attn, p.buf.attn_k_bhmd_fp8, p.B, Mk, p.H, p.D, stream);
+      if (err != cudaSuccess) return err;
+    }
+    if (!v_bhmd_packed && v_attn != p.buf.attn_v_bhmd_fp8) {
+      err = cosmos_fp8_bmhd_to_bhmd(v_attn, p.buf.attn_v_bhmd_fp8, p.B, Mk, p.H, p.D, stream);
+      if (err != cudaSuccess) return err;
+    }
+  }
+  (void)v_fp8_bhdm;
+  err = run_cudnn_fmha_packed_qkv_fp8(
+      q_cudnn, k_cudnn, v_cudnn, fp8_out,
+      p.buf.attn_tc_scale + kScaleSlot,
+      p.buf.attn_tc_scale + kScaleSlot,
+      p.buf.attn_tc_scale + kScaleSlot,
+      p.buf.attn_tc_scale + kScaleSlot,
+      p.buf.attn_tc_scale + kScaleSlot,
+      p.buf.attn_tc_scale + kScaleSlot,
+      p.buf.attn_tc_scale + kAmaxSSlot,
+      p.buf.attn_tc_scale + kAmaxOSlot,
+      p.B, p.M, Mk, p.H, p.D, /*causal=*/false, 0.0f, stream);
+  if (err != cudaSuccess) return err;
+
+  if (write_fp8_output) {
+    if (!write_bf16_output) {
+      return cudaSuccess;
+    }
+    if (!out) return cudaErrorInvalidValue;
+    return cosmos_fp8_to_half_bf16(out_fp8, nullptr, out, q_elems, stream);
+  }
+  if (!write_bf16_output) {
+    return cudaSuccess;
+  }
+  if (!out) return cudaErrorInvalidValue;
+  return cosmos_fp8_to_half_bf16(fp8_out, nullptr, out, q_elems, stream);
+}
+
 static cudaError_t cosmos_attention_bf16_or_fp8(
     const CosmosBlockParams& p,
     const cutlass::bfloat16_t* q,
@@ -1033,10 +1156,13 @@ static cudaError_t cosmos_attention_bf16_or_fp8(
     const cutlass::bfloat16_t* v,
     const cutlass::float_e4m3_t* q_fp8,
     const cutlass::float_e4m3_t* q_fp8_bhmd,
+    int q_fp8_bhmd_tokens,
     const cutlass::float_e4m3_t* k_fp8,
     const cutlass::float_e4m3_t* v_fp8,
     const cutlass::float_e4m3_t* k_fp8_bhmd,
     const cutlass::float_e4m3_t* v_fp8_bhmd,
+    int k_fp8_bhmd_tokens,
+    int v_fp8_bhmd_tokens,
     const cutlass::float_e4m3_t* v_fp8_bhdm,
     const uint8_t* q_sage3_fp4,
     const cutlass::float_e4m3_t* q_sage3_sf,
@@ -1051,9 +1177,41 @@ static cudaError_t cosmos_attention_bf16_or_fp8(
     int Mk,
     bool write_bf16_output,
     bool write_fp8_output,
-    bool allow_sage_backend,
+    bool allow_sparge_backend,
     cudaStream_t stream)
 {
+  if (p.attention_backend == CosmosAttentionBackend::SPARGE) {
+    if (!allow_sparge_backend) {
+      if (p.fp8_kv_cache_enabled) {
+        return cosmos_attention_fp8_cudnn(
+            p, q, k, v,
+            q_fp8, q_fp8_bhmd, q_fp8_bhmd_tokens,
+            k_fp8, v_fp8,
+            k_fp8_bhmd, v_fp8_bhmd,
+            k_fp8_bhmd_tokens, v_fp8_bhmd_tokens,
+            v_fp8_bhdm,
+            out, out_fp8, Mk,
+            write_bf16_output, write_fp8_output, stream);
+      }
+      if (!out) return cudaErrorInvalidValue;
+      return run_cudnn_fmha_packed_qkv(
+          q, k, v, out,
+          p.B, p.M, Mk, p.H, p.D, /*causal=*/false, /*scale=*/0.f, stream);
+    }
+    if (!write_bf16_output || write_fp8_output || !q || !k || !v || !out) {
+      return cudaErrorInvalidValue;
+    }
+    if (p.B != 1) {
+      return cudaErrorNotSupported;
+    }
+    return run_cosmos_sparge_attention_bf16(
+        q, k, v, out,
+        const_cast<ts::SpargeAttentionWorkspace*>(&p.buf.sparge),
+        p.buf.linear_half_scratch,
+        p.M, Mk, p.H, p.D, p.sparge_topk_ratio,
+        p.sparge_attention_sink, stream);
+  }
+
   if (p.attention_backend == CosmosAttentionBackend::SAGE3) {
     if (!write_bf16_output || write_fp8_output || !q || !k || !v || !out) {
       return cudaErrorInvalidValue;
@@ -1174,18 +1332,21 @@ static cudaError_t cosmos_attention_bf16_or_fp8(
       if (!p.buf.attn_q_bhmd_fp8 || !p.buf.attn_k_bhmd_fp8 || !p.buf.attn_v_bhmd_fp8) {
         return cudaErrorInvalidValue;
       }
-      q_cudnn = q_fp8_bhmd ? q_fp8_bhmd : p.buf.attn_q_bhmd_fp8;
-      k_cudnn = k_fp8_bhmd ? k_fp8_bhmd : p.buf.attn_k_bhmd_fp8;
-      v_cudnn = v_fp8_bhmd ? v_fp8_bhmd : p.buf.attn_v_bhmd_fp8;
-      if (!q_fp8_bhmd) {
+      const bool q_bhmd_packed = q_fp8_bhmd && q_fp8_bhmd_tokens == p.M;
+      const bool k_bhmd_packed = k_fp8_bhmd && k_fp8_bhmd_tokens == Mk;
+      const bool v_bhmd_packed = v_fp8_bhmd && v_fp8_bhmd_tokens == Mk;
+      q_cudnn = q_bhmd_packed ? q_fp8_bhmd : p.buf.attn_q_bhmd_fp8;
+      k_cudnn = k_bhmd_packed ? k_fp8_bhmd : p.buf.attn_k_bhmd_fp8;
+      v_cudnn = v_bhmd_packed ? v_fp8_bhmd : p.buf.attn_v_bhmd_fp8;
+      if (!q_bhmd_packed) {
         err = cosmos_fp8_bmhd_to_bhmd(q_attn, p.buf.attn_q_bhmd_fp8, p.B, p.M, p.H, p.D, stream);
         if (err != cudaSuccess) return err;
       }
-      if (!k_fp8_bhmd) {
+      if (!k_bhmd_packed) {
         err = cosmos_fp8_bmhd_to_bhmd(k_attn, p.buf.attn_k_bhmd_fp8, p.B, Mk, p.H, p.D, stream);
         if (err != cudaSuccess) return err;
       }
-      if (!v_fp8_bhmd && v_attn != p.buf.attn_v_bhmd_fp8) {
+      if (!v_bhmd_packed && v_attn != p.buf.attn_v_bhmd_fp8) {
         err = cosmos_fp8_bmhd_to_bhmd(v_attn, p.buf.attn_v_bhmd_fp8, p.B, Mk, p.H, p.D, stream);
         if (err != cudaSuccess) return err;
       }
@@ -2451,10 +2612,13 @@ cudaError_t cosmos_run_transformer_block_streaming(
       reinterpret_cast<const cutlass::bfloat16_t*>(p.v_self_cache),
       q_attn_fp8,
       q_attn_fp8_bhmd,
+      q_attn_fp8_bhmd ? p.M : 0,
       p.fp8_kv_cache_enabled ? p.k_self_cache_fp8 : nullptr,
       p.fp8_kv_cache_enabled ? p.v_self_cache_fp8 : nullptr,
       self_tc_cache_contiguous ? p.k_self_cache_fp8_bhmd : nullptr,
       self_tc_cache_contiguous ? p.v_self_cache_fp8_bhmd : nullptr,
+      self_tc_cache_contiguous ? read_end : 0,
+      self_tc_cache_contiguous ? read_end : 0,
       self_tc_cache_contiguous ? p.v_self_cache_fp8_bhdm : nullptr,
       q_attn_sage3_fp4,
       q_attn_sage3_sf,
@@ -2467,7 +2631,7 @@ cudaError_t cosmos_run_transformer_block_streaming(
       reinterpret_cast<cutlass::bfloat16_t*>(o_bmhk),
       sa_attn_writes_fp8 ? p.buf.linear_fp8_scratch : nullptr,
       read_end, !sa_out_proj_from_quantized_attention, sa_attn_writes_fp8,
-      /*allow_sage_backend=*/true, stream);
+      /*allow_sparge_backend=*/true, stream);
   if (err != cudaSuccess) return err;
   rec(EV_AFTER_SA_FMHA);
 
@@ -2551,10 +2715,15 @@ cudaError_t cosmos_run_transformer_block_streaming(
   const cutlass::float_e4m3_t* ca_q_attn_fp8_bhmd = nullptr;
   const uint8_t* ca_q_attn_sage3_fp4 = nullptr;
   const cutlass::float_e4m3_t* ca_q_attn_sage3_sf = nullptr;
+  const bool sparge_cross_fp8_fallback =
+      p.attention_backend == CosmosAttentionBackend::SPARGE &&
+      p.fp8_kv_cache_enabled;
+  const bool cross_quantized_attention =
+      quantized_attention || sparge_cross_fp8_fallback;
   const bool cross_fp8_cudnn_bhmd_input =
-      fp8_cudnn_attention &&
+      (fp8_cudnn_attention || sparge_cross_fp8_fallback) &&
       select_cosmos_fp8_sdpa(B, M, Mk_c, H, D).layout == "bhmd";
-  if (quantized_attention) {
+  if (cross_quantized_attention) {
     if (sage3_fp8_attention) {
       if (!p.buf.attn_q_sage3_fp4 || !p.buf.attn_q_sage3_sf) {
         return cudaErrorInvalidValue;
@@ -2587,23 +2756,27 @@ cudaError_t cosmos_run_transformer_block_streaming(
   //     K  [B*Mk_c, H, D]   (FlashDreams writes [B*V, Mk_c, H, D] -- with V==1 this is [B, Mk_c, H, D])
   //     V  [B*Mk_c, H, D]
   const bool ca_out_proj_from_quantized_attention =
-      quantized_attention && !sage3_fp8_attention && ca_out_fp8;
+      cross_quantized_attention && !sage3_fp8_attention && ca_out_fp8;
   const bool ca_attn_writes_fp8 =
       ca_out_proj_from_quantized_attention &&
-      p.attention_backend == CosmosAttentionBackend::FP8_CUDNN;
+      (p.attention_backend == CosmosAttentionBackend::FP8_CUDNN ||
+       sparge_cross_fp8_fallback);
   const bool fuse_ca_fp8_residual_postprocess =
-      ca_out_fp8 && quantized_attention;
+      ca_out_fp8 && cross_quantized_attention;
   err = cosmos_attention_bf16_or_fp8(
       p,
-      quantized_attention ? nullptr : reinterpret_cast<const cutlass::bfloat16_t*>(q_row),
+      cross_quantized_attention ? nullptr : reinterpret_cast<const cutlass::bfloat16_t*>(q_row),
       reinterpret_cast<const cutlass::bfloat16_t*>(p.k_cross),
       reinterpret_cast<const cutlass::bfloat16_t*>(p.v_cross),
       ca_q_attn_fp8,
       ca_q_attn_fp8_bhmd,
+      ca_q_attn_fp8_bhmd ? p.M : 0,
       p.fp8_kv_cache_enabled ? p.k_cross_fp8 : nullptr,
       p.fp8_kv_cache_enabled ? p.v_cross_fp8 : nullptr,
       p.fp8_kv_cache_enabled ? p.k_cross_fp8_bhmd : nullptr,
       p.fp8_kv_cache_enabled ? p.v_cross_fp8_bhmd : nullptr,
+      p.fp8_kv_cache_enabled ? p.k_cross_fp8_bhmd_tokens : 0,
+      p.fp8_kv_cache_enabled ? p.v_cross_fp8_bhmd_tokens : 0,
       p.fp8_kv_cache_enabled ? p.v_cross_fp8_bhdm : nullptr,
       ca_q_attn_sage3_fp4,
       ca_q_attn_sage3_sf,
@@ -2616,7 +2789,7 @@ cudaError_t cosmos_run_transformer_block_streaming(
       reinterpret_cast<cutlass::bfloat16_t*>(o_bmhk),
       ca_attn_writes_fp8 ? p.buf.linear_fp8_scratch : nullptr,
       Mk_c, !ca_out_proj_from_quantized_attention, ca_attn_writes_fp8,
-      /*allow_sage_backend=*/false, stream);
+      /*allow_sparge_backend=*/false, stream);
   if (err != cudaSuccess) return err;
   rec(EV_AFTER_CA_FMHA);
 
@@ -2700,6 +2873,7 @@ cudaError_t cosmos_run_transformer_block_streaming(
       if (err != cudaSuccess) return err;
     }
   }
+  if (err != cudaSuccess) return err;
   rec(EV_AFTER_FFN1);
 
   if (ffn1_fp8 && ffn2_fp8) {
@@ -2718,6 +2892,7 @@ cudaError_t cosmos_run_transformer_block_streaming(
         p.x, gate_ml, M * B, FF, K, stream);
     if (err != cudaSuccess) return err;
   }
+  if (err != cudaSuccess) return err;
   rec(EV_AFTER_FFN2);
   err = cosmos_trace_copy(p.trace_ffn_out, p.x, p.trace_elems, stream);
   if (err != cudaSuccess) return err;

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // cosmos_block.cu — streaming transformer block orchestrator for Cosmos DiT.
 //
 // One call per layer replaces the ~14 ATen ops the previous bridge issued

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cu
@@ -1,0 +1,2765 @@
+// cosmos_block.cu — streaming transformer block orchestrator for Cosmos DiT.
+//
+// One call per layer replaces the ~14 ATen ops the previous bridge issued
+// (3x adaln-LoRA × 4 ops + 3x LN + 7x matmul + 3x reshape + 3x gate add).
+// Internally the orchestrator drives:
+//
+//   - bf16 CUTLASS RRR GEMMs   (Q/K/V/out projections, FFN GEMM1+GELU, FFN GEMM2)
+//   - cosmos_layernorm_modulate (no-affine LN + (1+scale)+shift)
+//   - cosmos_residual_gate     (x + gate * y)
+//   - cosmos_rmsnorm_per_head  (Q/K RMSNorm before RoPE)
+//   - cosmos_rope_pack         (BMHK pack + rotate-half RoPE in one kernel)
+//   - cudaMemcpyAsync          (append K_rot, V into KV cache)
+//   - run_cudnn_fmha_packed_qkv (cuDNN SDPA, already optimal)
+//
+// The CA branch reuses the same primitives but skips QKV (the K/V come
+// from FlashDreams' pre-cached encoder buffers; only Q is projected here).
+
+#include "cosmos_block.cuh"
+#include "attention.cuh"            // run_cudnn_fmha_packed_qkv
+#include "cosmos_fp8_two_gemm.cuh"
+#include "dtype_utils.cuh"
+#include "ops.cuh"
+
+#include <cuda_runtime.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cutlass/numeric_types.h>
+#include <cutlass/numeric_conversion.h>
+#include <cutlass/bfloat16.h>
+#include <cutlass/half.h>
+
+namespace omnidreams_singleview {
+
+namespace {
+
+static constexpr float kCosmosFp8LinearPrescaleAlpha = 1.0f / 128.0f;
+static constexpr float kCosmosFp8LinearScaleMul = 1.0f / kCosmosFp8LinearPrescaleAlpha;
+
+static int cosmos_qkv_rope_threads_for_shape(int D) {
+  const char* env = std::getenv("OMNIDREAMS_DIT_QKV_ROPE_THREADS");
+  if (env && env[0]) {
+    int requested = std::atoi(env);
+    if (requested == 64 || requested == 128 || requested == 256) {
+      return requested;
+    }
+  }
+  return (D <= 128) ? 64 : 256;
+}
+
+__global__ void cosmos_bf16_to_fp8_kernel(
+    const cutlass::bfloat16_t* __restrict__ src,
+    cutlass::float_e4m3_t* __restrict__ dst,
+    int64_t n)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  dst[idx] = to_fp8(omnidreams_singleview::to_float(src[idx]));
+}
+
+__global__ void cosmos_half_to_bf16_kernel(
+    const cutlass::half_t* __restrict__ src,
+    cutlass::bfloat16_t* __restrict__ dst,
+    int64_t n)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  dst[idx] = omnidreams_singleview::from_float<cutlass::bfloat16_t>(omnidreams_singleview::to_float(src[idx]));
+}
+
+__global__ void cosmos_half_to_fp8_kernel(
+    const cutlass::half_t* __restrict__ src,
+    cutlass::float_e4m3_t* __restrict__ dst,
+    int64_t n)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  dst[idx] = to_fp8(omnidreams_singleview::to_float(src[idx]));
+}
+
+__global__ void cosmos_fp8_to_half_bf16_kernel(
+    const cutlass::float_e4m3_t* __restrict__ src,
+    cutlass::half_t* __restrict__ dst_half,
+    cutlass::bfloat16_t* __restrict__ dst_bf16,
+    int64_t n)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  cutlass::NumericConverter<float, cutlass::float_e4m3_t> to_f32;
+  float value = to_f32(src[idx]);
+  if (dst_half) {
+    cutlass::NumericConverter<cutlass::half_t, float> to_half;
+    dst_half[idx] = to_half(value);
+  }
+  if (dst_bf16) {
+    dst_bf16[idx] = omnidreams_singleview::from_float<cutlass::bfloat16_t>(value);
+  }
+}
+
+__global__ void cosmos_fill_float_kernel(float* __restrict__ dst, int64_t n, float value)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    dst[idx] = value;
+  }
+}
+
+__global__ void cosmos_fp8_bmhd_to_bhmd_kernel(
+    const cutlass::float_e4m3_t* __restrict__ src,
+    cutlass::float_e4m3_t* __restrict__ dst,
+    int B,
+    int M,
+    int H,
+    int D)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = int64_t(B) * M * H * D;
+  if (idx >= total) return;
+
+  const int d = int(idx % D);
+  int64_t t = idx / D;
+  const int h = int(t % H);
+  t /= H;
+  const int m = int(t % M);
+  const int b = int(t / M);
+  const int64_t dst_idx =
+      ((int64_t(b) * H + h) * M + m) * D + d;
+  dst[dst_idx] = src[idx];
+}
+
+__global__ void cosmos_col_scale_bias_to_bf16_kernel(
+    const cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    cutlass::bfloat16_t* __restrict__ output,
+    float scale_mul,
+    int out_features,
+    int64_t total_elems,
+    bool gelu)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = int(idx % out_features);
+  float x = omnidreams_singleview::to_float(data[idx]) * (omnidreams_singleview::to_float(scale[col]) * scale_mul);
+  if (bias) {
+    x += omnidreams_singleview::to_float(bias[col]);
+  }
+  if (gelu) {
+    constexpr float c = 0.044715f;
+    float y = 0.7978845608028654f * (x + c * x * x * x);
+    x = 0.5f * x * (1.0f + tanhf(y));
+  }
+  output[idx] = omnidreams_singleview::from_float<cutlass::bfloat16_t>(x);
+}
+
+__global__ void cosmos_col_scale_residual_gate_bf16_kernel(
+    const cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    cutlass::bfloat16_t* __restrict__ residual_inout,
+    const cutlass::bfloat16_t* __restrict__ gate,
+    float scale_mul,
+    int out_features,
+    int rows_per_b,
+    int64_t total_elems)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = int(idx % out_features);
+  int row = int(idx / out_features);
+  int b_row = (rows_per_b > 0) ? (row / rows_per_b) : 0;
+  float projected = omnidreams_singleview::to_float(data[idx]) * (omnidreams_singleview::to_float(scale[col]) * scale_mul);
+  float g = omnidreams_singleview::to_float(gate[size_t(b_row) * out_features + col]);
+  float x = omnidreams_singleview::to_float(residual_inout[idx]);
+  residual_inout[idx] = omnidreams_singleview::from_float<cutlass::bfloat16_t>(x + g * projected);
+}
+
+__global__ void cosmos_scale_gate_half_kernel(
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::bfloat16_t* __restrict__ gate,
+    cutlass::half_t* __restrict__ alpha,
+    int n,
+    float alpha_mul)
+{
+  int idx = int(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  float v = omnidreams_singleview::to_float(scale[idx]) * omnidreams_singleview::to_float(gate[idx]) * alpha_mul;
+  alpha[idx] = omnidreams_singleview::from_float<cutlass::half_t>(v);
+}
+
+__device__ inline void cosmos_atomic_max_float_nonneg(float* addr, float val) {
+  val = fmaxf(val, 0.0f);
+  unsigned int* addr_as_ui = reinterpret_cast<unsigned int*>(addr);
+  atomicMax(addr_as_ui, __float_as_uint(val));
+}
+
+__global__ void cosmos_bf16_absmax_kernel(
+    const cutlass::bfloat16_t* __restrict__ src,
+    float* __restrict__ out,
+    int64_t n)
+{
+  float local_max = 0.0f;
+  for (int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+       idx < n;
+       idx += int64_t(blockDim.x) * gridDim.x) {
+    local_max = fmaxf(local_max, fabsf(omnidreams_singleview::to_float(src[idx])));
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    local_max = fmaxf(local_max, __shfl_down_sync(0xffffffffu, local_max, offset));
+  }
+
+  __shared__ float warp_max[8];
+  int lane = threadIdx.x & 31;
+  int warp = threadIdx.x >> 5;
+  if (lane == 0) warp_max[warp] = local_max;
+  __syncthreads();
+
+  float block_max = 0.0f;
+  if (warp == 0) {
+    block_max = (threadIdx.x < (blockDim.x >> 5)) ? warp_max[lane] : 0.0f;
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      block_max = fmaxf(block_max, __shfl_down_sync(0xffffffffu, block_max, offset));
+    }
+    if (lane == 0) {
+      cosmos_atomic_max_float_nonneg(out, block_max);
+    }
+  }
+}
+
+__global__ void cosmos_split_qkv_row_kernel(
+    const cutlass::bfloat16_t* __restrict__ qkv,
+    cutlass::bfloat16_t* __restrict__ q,
+    cutlass::bfloat16_t* __restrict__ k,
+    cutlass::bfloat16_t* __restrict__ v,
+    int rows,
+    int features)
+{
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total = int64_t(rows) * features;
+  if (idx >= total) return;
+  int col = int(idx % features);
+  int row = int(idx / features);
+  const cutlass::bfloat16_t* src_row = qkv + size_t(row) * (3 * features);
+  q[idx] = src_row[col];
+  k[idx] = src_row[features + col];
+  v[idx] = src_row[2 * features + col];
+}
+
+__device__ __forceinline__ float cosmos_warp_sum(float x) {
+  for (int off = 16; off > 0; off >>= 1) {
+    x += __shfl_down_sync(0xffffffffu, x, off);
+  }
+  return x;
+}
+
+template <bool Enabled>
+__device__ __forceinline__ float cosmos_bf16_raw_or_zero(
+    const cutlass::bfloat16_t* __restrict__ src,
+    size_t idx)
+{
+  if constexpr (Enabled) {
+    return omnidreams_singleview::to_float(src[idx]);
+  } else {
+    return 0.0f;
+  }
+}
+
+template <bool Enabled>
+__device__ __forceinline__ void cosmos_store_warp_sum_if(
+    float* __restrict__ sums,
+    float value,
+    int lane,
+    int warp)
+{
+  if constexpr (Enabled) {
+    if (lane == 0) {
+      sums[warp] = value;
+    }
+  }
+}
+
+template <bool Enabled>
+__device__ __forceinline__ float cosmos_reduce_warp_sums_if(
+    float* __restrict__ sums,
+    int tid,
+    int warp,
+    int warp_count)
+{
+  if constexpr (Enabled) {
+    float total = (tid < warp_count) ? sums[tid] : 0.0f;
+    return (warp == 0) ? cosmos_warp_sum(total) : 0.0f;
+  } else {
+    return 0.0f;
+  }
+}
+
+template <bool Enabled>
+__device__ __forceinline__ void cosmos_store_block_sum_if(
+    float* __restrict__ sums,
+    float value,
+    int tid)
+{
+  if constexpr (Enabled) {
+    if (tid == 0) {
+      sums[0] = value;
+    }
+  }
+}
+
+template <bool Enabled>
+__device__ __forceinline__ float cosmos_rms_from_block_sum_if(
+    const float* __restrict__ sums,
+    int dim,
+    float eps)
+{
+  if constexpr (Enabled) {
+    return rsqrtf(sums[0] / float(dim) + eps);
+  } else {
+    return 0.0f;
+  }
+}
+
+static cudaError_t cosmos_bf16_to_fp8(
+    const cutlass::bfloat16_t* src,
+    cutlass::float_e4m3_t* dst,
+    int64_t n,
+    cudaStream_t stream)
+{
+  if (n <= 0) return cudaSuccess;
+  if (!src || !dst) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  cosmos_bf16_to_fp8_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(src, dst, n);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_half_to_bf16(
+    const cutlass::half_t* src,
+    cutlass::bfloat16_t* dst,
+    int64_t n,
+    cudaStream_t stream)
+{
+  if (n <= 0) return cudaSuccess;
+  if (!src || !dst) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  cosmos_half_to_bf16_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(src, dst, n);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_half_to_fp8(
+    const cutlass::half_t* src,
+    cutlass::float_e4m3_t* dst,
+    int64_t n,
+    cudaStream_t stream)
+{
+  if (n <= 0) return cudaSuccess;
+  if (!src || !dst) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  cosmos_half_to_fp8_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(src, dst, n);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_fp8_to_half_bf16(
+    const cutlass::float_e4m3_t* src,
+    cutlass::half_t* dst_half,
+    cutlass::bfloat16_t* dst_bf16,
+    int64_t n,
+    cudaStream_t stream)
+{
+  if (n <= 0) return cudaSuccess;
+  if (!src || (!dst_half && !dst_bf16)) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  cosmos_fp8_to_half_bf16_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      src, dst_half, dst_bf16, n);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_fill_float(float* dst, int64_t n, float value, cudaStream_t stream)
+{
+  if (n <= 0) return cudaSuccess;
+  if (!dst) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  cosmos_fill_float_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(dst, n, value);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_fp8_bmhd_to_bhmd(
+    const cutlass::float_e4m3_t* src,
+    cutlass::float_e4m3_t* dst,
+    int B,
+    int M,
+    int H,
+    int D,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0 || H <= 0 || D <= 0) return cudaSuccess;
+  if (!src || !dst) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t total = int64_t(B) * M * H * D;
+  int64_t blocks = (total + threads - 1) / threads;
+  cosmos_fp8_bmhd_to_bhmd_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      src, dst, B, M, H, D);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_col_scale_bias_to_bf16(
+    const cutlass::half_t* data,
+    const cutlass::half_t* scale,
+    const cutlass::half_t* bias,
+    cutlass::bfloat16_t* output,
+    int N,
+    int out_features,
+    bool gelu,
+    cudaStream_t stream,
+    float scale_mul)
+{
+  if (!data || !scale || !output) return cudaErrorInvalidValue;
+  int64_t total = int64_t(N) * out_features;
+  if (total <= 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int64_t blocks = (total + threads - 1) / threads;
+  cosmos_col_scale_bias_to_bf16_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      data, scale, bias, output, scale_mul, out_features, total, gelu);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_col_scale_residual_gate_bf16(
+    const cutlass::half_t* data,
+    const cutlass::half_t* scale,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* gate,
+    int N,
+    int out_features,
+    int B,
+    cudaStream_t stream,
+    float scale_mul)
+{
+  if (!data || !scale || !residual_inout || !gate) return cudaErrorInvalidValue;
+  int64_t total = int64_t(N) * out_features;
+  if (total <= 0) return cudaSuccess;
+  int rows_per_b = (B > 1) ? (N / B) : N;
+  constexpr int threads = 256;
+  int64_t blocks = (total + threads - 1) / threads;
+  cosmos_col_scale_residual_gate_bf16_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      data, scale, residual_inout, gate, scale_mul, out_features, rows_per_b, total);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_scale_gate_half(
+    const cutlass::half_t* scale,
+    const cutlass::bfloat16_t* gate,
+    cutlass::half_t* alpha,
+    int n,
+    cudaStream_t stream,
+    float alpha_mul = 1.0f)
+{
+  if (n <= 0) return cudaSuccess;
+  if (!scale || !gate || !alpha) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int blocks = (n + threads - 1) / threads;
+  cosmos_scale_gate_half_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      scale, gate, alpha, n, alpha_mul);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_record_bf16_absmax(
+    const cutlass::bfloat16_t* src,
+    float* dst,
+    int64_t n,
+    cudaStream_t stream)
+{
+  if (!dst) return cudaSuccess;
+  if (!src || n <= 0) return cudaErrorInvalidValue;
+  cudaError_t err = cudaMemsetAsync(dst, 0, sizeof(float), stream);
+  if (err != cudaSuccess) return err;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  blocks = blocks > 1024 ? 1024 : blocks;
+  cosmos_bf16_absmax_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(src, dst, n);
+  return cudaGetLastError();
+}
+
+static bool cosmos_linear_backend_allows_fp8(const CosmosBlockParams& p)
+{
+  return p.linear_backend == CosmosLinearBackend::FP8 ||
+         p.linear_backend == CosmosLinearBackend::MIXED;
+}
+
+static bool cosmos_weight_is_fp8(const CosmosBlockParams& p, const cutlass::half_t* weight_scale)
+{
+  return cosmos_linear_backend_allows_fp8(p) && weight_scale != nullptr;
+}
+
+static float cosmos_fp8_activation_scale_or_one(const CosmosBlockParams& p, int site)
+{
+  if (!p.fp8_activation_scales || site < 0 || site >= kCosmosFp8ActivationScaleSites) {
+    return 1.0f;
+  }
+  float scale = p.fp8_activation_scales[site];
+  return scale > 0.0f ? scale : 1.0f;
+}
+
+static cudaError_t cosmos_trace_copy(
+    cutlass::bfloat16_t* dst,
+    const cutlass::bfloat16_t* src,
+    int64_t elems,
+    cudaStream_t stream)
+{
+  if (!dst) return cudaSuccess;
+  if (!src || elems <= 0) return cudaErrorInvalidValue;
+  return cudaMemcpyAsync(dst, src, size_t(elems) * sizeof(cutlass::bfloat16_t),
+                         cudaMemcpyDeviceToDevice, stream);
+}
+
+static cudaError_t cosmos_split_qkv_row(
+    const cutlass::bfloat16_t* qkv,
+    cutlass::bfloat16_t* q,
+    cutlass::bfloat16_t* k,
+    cutlass::bfloat16_t* v,
+    int rows,
+    int features,
+    cudaStream_t stream)
+{
+  if (rows <= 0 || features <= 0) return cudaSuccess;
+  if (!qkv || !q || !k || !v) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t total = int64_t(rows) * features;
+  int64_t blocks = (total + threads - 1) / threads;
+  cosmos_split_qkv_row_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      qkv, q, k, v, rows, features);
+  return cudaGetLastError();
+}
+
+template <typename ElementT>
+__global__ void cosmos_pack_rope_to_fp8_kernel(
+    const ElementT* __restrict__ src,
+    const ElementT* __restrict__ cos_tab,
+    const ElementT* __restrict__ sin_tab,
+    cutlass::float_e4m3_t* __restrict__ dst,
+    cutlass::float_e4m3_t* __restrict__ dst_bhmd,
+    int B, int M, int H, int D)
+{
+  int row_m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  const int total_m = B * M;
+  if (row_m >= total_m || h >= H) return;
+
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  int b = row_m / M;
+  int m = row_m - b * M;
+  int d_half = D / 2;
+  size_t base_src = size_t(row_m) * (H * D) + size_t(h) * D;
+  size_t base_dst = (size_t(row_m) * H + size_t(h)) * D;
+  size_t base_dst_bhmd = ((size_t(b) * H + size_t(h)) * M + size_t(m)) * D;
+  size_t base_rt  = size_t(row_m) * D;
+
+  for (int d = tid; d < D; d += blockDim.x) {
+    float x_d  = omnidreams_singleview::to_float(src[base_src + d]);
+    int   d_op = (d < d_half) ? (d + d_half) : (d - d_half);
+    float x_op = omnidreams_singleview::to_float(src[base_src + d_op]);
+    float c    = omnidreams_singleview::to_float(cos_tab[base_rt + d]);
+    float s    = omnidreams_singleview::to_float(sin_tab[base_rt + d]);
+    float rot  = (d < d_half) ? (-x_op) : x_op;
+    cutlass::float_e4m3_t out = to_fp8(x_d * c + rot * s);
+    dst[base_dst + d] = out;
+    if (dst_bhmd) {
+      dst_bhmd[base_dst_bhmd + d] = out;
+    }
+  }
+}
+
+template <typename ElementT>
+static cudaError_t cosmos_pack_rope_to_fp8(
+    const ElementT* src,
+    const ElementT* cos_tab,
+    const ElementT* sin_tab,
+    cutlass::float_e4m3_t* dst,
+    cutlass::float_e4m3_t* dst_bhmd,
+    int B, int M, int H, int D,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0 || H <= 0 || D <= 0) return cudaSuccess;
+  if (!src || !cos_tab || !sin_tab || !dst) return cudaErrorInvalidValue;
+  int threads = (D <= 128) ? 64 : 128;
+  dim3 grid(H, B * M);
+  cosmos_pack_rope_to_fp8_kernel<ElementT><<<grid, threads, 0, stream>>>(
+      src, cos_tab, sin_tab, dst, dst_bhmd, B, M, H, D);
+  return cudaGetLastError();
+}
+
+template <typename ElementT>
+__global__ void cosmos_bf16_to_fp8_cache_write_kernel(
+    const ElementT* __restrict__ src,       // [M, H, D]
+    cutlass::float_e4m3_t* __restrict__ dst, // [B, cap, H, D]
+    int M, int H, int D,
+    int write_start, int cache_cap, int b_idx)
+{
+  int m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || h >= H) return;
+
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  size_t src_off = (size_t(m) * H + size_t(h)) * D;
+  size_t dst_off = ((size_t(b_idx) * cache_cap + size_t(write_start) + size_t(m)) * H + size_t(h)) * D;
+  for (int d = tid; d < D; d += blockDim.x) {
+    dst[dst_off + d] = to_fp8(omnidreams_singleview::to_float(src[src_off + d]));
+  }
+}
+
+template <typename ElementT>
+static cudaError_t cosmos_write_kv_cache_fp8(
+    const ElementT* k_src,
+    const ElementT* v_src,
+    cutlass::float_e4m3_t* k_cache,
+    cutlass::float_e4m3_t* v_cache,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0) return cudaSuccess;
+  if (!k_src || !v_src || !k_cache || !v_cache) return cudaErrorInvalidValue;
+  int threads = (D <= 128) ? 64 : 128;
+  dim3 grid(H, M);
+  for (int b = 0; b < B; ++b) {
+    cosmos_bf16_to_fp8_cache_write_kernel<ElementT><<<grid, threads, 0, stream>>>(
+        k_src + size_t(b) * M * H * D, k_cache, M, H, D, write_start, cache_cap, b);
+    cudaError_t e = cudaGetLastError();
+    if (e != cudaSuccess) return e;
+    cosmos_bf16_to_fp8_cache_write_kernel<ElementT><<<grid, threads, 0, stream>>>(
+        v_src + size_t(b) * M * H * D, v_cache, M, H, D, write_start, cache_cap, b);
+    e = cudaGetLastError();
+    if (e != cudaSuccess) return e;
+  }
+  return cudaSuccess;
+}
+
+static cudaError_t cosmos_linear_prequantized_fp8(
+    const CosmosBlockParams& p,
+    const cutlass::float_e4m3_t* input_fp8,
+    const void* weight,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* output,
+    int N,
+    int in_features,
+    int out_features,
+    bool gelu,
+    cudaStream_t stream,
+    float input_scale = 1.0f)
+{
+  if (p.linear_backend != CosmosLinearBackend::FP8) {
+    if (p.linear_backend != CosmosLinearBackend::MIXED) {
+      return cudaErrorNotSupported;
+    }
+  }
+  if (!cosmos_weight_is_fp8(p, weight_scale)) {
+    return cudaErrorNotSupported;
+  }
+  if (!input_fp8 || !p.buf.linear_half_scratch || !weight_scale) {
+    return cudaErrorInvalidValue;
+  }
+
+  if (!gelu && input_scale == 1.0f) {
+    cudaError_t fused = cutlass_linear_layer_rcr_fp8_colscale_bf16(
+        input_fp8,
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+        weight_scale,
+        output,
+        N, in_features, out_features, stream);
+    if (fused == cudaSuccess) {
+      return cudaSuccess;
+    }
+    if (fused != cudaErrorNotSupported) {
+      return fused;
+    }
+  }
+
+  cudaError_t err = cutlass_linear_layer_rcr_fp8(
+      input_fp8,
+      reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+      nullptr,
+      p.buf.linear_half_scratch,
+      N, in_features, out_features, stream,
+      kCosmosFp8LinearPrescaleAlpha);
+  if (err != cudaSuccess) return err;
+
+  return cosmos_col_scale_bias_to_bf16(
+      p.buf.linear_half_scratch, weight_scale, nullptr, output,
+      N, out_features, gelu, stream, kCosmosFp8LinearScaleMul * input_scale);
+}
+
+static cudaError_t cosmos_linear_bf16_or_fp8(
+    const CosmosBlockParams& p,
+    const cutlass::bfloat16_t* input,
+    const void* weight,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* output,
+    int N,
+    int in_features,
+    int out_features,
+    bool gelu,
+    cudaStream_t stream)
+{
+  const bool use_fp8 = cosmos_weight_is_fp8(p, weight_scale);
+  if (!use_fp8) {
+    if (p.linear_backend == CosmosLinearBackend::FP8) {
+      return cudaErrorInvalidValue;
+    }
+    auto* w_bf16 = reinterpret_cast<const cutlass::bfloat16_t*>(weight);
+    return gelu
+        ? cutlass_linear_layer_rrr_gelu_bf16(input, w_bf16, nullptr, output,
+                                             N, in_features, out_features, stream)
+        : cutlass_linear_layer_rrr_bf16(input, w_bf16, nullptr, output,
+                                        N, in_features, out_features, stream);
+  }
+
+  if (!cosmos_linear_backend_allows_fp8(p)) {
+    return cudaErrorNotSupported;
+  }
+  if (!p.buf.linear_fp8_scratch) {
+    return cudaErrorInvalidValue;
+  }
+
+  cudaError_t err = cosmos_bf16_to_fp8(
+      input, p.buf.linear_fp8_scratch, int64_t(N) * in_features, stream);
+  if (err != cudaSuccess) return err;
+
+  return cosmos_linear_prequantized_fp8(
+      p, p.buf.linear_fp8_scratch, weight, weight_scale, output,
+      N, in_features, out_features, gelu, stream);
+}
+
+static cudaError_t cosmos_linear_bf16_or_fp8_prepared(
+    const CosmosBlockParams& p,
+    const cutlass::bfloat16_t* input,
+    const void* weight,
+    const cutlass::bfloat16_t* weight_prepared,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* output,
+    int N,
+    int in_features,
+    int out_features,
+    bool gelu,
+    cudaStream_t stream)
+{
+  const bool use_fp8 = cosmos_weight_is_fp8(p, weight_scale);
+  if (!use_fp8 && weight_prepared) {
+    if (p.linear_backend == CosmosLinearBackend::FP8) {
+      return cudaErrorInvalidValue;
+    }
+    return gelu
+        ? cutlass_linear_layer_rrr_gelu_bf16_prepared(
+            input, weight_prepared, nullptr, output,
+            N, in_features, out_features, stream)
+        : cutlass_linear_layer_rrr_bf16_prepared(
+            input, weight_prepared, nullptr, output,
+            N, in_features, out_features, stream);
+  }
+  return cosmos_linear_bf16_or_fp8(
+      p, input, weight, weight_scale, output,
+      N, in_features, out_features, gelu, stream);
+}
+
+static cudaError_t cosmos_linear_prequantized_fp8_output(
+    const CosmosBlockParams& p,
+    const cutlass::float_e4m3_t* input_fp8,
+    const void* weight,
+    const cutlass::half_t* weight_scale,
+    cutlass::float_e4m3_t* output_fp8,
+    int N,
+    int in_features,
+    int out_features,
+    bool gelu,
+    cudaStream_t stream,
+    float output_scale = 1.0f)
+{
+  if (!cosmos_weight_is_fp8(p, weight_scale)) {
+    return cudaErrorNotSupported;
+  }
+  if (!input_fp8 || !p.buf.linear_half_scratch || !output_fp8 || !weight_scale) {
+    return cudaErrorInvalidValue;
+  }
+
+  if (gelu && output_scale == 1.0f) {
+    cudaError_t fused = cutlass_linear_layer_rcr_fp8_colscale_gelu_fp8(
+        input_fp8,
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+        weight_scale,
+        output_fp8,
+        N, in_features, out_features, stream);
+    if (fused == cudaSuccess) {
+      return cudaSuccess;
+    }
+    if (fused != cudaErrorNotSupported) {
+      return fused;
+    }
+  }
+
+  cudaError_t err = cutlass_linear_layer_rcr_fp8(
+      input_fp8,
+      reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+      nullptr,
+      p.buf.linear_half_scratch,
+      N, in_features, out_features, stream,
+      kCosmosFp8LinearPrescaleAlpha);
+  if (err != cudaSuccess) return err;
+
+  return gelu
+      ? apply_col_scale_bias_gelu_to_fp8(
+            p.buf.linear_half_scratch, output_fp8, weight_scale, nullptr,
+            N, out_features, stream, kCosmosFp8LinearScaleMul, output_scale)
+      : apply_col_scale_bias_to_fp8(
+            p.buf.linear_half_scratch, output_fp8, weight_scale, nullptr,
+            N, out_features, stream, kCosmosFp8LinearScaleMul, output_scale);
+}
+
+static cudaError_t cosmos_linear_prequantized_fp8_residual(
+    const CosmosBlockParams& p,
+    const cutlass::float_e4m3_t* input_fp8,
+    const void* weight,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* gate,
+    int N,
+    int in_features,
+    int out_features,
+    cudaStream_t stream,
+    float input_scale = 1.0f)
+{
+  if (!cosmos_weight_is_fp8(p, weight_scale)) {
+    return cudaErrorNotSupported;
+  }
+  if (!input_fp8 || !p.buf.linear_half_scratch || !weight_scale || !residual_inout || !gate) {
+    return cudaErrorInvalidValue;
+  }
+
+  if (p.B == 1) {
+    cudaError_t prep = cosmos_scale_gate_half(
+        weight_scale, gate, p.buf.linear_half_scratch, out_features, stream, input_scale);
+    if (prep != cudaSuccess) return prep;
+    cudaError_t fused = cutlass_linear_layer_rcr_fp8_colscale_residual_bf16(
+        input_fp8,
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+        p.buf.linear_half_scratch,
+        residual_inout,
+        N, in_features, out_features, stream);
+    if (fused == cudaSuccess) {
+      return cudaSuccess;
+    }
+    if (fused != cudaErrorNotSupported) {
+      return fused;
+    }
+  }
+
+  cudaError_t err = cutlass_linear_layer_rcr_fp8(
+      input_fp8,
+      reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+      nullptr,
+      p.buf.linear_half_scratch,
+      N, in_features, out_features, stream,
+      kCosmosFp8LinearPrescaleAlpha);
+  if (err != cudaSuccess) return err;
+
+  return cosmos_col_scale_residual_gate_bf16(
+      p.buf.linear_half_scratch, weight_scale, residual_inout, gate,
+      N, out_features, p.B, stream, kCosmosFp8LinearScaleMul * input_scale);
+}
+
+// Default-on toggle for the fused (col_scale + residual + LN + modulate -> FP8)
+// path that replaces the back-to-back col_scale_residual_bf16 +
+// cosmos_layernorm_modulate_to_fp8_only pair after FP8 SA-out / CA-out
+// projections. Set OMNIDREAMS_DIT_FUSE_RESIDUAL_LN=0 to fall back to the unfused
+// two-step sequence.
+static bool cosmos_fuse_residual_ln_fp8_enabled() {
+  const char* env = std::getenv("OMNIDREAMS_DIT_FUSE_RESIDUAL_LN");
+  if (!env || !env[0]) return true;
+  return env[0] != '0' &&
+         env[0] != 'f' && env[0] != 'F' &&
+         env[0] != 'n' && env[0] != 'N';
+}
+
+// Fused: FP8 GEMM + (residual into x) + LN/modulate -> FP8 input for the next
+// FP8 GEMM, all in one launch sequence (cuBLASLt FP8 GEMM + one combined
+// post-op kernel). Mirrors `cosmos_linear_prequantized_fp8_residual` for the
+// B==1 fast path; falls back to the unfused two-step path otherwise. Used at
+// the SA-out / CA-out call sites where the next op is an FP8-only LN/modulate.
+static cudaError_t cosmos_linear_prequantized_fp8_residual_layernorm_modulate_to_fp8_only(
+    const CosmosBlockParams& p,
+    const cutlass::float_e4m3_t* input_fp8,
+    const void* weight,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* gate,
+    const cutlass::bfloat16_t* ln_shift,
+    const cutlass::bfloat16_t* ln_scale,
+    cutlass::float_e4m3_t* fp8_out,
+    int N,
+    int in_features,
+    int out_features,
+    int B,
+    float eps,
+    cudaStream_t stream,
+    float input_scale = 1.0f)
+{
+  if (!cosmos_weight_is_fp8(p, weight_scale)) {
+    return cudaErrorNotSupported;
+  }
+  if (!input_fp8 || !p.buf.linear_half_scratch || !weight_scale ||
+      !residual_inout || !gate || !ln_shift || !ln_scale || !fp8_out) {
+    return cudaErrorInvalidValue;
+  }
+
+  if (p.B == 1 && cosmos_fuse_residual_ln_fp8_enabled()) {
+    cudaError_t prep = cosmos_scale_gate_half(
+        weight_scale, gate, p.buf.linear_half_scratch, out_features, stream, input_scale);
+    if (prep != cudaSuccess) return prep;
+    cudaError_t fused = cutlass_linear_layer_rcr_fp8_colscale_residual_layernorm_modulate_to_fp8(
+        input_fp8,
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+        p.buf.linear_half_scratch,
+        residual_inout,
+        ln_shift,
+        ln_scale,
+        fp8_out,
+        N, in_features, out_features, B, eps, stream);
+    if (fused == cudaSuccess) return cudaSuccess;
+    if (fused != cudaErrorNotSupported) return fused;
+  }
+
+  cudaError_t err = cosmos_linear_prequantized_fp8_residual(
+      p, input_fp8, weight, weight_scale, residual_inout, gate,
+      N, in_features, out_features, stream, input_scale);
+  if (err != cudaSuccess) return err;
+  return cosmos_layernorm_modulate_to_fp8_only<cutlass::bfloat16_t>(
+      residual_inout, ln_shift, ln_scale, fp8_out,
+      N, out_features, B, eps, stream);
+}
+
+static cudaError_t cosmos_linear_bf16_or_fp8_residual_prepared(
+    const CosmosBlockParams& p,
+    const cutlass::bfloat16_t* input,
+    const void* weight,
+    const cutlass::bfloat16_t* weight_prepared,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* gate,
+    int N,
+    int in_features,
+    int out_features,
+    cudaStream_t stream)
+{
+  const bool use_fp8 = cosmos_weight_is_fp8(p, weight_scale);
+  if (!use_fp8 && weight_prepared) {
+    if (p.linear_backend == CosmosLinearBackend::FP8) {
+      return cudaErrorInvalidValue;
+    }
+    return cutlass_linear_layer_rrr_bf16_prepared_gated_residual(
+        input, weight_prepared, gate, residual_inout,
+        N, in_features, out_features, stream);
+  }
+
+  cutlass::bfloat16_t* tmp = p.buf.normed;
+  cudaError_t err = cosmos_linear_bf16_or_fp8(
+      p, input, weight, weight_scale, tmp,
+      N, in_features, out_features, /*gelu=*/false, stream);
+  if (err != cudaSuccess) return err;
+  return cosmos_residual_gate<cutlass::bfloat16_t>(
+      residual_inout, residual_inout, tmp, gate, N, out_features, p.B, stream);
+}
+
+static cudaError_t cosmos_linear_bf16_input_fp8_residual(
+    const CosmosBlockParams& p,
+    const cutlass::bfloat16_t* input,
+    const void* weight,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* gate,
+    int N,
+    int in_features,
+    int out_features,
+    cudaStream_t stream)
+{
+  if (!p.buf.linear_fp8_scratch || !input) {
+    return cudaErrorInvalidValue;
+  }
+  cudaError_t err = cosmos_bf16_to_fp8(
+      input, p.buf.linear_fp8_scratch, int64_t(N) * in_features, stream);
+  if (err != cudaSuccess) return err;
+  return cosmos_linear_prequantized_fp8_residual(
+      p, p.buf.linear_fp8_scratch, weight, weight_scale, residual_inout, gate,
+      N, in_features, out_features, stream);
+}
+
+static cudaError_t cosmos_linear_half_input_fp8_residual(
+    const CosmosBlockParams& p,
+    const cutlass::half_t* input,
+    const void* weight,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* gate,
+    int N,
+    int in_features,
+    int out_features,
+    cudaStream_t stream)
+{
+  if (!cosmos_weight_is_fp8(p, weight_scale)) {
+    return cudaErrorNotSupported;
+  }
+  if (!p.buf.linear_fp8_scratch || !input) {
+    return cudaErrorInvalidValue;
+  }
+
+  cudaError_t err = cosmos_half_to_fp8(
+      input, p.buf.linear_fp8_scratch, int64_t(N) * in_features, stream);
+  if (err != cudaSuccess) return err;
+
+  return cosmos_linear_prequantized_fp8_residual(
+      p, p.buf.linear_fp8_scratch, weight, weight_scale, residual_inout, gate,
+      N, in_features, out_features, stream);
+}
+
+static cudaError_t cosmos_attention_bf16_or_fp8(
+    const CosmosBlockParams& p,
+    const cutlass::bfloat16_t* q,
+    const cutlass::bfloat16_t* k,
+    const cutlass::bfloat16_t* v,
+    const cutlass::float_e4m3_t* q_fp8,
+    const cutlass::float_e4m3_t* q_fp8_bhmd,
+    const cutlass::float_e4m3_t* k_fp8,
+    const cutlass::float_e4m3_t* v_fp8,
+    const cutlass::float_e4m3_t* k_fp8_bhmd,
+    const cutlass::float_e4m3_t* v_fp8_bhmd,
+    const cutlass::float_e4m3_t* v_fp8_bhdm,
+    const uint8_t* q_sage3_fp4,
+    const cutlass::float_e4m3_t* q_sage3_sf,
+    const uint8_t* k_sage3_fp4,
+    const uint8_t* v_sage3_fp4,
+    const cutlass::float_e4m3_t* k_sage3_sf,
+    const cutlass::float_e4m3_t* v_sage3_sf,
+    int q_sage3_padded,
+    int k_sage3_padded,
+    cutlass::bfloat16_t* out,
+    cutlass::float_e4m3_t* out_fp8,
+    int Mk,
+    bool write_bf16_output,
+    bool write_fp8_output,
+    bool allow_sage_backend,
+    cudaStream_t stream)
+{
+  if (p.attention_backend == CosmosAttentionBackend::SAGE3) {
+    if (!write_bf16_output || write_fp8_output || !q || !k || !v || !out) {
+      return cudaErrorInvalidValue;
+    }
+    return run_sage3_fmha_packed_qkv(
+        q, k, v, out,
+        p.B, p.M, Mk, p.H, p.D, /*causal=*/false, /*scale=*/0.f, stream);
+  }
+
+  if (p.attention_backend == CosmosAttentionBackend::SAGE3_FP8) {
+    if (!write_bf16_output || write_fp8_output || !out) {
+      return cudaErrorInvalidValue;
+    }
+    if (q_sage3_fp4 && q_sage3_sf && k_sage3_fp4 && v_sage3_fp4 &&
+        k_sage3_sf && v_sage3_sf) {
+      return run_sage3_fmha_packed_qkv_fp4(
+          q_sage3_fp4, k_sage3_fp4, v_sage3_fp4,
+          q_sage3_sf, k_sage3_sf, v_sage3_sf, out,
+          p.B, p.M, Mk, p.H, p.D, /*causal=*/false, /*scale=*/0.f,
+          q_sage3_padded, k_sage3_padded, stream);
+    }
+    if (q_sage3_fp4 && q_sage3_sf && k_fp8 && v_fp8) {
+      return run_sage3_fmha_packed_qfp4_kvfp8(
+          q_sage3_fp4, q_sage3_sf, k_fp8, v_fp8, out,
+          p.B, p.M, Mk, p.H, p.D, /*causal=*/false, /*scale=*/0.f,
+          q_sage3_padded, stream);
+    }
+    if (!q_fp8 || !k_fp8 || !v_fp8) {
+      return cudaErrorInvalidValue;
+    }
+    return run_sage3_fmha_packed_qkv_fp8(
+        q_fp8, k_fp8, v_fp8, out,
+        p.B, p.M, Mk, p.H, p.D, /*causal=*/false, /*scale=*/0.f, stream);
+  }
+
+  if (p.attention_backend == CosmosAttentionBackend::CUDNN_BF16) {
+    if (!out) return cudaErrorInvalidValue;
+    return run_cudnn_fmha_packed_qkv(
+        q, k, v, out,
+        p.B, p.M, Mk, p.H, p.D, /*causal=*/false, /*scale=*/0.f, stream);
+  }
+
+  const bool use_fp8_cudnn = p.attention_backend == CosmosAttentionBackend::FP8_CUDNN;
+  const bool use_fp8_dense_ref =
+      p.attention_backend == CosmosAttentionBackend::FP8_DENSE_REF;
+  if (!use_fp8_cudnn && !use_fp8_dense_ref) {
+    return cudaErrorNotSupported;
+  }
+  if (!p.buf.attn_q_fp8 || !p.buf.attn_k_fp8 || !p.buf.attn_v_fp8) {
+    return cudaErrorInvalidValue;
+  }
+
+  const int64_t q_elems = int64_t(p.B) * p.M * p.H * p.D;
+  const int64_t kv_elems = int64_t(p.B) * Mk * p.H * p.D;
+  cudaError_t err = cudaSuccess;
+  const cutlass::float_e4m3_t* q_attn = q_fp8;
+  if (!q_attn) {
+    err = cosmos_bf16_to_fp8(q, p.buf.attn_q_fp8, q_elems, stream);
+    if (err != cudaSuccess) return err;
+    q_attn = p.buf.attn_q_fp8;
+  }
+  const cutlass::float_e4m3_t* k_attn = k_fp8;
+  const cutlass::float_e4m3_t* v_attn = v_fp8;
+  if (!k_attn || !v_attn) {
+    err = cosmos_bf16_to_fp8(k, p.buf.attn_k_fp8, kv_elems, stream);
+    if (err != cudaSuccess) return err;
+    err = cosmos_bf16_to_fp8(v, p.buf.attn_v_fp8, kv_elems, stream);
+    if (err != cudaSuccess) return err;
+    k_attn = p.buf.attn_k_fp8;
+    v_attn = p.buf.attn_v_fp8;
+  }
+
+  if (write_fp8_output && !out_fp8) {
+    return cudaErrorInvalidValue;
+  }
+  if (!p.buf.attn_o_half && !(use_fp8_cudnn && write_fp8_output)) {
+    return cudaErrorInvalidValue;
+  }
+  if (use_fp8_dense_ref) {
+    if (!p.buf.attn_scores_half || !p.buf.attn_probs_fp8) {
+      return cudaErrorInvalidValue;
+    }
+    err = run_cosmos_fp8_dense_ref(
+        q_attn, k_attn, v_attn,
+        p.buf.attn_q_bhmd_fp8,
+        p.buf.attn_k_bhmd_fp8,
+        p.buf.attn_v_bhmd_fp8,
+        p.buf.attn_scores_half,
+        p.buf.attn_probs_fp8,
+        p.buf.attn_o_bhmd_half,
+        p.buf.attn_o_half,
+        p.B, p.M, Mk, p.H, p.D, /*causal=*/false, stream);
+  } else if (use_fp8_cudnn) {
+    // cuDNN frontend scalar tensors may be loaded with vectorized alignment
+    // assumptions. Keep every scalar pointer 16-byte aligned by using float
+    // slots spaced four floats apart.
+    constexpr int kScaleSlot = 0;
+    constexpr int kAmaxSSlot = 4;
+    constexpr int kAmaxOSlot = 8;
+    if (!p.buf.attn_tc_scale || p.buf.attn_tc_scale_elems <= kAmaxOSlot) {
+      return cudaErrorInvalidValue;
+    }
+    if (!p.buf.attn_tc_scale_is_ones) {
+      err = cosmos_fill_float(p.buf.attn_tc_scale + kScaleSlot, 1, 1.0f, stream);
+      if (err != cudaSuccess) return err;
+    }
+    cutlass::float_e4m3_t* fp8_out = out_fp8;
+    if (!fp8_out) {
+      if (!p.buf.linear_fp8_scratch) return cudaErrorInvalidValue;
+      fp8_out = p.buf.linear_fp8_scratch;
+    }
+    const auto sdpa_selection = select_cosmos_fp8_sdpa(p.B, p.M, Mk, p.H, p.D);
+    const bool input_bhmd = sdpa_selection.layout == "bhmd";
+    const cutlass::float_e4m3_t* q_cudnn = q_attn;
+    const cutlass::float_e4m3_t* k_cudnn = k_attn;
+    const cutlass::float_e4m3_t* v_cudnn = v_attn;
+    if (input_bhmd) {
+      if (!p.buf.attn_q_bhmd_fp8 || !p.buf.attn_k_bhmd_fp8 || !p.buf.attn_v_bhmd_fp8) {
+        return cudaErrorInvalidValue;
+      }
+      q_cudnn = q_fp8_bhmd ? q_fp8_bhmd : p.buf.attn_q_bhmd_fp8;
+      k_cudnn = k_fp8_bhmd ? k_fp8_bhmd : p.buf.attn_k_bhmd_fp8;
+      v_cudnn = v_fp8_bhmd ? v_fp8_bhmd : p.buf.attn_v_bhmd_fp8;
+      if (!q_fp8_bhmd) {
+        err = cosmos_fp8_bmhd_to_bhmd(q_attn, p.buf.attn_q_bhmd_fp8, p.B, p.M, p.H, p.D, stream);
+        if (err != cudaSuccess) return err;
+      }
+      if (!k_fp8_bhmd) {
+        err = cosmos_fp8_bmhd_to_bhmd(k_attn, p.buf.attn_k_bhmd_fp8, p.B, Mk, p.H, p.D, stream);
+        if (err != cudaSuccess) return err;
+      }
+      if (!v_fp8_bhmd && v_attn != p.buf.attn_v_bhmd_fp8) {
+        err = cosmos_fp8_bmhd_to_bhmd(v_attn, p.buf.attn_v_bhmd_fp8, p.B, Mk, p.H, p.D, stream);
+        if (err != cudaSuccess) return err;
+      }
+    }
+    (void)v_fp8_bhdm;
+    err = run_cudnn_fmha_packed_qkv_fp8(
+        q_cudnn, k_cudnn, v_cudnn, fp8_out,
+        p.buf.attn_tc_scale + kScaleSlot,
+        p.buf.attn_tc_scale + kScaleSlot,
+        p.buf.attn_tc_scale + kScaleSlot,
+        p.buf.attn_tc_scale + kScaleSlot,
+        p.buf.attn_tc_scale + kScaleSlot,
+        p.buf.attn_tc_scale + kScaleSlot,
+        p.buf.attn_tc_scale + kAmaxSSlot,
+        p.buf.attn_tc_scale + kAmaxOSlot,
+        p.B, p.M, Mk, p.H, p.D, /*causal=*/false, 0.0f, stream);
+    if (err != cudaSuccess) return err;
+    if (!out_fp8) {
+      err = cosmos_fp8_to_half_bf16(
+          fp8_out,
+          p.buf.attn_o_half,
+          write_bf16_output ? out : nullptr,
+          q_elems,
+          stream);
+      if (err != cudaSuccess) return err;
+    }
+  }
+  if (err != cudaSuccess) return err;
+
+  if (write_fp8_output && !use_fp8_cudnn) {
+    err = cosmos_half_to_fp8(p.buf.attn_o_half, out_fp8, q_elems, stream);
+    if (err != cudaSuccess) return err;
+  }
+
+  if (use_fp8_cudnn && write_fp8_output) {
+    if (!write_bf16_output) {
+      return cudaSuccess;
+    }
+    if (!out) return cudaErrorInvalidValue;
+    return cosmos_fp8_to_half_bf16(out_fp8, nullptr, out, q_elems, stream);
+  }
+
+  if (!write_bf16_output) {
+    return cudaSuccess;
+  }
+  if (!out) return cudaErrorInvalidValue;
+  return cosmos_half_to_bf16(p.buf.attn_o_half, out, q_elems, stream);
+}
+
+}  // namespace
+
+static bool cosmos_block_profile_enabled() {
+  const char* v = std::getenv("OMNIDREAMS_DIT_PROFILE");
+  return v && v[0] && v[0] != '0';
+}
+
+// ---------------------------------------------------------------------------
+// Pack [M, K] row-major activations into [M, H, D] BMHK layout AND apply
+// rotate-half RoPE in one fused kernel.
+//
+// Layout note: with K = H * D row-major, [M, K] is already byte-equivalent
+// to [M, H, D] row-major -- no transposition needed. So this kernel reduces
+// to: read element, multiply with cos/sin, write back. The "pack" is just
+// a memcpy when no RoPE is needed; with RoPE we apply rotate-half in-place.
+//
+// rotate-half convention (matches Cosmos's apply_cosmos_rope in the bridge):
+//   For each [M, H, D] row, with d_half = D / 2:
+//     out[..., :d_half]  = x[..., :d_half] * cos[..., :d_half]
+//                        - x[..., d_half:] * sin[..., :d_half]
+//     out[..., d_half:]  = x[..., d_half:] * cos[..., d_half:]
+//                        + x[..., :d_half] * sin[..., d_half:]
+//
+// (`cos`/`sin` are already broadcast across H -- only [M, D] -- since the
+// bridge precomputes them as `[M, 1, 1, D] -> [1, M, 1, D]`.)
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_pack_rope_kernel(
+    const ElementT* __restrict__ src,      // [M, K] row-major (K = H * D)
+    const ElementT* __restrict__ cos_tab,  // [M, D]
+    const ElementT* __restrict__ sin_tab,  // [M, D]
+    ElementT* __restrict__ dst,            // [M, H, D] row-major
+    int M, int H, int D)
+{
+  int m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || h >= H) return;
+
+  int d_half = D / 2;
+  size_t base_src = size_t(m) * (H * D) + size_t(h) * D;
+  size_t base_dst = (size_t(m) * H + size_t(h)) * D;
+  size_t base_rt  = size_t(m) * D;
+
+  for (int d = tid; d < D; d += blockDim.x) {
+    float x_d  = omnidreams_singleview::to_float(src[base_src + d]);
+    int   d_op = (d < d_half) ? (d + d_half) : (d - d_half);
+    float x_op = omnidreams_singleview::to_float(src[base_src + d_op]);
+    // For first half (d < d_half): rotate_half pairs (x[d], x[d_op]) where d_op = d + d_half.
+    //   pair: (-x_op, x_d) under rotate_half (negate second half, swap halves).
+    //   So: out[d] = x_d * cos[d] + (-x_op) * sin[d].
+    // For second half (d >= d_half):
+    //   pair element after rotate_half is x_op (which is x[d_op]=x[d-d_half], from the first half).
+    //   out[d] = x_d * cos[d] + x_op * sin[d].
+    float c    = omnidreams_singleview::to_float(cos_tab[base_rt + d]);
+    float s    = omnidreams_singleview::to_float(sin_tab[base_rt + d]);
+    float rot  = (d < d_half) ? (-x_op) : x_op;
+    dst[base_dst + d] = omnidreams_singleview::from_float<ElementT>(x_d * c + rot * s);
+  }
+}
+
+template <typename ElementT>
+static cudaError_t cosmos_pack_rope(
+    const ElementT* src,
+    const ElementT* cos_tab,
+    const ElementT* sin_tab,
+    ElementT* dst,
+    int M, int H, int D,
+    cudaStream_t stream)
+{
+  if (M <= 0 || H <= 0 || D <= 0) return cudaSuccess;
+  int threads = (D <= 128) ? 64 : 128;
+  dim3 grid(H, M);
+  cosmos_pack_rope_kernel<ElementT><<<grid, threads, 0, stream>>>(
+      src, cos_tab, sin_tab, dst, M, H, D);
+  return cudaGetLastError();
+}
+
+// ---------------------------------------------------------------------------
+// Split fused [M, 3K] QKV projection output into contiguous [M, K] buffers.
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_split_qkv_kernel(
+    const ElementT* __restrict__ qkv,
+    ElementT* __restrict__ q,
+    ElementT* __restrict__ k,
+    ElementT* __restrict__ v,
+    int M, int K)
+{
+  int m = blockIdx.y;
+  int which = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || which >= 3) return;
+
+  const ElementT* src = qkv + size_t(m) * 3 * K + size_t(which) * K;
+  ElementT* dst = (which == 0) ? q : ((which == 1) ? k : v);
+  dst += size_t(m) * K;
+  for (int j = tid; j < K; j += blockDim.x) {
+    dst[j] = src[j];
+  }
+}
+
+template <typename ElementT>
+cudaError_t cosmos_split_qkv(
+    const ElementT* qkv,
+    ElementT* q,
+    ElementT* k,
+    ElementT* v,
+    int M, int K,
+    cudaStream_t stream)
+{
+  if (M <= 0 || K <= 0) return cudaSuccess;
+  dim3 grid(3, M);
+  cosmos_split_qkv_kernel<ElementT><<<grid, 128, 0, stream>>>(qkv, q, k, v, M, K);
+  return cudaGetLastError();
+}
+
+template <typename ElementT>
+__global__ void cosmos_qkv_postprocess_cache_kernel(
+    const ElementT* __restrict__ qkv,       // [B*M, 3K]
+    const ElementT* __restrict__ q_gamma,   // [D]
+    const ElementT* __restrict__ k_gamma,   // [D]
+    const ElementT* __restrict__ cos_tab,   // [M, D]
+    const ElementT* __restrict__ sin_tab,   // [M, D]
+    ElementT* __restrict__ q_out,           // [B*M, H, D]
+    ElementT* __restrict__ k_cache,         // [B, cap, H, D]
+    ElementT* __restrict__ v_cache,         // [B, cap, H, D]
+    int B, int M, int H, int D,
+    int write_start, int cache_cap,
+    float eps)
+{
+  int mh = blockIdx.x;
+  int b = blockIdx.y;
+  int m = blockIdx.z;
+  int tid = threadIdx.x;
+  if (mh >= H || b >= B || m >= M) return;
+
+  int K = H * D;
+  int global_m = b * M + m;
+  size_t base = size_t(global_m) * 3 * K + size_t(mh) * D;
+  size_t q_base = base;
+  size_t k_base = base + K;
+  size_t v_base = base + 2 * K;
+
+  extern __shared__ float smem[];
+  float* q_smem = smem;
+  float* k_smem = smem + blockDim.x;
+  float q_acc = 0.f;
+  float k_acc = 0.f;
+  for (int d = tid; d < D; d += blockDim.x) {
+    float qv = omnidreams_singleview::to_float(qkv[q_base + d]);
+    float kv = omnidreams_singleview::to_float(qkv[k_base + d]);
+    q_acc += qv * qv;
+    k_acc += kv * kv;
+  }
+  q_smem[tid] = q_acc;
+  k_smem[tid] = k_acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) {
+      q_smem[tid] += q_smem[tid + off];
+      k_smem[tid] += k_smem[tid + off];
+    }
+    __syncthreads();
+  }
+  float q_rms = rsqrtf(q_smem[0] / float(D) + eps);
+  float k_rms = rsqrtf(k_smem[0] / float(D) + eps);
+  int d_half = D / 2;
+  size_t q_out_base = (size_t(global_m) * H + mh) * D;
+  size_t cache_base = ((size_t(b) * cache_cap + size_t(write_start + m)) * H + mh) * D;
+  size_t rope_base = size_t(m) * D;
+
+  for (int d = tid; d < D; d += blockDim.x) {
+    int d_op = (d < d_half) ? (d + d_half) : (d - d_half);
+    float c = omnidreams_singleview::to_float(cos_tab[rope_base + d]);
+    float s = omnidreams_singleview::to_float(sin_tab[rope_base + d]);
+
+    float qv = omnidreams_singleview::to_float(qkv[q_base + d]) * q_rms * omnidreams_singleview::to_float(q_gamma[d]);
+    float qop = omnidreams_singleview::to_float(qkv[q_base + d_op]) * q_rms * omnidreams_singleview::to_float(q_gamma[d_op]);
+    float qrot = (d < d_half) ? (-qop) : qop;
+    q_out[q_out_base + d] = omnidreams_singleview::from_float<ElementT>(qv * c + qrot * s);
+
+    float kv = omnidreams_singleview::to_float(qkv[k_base + d]) * k_rms * omnidreams_singleview::to_float(k_gamma[d]);
+    float kop = omnidreams_singleview::to_float(qkv[k_base + d_op]) * k_rms * omnidreams_singleview::to_float(k_gamma[d_op]);
+    float krot = (d < d_half) ? (-kop) : kop;
+    k_cache[cache_base + d] = omnidreams_singleview::from_float<ElementT>(kv * c + krot * s);
+
+    v_cache[cache_base + d] = qkv[v_base + d];
+  }
+}
+
+template <typename ElementT>
+static cudaError_t cosmos_qkv_postprocess_cache(
+    const ElementT* qkv,
+    const ElementT* q_gamma,
+    const ElementT* k_gamma,
+    const ElementT* cos_tab,
+    const ElementT* sin_tab,
+    ElementT* q_out,
+    ElementT* k_cache,
+    ElementT* v_cache,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0 || H <= 0 || D <= 0) return cudaSuccess;
+  int threads = (D <= 64) ? 64 : (D <= 128 ? 128 : 256);
+  dim3 grid(H, B, M);
+  size_t smem = 2 * threads * sizeof(float);
+  cosmos_qkv_postprocess_cache_kernel<ElementT><<<grid, threads, smem, stream>>>(
+      qkv, q_gamma, k_gamma, cos_tab, sin_tab, q_out, k_cache, v_cache,
+      B, M, H, D, write_start, cache_cap, 1e-6f);
+  return cudaGetLastError();
+}
+
+// ---------------------------------------------------------------------------
+// Pack [M, K] row-major into [M, H, D] without RoPE (V branch).
+// (Identity copy; included for clarity. Could be skipped entirely since
+// [M, K] and [M, H, D] share the same byte layout when K = H * D.)
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_pack_identity_kernel(
+    const ElementT* __restrict__ src,
+    ElementT* __restrict__ dst,
+    int M, int H, int D)
+{
+  int m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || h >= H) return;
+  size_t base_src = size_t(m) * (H * D) + size_t(h) * D;
+  size_t base_dst = (size_t(m) * H + size_t(h)) * D;
+  for (int d = tid; d < D; d += blockDim.x) {
+    dst[base_dst + d] = src[base_src + d];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unpack [M, H, D] BMHK layout back to [M, K] row-major (FMHA output -> out proj).
+// Same byte layout when K = H * D, so this is an identity copy.
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_unpack_kernel(
+    const ElementT* __restrict__ src,
+    ElementT* __restrict__ dst,
+    int M, int H, int D)
+{
+  int m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || h >= H) return;
+  size_t base_src = (size_t(m) * H + size_t(h)) * D;
+  size_t base_dst = size_t(m) * (H * D) + size_t(h) * D;
+  for (int d = tid; d < D; d += blockDim.x) {
+    dst[base_dst + d] = src[base_src + d];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Append packed [M, H, D] BMHK K and V buffers into a [B, cap, H, D] cache
+// at slot [write_start : write_start + M).
+//
+// Layout reminder:
+//   cache:   [B, cap, H, D]   -> stride is (cap * H * D, H * D, D, 1)
+//   src:     [M, H, D]        -> contiguous
+//
+// We do this as `cudaMemcpy2DAsync` would, but with a small kernel since
+// the BMHK rows are contiguous within each batch slice and we only write
+// for one batch (B=1 in the streaming path).
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_write_kv_cache_kernel(
+    const ElementT* __restrict__ src,      // [M, H, D]
+    ElementT* __restrict__ cache,          // [B, cap, H, D]
+    int M, int H, int D,
+    int write_start, int cache_cap, int b_idx)
+{
+  int m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || h >= H) return;
+  size_t src_off   = (size_t(m) * H + size_t(h)) * D;
+  size_t dst_off   = ((size_t(b_idx) * cache_cap + size_t(write_start) + size_t(m)) * H + size_t(h)) * D;
+  for (int d = tid; d < D; d += blockDim.x) {
+    cache[dst_off + d] = src[src_off + d];
+  }
+}
+
+template <typename ElementT>
+static cudaError_t cosmos_write_kv_cache(
+    const ElementT* k_src,
+    const ElementT* v_src,
+    ElementT* k_cache,
+    ElementT* v_cache,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0) return cudaSuccess;
+  int threads = (D <= 128) ? 64 : 128;
+  dim3 grid(H, M);
+  for (int b = 0; b < B; ++b) {
+    cosmos_write_kv_cache_kernel<ElementT><<<grid, threads, 0, stream>>>(
+        k_src + size_t(b) * M * H * D, k_cache, M, H, D, write_start, cache_cap, b);
+    cudaError_t e = cudaGetLastError();
+    if (e != cudaSuccess) return e;
+    cosmos_write_kv_cache_kernel<ElementT><<<grid, threads, 0, stream>>>(
+        v_src + size_t(b) * M * H * D, v_cache, M, H, D, write_start, cache_cap, b);
+    e = cudaGetLastError();
+    if (e != cudaSuccess) return e;
+  }
+  return cudaSuccess;
+}
+
+template <typename ElementT>
+__global__ void cosmos_write_kv_cache_bf16_and_fp8_kernel(
+    const ElementT* __restrict__ k_src,       // [M, H, D]
+    const ElementT* __restrict__ v_src,       // [M, H, D]
+    ElementT* __restrict__ k_cache,           // [B, cap, H, D]
+    ElementT* __restrict__ v_cache,           // [B, cap, H, D]
+    cutlass::float_e4m3_t* __restrict__ k_cache_fp8,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8,
+    int M, int H, int D,
+    int write_start, int cache_cap, int b_idx)
+{
+  int m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || h >= H) return;
+
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  size_t src_off = (size_t(m) * H + size_t(h)) * D;
+  size_t dst_off = ((size_t(b_idx) * cache_cap + size_t(write_start) + size_t(m)) * H + size_t(h)) * D;
+  for (int d = tid; d < D; d += blockDim.x) {
+    ElementT k_val = k_src[src_off + d];
+    ElementT v_val = v_src[src_off + d];
+    k_cache[dst_off + d] = k_val;
+    v_cache[dst_off + d] = v_val;
+    k_cache_fp8[dst_off + d] = to_fp8(omnidreams_singleview::to_float(k_val));
+    v_cache_fp8[dst_off + d] = to_fp8(omnidreams_singleview::to_float(v_val));
+  }
+}
+
+template <typename ElementT>
+static cudaError_t cosmos_write_kv_cache_bf16_and_fp8(
+    const ElementT* k_src,
+    const ElementT* v_src,
+    ElementT* k_cache,
+    ElementT* v_cache,
+    cutlass::float_e4m3_t* k_cache_fp8,
+    cutlass::float_e4m3_t* v_cache_fp8,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0) return cudaSuccess;
+  if (!k_src || !v_src || !k_cache || !v_cache || !k_cache_fp8 || !v_cache_fp8) {
+    return cudaErrorInvalidValue;
+  }
+  int threads = (D <= 128) ? 64 : 128;
+  dim3 grid(H, M);
+  for (int b = 0; b < B; ++b) {
+    cosmos_write_kv_cache_bf16_and_fp8_kernel<ElementT><<<grid, threads, 0, stream>>>(
+        k_src + size_t(b) * M * H * D,
+        v_src + size_t(b) * M * H * D,
+        k_cache,
+        v_cache,
+        k_cache_fp8,
+        v_cache_fp8,
+        M, H, D, write_start, cache_cap, b);
+    cudaError_t e = cudaGetLastError();
+    if (e != cudaSuccess) return e;
+  }
+  return cudaSuccess;
+}
+
+template <typename ElementT>
+__global__ void cosmos_write_self_kv_cache_rope_bf16_and_fp8_kernel(
+    const ElementT* __restrict__ k_src,       // [M, H, D] row-major, pre-RMSNorm
+    const ElementT* __restrict__ v_src,       // [M, H, D] row-major
+    const ElementT* __restrict__ cos_tab,     // [M, D]
+    const ElementT* __restrict__ sin_tab,     // [M, D]
+    ElementT* __restrict__ k_cache,           // [B, cap, H, D]
+    ElementT* __restrict__ v_cache,           // [B, cap, H, D]
+    cutlass::float_e4m3_t* __restrict__ k_cache_fp8,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8,
+    cutlass::float_e4m3_t* __restrict__ k_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8_bhdm,
+    int M, int H, int D,
+    int write_start, int cache_cap, int b_idx)
+{
+  int m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  if (m >= M || h >= H) return;
+
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  int d_half = D / 2;
+  size_t src_off = (size_t(m) * H + size_t(h)) * D;
+  size_t rt_off = size_t(m) * D;
+  size_t cache_m = size_t(write_start) + size_t(m);
+  size_t dst_off = ((size_t(b_idx) * cache_cap + cache_m) * H + size_t(h)) * D;
+  size_t k_tc_off = ((size_t(b_idx) * H + size_t(h)) * cache_cap + cache_m) * D;
+  size_t v_tc_off = ((size_t(b_idx) * H + size_t(h)) * D + size_t(0)) * cache_cap + cache_m;
+  for (int d = tid; d < D; d += blockDim.x) {
+    float k_d = omnidreams_singleview::to_float(k_src[src_off + d]);
+    int d_op = (d < d_half) ? (d + d_half) : (d - d_half);
+    float k_op = omnidreams_singleview::to_float(k_src[src_off + d_op]);
+    float c = omnidreams_singleview::to_float(cos_tab[rt_off + d]);
+    float s = omnidreams_singleview::to_float(sin_tab[rt_off + d]);
+    float rot = (d < d_half) ? (-k_op) : k_op;
+    float k_out_f = k_d * c + rot * s;
+    ElementT k_out = omnidreams_singleview::from_float<ElementT>(k_out_f);
+    ElementT v_out = v_src[src_off + d];
+    if (k_cache) {
+      k_cache[dst_off + d] = k_out;
+    }
+    if (v_cache) {
+      v_cache[dst_off + d] = v_out;
+    }
+    cutlass::float_e4m3_t k_fp8 = to_fp8(k_out_f);
+    cutlass::float_e4m3_t v_fp8 = to_fp8(omnidreams_singleview::to_float(v_out));
+    k_cache_fp8[dst_off + d] = k_fp8;
+    v_cache_fp8[dst_off + d] = v_fp8;
+    if (k_cache_fp8_bhmd) {
+      k_cache_fp8_bhmd[k_tc_off + d] = k_fp8;
+    }
+    if (v_cache_fp8_bhmd) {
+      v_cache_fp8_bhmd[k_tc_off + d] = v_fp8;
+    }
+    if (v_cache_fp8_bhdm) {
+      v_cache_fp8_bhdm[v_tc_off + size_t(d) * cache_cap] = v_fp8;
+    }
+  }
+}
+
+template <typename ElementT>
+static cudaError_t cosmos_write_self_kv_cache_rope_bf16_and_fp8(
+    const ElementT* k_src,
+    const ElementT* v_src,
+    const ElementT* cos_tab,
+    const ElementT* sin_tab,
+    ElementT* k_cache,
+    ElementT* v_cache,
+    cutlass::float_e4m3_t* k_cache_fp8,
+    cutlass::float_e4m3_t* v_cache_fp8,
+    cutlass::float_e4m3_t* k_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* v_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* v_cache_fp8_bhdm,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0) return cudaSuccess;
+  if (!k_src || !v_src || !cos_tab || !sin_tab || !k_cache_fp8 || !v_cache_fp8) {
+    return cudaErrorInvalidValue;
+  }
+  int threads = (D <= 128) ? 64 : 128;
+  dim3 grid(H, M);
+  for (int b = 0; b < B; ++b) {
+    cosmos_write_self_kv_cache_rope_bf16_and_fp8_kernel<ElementT><<<grid, threads, 0, stream>>>(
+        k_src + size_t(b) * M * H * D,
+        v_src + size_t(b) * M * H * D,
+        cos_tab,
+        sin_tab,
+        k_cache,
+        v_cache,
+        k_cache_fp8,
+        v_cache_fp8,
+        k_cache_fp8_bhmd,
+        v_cache_fp8_bhmd,
+        v_cache_fp8_bhdm,
+        M, H, D, write_start, cache_cap, b);
+    cudaError_t e = cudaGetLastError();
+    if (e != cudaSuccess) return e;
+  }
+  return cudaSuccess;
+}
+
+template <bool WriteQFp8>
+__global__ void cosmos_fused_qkv_rope_cache_fp8_kernel(
+    const cutlass::bfloat16_t* __restrict__ qkv_row,
+    const cutlass::bfloat16_t* __restrict__ q_gamma,
+    const cutlass::bfloat16_t* __restrict__ k_gamma,
+    const cutlass::bfloat16_t* __restrict__ cos_tab,
+    const cutlass::bfloat16_t* __restrict__ sin_tab,
+    cutlass::float_e4m3_t* __restrict__ q_fp8,
+    cutlass::float_e4m3_t* __restrict__ q_fp8_bhmd,
+    cutlass::bfloat16_t* __restrict__ k_cache,
+    cutlass::bfloat16_t* __restrict__ v_cache,
+    cutlass::float_e4m3_t* __restrict__ k_cache_fp8,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8,
+    cutlass::float_e4m3_t* __restrict__ k_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8_bhdm,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap)
+{
+  int row_m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  const int total_m = B * M;
+  if (row_m >= total_m || h >= H) return;
+
+  __shared__ float q_warp_sums[WriteQFp8 ? 8 : 1];
+  __shared__ float k_warp_sums[8];
+
+  const int b = row_m / M;
+  const int m = row_m - b * M;
+  const int K = H * D;
+  const int d_half = D / 2;
+  const size_t row_base = size_t(row_m) * (3 * K);
+  const size_t q_base = row_base + size_t(h) * D;
+  const size_t k_base = row_base + size_t(K) + size_t(h) * D;
+  const size_t v_base = row_base + size_t(2 * K) + size_t(h) * D;
+  const size_t rt_base = size_t(row_m) * D;
+  const size_t bmhk_base = (size_t(row_m) * H + size_t(h)) * D;
+  const size_t cache_m = size_t(write_start) + size_t(m);
+  const size_t cache_base = ((size_t(b) * cache_cap + cache_m) * H + size_t(h)) * D;
+  const size_t k_tc_base = ((size_t(b) * H + size_t(h)) * cache_cap + cache_m) * D;
+  const size_t v_tc_base = ((size_t(b) * H + size_t(h)) * D) * cache_cap + cache_m;
+
+  float q_acc = 0.0f;
+  float k_acc = 0.0f;
+  for (int d = tid; d < D; d += blockDim.x) {
+    if constexpr (WriteQFp8) {
+      float q = cosmos_bf16_raw_or_zero<WriteQFp8>(qkv_row, q_base + d);
+      q_acc += q * q;
+    }
+    float k = omnidreams_singleview::to_float(qkv_row[k_base + d]);
+    k_acc += k * k;
+  }
+  if constexpr (WriteQFp8) {
+    q_acc = cosmos_warp_sum(q_acc);
+  }
+  k_acc = cosmos_warp_sum(k_acc);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warp_count = (blockDim.x + 31) >> 5;
+  if (lane == 0) {
+    k_warp_sums[warp] = k_acc;
+  }
+  cosmos_store_warp_sum_if<WriteQFp8>(q_warp_sums, q_acc, lane, warp);
+  __syncthreads();
+  float q_total = cosmos_reduce_warp_sums_if<WriteQFp8>(
+      q_warp_sums, tid, warp, warp_count);
+  float k_total = (tid < warp_count) ? k_warp_sums[tid] : 0.0f;
+  k_total = (warp == 0) ? cosmos_warp_sum(k_total) : 0.0f;
+  if (tid == 0) {
+    k_warp_sums[0] = k_total;
+  }
+  cosmos_store_block_sum_if<WriteQFp8>(q_warp_sums, q_total, tid);
+  __syncthreads();
+  const float q_rms = cosmos_rms_from_block_sum_if<WriteQFp8>(
+      q_warp_sums, D, 1e-6f);
+  const float k_rms = rsqrtf(k_warp_sums[0] / float(D) + 1e-6f);
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  for (int d = tid; d < D; d += blockDim.x) {
+    int d_op = (d < d_half) ? (d + d_half) : (d - d_half);
+
+    float c = omnidreams_singleview::to_float(cos_tab[rt_base + d]);
+    float s = omnidreams_singleview::to_float(sin_tab[rt_base + d]);
+    if constexpr (WriteQFp8) {
+      float q_d = omnidreams_singleview::to_float(qkv_row[q_base + d]) *
+                  q_rms * omnidreams_singleview::to_float(q_gamma[d]);
+      float q_op = omnidreams_singleview::to_float(qkv_row[q_base + d_op]) *
+                   q_rms * omnidreams_singleview::to_float(q_gamma[d_op]);
+      cutlass::bfloat16_t q_d_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(q_d);
+      cutlass::bfloat16_t q_op_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(q_op);
+      float q_norm = omnidreams_singleview::to_float(q_d_bf16);
+      float q_norm_op = omnidreams_singleview::to_float(q_op_bf16);
+      float q_rot = q_norm * c + ((d < d_half) ? -q_norm_op : q_norm_op) * s;
+      cutlass::float_e4m3_t q_out = to_fp8(q_rot);
+      q_fp8[bmhk_base + d] = q_out;
+      if (q_fp8_bhmd) {
+        size_t q_tc_idx = ((size_t(b) * H + size_t(h)) * M + size_t(m)) * D + d;
+        q_fp8_bhmd[q_tc_idx] = q_out;
+      }
+    }
+
+    float k_d = omnidreams_singleview::to_float(qkv_row[k_base + d]) *
+                k_rms * omnidreams_singleview::to_float(k_gamma[d]);
+    float k_op = omnidreams_singleview::to_float(qkv_row[k_base + d_op]) *
+                 k_rms * omnidreams_singleview::to_float(k_gamma[d_op]);
+    cutlass::bfloat16_t k_d_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(k_d);
+    cutlass::bfloat16_t k_op_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(k_op);
+    float k_norm = omnidreams_singleview::to_float(k_d_bf16);
+    float k_norm_op = omnidreams_singleview::to_float(k_op_bf16);
+    float k_rot = k_norm * c + ((d < d_half) ? -k_norm_op : k_norm_op) * s;
+    cutlass::bfloat16_t k_out_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(k_rot);
+    cutlass::bfloat16_t v_out_bf16 = qkv_row[v_base + d];
+    if (k_cache) {
+      k_cache[cache_base + d] = k_out_bf16;
+    }
+    if (v_cache) {
+      v_cache[cache_base + d] = v_out_bf16;
+    }
+    cutlass::float_e4m3_t k_out_fp8 = to_fp8(k_rot);
+    cutlass::float_e4m3_t v_out_fp8 = to_fp8(omnidreams_singleview::to_float(v_out_bf16));
+    if (k_cache_fp8) {
+      k_cache_fp8[cache_base + d] = k_out_fp8;
+    }
+    if (v_cache_fp8) {
+      v_cache_fp8[cache_base + d] = v_out_fp8;
+    }
+    if (k_cache_fp8_bhmd) {
+      k_cache_fp8_bhmd[k_tc_base + d] = k_out_fp8;
+    }
+    if (v_cache_fp8_bhmd) {
+      v_cache_fp8_bhmd[k_tc_base + d] = v_out_fp8;
+    }
+    if (v_cache_fp8_bhdm) {
+      v_cache_fp8_bhdm[v_tc_base + size_t(d) * cache_cap] = v_out_fp8;
+    }
+  }
+}
+
+template <bool WriteQFp8>
+__global__ void cosmos_fused_qkv_rope_cache_fp8_d128_kernel(
+    const cutlass::bfloat16_t* __restrict__ qkv_row,
+    const cutlass::bfloat16_t* __restrict__ q_gamma,
+    const cutlass::bfloat16_t* __restrict__ k_gamma,
+    const cutlass::bfloat16_t* __restrict__ cos_tab,
+    const cutlass::bfloat16_t* __restrict__ sin_tab,
+    cutlass::float_e4m3_t* __restrict__ q_fp8,
+    cutlass::float_e4m3_t* __restrict__ q_fp8_bhmd,
+    cutlass::bfloat16_t* __restrict__ k_cache,
+    cutlass::bfloat16_t* __restrict__ v_cache,
+    cutlass::float_e4m3_t* __restrict__ k_cache_fp8,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8,
+    cutlass::float_e4m3_t* __restrict__ k_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* __restrict__ v_cache_fp8_bhdm,
+    int B, int M, int H,
+    int write_start, int cache_cap)
+{
+  constexpr int D = 128;
+  constexpr int d_half = D / 2;
+  int row_m = blockIdx.y;
+  int h = blockIdx.x;
+  int tid = threadIdx.x;
+  const int total_m = B * M;
+  if (row_m >= total_m || h >= H || tid >= d_half) return;
+
+  __shared__ float q_warp_sums[WriteQFp8 ? 2 : 1];
+  __shared__ float k_warp_sums[2];
+
+  const int b = row_m / M;
+  const int m = row_m - b * M;
+  const int K = H * D;
+  const size_t row_base = size_t(row_m) * (3 * K);
+  const size_t q_base = row_base + size_t(h) * D;
+  const size_t k_base = row_base + size_t(K) + size_t(h) * D;
+  const size_t v_base = row_base + size_t(2 * K) + size_t(h) * D;
+  const size_t rt_base = size_t(row_m) * D;
+  const size_t bmhk_base = (size_t(row_m) * H + size_t(h)) * D;
+  const size_t cache_m = size_t(write_start) + size_t(m);
+  const size_t cache_base = ((size_t(b) * cache_cap + cache_m) * H + size_t(h)) * D;
+  const size_t k_tc_base = ((size_t(b) * H + size_t(h)) * cache_cap + cache_m) * D;
+  const size_t v_tc_base = ((size_t(b) * H + size_t(h)) * D) * cache_cap + cache_m;
+
+  const int j0 = tid;
+  const int j1 = tid + d_half;
+  float q0_raw = 0.0f;
+  float q1_raw = 0.0f;
+  float q_acc = 0.0f;
+  if constexpr (WriteQFp8) {
+    q0_raw = omnidreams_singleview::to_float(qkv_row[q_base + j0]);
+    q1_raw = omnidreams_singleview::to_float(qkv_row[q_base + j1]);
+    q_acc = q0_raw * q0_raw + q1_raw * q1_raw;
+    q_acc = cosmos_warp_sum(q_acc);
+  }
+  float k0_raw = omnidreams_singleview::to_float(qkv_row[k_base + j0]);
+  float k1_raw = omnidreams_singleview::to_float(qkv_row[k_base + j1]);
+  float k_acc = k0_raw * k0_raw + k1_raw * k1_raw;
+
+  k_acc = cosmos_warp_sum(k_acc);
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  if (lane == 0) {
+    k_warp_sums[warp] = k_acc;
+  }
+  cosmos_store_warp_sum_if<WriteQFp8>(q_warp_sums, q_acc, lane, warp);
+  __syncthreads();
+  float q_total = cosmos_reduce_warp_sums_if<WriteQFp8>(
+      q_warp_sums, tid, warp, 2);
+  float k_total = (tid < 2) ? k_warp_sums[tid] : 0.0f;
+  k_total = (warp == 0) ? cosmos_warp_sum(k_total) : 0.0f;
+  if (tid == 0) {
+    k_warp_sums[0] = k_total;
+  }
+  cosmos_store_block_sum_if<WriteQFp8>(q_warp_sums, q_total, tid);
+  __syncthreads();
+  const float q_rms = cosmos_rms_from_block_sum_if<WriteQFp8>(
+      q_warp_sums, D, 1e-6f);
+  const float k_rms = rsqrtf(k_warp_sums[0] / float(D) + 1e-6f);
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  float c0 = omnidreams_singleview::to_float(cos_tab[rt_base + j0]);
+  float s0 = omnidreams_singleview::to_float(sin_tab[rt_base + j0]);
+  float c1 = omnidreams_singleview::to_float(cos_tab[rt_base + j1]);
+  float s1 = omnidreams_singleview::to_float(sin_tab[rt_base + j1]);
+
+  if constexpr (WriteQFp8) {
+    float q0 = q0_raw * q_rms * omnidreams_singleview::to_float(q_gamma[j0]);
+    float q1 = q1_raw * q_rms * omnidreams_singleview::to_float(q_gamma[j1]);
+    cutlass::bfloat16_t q0_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(q0);
+    cutlass::bfloat16_t q1_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(q1);
+    float qn0 = omnidreams_singleview::to_float(q0_bf16);
+    float qn1 = omnidreams_singleview::to_float(q1_bf16);
+    cutlass::float_e4m3_t q_out0 = to_fp8(qn0 * c0 - qn1 * s0);
+    cutlass::float_e4m3_t q_out1 = to_fp8(qn1 * c1 + qn0 * s1);
+    q_fp8[bmhk_base + j0] = q_out0;
+    q_fp8[bmhk_base + j1] = q_out1;
+    if (q_fp8_bhmd) {
+      size_t q_tc_base = ((size_t(b) * H + size_t(h)) * M + size_t(m)) * D;
+      q_fp8_bhmd[q_tc_base + j0] = q_out0;
+      q_fp8_bhmd[q_tc_base + j1] = q_out1;
+    }
+  }
+
+  float k0 = k0_raw * k_rms * omnidreams_singleview::to_float(k_gamma[j0]);
+  float k1 = k1_raw * k_rms * omnidreams_singleview::to_float(k_gamma[j1]);
+  cutlass::bfloat16_t k0_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(k0);
+  cutlass::bfloat16_t k1_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(k1);
+  float kn0 = omnidreams_singleview::to_float(k0_bf16);
+  float kn1 = omnidreams_singleview::to_float(k1_bf16);
+  float k_rot0 = kn0 * c0 - kn1 * s0;
+  float k_rot1 = kn1 * c1 + kn0 * s1;
+  cutlass::bfloat16_t k_out0_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(k_rot0);
+  cutlass::bfloat16_t k_out1_bf16 = omnidreams_singleview::from_float<cutlass::bfloat16_t>(k_rot1);
+  cutlass::bfloat16_t v_out0_bf16 = qkv_row[v_base + j0];
+  cutlass::bfloat16_t v_out1_bf16 = qkv_row[v_base + j1];
+  if (k_cache) {
+    k_cache[cache_base + j0] = k_out0_bf16;
+    k_cache[cache_base + j1] = k_out1_bf16;
+  }
+  if (v_cache) {
+    v_cache[cache_base + j0] = v_out0_bf16;
+    v_cache[cache_base + j1] = v_out1_bf16;
+  }
+  cutlass::float_e4m3_t k_out0_fp8 = to_fp8(k_rot0);
+  cutlass::float_e4m3_t k_out1_fp8 = to_fp8(k_rot1);
+  cutlass::float_e4m3_t v_out0_fp8 = to_fp8(omnidreams_singleview::to_float(v_out0_bf16));
+  cutlass::float_e4m3_t v_out1_fp8 = to_fp8(omnidreams_singleview::to_float(v_out1_bf16));
+  if (k_cache_fp8) {
+    k_cache_fp8[cache_base + j0] = k_out0_fp8;
+    k_cache_fp8[cache_base + j1] = k_out1_fp8;
+  }
+  if (v_cache_fp8) {
+    v_cache_fp8[cache_base + j0] = v_out0_fp8;
+    v_cache_fp8[cache_base + j1] = v_out1_fp8;
+  }
+  if (k_cache_fp8_bhmd) {
+    k_cache_fp8_bhmd[k_tc_base + j0] = k_out0_fp8;
+    k_cache_fp8_bhmd[k_tc_base + j1] = k_out1_fp8;
+  }
+  if (v_cache_fp8_bhmd) {
+    v_cache_fp8_bhmd[k_tc_base + j0] = v_out0_fp8;
+    v_cache_fp8_bhmd[k_tc_base + j1] = v_out1_fp8;
+  }
+  if (v_cache_fp8_bhdm) {
+    v_cache_fp8_bhdm[v_tc_base + size_t(j0) * cache_cap] = v_out0_fp8;
+    v_cache_fp8_bhdm[v_tc_base + size_t(j1) * cache_cap] = v_out1_fp8;
+  }
+}
+
+template <bool WriteQFp8>
+static cudaError_t cosmos_launch_fused_qkv_rope_cache_fp8_kernel(
+    dim3 grid,
+    int threads,
+    cudaStream_t stream,
+    const cutlass::bfloat16_t* qkv_row,
+    const cutlass::bfloat16_t* q_gamma,
+    const cutlass::bfloat16_t* k_gamma,
+    const cutlass::bfloat16_t* cos_tab,
+    const cutlass::bfloat16_t* sin_tab,
+    cutlass::float_e4m3_t* q_fp8,
+    cutlass::float_e4m3_t* q_fp8_bhmd,
+    cutlass::bfloat16_t* k_cache,
+    cutlass::bfloat16_t* v_cache,
+    cutlass::float_e4m3_t* k_cache_fp8,
+    cutlass::float_e4m3_t* v_cache_fp8,
+    cutlass::float_e4m3_t* k_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* v_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* v_cache_fp8_bhdm,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap)
+{
+  cosmos_fused_qkv_rope_cache_fp8_kernel<WriteQFp8><<<grid, threads, 0, stream>>>(
+      qkv_row, q_gamma, k_gamma, cos_tab, sin_tab,
+      q_fp8, q_fp8_bhmd,
+      k_cache, v_cache,
+      k_cache_fp8, v_cache_fp8,
+      k_cache_fp8_bhmd, v_cache_fp8_bhmd, v_cache_fp8_bhdm,
+      B, M, H, D, write_start, cache_cap);
+  return cudaGetLastError();
+}
+
+static cudaError_t cosmos_fused_qkv_rope_cache_fp8(
+    const cutlass::bfloat16_t* qkv_row,
+    const cutlass::bfloat16_t* q_gamma,
+    const cutlass::bfloat16_t* k_gamma,
+    const cutlass::bfloat16_t* cos_tab,
+    const cutlass::bfloat16_t* sin_tab,
+    cutlass::float_e4m3_t* q_fp8,
+    cutlass::float_e4m3_t* q_fp8_bhmd,
+    cutlass::bfloat16_t* k_cache,
+    cutlass::bfloat16_t* v_cache,
+    cutlass::float_e4m3_t* k_cache_fp8,
+    cutlass::float_e4m3_t* v_cache_fp8,
+    cutlass::float_e4m3_t* k_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* v_cache_fp8_bhmd,
+    cutlass::float_e4m3_t* v_cache_fp8_bhdm,
+    int B, int M, int H, int D,
+    int write_start, int cache_cap,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0 || H <= 0 || D <= 0) return cudaSuccess;
+  if (!qkv_row || !q_gamma || !k_gamma || !cos_tab || !sin_tab) {
+    return cudaErrorInvalidValue;
+  }
+  int threads = cosmos_qkv_rope_threads_for_shape(D);
+  dim3 grid(H, B * M);
+  if (D == 128 && threads == 64) {
+    if (q_fp8) {
+      cosmos_fused_qkv_rope_cache_fp8_d128_kernel<true><<<grid, 64, 0, stream>>>(
+          qkv_row, q_gamma, k_gamma, cos_tab, sin_tab,
+          q_fp8, q_fp8_bhmd,
+          k_cache, v_cache,
+          k_cache_fp8, v_cache_fp8,
+          k_cache_fp8_bhmd, v_cache_fp8_bhmd, v_cache_fp8_bhdm,
+          B, M, H, write_start, cache_cap);
+    } else {
+      cosmos_fused_qkv_rope_cache_fp8_d128_kernel<false><<<grid, 64, 0, stream>>>(
+          qkv_row, q_gamma, k_gamma, cos_tab, sin_tab,
+          q_fp8, q_fp8_bhmd,
+          k_cache, v_cache,
+          k_cache_fp8, v_cache_fp8,
+          k_cache_fp8_bhmd, v_cache_fp8_bhmd, v_cache_fp8_bhdm,
+          B, M, H, write_start, cache_cap);
+    }
+    return cudaGetLastError();
+  }
+  auto launch = q_fp8
+      ? &cosmos_launch_fused_qkv_rope_cache_fp8_kernel<true>
+      : &cosmos_launch_fused_qkv_rope_cache_fp8_kernel<false>;
+  return launch(
+      grid, threads, stream,
+      qkv_row, q_gamma, k_gamma, cos_tab, sin_tab,
+      q_fp8, q_fp8_bhmd,
+      k_cache, v_cache,
+      k_cache_fp8, v_cache_fp8,
+      k_cache_fp8_bhmd, v_cache_fp8_bhmd, v_cache_fp8_bhdm,
+      B, M, H, D, write_start, cache_cap);
+}
+
+// ---------------------------------------------------------------------------
+// Streaming transformer block orchestrator.
+// ---------------------------------------------------------------------------
+cudaError_t cosmos_run_transformer_block_streaming(
+    const CosmosBlockParams& p,
+    cudaStream_t stream)
+{
+  using bf16 = cutlass::bfloat16_t;
+  cudaError_t err;
+
+  const int M    = p.M;
+  const int K    = p.K;
+  const int H    = p.H;
+  const int D    = p.D;
+  const int FF   = p.FF;
+  const int B    = p.B;
+  const int Mk_c = p.Mk_cross;
+  const int read_end = p.self_attn_write_start + M;
+  bool prof = cosmos_block_profile_enabled();
+  enum {
+    EV_START = 0,
+    EV_AFTER_LORA,
+    EV_AFTER_SA_LN,
+    EV_AFTER_SA_QKV,
+    EV_AFTER_SA_POST_QKV,
+    EV_AFTER_SA_FMHA,
+    EV_AFTER_SA_OUT,
+    EV_AFTER_CA_LN_Q,
+    EV_AFTER_CA_FMHA,
+    EV_AFTER_CA_OUT,
+    EV_AFTER_MLP_LN,
+    EV_AFTER_FFN1,
+    EV_AFTER_FFN2,
+    EV_AFTER_DONE,
+    EV_COUNT
+  };
+  cudaEvent_t ev[EV_COUNT];
+  auto rec = [&](int idx) {
+    if (prof) cudaEventRecord(ev[idx], stream);
+  };
+  if (prof) {
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventCreate(&ev[i]);
+    rec(EV_START);
+  }
+
+  // ===========================================================================
+  // 0) adaln-LoRA: produce three (shift, scale, gate) bundles per block.
+  //
+  // The bridge passes a SiLU-applied t_emb buffer (shape [B, K]) so each
+  // sub-layer's helper just runs two GEMMs + an add. Fixed scheduler-step
+  // replay may precompute the final [B, 3K] bundles and pass them directly.
+  // ===========================================================================
+  const bool has_any_precomputed_mods =
+      p.precomputed_mods_sa || p.precomputed_mods_ca || p.precomputed_mods_mlp;
+  const bool has_all_precomputed_mods =
+      p.precomputed_mods_sa && p.precomputed_mods_ca && p.precomputed_mods_mlp;
+  if (has_any_precomputed_mods && !has_all_precomputed_mods) {
+    return cudaErrorInvalidValue;
+  }
+  // Skip the per-block AdaLN GEMMs when either mechanism says mods are
+  // precomputed: main's external `precomputed_mods_*` pointers, or this
+  // branch's `adaln_precomputed` flag (bridge has already populated
+  // `p.buf.mods_*` via the pre-stacked + batched up-GEMM path).
+  if (!p.adaln_precomputed && !has_all_precomputed_mods) {
+    err = cosmos_adaln_lora_split<bf16>(
+        p.t_emb, p.w.adaln_sa_down, p.w.adaln_sa_up, p.adaln_lora_3D,
+        p.buf.lora_hidden_sa, p.buf.mods_sa, B, K, p.lora_dim, stream);
+    if (err != cudaSuccess) return err;
+    err = cosmos_adaln_lora_split<bf16>(
+        p.t_emb, p.w.adaln_ca_down, p.w.adaln_ca_up, p.adaln_lora_3D,
+        p.buf.lora_hidden_ca, p.buf.mods_ca, B, K, p.lora_dim, stream);
+    if (err != cudaSuccess) return err;
+    err = cosmos_adaln_lora_split<bf16>(
+        p.t_emb, p.w.adaln_mlp_down, p.w.adaln_mlp_up, p.adaln_lora_3D,
+        p.buf.lora_hidden_mlp, p.buf.mods_mlp, B, K, p.lora_dim, stream);
+    if (err != cudaSuccess) return err;
+  }
+  rec(EV_AFTER_LORA);
+
+  // (shift, scale, gate) views into the [B, 3K] mods buffer.
+  const bf16* mods_sa = has_all_precomputed_mods ? p.precomputed_mods_sa : p.buf.mods_sa;
+  const bf16* mods_ca = has_all_precomputed_mods ? p.precomputed_mods_ca : p.buf.mods_ca;
+  const bf16* mods_ml = has_all_precomputed_mods ? p.precomputed_mods_mlp : p.buf.mods_mlp;
+  const bf16* shift_sa = mods_sa;
+  const bf16* scale_sa = mods_sa + size_t(K);
+  const bf16* gate_sa  = mods_sa + size_t(2 * K);
+  const bf16* shift_ca = mods_ca;
+  const bf16* scale_ca = mods_ca + size_t(K);
+  const bf16* gate_ca  = mods_ca + size_t(2 * K);
+  const bf16* shift_ml = mods_ml;
+  const bf16* scale_ml = mods_ml + size_t(K);
+  const bf16* gate_ml  = mods_ml + size_t(2 * K);
+
+  // The mods buffer is laid out [B, 3K] so the three vectors for batch b
+  // live at offsets (3K*b + 0K, 3K*b + K, 3K*b + 2K). For B==1 this is
+  // exactly what cosmos_layernorm_modulate consumes (stride = K, b_row=0).
+  // For B>1 we need to pass stride = 3K so the sub-vector picker advances
+  // 3K bytes per batch row -- but cosmos_layernorm_modulate currently
+  // assumes scale/shift are tightly packed [B, K]. So we restrict to B==1
+  // (the only case the streaming path actually uses).
+  //
+  // FlashDreams' generate() runs uncond and cond as separate forwards
+  // (not CFG-batched into B=2), so this is the correct steady-state
+  // assumption. If a caller ever passes B>1 we fall back to a slow path
+  // (TODO Phase 2).
+
+  // ===========================================================================
+  // 1) Self-attention residual
+  //    a) ln+modulate  -> normed
+  // ===========================================================================
+  bf16* normed = p.buf.normed;
+  const bool sage3_fp8_attention =
+      p.attention_backend == CosmosAttentionBackend::SAGE3_FP8;
+  const int sage3_q_padded = ((M + 127) / 128) * 128;
+  const bool quantized_attention =
+      p.attention_backend == CosmosAttentionBackend::FP8_CUDNN ||
+      p.attention_backend == CosmosAttentionBackend::FP8_DENSE_REF ||
+      sage3_fp8_attention;
+  const bool fp8_cudnn_attention =
+      p.attention_backend == CosmosAttentionBackend::FP8_CUDNN;
+  const bool self_fp8_cudnn_bhmd_input =
+      fp8_cudnn_attention &&
+      select_cosmos_fp8_sdpa(B, M, read_end, H, D).layout == "bhmd";
+  const bool sa_q_fp8 = cosmos_weight_is_fp8(p, p.w.sa_w_q_scale);
+  const bool sa_k_fp8 = cosmos_weight_is_fp8(p, p.w.sa_w_k_scale);
+  const bool sa_v_fp8 = cosmos_weight_is_fp8(p, p.w.sa_w_v_scale);
+  const bool sa_qkv_fp8 = cosmos_weight_is_fp8(p, p.w.sa_w_qkv_scale);
+  const bool sa_out_fp8 = cosmos_weight_is_fp8(p, p.w.sa_w_out_scale);
+  const bool ca_q_fp8 = cosmos_weight_is_fp8(p, p.w.ca_w_q_scale);
+  const bool ca_out_fp8 = cosmos_weight_is_fp8(p, p.w.ca_w_out_scale);
+  const bool ffn1_fp8 = cosmos_weight_is_fp8(p, p.w.ffn_w1_scale);
+  const bool ffn2_fp8 = cosmos_weight_is_fp8(p, p.w.ffn_w2_scale);
+  const bool sa_normed_needs_fp8 = sa_qkv_fp8 || sa_q_fp8 || sa_k_fp8 || sa_v_fp8;
+  const bool ca_normed_needs_fp8 = ca_q_fp8;
+  const bool ffn_normed_needs_fp8 = ffn1_fp8;
+  const bool use_fused_fp8_qkv =
+      sa_qkv_fp8 && p.w.sa_w_qkv && p.w.sa_w_qkv_scale && p.buf.qkv_row;
+  const bool sa_normed_fp8_only =
+      use_fused_fp8_qkv || (sa_q_fp8 && sa_k_fp8 && sa_v_fp8);
+  if (sa_normed_needs_fp8) {
+    err = sa_normed_fp8_only
+        ? cosmos_layernorm_modulate_to_fp8_only<bf16>(
+            p.x, shift_sa, scale_sa, p.buf.linear_fp8_scratch, M * B, K, B, 1e-6f, stream)
+        : cosmos_layernorm_modulate_to_fp8<bf16>(
+            p.x, shift_sa, scale_sa, normed, p.buf.linear_fp8_scratch, M * B, K, B, 1e-6f, stream);
+  } else {
+    err = cosmos_layernorm_modulate<bf16>(
+        p.x, shift_sa, scale_sa, normed, M * B, K, B, 1e-6f, stream);
+  }
+  if (err != cudaSuccess) return err;
+  rec(EV_AFTER_SA_LN);
+
+  // 1b) Q/K/V projections (three separate [K, K] GEMMs).
+  //
+  //     The FP8 path can consume an offline pre-fused [3K, K] QKV tensor to
+  //     turn three small GEMMs into one larger tensor-core GEMM. When callers
+  //     do not provide it, the split Q/K/V tensors remain the fallback.
+  bf16* q_row = p.buf.q_row;
+  bf16* k_row = p.buf.k_row;
+  bf16* v_row = p.buf.v_row;
+  const bool use_fused_bf16_qkv =
+      !use_fused_fp8_qkv && !sa_normed_needs_fp8 && p.w.sa_w_qkv_prepared &&
+      p.buf.qkv_row && !quantized_attention && !p.fp8_kv_cache_enabled;
+  if (use_fused_fp8_qkv) {
+    err = cosmos_linear_prequantized_fp8(
+        p, p.buf.linear_fp8_scratch, p.w.sa_w_qkv, p.w.sa_w_qkv_scale, p.buf.qkv_row,
+        M * B, K, 3 * K, /*gelu=*/false, stream);
+    if (err != cudaSuccess) return err;
+    if (!quantized_attention) {
+      err = cosmos_split_qkv_row(p.buf.qkv_row, q_row, k_row, v_row, M * B, K, stream);
+      if (err != cudaSuccess) return err;
+    }
+  } else if (use_fused_bf16_qkv) {
+    err = cutlass_linear_layer_rrr_bf16_prepared(
+        normed, p.w.sa_w_qkv_prepared, /*bias=*/nullptr, p.buf.qkv_row,
+        M * B, K, 3 * K, stream);
+    if (err != cudaSuccess) return err;
+  } else if (sa_normed_needs_fp8) {
+    if (!p.buf.linear_fp8_scratch) return cudaErrorInvalidValue;
+    err = sa_q_fp8
+        ? cosmos_linear_prequantized_fp8(p, p.buf.linear_fp8_scratch, p.w.sa_w_q, p.w.sa_w_q_scale, q_row,
+                                         M * B, K, K, /*gelu=*/false, stream)
+        : cosmos_linear_bf16_or_fp8(p, normed, p.w.sa_w_q, p.w.sa_w_q_scale, q_row,
+                                    M * B, K, K, /*gelu=*/false, stream);
+    if (err != cudaSuccess) return err;
+    err = sa_k_fp8
+        ? cosmos_linear_prequantized_fp8(p, p.buf.linear_fp8_scratch, p.w.sa_w_k, p.w.sa_w_k_scale, k_row,
+                                         M * B, K, K, /*gelu=*/false, stream)
+        : cosmos_linear_bf16_or_fp8(p, normed, p.w.sa_w_k, p.w.sa_w_k_scale, k_row,
+                                    M * B, K, K, /*gelu=*/false, stream);
+    if (err != cudaSuccess) return err;
+    err = sa_v_fp8
+        ? cosmos_linear_prequantized_fp8(p, p.buf.linear_fp8_scratch, p.w.sa_w_v, p.w.sa_w_v_scale, v_row,
+                                         M * B, K, K, /*gelu=*/false, stream)
+        : cosmos_linear_bf16_or_fp8(p, normed, p.w.sa_w_v, p.w.sa_w_v_scale, v_row,
+                                    M * B, K, K, /*gelu=*/false, stream);
+    if (err != cudaSuccess) return err;
+  } else {
+    err = cosmos_linear_bf16_or_fp8_prepared(
+        p, normed, p.w.sa_w_q, nullptr, p.w.sa_w_q_scale, q_row,
+        M * B, K, K, /*gelu=*/false, stream);
+    if (err != cudaSuccess) return err;
+    err = cosmos_linear_bf16_or_fp8_prepared(
+        p, normed, p.w.sa_w_k, nullptr, p.w.sa_w_k_scale, k_row,
+        M * B, K, K, /*gelu=*/false, stream);
+    if (err != cudaSuccess) return err;
+    err = cosmos_linear_bf16_or_fp8_prepared(
+        p, normed, p.w.sa_w_v, nullptr, p.w.sa_w_v_scale, v_row,
+        M * B, K, K, /*gelu=*/false, stream);
+    if (err != cudaSuccess) return err;
+  }
+  rec(EV_AFTER_SA_QKV);
+
+  // 1c-1e) Per-head RMSNorm, RoPE, Q FP8 production, and KV cache write.
+  bf16* q_bmhk = p.buf.q_bmhk;
+  bf16* k_bmhk = p.buf.k_bmhk;
+  bf16* v_bmhk = p.buf.v_bmhk;
+  const cutlass::float_e4m3_t* q_attn_fp8 = nullptr;
+  const cutlass::float_e4m3_t* q_attn_fp8_bhmd = nullptr;
+  const uint8_t* q_attn_sage3_fp4 = nullptr;
+  const cutlass::float_e4m3_t* q_attn_sage3_sf = nullptr;
+  if (use_fused_bf16_qkv) {
+    err = cosmos_qkv_postprocess_cache<bf16>(
+        p.buf.qkv_row,
+        p.w.sa_q_norm,
+        p.w.sa_k_norm,
+        p.rope_cos,
+        p.rope_sin,
+        q_bmhk,
+        p.k_self_cache,
+        p.v_self_cache,
+        B, M, H, D, p.self_attn_write_start, p.self_attn_cache_cap, stream);
+    if (err != cudaSuccess) return err;
+  } else if (use_fused_fp8_qkv && quantized_attention) {
+    if (sage3_fp8_attention) {
+      if (!p.buf.attn_q_sage3_fp4 || !p.buf.attn_q_sage3_sf) {
+        return cudaErrorInvalidValue;
+      }
+      err = sage3_quantize_q_bf16(
+          p.buf.qkv_row, p.w.sa_q_norm, p.rope_cos, p.rope_sin,
+          p.buf.attn_q_sage3_fp4, p.buf.attn_q_sage3_sf,
+          B, M, H, D, 3 * K, /*input_head_offset=*/0,
+          /*apply_rope=*/true, sage3_q_padded, stream);
+      if (err != cudaSuccess) return err;
+      q_attn_sage3_fp4 = p.buf.attn_q_sage3_fp4;
+      q_attn_sage3_sf = p.buf.attn_q_sage3_sf;
+    }
+    cutlass::float_e4m3_t* q_bhmd_out =
+        (!sage3_fp8_attention && self_fp8_cudnn_bhmd_input)
+            ? p.buf.attn_q_bhmd_fp8
+            : nullptr;
+    err = cosmos_fused_qkv_rope_cache_fp8(
+        p.buf.qkv_row,
+        p.w.sa_q_norm,
+        p.w.sa_k_norm,
+        p.rope_cos,
+        p.rope_sin,
+        sage3_fp8_attention ? nullptr : p.buf.attn_q_fp8,
+        q_bhmd_out,
+        p.write_bf16_self_kv_cache ? p.k_self_cache : nullptr,
+        p.write_bf16_self_kv_cache ? p.v_self_cache : nullptr,
+        p.fp8_kv_cache_enabled ? p.k_self_cache_fp8 : nullptr,
+        p.fp8_kv_cache_enabled ? p.v_self_cache_fp8 : nullptr,
+        p.k_self_cache_fp8_bhmd,
+        p.v_self_cache_fp8_bhmd,
+        p.v_self_cache_fp8_bhdm,
+        B, M, H, D, p.self_attn_write_start, p.self_attn_cache_cap, stream);
+    if (err != cudaSuccess) return err;
+    q_attn_fp8 = sage3_fp8_attention ? nullptr : p.buf.attn_q_fp8;
+    q_attn_fp8_bhmd = q_bhmd_out;
+  } else {
+    // Per-head RMSNorm on Q and K. Operates in-place on the [M, K] row
+    // buffers viewed as [B*M, H, D].
+    if (!sage3_fp8_attention) {
+      err = cosmos_rmsnorm_per_head<bf16>(q_row, p.w.sa_q_norm, B, M, H, D, 1e-6f, stream);
+      if (err != cudaSuccess) return err;
+    }
+    err = cosmos_rmsnorm_per_head<bf16>(k_row, p.w.sa_k_norm, B, M, H, D, 1e-6f, stream);
+    if (err != cudaSuccess) return err;
+
+    if (quantized_attention) {
+      if (sage3_fp8_attention) {
+        if (!p.buf.attn_q_sage3_fp4 || !p.buf.attn_q_sage3_sf) {
+          return cudaErrorInvalidValue;
+        }
+        err = sage3_quantize_q_bf16(
+            q_row, p.w.sa_q_norm, p.rope_cos, p.rope_sin,
+            p.buf.attn_q_sage3_fp4, p.buf.attn_q_sage3_sf,
+            B, M, H, D, H * D, /*input_head_offset=*/0,
+            /*apply_rope=*/true, sage3_q_padded, stream);
+        if (err != cudaSuccess) return err;
+        q_attn_sage3_fp4 = p.buf.attn_q_sage3_fp4;
+        q_attn_sage3_sf = p.buf.attn_q_sage3_sf;
+      } else {
+        cutlass::float_e4m3_t* q_bhmd_out =
+            self_fp8_cudnn_bhmd_input ? p.buf.attn_q_bhmd_fp8 : nullptr;
+        err = cosmos_pack_rope_to_fp8<bf16>(
+            q_row, p.rope_cos, p.rope_sin, p.buf.attn_q_fp8, q_bhmd_out, B, M, H, D, stream);
+        if (err != cudaSuccess) return err;
+        q_attn_fp8 = p.buf.attn_q_fp8;
+        q_attn_fp8_bhmd = q_bhmd_out;
+      }
+    } else {
+      err = cosmos_pack_rope<bf16>(q_row, p.rope_cos, p.rope_sin, q_bmhk, B * M, H, D, stream);
+      if (err != cudaSuccess) return err;
+    }
+    if (!p.fp8_kv_cache_enabled) {
+      err = cosmos_pack_rope<bf16>(k_row, p.rope_cos, p.rope_sin, k_bmhk, B * M, H, D, stream);
+      if (err != cudaSuccess) return err;
+    }
+    // V: identity copy (V_row -> V_bmhk). Since K = H*D, the layouts are
+    // byte-equivalent and we can avoid the kernel; just alias the pointer.
+    v_bmhk = v_row;
+
+    // Append K_bmhk, V_bmhk into the self-attn KV cache at the configured
+    // write cursor. After this, the cache holds the valid prefix
+    // [0 : write_start + M).
+    if (p.fp8_kv_cache_enabled) {
+      err = cosmos_write_self_kv_cache_rope_bf16_and_fp8<bf16>(
+          k_row, v_bmhk, p.rope_cos, p.rope_sin,
+          p.write_bf16_self_kv_cache ? p.k_self_cache : nullptr,
+          p.write_bf16_self_kv_cache ? p.v_self_cache : nullptr,
+          p.k_self_cache_fp8, p.v_self_cache_fp8,
+          p.k_self_cache_fp8_bhmd, p.v_self_cache_fp8_bhmd, p.v_self_cache_fp8_bhdm,
+          B, M, H, D, p.self_attn_write_start, p.self_attn_cache_cap, stream);
+      if (err != cudaSuccess) return err;
+    } else {
+      err = cosmos_write_kv_cache<bf16>(
+          k_bmhk, v_bmhk, p.k_self_cache, p.v_self_cache,
+          B, M, H, D, p.self_attn_write_start, p.self_attn_cache_cap, stream);
+      if (err != cudaSuccess) return err;
+    }
+  }
+  rec(EV_AFTER_SA_POST_QKV);
+
+  // 1f) cuDNN FMHA against the historical cache + just-written tokens.
+  //     Q is [B*M, H, D]; K, V are [B*read_end, H, D] (the valid prefix of
+  //     the cache for this batch).
+  bf16* o_bmhk = p.buf.o_bmhk;
+  const bool sa_out_proj_from_quantized_attention =
+      quantized_attention && !sage3_fp8_attention && sa_out_fp8;
+  const bool sa_attn_writes_fp8 =
+      sa_out_proj_from_quantized_attention &&
+      p.attention_backend == CosmosAttentionBackend::FP8_CUDNN;
+  const bool fuse_sa_fp8_residual_postprocess =
+      sa_out_fp8 && quantized_attention;
+  const bool self_tc_cache_contiguous =
+      p.fp8_kv_cache_enabled && p.k_self_cache_fp8_bhmd &&
+      p.v_self_cache_fp8_bhmd &&
+      read_end == p.self_attn_cache_cap;
+  err = cosmos_attention_bf16_or_fp8(
+      p,
+      quantized_attention ? nullptr : reinterpret_cast<const cutlass::bfloat16_t*>(q_bmhk),
+      reinterpret_cast<const cutlass::bfloat16_t*>(p.k_self_cache),
+      reinterpret_cast<const cutlass::bfloat16_t*>(p.v_self_cache),
+      q_attn_fp8,
+      q_attn_fp8_bhmd,
+      p.fp8_kv_cache_enabled ? p.k_self_cache_fp8 : nullptr,
+      p.fp8_kv_cache_enabled ? p.v_self_cache_fp8 : nullptr,
+      self_tc_cache_contiguous ? p.k_self_cache_fp8_bhmd : nullptr,
+      self_tc_cache_contiguous ? p.v_self_cache_fp8_bhmd : nullptr,
+      self_tc_cache_contiguous ? p.v_self_cache_fp8_bhdm : nullptr,
+      q_attn_sage3_fp4,
+      q_attn_sage3_sf,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      sage3_q_padded,
+      0,
+      reinterpret_cast<cutlass::bfloat16_t*>(o_bmhk),
+      sa_attn_writes_fp8 ? p.buf.linear_fp8_scratch : nullptr,
+      read_end, !sa_out_proj_from_quantized_attention, sa_attn_writes_fp8,
+      /*allow_sage_backend=*/true, stream);
+  if (err != cudaSuccess) return err;
+  rec(EV_AFTER_SA_FMHA);
+
+  // 1g) Unpack [M, H, D] -> [M, K]. Same byte layout when K = H*D, so
+  //     we can alias the pointer; we use the existing q_row buffer as the
+  //     output slot for the SA out projection.
+  bf16* attn_out_row = p.buf.attn_out_row;
+  // Identity unpack: src pointer can be reused directly because BMHK packed
+  // [M, H, D] and row-major [M, K] have identical byte layout for K = H*D.
+  attn_out_row = o_bmhk;
+
+  // 1h) SA output GEMM and gated residual.
+  //     Cosmos has no bias on output_proj (Linear with bias=False).
+  // Fast path: when the next op is the CA LN/modulate-to-FP8, fuse the
+  // (col_scale + residual) post-op with the LN/modulate-to-FP8 in one kernel
+  // to skip the BF16 re-read of x.
+  const bool fuse_sa_out_with_ca_ln =
+      fuse_sa_fp8_residual_postprocess && sa_attn_writes_fp8 && ca_normed_needs_fp8;
+  bool ca_ln_already_done = false;
+  if (fuse_sa_fp8_residual_postprocess) {
+    if (fuse_sa_out_with_ca_ln) {
+      err = cosmos_linear_prequantized_fp8_residual_layernorm_modulate_to_fp8_only(
+          p, p.buf.linear_fp8_scratch, p.w.sa_w_out, p.w.sa_w_out_scale,
+          p.x, gate_sa,
+          shift_ca, scale_ca, p.buf.linear_fp8_scratch,
+          M * B, K, K, B, 1e-6f, stream);
+      ca_ln_already_done = (err == cudaSuccess);
+    } else if (sa_attn_writes_fp8) {
+      err = cosmos_linear_prequantized_fp8_residual(
+          p, p.buf.linear_fp8_scratch, p.w.sa_w_out, p.w.sa_w_out_scale,
+          p.x, gate_sa, M * B, K, K, stream);
+    } else if (sa_out_proj_from_quantized_attention) {
+      err = cosmos_linear_half_input_fp8_residual(
+          p, p.buf.attn_o_half, p.w.sa_w_out, p.w.sa_w_out_scale,
+          p.x, gate_sa, M * B, K, K, stream);
+    } else {
+      err = cosmos_linear_bf16_input_fp8_residual(
+          p, attn_out_row, p.w.sa_w_out, p.w.sa_w_out_scale,
+          p.x, gate_sa, M * B, K, K, stream);
+    }
+  } else {
+    err = cosmos_linear_bf16_or_fp8_residual_prepared(
+        p, attn_out_row, p.w.sa_w_out, p.w.sa_w_out_prepared, p.w.sa_w_out_scale,
+        p.x, gate_sa, M * B, K, K, stream);
+  }
+  if (err != cudaSuccess) return err;
+  err = cosmos_trace_copy(p.trace_sa_out, p.x, p.trace_elems, stream);
+  if (err != cudaSuccess) return err;
+  rec(EV_AFTER_SA_OUT);
+
+  // ===========================================================================
+  // 2) Cross-attention residual (Q only -- K/V are pre-cached)
+  // ===========================================================================
+  if (ca_ln_already_done) {
+    // CA LN/modulate -> FP8 was fused into the SA-out residual kernel above.
+    err = cudaSuccess;
+  } else if (ca_normed_needs_fp8) {
+    err = cosmos_layernorm_modulate_to_fp8_only<bf16>(
+        p.x, shift_ca, scale_ca, p.buf.linear_fp8_scratch, M * B, K, B, 1e-6f, stream);
+  } else {
+    err = cosmos_layernorm_modulate<bf16>(
+        p.x, shift_ca, scale_ca, normed, M * B, K, B, 1e-6f, stream);
+  }
+  if (err != cudaSuccess) return err;
+
+  // 2b) CA Q projection (no K/V projection; encoder K/V are pre-cached).
+  if (ca_q_fp8) {
+    err = cosmos_linear_prequantized_fp8(p, p.buf.linear_fp8_scratch, p.w.ca_w_q, p.w.ca_w_q_scale, q_row,
+                                         M * B, K, K, /*gelu=*/false, stream);
+  } else {
+    err = cosmos_linear_bf16_or_fp8_prepared(
+        p, normed, p.w.ca_w_q, p.w.ca_w_q_prepared, p.w.ca_w_q_scale, q_row,
+        M * B, K, K, /*gelu=*/false, stream);
+  }
+  if (err != cudaSuccess) return err;
+
+  // 2c) Per-head Q RMSNorm. No RoPE on cross-attn. For quantized attention,
+  // emit the post-RMSNorm Q directly as FP8 here so the attention launcher
+  // does not need a separate BF16-to-FP8 conversion for cross-Q.
+  const cutlass::float_e4m3_t* ca_q_attn_fp8 = nullptr;
+  const cutlass::float_e4m3_t* ca_q_attn_fp8_bhmd = nullptr;
+  const uint8_t* ca_q_attn_sage3_fp4 = nullptr;
+  const cutlass::float_e4m3_t* ca_q_attn_sage3_sf = nullptr;
+  const bool cross_fp8_cudnn_bhmd_input =
+      fp8_cudnn_attention &&
+      select_cosmos_fp8_sdpa(B, M, Mk_c, H, D).layout == "bhmd";
+  if (quantized_attention) {
+    if (sage3_fp8_attention) {
+      if (!p.buf.attn_q_sage3_fp4 || !p.buf.attn_q_sage3_sf) {
+        return cudaErrorInvalidValue;
+      }
+      err = sage3_quantize_q_bf16(
+          q_row, p.w.ca_q_norm, nullptr, nullptr,
+          p.buf.attn_q_sage3_fp4, p.buf.attn_q_sage3_sf,
+          B, M, H, D, H * D, /*input_head_offset=*/0,
+          /*apply_rope=*/false, sage3_q_padded, stream);
+      if (err != cudaSuccess) return err;
+      ca_q_attn_sage3_fp4 = p.buf.attn_q_sage3_fp4;
+      ca_q_attn_sage3_sf = p.buf.attn_q_sage3_sf;
+    } else {
+      cutlass::float_e4m3_t* ca_q_bhmd_out =
+          cross_fp8_cudnn_bhmd_input ? p.buf.attn_q_bhmd_fp8 : nullptr;
+      err = cosmos_rmsnorm_per_head_to_fp8<bf16>(
+          q_row, p.w.ca_q_norm, p.buf.attn_q_fp8, ca_q_bhmd_out, B, M, H, D, 1e-6f, stream);
+      if (err != cudaSuccess) return err;
+      ca_q_attn_fp8 = p.buf.attn_q_fp8;
+      ca_q_attn_fp8_bhmd = ca_q_bhmd_out;
+    }
+  } else {
+    err = cosmos_rmsnorm_per_head<bf16>(q_row, p.w.ca_q_norm, B, M, H, D, 1e-6f, stream);
+    if (err != cudaSuccess) return err;
+  }
+  rec(EV_AFTER_CA_LN_Q);
+
+  // 2d) FMHA against pre-cached encoder K/V.
+  //     Q  [B*M, H, D]
+  //     K  [B*Mk_c, H, D]   (FlashDreams writes [B*V, Mk_c, H, D] -- with V==1 this is [B, Mk_c, H, D])
+  //     V  [B*Mk_c, H, D]
+  const bool ca_out_proj_from_quantized_attention =
+      quantized_attention && !sage3_fp8_attention && ca_out_fp8;
+  const bool ca_attn_writes_fp8 =
+      ca_out_proj_from_quantized_attention &&
+      p.attention_backend == CosmosAttentionBackend::FP8_CUDNN;
+  const bool fuse_ca_fp8_residual_postprocess =
+      ca_out_fp8 && quantized_attention;
+  err = cosmos_attention_bf16_or_fp8(
+      p,
+      quantized_attention ? nullptr : reinterpret_cast<const cutlass::bfloat16_t*>(q_row),
+      reinterpret_cast<const cutlass::bfloat16_t*>(p.k_cross),
+      reinterpret_cast<const cutlass::bfloat16_t*>(p.v_cross),
+      ca_q_attn_fp8,
+      ca_q_attn_fp8_bhmd,
+      p.fp8_kv_cache_enabled ? p.k_cross_fp8 : nullptr,
+      p.fp8_kv_cache_enabled ? p.v_cross_fp8 : nullptr,
+      p.fp8_kv_cache_enabled ? p.k_cross_fp8_bhmd : nullptr,
+      p.fp8_kv_cache_enabled ? p.v_cross_fp8_bhmd : nullptr,
+      p.fp8_kv_cache_enabled ? p.v_cross_fp8_bhdm : nullptr,
+      ca_q_attn_sage3_fp4,
+      ca_q_attn_sage3_sf,
+      p.k_cross_sage3_fp4,
+      p.v_cross_sage3_fp4,
+      p.k_cross_sage3_sf,
+      p.v_cross_sage3_sf,
+      sage3_q_padded,
+      p.Mk_cross_sage3_padded,
+      reinterpret_cast<cutlass::bfloat16_t*>(o_bmhk),
+      ca_attn_writes_fp8 ? p.buf.linear_fp8_scratch : nullptr,
+      Mk_c, !ca_out_proj_from_quantized_attention, ca_attn_writes_fp8,
+      /*allow_sage_backend=*/false, stream);
+  if (err != cudaSuccess) return err;
+  rec(EV_AFTER_CA_FMHA);
+
+  // 2e) CA out projection (and possibly fused MLP LN/modulate -> FP8).
+  // Same fusion pattern as SA-out: when CA-out residual is the FP8 fast path
+  // and the next op is MLP LN/modulate-to-FP8, fold both into one launch.
+  const bool fuse_ca_out_with_mlp_ln =
+      fuse_ca_fp8_residual_postprocess && ca_attn_writes_fp8 && ffn_normed_needs_fp8;
+  bool mlp_ln_already_done = false;
+  if (fuse_ca_fp8_residual_postprocess) {
+    if (fuse_ca_out_with_mlp_ln) {
+      err = cosmos_linear_prequantized_fp8_residual_layernorm_modulate_to_fp8_only(
+          p, p.buf.linear_fp8_scratch, p.w.ca_w_out, p.w.ca_w_out_scale,
+          p.x, gate_ca,
+          shift_ml, scale_ml, p.buf.linear_fp8_scratch,
+          M * B, K, K, B, 1e-6f, stream);
+      mlp_ln_already_done = (err == cudaSuccess);
+    } else if (ca_attn_writes_fp8) {
+      err = cosmos_linear_prequantized_fp8_residual(
+          p, p.buf.linear_fp8_scratch, p.w.ca_w_out, p.w.ca_w_out_scale,
+          p.x, gate_ca, M * B, K, K, stream);
+    } else if (ca_out_proj_from_quantized_attention) {
+      err = cosmos_linear_half_input_fp8_residual(
+          p, p.buf.attn_o_half, p.w.ca_w_out, p.w.ca_w_out_scale,
+          p.x, gate_ca, M * B, K, K, stream);
+    } else {
+      err = cosmos_linear_bf16_input_fp8_residual(
+          p, o_bmhk, p.w.ca_w_out, p.w.ca_w_out_scale,
+          p.x, gate_ca, M * B, K, K, stream);
+    }
+  } else {
+    err = cosmos_linear_bf16_or_fp8_residual_prepared(
+        p, o_bmhk, p.w.ca_w_out, p.w.ca_w_out_prepared, p.w.ca_w_out_scale,
+        p.x, gate_ca, M * B, K, K, stream);
+  }
+  if (err != cudaSuccess) return err;
+  err = cosmos_trace_copy(p.trace_ca_out, p.x, p.trace_elems, stream);
+  if (err != cudaSuccess) return err;
+  rec(EV_AFTER_CA_OUT);
+
+  // ===========================================================================
+  // 3) FFN residual
+  // ===========================================================================
+  if (mlp_ln_already_done) {
+    // MLP LN/modulate -> FP8 was fused into the CA-out residual kernel above.
+    err = cudaSuccess;
+  } else if (ffn_normed_needs_fp8) {
+    err = cosmos_layernorm_modulate_to_fp8_only<bf16>(
+        p.x, shift_ml, scale_ml, p.buf.linear_fp8_scratch, M * B, K, B, 1e-6f, stream);
+  } else {
+    err = cosmos_layernorm_modulate<bf16>(
+        p.x, shift_ml, scale_ml, normed, M * B, K, B, 1e-6f, stream);
+  }
+  if (err != cudaSuccess) return err;
+  rec(EV_AFTER_MLP_LN);
+
+  // 3b) FFN GEMM1 + GELU: [M, K] x [K, FF] -> [M, FF]
+  // 3c) FFN GEMM2: [M, FF] x [FF, K] -> [M, K]
+  const float ffn1_gelu_fp8_scale =
+      cosmos_fp8_activation_scale_or_one(p, kCosmosFp8ActivationScaleFfn1Gelu);
+  if (ffn1_fp8 && ffn2_fp8) {
+    err = cosmos_linear_prequantized_fp8_output(
+        p, p.buf.linear_fp8_scratch, p.w.ffn_w1, p.w.ffn_w1_scale, p.buf.linear_fp8_scratch,
+        M * B, K, FF, /*gelu=*/true, stream, ffn1_gelu_fp8_scale);
+    if (err != cudaSuccess) return err;
+  } else {
+    err = ffn1_fp8
+        ? cosmos_linear_prequantized_fp8(
+            p, p.buf.linear_fp8_scratch, p.w.ffn_w1, p.w.ffn_w1_scale, p.buf.ffn_intermediate,
+            M * B, K, FF, /*gelu=*/true, stream)
+        : cosmos_linear_bf16_or_fp8_prepared(
+            p, normed, p.w.ffn_w1, p.w.ffn_w1_prepared, p.w.ffn_w1_scale, p.buf.ffn_intermediate,
+            M * B, K, FF, /*gelu=*/true, stream);
+    if (err != cudaSuccess) return err;
+    if (p.fp8_activation_amax_out) {
+      err = cosmos_record_bf16_absmax(
+          p.buf.ffn_intermediate,
+          p.fp8_activation_amax_out + kCosmosFp8ActivationScaleFfn1Gelu,
+          int64_t(M) * B * FF,
+          stream);
+      if (err != cudaSuccess) return err;
+    }
+  }
+  rec(EV_AFTER_FFN1);
+
+  if (ffn1_fp8 && ffn2_fp8) {
+    err = cosmos_linear_prequantized_fp8_residual(
+        p, p.buf.linear_fp8_scratch, p.w.ffn_w2, p.w.ffn_w2_scale,
+        p.x, gate_ml, M * B, FF, K, stream, ffn1_gelu_fp8_scale);
+    if (err != cudaSuccess) return err;
+  } else if (ffn2_fp8) {
+    err = cosmos_linear_bf16_input_fp8_residual(
+        p, p.buf.ffn_intermediate, p.w.ffn_w2, p.w.ffn_w2_scale,
+        p.x, gate_ml, M * B, FF, K, stream);
+    if (err != cudaSuccess) return err;
+  } else {
+    err = cosmos_linear_bf16_or_fp8_residual_prepared(
+        p, p.buf.ffn_intermediate, p.w.ffn_w2, p.w.ffn_w2_prepared, p.w.ffn_w2_scale,
+        p.x, gate_ml, M * B, FF, K, stream);
+    if (err != cudaSuccess) return err;
+  }
+  rec(EV_AFTER_FFN2);
+  err = cosmos_trace_copy(p.trace_ffn_out, p.x, p.trace_elems, stream);
+  if (err != cudaSuccess) return err;
+  err = cosmos_trace_copy(p.trace_block_out, p.x, p.trace_elems, stream);
+  if (err != cudaSuccess) return err;
+  rec(EV_AFTER_DONE);
+
+  if (prof) {
+    cudaEventSynchronize(ev[EV_AFTER_DONE]);
+    auto ms = [&](int a, int b) -> float {
+      float out = 0.f;
+      cudaEventElapsedTime(&out, ev[a], ev[b]);
+      return out;
+    };
+    std::printf(
+        "[cosmos_block] lora=%.3f sa_ln=%.3f sa_qkv=%.3f sa_post=%.3f sa_fmha=%.3f sa_out=%.3f "
+        "ca_ln_q=%.3f ca_fmha=%.3f ca_out=%.3f mlp_ln=%.3f ffn1=%.3f ffn2=%.3f mlp_gate=%.3f total=%.3f ms\n",
+        ms(EV_START, EV_AFTER_LORA),
+        ms(EV_AFTER_LORA, EV_AFTER_SA_LN),
+        ms(EV_AFTER_SA_LN, EV_AFTER_SA_QKV),
+        ms(EV_AFTER_SA_QKV, EV_AFTER_SA_POST_QKV),
+        ms(EV_AFTER_SA_POST_QKV, EV_AFTER_SA_FMHA),
+        ms(EV_AFTER_SA_FMHA, EV_AFTER_SA_OUT),
+        ms(EV_AFTER_SA_OUT, EV_AFTER_CA_LN_Q),
+        ms(EV_AFTER_CA_LN_Q, EV_AFTER_CA_FMHA),
+        ms(EV_AFTER_CA_FMHA, EV_AFTER_CA_OUT),
+        ms(EV_AFTER_CA_OUT, EV_AFTER_MLP_LN),
+        ms(EV_AFTER_MLP_LN, EV_AFTER_FFN1),
+        ms(EV_AFTER_FFN1, EV_AFTER_FFN2),
+        ms(EV_AFTER_FFN2, EV_AFTER_DONE),
+        ms(EV_START, EV_AFTER_DONE));
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventDestroy(ev[i]);
+  }
+
+  return cudaSuccess;
+}
+
+template cudaError_t cosmos_split_qkv<cutlass::bfloat16_t>(
+    const cutlass::bfloat16_t*, cutlass::bfloat16_t*, cutlass::bfloat16_t*,
+    cutlass::bfloat16_t*, int, int, cudaStream_t);
+template cudaError_t cosmos_split_qkv<cutlass::half_t>(
+    const cutlass::half_t*, cutlass::half_t*, cutlass::half_t*,
+    cutlass::half_t*, int, int, cudaStream_t);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cuh
@@ -1,0 +1,535 @@
+#pragma once
+
+// cosmos_block.cuh — declarations for the Cosmos DiT streaming transformer block.
+//
+// This header is independent of the WAN block (it does not include
+// `transformer_block.cuh` / `attention.cuh` to keep compile-time clean and
+// to avoid coupling the cosmos param struct to the WAN one). The cosmos
+// orchestrator calls into:
+//   - `cutlass_linear_layer_rrr*_bf16` -- bf16 CUTLASS GEMMs (this header)
+//   - `cosmos_layernorm_modulate` / `cosmos_residual_gate` / `cosmos_rmsnorm_per_head`
+//     -- elementwise primitives (this header)
+//   - `cosmos_adaln_lora_split` -- adaln-LoRA helper (this header)
+//   - `omnidreams_singleview::run_cudnn_fmha_packed_qkv` -- cuDNN SDPA (existing, attention.cuh)
+//
+// All buffers are externally provided by the bridge (no Workspace yet --
+// Phase 1 sticks with at::empty per-call allocations to keep the diff small).
+
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cutlass/numeric_types.h>
+#include <cutlass/bfloat16.h>
+#include <cutlass/half.h>
+#include "workspace.cuh"
+
+namespace omnidreams_singleview {
+
+enum class CosmosLinearBackend : int {
+  BF16 = 0,
+  FP8 = 1,
+  MIXED = 2,
+};
+
+enum class CosmosAttentionBackend : int {
+  CUDNN_BF16 = 0,
+  FP8_DENSE_REF = 4,
+  SAGE3 = 7,
+  FP8_CUDNN = 8,
+  SAGE3_FP8 = 9,
+};
+
+static constexpr int kCosmosFp8ActivationScaleSites = 10;
+static constexpr int kCosmosFp8ActivationScaleFfn1Gelu = 9;
+
+// ---------------------------------------------------------------------------
+// 1) bf16 CUTLASS GEMMs (host launchers, defined in `cosmos_gemm_bf16.cu`)
+//
+// The existing `cutlass_linear_layer_rrr*` kernels are fp16-only and accept
+// WAN's pre-transposed `[in_features, out_features]` weight layout (WAN
+// does the transpose offline in `native/common/weight_utils.py`). Cosmos
+// has no offline weight-extraction step, so it consumes raw PyTorch
+// `nn.Linear.weight` (`[out_features, in_features]` row-major). To match
+// PyTorch's `output = input @ weight.T` math without an offline transpose,
+// these kernels use CUTLASS's **RCR** layout (Row-Col-Row): input
+// row-major × weight column-major × output row-major. PyTorch's
+// `[out, in]` row-major weight is byte-equivalent to `[in, out]`
+// column-major -- so the same memory consumed by an RCR GEMM with
+// ldb=in_features computes `output = input @ weight^T` directly.
+//
+// Tile shapes mirror the fp16 RRR kernels (256×128×32 SM80 tensor cores
+// for large M, 128×128×32 for small M) so the bf16 path inherits the same
+// large-M / small-M tuning the WAN team converged on.
+//
+// Naming note: kept the `_rrr_` suffix in the function names even though
+// the underlying CUTLASS layout is RCR. The `_rrr_` here describes the
+// CALLER's perception (input row-major, weight in PyTorch's natural
+// row-major shape, output row-major), not the internal CUTLASS layout
+// triple. This keeps the call-site code readable for someone coming from
+// the Python side.
+// ---------------------------------------------------------------------------
+
+// D = input @ weight^T + bias  (PyTorch nn.Linear math)
+//   input:  [N, in_features]              row-major
+//   weight: [out_features, in_features]   row-major  (PyTorch nn.Linear.weight)
+//   bias:   [out_features] or nullptr     (broadcast via stride-0 trick)
+//   output: [N, out_features]             row-major
+cudaError_t cutlass_linear_layer_rrr_bf16(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream);
+
+// D = input @ prepared_weight  where prepared_weight is [in_features, out_features]
+// row-major. This matches the native WAN/native GEMM layout and avoids the
+// raw PyTorch [out, in] ColumnMajor reinterpretation in the hot path.
+cudaError_t cutlass_linear_layer_rrr_bf16_prepared(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row_prepared,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream);
+
+// D = GELU(input @ weight^T + bias)
+cudaError_t cutlass_linear_layer_rrr_gelu_bf16(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream);
+
+// D = GELU(input @ prepared_weight + bias)
+cudaError_t cutlass_linear_layer_rrr_gelu_bf16_prepared(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row_prepared,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream);
+
+// residual_inout = residual_inout + gate * (input @ prepared_weight)
+// gate is a [out_features] vector broadcast across rows (B==1 streaming path).
+cudaError_t cutlass_linear_layer_rrr_bf16_prepared_gated_residual(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row_prepared,
+    const cutlass::bfloat16_t* gate,
+    cutlass::bfloat16_t* residual_inout,
+    int N, int in_features, int out_features,
+    cudaStream_t stream);
+
+// D = SiLU(input @ weight^T + bias)
+cudaError_t cutlass_linear_layer_rrr_silu_bf16(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream);
+
+// Strided-batched BF16 GEMM via cuBLASLt: D[b] = A[b] @ B[b]^T + bias_per_instance
+//
+// Each batch instance computes M x N x K matmul with B^T applied (i.e. PyTorch
+// nn.Linear semantics: output = input @ weight.T). Strides advance pointers
+// across the batch dimension; pass stride = 0 to broadcast a single matrix
+// across all instances. Bias is added per-instance via cuBLASLt's epilogue
+// when bias_stride > 0; pass bias = nullptr to skip the bias add.
+//
+// Used for the AdaLN-LoRA pre-stack path's batched up GEMM. With M = 1
+// (B = 1 streaming) and batchCount = num_blocks * 3, the batch dim fills
+// the GPU even though per-instance M is a vector.
+cudaError_t cublaslt_strided_batched_bf16_gemm(
+    const cutlass::bfloat16_t* a_row,           // [batchCount, M, K] row-major
+    const cutlass::bfloat16_t* b_row,           // [batchCount, N, K] row-major (PyTorch nn.Linear weight)
+    const cutlass::bfloat16_t* bias,            // [batchCount, N] or nullptr; broadcast over M rows
+    cutlass::bfloat16_t* d_row,                 // [batchCount, M, N] row-major output
+    int M, int K, int N,
+    int batchCount,
+    int64_t stride_a,                           // elements between consecutive A instances (0 = broadcast)
+    int64_t stride_b,                           // elements between consecutive B instances (0 = broadcast)
+    int64_t stride_d,                           // elements between consecutive D instances
+    int64_t stride_bias,                        // elements between consecutive bias vectors (0 = broadcast)
+    cudaStream_t stream);
+
+// residual_inout = (A @ B) + residual   (no bias variant; cosmos out-projs are bias-free)
+// Useful for fusing the SA/CA out projection's residual add into the GEMM
+// epilogue. Cosmos's SA/CA `output_proj.weight` is `[D, D]` with no bias and
+// the gated residual is `x + gate * out`, so we use the simpler
+// linear+residual fusion and apply the gate via `cosmos_residual_gate`
+// AFTER the GEMM (gate scaling is per-row from adaln-LoRA, not a constant
+// the CUTLASS epilogue can broadcast).
+//
+// For Phase 1 we keep things simple: GEMM -> separate gated_residual kernel.
+// (Future: write a custom epilogue that bakes gate*y + x into the GEMM.)
+
+// ---------------------------------------------------------------------------
+// 2) Element-wise primitives (defined in `cosmos_modulate.cu`)
+// ---------------------------------------------------------------------------
+
+// Y = norm(X) * (1 + scale) + shift
+//   X      [M, K]    activations (no-affine LayerNorm input)
+//   shift  [B, K]    per-row modulation shift; broadcast to (M / B) rows each
+//   scale  [B, K]    per-row modulation scale
+template <typename ElementT>
+cudaError_t cosmos_layernorm_modulate(
+    const ElementT* X,
+    const ElementT* shift,
+    const ElementT* scale,
+    ElementT* Y,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream);
+
+// Same as cosmos_layernorm_modulate, but also emits the modulated activation
+// as raw E4M3 bytes for FP8 linears that immediately consume it.
+template <typename ElementT>
+cudaError_t cosmos_layernorm_modulate_to_fp8(
+    const ElementT* X,
+    const ElementT* shift,
+    const ElementT* scale,
+    ElementT* Y,
+    cutlass::float_e4m3_t* Y_fp8,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream);
+
+// Same normalization/modulation as above, but emits only raw E4M3 bytes. Use
+// when the BF16 modulated activation is not consumed before being overwritten.
+template <typename ElementT>
+cudaError_t cosmos_layernorm_modulate_to_fp8_only(
+    const ElementT* X,
+    const ElementT* shift,
+    const ElementT* scale,
+    cutlass::float_e4m3_t* Y_fp8,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream);
+
+// Fused col_scale + residual + LayerNorm + modulate -> FP8. Replaces the
+// back-to-back pair (col_scale_residual_bf16 + cosmos_layernorm_modulate_to_fp8_only)
+// that runs after FP8 SA-out / CA-out projections, saving one full BF16 read
+// of x between the residual write and the LN reduce. `gemm_half` is the FP16
+// scratch produced by the cuBLASLt FP8 GEMM; `alpha` is the per-column
+// (weight_scale * gate * input_scale) precomputed by `cosmos_scale_gate_half`.
+template <typename ElementT>
+cudaError_t cosmos_col_scale_residual_layernorm_modulate_to_fp8_only(
+    const cutlass::half_t* gemm_half,
+    const cutlass::half_t* alpha,
+    ElementT* residual_inout,
+    const ElementT* ln_shift,
+    const ElementT* ln_scale,
+    cutlass::float_e4m3_t* fp8_out,
+    float scale_mul,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream);
+
+// dest = src + gate * y   (per-row gate, broadcast across head dim)
+template <typename ElementT>
+cudaError_t cosmos_residual_gate(
+    ElementT* dest,
+    const ElementT* src,
+    const ElementT* y,
+    const ElementT* gate,                   // [B, K]
+    int M, int K,
+    int B,
+    cudaStream_t stream);
+
+// In-place per-head RMSNorm on packed [B, M, H, D] data.
+// gamma is [D] -- same scale per head.
+template <typename ElementT>
+cudaError_t cosmos_rmsnorm_per_head(
+    ElementT* data,
+    const ElementT* gamma,
+    int B, int M, int H, int D,
+    float eps,
+    cudaStream_t stream);
+
+// In-place per-head RMSNorm plus FP8 copy for quantized attention Q paths.
+// `data` remains normalized in its original dtype; `fp8_out` receives the same
+// BMHK values quantized as raw E4M3 bytes.
+template <typename ElementT>
+cudaError_t cosmos_rmsnorm_per_head_to_fp8(
+    ElementT* data,
+    const ElementT* gamma,
+    cutlass::float_e4m3_t* fp8_out,
+    cutlass::float_e4m3_t* fp8_out_bhmd,
+    int B, int M, int H, int D,
+    float eps,
+    cudaStream_t stream);
+
+// ---------------------------------------------------------------------------
+// 3) adaln-LoRA helper (defined in `cosmos_adaln_lora.cu`)
+//
+// Computes:
+//   h     = SiLU(t_emb @ down.T)            -- [B, lora_dim]
+//   mods  = h @ up.T + adaln_lora_3D        -- [B, 3K]
+//   shift = mods[:, 0:K]                    -- [B, K]
+//   scale = mods[:, K:2K]                   -- [B, K]
+//   gate  = mods[:, 2K:3K]                  -- [B, K]
+//
+// The output `mods_out` is a [B, 3K] buffer the caller carves into three
+// [B, K] views (no extra copy). This replaces three separate ATen matmuls.
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+cudaError_t cosmos_adaln_lora_split(
+    const ElementT* t_emb,                  // [B, K] -- caller has already applied SiLU
+    const ElementT* down_weight,            // [lora_dim, K] row-major (PyTorch layout)
+    const ElementT* up_weight,              // [3K, lora_dim] row-major
+    const ElementT* adaln_lora_3D,          // [B, 3K] additive component
+    ElementT* lora_hidden_buf,              // [B, lora_dim] scratch
+    ElementT* mods_out,                     // [B, 3K]
+    int B, int K, int lora_dim,
+    cudaStream_t stream);
+
+// In-place SiLU on a flat buffer. Used once per forward by the bridge to
+// pre-compute SiLU(t_emb) before the per-sub-layer adaln-LoRA helpers
+// (the SiLU happens BEFORE the down GEMM, not as a fused epilogue).
+template <typename ElementT>
+cudaError_t cosmos_silu_inplace(
+    ElementT* data,
+    int64_t numel,
+    cudaStream_t stream);
+
+// Split fused QKV projection output [M, 3K] into contiguous [M, K] Q/K/V rows.
+template <typename ElementT>
+cudaError_t cosmos_split_qkv(
+    const ElementT* qkv,
+    ElementT* q,
+    ElementT* k,
+    ElementT* v,
+    int M, int K,
+    cudaStream_t stream);
+
+// ---------------------------------------------------------------------------
+// 4) Streaming transformer block orchestrator (defined in `cosmos_block.cu`)
+//
+// All pointers are device-resident, all weights are bf16 row-major
+// (PyTorch's default state_dict layout).
+//
+// Per-block streaming flow (mirrors `optimized_dit_forward` in the
+// existing bridge but routes everything through CUTLASS GEMMs and the
+// fused modulate/residual kernels):
+//
+//   1) adaln_lora_split  -> (shift_sa, scale_sa, gate_sa)
+//      adaln_lora_split  -> (shift_ca, scale_ca, gate_ca)
+//      adaln_lora_split  -> (shift_mlp, scale_mlp, gate_mlp)
+//
+//   2) Self-attention residual (in-place into x):
+//       a) ln+modulate(x)              -> normed
+//       b) QKV GEMM (3K, K)            -> qkv_row [M, 3K]
+//       c) split + per-head RMSNorm Q, K
+//       d) apply rotate-half RoPE to Q, K   (caller passes rope_emb)
+//       e) write K_rot, V into KV cache at [write_start : write_start + M)
+//       f) cuDNN FMHA over [0 : write_start + M)
+//       g) out GEMM (K, K)             -> sa_out
+//       h) gated_residual:  x = x + gate_sa * sa_out
+//
+//   3) Cross-attention residual (in-place into x):
+//       a) ln+modulate(x)              -> normed
+//       b) Q GEMM (K, K)               -> q_row
+//       c) per-head RMSNorm Q
+//       d) cuDNN FMHA against pre-cached k_cross / v_cross
+//       e) out GEMM (K, K)             -> ca_out
+//       f) gated_residual:  x = x + gate_ca * ca_out
+//
+//   4) FFN residual (in-place into x):
+//       a) ln+modulate(x)              -> normed
+//       b) GEMM1 + GELU (FF, K)        -> ffn1_out
+//       c) GEMM2 (K, FF)               -> ffn2_out
+//       d) gated_residual:  x = x + gate_mlp * ffn2_out
+//
+// All GEMMs are bf16 (cutlass_linear_layer_rrr*_bf16). FMHA stays bf16
+// via `run_cudnn_fmha_packed_qkv`. KV-cache I/O is bf16 (FlashDreams'
+// caches are bf16 tensors).
+
+struct CosmosBlockWeights {
+  // Self-attention
+  const void* sa_w_qkv;                       // optional [3K, K] row-major raw E4M3 bytes
+  const void* sa_w_q;                         // [K, K] row-major bf16 or raw E4M3 bytes
+  const void* sa_w_k;                         // [K, K]
+  const void* sa_w_v;                         // [K, K]
+  const void* sa_w_out;                       // [K, K]
+  const cutlass::half_t* sa_w_qkv_scale;      // [3K] for optional fused FP8 QKV
+  const cutlass::half_t* sa_w_q_scale;        // [K] for FP8, nullptr for bf16
+  const cutlass::half_t* sa_w_k_scale;
+  const cutlass::half_t* sa_w_v_scale;
+  const cutlass::half_t* sa_w_out_scale;
+  const cutlass::bfloat16_t* sa_w_qkv_prepared;  // optional [K, 3K] row-major BF16
+  const cutlass::bfloat16_t* sa_w_out_prepared;  // optional [K, K] row-major BF16
+  const cutlass::bfloat16_t* sa_q_norm;       // [D]
+  const cutlass::bfloat16_t* sa_k_norm;       // [D]
+
+  // Cross-attention (Q only -- K/V come from pre-cached encoder buffers)
+  const void* ca_w_q;                         // [K, K] row-major bf16 or raw E4M3 bytes
+  const void* ca_w_out;                       // [K, K]
+  const cutlass::half_t* ca_w_q_scale;
+  const cutlass::half_t* ca_w_out_scale;
+  const cutlass::bfloat16_t* ca_w_q_prepared;    // optional [K, K] row-major BF16
+  const cutlass::bfloat16_t* ca_w_out_prepared;  // optional [K, K] row-major BF16
+  const cutlass::bfloat16_t* ca_q_norm;       // [D]
+
+  // FFN
+  const void* ffn_w1;                         // [FF, K] row-major bf16 or raw E4M3 bytes
+  const void* ffn_w2;                         // [K, FF]
+  const cutlass::half_t* ffn_w1_scale;
+  const cutlass::half_t* ffn_w2_scale;
+  const cutlass::bfloat16_t* ffn_w1_prepared;    // optional [K, FF] row-major BF16
+  const cutlass::bfloat16_t* ffn_w2_prepared;    // optional [FF, K] row-major BF16
+
+  // adaln-LoRA (per sub-layer)
+  const cutlass::bfloat16_t* adaln_sa_down;   // [lora_dim, K]
+  const cutlass::bfloat16_t* adaln_sa_up;     // [3K, lora_dim]
+  const cutlass::bfloat16_t* adaln_ca_down;
+  const cutlass::bfloat16_t* adaln_ca_up;
+  const cutlass::bfloat16_t* adaln_mlp_down;
+  const cutlass::bfloat16_t* adaln_mlp_up;
+};
+
+struct CosmosBlockBuffers {
+  // Per-call scratch (caller allocates via at::empty; sized below).
+  // qkv_row is used only when optional pre-fused self-attention QKV FP8
+  // weights are supplied. Split q_row/k_row/v_row remain the fallback.
+  cutlass::bfloat16_t* qkv_row;           // [M, 3K]
+  cutlass::bfloat16_t* q_row;             // [M, K]
+  cutlass::bfloat16_t* k_row;             // [M, K]
+  cutlass::bfloat16_t* v_row;             // [M, K]
+  cutlass::bfloat16_t* q_bmhk;            // [M, H, D]
+  cutlass::bfloat16_t* k_bmhk;            // [M, H, D]
+  cutlass::bfloat16_t* v_bmhk;            // [M, H, D]
+  cutlass::bfloat16_t* o_bmhk;            // [M, H, D]
+  cutlass::bfloat16_t* attn_out_row;      // [M, K] (after re-flatten)
+  cutlass::bfloat16_t* normed;            // [M, K] (pre-attn / pre-FFN normed input)
+  cutlass::bfloat16_t* ffn_intermediate;  // [M, FF]
+
+  // adaln-LoRA scratch (one per sub-layer).
+  cutlass::bfloat16_t* lora_hidden_sa;    // [B, lora_dim]
+  cutlass::bfloat16_t* lora_hidden_ca;
+  cutlass::bfloat16_t* lora_hidden_mlp;
+  cutlass::bfloat16_t* mods_sa;           // [B, 3K]
+  cutlass::bfloat16_t* mods_ca;
+  cutlass::bfloat16_t* mods_mlp;
+
+  // Quantized path scratch, reused sequentially by per-block linears/attention.
+  cutlass::float_e4m3_t* linear_fp8_scratch;  // [M, max(K, FF)]
+  cutlass::half_t* linear_half_scratch;       // [M, max(K, FF)]
+  cutlass::float_e4m3_t* attn_q_fp8;          // [B, M, H, D]
+  cutlass::float_e4m3_t* attn_k_fp8;          // [B, max_attn_tokens, H, D]
+  cutlass::float_e4m3_t* attn_v_fp8;          // [B, max_attn_tokens, H, D]
+  cutlass::float_e4m3_t* attn_q_bhmd_fp8;     // [B, H, M, D] dense two-GEMM scratch
+  cutlass::float_e4m3_t* attn_k_bhmd_fp8;     // [B, H, max_attn_tokens, D]
+  cutlass::float_e4m3_t* attn_v_bhmd_fp8;     // [B, H, max_attn_tokens, D]
+  cutlass::float_e4m3_t* attn_v_bhdm_fp8;     // [B, H, D, max_attn_tokens] SM120 TN PV scratch
+  uint8_t* attn_q_sage3_fp4;                  // [B, H, round_up(M, 128), D / 2]
+  cutlass::float_e4m3_t* attn_q_sage3_sf;     // [B, H, round_up(M, 128), D / 16]
+  cutlass::half_t* attn_scores_half;          // [B * H, M, max_attn_tokens] for dense FP8 two-GEMM
+  cutlass::bfloat16_t* attn_scores_bf16;      // [B * H, M, max_attn_tokens] for SM120 FP8 TC diagnostic
+  cutlass::bfloat16_t* attn_score_c_bf16;     // [B * H, M, max_attn_tokens] C scratch for SM120 FP8 TC diagnostic
+  cutlass::float_e4m3_t* attn_probs_fp8;      // [B * H, M, max_attn_tokens] for dense FP8 two-GEMM
+  cutlass::half_t* attn_o_bhmd_half;          // [B, H, M, D] dense two-GEMM scratch
+  cutlass::bfloat16_t* attn_o_bhmd_bf16;      // [B, H, M, D] SM120 FP8 TC diagnostic output scratch
+  cutlass::bfloat16_t* attn_o_c_bf16;         // [B, H, M, D] C scratch for SM120 FP8 TC diagnostic
+  cutlass::half_t* attn_o_half;               // [B, M, H, D]
+  float* attn_tc_scale;                       // [scale_elems] all-ones block-scale scratch
+  int64_t attn_tc_scale_elems;
+  bool attn_tc_scale_is_ones;                 // true when caller initialized attn_tc_scale to 1.0f
+
+};
+
+struct CosmosBlockParams {
+  // Geometry
+  int B;             // batch size (typically 1; CFG could be 2)
+  int M;             // L_new -- per-call query length
+  int K;             // model_channels
+  int H;             // num_heads
+  int D;             // head_dim = K / H
+  int FF;            // FFN inner dim (usually 4 * K)
+  int lora_dim;      // adaln_lora_dim (256 for cosmos production)
+  int Mk_cross;      // length of pre-cached cross-attn K/V (text tokens)
+  int self_attn_cache_cap;   // total slots in self-attn KV cache
+  int self_attn_write_start; // append new K/V at [write_start : write_start + M)
+  CosmosLinearBackend linear_backend;         // bf16 or FP8 block linear weights
+  CosmosAttentionBackend attention_backend;   // cuDNN bf16 or FP8 fused candidate
+  bool fp8_kv_cache_enabled;                  // use externally managed FP8 shadow K/V caches for FP8 attention
+  bool write_bf16_self_kv_cache;              // keep BF16 self-cache in sync when using FP8 KV caches
+
+  // Optional trace outputs. Each pointer, when non-null, receives a device copy
+  // of x after the corresponding residual update.
+  cutlass::bfloat16_t* trace_sa_out;
+  cutlass::bfloat16_t* trace_ca_out;
+  cutlass::bfloat16_t* trace_ffn_out;
+  cutlass::bfloat16_t* trace_block_out;
+  int64_t trace_elems;
+
+  // Optional activation calibration I/O. `fp8_activation_scales` is a host
+  // pointer consumed as [kCosmosFp8ActivationScaleSites] scale values for this
+  // block. `fp8_activation_amax_out` is a device pointer that receives BF16
+  // amax values for sites that the runtime can observe.
+  const float* fp8_activation_scales;
+  float* fp8_activation_amax_out;
+
+  // Inputs
+  cutlass::bfloat16_t* x;          // [M, K] in/out (residual updated in-place)
+  const cutlass::bfloat16_t* t_emb;             // [B, K]            timestep embedding (post-RMSNorm)
+  const cutlass::bfloat16_t* adaln_lora_3D;     // [B, 3K]           per-block lora component (added inside helper)
+  const cutlass::bfloat16_t* precomputed_mods_sa;  // [B, 3K] optional (shift, scale, gate)
+  const cutlass::bfloat16_t* precomputed_mods_ca;  // [B, 3K] optional (shift, scale, gate)
+  const cutlass::bfloat16_t* precomputed_mods_mlp; // [B, 3K] optional (shift, scale, gate)
+
+  // Cross-attn pre-cached K/V (post k_norm, no RoPE; these are written by
+  // FlashDreams' CrossAttention.initialize_cache and stay constant for the
+  // full streaming run).
+  const cutlass::bfloat16_t* k_cross;           // [B, Mk_cross, H, D]
+  const cutlass::bfloat16_t* v_cross;           // [B, Mk_cross, H, D]
+
+  // Self-attn KV ring buffer (mutated in place)
+  cutlass::bfloat16_t* k_self_cache;            // [B, self_attn_cache_cap, H, D]
+  cutlass::bfloat16_t* v_self_cache;            // [B, self_attn_cache_cap, H, D]
+  cutlass::float_e4m3_t* k_self_cache_fp8;       // [B, self_attn_cache_cap, H, D] optional shadow cache
+  cutlass::float_e4m3_t* v_self_cache_fp8;       // [B, self_attn_cache_cap, H, D] optional shadow cache
+  const cutlass::float_e4m3_t* k_cross_fp8;      // [B, Mk_cross, H, D] optional pre-quantized cross cache
+  const cutlass::float_e4m3_t* v_cross_fp8;      // [B, Mk_cross, H, D] optional pre-quantized cross cache
+  cutlass::float_e4m3_t* k_self_cache_fp8_bhmd;  // [B, H, self_attn_cache_cap, D] optional TC-layout cache
+  cutlass::float_e4m3_t* v_self_cache_fp8_bhmd;  // [B, H, self_attn_cache_cap, D] optional cuDNN input-layout cache
+  cutlass::float_e4m3_t* v_self_cache_fp8_bhdm;  // [B, H, D, self_attn_cache_cap] optional custom TC-layout cache
+  const cutlass::float_e4m3_t* k_cross_fp8_bhmd; // [B, H, Mk_cross, D] optional TC-layout cross cache
+  const cutlass::float_e4m3_t* v_cross_fp8_bhmd; // [B, H, Mk_cross, D] optional cuDNN input-layout cross cache
+  const cutlass::float_e4m3_t* v_cross_fp8_bhdm; // [B, H, D, Mk_cross] optional custom TC-layout cross cache
+  const uint8_t* k_cross_sage3_fp4;            // [B, H, round_up(Mk_cross, 128), D / 2]
+  const uint8_t* v_cross_sage3_fp4;            // [B, H, D, round_up(Mk_cross, 128) / 2]
+  const cutlass::float_e4m3_t* k_cross_sage3_sf; // [B, H, round_up(Mk_cross, 128), D / 16]
+  const cutlass::float_e4m3_t* v_cross_sage3_sf; // [B, H, D, round_up(Mk_cross, 128) / 16]
+  int Mk_cross_sage3_padded;
+
+  // Pre-computed RoPE cos/sin in q.dtype, broadcast as [1, M, 1, D].
+  // (Cosmos uses rotate-half; the bridge precomputes cos/sin from rope_emb
+  //  once per forward and reuses across blocks.)
+  const cutlass::bfloat16_t* rope_cos;          // [M, D]
+  const cutlass::bfloat16_t* rope_sin;          // [M, D]
+
+  CosmosBlockWeights w;
+  CosmosBlockBuffers buf;
+
+  // When true, the bridge has already computed the (shift, scale, gate) bundles
+  // for all 28 blocks and stored them at `buf.mods_sa / buf.mods_ca / buf.mods_mlp`.
+  // The orchestrator will skip the three per-sub-layer cosmos_adaln_lora_split
+  // calls and consume the pre-computed mods directly. See the
+  // "AdaLN-LoRA pre-stack + strided-batched up GEMM" Phase 1 plan.
+  bool adaln_precomputed;
+};
+
+// Runs one Cosmos transformer block in streaming mode. After this returns,
+// `params.x` holds the post-block hidden state and the self-attn KV caches
+// at slots [write_start : write_start + M) are populated with this block's
+// post-RoPE / post-RMSNorm K and post-projection V.
+cudaError_t cosmos_run_transformer_block_streaming(
+    const CosmosBlockParams& params,
+    cudaStream_t stream);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 // cosmos_block.cuh — declarations for the Cosmos DiT streaming transformer block.

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_block.cuh
@@ -33,6 +33,7 @@ enum class CosmosLinearBackend : int {
 enum class CosmosAttentionBackend : int {
   CUDNN_BF16 = 0,
   FP8_DENSE_REF = 4,
+  SPARGE = 6,
   SAGE3 = 7,
   FP8_CUDNN = 8,
   SAGE3_FP8 = 9,
@@ -439,6 +440,7 @@ struct CosmosBlockBuffers {
   float* attn_tc_scale;                       // [scale_elems] all-ones block-scale scratch
   int64_t attn_tc_scale_elems;
   bool attn_tc_scale_is_ones;                 // true when caller initialized attn_tc_scale to 1.0f
+  ts::SpargeAttentionWorkspace sparge;
 
 };
 
@@ -458,6 +460,8 @@ struct CosmosBlockParams {
   CosmosAttentionBackend attention_backend;   // cuDNN bf16 or FP8 fused candidate
   bool fp8_kv_cache_enabled;                  // use externally managed FP8 shadow K/V caches for FP8 attention
   bool write_bf16_self_kv_cache;              // keep BF16 self-cache in sync when using FP8 KV caches
+  float sparge_topk_ratio;                    // self-attn block-selection ratio for Sparge
+  bool sparge_attention_sink;                 // force K block 0 into the sparse map after selection
 
   // Optional trace outputs. Each pointer, when non-null, receives a device copy
   // of x after the corresponding residual update.
@@ -501,6 +505,8 @@ struct CosmosBlockParams {
   const cutlass::float_e4m3_t* k_cross_fp8_bhmd; // [B, H, Mk_cross, D] optional TC-layout cross cache
   const cutlass::float_e4m3_t* v_cross_fp8_bhmd; // [B, H, Mk_cross, D] optional cuDNN input-layout cross cache
   const cutlass::float_e4m3_t* v_cross_fp8_bhdm; // [B, H, D, Mk_cross] optional custom TC-layout cross cache
+  int k_cross_fp8_bhmd_tokens;                   // physical token dimension for k_cross_fp8_bhmd
+  int v_cross_fp8_bhmd_tokens;                   // physical token dimension for v_cross_fp8_bhmd
   const uint8_t* k_cross_sage3_fp4;            // [B, H, round_up(Mk_cross, 128), D / 2]
   const uint8_t* v_cross_sage3_fp4;            // [B, H, D, round_up(Mk_cross, 128) / 2]
   const cutlass::float_e4m3_t* k_cross_sage3_sf; // [B, H, round_up(Mk_cross, 128), D / 16]

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cu
@@ -1,0 +1,174 @@
+#include "cosmos_fp8_flash.cuh"
+
+#include "cutlass/numeric_conversion.h"
+
+#include <cmath>
+
+namespace omnidreams_singleview {
+namespace {
+
+// V0 fused FlashAttention contract kernel. It is intentionally simple and
+// exists to lock correctness/API behavior before replacing the inner loop with
+// SM120 FP8 MMA tiling.
+template <int HeadDim>
+__global__ void cosmos_fp8_flash_online_warp_kernel(
+    const cutlass::float_e4m3_t* __restrict__ q,
+    const cutlass::float_e4m3_t* __restrict__ k,
+    const cutlass::float_e4m3_t* __restrict__ v,
+    cutlass::half_t* __restrict__ o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    bool causal,
+    float softmax_scale) {
+    constexpr int kWarpSize = 32;
+    constexpr int kWarpsPerBlock = 4;
+    constexpr int kElemsPerLane = (HeadDim + kWarpSize - 1) / kWarpSize;
+
+    const int lane = threadIdx.x & (kWarpSize - 1);
+    const int warp = threadIdx.x / kWarpSize;
+    const int row_linear = static_cast<int>(blockIdx.x) * kWarpsPerBlock + warp;
+    const int total_rows = B * H * Mq;
+    if (row_linear >= total_rows) {
+        return;
+    }
+
+    const int q_idx = row_linear % Mq;
+    const int head_batch = row_linear / Mq;
+    const int head = head_batch % H;
+    const int batch = head_batch / H;
+
+    cutlass::NumericConverter<float, cutlass::float_e4m3_t> to_float;
+    cutlass::NumericConverter<cutlass::half_t, float> to_half;
+
+    const size_t q_base =
+        ((static_cast<size_t>(batch) * Mq + q_idx) * H + head) * HeadDim;
+    const size_t o_base = q_base;
+
+    float row_max = -INFINITY;
+    float row_sum = 0.0f;
+    float q_frag[kElemsPerLane];
+    float out_frag[kElemsPerLane];
+
+#pragma unroll
+    for (int i = 0; i < kElemsPerLane; ++i) {
+        const int d = lane + i * kWarpSize;
+        q_frag[i] = d < HeadDim ? to_float(q[q_base + d]) : 0.0f;
+        out_frag[i] = 0.0f;
+    }
+
+    for (int k_idx = 0; k_idx < Mk; ++k_idx) {
+        const size_t kv_base =
+            ((static_cast<size_t>(batch) * Mk + k_idx) * H + head) * HeadDim;
+
+        float dot = 0.0f;
+#pragma unroll
+        for (int i = 0; i < kElemsPerLane; ++i) {
+            const int d = lane + i * kWarpSize;
+            if (d < HeadDim) {
+                dot += q_frag[i] * to_float(k[kv_base + d]);
+            }
+        }
+
+        unsigned mask = 0xffffffffu;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            dot += __shfl_down_sync(mask, dot, offset);
+        }
+
+        float old_scale = 1.0f;
+        float new_weight = 0.0f;
+        if (lane == 0) {
+            const bool valid = !causal || (k_idx <= q_idx);
+            if (valid) {
+                const float score = dot * softmax_scale;
+                const float new_max = fmaxf(row_max, score);
+                old_scale = row_sum == 0.0f ? 0.0f : __expf(row_max - new_max);
+                new_weight = __expf(score - new_max);
+                row_sum = row_sum * old_scale + new_weight;
+                row_max = new_max;
+            }
+        }
+
+        old_scale = __shfl_sync(mask, old_scale, 0);
+        new_weight = __shfl_sync(mask, new_weight, 0);
+
+#pragma unroll
+        for (int i = 0; i < kElemsPerLane; ++i) {
+            const int d = lane + i * kWarpSize;
+            if (d < HeadDim) {
+                const float v_value = to_float(v[kv_base + d]);
+                out_frag[i] = out_frag[i] * old_scale + v_value * new_weight;
+            }
+        }
+    }
+
+    float inv_sum = 0.0f;
+    if (lane == 0) {
+        inv_sum = row_sum > 0.0f ? (1.0f / row_sum) : 0.0f;
+    }
+    inv_sum = __shfl_sync(0xffffffffu, inv_sum, 0);
+
+#pragma unroll
+    for (int i = 0; i < kElemsPerLane; ++i) {
+        const int d = lane + i * kWarpSize;
+        if (d < HeadDim) {
+            o[o_base + d] = to_half(out_frag[i] * inv_sum);
+        }
+    }
+}
+
+template <int HeadDim>
+cudaError_t launch_cosmos_fp8_flash_online(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::half_t* o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    bool causal,
+    cudaStream_t stream) {
+    constexpr int kWarpsPerBlock = 4;
+    constexpr int kThreads = 32 * kWarpsPerBlock;
+    const int total_rows = B * H * Mq;
+    const int blocks = (total_rows + kWarpsPerBlock - 1) / kWarpsPerBlock;
+    const float softmax_scale = 1.0f / std::sqrt(static_cast<float>(HeadDim));
+    cosmos_fp8_flash_online_warp_kernel<HeadDim>
+        <<<blocks, kThreads, 0, stream>>>(q, k, v, o, B, Mq, Mk, H, causal, softmax_scale);
+    return cudaGetLastError();
+}
+
+}  // namespace
+
+cudaError_t run_cosmos_cute_flash_fp8(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::half_t* o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    cudaStream_t stream) {
+    if (!q || !k || !v || !o || B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    switch (D) {
+    case 32:
+        return launch_cosmos_fp8_flash_online<32>(q, k, v, o, B, Mq, Mk, H, causal, stream);
+    case 64:
+        return launch_cosmos_fp8_flash_online<64>(q, k, v, o, B, Mq, Mk, H, causal, stream);
+    case 128:
+        return launch_cosmos_fp8_flash_online<128>(q, k, v, o, B, Mq, Mk, H, causal, stream);
+    default:
+        return cudaErrorInvalidValue;
+    }
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "cosmos_fp8_flash.cuh"
 
 #include "cutlass/numeric_conversion.h"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cuh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "cutlass/numeric_types.h"
+#include <cuda_runtime.h>
+
+namespace omnidreams_singleview {
+
+// Fused FP8 attention bring-up path for Cosmos-layout tensors:
+//   Q: [B, Mq, H, D] raw E4M3 bytes
+//   K: [B, Mk, H, D] raw E4M3 bytes
+//   V: [B, Mk, H, D] raw E4M3 bytes
+//   O: [B, Mq, H, D] fp16
+//
+// This kernel keeps the softmax online within a single kernel and does not
+// materialize the Mq x Mk score/probability matrix.
+cudaError_t run_cosmos_cute_flash_fp8(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::half_t* o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    cudaStream_t stream);
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "cutlass/numeric_types.h"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cu
@@ -1,0 +1,586 @@
+#include "cosmos_fp8_flash_tc.cuh"
+
+#include "cosmos_fp8_tc_probe.cuh"
+
+#include "cutlass/numeric_conversion.h"
+#include "cutlass/util/device_memory.h"
+
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+
+namespace omnidreams_singleview {
+namespace {
+
+constexpr int kTcTileMultiple = 128;
+
+static bool is_tc_tile_multiple(int value) {
+  return value > 0 && (value % kTcTileMultiple) == 0;
+}
+
+__global__ void fill_float_kernel(float* __restrict__ dst, int64_t n, float value) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    dst[idx] = value;
+  }
+}
+
+__global__ void pack_qkv_bmhk_to_tc_layouts_kernel(
+    const cutlass::float_e4m3_t* __restrict__ q_src,
+    const cutlass::float_e4m3_t* __restrict__ k_src,
+    const cutlass::float_e4m3_t* __restrict__ v_src,
+    cutlass::float_e4m3_t* __restrict__ q_dst_bhmd,
+    cutlass::float_e4m3_t* __restrict__ k_dst_bhmd,
+    cutlass::float_e4m3_t* __restrict__ v_dst_bhdm,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t q_total = static_cast<int64_t>(B) * Mq * H * D;
+  const int64_t kv_total = static_cast<int64_t>(B) * Mk * H * D;
+  const int64_t total = q_total + 2 * kv_total;
+  if (idx >= total) return;
+
+  if (idx < q_total) {
+    int d = static_cast<int>(idx % D);
+    int h = static_cast<int>((idx / D) % H);
+    int m = static_cast<int>((idx / (static_cast<int64_t>(D) * H)) % Mq);
+    int b = static_cast<int>(idx / (static_cast<int64_t>(Mq) * H * D));
+    size_t dst_idx = ((static_cast<size_t>(b) * H + h) * Mq + m) * D + d;
+    q_dst_bhmd[dst_idx] = q_src[idx];
+    return;
+  }
+
+  idx -= q_total;
+  if (idx < kv_total) {
+    int d = static_cast<int>(idx % D);
+    int h = static_cast<int>((idx / D) % H);
+    int m = static_cast<int>((idx / (static_cast<int64_t>(D) * H)) % Mk);
+    int b = static_cast<int>(idx / (static_cast<int64_t>(Mk) * H * D));
+    size_t dst_idx = ((static_cast<size_t>(b) * H + h) * Mk + m) * D + d;
+    k_dst_bhmd[dst_idx] = k_src[idx];
+    return;
+  }
+
+  idx -= kv_total;
+  int d = static_cast<int>(idx % D);
+  int h = static_cast<int>((idx / D) % H);
+  int m = static_cast<int>((idx / (static_cast<int64_t>(D) * H)) % Mk);
+  int b = static_cast<int>(idx / (static_cast<int64_t>(Mk) * H * D));
+  size_t dst_idx = ((static_cast<size_t>(b) * H + h) * D + d) * Mk + m;
+  v_dst_bhdm[dst_idx] = v_src[idx];
+}
+
+__global__ void pack_q_bmhk_to_bhmd_kernel(
+    const cutlass::float_e4m3_t* __restrict__ q_src,
+    cutlass::float_e4m3_t* __restrict__ q_dst_bhmd,
+    int B,
+    int Mq,
+    int H,
+    int D) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = static_cast<int64_t>(B) * Mq * H * D;
+  if (idx >= total) return;
+
+  int d = static_cast<int>(idx % D);
+  int h = static_cast<int>((idx / D) % H);
+  int m = static_cast<int>((idx / (static_cast<int64_t>(D) * H)) % Mq);
+  int b = static_cast<int>(idx / (static_cast<int64_t>(Mq) * H * D));
+  size_t dst_idx = ((static_cast<size_t>(b) * H + h) * Mq + m) * D + d;
+  q_dst_bhmd[dst_idx] = q_src[idx];
+}
+
+__global__ void softmax_bf16_scores_to_fp8_kernel(
+    const cutlass::bfloat16_t* __restrict__ scores,
+    cutlass::float_e4m3_t* __restrict__ probs,
+    int groups,
+    int rows,
+    int cols,
+    bool causal,
+    float softmax_scale) {
+  int row = blockIdx.x;
+  int group = blockIdx.y;
+  if (group >= groups || row >= rows) return;
+
+  int tid = threadIdx.x;
+  extern __shared__ float smem[];
+  cutlass::NumericConverter<float, cutlass::bfloat16_t> to_f32;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  const size_t group_offset = static_cast<size_t>(group) * rows * cols;
+  const cutlass::bfloat16_t* score_row = scores + group_offset + static_cast<size_t>(row) * cols;
+  cutlass::float_e4m3_t* prob_row = probs + group_offset + static_cast<size_t>(row) * cols;
+
+  float max_val = -FLT_MAX;
+  for (int col = tid; col < cols; col += blockDim.x) {
+    bool valid = !causal || col <= row;
+    if (valid) {
+      float value = to_f32(score_row[col]) * softmax_scale;
+      max_val = fmaxf(max_val, value);
+    }
+  }
+  smem[tid] = max_val;
+  __syncthreads();
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) smem[tid] = fmaxf(smem[tid], smem[tid + offset]);
+    __syncthreads();
+  }
+  max_val = smem[0];
+
+  float sum = 0.0f;
+  for (int col = tid; col < cols; col += blockDim.x) {
+    bool valid = !causal || col <= row;
+    if (valid) {
+      float value = to_f32(score_row[col]) * softmax_scale;
+      sum += expf(value - max_val);
+    }
+  }
+  smem[tid] = sum;
+  __syncthreads();
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) smem[tid] += smem[tid + offset];
+    __syncthreads();
+  }
+  sum = smem[0];
+
+  for (int col = tid; col < cols; col += blockDim.x) {
+    bool valid = !causal || col <= row;
+    float p = 0.0f;
+    if (valid && sum > 0.0f) {
+      float value = to_f32(score_row[col]) * softmax_scale;
+      p = expf(value - max_val) / sum;
+    }
+    prob_row[col] = to_fp8(p);
+  }
+}
+
+__global__ void unpack_bhmd_bf16_to_bmhk_half_fp8_kernel(
+    const cutlass::bfloat16_t* __restrict__ src,
+    cutlass::half_t* __restrict__ dst_half,
+    cutlass::float_e4m3_t* __restrict__ dst_fp8,
+    int B,
+    int M,
+    int H,
+    int D) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total = static_cast<int64_t>(B) * H * M * D;
+  if (idx >= total) return;
+
+  int d = static_cast<int>(idx % D);
+  int m = static_cast<int>((idx / D) % M);
+  int h = static_cast<int>((idx / (static_cast<int64_t>(D) * M)) % H);
+  int b = static_cast<int>(idx / (static_cast<int64_t>(H) * M * D));
+  size_t dst_idx = ((static_cast<size_t>(b) * M + m) * H + h) * D + d;
+
+  cutlass::NumericConverter<float, cutlass::bfloat16_t> to_f32;
+  float value = to_f32(src[idx]);
+  if (dst_half) {
+    cutlass::NumericConverter<cutlass::half_t, float> to_half;
+    dst_half[dst_idx] = to_half(value);
+  }
+  if (dst_fp8) {
+    cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+    dst_fp8[dst_idx] = to_fp8(value);
+  }
+}
+
+static cudaError_t pack_qkv_bmhk_to_tc_layouts(
+    const cutlass::float_e4m3_t* q_src,
+    const cutlass::float_e4m3_t* k_src,
+    const cutlass::float_e4m3_t* v_src,
+    cutlass::float_e4m3_t* q_dst_bhmd,
+    cutlass::float_e4m3_t* k_dst_bhmd,
+    cutlass::float_e4m3_t* v_dst_bhdm,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    cudaStream_t stream) {
+  int64_t q_total = static_cast<int64_t>(B) * Mq * H * D;
+  int64_t kv_total = static_cast<int64_t>(B) * Mk * H * D;
+  int64_t total = q_total + 2 * kv_total;
+  if (total <= 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int64_t blocks = (total + threads - 1) / threads;
+  pack_qkv_bmhk_to_tc_layouts_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      q_src, k_src, v_src, q_dst_bhmd, k_dst_bhmd, v_dst_bhdm, B, Mq, Mk, H, D);
+  return cudaGetLastError();
+}
+
+static cudaError_t pack_q_bmhk_to_bhmd(
+    const cutlass::float_e4m3_t* q_src,
+    cutlass::float_e4m3_t* q_dst_bhmd,
+    int B,
+    int Mq,
+    int H,
+    int D,
+    cudaStream_t stream) {
+  int64_t total = static_cast<int64_t>(B) * Mq * H * D;
+  if (total <= 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int64_t blocks = (total + threads - 1) / threads;
+  pack_q_bmhk_to_bhmd_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      q_src, q_dst_bhmd, B, Mq, H, D);
+  return cudaGetLastError();
+}
+
+static cudaError_t unpack_bhmd_bf16_to_bmhk_half_fp8(
+    const cutlass::bfloat16_t* src,
+    cutlass::half_t* dst_half,
+    cutlass::float_e4m3_t* dst_fp8,
+    int B,
+    int M,
+    int H,
+    int D,
+    cudaStream_t stream) {
+  int64_t total = static_cast<int64_t>(B) * M * H * D;
+  if (total <= 0) return cudaSuccess;
+  if (!src || (!dst_half && !dst_fp8)) return cudaErrorInvalidValue;
+  constexpr int threads = 256;
+  int64_t blocks = (total + threads - 1) / threads;
+  unpack_bhmd_bf16_to_bmhk_half_fp8_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      src, dst_half, dst_fp8, B, M, H, D);
+  return cudaGetLastError();
+}
+
+static cudaError_t fill_float(float* dst, int64_t n, float value, cudaStream_t stream) {
+  if (n <= 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int64_t blocks = (n + threads - 1) / threads;
+  fill_float_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(dst, n, value);
+  return cudaGetLastError();
+}
+
+}  // namespace
+
+cudaError_t run_cosmos_fp8_flash_tc(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::half_t* o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    cudaStream_t stream) {
+  if (!q || !k || !v || !o || B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0 || D <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  if (D != 128) {
+    return cudaErrorInvalidValue;
+  }
+  if (!is_tc_tile_multiple(Mq) || !is_tc_tile_multiple(Mk)) {
+    return cudaErrorNotSupported;
+  }
+
+  const int groups = B * H;
+  const size_t q_group_elems = static_cast<size_t>(Mq) * D;
+  const size_t k_group_elems = static_cast<size_t>(Mk) * D;
+  const size_t score_group_elems = static_cast<size_t>(Mq) * Mk;
+  const size_t out_group_elems = static_cast<size_t>(Mq) * D;
+  const int64_t q_total = static_cast<int64_t>(groups) * q_group_elems;
+  const int64_t k_total = static_cast<int64_t>(groups) * k_group_elems;
+  const int64_t v_t_total = static_cast<int64_t>(groups) * static_cast<int64_t>(D) * Mk;
+  const int64_t score_total = static_cast<int64_t>(groups) * score_group_elems;
+  const int64_t out_total = static_cast<int64_t>(groups) * out_group_elems;
+  const int64_t scale_elems_per_group = std::max<int64_t>(
+      std::max<int64_t>(q_group_elems, k_group_elems),
+      score_group_elems);
+  const int64_t scale_elems = static_cast<int64_t>(groups) * scale_elems_per_group;
+
+  cutlass::device_memory::allocation<cutlass::float_e4m3_t> q_bhmd(q_total);
+  cutlass::device_memory::allocation<cutlass::float_e4m3_t> k_bhmd(k_total);
+  cutlass::device_memory::allocation<cutlass::float_e4m3_t> v_bhdm(v_t_total);
+  cutlass::device_memory::allocation<cutlass::bfloat16_t> scores(score_total);
+  cutlass::device_memory::allocation<cutlass::bfloat16_t> score_c_scratch(score_total);
+  cutlass::device_memory::allocation<cutlass::float_e4m3_t> probs(score_total);
+  cutlass::device_memory::allocation<cutlass::bfloat16_t> out_bhmd(out_total);
+  cutlass::device_memory::allocation<cutlass::bfloat16_t> out_c_scratch(out_total);
+  cutlass::device_memory::allocation<float> tc_scale(scale_elems);
+
+  return run_cosmos_fp8_flash_tc_workspace(
+      q,
+      k,
+      v,
+      q_bhmd.get(),
+      k_bhmd.get(),
+      v_bhdm.get(),
+      scores.get(),
+      score_c_scratch.get(),
+      probs.get(),
+      out_bhmd.get(),
+      out_c_scratch.get(),
+      o,
+      nullptr,
+      tc_scale.get(),
+      scale_elems,
+      B, Mq, Mk, H, D, causal, /*tc_scale_is_ones=*/false, stream);
+}
+
+cudaError_t run_cosmos_fp8_flash_tc_workspace(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::float_e4m3_t* q_bhmd,
+    cutlass::float_e4m3_t* k_bhmd,
+    cutlass::float_e4m3_t* v_bhdm,
+    cutlass::bfloat16_t* scores,
+    cutlass::bfloat16_t* score_c_scratch,
+    cutlass::float_e4m3_t* probs,
+    cutlass::bfloat16_t* out_bhmd,
+    cutlass::bfloat16_t* out_c_scratch,
+    cutlass::half_t* o,
+    cutlass::float_e4m3_t* o_fp8,
+    float* tc_scale,
+    int64_t tc_scale_elems,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    bool tc_scale_is_ones,
+    cudaStream_t stream) {
+  if (!q || !k || !v || !q_bhmd || !k_bhmd || !v_bhdm || !scores || !score_c_scratch ||
+      !probs || !out_bhmd || !out_c_scratch || (!o && !o_fp8) || !tc_scale ||
+      B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0 || D <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  if (D != 128) {
+    return cudaErrorInvalidValue;
+  }
+  if (!is_tc_tile_multiple(Mq) || !is_tc_tile_multiple(Mk)) {
+    return cudaErrorNotSupported;
+  }
+
+  const int groups = B * H;
+  const size_t q_group_elems = static_cast<size_t>(Mq) * D;
+  const size_t k_group_elems = static_cast<size_t>(Mk) * D;
+  const size_t score_group_elems = static_cast<size_t>(Mq) * Mk;
+  const int64_t scale_elems_per_group = std::max<int64_t>(
+      std::max<int64_t>(q_group_elems, k_group_elems),
+      score_group_elems);
+  const int64_t required_scale_elems = static_cast<int64_t>(groups) * scale_elems_per_group;
+  if (tc_scale_elems < required_scale_elems) {
+    return cudaErrorInvalidValue;
+  }
+
+  cudaError_t err = cudaSuccess;
+  if (!tc_scale_is_ones) {
+    err = fill_float(tc_scale, required_scale_elems, 1.0f, stream);
+    if (err != cudaSuccess) return err;
+  }
+  err = pack_qkv_bmhk_to_tc_layouts(q, k, v, q_bhmd, k_bhmd, v_bhdm, B, Mq, Mk, H, D, stream);
+  if (err != cudaSuccess) return err;
+
+  err = run_cosmos_fp8_tc_probe_qk_batched(
+      q_bhmd,
+      k_bhmd,
+      tc_scale,
+      tc_scale,
+      score_c_scratch,
+      scores,
+      Mq, Mk, D, groups, stream);
+  if (err != cudaSuccess) return err;
+
+  constexpr int softmax_threads = 256;
+  const float softmax_scale = 1.0f / std::sqrt(static_cast<float>(D));
+  softmax_bf16_scores_to_fp8_kernel<<<
+      dim3(Mq, groups),
+      softmax_threads,
+      softmax_threads * sizeof(float),
+      stream>>>(scores, probs, groups, Mq, Mk, causal, softmax_scale);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  err = run_cosmos_fp8_tc_probe_pv_batched(
+      probs,
+      v_bhdm,
+      tc_scale,
+      tc_scale,
+      out_c_scratch,
+      out_bhmd,
+      Mq, Mk, D, groups, stream);
+  if (err != cudaSuccess) return err;
+
+  return unpack_bhmd_bf16_to_bmhk_half_fp8(out_bhmd, o, o_fp8, B, Mq, H, D, stream);
+}
+
+cudaError_t run_cosmos_fp8_flash_tc_workspace_prepacked_kv(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k_bhmd,
+    const cutlass::float_e4m3_t* v_bhdm,
+    cutlass::float_e4m3_t* q_bhmd,
+    cutlass::bfloat16_t* scores,
+    cutlass::bfloat16_t* score_c_scratch,
+    cutlass::float_e4m3_t* probs,
+    cutlass::bfloat16_t* out_bhmd,
+    cutlass::bfloat16_t* out_c_scratch,
+    cutlass::half_t* o,
+    cutlass::float_e4m3_t* o_fp8,
+    float* tc_scale,
+    int64_t tc_scale_elems,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    bool tc_scale_is_ones,
+    cudaStream_t stream) {
+  if (!q || !k_bhmd || !v_bhdm || !q_bhmd || !scores || !score_c_scratch ||
+      !probs || !out_bhmd || !out_c_scratch || (!o && !o_fp8) || !tc_scale ||
+      B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0 || D <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  if (D != 128) {
+    return cudaErrorInvalidValue;
+  }
+  if (!is_tc_tile_multiple(Mq) || !is_tc_tile_multiple(Mk)) {
+    return cudaErrorNotSupported;
+  }
+
+  const int groups = B * H;
+  const size_t q_group_elems = static_cast<size_t>(Mq) * D;
+  const size_t k_group_elems = static_cast<size_t>(Mk) * D;
+  const size_t score_group_elems = static_cast<size_t>(Mq) * Mk;
+  const int64_t scale_elems_per_group = std::max<int64_t>(
+      std::max<int64_t>(q_group_elems, k_group_elems),
+      score_group_elems);
+  const int64_t required_scale_elems = static_cast<int64_t>(groups) * scale_elems_per_group;
+  if (tc_scale_elems < required_scale_elems) {
+    return cudaErrorInvalidValue;
+  }
+
+  cudaError_t err = cudaSuccess;
+  if (!tc_scale_is_ones) {
+    err = fill_float(tc_scale, required_scale_elems, 1.0f, stream);
+    if (err != cudaSuccess) return err;
+  }
+  err = pack_q_bmhk_to_bhmd(q, q_bhmd, B, Mq, H, D, stream);
+  if (err != cudaSuccess) return err;
+
+  err = run_cosmos_fp8_tc_probe_qk_batched(
+      q_bhmd,
+      k_bhmd,
+      tc_scale,
+      tc_scale,
+      score_c_scratch,
+      scores,
+      Mq, Mk, D, groups, stream);
+  if (err != cudaSuccess) return err;
+
+  constexpr int softmax_threads = 256;
+  const float softmax_scale = 1.0f / std::sqrt(static_cast<float>(D));
+  softmax_bf16_scores_to_fp8_kernel<<<
+      dim3(Mq, groups),
+      softmax_threads,
+      softmax_threads * sizeof(float),
+      stream>>>(scores, probs, groups, Mq, Mk, causal, softmax_scale);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  err = run_cosmos_fp8_tc_probe_pv_batched(
+      probs,
+      v_bhdm,
+      tc_scale,
+      tc_scale,
+      out_c_scratch,
+      out_bhmd,
+      Mq, Mk, D, groups, stream);
+  if (err != cudaSuccess) return err;
+
+  return unpack_bhmd_bf16_to_bmhk_half_fp8(out_bhmd, o, o_fp8, B, Mq, H, D, stream);
+}
+
+cudaError_t run_cosmos_fp8_flash_tc_workspace_prepacked_qkv(
+    const cutlass::float_e4m3_t* q_bhmd,
+    const cutlass::float_e4m3_t* k_bhmd,
+    const cutlass::float_e4m3_t* v_bhdm,
+    cutlass::bfloat16_t* scores,
+    cutlass::bfloat16_t* score_c_scratch,
+    cutlass::float_e4m3_t* probs,
+    cutlass::bfloat16_t* out_bhmd,
+    cutlass::bfloat16_t* out_c_scratch,
+    cutlass::half_t* o,
+    cutlass::float_e4m3_t* o_fp8,
+    float* tc_scale,
+    int64_t tc_scale_elems,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    bool tc_scale_is_ones,
+    cudaStream_t stream) {
+  if (!q_bhmd || !k_bhmd || !v_bhdm || !scores || !score_c_scratch ||
+      !probs || !out_bhmd || !out_c_scratch || (!o && !o_fp8) || !tc_scale ||
+      B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0 || D <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  if (D != 128) {
+    return cudaErrorInvalidValue;
+  }
+  if (!is_tc_tile_multiple(Mq) || !is_tc_tile_multiple(Mk)) {
+    return cudaErrorNotSupported;
+  }
+
+  const int groups = B * H;
+  const size_t q_group_elems = static_cast<size_t>(Mq) * D;
+  const size_t k_group_elems = static_cast<size_t>(Mk) * D;
+  const size_t score_group_elems = static_cast<size_t>(Mq) * Mk;
+  const int64_t scale_elems_per_group = std::max<int64_t>(
+      std::max<int64_t>(q_group_elems, k_group_elems),
+      score_group_elems);
+  const int64_t required_scale_elems = static_cast<int64_t>(groups) * scale_elems_per_group;
+  if (tc_scale_elems < required_scale_elems) {
+    return cudaErrorInvalidValue;
+  }
+
+  cudaError_t err = cudaSuccess;
+  if (!tc_scale_is_ones) {
+    err = fill_float(tc_scale, required_scale_elems, 1.0f, stream);
+    if (err != cudaSuccess) return err;
+  }
+
+  err = run_cosmos_fp8_tc_probe_qk_batched(
+      q_bhmd,
+      k_bhmd,
+      tc_scale,
+      tc_scale,
+      score_c_scratch,
+      scores,
+      Mq, Mk, D, groups, stream);
+  if (err != cudaSuccess) return err;
+
+  constexpr int softmax_threads = 256;
+  const float softmax_scale = 1.0f / std::sqrt(static_cast<float>(D));
+  softmax_bf16_scores_to_fp8_kernel<<<
+      dim3(Mq, groups),
+      softmax_threads,
+      softmax_threads * sizeof(float),
+      stream>>>(scores, probs, groups, Mq, Mk, causal, softmax_scale);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  err = run_cosmos_fp8_tc_probe_pv_batched(
+      probs,
+      v_bhdm,
+      tc_scale,
+      tc_scale,
+      out_c_scratch,
+      out_bhmd,
+      Mq, Mk, D, groups, stream);
+  if (err != cudaSuccess) return err;
+
+  return unpack_bhmd_bf16_to_bmhk_half_fp8(out_bhmd, o, o_fp8, B, Mq, H, D, stream);
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "cosmos_fp8_flash_tc.cuh"
 
 #include "cosmos_fp8_tc_probe.cuh"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cuh
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "cutlass/numeric_types.h"
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace omnidreams_singleview {
+
+// Planned SM120 tensor-core FP8 FlashAttention path for Cosmos BMHK tensors.
+// This is intentionally separate from `run_cosmos_cute_flash_fp8`, whose V0
+// implementation is correctness-oriented and scalar/warp-online.
+cudaError_t run_cosmos_fp8_flash_tc(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::half_t* o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    cudaStream_t stream);
+
+cudaError_t run_cosmos_fp8_flash_tc_workspace(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::float_e4m3_t* q_bhmd,
+    cutlass::float_e4m3_t* k_bhmd,
+    cutlass::float_e4m3_t* v_bhdm,
+    cutlass::bfloat16_t* scores,
+    cutlass::bfloat16_t* score_c_scratch,
+    cutlass::float_e4m3_t* probs,
+    cutlass::bfloat16_t* out_bhmd,
+    cutlass::bfloat16_t* out_c_scratch,
+    cutlass::half_t* o,
+    cutlass::float_e4m3_t* o_fp8,
+    float* tc_scale,
+    int64_t tc_scale_elems,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    bool tc_scale_is_ones,
+    cudaStream_t stream);
+
+cudaError_t run_cosmos_fp8_flash_tc_workspace_prepacked_kv(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k_bhmd,
+    const cutlass::float_e4m3_t* v_bhdm,
+    cutlass::float_e4m3_t* q_bhmd,
+    cutlass::bfloat16_t* scores,
+    cutlass::bfloat16_t* score_c_scratch,
+    cutlass::float_e4m3_t* probs,
+    cutlass::bfloat16_t* out_bhmd,
+    cutlass::bfloat16_t* out_c_scratch,
+    cutlass::half_t* o,
+    cutlass::float_e4m3_t* o_fp8,
+    float* tc_scale,
+    int64_t tc_scale_elems,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    bool tc_scale_is_ones,
+    cudaStream_t stream);
+
+cudaError_t run_cosmos_fp8_flash_tc_workspace_prepacked_qkv(
+    const cutlass::float_e4m3_t* q_bhmd,
+    const cutlass::float_e4m3_t* k_bhmd,
+    const cutlass::float_e4m3_t* v_bhdm,
+    cutlass::bfloat16_t* scores,
+    cutlass::bfloat16_t* score_c_scratch,
+    cutlass::float_e4m3_t* probs,
+    cutlass::bfloat16_t* out_bhmd,
+    cutlass::bfloat16_t* out_c_scratch,
+    cutlass::half_t* o,
+    cutlass::float_e4m3_t* o_fp8,
+    float* tc_scale,
+    int64_t tc_scale_elems,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    bool tc_scale_is_ones,
+    cudaStream_t stream);
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_flash_tc.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "cutlass/numeric_types.h"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cu
@@ -1,0 +1,384 @@
+#include "cosmos_fp8_tc_probe.cuh"
+
+#include "cute/tensor.hpp"
+
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/kernel/tile_scheduler_params.h"
+#include "cutlass/util/packed_stride.hpp"
+
+#include <cstdlib>
+#include <string>
+
+namespace omnidreams_singleview {
+namespace {
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+
+using namespace cute;
+
+using ProbeClusterShape = Shape<_1, _1, _1>;
+
+void* g_probe_workspace = nullptr;
+size_t g_probe_workspace_size = 0;
+
+cudaError_t ensure_probe_workspace(size_t needed, void** workspace) {
+  if (!workspace) return cudaErrorInvalidValue;
+  if (needed == 0) {
+    *workspace = nullptr;
+    return cudaSuccess;
+  }
+  if (needed > g_probe_workspace_size) {
+    if (g_probe_workspace) {
+      cudaError_t free_err = cudaFree(g_probe_workspace);
+      if (free_err != cudaSuccess) return free_err;
+      g_probe_workspace = nullptr;
+      g_probe_workspace_size = 0;
+    }
+    cudaError_t alloc_err = cudaMalloc(&g_probe_workspace, needed);
+    if (alloc_err != cudaSuccess) return alloc_err;
+    g_probe_workspace_size = needed;
+  }
+  *workspace = g_probe_workspace;
+  return cudaSuccess;
+}
+
+static bool env_equals(const char* name, const char* value) {
+  const char* actual = std::getenv(name);
+  return actual && std::string(actual) == value;
+}
+
+template <
+    class LayoutB,
+    class MmaTileShape,
+    class BuilderScheduleTag,
+    int StageCountOverride>
+struct Sm120Fp8ProbeGemm {
+  using ElementA = cutlass::float_e4m3_t;
+  using ElementB = cutlass::float_e4m3_t;
+  using ElementC = cutlass::bfloat16_t;
+  using ElementD = cutlass::bfloat16_t;
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+  using ScaleConfig = decltype(cutlass::detail::sm120_trivial_blockwise_scale_config(MmaTileShape{}));
+  using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+  using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+
+  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm120,
+      cutlass::arch::OpClassTensorOp,
+      MmaTileShape,
+      ProbeClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator,
+      ElementCompute,
+      ElementC,
+      LayoutC,
+      AlignmentC,
+      ElementD,
+      LayoutD,
+      AlignmentD,
+      cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+  using MainloopStageCount = cute::conditional_t<
+      StageCountOverride == 0,
+      cutlass::gemm::collective::StageCountAutoCarveout<
+          static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::collective::StageCount<StageCountOverride>>;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm120,
+      cutlass::arch::OpClassTensorOp,
+      ElementA,
+      cute::tuple<LayoutA, LayoutSFA>,
+      AlignmentA,
+      ElementB,
+      cute::tuple<LayoutB, LayoutSFB>,
+      AlignmentB,
+      ElementAccumulator,
+      MmaTileShape,
+      ProbeClusterShape,
+      MainloopStageCount,
+      BuilderScheduleTag>::CollectiveOp;
+
+  using Kernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+};
+
+template <
+    class LayoutB,
+    class MmaTileShape,
+    class BuilderScheduleTag,
+    int StageCountOverride>
+cudaError_t run_probe_gemm(
+    const cutlass::float_e4m3_t* a,
+    const cutlass::float_e4m3_t* b,
+    const float* a_scale,
+    const float* b_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int m,
+    int n,
+    int k,
+    int batch_count,
+    cudaStream_t stream) {
+  if (!a || !b || !a_scale || !b_scale || !c_scratch || !out) {
+    return cudaErrorInvalidValue;
+  }
+  if (m <= 0 || n <= 0 || k <= 0 || batch_count <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  if ((m % 128) != 0 || (n % 128) != 0 || (k % 128) != 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  using Probe = Sm120Fp8ProbeGemm<LayoutB, MmaTileShape, BuilderScheduleTag, StageCountOverride>;
+  using ScaleConfig = typename Probe::ScaleConfig;
+  using Gemm = typename Probe::Gemm;
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+
+  auto shape_a = cute::make_shape(m, k, batch_count);
+  auto shape_b = cute::make_shape(n, k, batch_count);
+  auto shape_c = cute::make_shape(m, n, batch_count);
+  auto stride_a = cutlass::make_cute_packed_stride(StrideA{}, shape_a);
+  auto stride_b = cutlass::make_cute_packed_stride(StrideB{}, shape_b);
+  auto stride_c = cutlass::make_cute_packed_stride(StrideC{}, shape_c);
+  auto stride_d = cutlass::make_cute_packed_stride(StrideD{}, shape_c);
+  auto layout_sfa = ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(m, n, k, batch_count));
+  auto layout_sfb = ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(m, n, k, batch_count));
+
+  typename Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {m, n, k, batch_count},
+      {a, stride_a, b, stride_b, a_scale, layout_sfa, b_scale, layout_sfb},
+      {
+          {},
+          c_scratch,
+          stride_c,
+          out,
+          stride_d,
+      }};
+  arguments.epilogue.thread.alpha = 1.0f;
+  arguments.epilogue.thread.beta = 0.0f;
+
+  Gemm gemm;
+  cutlass::Status status = gemm.can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    return cudaErrorNotSupported;
+  }
+
+  size_t workspace_size = Gemm::get_workspace_size(arguments);
+  void* workspace = nullptr;
+  cudaError_t err = ensure_probe_workspace(workspace_size, &workspace);
+  if (err != cudaSuccess) {
+    return err;
+  }
+  status = gemm.initialize(arguments, workspace, stream);
+  if (status != cutlass::Status::kSuccess) {
+    return cudaErrorUnknown;
+  }
+  status = gemm.run(stream);
+  if (status != cutlass::Status::kSuccess) {
+    return cudaErrorUnknown;
+  }
+  return cudaGetLastError();
+}
+
+template <class LayoutB>
+cudaError_t run_probe_gemm_autotuned(
+    const cutlass::float_e4m3_t* a,
+    const cutlass::float_e4m3_t* b,
+    const float* a_scale,
+    const float* b_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int m,
+    int n,
+    int k,
+    int batch_count,
+    cudaStream_t stream) {
+  const bool use_m128n64k128 = env_equals("OMNIDREAMS_DIT_FP8_TC_TILE", "m128n64k128");
+  const bool use_pingpong = env_equals("OMNIDREAMS_DIT_FP8_TC_SCHEDULE", "pingpong");
+  const bool use_stage2 = env_equals("OMNIDREAMS_DIT_FP8_TC_STAGE", "2");
+
+  if (use_m128n64k128) {
+    if (use_stage2 && use_pingpong) {
+      return run_probe_gemm<
+          LayoutB,
+          Shape<_128, _64, _128>,
+          cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120,
+          2>(
+              a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+    }
+    if (use_stage2) {
+      return run_probe_gemm<
+          LayoutB,
+          Shape<_128, _64, _128>,
+          cutlass::gemm::collective::KernelScheduleAuto,
+          2>(
+              a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+    }
+    if (use_pingpong) {
+      return run_probe_gemm<
+          LayoutB,
+          Shape<_128, _64, _128>,
+          cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120,
+          0>(
+              a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+    }
+    return run_probe_gemm<
+        LayoutB,
+        Shape<_128, _64, _128>,
+        cutlass::gemm::collective::KernelScheduleAuto,
+        0>(
+            a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+  }
+
+  if (use_stage2 && use_pingpong) {
+    return run_probe_gemm<
+        LayoutB,
+        Shape<_128, _128, _128>,
+        cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120,
+        2>(
+            a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+  }
+  if (use_stage2) {
+    return run_probe_gemm<
+        LayoutB,
+        Shape<_128, _128, _128>,
+        cutlass::gemm::collective::KernelScheduleAuto,
+        2>(
+            a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+  }
+  if (use_pingpong) {
+    return run_probe_gemm<
+        LayoutB,
+        Shape<_128, _128, _128>,
+        cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120,
+        0>(
+            a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+  }
+  return run_probe_gemm<
+      LayoutB,
+      Shape<_128, _128, _128>,
+      cutlass::gemm::collective::KernelScheduleAuto,
+      0>(
+          a, b, a_scale, b_scale, c_scratch, out, m, n, k, batch_count, stream);
+}
+
+#endif
+
+}  // namespace
+
+cudaError_t run_cosmos_fp8_tc_probe_qk(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const float* q_scale,
+    const float* k_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    cudaStream_t stream) {
+  return run_cosmos_fp8_tc_probe_qk_batched(
+      q, k, q_scale, k_scale, c_scratch, out, Mq, Mk, D, 1, stream);
+}
+
+cudaError_t run_cosmos_fp8_tc_probe_qk_batched(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const float* q_scale,
+    const float* k_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    int batch_count,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  return run_probe_gemm_autotuned<cutlass::layout::ColumnMajor>(
+      q, k, q_scale, k_scale, c_scratch, out, Mq, Mk, D, batch_count, stream);
+#else
+  (void)q;
+  (void)k;
+  (void)q_scale;
+  (void)k_scale;
+  (void)c_scratch;
+  (void)out;
+  (void)Mq;
+  (void)Mk;
+  (void)D;
+  (void)batch_count;
+  (void)stream;
+  return cudaErrorNotSupported;
+#endif
+}
+
+cudaError_t run_cosmos_fp8_tc_probe_pv(
+    const cutlass::float_e4m3_t* probs,
+    const cutlass::float_e4m3_t* v,
+    const float* probs_scale,
+    const float* v_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    cudaStream_t stream) {
+  return run_cosmos_fp8_tc_probe_pv_batched(
+      probs, v, probs_scale, v_scale, c_scratch, out, Mq, Mk, D, 1, stream);
+}
+
+cudaError_t run_cosmos_fp8_tc_probe_pv_batched(
+    const cutlass::float_e4m3_t* probs,
+    const cutlass::float_e4m3_t* v,
+    const float* probs_scale,
+    const float* v_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    int batch_count,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  return run_probe_gemm_autotuned<cutlass::layout::ColumnMajor>(
+      probs, v, probs_scale, v_scale, c_scratch, out, Mq, D, Mk, batch_count, stream);
+#else
+  (void)probs;
+  (void)v;
+  (void)probs_scale;
+  (void)v_scale;
+  (void)c_scratch;
+  (void)out;
+  (void)Mq;
+  (void)Mk;
+  (void)D;
+  (void)batch_count;
+  (void)stream;
+  return cudaErrorNotSupported;
+#endif
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "cosmos_fp8_tc_probe.cuh"
 
 #include "cute/tensor.hpp"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cuda_runtime.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_tc_probe.cuh
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cutlass/bfloat16.h>
+#include <cutlass/numeric_types.h>
+
+namespace omnidreams_singleview {
+
+cudaError_t run_cosmos_fp8_tc_probe_qk(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const float* q_scale,
+    const float* k_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    cudaStream_t stream);
+
+cudaError_t run_cosmos_fp8_tc_probe_qk_batched(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const float* q_scale,
+    const float* k_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    int batch_count,
+    cudaStream_t stream);
+
+cudaError_t run_cosmos_fp8_tc_probe_pv(
+    const cutlass::float_e4m3_t* probs,
+    const cutlass::float_e4m3_t* v,
+    const float* probs_scale,
+    const float* v_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    cudaStream_t stream);
+
+cudaError_t run_cosmos_fp8_tc_probe_pv_batched(
+    const cutlass::float_e4m3_t* probs,
+    const cutlass::float_e4m3_t* v,
+    const float* probs_scale,
+    const float* v_scale,
+    const cutlass::bfloat16_t* c_scratch,
+    cutlass::bfloat16_t* out,
+    int Mq,
+    int Mk,
+    int D,
+    int batch_count,
+    cudaStream_t stream);
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cu
@@ -1,0 +1,271 @@
+#include "cosmos_fp8_two_gemm.cuh"
+
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/gemm/device/gemm_batched.h"
+#include "cutlass/numeric_conversion.h"
+
+#include <cfloat>
+#include <cmath>
+
+namespace omnidreams_singleview {
+namespace {
+
+using CosmosFp8BatchedRcrGemm = cutlass::gemm::device::GemmBatched<
+    cutlass::float_e4m3_t,
+    cutlass::layout::RowMajor,
+    cutlass::float_e4m3_t,
+    cutlass::layout::ColumnMajor,
+    cutlass::half_t,
+    cutlass::layout::RowMajor,
+    float,
+    cutlass::arch::OpClassTensorOp,
+    cutlass::arch::Sm89,
+    cutlass::gemm::GemmShape<128, 64, 128>,
+    cutlass::gemm::GemmShape<64, 32, 128>,
+    cutlass::gemm::GemmShape<16, 8, 32>,
+    cutlass::epilogue::thread::LinearCombination<cutlass::half_t, 8, float, float>,
+    cutlass::gemm::threadblock::GemmBatchedIdentityThreadblockSwizzle,
+    3>;
+
+static cudaError_t fp8_batched_rcr_gemm(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_col,
+    cutlass::half_t* output_row,
+    int batch_count,
+    int m,
+    int k,
+    int n,
+    int64_t batch_stride_a,
+    int64_t batch_stride_b,
+    int64_t batch_stride_c,
+    float alpha,
+    cudaStream_t stream) {
+  CosmosFp8BatchedRcrGemm gemm_op;
+  CosmosFp8BatchedRcrGemm::Arguments args(
+      {m, n, k},
+      {input_row, k},
+      batch_stride_a,
+      {weight_col, k},
+      batch_stride_b,
+      {output_row, n},
+      batch_stride_c,
+      {output_row, n},
+      batch_stride_c,
+      {alpha, 0.0f},
+      batch_count);
+
+  cutlass::Status status = gemm_op.initialize(args, nullptr, stream);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+  status = gemm_op(stream);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+  return cudaSuccess;
+}
+
+__global__ void fp8_dense_ref_softmax_kernel(
+    const cutlass::half_t* __restrict__ scores,
+    cutlass::float_e4m3_t* __restrict__ probs,
+    int groups,
+    int rows,
+    int cols,
+    bool causal) {
+  int row = blockIdx.x;
+  int group = blockIdx.y;
+  if (group >= groups || row >= rows) return;
+
+  int tid = threadIdx.x;
+  extern __shared__ float smem[];
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  const size_t group_offset = static_cast<size_t>(group) * rows * cols;
+  const cutlass::half_t* score_row = scores + group_offset + static_cast<size_t>(row) * cols;
+  cutlass::float_e4m3_t* prob_row = probs + group_offset + static_cast<size_t>(row) * cols;
+
+  float max_val = -FLT_MAX;
+  for (int col = tid; col < cols; col += blockDim.x) {
+    bool valid = !causal || col <= row;
+    if (valid) {
+      max_val = fmaxf(max_val, to_f32(score_row[col]));
+    }
+  }
+  smem[tid] = max_val;
+  __syncthreads();
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) smem[tid] = fmaxf(smem[tid], smem[tid + offset]);
+    __syncthreads();
+  }
+  max_val = smem[0];
+
+  float sum = 0.0f;
+  for (int col = tid; col < cols; col += blockDim.x) {
+    bool valid = !causal || col <= row;
+    if (valid) {
+      sum += expf(to_f32(score_row[col]) - max_val);
+    }
+  }
+  smem[tid] = sum;
+  __syncthreads();
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) smem[tid] += smem[tid + offset];
+    __syncthreads();
+  }
+  sum = smem[0];
+
+  for (int col = tid; col < cols; col += blockDim.x) {
+    bool valid = !causal || col <= row;
+    float p = 0.0f;
+    if (valid && sum > 0.0f) {
+      p = expf(to_f32(score_row[col]) - max_val) / sum;
+    }
+    prob_row[col] = to_fp8(p);
+  }
+}
+
+template <typename ElementT>
+__global__ void pack_bmhk_to_bhmd_kernel(
+    const ElementT* __restrict__ src,
+    ElementT* __restrict__ dst,
+    int B,
+    int M,
+    int H,
+    int D) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total = static_cast<int64_t>(B) * M * H * D;
+  if (idx >= total) return;
+  int d = static_cast<int>(idx % D);
+  int h = static_cast<int>((idx / D) % H);
+  int m = static_cast<int>((idx / (D * H)) % M);
+  int b = static_cast<int>(idx / (static_cast<int64_t>(M) * H * D));
+  size_t dst_idx = ((static_cast<size_t>(b) * H + h) * M + m) * D + d;
+  dst[dst_idx] = src[idx];
+}
+
+template <typename ElementT>
+__global__ void pack_bhmd_to_bmhk_kernel(
+    const ElementT* __restrict__ src,
+    ElementT* __restrict__ dst,
+    int B,
+    int M,
+    int H,
+    int D) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total = static_cast<int64_t>(B) * H * M * D;
+  if (idx >= total) return;
+  int d = static_cast<int>(idx % D);
+  int m = static_cast<int>((idx / D) % M);
+  int h = static_cast<int>((idx / (D * M)) % H);
+  int b = static_cast<int>(idx / (static_cast<int64_t>(H) * M * D));
+  size_t dst_idx = ((static_cast<size_t>(b) * M + m) * H + h) * D + d;
+  dst[dst_idx] = src[idx];
+}
+
+template <typename ElementT>
+static cudaError_t pack_bmhk_to_bhmd(
+    const ElementT* src,
+    ElementT* dst,
+    int B,
+    int M,
+    int H,
+    int D,
+    cudaStream_t stream) {
+  int64_t total = static_cast<int64_t>(B) * M * H * D;
+  if (total <= 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int64_t blocks = (total + threads - 1) / threads;
+  pack_bmhk_to_bhmd_kernel<ElementT><<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      src, dst, B, M, H, D);
+  return cudaGetLastError();
+}
+
+template <typename ElementT>
+static cudaError_t pack_bhmd_to_bmhk(
+    const ElementT* src,
+    ElementT* dst,
+    int B,
+    int M,
+    int H,
+    int D,
+    cudaStream_t stream) {
+  int64_t total = static_cast<int64_t>(B) * M * H * D;
+  if (total <= 0) return cudaSuccess;
+  constexpr int threads = 256;
+  int64_t blocks = (total + threads - 1) / threads;
+  pack_bhmd_to_bmhk_kernel<ElementT><<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+      src, dst, B, M, H, D);
+  return cudaGetLastError();
+}
+
+}  // namespace
+
+cudaError_t run_cosmos_fp8_dense_ref(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::float_e4m3_t* q_bhmd,
+    cutlass::float_e4m3_t* k_bhmd,
+    cutlass::float_e4m3_t* v_bhmd,
+    cutlass::half_t* scores,
+    cutlass::float_e4m3_t* probs,
+    cutlass::half_t* o_bhmd,
+    cutlass::half_t* o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    cudaStream_t stream) {
+  if (!q || !k || !v || !q_bhmd || !k_bhmd || !v_bhmd || !scores || !probs || !o_bhmd || !o) {
+    return cudaErrorInvalidValue;
+  }
+  if (B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0 || D <= 0) return cudaErrorInvalidValue;
+  if (!(D == 32 || D == 64 || D == 128)) return cudaErrorInvalidValue;
+
+  cudaError_t err = pack_bmhk_to_bhmd(q, q_bhmd, B, Mq, H, D, stream);
+  if (err != cudaSuccess) return err;
+  err = pack_bmhk_to_bhmd(k, k_bhmd, B, Mk, H, D, stream);
+  if (err != cudaSuccess) return err;
+  err = pack_bmhk_to_bhmd(v, v_bhmd, B, Mk, H, D, stream);
+  if (err != cudaSuccess) return err;
+
+  const int groups = B * H;
+  const size_t q_group_elems = static_cast<size_t>(Mq) * D;
+  const size_t kv_group_elems = static_cast<size_t>(Mk) * D;
+  const size_t score_group_elems = static_cast<size_t>(Mq) * Mk;
+  const float attn_scale = 1.0f / std::sqrt(static_cast<float>(D));
+
+  err = fp8_batched_rcr_gemm(
+      q_bhmd,
+      k_bhmd,
+      scores,
+      groups,
+      Mq, D, Mk,
+      static_cast<int64_t>(q_group_elems),
+      static_cast<int64_t>(kv_group_elems),
+      static_cast<int64_t>(score_group_elems),
+      attn_scale,
+      stream);
+  if (err != cudaSuccess) return err;
+
+  fp8_dense_ref_softmax_kernel<<<dim3(Mq, groups), 256, 256 * sizeof(float), stream>>>(
+      scores, probs, groups, Mq, Mk, causal);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) return err;
+
+  err = fp8_batched_rcr_gemm(
+      probs,
+      v_bhmd,
+      o_bhmd,
+      groups,
+      Mq, Mk, D,
+      static_cast<int64_t>(score_group_elems),
+      static_cast<int64_t>(kv_group_elems),
+      static_cast<int64_t>(q_group_elems),
+      1.0f,
+      stream);
+  if (err != cudaSuccess) return err;
+
+  return pack_bhmd_to_bmhk(o_bhmd, o, B, Mq, H, D, stream);
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "cosmos_fp8_two_gemm.cuh"
 
 #include "cutlass/epilogue/thread/linear_combination.h"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cuh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "cutlass/numeric_types.h"
+#include <cuda_runtime.h>
+
+namespace omnidreams_singleview {
+
+cudaError_t run_cosmos_fp8_dense_ref(
+    const cutlass::float_e4m3_t* q,
+    const cutlass::float_e4m3_t* k,
+    const cutlass::float_e4m3_t* v,
+    cutlass::float_e4m3_t* q_bhmd,
+    cutlass::float_e4m3_t* k_bhmd,
+    cutlass::float_e4m3_t* v_bhmd,
+    cutlass::half_t* scores,
+    cutlass::float_e4m3_t* probs,
+    cutlass::half_t* o_bhmd,
+    cutlass::half_t* o,
+    int B,
+    int Mq,
+    int Mk,
+    int H,
+    int D,
+    bool causal,
+    cudaStream_t stream);
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_fp8_two_gemm.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "cutlass/numeric_types.h"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_gemm_bf16.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_gemm_bf16.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // cosmos_gemm_bf16.cu — bf16 CUTLASS GEMMs for the Cosmos DiT block.
 //
 // The existing `cutlass_linear_layer_rrr*` kernels in `ops.cu` are fp16-only

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_gemm_bf16.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_gemm_bf16.cu
@@ -1,0 +1,522 @@
+// cosmos_gemm_bf16.cu — bf16 CUTLASS GEMMs for the Cosmos DiT block.
+//
+// The existing `cutlass_linear_layer_rrr*` kernels in `ops.cu` are fp16-only
+// and accept WAN's pre-transposed weight layout `[in_features, out_features]`
+// row-major. Cosmos consumes raw PyTorch state_dict weights directly (no
+// offline weight extraction step like WAN's `extract_weights.py`), so its
+// weights are stored as `[out_features, in_features]` row-major -- the
+// PyTorch `nn.Linear.weight` convention.
+//
+// To match `output = input @ weight.T` (PyTorch's `nn.Linear` math) without
+// a pre-transpose pass, these kernels use the **RCR** (Row-Col-Row) CUTLASS
+// layout: A row-major × B column-major → C row-major. PyTorch's
+// `[out, in]` row-major weight, when reinterpreted as `[in, out]`
+// column-major (same byte layout, different stride interpretation), is
+// exactly the B operand CUTLASS expects for an RCR GEMM. The result is
+// `output = input @ weight^T` -- matching PyTorch's `nn.Linear`.
+//
+// Tile shapes mirror the fp16 RRR kernels (256×128×32 SM80 tensor cores
+// for large M, 128×128×32 for small M) so the bf16 path inherits the same
+// large-M / small-M tuning the WAN team converged on.
+
+#include "cosmos_block.cuh"
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/device/gemm.h"
+#include "cutlass/gemm/device/gemm_universal_with_broadcast.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/epilogue/thread/linear_combination_gelu.h"
+#include "cutlass/epilogue/thread/linear_combination_silu.h"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/bfloat16.h"
+
+namespace omnidreams_singleview {
+
+namespace {
+// Same threshold heuristic as `cutlass_linear_layer_rrr` in `ops.cu`:
+// large M -> 256x128x32, small M -> 128x128x32.
+constexpr int k_cosmos_gemm_tile_threshold = 1024;
+} // namespace
+
+template <typename ElementOutput_, int ElementsPerAccess, typename ElementAccumulator_, typename ElementCompute_>
+class LinearCombinationGateTimesAccumPlusResidual {
+public:
+  using ElementOutput = ElementOutput_;
+  using ElementD = ElementOutput;
+  using ElementC = ElementOutput;
+  using ElementAccumulator = ElementAccumulator_;
+  using ElementCompute = ElementCompute_;
+  using ElementScalar = ElementCompute;
+  using ElementVector = ElementOutput;
+  using ElementZ = ElementOutput;
+  using ElementT = ElementOutput;
+
+  static int const kElementsPerAccess = ElementsPerAccess;
+  static int const kCount = kElementsPerAccess;
+  static bool const kIsSingleSource = true;
+  static bool const kStoreZ = true;
+  static bool const kStoreT = false;
+
+  using FragmentAccumulator = cutlass::Array<ElementAccumulator, kElementsPerAccess>;
+  using FragmentCompute = cutlass::Array<ElementCompute, kElementsPerAccess>;
+  using FragmentC = cutlass::Array<ElementC, kElementsPerAccess>;
+  using FragmentVector = cutlass::Array<ElementVector, kElementsPerAccess>;
+  using FragmentZ = cutlass::Array<ElementZ, kElementsPerAccess>;
+  using FragmentT = cutlass::Array<ElementT, kElementsPerAccess>;
+
+  struct Params {
+    ElementCompute alpha;
+    CUTLASS_HOST_DEVICE
+    Params() : alpha(ElementCompute(1)) {}
+    CUTLASS_HOST_DEVICE
+    Params(ElementCompute alpha_) : alpha(alpha_) {}
+  };
+
+private:
+  ElementCompute alpha_;
+
+public:
+  CUTLASS_HOST_DEVICE
+  LinearCombinationGateTimesAccumPlusResidual(Params const& params) : alpha_(params.alpha) {}
+
+  CUTLASS_HOST_DEVICE
+  bool is_source_needed() const { return true; }
+
+  CUTLASS_HOST_DEVICE
+  void set_k_partition(int, int) {}
+
+  CUTLASS_HOST_DEVICE
+  void operator()(
+      FragmentZ& frag_Z,
+      FragmentT&,
+      FragmentAccumulator const& AB,
+      FragmentC const& frag_C,
+      FragmentCompute const& V) const {
+    FragmentCompute acc =
+        cutlass::NumericArrayConverter<ElementCompute, ElementAccumulator, kElementsPerAccess>()(AB);
+    FragmentCompute residual =
+        cutlass::NumericArrayConverter<ElementCompute, ElementC, kElementsPerAccess>()(frag_C);
+    FragmentCompute result;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < kElementsPerAccess; ++i) {
+      result[i] = residual[i] + alpha_ * V[i] * acc[i];
+    }
+    frag_Z = cutlass::NumericArrayConverter<ElementZ, ElementCompute, kElementsPerAccess>()(result);
+  }
+
+  CUTLASS_HOST_DEVICE
+  void operator()(
+      FragmentZ& frag_Z,
+      FragmentT& frag_T,
+      FragmentAccumulator const& AB,
+      FragmentCompute const& V) const {
+    FragmentC zeros;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < kElementsPerAccess; ++i) zeros[i] = ElementC(0);
+    operator()(frag_Z, frag_T, AB, zeros, V);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// D = A @ B^T + bias  (PyTorch nn.Linear math)
+//   A: [N, in_features]    row-major
+//   B: [out_features, in_features]  row-major  (PyTorch weight)
+//      reinterpreted as [in_features, out_features] column-major for CUTLASS
+//   D: [N, out_features]   row-major
+// bias: [out_features] or nullptr (broadcast via stride-0 trick)
+// ---------------------------------------------------------------------------
+cudaError_t cutlass_linear_layer_rrr_bf16(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row,    // [out_features, in_features] PyTorch layout
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream)
+{
+  if (N <= 0 || in_features <= 0 || out_features <= 0) return cudaSuccess;
+
+  using ElementInputA = cutlass::bfloat16_t;
+  using ElementInputB = cutlass::bfloat16_t;
+  using ElementOutput = cutlass::bfloat16_t;
+  using ElementAccumulator = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;       // ← key change: B is column-major
+  using LayoutC = cutlass::layout::RowMajor;
+
+  const ElementInputA* a_ptr = input_row;
+  const ElementInputB* b_ptr = weight_row;
+  const ElementOutput* c_ptr = bias ? bias : output_row;
+  int ldc = bias ? 0 : out_features;
+  ElementOutput beta = bias ? ElementOutput(1.0f) : ElementOutput(0.0f);
+
+  cutlass::Status status;
+
+  // For ColumnMajor B with logical shape [in_features, out_features],
+  // the leading dimension (stride between columns) equals the number of
+  // ROWS, which is in_features. PyTorch's [out_features, in_features]
+  // row-major weight stored contiguously has byte layout
+  // weight[i, j] = data[i*in_features + j]. Reinterpreting that same
+  // memory as ColumnMajor [in_features, out_features] with ldb=in_features
+  // gives B[k, n] = data[n*in_features + k] = weight[n, k] -- exactly the
+  // transpose we want for `output = input @ weight^T`.
+  if (N < k_cosmos_gemm_tile_threshold) {
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>>;
+    Gemm gemm_op;
+    Gemm::Arguments args(
+        {N, out_features, in_features},   // (M, N, K)  problem size
+        {a_ptr, in_features},             // A: row-major, lda = in_features
+        {b_ptr, in_features},             // B: col-major, ldb = in_features
+        {c_ptr, ldc},
+        {output_row, out_features},
+        {ElementOutput(1.0f), beta});
+    status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+  } else {
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<256, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>>;
+    Gemm gemm_op;
+    Gemm::Arguments args(
+        {N, out_features, in_features},
+        {a_ptr, in_features},
+        {b_ptr, in_features},
+        {c_ptr, ldc},
+        {output_row, out_features},
+        {ElementOutput(1.0f), beta});
+    status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+  }
+
+  return (status == cutlass::Status::kSuccess) ? cudaSuccess : cudaErrorUnknown;
+}
+
+// ---------------------------------------------------------------------------
+// D = A @ B + bias, where B is already prepared as [in_features, out_features]
+// row-major. This is the native row/row/row layout used by the fast WAN path.
+// ---------------------------------------------------------------------------
+cudaError_t cutlass_linear_layer_rrr_bf16_prepared(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row_prepared,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream)
+{
+  if (N <= 0 || in_features <= 0 || out_features <= 0) return cudaSuccess;
+
+  using ElementInputA = cutlass::bfloat16_t;
+  using ElementInputB = cutlass::bfloat16_t;
+  using ElementOutput = cutlass::bfloat16_t;
+  using ElementAccumulator = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  const ElementOutput* c_ptr = bias ? bias : output_row;
+  int ldc = bias ? 0 : out_features;
+  ElementOutput beta = bias ? ElementOutput(1.0f) : ElementOutput(0.0f);
+  cutlass::Status status;
+
+  if (N < k_cosmos_gemm_tile_threshold) {
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>>;
+    Gemm gemm_op;
+    typename Gemm::Arguments args(
+        {N, out_features, in_features},
+        {input_row, in_features},
+        {weight_row_prepared, out_features},
+        {c_ptr, ldc},
+        {output_row, out_features},
+        {ElementOutput(1.0f), beta});
+    status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+  } else {
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<256, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>>;
+    Gemm gemm_op;
+    typename Gemm::Arguments args(
+        {N, out_features, in_features},
+        {input_row, in_features},
+        {weight_row_prepared, out_features},
+        {c_ptr, ldc},
+        {output_row, out_features},
+        {ElementOutput(1.0f), beta});
+    status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+  }
+
+  return (status == cutlass::Status::kSuccess) ? cudaSuccess : cudaErrorUnknown;
+}
+
+// ---------------------------------------------------------------------------
+// D = GELU(A @ B^T + bias)
+// ---------------------------------------------------------------------------
+cudaError_t cutlass_linear_layer_rrr_gelu_bf16(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream)
+{
+  if (N <= 0 || in_features <= 0 || out_features <= 0) return cudaSuccess;
+
+  using ElementInputA = cutlass::bfloat16_t;
+  using ElementInputB = cutlass::bfloat16_t;
+  using ElementOutput = cutlass::bfloat16_t;
+  using ElementAccumulator = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationGELU<
+      ElementOutput,
+      kElementsPerAccess,
+      ElementAccumulator,
+      float>;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      ElementInputA, LayoutA,
+      ElementInputB, LayoutB,
+      ElementOutput, LayoutC,
+      ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 32>,
+      cutlass::gemm::GemmShape<64, 64, 32>,
+      cutlass::gemm::GemmShape<16, 8, 16>,
+      EpilogueOp>;
+
+  Gemm gemm_op;
+  typename EpilogueOp::Params epilogue_params(1.0f, 1.0f);
+  Gemm::Arguments args(
+      {N, out_features, in_features},
+      {input_row, in_features},
+      {weight_row, in_features},
+      {bias, 0},
+      {output_row, out_features},
+      epilogue_params);
+
+  cutlass::Status status = gemm_op.initialize(args, nullptr);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+  status = gemm_op(stream);
+  return (status == cutlass::Status::kSuccess) ? cudaSuccess : cudaErrorUnknown;
+}
+
+// ---------------------------------------------------------------------------
+// D = GELU(A @ B + bias), B prepared as [in_features, out_features] row-major.
+// ---------------------------------------------------------------------------
+cudaError_t cutlass_linear_layer_rrr_gelu_bf16_prepared(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row_prepared,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream)
+{
+  if (N <= 0 || in_features <= 0 || out_features <= 0) return cudaSuccess;
+
+  using ElementInputA = cutlass::bfloat16_t;
+  using ElementInputB = cutlass::bfloat16_t;
+  using ElementOutput = cutlass::bfloat16_t;
+  using ElementAccumulator = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationGELU<
+      ElementOutput,
+      kElementsPerAccess,
+      ElementAccumulator,
+      float>;
+
+  using Gemm = cutlass::gemm::device::Gemm<
+      ElementInputA, LayoutA,
+      ElementInputB, LayoutB,
+      ElementOutput, LayoutC,
+      ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 32>,
+      cutlass::gemm::GemmShape<64, 64, 32>,
+      cutlass::gemm::GemmShape<16, 8, 16>,
+      EpilogueOp>;
+
+  Gemm gemm_op;
+  typename EpilogueOp::Params epilogue_params(1.0f, 1.0f);
+  typename Gemm::Arguments args(
+      {N, out_features, in_features},
+      {input_row, in_features},
+      {weight_row_prepared, out_features},
+      {bias, 0},
+      {output_row, out_features},
+      epilogue_params);
+
+  cutlass::Status status = gemm_op.initialize(args, nullptr);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+  status = gemm_op(stream);
+  return (status == cutlass::Status::kSuccess) ? cudaSuccess : cudaErrorUnknown;
+}
+
+cudaError_t cutlass_linear_layer_rrr_bf16_prepared_gated_residual(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row_prepared,
+    const cutlass::bfloat16_t* gate,
+    cutlass::bfloat16_t* residual_inout,
+    int N, int in_features, int out_features,
+    cudaStream_t stream)
+{
+  if (N <= 0 || in_features <= 0 || out_features <= 0) return cudaSuccess;
+
+  using ElementInputA = cutlass::bfloat16_t;
+  using ElementInputB = cutlass::bfloat16_t;
+  using ElementOutput = cutlass::bfloat16_t;
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+  using EpilogueOp = LinearCombinationGateTimesAccumPlusResidual<
+      ElementOutput, kElementsPerAccess, ElementAccumulator, ElementCompute>;
+
+  using DefaultConfig = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalWithBroadcast<
+      ElementInputA, LayoutA,
+      ElementInputB, LayoutB,
+      ElementOutput, LayoutC,
+      ElementAccumulator,
+      cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<256, 128, 32>,
+      cutlass::gemm::GemmShape<64, 64, 32>,
+      cutlass::gemm::GemmShape<16, 8, 16>,
+      EpilogueOp,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+      DefaultConfig::kStages,
+      DefaultConfig::kAlignmentA,
+      DefaultConfig::kAlignmentB>;
+
+  Gemm gemm_op;
+  typename EpilogueOp::Params epilogue_params(ElementCompute(1.0f));
+  typename Gemm::Arguments args(
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {N, out_features, in_features},
+      1,
+      epilogue_params,
+      input_row,
+      weight_row_prepared,
+      residual_inout,
+      residual_inout,
+      const_cast<cutlass::bfloat16_t*>(gate),
+      nullptr,
+      int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0),
+      int64_t(in_features), int64_t(out_features),
+      int64_t(out_features),
+      int64_t(out_features),
+      int64_t(0),
+      int64_t(0));
+
+  cutlass::Status status = gemm_op.initialize(args, nullptr);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+  status = gemm_op(stream);
+  return (status == cutlass::Status::kSuccess) ? cudaSuccess : cudaErrorUnknown;
+}
+
+// ---------------------------------------------------------------------------
+// D = SiLU(A @ B^T + bias)
+// ---------------------------------------------------------------------------
+cudaError_t cutlass_linear_layer_rrr_silu_bf16(
+    const cutlass::bfloat16_t* input_row,
+    const cutlass::bfloat16_t* weight_row,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream)
+{
+  if (N <= 0 || in_features <= 0 || out_features <= 0) return cudaSuccess;
+
+  using ElementInputA = cutlass::bfloat16_t;
+  using ElementInputB = cutlass::bfloat16_t;
+  using ElementOutput = cutlass::bfloat16_t;
+  using ElementAccumulator = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationSilu<
+      ElementOutput,
+      kElementsPerAccess,
+      ElementAccumulator,
+      float>;
+
+  // adaln-LoRA's SiLU GEMM has small-N (just one row per batch); use the
+  // 128x128x32 tile to get reasonable coverage for small matrices.
+  using Gemm = cutlass::gemm::device::Gemm<
+      ElementInputA, LayoutA,
+      ElementInputB, LayoutB,
+      ElementOutput, LayoutC,
+      ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<128, 128, 32>,
+      cutlass::gemm::GemmShape<64, 64, 32>,
+      cutlass::gemm::GemmShape<16, 8, 16>,
+      EpilogueOp>;
+
+  Gemm gemm_op;
+  typename Gemm::Arguments args(
+      {N, out_features, in_features},
+      {input_row, in_features},
+      {weight_row, in_features},
+      {bias, 0},
+      {output_row, out_features},
+      {1.0f, 1.0f});
+
+  cutlass::Status status = gemm_op.initialize(args, nullptr);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+  status = gemm_op(stream);
+  return (status == cutlass::Status::kSuccess) ? cudaSuccess : cudaErrorUnknown;
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_modulate.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_modulate.cu
@@ -1,0 +1,870 @@
+// cosmos_modulate.cu — fused element-wise primitives for the Cosmos DiT block.
+//
+// Two kernels are exposed:
+//
+//   cosmos_layernorm_modulate_kernel<ElementT>
+//       fused (no-affine LayerNorm) + (1 + scale) + shift in one launch.
+//       Mirrors the WAN `layernorm_modulate_row_rm_to_row_half_kernel` shape but
+//       sources the per-block (shift, scale) tensors externally instead of
+//       indexing into a static `scale_shift_table` -- adaln-LoRA produces
+//       fresh values per call.
+//
+//   cosmos_residual_gate_kernel<ElementT>
+//       fused gated residual: dest = src + gate * y, where `gate` is a
+//       per-row [B, K] tensor produced by adaln-LoRA. Mirrors the WAN
+//       `residual_gate_add_kernel_*` family.
+//
+// Both kernels are templated on the activation type so the cosmos forward
+// can stay end-to-end bf16 (matches FlashDreams' CosmosDiTNetwork dtype).
+
+#include "cosmos_block.cuh"
+#include "dtype_utils.cuh"
+
+#include <cstdlib>
+#include <cuda_runtime.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/numeric_conversion.h>
+#include <cutlass/bfloat16.h>
+#include <cutlass/half.h>
+
+namespace omnidreams_singleview {
+
+namespace {
+
+// Default-on toggle for the 1-warp-per-row D=128 RMSNorm-to-FP8 path.
+// Set OMNIDREAMS_DIT_RMSNORM_V2=0 (or false/no) to fall back to the 2-warp variant
+// that uses __syncthreads. The v2 path is independent of attention backend
+// (Sage3 / cuDNN) because RMSNorm runs before attention.
+static bool cosmos_rmsnorm_d128_v2_enabled() {
+  const char* env = std::getenv("OMNIDREAMS_DIT_RMSNORM_V2");
+  if (!env || !env[0]) return true;
+  return env[0] != '0' &&
+         env[0] != 'f' && env[0] != 'F' &&
+         env[0] != 'n' && env[0] != 'N';
+}
+
+__device__ __forceinline__ float cosmos_mod_warp_sum(float x) {
+  for (int off = 16; off > 0; off >>= 1) {
+    x += __shfl_down_sync(0xffffffffu, x, off);
+  }
+  return x;
+}
+
+__device__ __forceinline__ float cosmos_mod_block_sum_2warps(float x) {
+  x = cosmos_mod_warp_sum(x);
+  __shared__ float warp_sums[2];
+  int lane = threadIdx.x & 31;
+  int warp = threadIdx.x >> 5;
+  if (lane == 0) {
+    warp_sums[warp] = x;
+  }
+  __syncthreads();
+  float total = (threadIdx.x < 2) ? warp_sums[lane] : 0.0f;
+  total = (warp == 0) ? cosmos_mod_warp_sum(total) : 0.0f;
+  if (threadIdx.x == 0) {
+    warp_sums[0] = total;
+  }
+  __syncthreads();
+  return warp_sums[0];
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// 1) layernorm + modulate (no-affine LN, then * (1 + scale) + shift)
+//
+// X         [M, K]            row-major activations
+// scale     [B, K] or [1, K]  per-row modulation scale (broadcast on M-axis when stride=0)
+// shift     [B, K] or [1, K]  per-row modulation shift
+// row_to_b  optional mapping M -> B (nullptr means M==1 broadcast or per-row identical scale)
+//
+// scale_row_stride, shift_row_stride: stride between rows in `scale`/`shift`.
+//   - 0  -> broadcast a single [K] vector across all M rows (Cosmos streaming
+//           uses one timestep per batch -> one (shift,scale) per batch).
+//   - K  -> per-row vectors; row index used directly.
+//
+// In the streaming forward we always have B=1 or B=2 (CFG) and M = L_new for
+// the entire layer, so the scale/shift are broadcast (stride = 0) -> the
+// kernel is purely memory-bound on X.
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_layernorm_modulate_kernel(
+    const ElementT* __restrict__ X,
+    const ElementT* __restrict__ shift,    // [B, K] or [K]
+    const ElementT* __restrict__ scale,    // [B, K] or [K]
+    ElementT* __restrict__ Y,
+    int M, int K, float eps,
+    int shift_row_stride,                  // 0 = broadcast, K = per-row
+    int scale_row_stride,                  // 0 = broadcast, K = per-row
+    int rows_per_b)                        // M / B; rows [r..r+rows_per_b) use shift/scale row r/rows_per_b
+{
+  int row = blockIdx.x;
+  if (row >= M) return;
+
+  int tid = threadIdx.x;
+  int lane = tid & 31;
+  int warp = tid >> 5;
+  int warp_count = (blockDim.x + 31) >> 5;
+  extern __shared__ float smem[];
+  float* ssum = smem;
+  float* ssum2 = smem + warp_count;
+
+  // Pass 1: mean + variance.
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(X[size_t(row) * K + j]);
+    acc1 += v;
+    acc2 += v * v;
+  }
+  acc1 = cosmos_mod_warp_sum(acc1);
+  acc2 = cosmos_mod_warp_sum(acc2);
+  if (lane == 0) {
+    ssum[warp] = acc1;
+    ssum2[warp] = acc2;
+  }
+  __syncthreads();
+  float total1 = (tid < warp_count) ? ssum[tid] : 0.0f;
+  float total2 = (tid < warp_count) ? ssum2[tid] : 0.0f;
+  total1 = (warp == 0) ? cosmos_mod_warp_sum(total1) : 0.0f;
+  total2 = (warp == 0) ? cosmos_mod_warp_sum(total2) : 0.0f;
+  if (tid == 0) {
+    ssum[0] = total1;
+    ssum2[0] = total2;
+  }
+  __syncthreads();
+  float mean = ssum[0]  / float(K);
+  float var  = ssum2[0] / float(K) - mean * mean;
+  float inv  = rsqrtf(var + eps);
+
+  // Determine which (shift, scale) row this M-row consumes.
+  // rows_per_b == M when broadcast (B == 1 effectively; row_in_b always = 0).
+  int b_row = (rows_per_b > 0) ? (row / rows_per_b) : 0;
+
+  // Pass 2: normalize + modulate.
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = (omnidreams_singleview::to_float(X[size_t(row) * K + j]) - mean) * inv;
+    float sh = omnidreams_singleview::to_float(shift[size_t(b_row) * shift_row_stride + j]);
+    float sc = omnidreams_singleview::to_float(scale[size_t(b_row) * scale_row_stride + j]);
+    v = v * (1.f + sc) + sh;
+    Y[size_t(row) * K + j] = omnidreams_singleview::from_float<ElementT>(v);
+  }
+}
+
+template <typename ElementT>
+__global__ void cosmos_layernorm_modulate_to_fp8_kernel(
+    const ElementT* __restrict__ X,
+    const ElementT* __restrict__ shift,
+    const ElementT* __restrict__ scale,
+    ElementT* __restrict__ Y,
+    cutlass::float_e4m3_t* __restrict__ Y_fp8,
+    int M, int K, float eps,
+    int shift_row_stride,
+    int scale_row_stride,
+    int rows_per_b)
+{
+  int row = blockIdx.x;
+  if (row >= M) return;
+
+  int tid = threadIdx.x;
+  int lane = tid & 31;
+  int warp = tid >> 5;
+  int warp_count = (blockDim.x + 31) >> 5;
+  extern __shared__ float smem[];
+  float* ssum = smem;
+  float* ssum2 = smem + warp_count;
+
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(X[size_t(row) * K + j]);
+    acc1 += v;
+    acc2 += v * v;
+  }
+  acc1 = cosmos_mod_warp_sum(acc1);
+  acc2 = cosmos_mod_warp_sum(acc2);
+  if (lane == 0) {
+    ssum[warp] = acc1;
+    ssum2[warp] = acc2;
+  }
+  __syncthreads();
+  float total1 = (tid < warp_count) ? ssum[tid] : 0.0f;
+  float total2 = (tid < warp_count) ? ssum2[tid] : 0.0f;
+  total1 = (warp == 0) ? cosmos_mod_warp_sum(total1) : 0.0f;
+  total2 = (warp == 0) ? cosmos_mod_warp_sum(total2) : 0.0f;
+  if (tid == 0) {
+    ssum[0] = total1;
+    ssum2[0] = total2;
+  }
+  __syncthreads();
+  float mean = ssum[0]  / float(K);
+  float var  = ssum2[0] / float(K) - mean * mean;
+  float inv  = rsqrtf(var + eps);
+  int b_row = (rows_per_b > 0) ? (row / rows_per_b) : 0;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  for (int j = tid; j < K; j += blockDim.x) {
+    size_t idx = size_t(row) * K + j;
+    float v = (omnidreams_singleview::to_float(X[idx]) - mean) * inv;
+    float sh = omnidreams_singleview::to_float(shift[size_t(b_row) * shift_row_stride + j]);
+    float sc = omnidreams_singleview::to_float(scale[size_t(b_row) * scale_row_stride + j]);
+    v = v * (1.f + sc) + sh;
+    Y[idx] = omnidreams_singleview::from_float<ElementT>(v);
+    Y_fp8[idx] = to_fp8(v);
+  }
+}
+
+template <typename ElementT>
+__global__ void cosmos_layernorm_modulate_to_fp8_only_kernel(
+    const ElementT* __restrict__ X,
+    const ElementT* __restrict__ shift,
+    const ElementT* __restrict__ scale,
+    cutlass::float_e4m3_t* __restrict__ Y_fp8,
+    int M, int K, float eps,
+    int shift_row_stride,
+    int scale_row_stride,
+    int rows_per_b)
+{
+  int row = blockIdx.x;
+  if (row >= M) return;
+
+  int tid = threadIdx.x;
+  int lane = tid & 31;
+  int warp = tid >> 5;
+  int warp_count = (blockDim.x + 31) >> 5;
+  extern __shared__ float smem[];
+  float* ssum = smem;
+  float* ssum2 = smem + warp_count;
+
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(X[size_t(row) * K + j]);
+    acc1 += v;
+    acc2 += v * v;
+  }
+  acc1 = cosmos_mod_warp_sum(acc1);
+  acc2 = cosmos_mod_warp_sum(acc2);
+  if (lane == 0) {
+    ssum[warp] = acc1;
+    ssum2[warp] = acc2;
+  }
+  __syncthreads();
+  float total1 = (tid < warp_count) ? ssum[tid] : 0.0f;
+  float total2 = (tid < warp_count) ? ssum2[tid] : 0.0f;
+  total1 = (warp == 0) ? cosmos_mod_warp_sum(total1) : 0.0f;
+  total2 = (warp == 0) ? cosmos_mod_warp_sum(total2) : 0.0f;
+  if (tid == 0) {
+    ssum[0] = total1;
+    ssum2[0] = total2;
+  }
+  __syncthreads();
+  float mean = ssum[0]  / float(K);
+  float var  = ssum2[0] / float(K) - mean * mean;
+  float inv  = rsqrtf(var + eps);
+  int b_row = (rows_per_b > 0) ? (row / rows_per_b) : 0;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  for (int j = tid; j < K; j += blockDim.x) {
+    size_t idx = size_t(row) * K + j;
+    float v = (omnidreams_singleview::to_float(X[idx]) - mean) * inv;
+    float sh = omnidreams_singleview::to_float(shift[size_t(b_row) * shift_row_stride + j]);
+    float sc = omnidreams_singleview::to_float(scale[size_t(b_row) * scale_row_stride + j]);
+    v = v * (1.f + sc) + sh;
+    Y_fp8[idx] = to_fp8(v);
+  }
+}
+
+// Host launcher
+template <typename ElementT>
+cudaError_t cosmos_layernorm_modulate(
+    const ElementT* X,
+    const ElementT* shift,
+    const ElementT* scale,
+    ElementT* Y,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream)
+{
+  if (M <= 0 || K <= 0) return cudaSuccess;
+
+  // shift/scale are [B, K] from adaln-LoRA. When M > B we broadcast each
+  // row of shift/scale to (M / B) consecutive rows of X.
+  int rows_per_b = (B > 0) ? (M / B) : M;
+  int shift_row_stride = K;
+  int scale_row_stride = K;
+  if (B == 1) {
+    // Single batch -> single shift/scale row consumed by all M rows. We still
+    // pass row_stride=K (b_row always lands at 0) for simplicity.
+    rows_per_b = M;
+  }
+
+  int threads = 256;
+  size_t smem = 2 * ((threads + 31) / 32) * sizeof(float);
+  cosmos_layernorm_modulate_kernel<ElementT><<<M, threads, smem, stream>>>(
+      X, shift, scale, Y, M, K, eps, shift_row_stride, scale_row_stride, rows_per_b);
+  return cudaGetLastError();
+}
+
+template <typename ElementT>
+cudaError_t cosmos_layernorm_modulate_to_fp8(
+    const ElementT* X,
+    const ElementT* shift,
+    const ElementT* scale,
+    ElementT* Y,
+    cutlass::float_e4m3_t* Y_fp8,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream)
+{
+  if (M <= 0 || K <= 0) return cudaSuccess;
+  if (!X || !shift || !scale || !Y || !Y_fp8) return cudaErrorInvalidValue;
+
+  int rows_per_b = (B > 0) ? (M / B) : M;
+  int shift_row_stride = K;
+  int scale_row_stride = K;
+  if (B == 1) {
+    rows_per_b = M;
+  }
+
+  int threads = 256;
+  size_t smem = 2 * ((threads + 31) / 32) * sizeof(float);
+  cosmos_layernorm_modulate_to_fp8_kernel<ElementT><<<M, threads, smem, stream>>>(
+      X, shift, scale, Y, Y_fp8, M, K, eps, shift_row_stride, scale_row_stride, rows_per_b);
+  return cudaGetLastError();
+}
+
+template <typename ElementT>
+cudaError_t cosmos_layernorm_modulate_to_fp8_only(
+    const ElementT* X,
+    const ElementT* shift,
+    const ElementT* scale,
+    cutlass::float_e4m3_t* Y_fp8,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream)
+{
+  if (M <= 0 || K <= 0) return cudaSuccess;
+  if (!X || !shift || !scale || !Y_fp8) return cudaErrorInvalidValue;
+
+  int rows_per_b = (B > 0) ? (M / B) : M;
+  int shift_row_stride = K;
+  int scale_row_stride = K;
+  if (B == 1) {
+    rows_per_b = M;
+  }
+
+  int threads = 256;
+  size_t smem = 2 * ((threads + 31) / 32) * sizeof(float);
+  cosmos_layernorm_modulate_to_fp8_only_kernel<ElementT><<<M, threads, smem, stream>>>(
+      X, shift, scale, Y_fp8, M, K, eps, shift_row_stride, scale_row_stride, rows_per_b);
+  return cudaGetLastError();
+}
+
+// ---------------------------------------------------------------------------
+// Fused: col_scale + residual + LayerNorm + modulate -> FP8
+//
+// Replaces the back-to-back pair
+//   col_scale_residual_bf16_vec2_kernel  (gemm_half + alpha * scale_mul -> += residual_inout)
+//   cosmos_layernorm_modulate_to_fp8_only_kernel (LN(residual_inout), modulate, FP8)
+// with a single launch that keeps the BF16-truncated `x_new` row in shared
+// memory between the residual write and the LN read, eliminating one full BF16
+// re-read of x from DRAM.
+//
+// Layout:
+//   gemm_half        FP16 [M, K]   row-major cuBLASLt FP8 GEMM scratch
+//   alpha            FP16 [K]      precomputed weight_scale * gate * input_scale
+//   residual_inout   BF16 [M, K]   x, updated in place to x + scale_mul*alpha*gemm_half
+//   ln_shift         BF16 [B, K] or [K]  LN modulate shift (broadcast on M-axis)
+//   ln_scale         BF16 [B, K] or [K]  LN modulate scale
+//   fp8_out          E4M3 [M, K]   modulated FP8 output for the next FP8 GEMM
+//
+// One CTA per row. Each thread strides over D in chunks of blockDim.x. The
+// new x_new value is BF16-truncated to match the byte-equivalent semantics of
+// the unfused two-kernel sequence (DRAM round-trip would have done the same).
+template <typename ElementT>
+__global__ void cosmos_col_scale_residual_layernorm_modulate_to_fp8_kernel(
+    const cutlass::half_t* __restrict__ gemm_half,
+    const cutlass::half_t* __restrict__ alpha,
+    ElementT* __restrict__ residual_inout,
+    const ElementT* __restrict__ ln_shift,
+    const ElementT* __restrict__ ln_scale,
+    cutlass::float_e4m3_t* __restrict__ fp8_out,
+    float scale_mul,
+    int M, int K, float eps,
+    int shift_row_stride,
+    int scale_row_stride,
+    int rows_per_b)
+{
+  int row = blockIdx.x;
+  if (row >= M) return;
+
+  int tid = threadIdx.x;
+  int lane = tid & 31;
+  int warp = tid >> 5;
+  int warp_count = (blockDim.x + 31) >> 5;
+  extern __shared__ float smem[];
+  float* ssum = smem;
+  float* ssum2 = smem + warp_count;
+  // sx[K] holds the BF16-truncated new x for the LN second pass, eliminating
+  // the BF16 re-read from DRAM. Layout: smem = [ssum(warp_count), ssum2(warp_count), sx(K)]
+  float* sx = smem + 2 * warp_count;
+
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    size_t idx = size_t(row) * K + j;
+    float gv = __half2float(reinterpret_cast<const half*>(gemm_half)[idx]);
+    float av = __half2float(reinterpret_cast<const half*>(alpha)[j]);
+    float scaled = gv * (av * scale_mul);
+    float resv = omnidreams_singleview::to_float(residual_inout[idx]);
+    float xnew = scaled + resv;
+    ElementT xnew_e = omnidreams_singleview::from_float<ElementT>(xnew);
+    residual_inout[idx] = xnew_e;
+    float xnew_f = omnidreams_singleview::to_float(xnew_e);
+    sx[j] = xnew_f;
+    acc1 += xnew_f;
+    acc2 += xnew_f * xnew_f;
+  }
+  acc1 = cosmos_mod_warp_sum(acc1);
+  acc2 = cosmos_mod_warp_sum(acc2);
+  if (lane == 0) {
+    ssum[warp] = acc1;
+    ssum2[warp] = acc2;
+  }
+  __syncthreads();
+  float total1 = (tid < warp_count) ? ssum[tid] : 0.0f;
+  float total2 = (tid < warp_count) ? ssum2[tid] : 0.0f;
+  total1 = (warp == 0) ? cosmos_mod_warp_sum(total1) : 0.0f;
+  total2 = (warp == 0) ? cosmos_mod_warp_sum(total2) : 0.0f;
+  if (tid == 0) {
+    ssum[0] = total1;
+    ssum2[0] = total2;
+  }
+  __syncthreads();
+  float mean = ssum[0]  / float(K);
+  float var  = ssum2[0] / float(K) - mean * mean;
+  float inv  = rsqrtf(var + eps);
+  int b_row = (rows_per_b > 0) ? (row / rows_per_b) : 0;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  for (int j = tid; j < K; j += blockDim.x) {
+    size_t idx = size_t(row) * K + j;
+    float v = (sx[j] - mean) * inv;
+    float sh = omnidreams_singleview::to_float(ln_shift[size_t(b_row) * shift_row_stride + j]);
+    float sc = omnidreams_singleview::to_float(ln_scale[size_t(b_row) * scale_row_stride + j]);
+    v = v * (1.f + sc) + sh;
+    fp8_out[idx] = to_fp8(v);
+  }
+}
+
+template <typename ElementT>
+cudaError_t cosmos_col_scale_residual_layernorm_modulate_to_fp8_only(
+    const cutlass::half_t* gemm_half,
+    const cutlass::half_t* alpha,
+    ElementT* residual_inout,
+    const ElementT* ln_shift,
+    const ElementT* ln_scale,
+    cutlass::float_e4m3_t* fp8_out,
+    float scale_mul,
+    int M, int K,
+    int B,
+    float eps,
+    cudaStream_t stream)
+{
+  if (M <= 0 || K <= 0) return cudaSuccess;
+  if (!gemm_half || !alpha || !residual_inout || !ln_shift || !ln_scale || !fp8_out) {
+    return cudaErrorInvalidValue;
+  }
+
+  int rows_per_b = (B > 0) ? (M / B) : M;
+  int shift_row_stride = K;
+  int scale_row_stride = K;
+  if (B == 1) {
+    rows_per_b = M;
+  }
+
+  int threads = 256;
+  int warp_count = (threads + 31) / 32;
+  size_t smem = (2 * warp_count + K) * sizeof(float);
+  cosmos_col_scale_residual_layernorm_modulate_to_fp8_kernel<ElementT>
+      <<<M, threads, smem, stream>>>(
+          gemm_half, alpha, residual_inout, ln_shift, ln_scale, fp8_out,
+          scale_mul, M, K, eps, shift_row_stride, scale_row_stride, rows_per_b);
+  return cudaGetLastError();
+}
+
+// ---------------------------------------------------------------------------
+// 2) gated residual: dest = src + gate * y
+//
+// dest, src, y: [M, K] row-major
+// gate:         [B, K] or [K] broadcast across M-rows in batches of (M / B)
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_residual_gate_kernel(
+    ElementT* __restrict__ dest,
+    const ElementT* __restrict__ src,
+    const ElementT* __restrict__ y,
+    const ElementT* __restrict__ gate,     // [B, K] or [K]
+    int M, int K,
+    int gate_row_stride,                   // 0 = broadcast, K = per-row
+    int rows_per_b)                        // M / B
+{
+  int i = blockIdx.y * blockDim.y + threadIdx.y;
+  int j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= M || j >= K) return;
+
+  size_t pos = size_t(i) * K + j;
+  int b_row = (rows_per_b > 0) ? (i / rows_per_b) : 0;
+  float g = omnidreams_singleview::to_float(gate[size_t(b_row) * gate_row_stride + j]);
+  float s = omnidreams_singleview::to_float(src[pos]);
+  float yv = omnidreams_singleview::to_float(y[pos]);
+  dest[pos] = omnidreams_singleview::from_float<ElementT>(s + g * yv);
+}
+
+template <typename ElementT>
+cudaError_t cosmos_residual_gate(
+    ElementT* dest,
+    const ElementT* src,
+    const ElementT* y,
+    const ElementT* gate,
+    int M, int K,
+    int B,
+    cudaStream_t stream)
+{
+  if (M <= 0 || K <= 0) return cudaSuccess;
+
+  int rows_per_b = (B > 0) ? (M / B) : M;
+  int gate_row_stride = (B > 1) ? K : K;  // always K; b_row stays 0 when B==1
+  if (B <= 1) rows_per_b = M;
+
+  dim3 block(32, 8);
+  dim3 grid((K + block.x - 1) / block.x, (M + block.y - 1) / block.y);
+  cosmos_residual_gate_kernel<ElementT><<<grid, block, 0, stream>>>(
+      dest, src, y, gate, M, K, gate_row_stride, rows_per_b);
+  return cudaGetLastError();
+}
+
+// ---------------------------------------------------------------------------
+// 3) RMSNorm on packed [B, M, H, D] Q or K (per-head-dim normalization)
+//
+// Cosmos applies q_norm / k_norm AFTER QKV projection but BEFORE RoPE. The
+// existing WAN `apply_rmsnorm_pack_rope` kernel bakes adjacent-pair RoPE in,
+// which is the wrong rotation convention for Cosmos. We factor RMSNorm out
+// here so the bridge can chain it with `apply_cosmos_rope` (rotate-half).
+//
+// Layout: data is [B, M, H, D] row-major (BMHK). gamma is [D] -- same gamma
+// applies per-head.
+// ---------------------------------------------------------------------------
+template <typename ElementT>
+__global__ void cosmos_rmsnorm_per_head_kernel(
+    ElementT* __restrict__ data,           // in-place [B*M*H, D]
+    const ElementT* __restrict__ gamma,    // [D]
+    int total_rows, int D, float eps)
+{
+  int row = blockIdx.x;
+  if (row >= total_rows) return;
+
+  extern __shared__ float smem[];
+  float* ssum2 = smem;
+  int tid = threadIdx.x;
+
+  float acc = 0.f;
+  for (int j = tid; j < D; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(data[size_t(row) * D + j]);
+    acc += v * v;
+  }
+  ssum2[tid] = acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) ssum2[tid] += ssum2[tid + off];
+    __syncthreads();
+  }
+  float rms = rsqrtf(ssum2[0] / float(D) + eps);
+
+  for (int j = tid; j < D; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(data[size_t(row) * D + j]) * rms;
+    float g = omnidreams_singleview::to_float(gamma[j]);
+    data[size_t(row) * D + j] = omnidreams_singleview::from_float<ElementT>(v * g);
+  }
+}
+
+template <typename ElementT>
+__global__ void cosmos_rmsnorm_per_head_to_fp8_kernel(
+    ElementT* __restrict__ data,                   // in-place [B*M*H, D]
+    const ElementT* __restrict__ gamma,            // [D]
+    cutlass::float_e4m3_t* __restrict__ fp8_out,   // [B*M*H, D]
+    cutlass::float_e4m3_t* __restrict__ fp8_out_bhmd, // optional [B,H,M,D]
+    int B, int M, int H, int D, float eps)
+{
+  int total_rows = B * M * H;
+  int row = blockIdx.x;
+  if (row >= total_rows) return;
+
+  extern __shared__ float smem[];
+  float* ssum2 = smem;
+  int tid = threadIdx.x;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+  float acc = 0.f;
+  for (int j = tid; j < D; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(data[size_t(row) * D + j]);
+    acc += v * v;
+  }
+  ssum2[tid] = acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) ssum2[tid] += ssum2[tid + off];
+    __syncthreads();
+  }
+  float rms = rsqrtf(ssum2[0] / float(D) + eps);
+
+  for (int j = tid; j < D; j += blockDim.x) {
+    size_t idx = size_t(row) * D + j;
+    float v = omnidreams_singleview::to_float(data[idx]) * rms;
+    float g = omnidreams_singleview::to_float(gamma[j]);
+    float out = v * g;
+    data[idx] = omnidreams_singleview::from_float<ElementT>(out);
+    fp8_out[idx] = to_fp8(out);
+    if (fp8_out_bhmd) {
+      int h = row % H;
+      int m = (row / H) % M;
+      int b = row / (M * H);
+      size_t bhmd_idx = ((size_t(b) * H + size_t(h)) * M + size_t(m)) * D + j;
+      fp8_out_bhmd[bhmd_idx] = to_fp8(out);
+    }
+  }
+}
+
+template <typename ElementT>
+__global__ void cosmos_rmsnorm_per_head_to_fp8_d128_kernel(
+    ElementT* __restrict__ data,
+    const ElementT* __restrict__ gamma,
+    cutlass::float_e4m3_t* __restrict__ fp8_out,
+    cutlass::float_e4m3_t* __restrict__ fp8_out_bhmd,
+    int B, int M, int H, float eps)
+{
+  constexpr int D = 128;
+  int total_rows = B * M * H;
+  int row = blockIdx.x;
+  int tid = threadIdx.x;
+  if (row >= total_rows || tid >= 64) return;
+
+  int j0 = tid;
+  int j1 = tid + 64;
+  size_t base = size_t(row) * D;
+  float v0 = omnidreams_singleview::to_float(data[base + j0]);
+  float v1 = omnidreams_singleview::to_float(data[base + j1]);
+  float sum2 = cosmos_mod_block_sum_2warps(v0 * v0 + v1 * v1);
+  float rms = rsqrtf(sum2 / float(D) + eps);
+
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  float o0 = v0 * rms * omnidreams_singleview::to_float(gamma[j0]);
+  float o1 = v1 * rms * omnidreams_singleview::to_float(gamma[j1]);
+  data[base + j0] = omnidreams_singleview::from_float<ElementT>(o0);
+  data[base + j1] = omnidreams_singleview::from_float<ElementT>(o1);
+  cutlass::float_e4m3_t fp0 = to_fp8(o0);
+  cutlass::float_e4m3_t fp1 = to_fp8(o1);
+  fp8_out[base + j0] = fp0;
+  fp8_out[base + j1] = fp1;
+  if (fp8_out_bhmd) {
+    int h = row % H;
+    int m = (row / H) % M;
+    int b = row / (M * H);
+    size_t bhmd_base = ((size_t(b) * H + size_t(h)) * M + size_t(m)) * D;
+    fp8_out_bhmd[bhmd_base + j0] = fp0;
+    fp8_out_bhmd[bhmd_base + j1] = fp1;
+  }
+}
+
+// D=128 RMSNorm-to-FP8 v2: one warp per row, two rows per CTA, no __syncthreads.
+//
+// Motivation: the original `_d128_kernel` uses block size 64 (2 warps) and an
+// inter-warp `__syncthreads()` for the RMS reduction. With only 2 warps in a
+// CTA there is nothing for the warp scheduler to do during the barrier wait,
+// so achieved occupancy is ~30% (vs theoretical 100%) per NCU. This v2 layout
+// has each warp own its own row and reduce purely with `__shfl_*_sync`,
+// removing the barrier and lifting achieved occupancy to the same range as
+// every other kernel in the block (~80%).
+//
+// Layout per warp (lane = threadIdx.x & 31):
+//   row offsets per thread = {lane, lane+32, lane+64, lane+96}
+//   covers all 128 D values with a single 32-thread warp using vec1 loads.
+template <typename ElementT>
+__global__ void cosmos_rmsnorm_per_head_to_fp8_d128_v2_kernel(
+    ElementT* __restrict__ data,
+    const ElementT* __restrict__ gamma,
+    cutlass::float_e4m3_t* __restrict__ fp8_out,
+    cutlass::float_e4m3_t* __restrict__ fp8_out_bhmd,
+    int B, int M, int H, float eps)
+{
+  constexpr int D = 128;
+  const int total_rows = B * M * H;
+  const int warp_id = threadIdx.x >> 5;          // 0 or 1
+  const int lane    = threadIdx.x & 31;
+  const int row     = blockIdx.x * 2 + warp_id;
+  if (row >= total_rows) return;
+
+  const size_t base = size_t(row) * D;
+  const int j0 = lane;
+  const int j1 = lane + 32;
+  const int j2 = lane + 64;
+  const int j3 = lane + 96;
+
+  float v0 = omnidreams_singleview::to_float(data[base + j0]);
+  float v1 = omnidreams_singleview::to_float(data[base + j1]);
+  float v2 = omnidreams_singleview::to_float(data[base + j2]);
+  float v3 = omnidreams_singleview::to_float(data[base + j3]);
+
+  float s = v0 * v0 + v1 * v1 + v2 * v2 + v3 * v3;
+  #pragma unroll
+  for (int off = 16; off > 0; off >>= 1) {
+    s += __shfl_down_sync(0xffffffffu, s, off);
+  }
+  s = __shfl_sync(0xffffffffu, s, 0);
+  float rms = rsqrtf(s / float(D) + eps);
+
+  float g0 = omnidreams_singleview::to_float(gamma[j0]);
+  float g1 = omnidreams_singleview::to_float(gamma[j1]);
+  float g2 = omnidreams_singleview::to_float(gamma[j2]);
+  float g3 = omnidreams_singleview::to_float(gamma[j3]);
+
+  float o0 = v0 * rms * g0;
+  float o1 = v1 * rms * g1;
+  float o2 = v2 * rms * g2;
+  float o3 = v3 * rms * g3;
+
+  data[base + j0] = omnidreams_singleview::from_float<ElementT>(o0);
+  data[base + j1] = omnidreams_singleview::from_float<ElementT>(o1);
+  data[base + j2] = omnidreams_singleview::from_float<ElementT>(o2);
+  data[base + j3] = omnidreams_singleview::from_float<ElementT>(o3);
+
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  cutlass::float_e4m3_t f0 = to_fp8(o0);
+  cutlass::float_e4m3_t f1 = to_fp8(o1);
+  cutlass::float_e4m3_t f2 = to_fp8(o2);
+  cutlass::float_e4m3_t f3 = to_fp8(o3);
+
+  fp8_out[base + j0] = f0;
+  fp8_out[base + j1] = f1;
+  fp8_out[base + j2] = f2;
+  fp8_out[base + j3] = f3;
+
+  if (fp8_out_bhmd) {
+    int h = row % H;
+    int m = (row / H) % M;
+    int b = row / (M * H);
+    size_t bhmd_base = ((size_t(b) * H + size_t(h)) * M + size_t(m)) * D;
+    fp8_out_bhmd[bhmd_base + j0] = f0;
+    fp8_out_bhmd[bhmd_base + j1] = f1;
+    fp8_out_bhmd[bhmd_base + j2] = f2;
+    fp8_out_bhmd[bhmd_base + j3] = f3;
+  }
+}
+
+template <typename ElementT>
+cudaError_t cosmos_rmsnorm_per_head(
+    ElementT* data,
+    const ElementT* gamma,
+    int B, int M, int H, int D,
+    float eps,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0 || H <= 0 || D <= 0) return cudaSuccess;
+  int total_rows = B * M * H;
+  int threads = (D <= 64) ? 64 : (D <= 128 ? 128 : 256);
+  size_t smem = threads * sizeof(float);
+  cosmos_rmsnorm_per_head_kernel<ElementT><<<total_rows, threads, smem, stream>>>(
+      data, gamma, total_rows, D, eps);
+  return cudaGetLastError();
+}
+
+template <typename ElementT>
+cudaError_t cosmos_rmsnorm_per_head_to_fp8(
+    ElementT* data,
+    const ElementT* gamma,
+    cutlass::float_e4m3_t* fp8_out,
+    cutlass::float_e4m3_t* fp8_out_bhmd,
+    int B, int M, int H, int D,
+    float eps,
+    cudaStream_t stream)
+{
+  if (B <= 0 || M <= 0 || H <= 0 || D <= 0) return cudaSuccess;
+  if (!data || !gamma || !fp8_out) return cudaErrorInvalidValue;
+  int total_rows = B * M * H;
+  if (D == 128) {
+    if (cosmos_rmsnorm_d128_v2_enabled()) {
+      // Block size 64 = 2 warps, each warp owns one row -> 2 rows per CTA.
+      int blocks = (total_rows + 1) / 2;
+      cosmos_rmsnorm_per_head_to_fp8_d128_v2_kernel<ElementT>
+          <<<blocks, 64, 0, stream>>>(
+              data, gamma, fp8_out, fp8_out_bhmd, B, M, H, eps);
+      return cudaGetLastError();
+    }
+    cosmos_rmsnorm_per_head_to_fp8_d128_kernel<ElementT><<<total_rows, 64, 0, stream>>>(
+        data, gamma, fp8_out, fp8_out_bhmd, B, M, H, eps);
+    return cudaGetLastError();
+  }
+  int threads = (D <= 64) ? 64 : (D <= 128 ? 128 : 256);
+  size_t smem = threads * sizeof(float);
+  cosmos_rmsnorm_per_head_to_fp8_kernel<ElementT><<<total_rows, threads, smem, stream>>>(
+      data, gamma, fp8_out, fp8_out_bhmd, B, M, H, D, eps);
+  return cudaGetLastError();
+}
+
+// ---------------------------------------------------------------------------
+// Explicit instantiations for the dtypes the cosmos forward needs.
+// (CUDA __global__ functions can't be explicitly instantiated, but the host
+// launchers can.)
+// ---------------------------------------------------------------------------
+template cudaError_t cosmos_layernorm_modulate<cutlass::bfloat16_t>(
+    const cutlass::bfloat16_t*, const cutlass::bfloat16_t*, const cutlass::bfloat16_t*,
+    cutlass::bfloat16_t*, int, int, int, float, cudaStream_t);
+template cudaError_t cosmos_layernorm_modulate<cutlass::half_t>(
+    const cutlass::half_t*, const cutlass::half_t*, const cutlass::half_t*,
+    cutlass::half_t*, int, int, int, float, cudaStream_t);
+
+template cudaError_t cosmos_layernorm_modulate_to_fp8<cutlass::bfloat16_t>(
+    const cutlass::bfloat16_t*, const cutlass::bfloat16_t*, const cutlass::bfloat16_t*,
+    cutlass::bfloat16_t*, cutlass::float_e4m3_t*, int, int, int, float, cudaStream_t);
+template cudaError_t cosmos_layernorm_modulate_to_fp8<cutlass::half_t>(
+    const cutlass::half_t*, const cutlass::half_t*, const cutlass::half_t*,
+    cutlass::half_t*, cutlass::float_e4m3_t*, int, int, int, float, cudaStream_t);
+
+template cudaError_t cosmos_layernorm_modulate_to_fp8_only<cutlass::bfloat16_t>(
+    const cutlass::bfloat16_t*, const cutlass::bfloat16_t*, const cutlass::bfloat16_t*,
+    cutlass::float_e4m3_t*, int, int, int, float, cudaStream_t);
+template cudaError_t cosmos_layernorm_modulate_to_fp8_only<cutlass::half_t>(
+    const cutlass::half_t*, const cutlass::half_t*, const cutlass::half_t*,
+    cutlass::float_e4m3_t*, int, int, int, float, cudaStream_t);
+
+template cudaError_t cosmos_col_scale_residual_layernorm_modulate_to_fp8_only<cutlass::bfloat16_t>(
+    const cutlass::half_t*, const cutlass::half_t*,
+    cutlass::bfloat16_t*, const cutlass::bfloat16_t*, const cutlass::bfloat16_t*,
+    cutlass::float_e4m3_t*, float, int, int, int, float, cudaStream_t);
+template cudaError_t cosmos_col_scale_residual_layernorm_modulate_to_fp8_only<cutlass::half_t>(
+    const cutlass::half_t*, const cutlass::half_t*,
+    cutlass::half_t*, const cutlass::half_t*, const cutlass::half_t*,
+    cutlass::float_e4m3_t*, float, int, int, int, float, cudaStream_t);
+
+template cudaError_t cosmos_residual_gate<cutlass::bfloat16_t>(
+    cutlass::bfloat16_t*, const cutlass::bfloat16_t*, const cutlass::bfloat16_t*,
+    const cutlass::bfloat16_t*, int, int, int, cudaStream_t);
+template cudaError_t cosmos_residual_gate<cutlass::half_t>(
+    cutlass::half_t*, const cutlass::half_t*, const cutlass::half_t*,
+    const cutlass::half_t*, int, int, int, cudaStream_t);
+
+template cudaError_t cosmos_rmsnorm_per_head<cutlass::bfloat16_t>(
+    cutlass::bfloat16_t*, const cutlass::bfloat16_t*,
+    int, int, int, int, float, cudaStream_t);
+template cudaError_t cosmos_rmsnorm_per_head<cutlass::half_t>(
+    cutlass::half_t*, const cutlass::half_t*,
+    int, int, int, int, float, cudaStream_t);
+
+template cudaError_t cosmos_rmsnorm_per_head_to_fp8<cutlass::bfloat16_t>(
+    cutlass::bfloat16_t*, const cutlass::bfloat16_t*, cutlass::float_e4m3_t*,
+    cutlass::float_e4m3_t*, int, int, int, int, float, cudaStream_t);
+template cudaError_t cosmos_rmsnorm_per_head_to_fp8<cutlass::half_t>(
+    cutlass::half_t*, const cutlass::half_t*, cutlass::float_e4m3_t*,
+    cutlass::float_e4m3_t*, int, int, int, int, float, cudaStream_t);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_modulate.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cosmos_modulate.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // cosmos_modulate.cu — fused element-wise primitives for the Cosmos DiT block.
 //
 // Two kernels are exposed:

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cute_int8_gemm.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cute_int8_gemm.cuh
@@ -1,0 +1,782 @@
+#pragma once
+
+/**
+ * INT8 GEMM for SM80+ Tensor Cores.
+ *
+ * High-performance implementation with:
+ * - 128x128 output tiles with K=128 (matches quantization blocks)
+ * - 256 threads (8 warps), 4x2 warp layout
+ * - XOR swizzle for bank-conflict-free shared memory
+ * - LDMATRIX (SM75+) for efficient shared-to-register loads
+ * - cp.async for asynchronous global->shared transfers
+ * - Triple buffering (3-stage pipeline) for latency hiding
+ * - Per-block (128x128) quantization scale support
+ */
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+#include "block_quant.cuh"
+
+// CUTLASS cute for LDMATRIX S2R copy and MMA dispatch
+#include <cute/tensor.hpp>
+#include <cute/atom/mma_atom.hpp>
+#include <cute/atom/copy_atom.hpp>
+
+namespace omnidreams_singleview {
+
+using namespace cute;
+
+// =============================================================================
+// Configuration Constants
+// =============================================================================
+
+// Tile sizes
+static constexpr int kTileM = 128;
+static constexpr int kTileN = 128;
+static constexpr int kTileK = 128;  // Match quantization block
+
+// MMA shape (m16n8k32 for INT8)
+static constexpr int kMmaM = 16;
+static constexpr int kMmaN = 8;
+static constexpr int kMmaK = 32;
+
+// Thread configuration
+static constexpr int kThreads = 256;  // 8 warps
+
+// Warp layout: 4 warps along M, 2 along N
+static constexpr int kWarpsM = 4;
+static constexpr int kWarpsN = 2;
+
+// Per-warp output tile
+static constexpr int kWarpTileM = kTileM / kWarpsM;  // 32
+static constexpr int kWarpTileN = kTileN / kWarpsN;   // 64
+
+// MMA iterations per warp
+static constexpr int kMmasM = kWarpTileM / kMmaM;  // 2
+static constexpr int kMmasN = kWarpTileN / kMmaN;   // 8
+
+// Shared memory layout
+static constexpr int kSmemStrideK = 128;  // With XOR swizzle, no padding needed
+static constexpr int kTileBytes = kTileM * kSmemStrideK;  // 16384 bytes per A or B tile
+static constexpr int kStageBytes = 2 * kTileBytes;        // 32768 bytes per stage (A+B)
+static constexpr int kSmemSize3 = 3 * kStageBytes;        // 98304 bytes (3-stage pipeline)
+static constexpr int kSmemSize2 = 2 * kStageBytes;        // 65536 bytes (2-stage fallback)
+// Legacy alias used by configure_smem -- always tries 3-stage first
+static constexpr int kSmemSize = kSmemSize3;
+
+// Pre-swizzled B storage: 128-row tiles (matches tile size exactly)
+static constexpr int kBTile128Bytes = 128 * kSmemStrideK;  // 16384 bytes
+
+// Quantization block size
+static constexpr int kQuantBlock = 128;
+
+// Loads per thread: 128*128 / (256*16) = 4
+static constexpr int kLoadsPerThread = (kTileM * kTileK) / (kThreads * 16);
+
+// Per-thread accumulator count: 2 MMA-M * 8 MMA-N * 4 outputs/MMA = 64
+static constexpr int kAccSize = kMmasM * kMmasN * 4;
+
+// Epilogue: coalesced store via shared memory
+// Padded stride avoids bank conflicts on 16-byte reads (4 banks shift per row)
+static constexpr int kEpilogueStride = kTileN + 8;            // 136 halves per row
+static constexpr int kEpilogueColGroups = kTileN / 8;         // 16 groups of 8 halves
+static constexpr int kEpilogueRowsPerIter = kThreads / kEpilogueColGroups;  // 16 rows
+static constexpr int kEpilogueIters = kTileM / kEpilogueRowsPerIter;        // 8 iters
+
+// INT8 epilogue: coalesced 16-byte (16 int8_t) stores
+static constexpr int kInt8EpilogueStride = kTileN + 16;       // 144 bytes per row (pad to avoid bank conflicts)
+static constexpr int kInt8ColGroups = kTileN / 16;            // 8 groups of 16 bytes
+static constexpr int kInt8RowsPerIter = kThreads / kInt8ColGroups;  // 32 rows
+static constexpr int kInt8Iters = kTileM / kInt8RowsPerIter;        // 4 iters
+
+// =============================================================================
+// Cute Type Definitions for LDMATRIX S2R and MMA
+// =============================================================================
+
+// Smem layout atom matching our XOR swizzle: col ^ ((row & 7) << 3)
+// Swizzle<B=3, M=4, S=3>: XOR 3 bits from position 7 (row) into position 3 (col)
+// This pattern is compatible with LDMATRIX 16-byte alignment
+using SmemLayoutAtom_ = decltype(
+    composition(
+        Swizzle<3, 4, 3>{},
+        make_layout(
+            make_shape(Int<8>{}, Int<kTileK>{}),
+            make_stride(Int<kTileK>{}, Int<1>{})
+        )
+    )
+);
+
+// Full tile layout (128x128) by tiling the 8-row atom
+using SmemLayoutTile_ = decltype(
+    tile_to_shape(SmemLayoutAtom_{}, make_shape(Int<kTileM>{}, Int<kTileK>{}))
+);
+
+// TiledMma: SM80 INT8 m16n8k32 with 4x2 warp layout
+// Matches TurboDiffusion's proven configuration for 128x128 tiles
+using MmaOp_ = SM80_16x8x32_S32S8S8S32_TN;
+using CuteTiledMma_ = decltype(
+    make_tiled_mma(
+        MMA_Atom<MMA_Traits<MmaOp_>>{},
+        make_layout(make_shape(_4{}, _2{}, _1{})),
+        make_tile(Int<64>{}, Int<32>{}, Int<32>{})
+    )
+);
+
+// S2R copy using LDMATRIX (warp-collective, 1 instruction per fragment)
+using S2RCopyAtomA_ = Copy_Atom<Copy_Traits<SM75_U32x4_LDSM_N>, int8_t>;
+using S2RCopyAtomB_ = Copy_Atom<Copy_Traits<SM75_U32x4_LDSM_N>, int8_t>;
+using S2RTiledCopyA_ = decltype(make_tiled_copy_A(S2RCopyAtomA_{}, CuteTiledMma_{}));
+using S2RTiledCopyB_ = decltype(make_tiled_copy_B(S2RCopyAtomB_{}, CuteTiledMma_{}));
+
+// =============================================================================
+// GELU Activation
+// =============================================================================
+
+__device__ __forceinline__ float gelu_tanh(float x) {
+    constexpr float kAlpha = 0.7978845608028654f;  // sqrt(2/pi)
+    constexpr float kBeta = 0.044715f;
+    float y = kAlpha * (x + kBeta * x * x * x);
+    return 0.5f * x * (1.0f + tanhf(y));
+}
+
+// =============================================================================
+// Swizzle Functions (used by manual G2S copy)
+// =============================================================================
+
+__device__ __forceinline__
+int swizzle_offset(int row, int col) {
+    // Must match cute Swizzle<3, 4, 3>: XOR bits 7-9 into bits 4-6
+    // = col ^ ((row & 7) << 4)
+    int swizzled_col = col ^ ((row & 7) << 4);
+    return row * kSmemStrideK + swizzled_col;
+}
+
+__device__ __forceinline__
+uint32_t get_swizzled_smem_addr(const int8_t* smem_base, int row, int col) {
+    int offset = swizzle_offset(row, col);
+    return static_cast<uint32_t>(__cvta_generic_to_shared(smem_base + offset));
+}
+
+// =============================================================================
+// cp.async Helpers (used by manual G2S copy)
+// =============================================================================
+
+__device__ __forceinline__
+void cp_async_16B_swizzled(int8_t* smem_base, const int8_t* gmem_ptr,
+                           int row, int col, bool valid) {
+    uint32_t smem_addr = get_swizzled_smem_addr(smem_base, row, col);
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    asm volatile(
+        "{\n"
+        "  .reg .pred p;\n"
+        "  setp.ne.b32 p, %2, 0;\n"
+        "  @p cp.async.ca.shared.global [%0], [%1], 16;\n"
+        "  @!p st.shared.v4.b32 [%0], {0, 0, 0, 0};\n"
+        "}\n"
+        :: "r"(smem_addr), "l"(gmem_ptr), "r"((int)valid)
+    );
+#else
+    if (valid) {
+        *reinterpret_cast<int4*>(smem_base + swizzle_offset(row, col)) =
+            *reinterpret_cast<const int4*>(gmem_ptr);
+    }
+#endif
+}
+
+__device__ __forceinline__
+void cp_async_commit() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.commit_group;\n" ::);
+#endif
+}
+
+template<int N>
+__device__ __forceinline__
+void cp_async_wait_group() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.wait_group %0;\n" :: "n"(N));
+#endif
+}
+
+// =============================================================================
+// Main Kernel
+// =============================================================================
+
+template<bool ApplyGelu = false, bool EmitInt8 = false, bool FuseGatedResidual = false, int NumStages = 3>
+static __global__ void __launch_bounds__(kThreads, 1)
+int8_gemm_kernel(
+    const int8_t* __restrict__ A_ptr,
+    const float* __restrict__ A_scales,
+    const int8_t* __restrict__ B_swizzled,
+    const float* __restrict__ B_scales,
+    half* __restrict__ C_ptr,              // FP16 output (unused when EmitInt8/FuseGatedResidual)
+    const half* __restrict__ bias,
+    int M, int N, int K,
+    int num_k_blocks,                      // K/128
+    int num_quant_n_blocks,                // N/128
+    int8_t* __restrict__ C_int8 = nullptr, // INT8 output (EmitInt8 only)
+    float* __restrict__ C_scales = nullptr, // Output scales [M/128, N/128] (EmitInt8 only)
+    // Gated residual parameters (FuseGatedResidual only):
+    half* __restrict__ residual = nullptr,          // In/Out hidden states [M, N]
+    const half* __restrict__ gate_sst = nullptr,    // sst + gate_idx*N, broadcast [N]
+    const half* __restrict__ gate_temb = nullptr,   // temb + gate_idx*N, per-row [M, stride]
+    int temb_row_stride = 0                         // Row stride of temb
+) {
+    static_assert(!(EmitInt8 && FuseGatedResidual),
+        "EmitInt8 and FuseGatedResidual are mutually exclusive");
+    // Thread indexing
+    const int tid = threadIdx.x;
+
+    // Block coordinates (128x128 tiles = exactly one quantization block)
+    const int m_tile = blockIdx.y;
+    const int n_tile = blockIdx.x;
+    const int m_base = m_tile * kTileM;
+    const int n_base = n_tile * kTileN;
+
+    // Quantization block indices (1:1 with tiles now)
+    const int quant_m = m_tile;
+    const int quant_n = n_tile;
+
+    // Dynamic shared memory: [A0][B0][A1][B1][A2][B2]
+    extern __shared__ int8_t int8_gemm_smem[];
+    auto get_smem_A = [&](int stage) -> int8_t* { return int8_gemm_smem + stage * kStageBytes; };
+    auto get_smem_B = [&](int stage) -> int8_t* { return int8_gemm_smem + stage * kStageBytes + kTileBytes; };
+
+    // =========================================================================
+    // Cute MMA and S2R setup
+    // =========================================================================
+    CuteTiledMma_ tiled_mma;
+    auto thr_mma = tiled_mma.get_slice(tid);
+
+    // Allocate register fragments using simple (non-swizzled) layouts
+    // The fragment shape depends only on tile dimensions, not smem swizzle
+    auto tCrA = thr_mma.partition_fragment_A(
+        make_tensor(make_gmem_ptr(static_cast<int8_t const*>(nullptr)),
+                    make_shape(Int<kTileM>{}, Int<kTileK>{})));
+    auto tCrB = thr_mma.partition_fragment_B(
+        make_tensor(make_gmem_ptr(static_cast<int8_t const*>(nullptr)),
+                    make_shape(Int<kTileN>{}, Int<kTileK>{})));
+    auto tDrC = thr_mma.partition_fragment_C(
+        make_tensor(make_gmem_ptr(static_cast<int32_t const*>(nullptr)),
+                    make_shape(Int<kTileM>{}, Int<kTileN>{})));
+
+    // S2R copy with LDMATRIX
+    S2RTiledCopyA_ s2r_copy_a;
+    auto s2r_thr_a = s2r_copy_a.get_slice(tid);
+    auto tCrA_view = s2r_thr_a.retile_D(tCrA);
+
+    S2RTiledCopyB_ s2r_copy_b;
+    auto s2r_thr_b = s2r_copy_b.get_slice(tid);
+    auto tCrB_view = s2r_thr_b.retile_D(tCrB);
+
+    // Coordinate mapping for epilogue (identity tensor partitioned like C)
+    auto cC = make_identity_tensor(make_shape(Int<kTileM>{}, Int<kTileN>{}));
+    auto tDcC = thr_mma.partition_C(cC);
+
+    // Float accumulators
+    float acc[kAccSize];
+    #pragma unroll
+    for (int i = 0; i < kAccSize; ++i) acc[i] = 0.0f;
+
+    // =========================================================================
+    // G2S copy lambdas (manual, with our swizzle)
+    // =========================================================================
+
+    // Load A tile (128x128) from global to shared with swizzle
+    // Use tid + i*kThreads so threads in a warp load from the same row (coalesced)
+    auto load_A = [&](int8_t* buf, int k_base) {
+        #pragma unroll
+        for (int i = 0; i < kLoadsPerThread; ++i) {
+            int linear_idx = tid + i * kThreads;
+            int lm = linear_idx / (kTileK / 16);       // row within tile
+            int lk = (linear_idx % (kTileK / 16)) * 16; // col within tile
+            int gm = m_base + lm;
+            int gk = k_base + lk;
+            bool valid = (gm < M) && (gk + 15 < K);
+            cp_async_16B_swizzled(buf, A_ptr + gm * K + gk, lm, lk, valid);
+        }
+    };
+
+    // Load B tile (128x128, already pre-swizzled in 128-row tiles)
+    auto load_B = [&](int8_t* buf, int k_blk) {
+        int64_t b_tile_idx = (int64_t)n_tile * num_k_blocks + k_blk;
+        const int8_t* b_tile_ptr = B_swizzled + b_tile_idx * kBTile128Bytes;
+        #pragma unroll
+        for (int i = 0; i < kLoadsPerThread; ++i) {
+            int linear_idx = tid + i * kThreads;
+            int byte_offset = linear_idx * 16;
+            uint32_t smem_addr = static_cast<uint32_t>(__cvta_generic_to_shared(buf + byte_offset));
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+            asm volatile("cp.async.ca.shared.global [%0], [%1], 16;\n"
+                :: "r"(smem_addr), "l"(b_tile_ptr + byte_offset));
+#endif
+        }
+    };
+
+    // =========================================================================
+    // Prologue: fill pipeline stages (NumStages-1 stages prefilled)
+    // =========================================================================
+    if (num_k_blocks > 0) {
+        load_A(get_smem_A(0), 0);
+        load_B(get_smem_B(0), 0);
+        cp_async_commit();
+    }
+    if constexpr (NumStages >= 3) {
+        if (num_k_blocks > 1) {
+            load_A(get_smem_A(1), kTileK);
+            load_B(get_smem_B(1), 1);
+            cp_async_commit();
+        }
+    }
+
+    // =========================================================================
+    // Main loop with NumStages-stage pipeline
+    // =========================================================================
+    for (int k_blk = 0; k_blk < num_k_blocks; ++k_blk) {
+        int curr = k_blk % NumStages;
+
+        if constexpr (NumStages >= 3) {
+            // 3-stage: prefetch k_blk+2
+            if (k_blk + 2 < num_k_blocks) {
+                int fill = (k_blk + 2) % NumStages;
+                load_A(get_smem_A(fill), (k_blk + 2) * kTileK);
+                load_B(get_smem_B(fill), k_blk + 2);
+                cp_async_commit();
+                cp_async_wait_group<2>();
+            } else if (k_blk + 1 < num_k_blocks) {
+                cp_async_wait_group<1>();
+            } else {
+                cp_async_wait_group<0>();
+            }
+        } else {
+            // 2-stage: prefetch k_blk+1, wait for current
+            if (k_blk + 1 < num_k_blocks) {
+                int fill = (k_blk + 1) % NumStages;
+                load_A(get_smem_A(fill), (k_blk + 1) * kTileK);
+                load_B(get_smem_B(fill), k_blk + 1);
+                cp_async_commit();
+            }
+            cp_async_wait_group<0>();
+        }
+        __syncthreads();
+
+        // Create cute smem tensors for current stage
+        auto sA = make_tensor(make_smem_ptr<int8_t>(get_smem_A(curr)), SmemLayoutTile_{});
+        auto sB = make_tensor(make_smem_ptr<int8_t>(get_smem_B(curr)), SmemLayoutTile_{});
+
+        // Partition smem for S2R copy (compile-time layout, runtime pointer)
+        auto tCsA = s2r_thr_a.partition_S(sA);
+        auto tCsB = s2r_thr_b.partition_S(sB);
+
+        // Get quantization scales for this K-block
+        float scale_a = A_scales[quant_m * num_k_blocks + k_blk];
+        float scale_b = B_scales[k_blk * num_quant_n_blocks + quant_n];
+        float combined_scale = scale_a * scale_b;
+
+        // Reset int32 accumulator for this K-block
+        clear(tDrC);
+
+        // Inner K loop: LDMATRIX S2R + tensor core MMA
+        // nk = kTileK / kMmaK = 128 / 32 = 4 iterations
+        #pragma unroll
+        for (int ik = 0; ik < size<2>(tCrA); ++ik) {
+            cute::copy(s2r_copy_a, tCsA(_, _, ik), tCrA_view(_, _, ik));
+            cute::copy(s2r_copy_b, tCsB(_, _, ik), tCrB_view(_, _, ik));
+            cute::gemm(tiled_mma, tDrC, tCrA(_, _, ik), tCrB(_, _, ik), tDrC);
+        }
+
+        // Dequantize int32 -> float and accumulate
+        #pragma unroll
+        for (int i = 0; i < kAccSize; ++i) {
+            acc[i] += float(tDrC(i)) * combined_scale;
+        }
+    }
+
+    // =========================================================================
+    // Epilogue: Coalesced stores via shared memory
+    // =========================================================================
+
+    if constexpr (EmitInt8) {
+        // =====================================================================
+        // INT8 Epilogue: bias + GELU + absmax reduction + quantize + coalesced stores
+        // Works entirely from acc[] registers — no FP16 smem intermediate.
+        // Total syncs: 3 (reduction write, reduction read, INT8 scatter)
+        // =====================================================================
+
+        // Phase 1: Apply bias + GELU in-place to acc[], compute thread-local absmax
+        float thread_amax = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < kAccSize; ++i) {
+            float val = acc[i];
+            if (bias != nullptr) {
+                val += __half2float(bias[n_base + get<1>(tDcC(i))]);
+            }
+            if constexpr (ApplyGelu) {
+                val = gelu_tanh(val);
+            }
+            val = fminf(fmaxf(val, -65504.0f), 65504.0f);
+            acc[i] = val;
+            thread_amax = fmaxf(thread_amax, fabsf(val));
+        }
+
+        // Phase 2: Tile-wide absmax reduction (warp shuffle + cross-warp smem)
+        #pragma unroll
+        for (int offset = 16; offset >= 1; offset >>= 1) {
+            thread_amax = fmaxf(thread_amax, __shfl_xor_sync(0xFFFFFFFF, thread_amax, offset));
+        }
+
+        float* warp_amax = reinterpret_cast<float*>(int8_gemm_smem);  // 8 floats = 32 bytes
+        const int warp_id = tid / 32;
+        const int lane_id = tid % 32;
+
+        if (lane_id == 0) warp_amax[warp_id] = thread_amax;
+        __syncthreads();
+
+        float tile_amax;
+        if (tid < 8) {
+            tile_amax = warp_amax[tid];
+            #pragma unroll
+            for (int offset = 4; offset >= 1; offset >>= 1) {
+                tile_amax = fmaxf(tile_amax, __shfl_xor_sync(0xFF, tile_amax, offset));
+            }
+            if (tid == 0) warp_amax[0] = tile_amax;
+        }
+        __syncthreads();
+        tile_amax = warp_amax[0];
+
+        float inv_scale = (tile_amax > 0.0f) ? 127.0f / tile_amax : 0.0f;
+
+        // Write per-tile scale (1:1 with quantization blocks)
+        if (tid == 0) {
+            C_scales[quant_m * num_quant_n_blocks + quant_n] = tile_amax / 127.0f;
+        }
+
+        // Phase 3: Quantize from acc[] registers and scatter INT8 to smem
+        // smem layout: [128, kInt8EpilogueStride] int8_t starting at offset 32
+        int8_t* smem_int8 = int8_gemm_smem + 32;  // After warp_amax (32 bytes)
+        #pragma unroll
+        for (int i = 0; i < kAccSize; ++i) {
+            int lm = get<0>(tDcC(i));
+            int ln = get<1>(tDcC(i));
+            int q = __float2int_rn(acc[i] * inv_scale);
+            q = max(-127, min(127, q));
+            smem_int8[lm * kInt8EpilogueStride + ln] = static_cast<int8_t>(q);
+        }
+        __syncthreads();
+
+        // Phase 4: Coalesced 16-byte vectorized INT8 stores to global memory
+        // 256 threads x 16 bytes = 4096 bytes/iter = 32 rows/iter, 4 iterations
+        #pragma unroll
+        for (int iter = 0; iter < kInt8Iters; ++iter) {
+            int linear = iter * kThreads + tid;
+            int row = linear / kInt8ColGroups;
+            int col = (linear % kInt8ColGroups) * 16;
+            int gm = m_base + row;
+            int gn = n_base + col;
+
+            if (gm < M && gn + 15 < N) {
+                *reinterpret_cast<int4*>(&C_int8[gm * N + gn]) =
+                    *reinterpret_cast<const int4*>(&smem_int8[row * kInt8EpilogueStride + col]);
+            } else if (gm < M) {
+                #pragma unroll
+                for (int j = 0; j < 16; ++j) {
+                    if (gn + j < N) {
+                        C_int8[gm * N + gn + j] = smem_int8[row * kInt8EpilogueStride + col + j];
+                    }
+                }
+            }
+        }
+    } else {
+        // =====================================================================
+        // FP16 Epilogue: scatter to smem + coalesced 16-byte vectorized stores
+        // =====================================================================
+        half* smem_out = reinterpret_cast<half*>(int8_gemm_smem);
+
+        // Phase 1: scatter-write accumulators to smem with bias + GELU
+        #pragma unroll
+        for (int i = 0; i < kAccSize; ++i) {
+            int lm = get<0>(tDcC(i));
+            int ln = get<1>(tDcC(i));
+            float val = acc[i];
+            if (bias != nullptr) {
+                val += __half2float(bias[n_base + ln]);
+            }
+            if constexpr (ApplyGelu) {
+                val = gelu_tanh(val);
+            }
+            val = fminf(fmaxf(val, -65504.0f), 65504.0f);
+            smem_out[lm * kEpilogueStride + ln] = __float2half(val);
+        }
+        __syncthreads();
+
+        // Phase 2: coalesced 16-byte vectorized stores to global memory
+        // 256 threads x 8 halves = 2048 elems/iter = 16 rows/iter, 8 iterations
+        #pragma unroll
+        for (int iter = 0; iter < kEpilogueIters; ++iter) {
+            int linear = iter * kThreads + tid;
+            int row = linear / kEpilogueColGroups;
+            int col = (linear % kEpilogueColGroups) * 8;
+            int gm = m_base + row;
+            int gn = n_base + col;
+
+            if constexpr (FuseGatedResidual) {
+                // Fused gated residual: hidden = hidden + gemm_out * gate
+                // gate = sst[gn] + temb[gm * stride + gn]
+                // Eliminates separate dFF2_row write/read (~894 MB DRAM) and kernel #37
+                if (gm < M && gn + 7 < N) {
+                    int4 gemm_v = *reinterpret_cast<const int4*>(&smem_out[row * kEpilogueStride + col]);
+                    int4 sst_v  = *reinterpret_cast<const int4*>(&gate_sst[gn]);
+                    int4 temb_v = *reinterpret_cast<const int4*>(&gate_temb[(size_t)gm * temb_row_stride + gn]);
+                    int4 res_v  = *reinterpret_cast<const int4*>(&residual[(size_t)gm * N + gn]);
+                    half* gv = reinterpret_cast<half*>(&gemm_v);
+                    half* sv = reinterpret_cast<half*>(&sst_v);
+                    half* tv = reinterpret_cast<half*>(&temb_v);
+                    half* rv = reinterpret_cast<half*>(&res_v);
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) {
+                        float gate = __half2float(sv[j]) + __half2float(tv[j]);
+                        float r = __half2float(rv[j]);
+                        float s = __half2float(gv[j]);
+                        rv[j] = __float2half(r + s * gate);
+                    }
+                    *reinterpret_cast<int4*>(&residual[(size_t)gm * N + gn]) = res_v;
+                } else if (gm < M) {
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) {
+                        if (gn + j < N) {
+                            float val = __half2float(smem_out[row * kEpilogueStride + col + j]);
+                            float gate = __half2float(gate_sst[gn + j])
+                                       + __half2float(gate_temb[(size_t)gm * temb_row_stride + gn + j]);
+                            float r = __half2float(residual[(size_t)gm * N + gn + j]);
+                            residual[(size_t)gm * N + gn + j] = __float2half(r + val * gate);
+                        }
+                    }
+                }
+            } else {
+                if (gm < M && gn + 7 < N) {
+                    *reinterpret_cast<int4*>(&C_ptr[gm * N + gn]) =
+                        *reinterpret_cast<const int4*>(&smem_out[row * kEpilogueStride + col]);
+                } else if (gm < M) {
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) {
+                        if (gn + j < N) {
+                            C_ptr[gm * N + gn + j] = smem_out[row * kEpilogueStride + col + j];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Host API
+// =============================================================================
+
+namespace detail {
+
+// Determine pipeline stage count for INT8 GEMM.
+// Ada/Ampere (SM < 10): 2-stage (64KB). All kernel variants fit.
+// Blackwell+ (SM >= 10): 3-stage (96KB). More smem available per SM.
+// We use compute capability as the discriminator because cudaFuncSetAttribute
+// lies on Ada -- it reports success for 96KB but the GELU kernel variant
+// (higher register pressure) actually can't launch with that much smem.
+inline int get_num_stages() {
+    static int cached = -1;
+    if (cached > 0) return cached;
+
+    int device;
+    cudaGetDevice(&device);
+    int major = 0;
+    cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
+
+    if (major >= 10) {
+        // Blackwell+: try 3-stage
+        cached = 3;
+    } else {
+        // Ada/Ampere: 2-stage (safe for all kernel variants)
+        cached = 2;
+    }
+    (void)cudaGetLastError();
+    return cached;
+}
+
+// Configure smem for ONE specific kernel variant right before launch.
+// Avoids error poisoning from configuring variants this GPU can't support.
+template<bool AG, bool EI, bool FGR, int S>
+inline void configure_one_kernel() {
+    constexpr int smem = (S >= 3) ? kSmemSize3 : kSmemSize2;
+    (void)cudaGetLastError();  // clear any prior error
+    cudaFuncSetAttribute(int8_gemm_kernel<AG, EI, FGR, S>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+}
+
+}  // namespace detail
+
+/**
+ * Launch the INT8 GEMM kernel. Automatically selects 2 or 3 pipeline stages.
+ */
+inline cudaError_t int8_gemm(
+    const int8_t* A, const float* A_scales,
+    const int8_t* B, const float* B_scales,
+    half* C, const half* bias,
+    int M, int N, int K,
+    cudaStream_t stream = nullptr
+) {
+    int num_m_tiles = (M + kTileM - 1) / kTileM;
+    int num_n_tiles = (N + kTileN - 1) / kTileN;
+    int num_k_blocks = (K + kQuantBlock - 1) / kQuantBlock;
+    int num_quant_n_blocks = (N + kQuantBlock - 1) / kQuantBlock;
+    dim3 grid(num_n_tiles, num_m_tiles);
+    dim3 block(kThreads);
+
+    int stages = detail::get_num_stages();
+    if (stages >= 3) {
+        detail::configure_one_kernel<false, false, false, 3>();
+        int8_gemm_kernel<false, false, false, 3><<<grid, block, kSmemSize3, stream>>>(
+            A, A_scales, B, B_scales, C, bias, M, N, K, num_k_blocks, num_quant_n_blocks);
+    } else {
+        detail::configure_one_kernel<false, false, false, 2>();
+        int8_gemm_kernel<false, false, false, 2><<<grid, block, kSmemSize2, stream>>>(
+            A, A_scales, B, B_scales, C, bias, M, N, K, num_k_blocks, num_quant_n_blocks);
+    }
+    return cudaGetLastError();
+}
+
+/**
+ * INT8 GEMM with fused GELU. Automatically selects 2 or 3 pipeline stages.
+ */
+inline cudaError_t int8_gemm_gelu(
+    const int8_t* A, const float* A_scales,
+    const int8_t* B, const float* B_scales,
+    half* C, const half* bias,
+    int M, int N, int K,
+    cudaStream_t stream = nullptr
+) {
+    int num_m_tiles = (M + kTileM - 1) / kTileM;
+    int num_n_tiles = (N + kTileN - 1) / kTileN;
+    int num_k_blocks = (K + kQuantBlock - 1) / kQuantBlock;
+    int num_quant_n_blocks = (N + kQuantBlock - 1) / kQuantBlock;
+    dim3 grid(num_n_tiles, num_m_tiles);
+    dim3 block(kThreads);
+
+    int stages = detail::get_num_stages();
+    if (stages >= 3) {
+        detail::configure_one_kernel<true, false, false, 3>();
+        int8_gemm_kernel<true, false, false, 3><<<grid, block, kSmemSize3, stream>>>(
+            A, A_scales, B, B_scales, C, bias, M, N, K, num_k_blocks, num_quant_n_blocks);
+    } else {
+        detail::configure_one_kernel<true, false, false, 2>();
+        int8_gemm_kernel<true, false, false, 2><<<grid, block, kSmemSize2, stream>>>(
+            A, A_scales, B, B_scales, C, bias, M, N, K, num_k_blocks, num_quant_n_blocks);
+    }
+    return cudaGetLastError();
+}
+
+/**
+ * INT8 GEMM with fused GELU + requantize epilogue.
+ * On Blackwell (3-stage supported): single fused kernel.
+ * On Ada (2-stage fallback): decomposed into GEMM+GELU then separate quantize.
+ */
+inline cudaError_t int8_gemm_gelu_requant(
+    const int8_t* A, const float* A_scales,
+    const int8_t* B, const float* B_scales,
+    int8_t* C_int8, float* C_scales,
+    const half* bias,
+    int M, int N, int K,
+    cudaStream_t stream = nullptr,
+    half* fp16_temp = nullptr  // Required for 2-stage (unfused) path; caller must provide M*N halves
+) {
+    int num_m_tiles = (M + kTileM - 1) / kTileM;
+    int num_n_tiles = (N + kTileN - 1) / kTileN;
+    int num_k_blocks = (K + kQuantBlock - 1) / kQuantBlock;
+    int num_quant_n_blocks = (N + kQuantBlock - 1) / kQuantBlock;
+    dim3 grid(num_n_tiles, num_m_tiles);
+    dim3 block(kThreads);
+
+    int stages = detail::get_num_stages();
+    if (stages >= 3) {
+        detail::configure_one_kernel<true, true, false, 3>();
+        int8_gemm_kernel<true, true, false, 3><<<grid, block, kSmemSize3, stream>>>(
+            A, A_scales, B, B_scales, nullptr, bias,
+            M, N, K, num_k_blocks, num_quant_n_blocks, C_int8, C_scales);
+        return cudaGetLastError();
+    } else {
+        if (fp16_temp == nullptr) return cudaErrorInvalidValue;
+        detail::configure_one_kernel<true, false, false, 2>();
+        int8_gemm_kernel<true, false, false, 2><<<grid, block, kSmemSize2, stream>>>(
+            A, A_scales, B, B_scales, fp16_temp, bias,
+            M, N, K, num_k_blocks, num_quant_n_blocks);
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) return err;
+        return quantize_per_block_128(
+            reinterpret_cast<const half*>(fp16_temp), C_int8, C_scales,
+            M, N, stream, false);
+    }
+}
+
+/**
+ * INT8 GEMM with fused gated residual epilogue.
+ * Computes: residual[i,j] = residual[i,j] + (A @ B + bias)[i,j] * gate[i,j]
+ * where gate[i,j] = sst[gate_idx*N + j] + temb[i*temb_stride + gate_idx*N + j]
+ *
+ * Eliminates the separate residual_gate_add kernel and the dFF2_row intermediate
+ * buffer write/read (~894 MB DRAM traffic saved).
+ *
+ * @param A               INT8 activations [M, K] row-major
+ * @param A_scales        Per-block scales [M/128, K/128]
+ * @param B               INT8 weights pre-swizzled (128x128 tiles)
+ * @param B_scales        Per-block scales [K/128, N/128]
+ * @param residual        In/Out FP16 hidden states [M, N]
+ * @param bias            Optional FP16 bias [N]
+ * @param sst             Scale-shift table [6, N] half
+ * @param temb            Temporal embedding [M, temb_stride] half
+ * @param temb_row_stride Row stride of temb (elements)
+ * @param gate_idx        Gate index in sst/temb (e.g., 5 for FFN)
+ * @param M, N, K         Problem dimensions
+ * @param stream          CUDA stream
+ */
+/**
+ * INT8 GEMM with fused gated residual epilogue.
+ * Automatically selects 2 or 3 pipeline stages.
+ */
+inline cudaError_t int8_gemm_gated_residual(
+    const int8_t* A, const float* A_scales,
+    const int8_t* B, const float* B_scales,
+    half* residual, const half* bias,
+    const half* sst, const half* temb,
+    int temb_row_stride, int gate_idx,
+    int M, int N, int K,
+    cudaStream_t stream = nullptr
+) {
+    int num_m_tiles = (M + kTileM - 1) / kTileM;
+    int num_n_tiles = (N + kTileN - 1) / kTileN;
+    int num_k_blocks = (K + kQuantBlock - 1) / kQuantBlock;
+    int num_quant_n_blocks = (N + kQuantBlock - 1) / kQuantBlock;
+    dim3 grid(num_n_tiles, num_m_tiles);
+    dim3 block(kThreads);
+
+    const half* gate_sst  = sst  + gate_idx * N;
+    const half* gate_temb = temb + gate_idx * N;
+
+    int stages = detail::get_num_stages();
+    if (stages >= 3) {
+        detail::configure_one_kernel<false, false, true, 3>();
+        int8_gemm_kernel<false, false, true, 3><<<grid, block, kSmemSize3, stream>>>(
+            A, A_scales, B, B_scales, nullptr, bias,
+            M, N, K, num_k_blocks, num_quant_n_blocks,
+            nullptr, nullptr, residual, gate_sst, gate_temb, temb_row_stride);
+    } else {
+        detail::configure_one_kernel<false, false, true, 2>();
+        int8_gemm_kernel<false, false, true, 2><<<grid, block, kSmemSize2, stream>>>(
+            A, A_scales, B, B_scales, nullptr, bias,
+            M, N, K, num_k_blocks, num_quant_n_blocks,
+            nullptr, nullptr, residual, gate_sst, gate_temb, temb_row_stride);
+    }
+    return cudaGetLastError();
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cute_int8_gemm.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/cute_int8_gemm.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 /**

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/debug_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/debug_utils.cuh
@@ -1,0 +1,409 @@
+#pragma once
+
+/**
+ * Debug utilities for INT8 per-block quantization validation.
+ *
+ * These utilities help validate numerical correctness during development:
+ * - Tensor validation (NaN/Inf detection)
+ * - Tensor statistics (min, max, mean, std)
+ * - Tensor comparison (MSE, max diff)
+ */
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdio>
+#include <cmath>
+
+namespace omnidreams_singleview {
+namespace debug {
+
+// Enable verbose debug output (0 = off, 1 = basic, 2 = detailed)
+#ifndef DEBUG_BLOCK_QUANT
+#define DEBUG_BLOCK_QUANT 0
+#endif
+
+// =============================================================================
+// Tensor Validation Kernels
+// =============================================================================
+
+/**
+ * Check if any element in tensor is NaN or Inf.
+ * Sets error_flag to 1 if invalid value found.
+ */
+template<typename T>
+__global__ void validate_tensor_kernel(
+    const T* __restrict__ data,
+    int64_t n,
+    int* __restrict__ error_flag,
+    int* __restrict__ nan_count,
+    int* __restrict__ inf_count
+) {
+    int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+
+    float v = static_cast<float>(data[idx]);
+    if (isnan(v)) {
+        atomicAdd(nan_count, 1);
+        atomicExch(error_flag, 1);
+    }
+    if (isinf(v)) {
+        atomicAdd(inf_count, 1);
+        atomicExch(error_flag, 1);
+    }
+}
+
+// Specialization for half
+template<>
+__global__ void validate_tensor_kernel<half>(
+    const half* __restrict__ data,
+    int64_t n,
+    int* __restrict__ error_flag,
+    int* __restrict__ nan_count,
+    int* __restrict__ inf_count
+) {
+    int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+
+    float v = __half2float(data[idx]);
+    if (isnan(v)) {
+        atomicAdd(nan_count, 1);
+        atomicExch(error_flag, 1);
+    }
+    if (isinf(v)) {
+        atomicAdd(inf_count, 1);
+        atomicExch(error_flag, 1);
+    }
+}
+
+// =============================================================================
+// Tensor Statistics Kernels
+// =============================================================================
+
+/**
+ * Compute min, max, sum, sum_sq for tensor statistics.
+ * Uses atomic operations for simplicity (not optimal for performance).
+ */
+template<typename T>
+__global__ void tensor_stats_kernel(
+    const T* __restrict__ data,
+    int64_t n,
+    float* __restrict__ min_val,
+    float* __restrict__ max_val,
+    double* __restrict__ sum,
+    double* __restrict__ sum_sq
+) {
+    __shared__ float s_min;
+    __shared__ float s_max;
+    __shared__ double s_sum;
+    __shared__ double s_sum_sq;
+
+    if (threadIdx.x == 0) {
+        s_min = 1e30f;
+        s_max = -1e30f;
+        s_sum = 0.0;
+        s_sum_sq = 0.0;
+    }
+    __syncthreads();
+
+    float local_min = 1e30f;
+    float local_max = -1e30f;
+    double local_sum = 0.0;
+    double local_sum_sq = 0.0;
+
+    int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = idx; i < n; i += stride) {
+        float v = static_cast<float>(data[i]);
+        local_min = fminf(local_min, v);
+        local_max = fmaxf(local_max, v);
+        local_sum += v;
+        local_sum_sq += v * v;
+    }
+
+    // Block reduction
+    atomicMin(reinterpret_cast<int*>(&s_min), __float_as_int(local_min));
+    atomicMax(reinterpret_cast<int*>(&s_max), __float_as_int(local_max));
+    __syncthreads();
+
+    // Global reduction (one thread per block)
+    if (threadIdx.x == 0) {
+        atomicMin(reinterpret_cast<int*>(min_val), __float_as_int(s_min));
+        atomicMax(reinterpret_cast<int*>(max_val), __float_as_int(s_max));
+        // Note: atomic double add not available on all architectures
+        // Using atomicAdd for double requires sm_60+
+        atomicAdd(sum, local_sum);
+        atomicAdd(sum_sq, local_sum_sq);
+    }
+}
+
+// Specialization for half
+template<>
+__global__ void tensor_stats_kernel<half>(
+    const half* __restrict__ data,
+    int64_t n,
+    float* __restrict__ min_val,
+    float* __restrict__ max_val,
+    double* __restrict__ sum,
+    double* __restrict__ sum_sq
+) {
+    float local_min = 1e30f;
+    float local_max = -1e30f;
+    double local_sum = 0.0;
+    double local_sum_sq = 0.0;
+
+    int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = idx; i < n; i += stride) {
+        float v = __half2float(data[i]);
+        local_min = fminf(local_min, v);
+        local_max = fmaxf(local_max, v);
+        local_sum += v;
+        local_sum_sq += v * v;
+    }
+
+    // Global atomic reduction
+    atomicMin(reinterpret_cast<int*>(min_val), __float_as_int(local_min));
+    atomicMax(reinterpret_cast<int*>(max_val), __float_as_int(local_max));
+    atomicAdd(sum, local_sum);
+    atomicAdd(sum_sq, local_sum_sq);
+}
+
+// =============================================================================
+// Tensor Comparison Kernels
+// =============================================================================
+
+/**
+ * Compute MSE and max absolute difference between two tensors.
+ */
+template<typename T>
+__global__ void compare_tensors_kernel(
+    const T* __restrict__ a,
+    const T* __restrict__ b,
+    int64_t n,
+    double* __restrict__ sum_sq_diff,
+    float* __restrict__ max_diff
+) {
+    double local_sum_sq_diff = 0.0;
+    float local_max_diff = 0.0f;
+
+    int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = idx; i < n; i += stride) {
+        float va = static_cast<float>(a[i]);
+        float vb = static_cast<float>(b[i]);
+        float diff = va - vb;
+        local_sum_sq_diff += diff * diff;
+        local_max_diff = fmaxf(local_max_diff, fabsf(diff));
+    }
+
+    atomicAdd(sum_sq_diff, local_sum_sq_diff);
+    atomicMax(reinterpret_cast<int*>(max_diff), __float_as_int(local_max_diff));
+}
+
+// Specialization for half
+template<>
+__global__ void compare_tensors_kernel<half>(
+    const half* __restrict__ a,
+    const half* __restrict__ b,
+    int64_t n,
+    double* __restrict__ sum_sq_diff,
+    float* __restrict__ max_diff
+) {
+    double local_sum_sq_diff = 0.0;
+    float local_max_diff = 0.0f;
+
+    int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = idx; i < n; i += stride) {
+        float va = __half2float(a[i]);
+        float vb = __half2float(b[i]);
+        float diff = va - vb;
+        local_sum_sq_diff += diff * diff;
+        local_max_diff = fmaxf(local_max_diff, fabsf(diff));
+    }
+
+    atomicAdd(sum_sq_diff, local_sum_sq_diff);
+    atomicMax(reinterpret_cast<int*>(max_diff), __float_as_int(local_max_diff));
+}
+
+// =============================================================================
+// Host-callable Debug Functions
+// =============================================================================
+
+/**
+ * Validate tensor for NaN/Inf values.
+ *
+ * @param data Device pointer to tensor data
+ * @param n Number of elements
+ * @param name Tensor name for debug output
+ * @param stream CUDA stream
+ * @return true if tensor is valid (no NaN/Inf), false otherwise
+ */
+template<typename T>
+bool validate_tensor(const T* data, int64_t n, const char* name, cudaStream_t stream) {
+    int* d_error_flag;
+    int* d_nan_count;
+    int* d_inf_count;
+    cudaMalloc(&d_error_flag, sizeof(int));
+    cudaMalloc(&d_nan_count, sizeof(int));
+    cudaMalloc(&d_inf_count, sizeof(int));
+    cudaMemset(d_error_flag, 0, sizeof(int));
+    cudaMemset(d_nan_count, 0, sizeof(int));
+    cudaMemset(d_inf_count, 0, sizeof(int));
+
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    blocks = min(blocks, 65535);
+
+    validate_tensor_kernel<<<blocks, threads, 0, stream>>>(
+        data, n, d_error_flag, d_nan_count, d_inf_count);
+
+    int h_error_flag, h_nan_count, h_inf_count;
+    cudaMemcpyAsync(&h_error_flag, d_error_flag, sizeof(int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(&h_nan_count, d_nan_count, sizeof(int), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(&h_inf_count, d_inf_count, sizeof(int), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+
+    cudaFree(d_error_flag);
+    cudaFree(d_nan_count);
+    cudaFree(d_inf_count);
+
+    if (h_error_flag) {
+        printf("[DEBUG] %s: INVALID - %d NaN, %d Inf (n=%lld)\n",
+               name, h_nan_count, h_inf_count, (long long)n);
+        return false;
+    }
+
+#if DEBUG_BLOCK_QUANT >= 2
+    printf("[DEBUG] %s: VALID (n=%lld)\n", name, (long long)n);
+#endif
+    return true;
+}
+
+/**
+ * Print tensor statistics (min, max, mean, std).
+ *
+ * @param data Device pointer to tensor data
+ * @param n Number of elements
+ * @param name Tensor name for output
+ * @param stream CUDA stream
+ */
+template<typename T>
+void print_tensor_stats(const T* data, int64_t n, const char* name, cudaStream_t stream) {
+    float* d_min;
+    float* d_max;
+    double* d_sum;
+    double* d_sum_sq;
+
+    cudaMalloc(&d_min, sizeof(float));
+    cudaMalloc(&d_max, sizeof(float));
+    cudaMalloc(&d_sum, sizeof(double));
+    cudaMalloc(&d_sum_sq, sizeof(double));
+
+    float init_min = 1e30f;
+    float init_max = -1e30f;
+    double init_zero = 0.0;
+    cudaMemcpy(d_min, &init_min, sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_max, &init_max, sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_sum, &init_zero, sizeof(double), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_sum_sq, &init_zero, sizeof(double), cudaMemcpyHostToDevice);
+
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    blocks = min(blocks, 1024);
+
+    tensor_stats_kernel<<<blocks, threads, 0, stream>>>(
+        data, n, d_min, d_max, d_sum, d_sum_sq);
+
+    float h_min, h_max;
+    double h_sum, h_sum_sq;
+    cudaMemcpyAsync(&h_min, d_min, sizeof(float), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(&h_max, d_max, sizeof(float), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(&h_sum, d_sum, sizeof(double), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(&h_sum_sq, d_sum_sq, sizeof(double), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+
+    cudaFree(d_min);
+    cudaFree(d_max);
+    cudaFree(d_sum);
+    cudaFree(d_sum_sq);
+
+    double mean = h_sum / n;
+    double var = h_sum_sq / n - mean * mean;
+    double std = sqrt(max(var, 0.0));
+
+    printf("[STATS] %s: n=%lld, min=%.6f, max=%.6f, mean=%.6f, std=%.6f\n",
+           name, (long long)n, h_min, h_max, mean, std);
+}
+
+/**
+ * Compare two tensors and report MSE and max difference.
+ *
+ * @param a First tensor
+ * @param b Second tensor
+ * @param n Number of elements
+ * @param stream CUDA stream
+ * @return MSE between tensors
+ */
+template<typename T>
+float compare_tensors_mse(const T* a, const T* b, int64_t n, cudaStream_t stream) {
+    double* d_sum_sq_diff;
+    float* d_max_diff;
+
+    cudaMalloc(&d_sum_sq_diff, sizeof(double));
+    cudaMalloc(&d_max_diff, sizeof(float));
+
+    double init_zero = 0.0;
+    float init_float_zero = 0.0f;
+    cudaMemcpy(d_sum_sq_diff, &init_zero, sizeof(double), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_max_diff, &init_float_zero, sizeof(float), cudaMemcpyHostToDevice);
+
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    blocks = min(blocks, 1024);
+
+    compare_tensors_kernel<<<blocks, threads, 0, stream>>>(
+        a, b, n, d_sum_sq_diff, d_max_diff);
+
+    double h_sum_sq_diff;
+    float h_max_diff;
+    cudaMemcpyAsync(&h_sum_sq_diff, d_sum_sq_diff, sizeof(double), cudaMemcpyDeviceToHost, stream);
+    cudaMemcpyAsync(&h_max_diff, d_max_diff, sizeof(float), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
+
+    cudaFree(d_sum_sq_diff);
+    cudaFree(d_max_diff);
+
+    float mse = static_cast<float>(h_sum_sq_diff / n);
+
+#if DEBUG_BLOCK_QUANT >= 1
+    printf("[COMPARE] n=%lld, MSE=%.6f, MaxDiff=%.6f\n",
+           (long long)n, mse, h_max_diff);
+#endif
+
+    return mse;
+}
+
+// =============================================================================
+// Debug Macros
+// =============================================================================
+
+#if DEBUG_BLOCK_QUANT >= 1
+#define DEBUG_VALIDATE(ptr, n, name, stream) \
+    omnidreams_singleview::debug::validate_tensor(ptr, n, name, stream)
+#define DEBUG_PRINT_STATS(ptr, n, name, stream) \
+    omnidreams_singleview::debug::print_tensor_stats(ptr, n, name, stream)
+#define DEBUG_COMPARE(a, b, n, stream) \
+    omnidreams_singleview::debug::compare_tensors_mse(a, b, n, stream)
+#else
+#define DEBUG_VALIDATE(ptr, n, name, stream) (true)
+#define DEBUG_PRINT_STATS(ptr, n, name, stream) ((void)0)
+#define DEBUG_COMPARE(a, b, n, stream) (0.0f)
+#endif
+
+} // namespace debug
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/debug_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/debug_utils.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 /**

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/dtype_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/dtype_utils.cuh
@@ -1,0 +1,193 @@
+// dtype_utils.cuh - Unified dtype support for fp16 and bf16
+// Provides type traits, conversion utilities, and common operations for both dtypes
+
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/half.h>
+#include <cutlass/bfloat16.h>
+
+namespace omnidreams_singleview {
+
+// =============================================================================
+// Type Traits - Map between CUDA native types and CUTLASS types
+// =============================================================================
+
+template <typename T>
+struct DTypeTraits;
+
+// FP16 specialization
+template <>
+struct DTypeTraits<cutlass::half_t> {
+    using cuda_type = __half;
+    using cuda_vec2 = __half2;
+    using cutlass_type = cutlass::half_t;
+    using accumulator_type = float;
+    static constexpr bool is_fp16 = true;
+    static constexpr bool is_bf16 = false;
+    static constexpr const char* name = "fp16";
+};
+
+template <>
+struct DTypeTraits<__half> : DTypeTraits<cutlass::half_t> {};
+
+// BF16 specialization
+template <>
+struct DTypeTraits<cutlass::bfloat16_t> {
+    using cuda_type = __nv_bfloat16;
+    using cuda_vec2 = __nv_bfloat162;
+    using cutlass_type = cutlass::bfloat16_t;
+    using accumulator_type = float;
+    static constexpr bool is_fp16 = false;
+    static constexpr bool is_bf16 = true;
+    static constexpr const char* name = "bf16";
+};
+
+template <>
+struct DTypeTraits<__nv_bfloat16> : DTypeTraits<cutlass::bfloat16_t> {};
+
+// =============================================================================
+// Conversion Utilities - Device functions for type conversion
+// =============================================================================
+
+// To float conversions
+__device__ __forceinline__ float to_float(cutlass::half_t x) {
+    return __half2float(reinterpret_cast<const __half&>(x));
+}
+
+__device__ __forceinline__ float to_float(cutlass::bfloat16_t x) {
+    return __bfloat162float(reinterpret_cast<const __nv_bfloat16&>(x));
+}
+
+__device__ __forceinline__ float to_float(__half x) {
+    return __half2float(x);
+}
+
+__device__ __forceinline__ float to_float(__nv_bfloat16 x) {
+    return __bfloat162float(x);
+}
+
+// From float conversions
+template <typename T>
+__device__ __forceinline__ T from_float(float x);
+
+template <>
+__device__ __forceinline__ cutlass::half_t from_float<cutlass::half_t>(float x) {
+    __half h = __float2half(x);
+    return reinterpret_cast<cutlass::half_t&>(h);
+}
+
+template <>
+__device__ __forceinline__ cutlass::bfloat16_t from_float<cutlass::bfloat16_t>(float x) {
+    __nv_bfloat16 b = __float2bfloat16(x);
+    return reinterpret_cast<cutlass::bfloat16_t&>(b);
+}
+
+template <>
+__device__ __forceinline__ __half from_float<__half>(float x) {
+    return __float2half(x);
+}
+
+template <>
+__device__ __forceinline__ __nv_bfloat16 from_float<__nv_bfloat16>(float x) {
+    return __float2bfloat16(x);
+}
+
+// =============================================================================
+// Vector Operations - For vectorized memory access
+// =============================================================================
+
+// Load 2 elements as vector
+template <typename T>
+__device__ __forceinline__ float2 load_vec2_as_float2(const T* ptr);
+
+template <>
+__device__ __forceinline__ float2 load_vec2_as_float2<cutlass::half_t>(const cutlass::half_t* ptr) {
+    __half2 v = *reinterpret_cast<const __half2*>(ptr);
+    return __half22float2(v);
+}
+
+template <>
+__device__ __forceinline__ float2 load_vec2_as_float2<cutlass::bfloat16_t>(const cutlass::bfloat16_t* ptr) {
+    __nv_bfloat162 v = *reinterpret_cast<const __nv_bfloat162*>(ptr);
+    return __bfloat1622float2(v);
+}
+
+// Store 2 floats as vector type
+template <typename T>
+__device__ __forceinline__ void store_float2_as_vec2(T* ptr, float2 v);
+
+template <>
+__device__ __forceinline__ void store_float2_as_vec2<cutlass::half_t>(cutlass::half_t* ptr, float2 v) {
+    __half2 h2 = __float22half2_rn(v);
+    *reinterpret_cast<__half2*>(ptr) = h2;
+}
+
+template <>
+__device__ __forceinline__ void store_float2_as_vec2<cutlass::bfloat16_t>(cutlass::bfloat16_t* ptr, float2 v) {
+    __nv_bfloat162 b2 = __float22bfloat162_rn(v);
+    *reinterpret_cast<__nv_bfloat162*>(ptr) = b2;
+}
+
+// =============================================================================
+// Make vec2 from two floats
+// =============================================================================
+
+template <typename T>
+__device__ __forceinline__ typename DTypeTraits<T>::cuda_vec2 make_vec2(float a, float b);
+
+template <>
+__device__ __forceinline__ __half2 make_vec2<cutlass::half_t>(float a, float b) {
+    return __floats2half2_rn(a, b);
+}
+
+template <>
+__device__ __forceinline__ __nv_bfloat162 make_vec2<cutlass::bfloat16_t>(float a, float b) {
+    return __floats2bfloat162_rn(a, b);
+}
+
+// =============================================================================
+// Fused multiply-add for vec2 types
+// =============================================================================
+
+__device__ __forceinline__ __half2 fma_vec2(__half2 a, __half2 b, __half2 c) {
+    return __hfma2(a, b, c);
+}
+
+__device__ __forceinline__ __nv_bfloat162 fma_vec2(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c) {
+    return __hfma2(a, b, c);  // BF16 uses same intrinsic name in CUDA 11+
+}
+
+// =============================================================================
+// Numeric Constants
+// =============================================================================
+
+template <typename T>
+__device__ __forceinline__ T zero();
+
+template <>
+__device__ __forceinline__ cutlass::half_t zero<cutlass::half_t>() {
+    return cutlass::half_t(0.0f);
+}
+
+template <>
+__device__ __forceinline__ cutlass::bfloat16_t zero<cutlass::bfloat16_t>() {
+    return cutlass::bfloat16_t(0.0f);
+}
+
+template <typename T>
+__device__ __forceinline__ T one();
+
+template <>
+__device__ __forceinline__ cutlass::half_t one<cutlass::half_t>() {
+    return cutlass::half_t(1.0f);
+}
+
+template <>
+__device__ __forceinline__ cutlass::bfloat16_t one<cutlass::bfloat16_t>() {
+    return cutlass::bfloat16_t(1.0f);
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/dtype_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/dtype_utils.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // dtype_utils.cuh - Unified dtype support for fp16 and bf16
 // Provides type traits, conversion utilities, and common operations for both dtypes
 

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_gemm_unified.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_gemm_unified.cuh
@@ -1,0 +1,46 @@
+#pragma once
+
+/**
+ * Unified INT8 GEMM API for SM80+ Tensor Cores.
+ *
+ * Features:
+ * - 64x64 output tiles, K=128 (matches quantization blocks)
+ * - XOR swizzle for bank-conflict-free shared memory
+ * - cp.async for asynchronous transfers
+ * - Double-buffered for latency hiding
+ */
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+#include "cute_int8_gemm.cuh"
+
+namespace omnidreams_singleview {
+
+/**
+ * INT8 GEMM with pre-quantized activations.
+ *
+ * @param A           INT8 activations [M, K] row-major
+ * @param A_scales    Per-block scales [M/128, K/128]
+ * @param B_swizzled  INT8 weights pre-swizzled
+ * @param B_scales    Per-block scales [K/128, N/128]
+ * @param C           FP16 output [M, N]
+ * @param bias        Optional FP16 bias [N]
+ * @param M, N, K     Problem dimensions
+ * @param stream      CUDA stream
+ */
+inline cudaError_t int8_gemm_unified(
+    const int8_t* A,
+    const float* A_scales,
+    const int8_t* B_swizzled,
+    const float* B_scales,
+    half* C,
+    const half* bias,
+    int M, int N, int K,
+    cudaStream_t stream
+) {
+    return int8_gemm(A, A_scales, B_swizzled, B_scales, C, bias, M, N, K, stream);
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_gemm_unified.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_gemm_unified.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 /**

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_swizzle.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_swizzle.cuh
@@ -1,0 +1,221 @@
+#pragma once
+
+/**
+ * Swizzle utilities for INT8 GEMM with SM80 Tensor Cores.
+ *
+ * This implements the memory swizzle pattern for bank-conflict-free shared memory
+ * access when using ldmatrix instructions with INT8 data.
+ *
+ * Swizzle pattern: Swizzle<BBits=2, MBase=4, SShift=3>
+ * - 2 swizzle bits for XOR pattern
+ * - 16-byte alignment (MBase=4 means lower 4 bits constant)
+ * - Shift distance of 3 for row contribution
+ *
+ * This creates a permutation that distributes accesses across all 32 banks,
+ * eliminating bank conflicts when 32 threads in a warp access shared memory
+ * in the pattern required by ldmatrix.
+ */
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace omnidreams_singleview {
+
+// =============================================================================
+// Swizzle Constants
+// =============================================================================
+
+// Swizzle parameters for INT8 with 128-bit (16-byte) access
+// Based on CUTLASS TensorOpMultiplicandCongruous pattern
+constexpr int kSwizzleBBits = 2;   // 2 swizzle bits
+constexpr int kSwizzleMBase = 4;   // Lower 4 bits constant (16-byte alignment)
+constexpr int kSwizzleSShift = 3;  // Shift distance
+
+// Shared memory tile dimensions
+constexpr int kSwizzleTileM = 128;
+constexpr int kSwizzleTileN = 128;
+constexpr int kSwizzleTileK = 128;
+
+// Stride for swizzled shared memory - using 128 (no padding) with XOR swizzle
+// The XOR swizzle pattern ensures bank-conflict-free access without needing padding
+constexpr int kSwizzledStrideK = 128;
+
+// =============================================================================
+// Swizzle Functions
+// =============================================================================
+
+/**
+ * Apply swizzle XOR pattern to compute shared memory offset.
+ *
+ * For INT8 MMA m16n8k32 fragment loads, each warp has 32 threads loading:
+ * - 8 different rows (groupID = lane_id >> 2, range 0-7)
+ * - 4 different column offsets (tid_in_grp = lane_id & 3, accessing col = tid*4)
+ *
+ * To avoid bank conflicts, we XOR row bits [0:2] into column bits [4:6].
+ * This is CUTLASS Swizzle<3,4,3>: XOR 3 bits from offset position 7
+ * (=row bits) into offset position 4 (=col bits 4-6). This preserves
+ * 16-byte alignment (bits 0-3 unchanged) for LDMATRIX compatibility.
+ *
+ * With stride 128:
+ *   swizzled_col = col ^ ((row & 7) << 4)
+ *   bank = (row * 128 / 4 + swizzled_col / 4) % 32
+ *
+ * This maps warp-wide access patterns to unique banks.
+ *
+ * @param row Row index within shared memory tile
+ * @param col Column byte offset within row (0-127)
+ * @param stride Row stride in bytes (should be kSwizzledStrideK = 128)
+ * @return Swizzled byte offset into shared memory
+ */
+__device__ __forceinline__
+int swizzle_smem_offset(int row, int col, int stride) {
+    // Must match cute Swizzle<3, 4, 3>: XOR row bits 0-2 into column bits 4-6
+    // Preserves 16-byte alignment (bits 0-3 unchanged) for LDMATRIX compatibility
+    int swizzled_col = col ^ ((row & 7) << 4);
+    return row * stride + swizzled_col;
+}
+
+/**
+ * Compute swizzled shared memory address.
+ *
+ * Converts a logical (row, col) coordinate to a swizzled shared memory pointer.
+ * The returned address can be used directly with cp.async or ldmatrix.
+ *
+ * @param smem_base Base pointer to shared memory tile
+ * @param row Row index within tile
+ * @param col Column byte offset within row
+ * @param stride Row stride in bytes
+ * @return Shared memory address (as uint32_t for PTX instructions)
+ */
+__device__ __forceinline__
+uint32_t get_swizzled_smem_addr(const int8_t* smem_base, int row, int col, int stride) {
+    int offset = swizzle_smem_offset(row, col, stride);
+    return static_cast<uint32_t>(__cvta_generic_to_shared(smem_base + offset));
+}
+
+/**
+ * Inverse swizzle: given swizzled offset, recover original (row, col).
+ *
+ * Useful for debugging and verification that swizzle is self-inverse
+ * within the relevant bit positions.
+ *
+ * @param row Row index
+ * @param swizzled_col Column after swizzle (0-127)
+ * @param stride Row stride
+ * @return Original column byte offset
+ */
+__device__ __forceinline__
+int inverse_swizzle_col(int row, int swizzled_col, int stride) {
+    // Swizzle<3,4,3>: XOR is self-inverse, so inverse = forward
+    return swizzled_col ^ ((row & 7) << 4);
+}
+
+// =============================================================================
+// Utility Functions for Padded Dimensions
+// =============================================================================
+
+/**
+ * Round up dimension to multiple of 128 for swizzled storage.
+ */
+__host__ __device__ __forceinline__
+int pad_to_128(int dim) {
+    return ((dim + 127) / 128) * 128;
+}
+
+/**
+ * Calculate padded dimensions for swizzled weight storage.
+ *
+ * Weights are stored as [N_padded, K_padded] for column-major MMA access.
+ *
+ * @param K Input feature dimension (original)
+ * @param N Output feature dimension (original)
+ * @param K_padded Output: padded K dimension
+ * @param N_padded Output: padded N dimension
+ */
+__host__ __forceinline__
+void get_swizzled_weight_dims(int K, int N, int* K_padded, int* N_padded) {
+    *K_padded = pad_to_128(K);
+    *N_padded = pad_to_128(N);
+}
+
+/**
+ * Calculate storage size for swizzled weights in bytes.
+ *
+ * @param K Input feature dimension
+ * @param N Output feature dimension
+ * @return Size in bytes for swizzled weight storage
+ */
+__host__ __forceinline__
+size_t get_swizzled_weight_size(int K, int N) {
+    int K_padded = pad_to_128(K);
+    int N_padded = pad_to_128(N);
+    return static_cast<size_t>(N_padded) * K_padded;
+}
+
+// =============================================================================
+// Bank Conflict Analysis (for debugging)
+// =============================================================================
+
+/**
+ * Compute shared memory bank for a given address.
+ *
+ * Shared memory has 32 banks, each 4 bytes wide.
+ * Bank = (address / 4) % 32
+ *
+ * @param addr Shared memory byte address
+ * @return Bank index (0-31)
+ */
+__device__ __forceinline__
+int get_smem_bank(int addr) {
+    return (addr >> 2) & 0x1F;
+}
+
+/**
+ * Check if swizzle pattern eliminates bank conflicts for ldmatrix access.
+ *
+ * For ldmatrix with INT8, 32 threads access 32 consecutive 4-byte chunks.
+ * Without swizzle, this causes 4-way bank conflicts.
+ * With proper swizzle, each thread accesses a different bank.
+ *
+ * This function is for debugging - call from a single thread to verify
+ * the swizzle pattern.
+ *
+ * @param smem_base Base shared memory pointer
+ * @param tile_row Starting row for the 16x32 tile
+ * @param tile_col Starting column for the tile
+ * @param stride Shared memory stride
+ */
+__device__ inline
+void debug_check_bank_conflicts(const int8_t* smem_base, int tile_row, int tile_col, int stride) {
+#ifdef DEBUG_SWIZZLE
+    // Check banks for first row of ldmatrix pattern
+    int banks[32];
+    for (int lane = 0; lane < 32; ++lane) {
+        int groupID = lane >> 2;
+        int tid_in_grp = lane & 3;
+        int row = tile_row + groupID;
+        int col = tile_col + tid_in_grp * 4;
+        int offset = swizzle_smem_offset(row, col, stride);
+        banks[lane] = get_smem_bank(offset);
+    }
+
+    // Check for duplicates (bank conflicts)
+    bool has_conflict = false;
+    for (int i = 0; i < 32 && !has_conflict; ++i) {
+        for (int j = i + 1; j < 32; ++j) {
+            if (banks[i] == banks[j]) {
+                printf("[SWIZZLE DEBUG] Bank conflict: lane %d and %d both use bank %d\n",
+                       i, j, banks[i]);
+                has_conflict = true;
+                break;
+            }
+        }
+    }
+    if (!has_conflict) {
+        printf("[SWIZZLE DEBUG] No bank conflicts detected for tile (%d, %d)\n",
+               tile_row, tile_col);
+    }
+#endif
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_swizzle.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/int8_swizzle.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 /**

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cuda.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels.cuh
@@ -1,0 +1,1385 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <stdint.h>
+#include <assert.h>
+#include <stdexcept>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <mutex>
+#include <sstream>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+
+// Backend selector and common utilities
+#include "../common/attn_backend.h"
+#include "../common/cuda_utils.cuh"
+
+#include <cuda_fp16.h>
+
+// Provide missing __half comparison operators for CUTLASS compatibility
+#if defined(__CUDA_ARCH__) && !defined(__CUDA_NO_HALF_OPERATORS__)
+// Already have operators, do nothing
+#elif defined(__CUDACC__)
+// Define minimal operators needed by CUTLASS ArrayMaximum
+__device__ __forceinline__ bool operator<(const __half& lhs, const __half& rhs) {
+    #if __CUDA_ARCH__ >= 530
+    return __hlt(lhs, rhs);
+    #else
+    return __half2float(lhs) < __half2float(rhs);
+    #endif
+}
+#endif
+
+#include <cutlass/epilogue/thread/linear_combination_bias_relu.h>
+#include <cutlass/conv/kernel/default_conv2d_fprop_with_broadcast.h>
+
+#include <cutlass/cutlass.h>
+#include <cutlass/gemm/device/gemm.h>
+#include <cutlass/conv/device/implicit_gemm_convolution.h>
+#include <cutlass/conv/kernel/default_conv2d_fprop.h>
+#include <cutlass/epilogue/thread/linear_combination.h>
+#include <cutlass/layout/matrix.h>
+#include <cutlass/layout/tensor.h>
+
+
+namespace omnidreams_singleview {
+
+// Global workspace pool for conv3x3 to eliminate dynamic allocations
+namespace {
+    struct Conv3x3WorkspaceArena {
+        struct Entry {
+            at::Tensor storage;
+            size_t capacity;
+        };
+
+        std::vector<Entry> entries;
+        mutable std::mutex mtx;
+
+        static size_t round_capacity(size_t bytes) {
+            constexpr size_t kAlign = 128;
+            if (bytes == 0) return 0;
+            size_t rounded = (bytes + kAlign - 1) / kAlign * kAlign;
+            return rounded;
+        }
+
+        Entry* find_or_create(size_t required) {
+            size_t rounded = round_capacity(required);
+            std::lock_guard<std::mutex> lock(mtx);
+            Entry* best = nullptr;
+            for (auto& e : entries) {
+                if (e.capacity >= rounded) {
+                    if (!best || e.capacity < best->capacity) best = &e;
+                }
+            }
+            if (!best) {
+                Entry fresh;
+                if (rounded > 0) {
+                    auto options = at::TensorOptions().dtype(at::kByte).device(at::kCUDA);
+                    fresh.storage = at::empty({static_cast<long long>(rounded)}, options);
+                    fresh.capacity = rounded;
+                    entries.push_back(fresh);
+                    best = &entries.back();
+                } else {
+                    entries.push_back({});
+                    best = &entries.back();
+                }
+            }
+            return best;
+        }
+
+        void* get(size_t required_size, cudaStream_t stream, bool zero_fill) {
+            Entry* e = find_or_create(required_size);
+            if (!e || required_size == 0) return e ? e->storage.data_ptr() : nullptr;
+            void* ptr = e->storage.data_ptr();
+            if (zero_fill) {
+                OMNIDREAMS_SINGLEVIEW_CUDA_CHECK(cudaMemsetAsync(ptr, 0, required_size, stream));
+            }
+            return ptr;
+        }
+
+        void reset() {
+            std::lock_guard<std::mutex> lock(mtx);
+            entries.clear();
+        }
+
+        void pre_reserve(size_t size) {
+            if (size == 0) return;
+            size_t rounded = round_capacity(size);
+            std::lock_guard<std::mutex> lock(mtx);
+            Entry* best = nullptr;
+            for (auto& e : entries) {
+                if (e.capacity >= rounded) {
+                    best = &e;
+                    break;
+                }
+            }
+            if (!best) {
+                Entry fresh;
+                auto options = at::TensorOptions().dtype(at::kByte).device(at::kCUDA);
+                fresh.storage = at::empty({static_cast<long long>(rounded)}, options);
+                fresh.capacity = rounded;
+                entries.push_back(std::move(fresh));
+            }
+        }
+
+        size_t capacity() const {
+            std::lock_guard<std::mutex> lock(mtx);
+            size_t max_cap = 0;
+            for (const auto& e : entries) {
+                if (e.capacity > max_cap) max_cap = e.capacity;
+            }
+            return max_cap;
+        }
+    };
+
+    static Conv3x3WorkspaceArena g_conv3x3_workspace_arena;
+}
+
+// Reset all CUTLASS workspaces for reproducibility
+inline void reset_cutlass_workspaces() {
+    // Reset the global workspace pool
+    g_conv3x3_workspace_arena.reset();
+}
+
+// Pre-reserve conv3x3 workspace for maximum expected size
+// Call this once before decode to eliminate all malloc overhead during execution
+inline void pre_reserve_conv3x3_workspace(size_t workspace_bytes) {
+    g_conv3x3_workspace_arena.pre_reserve(workspace_bytes);
+}
+
+inline size_t get_conv3x3_workspace_capacity() {
+    return g_conv3x3_workspace_arena.capacity();
+}
+
+inline size_t estimate_conv3x3_workspace_bytes(
+    int N, int H_in, int W_in, int Cin, int Cout, int stride, int pad) {
+
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using ElementComputeEpilogue = float;
+
+    using LayoutInputA = cutlass::layout::TensorNHWC;
+    using LayoutInputB = cutlass::layout::TensorNHWC;
+    using LayoutOutput = cutlass::layout::TensorNHWC;
+
+    using ThreadblockShape = cutlass::gemm::GemmShape<256, 128, 32>;
+    using WarpShape = cutlass::gemm::GemmShape<64, 64, 32>;
+    using InstructionShape = cutlass::gemm::GemmShape<16, 8, 16>;
+
+    constexpr int NumStages = 3;
+    constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementInputA>::value;
+    constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementInputB>::value;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+        ElementOutput,
+        128 / cutlass::sizeof_bits<ElementOutput>::value,
+        ElementAccumulator,
+        ElementComputeEpilogue
+    >;
+
+    using Conv2dFpropKernelOpt = typename cutlass::conv::kernel::DefaultConv2dFprop<
+        ElementInputA, LayoutInputA,
+        ElementInputB, LayoutInputB,
+        ElementOutput, LayoutOutput,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        ThreadblockShape,
+        WarpShape,
+        InstructionShape,
+        EpilogueOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        NumStages,
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kOptimized,
+        cutlass::conv::StrideSupport::kStrided,
+        AlignmentA,
+        AlignmentB
+    >::Kernel;
+    using ImplicitGemmOpt = cutlass::conv::device::ImplicitGemmConvolution<Conv2dFpropKernelOpt>;
+
+    using Conv2dFpropKernelAna = typename cutlass::conv::kernel::DefaultConv2dFprop<
+        ElementInputA, LayoutInputA,
+        ElementInputB, LayoutInputB,
+        ElementOutput, LayoutOutput,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        ThreadblockShape,
+        WarpShape,
+        InstructionShape,
+        EpilogueOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        NumStages,
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kAnalytic,
+        cutlass::conv::StrideSupport::kStrided,
+        AlignmentA,
+        AlignmentB
+    >::Kernel;
+    using ImplicitGemmAna = cutlass::conv::device::ImplicitGemmConvolution<Conv2dFpropKernelAna>;
+
+    int H_out = conv3x3_out_dim(H_in, stride, pad);
+    int W_out = conv3x3_out_dim(W_in, stride, pad);
+
+    cutlass::conv::Mode mode = cutlass::conv::Mode::kCrossCorrelation;
+    int split_k_slices = 1;
+
+    cutlass::conv::Conv2dProblemSize problem_size(
+        {N, H_in, W_in, Cin},
+        {Cout, 3, 3, Cin},
+        {pad, pad, pad, pad},
+        {stride, stride},
+        {1, 1},
+        {N, H_out, W_out, Cout},
+        mode,
+        split_k_slices
+    );
+
+    LayoutInputA layout_a(LayoutInputA::packed({N, H_in, W_in, Cin}));
+    LayoutInputB layout_b(LayoutInputB::packed({Cout, 3, 3, Cin}));
+    LayoutOutput layout_c(LayoutOutput::packed({N, H_out, W_out, Cout}));
+
+    typename Conv2dFpropKernelOpt::TensorRefA tensor_a{nullptr, layout_a};
+    typename Conv2dFpropKernelOpt::TensorRefB tensor_b{nullptr, layout_b};
+    typename Conv2dFpropKernelOpt::TensorRefC tensor_c{nullptr, layout_c};
+    typename Conv2dFpropKernelOpt::TensorRefC tensor_d{nullptr, layout_c};
+
+    typename EpilogueOp::Params epilogue_params(
+        ElementComputeEpilogue(1.0f),
+        ElementComputeEpilogue(0.0f)
+    );
+
+    typename ImplicitGemmOpt::Arguments arguments_opt(
+        problem_size,
+        tensor_a,
+        tensor_b,
+        tensor_c,
+        tensor_d,
+        epilogue_params,
+        cutlass::conv::SplitKMode::kSerial
+    );
+    typename ImplicitGemmAna::Arguments arguments_ana(
+        problem_size,
+        tensor_a,
+        tensor_b,
+        tensor_c,
+        tensor_d,
+        epilogue_params,
+        cutlass::conv::SplitKMode::kSerial
+    );
+
+    ImplicitGemmOpt implicit_gemm_opt;
+    ImplicitGemmAna implicit_gemm_ana;
+
+    size_t ws_opt = implicit_gemm_opt.get_workspace_size(arguments_opt);
+    size_t ws_ana = implicit_gemm_ana.get_workspace_size(arguments_ana);
+    return std::max(ws_opt, ws_ana);
+}
+
+// Forward declarations for layout conversion functions
+inline void nchw_to_hwc_half(const half* in_nchw, half* out_hwc, int N, int H, int W, int C, cudaStream_t stream);
+inline void hwc_to_nchw_half(const half* in_hwc, half* out_nchw, int N, int H, int W, int C, cudaStream_t stream);
+
+#if defined(OMNIDREAMS_SINGLEVIEW_USE_CUTLASS)
+// Forward declaration for CUTLASS-backed NHWC 1x1
+inline void conv2d_1x1_nhwc_cutlass(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H, int W, int Cin, int Cout, Activation act, cudaStream_t stream);
+#endif
+
+#if defined(OMNIDREAMS_SINGLEVIEW_USE_CUTLASS)
+// Forward declaration for CUTLASS-backed NHWC 3x3 implicit convolution
+inline void conv2d_3x3_nhwc_cutlass_implicit(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H_in, int W_in, int Cin, int Cout, Activation act,
+    int stride, int pad, int H_out, int W_out, cudaStream_t stream,
+    int chunks);
+// (NCHW conv forward declarations removed)
+#endif
+
+// (cuDNN implementation removed)
+
+// apply_activation template kept here for CUTLASS kernels that use it
+template <Activation ACT>
+__device__ __forceinline__ float apply_activation(float x) {
+    if constexpr (ACT == Activation::ReLU) {
+        return x > 0.0f ? x : 0.0f;
+    } else if constexpr (ACT == Activation::ClampTanh3) {
+        return clamp_tanh3(x);
+    } else {
+        return x;
+    }
+}
+
+// CUTLASS-only implementation - no naive kernels
+
+// Transpose and reorder kernels moved to common; CUTLASS keeps wrappers using them
+
+// Runtime activation (for fused reorder path)
+__device__ __forceinline__ float apply_activation_runtime(float x, int act_code) {
+    // 0=None, 1=ReLU, 2=ClampTanh3
+    if (act_code == 1) return x > 0.0f ? x : 0.0f;
+    if (act_code == 2) return clamp_tanh3(x);
+    return x;
+}
+
+// (NCHW reorder+bias kernel removed)
+
+// CUTLASS-only implementation - no naive kernels
+
+// Trim first K frames from NTCHW buffer: in [N*T, C, H, W] with known N and T.
+__global__ void ntchw_trim_front_half_kernel(
+    const half* __restrict__ in, half* __restrict__ out,
+    int N, int T, int C, int H, int W, int K)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * (T - K) * C * H * W;
+    if (idx >= total) return;
+    int w = idx % W; idx /= W;
+    int h = idx % H; idx /= H;
+    int c = idx % C; idx /= C;
+    int t = idx % (T - K); idx /= (T - K);
+    int n = (int)idx;
+    long long in_base  = (((((long long)n * T + (t + K)) * C + c) * H + h) * W + w);
+    long long out_base = (((((long long)n * (T - K) + t) * C + c) * H + h) * W + w);
+    out[out_base] = in[in_base];
+}
+
+// CUTLASS-only implementation - no naive kernels
+
+// Public launchers
+
+// (NCHW tiled 3x3 kernel and helpers removed)
+
+// (NCHW 3x3 tiled host wrapper removed)
+// (NCHW 1x1 host wrapper removed)
+
+// (NCHW 3x3 host wrapper removed)
+
+inline void conv2d_3x3_nhwc_half(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H_in, int W_in, int Cin, int Cout, int groups, Activation act,
+    int stride, int pad,
+    int H_out, int W_out,
+    cudaStream_t stream,
+    int chunks = 0)
+{
+    // CUTLASS-only implementation
+    OMNIDREAMS_SINGLEVIEW_ASSERT(input != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(weight != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(output != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && Cin > 0 && Cout > 0 && H_in > 0 && W_in > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(groups > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT((Cin % groups) == 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT((Cout % groups) == 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(stride > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(H_out > 0 && W_out > 0);
+
+    if (groups != 1) {
+        throw std::runtime_error("conv2d_3x3_nhwc_half: Only groups=1 is supported with CUTLASS backend");
+    }
+
+    size_t required_ws = 0;
+    if (chunks <= 1) {
+        required_ws = estimate_conv3x3_workspace_bytes(N, H_in, W_in, Cin, Cout, stride, pad);
+    }
+    if (required_ws > 0) {
+        // Pre-allocate workspace (caches internally, return value not needed)
+        (void)g_conv3x3_workspace_arena.get(required_ws, stream, /*zero_fill=*/true);
+    }
+
+    conv2d_3x3_nhwc_cutlass_implicit(
+        input, weight, bias, output,
+        N, H_in, W_in, Cin, Cout, act, stride, pad, H_out, W_out, stream, chunks);
+}
+
+inline void conv2d_1x1_nhwc_half(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H, int W, int Cin, int Cout, int groups, Activation act,
+    cudaStream_t stream)
+{
+    // CUTLASS-only implementation
+    OMNIDREAMS_SINGLEVIEW_ASSERT(input != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(weight != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(output != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && Cin > 0 && Cout > 0 && H > 0 && W > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(groups > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT((Cin % groups) == 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT((Cout % groups) == 0);
+
+    conv2d_1x1_nhwc_cutlass(input, weight, bias, output, N, H, W, Cin, Cout, act, stream);
+}
+
+// Wrappers now provided by common/cuda_utils.cuh
+
+// Convenience wrappers for single-image CHW/HWC using N=1
+// Removed CHW single-image wrappers; use boundary permutes at call sites
+
+// NTHWC <-> NTCHW wrappers (for video inputs with time dimension), often with N=1
+// Wrappers now provided by common/cuda_utils.cuh
+
+// Convenience wrappers for TPool/TGrow semantics without data copies.
+// TPool: input NTCHW flattened as (N*T, C, H, W). After pooling with stride s,
+// pass N' = (N*T)/s and Cin' = s*C into 1x1 conv. Result is (N', C_out, H, W).
+inline void tpool_1x1_conv(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N_mul_T, int C, int H, int W, int stride, int C_out,
+    Activation act, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(input != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(weight != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(output != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N_mul_T > 0 && C > 0 && H > 0 && W > 0 && stride > 0 && C_out > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT((N_mul_T % stride) == 0);
+    int Nprime = N_mul_T / stride; // assume divisible
+    int CinPrime = stride * C;
+    // Reorder to NHWC, run NHWC 1x1, reorder back
+    static thread_local half* s_in_nhwc = nullptr;
+    static thread_local size_t s_in_elems = 0;
+    static thread_local half* s_out_nhwc = nullptr;
+    static thread_local size_t s_out_elems = 0;
+    size_t elems_in = (size_t)Nprime * H * W * CinPrime;
+    size_t elems_out = (size_t)Nprime * H * W * C_out;
+    if (elems_in > s_in_elems) {
+        if (s_in_nhwc) cudaFree(s_in_nhwc);
+        cudaError_t err = cudaMalloc(&s_in_nhwc, elems_in * sizeof(half));
+        if (err != cudaSuccess) {
+            s_in_nhwc = nullptr;
+            s_in_elems = 0;
+            throw std::runtime_error(std::string("cudaMalloc failed for clamp input (") +
+                std::to_string(elems_in * sizeof(half) / 1048576.0) + " MB): " + cudaGetErrorString(err));
+        }
+        s_in_elems = elems_in;
+    }
+    if (elems_out > s_out_elems) {
+        if (s_out_nhwc) cudaFree(s_out_nhwc);
+        cudaError_t err = cudaMalloc(&s_out_nhwc, elems_out * sizeof(half));
+        if (err != cudaSuccess) {
+            s_out_nhwc = nullptr;
+            s_out_elems = 0;
+            throw std::runtime_error(std::string("cudaMalloc failed for clamp output (") +
+                std::to_string(elems_out * sizeof(half) / 1048576.0) + " MB): " + cudaGetErrorString(err));
+        }
+        s_out_elems = elems_out;
+    }
+    half* in_nhwc = s_in_nhwc; half* out_nhwc = s_out_nhwc;
+    if (!in_nhwc || !out_nhwc) {
+        throw std::runtime_error("Internal error: null workspace pointers in clamp_1x1_conv");
+    }
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    nchw_to_hwc_half(input, in_nhwc, Nprime, H, W, CinPrime, stream);
+    conv2d_1x1_nhwc_half(in_nhwc, weight, bias, out_nhwc, Nprime, H, W, CinPrime, C_out, /*groups*/1, act, stream);
+    hwc_to_nchw_half(out_nhwc, output, Nprime, H, W, C_out, stream);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// TGrow: perform 1x1 conv to expand channels by stride, then reinterpret as (N*T*stride, C, H, W)
+inline void tgrow_1x1_conv(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N_mul_T, int C, int H, int W, int stride,
+    Activation act, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(input != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(weight != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(output != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N_mul_T > 0 && C > 0 && H > 0 && W > 0 && stride > 0);
+    int C_out = stride * C;
+    // Reorder to NHWC, run NHWC 1x1, reorder back
+    static thread_local half* s_in_nhwc = nullptr;
+    static thread_local size_t s_in_elems = 0;
+    static thread_local half* s_out_nhwc = nullptr;
+    static thread_local size_t s_out_elems = 0;
+    size_t elems_in = (size_t)N_mul_T * H * W * C;
+    size_t elems_out = (size_t)N_mul_T * H * W * C_out;
+    if (elems_in > s_in_elems) {
+        if (s_in_nhwc) cudaFree(s_in_nhwc);
+        cudaError_t err = cudaMalloc(&s_in_nhwc, elems_in * sizeof(half));
+        if (err != cudaSuccess) {
+            s_in_nhwc = nullptr;
+            s_in_elems = 0;
+            throw std::runtime_error(std::string("cudaMalloc failed for tgrow input (") +
+                std::to_string(elems_in * sizeof(half) / 1048576.0) + " MB): " + cudaGetErrorString(err));
+        }
+        s_in_elems = elems_in;
+    }
+    if (elems_out > s_out_elems) {
+        if (s_out_nhwc) cudaFree(s_out_nhwc);
+        cudaError_t err = cudaMalloc(&s_out_nhwc, elems_out * sizeof(half));
+        if (err != cudaSuccess) {
+            s_out_nhwc = nullptr;
+            s_out_elems = 0;
+            throw std::runtime_error(std::string("cudaMalloc failed for tgrow output (") +
+                std::to_string(elems_out * sizeof(half) / 1048576.0) + " MB): " + cudaGetErrorString(err));
+        }
+        s_out_elems = elems_out;
+    }
+    half* in_nhwc = s_in_nhwc; half* out_nhwc = s_out_nhwc;
+    if (!in_nhwc || !out_nhwc) {
+        throw std::runtime_error("Internal error: null workspace pointers in tgrow_1x1_conv");
+    }
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    nchw_to_hwc_half(input, in_nhwc, N_mul_T, H, W, C, stream);
+    conv2d_1x1_nhwc_half(in_nhwc, weight, bias, out_nhwc, N_mul_T, H, W, C, C_out, /*groups*/1, act, stream);
+    hwc_to_nchw_half(out_nhwc, output, N_mul_T, H, W, C_out, stream);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    // consumer should reinterpret output as (N*T*stride, C, H, W) if desired
+}
+
+// Optional CUTLASS/CuTe backends (disabled by default). Provide wrapper signatures
+// CUTLASS is required for all operations.
+
+#if defined(OMNIDREAMS_SINGLEVIEW_USE_CUTLASS)
+#include <cutlass/cutlass.h>
+#include <cutlass/gemm/device/gemm.h>
+// Note: A production-grade implementation would dispatch to cutlass convolution
+// (implicit GEMM) or GEMM for 1x1 with proper tensor layouts. Here we keep the
+// public API stable and, if CUTLASS is enabled later, these can be replaced.
+// CUTLASS implementation for 1x1 convolutions.
+__global__ void nhwc_add_bias_act_half_kernel_linear(
+    half* out, const half* bias, long long total_elems, int N, Activation act)
+{
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total_elems) return;
+    int n = (int)(idx % N);
+    float v = __half2float(out[idx]);
+    if (bias) v += __half2float(bias[n]);
+    // 0=None, 1=ReLU, 2=ClampTanh3 (match apply_activation equivalents)
+    if (act == Activation::ReLU) v = v > 0.0f ? v : 0.0f;
+    else if (act == Activation::ClampTanh3) v = clamp_tanh3(v);
+    out[idx] = __float2half(v);
+}
+
+inline void nhwc_add_bias_act_half(half* out, const half* bias, int M, int N, Activation act, cudaStream_t stream) {
+    // Process [M, N] as a flat 1D buffer to avoid gridDim.y > 65535 invalid configs
+    long long total = (long long)M * (long long)N;
+    int threads = 256;
+    // Chunk to keep gridDim.x within conservative limits across devices
+    long long max_chunk = (long long)threads * 65535; // ~16.7M elements per launch
+    for (long long processed = 0; processed < total; processed += max_chunk) {
+        long long chunk = std::min(max_chunk, total - processed);
+        int blocks = (int)((chunk + threads - 1) / threads);
+        nhwc_add_bias_act_half_kernel_linear<<<blocks, threads, 0, stream>>>(out + processed, bias, chunk, N, act);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    }
+}
+
+// Forward declarations for inline fusion kernels (defined later in file)
+__global__ void fused_residual_add_relu_nhwc_kernel(half* output, const half* residual, long long total);
+
+// Phase 5: Fused residual Add+ReLU helper (for MemBlock skip connections and other residual ops)
+// output = ReLU(output + residual)
+inline void nhwc_residual_add_relu_half(half* output, const half* residual, long long total_elements, cudaStream_t stream) {
+    int threads = 256;
+    long long max_chunk = (long long)threads * 65535;
+
+    for (long long processed = 0; processed < total_elements; processed += max_chunk) {
+        long long chunk = std::min(max_chunk, total_elements - processed);
+        int blocks = (int)((chunk + threads - 1) / threads);
+        fused_residual_add_relu_nhwc_kernel<<<blocks, threads, 0, stream>>>(
+            output + processed, residual + processed, chunk);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    }
+}
+
+inline void conv2d_1x1_nhwc_cutlass(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H, int W, int Cin, int Cout, Activation act, cudaStream_t stream)
+{
+    // Treat NHWC as RowMajor [M, K], M=N*H*W, K=Cin
+    // 1x1 convolution is just a matrix multiply: [M,K] × [K,N] = [M,N]
+    int M = N * H * W;
+    using Element = cutlass::half_t;
+    using LayoutA = cutlass::layout::RowMajor;      // [M,K]
+    using LayoutB = cutlass::layout::ColumnMajor;   // [K,N] via view of row-major [N,K]
+    using LayoutC = cutlass::layout::RowMajor;      // [M,N]
+    using Acc = float;
+    using Gemm = cutlass::gemm::device::Gemm<
+        Element, LayoutA,
+        Element, LayoutB,
+        Element, LayoutC,
+        Acc
+    >;
+
+    typename Gemm::Arguments args(
+        {M, Cout, Cin},   // problem size: (m, n, k)
+        {reinterpret_cast<const Element*>(input), Cin},   // A ptr, lda=K
+        {reinterpret_cast<const Element*>(weight), Cin},  // B ptr as ColumnMajor [K,N], ldb=K
+        {reinterpret_cast<Element*>(output), Cout},
+        {reinterpret_cast<Element*>(output), Cout},
+        {1.0f, 0.0f}  // alpha=1, beta=0
+    );
+    Gemm gemm;
+    cutlass::Status st = gemm.initialize(args);
+    if (st != cutlass::Status::kSuccess) {
+        throw std::runtime_error("CUTLASS GEMM initialization failed");
+    }
+    st = gemm(stream);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+
+    // Phase 4 extension: Apply bias/activation separately
+    // TODO: Fuse bias into GEMM epilogue for 1x1 convolutions (lower priority - GEMM is already fast)
+    if (bias || act != Activation::None) {
+        nhwc_add_bias_act_half(output, bias, M, Cout, act, stream);
+    }
+}
+
+// Utility: Compute minimum number of chunks needed to keep tensors under CUTLASS 2GB limit
+inline int compute_optimal_conv_chunks(int N, int H, int W, int C, int elem_bytes = 2) {
+    // CUTLASS device wrapper rejects tensors >= 2^31 bytes
+    // For NHWC: activation_size = N*H*W*C elements
+    unsigned long long total_elems = (unsigned long long)N * H * W * C;
+    unsigned long long total_bytes = total_elems * elem_bytes;
+    unsigned long long limit = (1ULL << 31);  // 2GB
+
+    if (total_bytes < limit) {
+        return 1;  // No chunking needed
+    }
+
+    // Find minimum chunks to bring each chunk under limit
+    // chunk_bytes = (total_bytes / chunks), need chunk_bytes < limit
+    // => chunks > total_bytes / limit
+    int min_chunks = (int)((total_bytes + limit - 1) / limit);
+
+    // Round up to next power of 2 for cleaner splits
+    int chunks = 1;
+    while (chunks < min_chunks) {
+        chunks *= 2;
+    }
+
+    // Cap at N to avoid empty chunks
+    if (chunks > N) chunks = N;
+
+    return chunks;
+}
+
+// --- Phase 3: Regular CUTLASS conv3x3 (no fusion) ---
+// Used for cases where bias is null OR activation is not ReLU
+// chunks: number of N-dimension splits (default 1 = no chunking; auto-computed if 0)
+static void conv2d_3x3_regular(
+    const half* input, const half* weight, half* output,
+    int N, int H_in, int W_in, int Cin, int Cout,
+    int stride, int pad, int H_out, int W_out, cudaStream_t stream,
+    int chunks = 1)
+{
+    // Enforce Tensor Core alignment requirements
+    OMNIDREAMS_SINGLEVIEW_ASSERT((Cin % 8) == 0 && "Cin must be a multiple of 8 for Tensor Core alignment");
+    OMNIDREAMS_SINGLEVIEW_ASSERT((Cout % 8) == 0 && "Cout must be a multiple of 8 for Tensor Core alignment");
+    // Follow CUTLASS example approach with explicit Tensor Core configuration
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using ElementComputeEpilogue = float;
+
+    using LayoutInputA = cutlass::layout::TensorNHWC;
+    using LayoutInputB = cutlass::layout::TensorNHWC;  // Weights in NHWC [Cout, R, S, Cin] (transposed at load time)
+    using LayoutOutput = cutlass::layout::TensorNHWC;
+
+    // Tile shapes chosen to match profiler-optimal kernels
+    using ThreadblockShape = cutlass::gemm::GemmShape<256, 128, 32>;  // M x N x K
+    using WarpShape = cutlass::gemm::GemmShape<64, 64, 32>;
+    using InstructionShape = cutlass::gemm::GemmShape<16, 8, 16>;  // Tensor Core MMA shape
+
+    constexpr int NumStages = 3;  // Multi-stage pipeline
+    constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementInputA>::value;
+    constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementInputB>::value;
+
+    // Regular epilogue: just alpha * conv_result + beta * source
+    // Bias and activation applied separately
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+        ElementOutput,
+        128 / cutlass::sizeof_bits<ElementOutput>::value,
+        ElementAccumulator,
+        ElementComputeEpilogue
+    >;
+
+    using Conv2dFpropKernelOpt = typename cutlass::conv::kernel::DefaultConv2dFprop<
+        ElementInputA, LayoutInputA,
+        ElementInputB, LayoutInputB,
+        ElementOutput, LayoutOutput,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        ThreadblockShape,
+        WarpShape,
+        InstructionShape,
+        EpilogueOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        NumStages,
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kOptimized,
+        cutlass::conv::StrideSupport::kStrided,
+        AlignmentA,
+        AlignmentB
+    >::Kernel;
+    using ImplicitGemmOpt = cutlass::conv::device::ImplicitGemmConvolution<Conv2dFpropKernelOpt>;
+
+    // Analytic fallback (same shapes) for permissive support when optimized rejects
+    using Conv2dFpropKernelAna = typename cutlass::conv::kernel::DefaultConv2dFprop<
+        ElementInputA, LayoutInputA,
+        ElementInputB, LayoutInputB,
+        ElementOutput, LayoutOutput,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        ThreadblockShape,
+        WarpShape,
+        InstructionShape,
+        EpilogueOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        NumStages,
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kAnalytic,
+        cutlass::conv::StrideSupport::kStrided,
+        AlignmentA,
+        AlignmentB
+    >::Kernel;
+    using ImplicitGemmAna = cutlass::conv::device::ImplicitGemmConvolution<Conv2dFpropKernelAna>;
+
+    // Setup problem size
+    cutlass::conv::Mode mode = cutlass::conv::Mode::kCrossCorrelation;
+    int split_k_slices = 1;
+
+    cutlass::conv::Conv2dProblemSize problem_size(
+        {N, H_in, W_in, Cin},       // input size NHWC
+        {Cout, 3, 3, Cin},          // filter size KRSC/NHWC (transposed from PyTorch at load time)
+        {pad, pad, pad, pad},       // padding (top, bottom, left, right)
+        {stride, stride},           // conv stride
+        {1, 1},                     // dilation
+        {N, H_out, W_out, Cout},    // output size NHWC
+        mode,
+        split_k_slices
+    );
+
+    // Construct kernel-specific TensorRef objects for raw pointers
+    // All tensors use NHWC layout - weights are transposed at model load time
+    auto stride_a = LayoutInputA::packed({N, H_in, W_in, Cin});          // NHWC
+    auto stride_b = LayoutInputB::packed({Cout, 3, 3, Cin});             // NHWC (KRSC)
+    auto stride_c = LayoutOutput::packed({N, H_out, W_out, Cout});       // NHWC
+
+    LayoutInputA layout_a(stride_a);
+    LayoutInputB layout_b(stride_b);
+    LayoutOutput layout_c(stride_c);
+
+    typename Conv2dFpropKernelOpt::TensorRefA tensor_a{
+        const_cast<ElementInputA*>(reinterpret_cast<ElementInputA const*>(input)),
+        layout_a
+    };
+
+    typename Conv2dFpropKernelOpt::TensorRefB tensor_b{
+        const_cast<ElementInputB*>(reinterpret_cast<ElementInputB const*>(weight)),
+        layout_b
+    };
+
+    typename Conv2dFpropKernelOpt::TensorRefC tensor_c{
+        reinterpret_cast<ElementOutput*>(output),
+        layout_c
+    };
+
+    typename Conv2dFpropKernelOpt::TensorRefC tensor_d{
+        reinterpret_cast<ElementOutput*>(output),
+        layout_c
+    };
+
+    // Regular epilogue parameters
+    typename EpilogueOp::Params epilogue_params(
+        ElementComputeEpilogue(1.0f),  // alpha
+        ElementComputeEpilogue(0.0f)   // beta
+    );
+
+    // Regular arguments (no broadcast)
+    typename ImplicitGemmOpt::Arguments arguments_opt(
+        problem_size,
+        tensor_a,
+        tensor_b,
+        tensor_c,
+        tensor_d,
+        epilogue_params,
+        cutlass::conv::SplitKMode::kSerial
+    );
+    typename ImplicitGemmAna::Arguments arguments_ana(
+        problem_size,
+        tensor_a,
+        tensor_b,
+        tensor_c,
+        tensor_d,
+        epilogue_params,
+        cutlass::conv::SplitKMode::kSerial
+    );
+
+    ImplicitGemmOpt implicit_gemm_opt;
+    ImplicitGemmAna implicit_gemm_ana;
+
+    // Note: Output is zero-initialized by torch::zeros in the caller
+    // The epilogue with beta=0.0 will overwrite all output elements
+
+    // Validate input dimensions before CUTLASS
+    if (Cin % 8 != 0 || Cout % 8 != 0) {
+        char err_msg[512];
+        snprintf(err_msg, sizeof(err_msg),
+                "CUTLASS conv3x3 requires Cin and Cout to be multiples of 8 for FP16: "
+                "N=%d Cin=%d Cout=%d H=%d W=%d (need padding)",
+                N, Cin, Cout, H_in, W_in);
+        throw std::runtime_error(err_msg);
+    }
+
+    if (N <= 0 || Cin <= 0 || Cout <= 0 || H_in <= 0 || W_in <= 0) {
+        char err_msg[512];
+        snprintf(err_msg, sizeof(err_msg),
+                "Invalid conv3x3 dimensions: N=%d Cin=%d Cout=%d H=%d W=%d",
+                N, Cin, Cout, H_in, W_in);
+        throw std::runtime_error(err_msg);
+    }
+
+    // Auto-compute chunks if requested (chunks==0)
+    if (chunks == 0) {
+        chunks = compute_optimal_conv_chunks(N, H_in, W_in, Cin, sizeof(half));
+        // Also check output size
+        int out_chunks = compute_optimal_conv_chunks(N, H_out, W_out, Cout, sizeof(half));
+        chunks = std::max(chunks, out_chunks);
+    }
+    if (chunks < 1) chunks = 1;
+
+    // Helper: run optimized kernel in 'num_chunks' along N (batch) dimension
+    auto run_optimized_in_chunks = [&](int num_chunks) -> bool {
+        if (num_chunks < 1) num_chunks = 1;
+        bool all_ok = true;
+        for (int i = 0; i < num_chunks; ++i) {
+            int n0 = (i * N) / num_chunks;
+            int n1 = ((i + 1) * N) / num_chunks;
+            int N_chunk = n1 - n0;
+            if (N_chunk <= 0) continue;
+
+            // Offset base pointers for chunk start
+            long long in_off_e = layout_a(typename LayoutInputA::TensorCoord(n0, 0, 0, 0));
+            long long out_off_e = layout_c(typename LayoutOutput::TensorCoord(n0, 0, 0, 0));
+
+            typename Conv2dFpropKernelOpt::TensorRefA ta{
+                const_cast<ElementInputA*>(reinterpret_cast<ElementInputA const*>(input)) + in_off_e,
+                layout_a
+            };
+            typename Conv2dFpropKernelOpt::TensorRefB tb{
+                const_cast<ElementInputB*>(reinterpret_cast<ElementInputB const*>(weight)),
+                layout_b
+            };
+            typename Conv2dFpropKernelOpt::TensorRefC tc{
+                reinterpret_cast<ElementOutput*>(output) + out_off_e,
+                layout_c
+            };
+            typename Conv2dFpropKernelOpt::TensorRefC td{
+                reinterpret_cast<ElementOutput*>(output) + out_off_e,
+                layout_c
+            };
+
+            cutlass::conv::Conv2dProblemSize ps(
+                {N_chunk, H_in, W_in, Cin},
+                {Cout, 3, 3, Cin},
+                {pad, pad, pad, pad},
+                {stride, stride},
+                {1, 1},
+                {N_chunk, H_out, W_out, Cout},
+                mode,
+                split_k_slices
+            );
+
+            typename ImplicitGemmOpt::Arguments args_opt(
+                ps, ta, tb, tc, td, epilogue_params, cutlass::conv::SplitKMode::kSerial
+            );
+
+            cutlass::Status st_ci = implicit_gemm_opt.can_implement(args_opt);
+            if (st_ci != cutlass::Status::kSuccess) { all_ok = false; break; }
+
+            size_t ws = implicit_gemm_opt.get_workspace_size(args_opt);
+            void* workspace = nullptr;
+            if (ws > 0) {
+                workspace = g_conv3x3_workspace_arena.get(ws, stream, true);
+                if (workspace == nullptr) { all_ok = false; break; }
+            }
+            cutlass::Status st = implicit_gemm_opt.initialize(args_opt, workspace);
+            if (st != cutlass::Status::kSuccess) { all_ok = false; break; }
+            st = implicit_gemm_opt(stream);
+            cudaError_t err = cudaPeekAtLastError();
+            if (st != cutlass::Status::kSuccess || err == cudaErrorInvalidConfiguration || err == cudaErrorInvalidValue) { all_ok = false; break; }
+        }
+        return all_ok;
+    };
+
+    // Helper: run analytic kernel in 'num_chunks' along N
+    auto run_analytic_in_chunks = [&](int num_chunks) -> bool {
+        if (num_chunks < 1) num_chunks = 1;
+        bool all_ok = true;
+        for (int i = 0; i < num_chunks; ++i) {
+            int n0 = (i * N) / num_chunks;
+            int n1 = ((i + 1) * N) / num_chunks;
+            int N_chunk = n1 - n0;
+            if (N_chunk <= 0) continue;
+            long long in_off_e = layout_a(typename LayoutInputA::TensorCoord(n0, 0, 0, 0));
+            long long out_off_e = layout_c(typename LayoutOutput::TensorCoord(n0, 0, 0, 0));
+            typename Conv2dFpropKernelAna::TensorRefA ta{
+                const_cast<ElementInputA*>(reinterpret_cast<ElementInputA const*>(input)) + in_off_e,
+                layout_a
+            };
+            typename Conv2dFpropKernelAna::TensorRefB tb{
+                const_cast<ElementInputB*>(reinterpret_cast<ElementInputB const*>(weight)),
+                layout_b
+            };
+            typename Conv2dFpropKernelAna::TensorRefC tc{
+                reinterpret_cast<ElementOutput*>(output) + out_off_e,
+                layout_c
+            };
+            typename Conv2dFpropKernelAna::TensorRefC td{
+                reinterpret_cast<ElementOutput*>(output) + out_off_e,
+                layout_c
+            };
+            cutlass::conv::Conv2dProblemSize ps(
+                {N_chunk, H_in, W_in, Cin}, {Cout, 3, 3, Cin}, {pad, pad, pad, pad}, {stride, stride}, {1, 1}, {N_chunk, H_out, W_out, Cout}, mode, split_k_slices
+            );
+            typename ImplicitGemmAna::Arguments args_ana(
+                ps, ta, tb, tc, td, epilogue_params, cutlass::conv::SplitKMode::kSerial
+            );
+            cutlass::Status st_ci = implicit_gemm_ana.can_implement(args_ana);
+            if (st_ci != cutlass::Status::kSuccess) { all_ok = false; break; }
+            size_t ws = implicit_gemm_ana.get_workspace_size(args_ana);
+            void* workspace = nullptr;
+            if (ws > 0) { workspace = g_conv3x3_workspace_arena.get(ws, stream, true); if (workspace == nullptr) { all_ok = false; break; } }
+            cutlass::Status st = implicit_gemm_ana.initialize(args_ana, workspace);
+            if (st != cutlass::Status::kSuccess) { all_ok = false; break; }
+            st = implicit_gemm_ana(stream);
+            cudaError_t err = cudaPeekAtLastError();
+            if (st != cutlass::Status::kSuccess || err == cudaErrorInvalidConfiguration || err == cudaErrorInvalidValue) { all_ok = false; break; }
+        }
+        return all_ok;
+    };
+
+    // Try optimized with requested chunking; escalate if needed
+    int current_chunks = chunks;
+    while (current_chunks <= std::max(1, N)) {
+        if (run_optimized_in_chunks(current_chunks)) {
+            OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+            return;
+        }
+        // can_implement or execution failed; try more chunks
+        current_chunks *= 2;
+    }
+
+    // Optimized failed even with max chunking; try analytic with requested chunks
+    if (run_analytic_in_chunks(chunks)) {
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        return;
+    }
+
+    // Both paths failed; construct diagnostic error
+    cutlass::Status can_impl_status = implicit_gemm_opt.can_implement(arguments_opt);
+    if (can_impl_status != cutlass::Status::kSuccess) {
+        // Derive helpful diagnostics without changing behavior
+        int const gemm_M = N * H_out * W_out;            // M tile dimension
+        int const gemm_N = Cout;                          // N tile dimension
+        int const gemm_K = 3 * 3 * Cin;                   // K tile dimension
+        // Vectorization assumptions (in elements) for FP16 with 128-bit accesses
+        int const vec128_elems = 128 / cutlass::sizeof_bits<ElementInputA>::value; // expected 8 for fp16
+        int const vec64_elems  =  64 / cutlass::sizeof_bits<ElementInputA>::value; // expected 4 for fp16
+        // Pointer alignment info
+        auto in_addr  = reinterpret_cast<uintptr_t>(input);
+        auto w_addr   = reinterpret_cast<uintptr_t>(weight);
+        auto out_addr = reinterpret_cast<uintptr_t>(output);
+        // Compile-time tile shapes
+        int const tb_m = ThreadblockShape::kM;
+        int const tb_n = ThreadblockShape::kN;
+        int const tb_k = ThreadblockShape::kK;
+        int const wp_m = WarpShape::kM;
+        int const wp_n = WarpShape::kN;
+        int const wp_k = WarpShape::kK;
+        int const inst_m = InstructionShape::kM;
+        int const inst_n = InstructionShape::kN;
+        int const inst_k = InstructionShape::kK;
+        // Epilogue vector length (elements)
+        int const epilogue_vec = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+        char err_msg[1024];
+        snprintf(err_msg, sizeof(err_msg),
+                "CUTLASS implicit conv2d (Optimized) can_implement failed (status=%d '%s')\n"
+                "  Problem: N=%d Cin=%d Cout=%d H=%d W=%d H_out=%d W_out=%d stride=%d pad=%d\n"
+                "  GEMM dims: M=%d N=%d K=%d (K=R*S*Cin)\n"
+                "  TB shape:  M=%d N=%d K=%d; Warp: M=%d N=%d K=%d; MMA: %d x %d x %d\n"
+                "  AlignA/B (elements): %d/%d; epilogue_vec=%d (128-bit); alt_vec64=%d\n"
+                "  Remainders: K%%vec128=%d N%%vec128=%d; K%%vec64=%d N%%vec64=%d\n"
+                "  Ptr align (bytes): input%%16=%llu weight%%16=%llu output%%16=%llu\n"
+                "  Note: Failure may be due to iterator/tile constraints in kOptimized, not 8-multiplicity.",
+                (int)can_impl_status, cutlass::cutlassGetStatusString(can_impl_status),
+                N, Cin, Cout, H_in, W_in, H_out, W_out, stride, pad,
+                gemm_M, gemm_N, gemm_K,
+                tb_m, tb_n, tb_k, wp_m, wp_n, wp_k, inst_m, inst_n, inst_k,
+                AlignmentA, AlignmentB, epilogue_vec, vec64_elems,
+                gemm_K % vec128_elems, gemm_N % vec128_elems,
+                gemm_K % vec64_elems,  gemm_N % vec64_elems,
+                (unsigned long long)(in_addr % 16ULL),
+                (unsigned long long)(w_addr % 16ULL),
+                (unsigned long long)(out_addr % 16ULL));
+        // Try analytic fallback
+        cutlass::Status can_impl_status_ana = implicit_gemm_ana.can_implement(arguments_ana);
+        if (can_impl_status_ana != cutlass::Status::kSuccess) {
+            // Both paths reject: throw with optimized diagnostics (includes tile details)
+            throw std::runtime_error(err_msg);
+        }
+        // Use analytic path
+        size_t workspace_size = implicit_gemm_ana.get_workspace_size(arguments_ana);
+        void* workspace = nullptr;
+        if (workspace_size > 0) {
+            workspace = g_conv3x3_workspace_arena.get(workspace_size, stream, true);
+            if (workspace == nullptr) {
+                char ws_err[512];
+                snprintf(ws_err, sizeof(ws_err),
+                        "CUTLASS (Analytic) workspace allocation failed: required=%zu bytes. ",
+                        workspace_size);
+                throw std::runtime_error(ws_err);
+            }
+        }
+        cutlass::Status st = implicit_gemm_ana.initialize(arguments_ana, workspace);
+        if (st != cutlass::Status::kSuccess) {
+            char ini_err[512];
+            snprintf(ini_err, sizeof(ini_err),
+                    "CUTLASS (Analytic) initialize failed (status=%d)", (int)st);
+            throw std::runtime_error(ini_err);
+        }
+        st = implicit_gemm_ana(stream);
+        cudaError_t err = cudaPeekAtLastError();
+        if (st != cutlass::Status::kSuccess || err == cudaErrorInvalidConfiguration || err == cudaErrorInvalidValue) {
+            char run_err[512];
+            snprintf(run_err, sizeof(run_err),
+                    "CUTLASS (Analytic) kernel launch failed (status=%d, cuda_err=%d '%s')",
+                    (int)st, (int)err, cudaGetErrorName(err));
+            throw std::runtime_error(run_err);
+        }
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        return; // analytic path completed successfully
+    }
+
+    // Optional success diagnostics gated by env var (no behavior change)
+    if (const char* dbg = std::getenv("OMNIDREAMS_DIT_CUTLASS_DEBUG")) {
+        (void)dbg; // suppress unused warning
+        int const gemm_M = N * H_out * W_out;
+        int const gemm_N = Cout;
+        int const gemm_K = 3 * 3 * Cin;
+        int const tb_m = ThreadblockShape::kM;
+        int const tb_n = ThreadblockShape::kN;
+        int const tb_k = ThreadblockShape::kK;
+        int const wp_m = WarpShape::kM;
+        int const wp_n = WarpShape::kN;
+        int const wp_k = WarpShape::kK;
+        int const inst_m = InstructionShape::kM;
+        int const inst_n = InstructionShape::kN;
+        int const inst_k = InstructionShape::kK;
+        fprintf(stderr,
+                "[CUTLASS] can_implement OK | N=%d Cin=%d Cout=%d H=%d W=%d -> H_out=%d W_out=%d stride=%d pad=%d\n"
+                "          GEMM M=%d N=%d K=%d | TB %dx%dx%d Warp %dx%dx%d MMA %dx%dx%d | AlignA/B=%d/%d\n",
+                N, Cin, Cout, H_in, W_in, H_out, W_out, stride, pad,
+                gemm_M, gemm_N, gemm_K,
+                tb_m, tb_n, tb_k, wp_m, wp_n, wp_k, inst_m, inst_n, inst_k,
+                AlignmentA, AlignmentB);
+    }
+
+    // Get workspace from global pool (optimized path)
+    size_t workspace_size = implicit_gemm_opt.get_workspace_size(arguments_opt);
+    void* workspace = nullptr;
+
+    if (workspace_size > 0) {
+        workspace = g_conv3x3_workspace_arena.get(workspace_size, stream, true);
+        // Check for allocation failure if workspace was needed
+        if (workspace == nullptr) {
+            char err_msg[512];
+            snprintf(err_msg, sizeof(err_msg),
+                    "CUTLASS workspace allocation failed: "
+                    "N=%d Cin=%d Cout=%d H=%d W=%d required=%zu bytes. "
+                    "Pool capacity=%zu. Try reducing batch size or pre-reserving workspace.",
+                    N, Cin, Cout, H_in, W_in, workspace_size,
+                    g_conv3x3_workspace_arena.capacity());
+            throw std::runtime_error(err_msg);
+        }
+    } else {
+        // workspace_size==0 means CUTLASS doesn't need workspace for this config
+        // Try using pre-allocated workspace if available (might help with some CUTLASS versions)
+        if (g_conv3x3_workspace_arena.capacity() > 0) {
+            workspace = g_conv3x3_workspace_arena.get(1, stream, true);  // Request minimal workspace
+        }
+    }
+
+    // Initialize
+    cutlass::Status st = implicit_gemm_opt.initialize(arguments_opt, workspace);
+    if (st != cutlass::Status::kSuccess) {
+        char err_msg[512];
+        snprintf(err_msg, sizeof(err_msg),
+                "CUTLASS implicit conv2d initialize failed (status=%d): "
+                "N=%d Cin=%d Cout=%d H=%d W=%d H_out=%d W_out=%d stride=%d pad=%d "
+                "workspace=%p workspace_size=%zu pool_capacity=%zu. "
+                "This may indicate unsupported tensor dimensions or alignment issues. "
+                "Ensure Cin and Cout are multiples of 8 for FP16 tensor cores.",
+                (int)st, N, Cin, Cout, H_in, W_in, H_out, W_out, stride, pad,
+                workspace, workspace_size, g_conv3x3_workspace_arena.capacity());
+        throw std::runtime_error(err_msg);
+    }
+
+    // Launch kernel
+    st = implicit_gemm_opt(stream);
+    cudaError_t err = cudaPeekAtLastError();
+    if (st != cutlass::Status::kSuccess || err == cudaErrorInvalidConfiguration || err == cudaErrorInvalidValue) {
+        char err_msg[512];
+        snprintf(err_msg, sizeof(err_msg),
+                "CUTLASS implicit conv2d kernel launch failed (status=%d, cuda_err=%d '%s'): "
+                "N=%d Cin=%d Cout=%d H=%d W=%d",
+                (int)st, (int)err, cudaGetErrorName(err),
+                N, Cin, Cout, H_in, W_in);
+        throw std::runtime_error(err_msg);
+    }
+
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// --- Phase 3-7: Inline fusion kernels ---
+// Applied immediately after CUTLASS convolution for true fusion
+// Avoids CUTLASS broadcast epilogue compatibility issues
+
+// Phase 3: Fused bias+ReLU kernel
+__global__ void fused_bias_relu_nhwc_kernel(
+    half* output, const half* bias, int M, int N)
+{
+    // M = N_batch * H * W (spatial dimensions)
+    // N = Cout (channels)
+    // Layout: NHWC, so output[m, n] = output[m * N + n]
+
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)M * N;
+
+    if (idx < total) {
+        int channel = idx % N;
+        float val = __half2float(output[idx]);
+        val += __half2float(bias[channel]);  // Add bias
+        val = fmaxf(val, 0.0f);              // ReLU
+        output[idx] = __float2half(val);
+    }
+}
+
+// Phase 4: Fused bias-only kernel (no activation)
+__global__ void fused_bias_nhwc_kernel(
+    half* output, const half* bias, int M, int N)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)M * N;
+
+    if (idx < total) {
+        int channel = idx % N;
+        float val = __half2float(output[idx]);
+        val += __half2float(bias[channel]);  // Add bias only
+        output[idx] = __float2half(val);
+    }
+}
+
+// Phase 5: Fused residual Add+ReLU kernel (for MemBlock skip connections)
+__global__ void fused_residual_add_relu_nhwc_kernel(
+    half* output, const half* residual, long long total)
+{
+    // output = ReLU(output + residual)
+    // Both tensors are same shape [N, H, W, C] in NHWC layout
+
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (idx < total) {
+        float val = __half2float(output[idx]);
+        val += __half2float(residual[idx]);  // Add residual
+        val = fmaxf(val, 0.0f);              // ReLU
+        output[idx] = __float2half(val);
+    }
+}
+
+// Phase 7: Fused bias+ClampTanh3 kernel (for final decoder layer)
+__global__ void fused_bias_clamptanh3_nhwc_kernel(
+    half* output, const half* bias, int M, int N)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)M * N;
+
+    if (idx < total) {
+        int channel = idx % N;
+        float val = __half2float(output[idx]);
+        val += __half2float(bias[channel]);  // Add bias
+        val = clamp_tanh3(val);              // ClampTanh3
+        output[idx] = __float2half(val);
+    }
+}
+
+// --- Phase 3: Fused bias+ReLU via CUTLASS + inline kernel ---
+// Uses regular CUTLASS conv followed by fused bias+ReLU kernel
+// This avoids DefaultConv2dFpropWithBroadcast compatibility issues
+static void conv2d_3x3_fused_bias_relu(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H_in, int W_in, int Cin, int Cout,
+    int stride, int pad, int H_out, int W_out, cudaStream_t stream,
+    int chunks = 0)
+{
+    // Run regular CUTLASS convolution (no epilogue fusion)
+    conv2d_3x3_regular(input, weight, output,
+                      N, H_in, W_in, Cin, Cout,
+                      stride, pad, H_out, W_out, stream, chunks);
+
+    // Immediately apply fused bias+ReLU kernel in chunks (like nhwc_add_bias_act_half)
+    int M = N * H_out * W_out;
+    long long total = (long long)M * Cout;
+    int threads = 256;
+    long long max_chunk = (long long)threads * 65535;  // Max elements per launch
+
+    for (long long processed = 0; processed < total; processed += max_chunk) {
+        long long chunk = std::min(max_chunk, total - processed);
+        int blocks = (int)((chunk + threads - 1) / threads);
+        fused_bias_relu_nhwc_kernel<<<blocks, threads, 0, stream>>>(
+            output + processed, bias, M, Cout);
+        cudaError_t err = cudaPeekAtLastError();
+        if (err != cudaSuccess) {
+            char err_msg[512];
+            snprintf(err_msg, sizeof(err_msg),
+                    "Fused bias+ReLU post-kernel failed (cuda_err=%d '%s')",
+                    (int)err, cudaGetErrorName(err));
+            throw std::runtime_error(err_msg);
+        }
+    }
+
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// --- Phase 4: Fused bias-only via CUTLASS + inline kernel ---
+static void conv2d_3x3_fused_bias_only(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H_in, int W_in, int Cin, int Cout,
+    int stride, int pad, int H_out, int W_out, cudaStream_t stream,
+    int chunks = 0)
+{
+    // Run regular CUTLASS convolution
+    conv2d_3x3_regular(input, weight, output,
+                      N, H_in, W_in, Cin, Cout,
+                      stride, pad, H_out, W_out, stream, chunks);
+
+    // Immediately apply fused bias kernel in chunks
+    int M = N * H_out * W_out;
+    long long total = (long long)M * Cout;
+    int threads = 256;
+    long long max_chunk = (long long)threads * 65535;
+
+    for (long long processed = 0; processed < total; processed += max_chunk) {
+        long long chunk = std::min(max_chunk, total - processed);
+        int blocks = (int)((chunk + threads - 1) / threads);
+        fused_bias_nhwc_kernel<<<blocks, threads, 0, stream>>>(
+            output + processed, bias, M, Cout);
+        cudaError_t err = cudaPeekAtLastError();
+        if (err != cudaSuccess) {
+            char err_msg[512];
+            snprintf(err_msg, sizeof(err_msg),
+                    "Fused bias post-kernel failed (cuda_err=%d '%s')",
+                    (int)err, cudaGetErrorName(err));
+            throw std::runtime_error(err_msg);
+        }
+    }
+
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// --- Phase 7: Fused bias+ClampTanh3 via CUTLASS + inline kernel ---
+static void conv2d_3x3_fused_bias_clamptanh3(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H_in, int W_in, int Cin, int Cout,
+    int stride, int pad, int H_out, int W_out, cudaStream_t stream,
+    int chunks = 0)
+{
+    // Run regular CUTLASS convolution
+    conv2d_3x3_regular(input, weight, output,
+                      N, H_in, W_in, Cin, Cout,
+                      stride, pad, H_out, W_out, stream, chunks);
+
+    // Immediately apply fused bias+ClampTanh3 kernel in chunks
+    int M = N * H_out * W_out;
+    long long total = (long long)M * Cout;
+    int threads = 256;
+    long long max_chunk = (long long)threads * 65535;
+
+    for (long long processed = 0; processed < total; processed += max_chunk) {
+        long long chunk = std::min(max_chunk, total - processed);
+        int blocks = (int)((chunk + threads - 1) / threads);
+        fused_bias_clamptanh3_nhwc_kernel<<<blocks, threads, 0, stream>>>(
+            output + processed, bias, M, Cout);
+        cudaError_t err = cudaPeekAtLastError();
+        if (err != cudaSuccess) {
+            char err_msg[512];
+            snprintf(err_msg, sizeof(err_msg),
+                    "Fused bias+ClampTanh3 post-kernel failed (cuda_err=%d '%s')",
+                    (int)err, cudaGetErrorName(err));
+            throw std::runtime_error(err_msg);
+        }
+    }
+
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// --- Main conv3x3 dispatcher ---
+// IMPORTANT: This function expects weights in NHWC format [Cout, R, S, Cin]
+// PyTorch weights [Cout, Cin, R, S] must be transposed to [Cout, R, S, Cin] at model load time
+//
+// ALIGNMENT REQUIREMENTS for Tensor Cores:
+// - Cin and Cout must be multiples of 8 (for 128-bit alignment with fp16)
+// chunks: 0 = auto-compute, 1 = no chunking, >1 = explicit N-splits
+inline void conv2d_3x3_nhwc_cutlass_implicit(
+    const half* input, const half* weight, const half* bias, half* output,
+    int N, int H_in, int W_in, int Cin, int Cout, Activation act,
+    int stride, int pad, int H_out, int W_out, cudaStream_t stream,
+    int chunks = 0)
+{
+    // Phase 3: Fused bias+ReLU (inline kernel approach - always works)
+    if (bias != nullptr && act == Activation::ReLU) {
+        conv2d_3x3_fused_bias_relu(input, weight, bias, output,
+                                     N, H_in, W_in, Cin, Cout,
+                                     stride, pad, H_out, W_out, stream, chunks);
+        return;
+    }
+
+    // Phase 4: Fused bias-only (no activation)
+    if (bias != nullptr && act == Activation::None) {
+        conv2d_3x3_fused_bias_only(input, weight, bias, output,
+                                     N, H_in, W_in, Cin, Cout,
+                                     stride, pad, H_out, W_out, stream, chunks);
+        return;
+    }
+
+    // Phase 7: Fused bias+ClampTanh3 (for final decoder layer)
+    if (bias != nullptr && act == Activation::ClampTanh3) {
+        conv2d_3x3_fused_bias_clamptanh3(input, weight, bias, output,
+                                          N, H_in, W_in, Cin, Cout,
+                                          stride, pad, H_out, W_out, stream, chunks);
+        return;
+    }
+
+    // Regular path: no bias or unsupported activation
+    conv2d_3x3_regular(input, weight, output,
+                      N, H_in, W_in, Cin, Cout,
+                      stride, pad, H_out, W_out, stream, chunks);
+
+    // Apply bias and/or activation separately if needed
+    if (bias || act != Activation::None) {
+        nhwc_add_bias_act_half(output, bias, N * H_out * W_out, Cout, act, stream);
+    }
+}
+
+inline void reset_conv3x3_workspace() {
+    g_conv3x3_workspace_arena.reset();
+}
+
+#endif // OMNIDREAMS_SINGLEVIEW_USE_CUTLASS
+
+} // namespace omnidreams_singleview
+
+// Backward-compat namespace alias during migration
+namespace taehv = native;

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_examples.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_examples.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cuda.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_examples.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_examples.cuh
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+#include "kernels.cuh"
+#include "kernels_ops.cuh"
+#include "kernels_exec.cuh"
+
+namespace omnidreams_singleview {
+
+struct MemBlockWeights {
+    const half* w1; const half* b1;
+    const half* w2; const half* b2;
+    const half* w3; const half* b3;
+    const half* wskip; // nullable if Cin==Cout (identity skip)
+};
+
+struct EncoderStageWeights {
+    // TPool conv 1x1: [Cout=C, Cin=stride*C]
+    const half* tpool_w; // bias is typically nullptr (bias=False in PyTorch)
+    const half* tpool_b; // nullable
+    int tpool_stride;    // 2, 2, 1 for the three stages in reference model
+    // Spatial downsample conv 3x3 stride=2
+    const half* down_w; const half* down_b; // bias may be nullptr
+    // Three MemBlocks at this spatial scale
+    MemBlockWeights mb[3];
+};
+
+struct TAEWeightsEncoder {
+    // Initial conv 3x3: 3->64
+    const half* c0_w; const half* c0_b;
+    // Three encoder stages
+    EncoderStageWeights stage[3];
+    // Final conv to latent channels (e.g., 64->16)
+    const half* final_w; const half* final_b;
+};
+
+// Channel constants to mirror Python defaults
+static constexpr int kImageChannels = 3;
+static constexpr int kLatentChannels = 16;
+
+inline void build_encoder_ops(/*in*/ const TAEWeightsEncoder& w, /*out*/ OpDesc* ops, int* num_ops, int c0_cin_padded = 8)
+{
+    int i = 0;
+    // Initial conv 3x3 + ReLU (use padded Cin for Tensor Core alignment)
+    ops[i++] = MakeConv3x3(w.c0_w, w.c0_b, /*Cin=*/c0_cin_padded, /*Cout=*/64, /*groups=*/1, /*stride=*/1, /*pad=*/1, Activation::ReLU);
+    int C = 64; // feature channels throughout encoder
+    // Three stages matching the reference: strides {2,2,1}
+    for (int s = 0; s < 3; ++s) {
+        const EncoderStageWeights& st = w.stage[s];
+        // TPool conv 1x1 (caller must reshape NT and Cin to (N*T/stride, stride*C))
+        ops[i++] = MakeTPool(st.tpool_stride);
+        ops[i++] = MakeConv1x1(st.tpool_w, st.tpool_b, /*Cin=*/st.tpool_stride*C, /*Cout=*/C, /*groups=*/1, Activation::None);
+        // Spatial downsample conv 3x3 stride=2
+        ops[i++] = MakeConv3x3(st.down_w, st.down_b, /*Cin=*/C, /*Cout=*/C, /*groups=*/1, /*stride=*/2, /*pad=*/1, Activation::None);
+        // Three MemBlocks
+        for (int k = 0; k < 3; ++k) {
+            const MemBlockWeights& m = st.mb[k];
+            ops[i++] = MakeMemBlock(m.w1, m.b1, m.w2, m.b2, m.w3, m.b3, m.wskip, /*Cout=*/C);
+        }
+    }
+    // Final conv to latent channels (no activation)
+    ops[i++] = MakeConv3x3(w.final_w, w.final_b, /*Cin=*/C, /*Cout=*/kLatentChannels, /*groups=*/1, /*stride=*/1, /*pad=*/1, Activation::None);
+    *num_ops = i;
+}
+
+struct DecoderStageWeights {
+    const half* tgrow_w; const half* tgrow_b; // bias typically nullptr
+    int tgrow_stride; // 1 or 2 depending on time upscale flag
+    const half* next_w; const half* next_b;
+    MemBlockWeights mb[3];
+};
+
+struct TAEWeightsDecoder {
+    const half* c0_w; const half* c0_b;
+    MemBlockWeights mb0[3];
+    DecoderStageWeights stage[3];
+    const half* final_w; const half* final_b;
+    int final_cout_padded;  // Padded channel count (e.g., 8 for RGB=3)
+    int final_cout_orig;    // Original channel count (e.g., 3 for RGB)
+};
+
+inline int compute_frames_to_trim(bool time_up0, bool time_up1)
+{
+    int sum = (time_up0 ? 1 : 0) + (time_up1 ? 1 : 0);
+    return (1 << sum) - 1;
+}
+
+inline void build_decoder_ops(/*in*/ const TAEWeightsDecoder& w, /*out*/ OpDesc* ops, int* num_ops,
+    bool time_up0=true, bool time_up1=true, bool space_up0=true, bool space_up1=true, bool space_up2=true)
+{
+    int i = 0;
+    // Clamp first (elementwise), then first conv 3x3 + ReLU to 256
+    ops[i++] = MakeClamp();
+    ops[i++] = MakeConv3x3(w.c0_w, w.c0_b, /*Cin=*/kLatentChannels, /*Cout=*/256, /*groups=*/1, /*stride=*/1, /*pad=*/1, Activation::ReLU);
+    int C = 256;
+    // Three MemBlocks at 256
+    for (int k = 0; k < 3; ++k) {
+        const MemBlockWeights& m = w.mb0[k];
+        ops[i++] = MakeMemBlock(m.w1, m.b1, m.w2, m.b2, m.w3, m.b3, m.wskip, /*Cout=*/C);
+    }
+    // Three decoder stages mapping 256->128->64->64
+    // Stage 0: no temporal growth (stride=1)
+    if (space_up0) ops[i++] = MakeUpsample2x();
+    ops[i++] = MakeTGrow(/*stride=*/1);
+    ops[i++] = MakeConv1x1(w.stage[0].tgrow_w, w.stage[0].tgrow_b, /*Cin=*/C, /*Cout=*/C, /*groups=*/1, Activation::None);
+    ops[i++] = MakeConv3x3(w.stage[0].next_w, w.stage[0].next_b, /*Cin=*/C, /*Cout=*/128, /*groups=*/1, /*stride=*/1, /*pad=*/1, Activation::None);
+    C = 128;
+    for (int k = 0; k < 3; ++k) {
+        const MemBlockWeights& m = w.stage[0].mb[k];
+        ops[i++] = MakeMemBlock(m.w1, m.b1, m.w2, m.b2, m.w3, m.b3, m.wskip, /*Cout=*/C);
+    }
+    // Stage 1: temporal growth based on time_up0
+    if (space_up1) ops[i++] = MakeUpsample2x();
+    ops[i++] = MakeTGrow(time_up0 ? 2 : 1);
+    ops[i++] = MakeConv1x1(w.stage[1].tgrow_w, w.stage[1].tgrow_b, /*Cin=*/C, /*Cout=*/(time_up0 ? 2*C : C), /*groups=*/1, Activation::None);
+    ops[i++] = MakeConv3x3(w.stage[1].next_w, w.stage[1].next_b, /*Cin=*/C, /*Cout=*/64, /*groups=*/1, /*stride=*/1, /*pad=*/1, Activation::None);
+    C = 64;
+    for (int k = 0; k < 3; ++k) {
+        const MemBlockWeights& m = w.stage[1].mb[k];
+        ops[i++] = MakeMemBlock(m.w1, m.b1, m.w2, m.b2, m.w3, m.b3, m.wskip, /*Cout=*/C);
+    }
+    // Stage 2: temporal growth based on time_up1
+    if (space_up2) ops[i++] = MakeUpsample2x();
+    ops[i++] = MakeTGrow(time_up1 ? 2 : 1);
+    ops[i++] = MakeConv1x1(w.stage[2].tgrow_w, w.stage[2].tgrow_b, /*Cin=*/C, /*Cout=*/(time_up1 ? 2*C : C), /*groups=*/1, Activation::None);
+    // Match Python decoder semantics (ReLU before final): fuse ReLU into s2 next conv
+    ops[i++] = MakeConv3x3(w.stage[2].next_w, w.stage[2].next_b, /*Cin=*/C, /*Cout=*/64, /*groups=*/1, /*stride=*/1, /*pad=*/1, Activation::ReLU);
+    C = 64;
+    // Final conv to RGB (padded to meet Tensor Core alignment, will be sliced later)
+    int final_cout = (w.final_cout_padded > 0) ? w.final_cout_padded : kImageChannels;
+    ops[i++] = MakeConv3x3(w.final_w, w.final_b, /*Cin=*/C, /*Cout=*/final_cout, /*groups=*/1, /*stride=*/1, /*pad=*/1, Activation::None);
+    *num_ops = i;
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_exec.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_exec.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cuda.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_exec.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_exec.cuh
@@ -1,0 +1,302 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+#include "kernels.cuh"
+#include "kernels_ops.cuh"
+
+namespace omnidreams_singleview {
+
+enum class OpType : uint32_t {
+    Conv1x1,
+    Conv3x3,
+    MemBlock,
+    TPool,
+    TGrow,
+    Upsample2x,
+    Clamp
+};
+
+struct ConvParams {
+    const half* weight;
+    const half* bias; // nullable
+    int Cin, Cout, groups;
+    int stride; // for 3x3
+    int pad;    // for 3x3
+    Activation act;
+};
+
+struct MemBlockParams {
+    const half* w1; const half* b1;
+    const half* w2; const half* b2;
+    const half* w3; const half* b3;
+    const half* wskip; // null if identity
+    int Cout;
+};
+
+struct PoolParams {
+    int stride;
+};
+
+struct GrowParams {
+    int stride;
+};
+
+struct UpsampleParams {
+    int scale; // currently only 2 is supported
+};
+
+struct OpDesc {
+    OpType type;
+    union {
+        ConvParams conv;
+        MemBlockParams mem;
+        PoolParams pool;
+        GrowParams grow;
+        UpsampleParams up;
+    } u;
+};
+
+inline OpDesc MakeConv1x1(const half* w, const half* b, int Cin, int Cout, int groups, Activation act)
+{
+    OpDesc o;
+    o.type = OpType::Conv1x1;
+    o.u.conv.weight = w;
+    o.u.conv.bias = b;
+    o.u.conv.Cin = Cin;
+    o.u.conv.Cout = Cout;
+    o.u.conv.groups = groups;
+    o.u.conv.stride = 1;
+    o.u.conv.pad = 0;
+    o.u.conv.act = act;
+    return o;
+}
+
+inline OpDesc MakeConv3x3(const half* w, const half* b, int Cin, int Cout, int groups, int stride, int pad, Activation act)
+{
+    OpDesc o;
+    o.type = OpType::Conv3x3;
+    o.u.conv.weight = w;
+    o.u.conv.bias = b;
+    o.u.conv.Cin = Cin;
+    o.u.conv.Cout = Cout;
+    o.u.conv.groups = groups;
+    o.u.conv.stride = stride;
+    o.u.conv.pad = pad;
+    o.u.conv.act = act;
+    return o;
+}
+
+inline OpDesc MakeMemBlock(const half* w1, const half* b1, const half* w2, const half* b2, const half* w3, const half* b3, const half* wskip, int Cout)
+{
+    OpDesc o;
+    o.type = OpType::MemBlock;
+    o.u.mem.w1 = w1; o.u.mem.b1 = b1;
+    o.u.mem.w2 = w2; o.u.mem.b2 = b2;
+    o.u.mem.w3 = w3; o.u.mem.b3 = b3;
+    o.u.mem.wskip = wskip;
+    o.u.mem.Cout = Cout;
+    return o;
+}
+
+inline OpDesc MakeTPool(int stride)
+{
+    OpDesc o;
+    o.type = OpType::TPool;
+    o.u.pool.stride = stride;
+    return o;
+}
+
+inline OpDesc MakeTGrow(int stride)
+{
+    OpDesc o;
+    o.type = OpType::TGrow;
+    o.u.grow.stride = stride;
+    return o;
+}
+
+inline OpDesc MakeUpsample2x()
+{
+    OpDesc o;
+    o.type = OpType::Upsample2x;
+    o.u.up.scale = 2;
+    return o;
+}
+
+inline OpDesc MakeClamp()
+{
+    OpDesc o;
+    o.type = OpType::Clamp;
+    return o;
+}
+
+inline void execute_sequence(
+    const OpDesc* ops, int num_ops,
+    const half* x0,            // input [N, C0, H0, W0]
+    half** stage_bufs,         // scratch buffers provided by caller
+    int N, int C, int H, int W,
+    cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(ops != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(num_ops >= 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x0 != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(stage_bufs != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && C > 0 && H > 0 && W > 0);
+    const half* x = x0;
+    const half* past = nullptr; // Phase 1: caller must supply zero-past if MemBlock appears at t=0
+    int Cin = C, Hc = H, Wc = W;
+
+    for (int i = 0; i < num_ops; ++i) {
+        const OpDesc& op = ops[i];
+        switch (op.type) {
+            case OpType::Conv1x1: {
+                const ConvParams& p = op.u.conv;
+                half* y = stage_bufs[i % 2];
+                // NHWC-only path: reinterpret [N,C,H,W] as [N,H,W,C]
+                conv2d_1x1_nhwc_half(
+                    x, p.weight, p.bias, y,
+                    /*N=*/N, /*H=*/Hc, /*W=*/Wc, /*Cin=*/p.Cin, /*Cout=*/p.Cout,
+                    p.groups, p.act, stream);
+                x = y; Cin = p.Cout;
+                break;
+            }
+            case OpType::Conv3x3: {
+                const ConvParams& p = op.u.conv;
+                half* y = stage_bufs[i % 2];
+                int H_out = conv3x3_out_dim(Hc, p.stride, p.pad);
+                int W_out = conv3x3_out_dim(Wc, p.stride, p.pad);
+                conv2d_3x3_nhwc_half(
+                    x, p.weight, p.bias, y,
+                    /*N=*/N, /*H_in=*/Hc, /*W_in=*/Wc, /*Cin=*/p.Cin, /*Cout=*/p.Cout,
+                    p.groups, p.act, p.stride, p.pad, H_out, W_out, stream);
+                x = y; Cin = p.Cout; Hc = H_out; Wc = W_out;
+                break;
+            }
+            case OpType::MemBlock: {
+                const MemBlockParams& m = op.u.mem;
+                // stage_bufs: tmp_cat, tmp1, tmp2, out
+                half* tmp_cat = stage_bufs[0];
+                half* tmp1    = stage_bufs[1];
+                half* tmp2    = stage_bufs[2];
+                half* y       = stage_bufs[3];
+                // Assert correct zero-past is supplied at t=0
+                OMNIDREAMS_SINGLEVIEW_ASSERT(past != nullptr && "MemBlock requires explicit zero-past at t=0; supply a zero buffer");
+                const half* past_in = past;
+                memblock_forward_nhwc(x, past_in, m.w1, m.b1, m.w2, m.b2, m.w3, m.b3, m.wskip, tmp_cat, tmp1, tmp2, y, N, Cin, Hc, Wc, m.Cout, stream);
+                past = x; x = y; Cin = m.Cout;
+                break;
+            }
+            case OpType::TPool: {
+                // No-op; handled by higher level wrapper
+                break;
+            }
+            case OpType::TGrow: {
+                // No-op; handled by higher level wrapper
+                break;
+            }
+            case OpType::Upsample2x: {
+                const UpsampleParams& up = op.u.up;
+                if (up.scale == 2) {
+                    half* y = stage_bufs[i % 2];
+                    dim3 block(16, 16, 1);
+                    dim3 grid((Wc * 2 + block.x - 1) / block.x, (Hc * 2 + block.y - 1) / block.y, N);
+                    upsample2x_nearest_nhwc(x, y, N, Hc, Wc, Cin, stream);
+                    x = y; Hc *= 2; Wc *= 2;
+                }
+                break;
+            }
+            case OpType::Clamp: {
+                // Apply elementwise ClampTanh3 in-place to current tensor x
+                clamp_tanh3_inplace(const_cast<half*>(x), N, Cin, Hc, Wc, stream);
+                break;
+            }
+        }
+    }
+}
+
+inline void execute_with_parallel_past(
+    const OpDesc* ops, int num_ops,
+    const half* x_nt,            // input [N*T, C0, H0, W0]
+    half** stage_bufs,           // scratch buffers provided by caller
+    int N, int T, int C, int H, int W,
+    cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(ops != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x_nt != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(stage_bufs != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > 0 && C > 0 && H > 0 && W > 0);
+    const half* x = x_nt;
+    int Cin = C, Hc = H, Wc = W;
+    // Allocate/build a shifted past buffer in stage_bufs[4]
+    half* past = stage_bufs[4];
+    OMNIDREAMS_SINGLEVIEW_ASSERT(past != nullptr);
+    build_past_shifted_nhwc(x, past, N, T, Cin, Hc, Wc, stream);
+
+    for (int i = 0; i < num_ops; ++i) {
+        const OpDesc& op = ops[i];
+        switch (op.type) {
+            case OpType::Conv1x1: {
+                const ConvParams& p = op.u.conv;
+                half* y = stage_bufs[i % 2];
+                conv2d_1x1_nhwc_half(
+                    x, p.weight, p.bias, y,
+                    /*N=*/N*T, /*H=*/Hc, /*W=*/Wc, /*Cin=*/p.Cin, /*Cout=*/p.Cout,
+                    p.groups, p.act, stream);
+                x = y; Cin = p.Cout;
+                break;
+            }
+            case OpType::Conv3x3: {
+                const ConvParams& p = op.u.conv;
+                half* y = stage_bufs[i % 2];
+                int H_out = conv3x3_out_dim(Hc, p.stride, p.pad);
+                int W_out = conv3x3_out_dim(Wc, p.stride, p.pad);
+                conv2d_3x3_nhwc_half(
+                    x, p.weight, p.bias, y,
+                    /*N=*/N*T, /*H_in=*/Hc, /*W_in=*/Wc, /*Cin=*/p.Cin, /*Cout=*/p.Cout,
+                    p.groups, p.act, p.stride, p.pad, H_out, W_out, stream);
+                x = y; Cin = p.Cout; Hc = H_out; Wc = W_out;
+                break;
+            }
+            case OpType::MemBlock: {
+                const MemBlockParams& m = op.u.mem;
+                half* tmp_cat = stage_bufs[0];
+                half* tmp1    = stage_bufs[1];
+                half* tmp2    = stage_bufs[2];
+                half* y       = stage_bufs[3];
+                memblock_forward_nhwc(x, past, m.w1, m.b1, m.w2, m.b2, m.w3, m.b3, m.wskip, tmp_cat, tmp1, tmp2, y, N*T, Cin, Hc, Wc, m.Cout, stream);
+                // Update past to be shifted version of new x for next MemBlock layer
+                past = stage_bufs[4];
+                build_past_shifted_nhwc(y, past, N, T, m.Cout, Hc, Wc, stream);
+                x = y; Cin = m.Cout;
+                break;
+            }
+            case OpType::TPool: {
+                // Coalesce with next Conv1x1 at higher level; no-op here
+                break;
+            }
+            case OpType::TGrow: {
+                // Coalesce with next Conv1x1 at higher level; no-op here
+                break;
+            }
+            case OpType::Upsample2x: {
+                const UpsampleParams& up = op.u.up;
+                if (up.scale == 2) {
+                    half* y = stage_bufs[i % 2];
+                    dim3 block(16, 16, 1);
+                    dim3 grid((Wc * 2 + block.x - 1) / block.x, (Hc * 2 + block.y - 1) / block.y, N*T);
+                    upsample2x_nearest_nhwc(x, y, N*T, Hc, Wc, Cin, stream);
+                    x = y; Hc *= 2; Wc *= 2;
+                }
+                break;
+            }
+            case OpType::Clamp: {
+                clamp_tanh3_inplace(const_cast<half*>(x), N*T, Cin, Hc, Wc, stream);
+                break;
+            }
+        }
+    }
+}
+
+} // namespace taehv

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_ops.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_ops.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cuda.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_ops.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/kernels_ops.cuh
@@ -1,0 +1,591 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <stdint.h>
+#include <algorithm>
+
+#include "kernels.cuh"
+
+namespace omnidreams_singleview {
+
+// Forward declaration so it can be used earlier in this TU
+inline void cat_channels_nhwc(const half* a, const half* b, half* out,
+                              int N, int H, int W, int Ca, int Cb, cudaStream_t stream);
+
+// Elementwise ClampTanh3: y = tanh(x/3) * 3
+__global__ void clamp_tanh3_inplace_half_kernel(half* __restrict__ x, int n)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    float v = __half2float(x[i]);
+    float r = tanhf(v * (1.0f/3.0f)) * 3.0f;
+    x[i] = __float2half(r);
+}
+
+inline void clamp_tanh3_inplace(half* x, int N, int C, int H, int W, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && C > 0 && H > 0 && W > 0);
+    int n = N * C * H * W;
+    int blk = 256;
+    int grd = (n + blk - 1) / blk;
+    clamp_tanh3_inplace_half_kernel<<<grd, blk, 0, stream>>>(x, n);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+// Build past by shifting time in flattened NT batches: for each (n, t), past(n,t)=x(n,t-1), and zero for t=0
+#if !OMNIDREAMS_SINGLEVIEW_BUILD_PAST_IN_COMMON
+#error "build_past_shifted must be provided by common/cuda_utils.cuh as NHWC/NTHWC variants"
+#endif
+
+// Contracts & invariants for ops (Phase 1):
+// - All tensors are contiguous NHWC unless explicitly noted.
+// - Elementwise ops require matching element counts and non-null pointers.
+// - cat_channels_nhwc: inputs [N,H,W,Ca], [N,H,W,Cb], output [N,H,W,Ca+Cb].
+// - upsample2x_nearest_nhwc: output has H*2,W*2; caller must allocate.
+// - memblock_forward_nhwc: follows Python MemBlock ordering with three 3x3 convs
+//   and an optional 1x1 skip; uses FP32 accum, bias+act in FP32, then cast.
+//   Temporal semantics (past) are defined by the executor; the kernel assumes
+//   shapes match and does not manage time.
+
+// Elementwise add: y = a + b
+__global__ void ew_add_half_kernel(const half* __restrict__ a, const half* __restrict__ b, half* __restrict__ y, int n)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    float va = __half2float(a[i]);
+    float vb = __half2float(b[i]);
+    y[i] = __float2half(va + vb);
+}
+
+// Elementwise ReLU in-place
+__global__ void relu_inplace_half_kernel(half* __restrict__ x, int n)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    float v = __half2float(x[i]);
+    x[i] = __float2half(v > 0.0f ? v : 0.0f);
+}
+
+// NCHW channel concat kernel removed in NHWC-only backend
+
+// Nearest 2x upsample (spatial) for NCHW removed in NHWC-only backend
+
+// (Removed) fused NCHW tiled conv3x3-cat+ReLU kernel and wrapper
+
+// MemBlock forward (NCHW):
+// y = ReLU( Conv3x3(ReLU(Conv3x3(ReLU(Conv3x3(cat(x, past))))) ) + Skip(x) )
+// - x: [N, Cin, H, W], past: [N, Cin, H, W], Cin may differ from Cout
+// - weights: w1[Co1,Ccat,3,3], w2[Co2,Co1,3,3], w3[Cout,Co2,3,3]
+// - skip: 1x1 if Cin!=Cout else identity
+inline void memblock_forward_nchw(
+    const half* x, const half* past,
+    const half* w1, const half* b1,
+    const half* w2, const half* b2,
+    const half* w3, const half* b3,
+    const half* wskip, // null if Cin==Cout
+    half* tmp_cat, half* tmp1, half* tmp2, half* y,
+    int N, int Cin, int H, int W, int Cout,
+    cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(past != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(w1 != nullptr && w2 != nullptr && w3 != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(y != nullptr && tmp_cat != nullptr && tmp1 != nullptr && tmp2 != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && H > 0 && W > 0 && Cin > 0 && Cout > 0);
+    // Always use NHWC convs with local reorders
+    {
+        half* x_nhwc = nullptr;
+        half* p_nhwc = nullptr;
+        half* cat_nhwc = nullptr;
+        half* t1_nhwc = nullptr;
+        half* t2_nhwc = nullptr;
+        half* y_nhwc = nullptr;
+        const size_t elems_in   = (size_t)N * H * W * Cin;
+        const size_t elems_cat  = (size_t)N * H * W * (size_t)(2 * Cin);
+        const size_t elems_cout = (size_t)N * H * W * Cout;
+
+        auto check_malloc = [](cudaError_t err, const char* name, size_t bytes) {
+            if (err != cudaSuccess) {
+                throw std::runtime_error(std::string("cudaMalloc failed for memblock ") + name + " (" +
+                    std::to_string(bytes / 1048576.0) + " MB): " + cudaGetErrorString(err));
+            }
+        };
+
+        check_malloc(cudaMalloc(&x_nhwc,   elems_in   * sizeof(half)), "x_nhwc",   elems_in   * sizeof(half));
+        check_malloc(cudaMalloc(&p_nhwc,   elems_in   * sizeof(half)), "p_nhwc",   elems_in   * sizeof(half));
+        check_malloc(cudaMalloc(&cat_nhwc, elems_cat  * sizeof(half)), "cat_nhwc", elems_cat  * sizeof(half));
+        check_malloc(cudaMalloc(&t1_nhwc,  elems_cout * sizeof(half)), "t1_nhwc",  elems_cout * sizeof(half));
+        check_malloc(cudaMalloc(&t2_nhwc,  elems_cout * sizeof(half)), "t2_nhwc",  elems_cout * sizeof(half));
+        check_malloc(cudaMalloc(&y_nhwc,   elems_cout * sizeof(half)), "y_nhwc",   elems_cout * sizeof(half));
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        nchw_to_hwc_half(x,    x_nhwc,   N, H, W, Cin, stream);
+        nchw_to_hwc_half(past, p_nhwc,   N, H, W, Cin, stream);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        cat_channels_nhwc(x_nhwc, p_nhwc, cat_nhwc, N, H, W, Cin, Cin, stream);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        conv2d_3x3_nhwc_half(cat_nhwc, w1, b1, t1_nhwc, N, H, W, /*Cin=*/Cin*2, /*Cout=*/Cout, /*groups=*/1, Activation::ReLU, /*stride=*/1, /*pad=*/1, /*H_out=*/H, /*W_out=*/W, stream);
+        conv2d_3x3_nhwc_half(t1_nhwc,  w2, b2, t2_nhwc, N, H, W, /*Cin=*/Cout,  /*Cout=*/Cout, /*groups=*/1, Activation::ReLU, /*stride=*/1, /*pad=*/1, /*H_out=*/H, /*W_out=*/W, stream);
+        conv2d_3x3_nhwc_half(t2_nhwc,  w3, b3, y_nhwc,  N, H, W, /*Cin=*/Cout,  /*Cout=*/Cout, /*groups=*/1, Activation::None, /*stride=*/1, /*pad=*/1, /*H_out=*/H, /*W_out=*/W, stream);
+        hwc_to_nchw_half(y_nhwc, y, N, H, W, Cout, stream);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        cudaFree(x_nhwc); cudaFree(p_nhwc); cudaFree(cat_nhwc);
+        cudaFree(t1_nhwc); cudaFree(t2_nhwc); cudaFree(y_nhwc);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    }
+
+    // skip path + final ReLU
+    if (wskip) {
+        // 1x1 project Cin->Cout and add (via NHWC path)
+        {
+            half* x_nhwc = nullptr; half* y_nhwc = nullptr;
+            const size_t elems_in = (size_t)N * H * W * Cin;
+            const size_t elems_out= (size_t)N * H * W * Cout;
+            cudaError_t err1 = cudaMalloc(&x_nhwc, elems_in * sizeof(half));
+            if (err1 != cudaSuccess) {
+                throw std::runtime_error(std::string("cudaMalloc failed for skip x_nhwc (") +
+                    std::to_string(elems_in * sizeof(half) / 1048576.0) + " MB): " + cudaGetErrorString(err1));
+            }
+            cudaError_t err2 = cudaMalloc(&y_nhwc, elems_out * sizeof(half));
+            if (err2 != cudaSuccess) {
+                cudaFree(x_nhwc);
+                throw std::runtime_error(std::string("cudaMalloc failed for skip y_nhwc (") +
+                    std::to_string(elems_out * sizeof(half) / 1048576.0) + " MB): " + cudaGetErrorString(err2));
+            }
+            OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+            nchw_to_hwc_half(x, x_nhwc, N, H, W, Cin, stream);
+            conv2d_1x1_nhwc_half(x_nhwc, wskip, nullptr, y_nhwc, N, H, W, Cin, Cout, /*groups=*/1, Activation::None, stream);
+            hwc_to_nchw_half(y_nhwc, tmp1, N, H, W, Cout, stream);
+            cudaFree(x_nhwc); cudaFree(y_nhwc);
+            OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        }
+        int n_elems = N * Cout * H * W;
+        int blk = 256;
+        int grd = (n_elems + blk - 1) / blk;
+        ew_add_half_kernel<<<grd, blk, 0, stream>>>(y, tmp1, y, n_elems);
+    } else {
+        // in-place add with identity
+        // nothing to add since channels match and skip is identity; y already holds conv output, just add x
+        int n_elems = N * Cout * H * W;
+        int blk = 256;
+        int grd = (n_elems + blk - 1) / blk;
+        ew_add_half_kernel<<<grd, blk, 0, stream>>>(y, x, y, n_elems);
+    }
+    // final ReLU
+    {
+        int n_elems = N * Cout * H * W;
+        int blk = 256;
+        int grd = (n_elems + blk - 1) / blk;
+        relu_inplace_half_kernel<<<grd, blk, 0, stream>>>(y, n_elems);
+    }
+}
+
+// --- Native NHWC implementations ---
+
+// Simple channel concatenation kernel for memblock use case with debug support
+__global__ void cat_channels_nhwc_simple_kernel(
+    const half* __restrict__ a, const half* __restrict__ b, half* __restrict__ out,
+    long long total_spatial, int channels_per_tensor)
+{
+    long long spatial_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (spatial_idx >= total_spatial) return;
+
+    // Calculate base offsets for this spatial position
+    long long in_base_a = spatial_idx * channels_per_tensor;
+    long long in_base_b = spatial_idx * channels_per_tensor;
+    long long out_base = spatial_idx * (channels_per_tensor * 2);
+
+    #if OMNIDREAMS_SINGLEVIEW_DEBUG
+    // Debug output for first few threads to track memory access patterns
+    if (spatial_idx < 4 && threadIdx.x == 0 && blockIdx.x == 0) {
+        printf("[KERNEL DEBUG] spatial_idx=%lld, in_base_a=%lld, in_base_b=%lld, out_base=%lld\n",
+               spatial_idx, in_base_a, in_base_b, out_base);
+        printf("[KERNEL DEBUG] channels_per_tensor=%d, total_spatial=%lld\n",
+               channels_per_tensor, total_spatial);
+    }
+    #endif
+
+
+    #if OMNIDREAMS_SINGLEVIEW_DEBUG
+    if (spatial_idx < 2) {
+        // Bounds checking with debug output
+        long long max_input_idx_a = in_base_a + channels_per_tensor - 1;
+        long long max_input_idx_b = in_base_b + channels_per_tensor - 1;
+        long long max_output_idx = out_base + (channels_per_tensor * 2) - 1;
+
+        printf("[KERNEL DEBUG] Thread %lld: max_input_idx_a=%lld, max_input_idx_b=%lld, max_output_idx=%lld\n",
+               spatial_idx, max_input_idx_a, max_input_idx_b, max_output_idx);
+    }
+    #endif
+
+    // Copy all channels from tensor a
+    for (int c = 0; c < channels_per_tensor; c++) {
+        long long src_idx = in_base_a + c;
+        long long dst_idx = out_base + c;
+
+        #if OMNIDREAMS_SINGLEVIEW_DEBUG
+        if (spatial_idx == 0 && c < 2) {
+            printf("[KERNEL DEBUG] Copy A: a[%lld] -> out[%lld]\n", src_idx, dst_idx);
+        }
+        #endif
+
+        out[dst_idx] = a[src_idx];
+    }
+
+    // Copy all channels from tensor b
+    for (int c = 0; c < channels_per_tensor; c++) {
+        long long src_idx = in_base_b + c;
+        long long dst_idx = out_base + channels_per_tensor + c;
+
+        #if OMNIDREAMS_SINGLEVIEW_DEBUG
+        if (spatial_idx == 0 && c < 2) {
+            printf("[KERNEL DEBUG] Copy B: b[%lld] -> out[%lld]\n", src_idx, dst_idx);
+        }
+        #endif
+
+        out[dst_idx] = b[src_idx];
+    }
+}
+
+// Channel concat: y[N, H, W, Cx+Cy] = concat(a, b) along C (NHWC)
+__global__ void cat_channels_nhwc_half_kernel(
+    const half* __restrict__ a, const half* __restrict__ b, half* __restrict__ out,
+    int N, int H, int W, int Ca, int Cb)
+{
+    // Extremely conservative approach - process one element at a time
+    long long total_elements_out = (long long)N * H * W * (Ca + Cb);
+    long long global_idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (global_idx >= total_elements_out) return;
+
+    // Decompose to spatial position and channel
+    long long spatial_pos = global_idx / (Ca + Cb);
+    int channel = global_idx % (Ca + Cb);
+
+    // Safety bounds check
+    if (spatial_pos >= (long long)N * H * W) return;
+    if (channel >= (Ca + Cb)) return;
+
+    if (channel < Ca) {
+        // Copy from tensor a
+        long long src_idx = spatial_pos * Ca + channel;
+        if (src_idx < (long long)N * H * W * Ca) {
+            out[global_idx] = a[src_idx];
+        }
+    } else {
+        // Copy from tensor b
+        int b_channel = channel - Ca;
+        long long src_idx = spatial_pos * Cb + b_channel;
+        if (src_idx < (long long)N * H * W * Cb && b_channel >= 0 && b_channel < Cb) {
+            out[global_idx] = b[src_idx];
+        }
+    }
+}
+
+inline void cat_channels_nhwc(const half* a, const half* b, half* out,
+                              int N, int H, int W, int Ca, int Cb, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(a != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(b != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(out != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && H > 0 && W > 0 && Ca > 0 && Cb > 0);
+
+    // Launch one thread per output element
+    long long total_elements = (long long)N * H * W * (Ca + Cb);
+    int threads = 256;
+
+    // For very large tensors, split into multiple kernel launches
+    while (total_elements > 0) {
+        long long chunk_size = min(total_elements, (long long)65535 * threads);
+        int blocks = (int)((chunk_size + threads - 1) / threads);
+
+        cat_channels_nhwc_half_kernel<<<blocks, threads, 0, stream>>>(a, b, out, N, H, W, Ca, Cb);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+
+        // For simplicity, process everything in one go for typical sizes
+        // Multi-chunk support can be added if needed for very large tensors
+        break;
+    }
+}
+
+// Nearest 2x upsample (spatial) for NHWC - vectorized over channels
+__global__ void upsample2x_nearest_nhwc_half_kernel(
+    const half* __restrict__ in, half* __restrict__ out,
+    int N, int H, int W, int C)
+{
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+    int n = blockIdx.z;
+    int H2 = H * 2, W2 = W * 2;
+    if (x >= W2 || y >= H2 || n >= N) return;
+    int ix = x >> 1;
+    int iy = y >> 1;
+    long long base_in  = (((((long long)n * H) + iy) * W + ix) * (long long)C);
+    long long base_out = (((((long long)n * H2) + y) * W2 + x) * (long long)C);
+
+    // Vectorize across channels when possible
+    int c2 = C / 2;
+    const half2* src_h2 = reinterpret_cast<const half2*>(in + base_in);
+    half2* dst_h2 = reinterpret_cast<half2*>(out + base_out);
+    for (int i = 0; i < c2; ++i) {
+        half2 v = src_h2[i];
+        dst_h2[i] = v;
+    }
+    // Handle odd tail channel
+    if ((C & 1) != 0) {
+        out[base_out + (C - 1)] = in[base_in + (C - 1)];
+    }
+}
+
+// Flat NHWC concat kernel removed - use cat_channels_nhwc() function instead
+
+inline void upsample2x_nearest_nhwc(const half* in, half* out, int N, int H, int W, int C, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(out != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && H > 0 && W > 0 && C > 0);
+    // Favor wider x for better global load coalescing
+    dim3 block(32, 8, 1);
+    dim3 grid((W * 2 + block.x - 1) / block.x,
+              (H * 2 + block.y - 1) / block.y,
+              N);
+    upsample2x_nearest_nhwc_half_kernel<<<grid, block, 0, stream>>>(in, out, N, H, W, C);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+#if !OMNIDREAMS_SINGLEVIEW_BUILD_PAST_IN_COMMON
+// Build past by shifting time in flattened NT batches for NHWC:
+// past(n,t,y,x,c) = x(n,t-1,y,x,c), and zero for t=0
+__global__ void build_past_shifted_nhwc_half_kernel(
+    const half* __restrict__ x, half* __restrict__ past,
+    int N, int T, int H, int W, int C)
+{
+    long long total = (long long)N * T * H * W * C;
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+    int c = (int)(idx % C); idx /= C;
+    int w = (int)(idx % W); idx /= W;
+    int h = (int)(idx % H); idx /= H;
+    int t = (int)(idx % T); idx /= T;
+    int n = (int)idx;
+    long long base = ((((((long long)n * T + t) * H + h) * W + w) * C) + c);
+    if (t == 0) {
+        past[base] = __float2half(0.0f);
+    } else {
+        int t_prev = t - 1;
+        long long base_prev = ((((((long long)n * T + t_prev) * H + h) * W + w) * C) + c);
+        past[base] = x[base_prev];
+    }
+}
+
+inline void build_past_shifted_nhwc(const half* x, half* past, int N, int T, int H, int W, int C, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x != nullptr && past != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && T > 0 && H > 0 && W > 0 && C > 0);
+    long long total = (long long)N * T * H * W * C;
+    int blk = 256;
+    int grd = (int)((total + blk - 1) / blk);
+    build_past_shifted_nhwc_half_kernel<<<grd, blk, 0, stream>>>(x, past, N, T, H, W, C);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+#endif
+
+// MemBlock forward (NHWC):
+// y = ReLU( Conv3x3(ReLU(Conv3x3(ReLU(Conv3x3(cat(x, past))))) ) + Skip(x) )
+// - x: [N, H, W, Cin], past: [N, H, W, Cin], Cin may differ from Cout
+// - weights: w1[Co1,Ccat,3,3], w2[Co2,Co1,3,3], w3[Cout,Co2,3,3]
+// - skip: 1x1 if Cin!=Cout else identity
+inline void memblock_forward_nhwc(
+    const half* x, const half* past,
+    const half* w1, const half* b1,
+    const half* w2, const half* b2,
+    const half* w3, const half* b3,
+    const half* wskip, // null if Cin==Cout
+    half* tmp_cat, half* tmp1, half* tmp2, half* y,
+    int N, int H, int W, int Cin, int Cout,
+    cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(x != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(past != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(w1 != nullptr && w2 != nullptr && w3 != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(y != nullptr && tmp_cat != nullptr && tmp1 != nullptr && tmp2 != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(N > 0 && H > 0 && W > 0 && Cin > 0 && Cout > 0);
+
+    #if OMNIDREAMS_SINGLEVIEW_DEBUG
+    printf("[DEBUG] MemBlock NHWC Entry: N=%d, H=%d, W=%d, Cin=%d, Cout=%d\n", N, H, W, Cin, Cout);
+    printf("[DEBUG] MemBlock NHWC Pointers: x=%p, past=%p, tmp_cat=%p, tmp1=%p, tmp2=%p, y=%p\n",
+           (void*)x, (void*)past, (void*)tmp_cat, (void*)tmp1, (void*)tmp2, (void*)y);
+    printf("[DEBUG] MemBlock NHWC Stream: %p\n", (void*)stream);
+
+    // Calculate expected tensor sizes for validation
+    long long spatial_size = (long long)N * H * W;
+    long long x_size = spatial_size * Cin;
+    long long past_size = spatial_size * Cin;
+    long long tmp_cat_size = spatial_size * (Cin + Cin);
+    long long tmp1_size = spatial_size * Cout;
+    long long tmp2_size = spatial_size * Cout;
+    long long y_size = spatial_size * Cout;
+
+    printf("[DEBUG] Expected tensor element counts: x=%lld, past=%lld, tmp_cat=%lld, tmp1=%lld, tmp2=%lld, y=%lld\n",
+           x_size, past_size, tmp_cat_size, tmp1_size, tmp2_size, y_size);
+
+    // Check for dangerous pointer relationships
+    if (tmp_cat == x || tmp_cat == past) {
+        printf("[ERROR] MemBlock NHWC: tmp_cat shares pointer with input tensor!\n");
+    }
+    if (y == x || y == past || y == tmp_cat) {
+        printf("[ERROR] MemBlock NHWC: Output y shares pointer with input/intermediate tensor!\n");
+    }
+    #endif
+
+    // Concatenate channels along C in NHWC - use coalesced element mapping
+    // Switch to the coalesced concat implementation to avoid uncoalesced per-thread inner loops
+    {
+        int threads = 256;
+        long long total_spatial = (long long)N * H * W;
+        int blocks = (int)min((total_spatial + threads - 1) / threads, 65535LL);
+        (void)threads; (void)total_spatial; (void)blocks;
+
+        #if OMNIDREAMS_SINGLEVIEW_DEBUG
+        printf("[DEBUG] HWC Concat: N=%d, H=%d, W=%d, Cin=%d, Cout=%d\n", N, H, W, Cin, Cout);
+        printf("[DEBUG] HWC Concat: total_spatial=%lld, blocks=%d, threads=%d\n", total_spatial, blocks, threads);
+        printf("[DEBUG] HWC Concat: x=%p, past=%p, tmp_cat=%p\n", (void*)x, (void*)past, (void*)tmp_cat);
+
+        // Validate pointer alignment and basic sanity
+        if (x == nullptr || past == nullptr || tmp_cat == nullptr) {
+            printf("[ERROR] HWC Concat: Null pointer detected! x=%p, past=%p, tmp_cat=%p\n",
+                   (void*)x, (void*)past, (void*)tmp_cat);
+        }
+
+        // Check for pointer overlap that could cause corruption
+        char* x_end = (char*)x + total_spatial * Cin * sizeof(half);
+        char* past_end = (char*)past + total_spatial * Cin * sizeof(half);
+        char* tmp_cat_end = (char*)tmp_cat + total_spatial * (Cin + Cin) * sizeof(half);
+
+        if ((char*)tmp_cat < x_end && (char*)x < tmp_cat_end) {
+            printf("[WARNING] HWC Concat: Potential overlap between x and tmp_cat!\n");
+        }
+        if ((char*)tmp_cat < past_end && (char*)past < tmp_cat_end) {
+            printf("[WARNING] HWC Concat: Potential overlap between past and tmp_cat!\n");
+        }
+
+        printf("[DEBUG] HWC Concat: Expected tensor sizes - x:%lld bytes, past:%lld bytes, tmp_cat:%lld bytes\n",
+               total_spatial * Cin * sizeof(half),
+               total_spatial * Cin * sizeof(half),
+               total_spatial * (Cin + Cin) * sizeof(half));
+        #endif
+
+        // Use coalesced concat implementation
+        cat_channels_nhwc(x, past, tmp_cat, N, H, W, Cin, Cin, stream);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+
+        #if OMNIDREAMS_SINGLEVIEW_DEBUG
+        printf("[DEBUG] HWC Concat: Coalesced concat completed successfully\n");
+        #endif
+    }
+
+    #if OMNIDREAMS_SINGLEVIEW_DEBUG
+    printf("[DEBUG] MemBlock NHWC: Starting 3x3 convolutions sequence\n");
+    #endif
+
+    // Three 3x3 convs with ReLU, ReLU, None
+    conv2d_3x3_nhwc_half(tmp_cat, w1, b1, tmp1,
+                         N, /*H_in=*/H, /*W_in=*/W, /*Cin=*/Cin * 2, /*Cout=*/Cout, /*groups=*/1,
+                         Activation::ReLU,
+                         /*stride=*/1, /*pad=*/1,
+                         /*H_out=*/H, /*W_out=*/W,
+                         stream);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+
+    #if OMNIDREAMS_SINGLEVIEW_DEBUG
+    printf("[DEBUG] MemBlock NHWC: First 3x3 conv completed\n");
+    #endif
+
+    conv2d_3x3_nhwc_half(tmp1, w2, b2, tmp2,
+                         N, /*H_in=*/H, /*W_in=*/W, /*Cin=*/Cout, /*Cout=*/Cout, /*groups=*/1,
+                         Activation::ReLU,
+                         /*stride=*/1, /*pad=*/1,
+                         /*H_out=*/H, /*W_out=*/W,
+                         stream);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+
+    #if OMNIDREAMS_SINGLEVIEW_DEBUG
+    printf("[DEBUG] MemBlock NHWC: Second 3x3 conv completed\n");
+    #endif
+
+    conv2d_3x3_nhwc_half(tmp2, w3, b3, y,
+                         N, /*H_in=*/H, /*W_in=*/W, /*Cin=*/Cout, /*Cout=*/Cout, /*groups=*/1,
+                         Activation::None,
+                         /*stride=*/1, /*pad=*/1,
+                         /*H_out=*/H, /*W_out=*/W,
+                         stream);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+
+    #if OMNIDREAMS_SINGLEVIEW_DEBUG
+    printf("[DEBUG] MemBlock NHWC: Third 3x3 conv completed\n");
+    #endif
+
+    // skip path + final ReLU
+    long long n_elems_ll = (long long)N * (long long)H * (long long)W * (long long)Cout;
+    OMNIDREAMS_SINGLEVIEW_ASSERT(n_elems_ll > 0);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(n_elems_ll <= (long long)std::numeric_limits<int>::max());
+    int n_elems = (int)n_elems_ll;
+    if (wskip != nullptr) {
+        // Compute skip projection into tmp1, then accumulate in-place into y
+        conv2d_1x1_nhwc_half(x, wskip, nullptr, tmp1,
+                             N, H, W, Cin, Cout, /*groups=*/1, Activation::None, stream);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+        int blk = 256;
+        int grd = (n_elems + blk - 1) / blk;
+        ew_add_half_kernel<<<grd, blk, 0, stream>>>(y, tmp1, y, n_elems);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    } else if (Cin == Cout) {
+        // Identity skip: accumulate x into y in-place
+        int blk = 256;
+        int grd = (n_elems + blk - 1) / blk;
+        ew_add_half_kernel<<<grd, blk, 0, stream>>>(y, x, y, n_elems);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    } else {
+        // No skip provided and channels differ: do nothing
+    }
+    {
+        int blk = 256;
+        int grd = (n_elems + blk - 1) / blk;
+        relu_inplace_half_kernel<<<grd, blk, 0, stream>>>(y, n_elems);
+        OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+    }
+}
+
+// Unpack TGrow for NHWC: input [NT, H, W, stride*Cin] -> output [NT*stride, H, W, Cin]
+__global__ void tgrow_unpack_nhwc_half_kernel(
+    const half* __restrict__ in, half* __restrict__ out,
+    int NT, int H, int W, int Cin, int stride)
+{
+    long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)NT * stride * H * W * Cin;
+    if (idx >= total) return;
+    int c = (int)(idx % Cin); idx /= Cin;
+    int w = (int)(idx % W); idx /= W;
+    int h = (int)(idx % H); idx /= H;
+    int nt_new = (int)(idx % (NT * stride));
+    int s = nt_new % stride;
+    int nt_old = nt_new / stride;
+    long long in_base  = (((((long long)nt_old * H) + h) * W + w) * (long long)(stride * Cin)) + (long long)s * Cin + c;
+    long long out_base = (((((long long)nt_new * H) + h) * W + w) * (long long)Cin) + c;
+    out[out_base] = in[in_base];
+}
+
+inline void tgrow_unpack_nhwc(const half* in, half* out,
+                              int NT, int H, int W, int Cin, int stride, cudaStream_t stream)
+{
+    OMNIDREAMS_SINGLEVIEW_ASSERT(in != nullptr && out != nullptr);
+    OMNIDREAMS_SINGLEVIEW_ASSERT(NT > 0 && H > 0 && W > 0 && Cin > 0 && stride > 0);
+    long long total = (long long)NT * stride * H * W * Cin;
+    int threads = 256;
+    int blocks = (int)((total + threads - 1) / threads);
+    tgrow_unpack_nhwc_half_kernel<<<blocks, threads, 0, stream>>>(in, out, NT, H, W, Cin, stride);
+    OMNIDREAMS_SINGLEVIEW_CUDA_CHECK();
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/linear_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/linear_utils.cuh
@@ -1,0 +1,583 @@
+#pragma once
+
+#include "ops.cuh"
+#include "block_quant.cuh"
+#include "cute_int8_gemm.cuh"
+#include <cutlass/numeric_types.h>
+#include <type_traits>
+#include <cstdint>
+
+namespace omnidreams_singleview {
+
+// When a per-column weight_scale is provided for FP8 linear, we run the GEMM with a small scalar alpha
+// (so the half output doesn't overflow) and compensate by scaling the per-column scale in the epilogue.
+// This preserves the effective output: (alpha * (A@B)) * (scale * (1/alpha)) == (A@B) * scale
+static constexpr float k_fp8_linear_prescale_alpha = 1.0f / 128.0f;
+static constexpr float k_fp8_linear_scale_mul = 1.0f / k_fp8_linear_prescale_alpha;  // 128
+
+// INT8 uses the same pattern as FP8 when a per-column weight_scale is present:
+// We scale down the GEMM output to avoid FP16 overflow, then scale up inside apply_col_scale_bias.
+// Note: INT8 intermediate (A_int8 @ W_int8) can be very large for K=1536, so we use a more conservative prescale.
+static constexpr float k_int8_linear_prescale_alpha = 1.0f / 1024.0f;
+static constexpr float k_int8_linear_scale_mul = 1.0f / k_int8_linear_prescale_alpha;  // 1024
+
+// Common helpers to dispatch linear layers for different WeightT (half, fp8, int8).
+// For INT8: Uses per-block (128x128) quantization for better precision when weight_block_scale is provided.
+//   - weight_block_scale: [in_features/128, out_features/128] float32 per-block scales
+//   - int8_act_block_scales: [M/128, in_features/128] float32 activation block scales
+//   - use_swizzled_weights: Set to true if weights are pre-swizzled for tensor core optimization
+// Falls back to per-column INT8 path (with prescale) when weight_block_scale is nullptr.
+template <typename WeightT>
+static inline cudaError_t apply_linear_row(
+    const cutlass::half_t* input_row,
+    const WeightT* weight,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int M, int in_features, int out_features,
+    cudaStream_t stream,
+    cutlass::half_t* fp8_scratch,
+    const cutlass::half_t* weight_scale = nullptr,  // For FP8: per-channel scales
+    int8_t* int8_scratch = nullptr,
+    float* int8_act_block_scales = nullptr,  // For INT8: activation block scales buffer [M/128, in_features/128]
+    const float* weight_block_scale = nullptr,  // For INT8: weight per-block scales
+    bool use_swizzled_weights = false,  // For INT8: use swizzled weight format
+    bool fp8_input_preconverted = false) {  // FP8 fusion: fp8_scratch already has FP8 data
+
+  if constexpr (std::is_same<WeightT, cutlass::half_t>::value) {
+    return cutlass_linear_layer_rrr(
+      reinterpret_cast<const half*>(input_row),
+      reinterpret_cast<const half*>(weight),
+      reinterpret_cast<const half*>(bias),
+      reinterpret_cast<half*>(output_row),
+      M, in_features, out_features, stream);
+  } else if constexpr (std::is_same<WeightT, cutlass::float_e4m3_t>::value) {
+    if (fp8_scratch == nullptr) return cudaErrorInvalidValue;
+    auto fp8_buf = reinterpret_cast<cutlass::float_e4m3_t*>(fp8_scratch);
+    if (!fp8_input_preconverted) {
+      cudaError_t cvt = convert_half_to_fp8_e4m3(
+        reinterpret_cast<const cutlass::half_t*>(input_row),
+        fp8_buf,
+        int64_t(M) * in_features,
+        stream);
+      if (cvt != cudaSuccess) return cvt;
+    }
+    if (weight_scale == nullptr) {
+      return cutlass_linear_layer_rcr_fp8(
+        fp8_buf,
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+        reinterpret_cast<const cutlass::half_t*>(bias),
+        reinterpret_cast<cutlass::half_t*>(output_row),
+        M, in_features, out_features, stream);
+    }
+    cudaError_t gemm = cutlass_linear_layer_rcr_fp8(
+      fp8_buf,
+      reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+      nullptr,
+      reinterpret_cast<cutlass::half_t*>(output_row),
+      M, in_features, out_features, stream,
+      k_fp8_linear_prescale_alpha);
+    if (gemm != cudaSuccess) return gemm;
+    return apply_col_scale_bias(
+      reinterpret_cast<cutlass::half_t*>(output_row),
+      weight_scale,
+      reinterpret_cast<const cutlass::half_t*>(bias),
+      M, out_features,
+      stream,
+      k_fp8_linear_scale_mul);
+  } else {
+    static_assert(std::is_same<WeightT, int8_t>::value || std::is_same<WeightT, cutlass::half_t>::value || std::is_same<WeightT, cutlass::float_e4m3_t>::value,
+                  "Unsupported WeightT");
+    if constexpr (std::is_same<WeightT, int8_t>::value) {
+      if (weight_block_scale != nullptr) {
+        // Per-block (128x128) INT8 quantization path
+        if (int8_scratch == nullptr) {
+          printf("[ERROR] apply_linear_row<int8_t>: int8_scratch is nullptr\n");
+          return cudaErrorInvalidValue;
+        }
+        if (int8_act_block_scales == nullptr) {
+          printf("[ERROR] apply_linear_row<int8_t>: int8_act_block_scales is nullptr\n");
+          return cudaErrorInvalidValue;
+        }
+        (void)use_swizzled_weights;  // Always uses swizzled path
+
+        // Step 1: Quantize activations to INT8 with per-block scales
+        cudaError_t quant_err = quantize_per_block_128(
+          reinterpret_cast<const half*>(input_row),
+          int8_scratch,
+          int8_act_block_scales,
+          M, in_features, stream, false);
+        if (quant_err != cudaSuccess) return quant_err;
+
+        // Step 2: Run INT8 GEMM with pre-quantized activations
+        return int8_gemm(
+          int8_scratch,
+          int8_act_block_scales,
+          reinterpret_cast<const int8_t*>(weight),
+          weight_block_scale,
+          reinterpret_cast<half*>(output_row),
+          reinterpret_cast<const half*>(bias),
+          M, out_features, in_features, stream);
+      } else {
+        // Per-column INT8 path with prescale
+        if (fp8_scratch == nullptr) return cudaErrorInvalidValue;
+        float activation_scale = 1.0f;
+        cudaError_t act = compute_activation_scale(
+          reinterpret_cast<const cutlass::half_t*>(input_row),
+          int64_t(M) * in_features,
+          &activation_scale,
+          stream);
+        if (act != cudaSuccess) return act;
+        auto int8_buf = reinterpret_cast<int8_t*>(fp8_scratch);
+        cudaError_t cvt = convert_half_to_int8(
+          reinterpret_cast<const cutlass::half_t*>(input_row),
+          int8_buf,
+          int64_t(M) * in_features,
+          stream,
+          activation_scale);
+        if (cvt != cudaSuccess) return cvt;
+        if (weight_scale == nullptr) {
+          return cutlass_linear_layer_rcr_int8(
+            int8_buf,
+            reinterpret_cast<const int8_t*>(weight),
+            reinterpret_cast<const cutlass::half_t*>(bias),
+            reinterpret_cast<cutlass::half_t*>(output_row),
+            M, in_features, out_features, stream, activation_scale);
+        }
+        cudaError_t gemm = cutlass_linear_layer_rcr_int8(
+          int8_buf,
+          reinterpret_cast<const int8_t*>(weight),
+          nullptr,
+          reinterpret_cast<cutlass::half_t*>(output_row),
+          M, in_features, out_features, stream, activation_scale * k_int8_linear_prescale_alpha);
+        if (gemm != cudaSuccess) return gemm;
+        return apply_col_scale_bias(
+          reinterpret_cast<cutlass::half_t*>(output_row),
+          weight_scale,
+          reinterpret_cast<const cutlass::half_t*>(bias),
+          M, out_features,
+          stream,
+          k_int8_linear_scale_mul);
+      }
+    } else {
+      return cudaErrorNotSupported;
+    }
+  }
+}
+
+template <typename WeightT>
+static inline cudaError_t apply_linear_row_gelu(
+    const cutlass::half_t* input_row,
+    const WeightT* weight,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int M, int in_features, int out_features,
+    cudaStream_t stream,
+    cutlass::half_t* fp8_scratch,
+    const cutlass::half_t* weight_scale = nullptr,  // For FP8: per-channel scales
+    int8_t* int8_scratch = nullptr,
+    float* int8_act_block_scales = nullptr,  // For INT8: activation block scales buffer [M/128, in_features/128]
+    const float* weight_block_scale = nullptr,  // For INT8: weight per-block scales
+    bool use_swizzled_weights = false,  // For INT8: use swizzled weight format
+    cutlass::float_e4m3_t* fp8_next_input = nullptr) {  // FP8 fusion: write FP8 here instead of FP16
+
+  if constexpr (std::is_same<WeightT, cutlass::half_t>::value) {
+    return cutlass_linear_layer_rrr_gelu(
+      reinterpret_cast<const half*>(input_row),
+      reinterpret_cast<const half*>(weight),
+      reinterpret_cast<const half*>(bias),
+      reinterpret_cast<half*>(output_row),
+      M, in_features, out_features, stream);
+  } else if constexpr (std::is_same<WeightT, cutlass::float_e4m3_t>::value) {
+    if (fp8_scratch == nullptr) return cudaErrorInvalidValue;
+    auto fp8_buf = reinterpret_cast<cutlass::float_e4m3_t*>(fp8_scratch);
+    cudaError_t cvt = convert_half_to_fp8_e4m3(
+      reinterpret_cast<const cutlass::half_t*>(input_row),
+      fp8_buf,
+      int64_t(M) * in_features,
+      stream);
+    if (cvt != cudaSuccess) return cvt;
+    if (weight_scale == nullptr) {
+      return cutlass_linear_layer_rcr_fp8_gelu(
+        fp8_buf,
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+        reinterpret_cast<const cutlass::half_t*>(bias),
+        reinterpret_cast<cutlass::half_t*>(output_row),
+        M, in_features, out_features, stream);
+    }
+    cudaError_t gemm = cutlass_linear_layer_rcr_fp8(
+      fp8_buf,
+      reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+      nullptr,
+      reinterpret_cast<cutlass::half_t*>(output_row),
+      M, in_features, out_features, stream,
+      k_fp8_linear_prescale_alpha);
+    if (gemm != cudaSuccess) return gemm;
+    // If fp8_next_input is provided, fuse scale+GELU+FP8 conversion (eliminates intermediate FP16)
+    if (fp8_next_input) {
+      return apply_col_scale_bias_gelu_to_fp8(
+        reinterpret_cast<cutlass::half_t*>(output_row),
+        fp8_next_input,
+        weight_scale,
+        reinterpret_cast<const cutlass::half_t*>(bias),
+        M, out_features,
+        stream,
+        k_fp8_linear_scale_mul);
+    }
+    return apply_col_scale_bias_gelu(
+      reinterpret_cast<cutlass::half_t*>(output_row),
+      weight_scale,
+      reinterpret_cast<const cutlass::half_t*>(bias),
+      M, out_features,
+      stream,
+      k_fp8_linear_scale_mul);
+  } else {
+    static_assert(std::is_same<WeightT, int8_t>::value || std::is_same<WeightT, cutlass::half_t>::value || std::is_same<WeightT, cutlass::float_e4m3_t>::value,
+                  "Unsupported WeightT");
+    if constexpr (std::is_same<WeightT, int8_t>::value) {
+      if (weight_block_scale != nullptr) {
+        // Per-block (128x128) INT8 quantization + GELU activation
+        if (int8_scratch == nullptr) {
+          printf("[ERROR] apply_linear_row_gelu<int8_t>: int8_scratch is nullptr\n");
+          return cudaErrorInvalidValue;
+        }
+        if (int8_act_block_scales == nullptr) {
+          printf("[ERROR] apply_linear_row_gelu<int8_t>: int8_act_block_scales is nullptr\n");
+          return cudaErrorInvalidValue;
+        }
+        (void)use_swizzled_weights;  // Always uses swizzled path
+
+        // Step 1: Quantize activations to INT8 with per-block scales
+        cudaError_t quant_err = quantize_per_block_128(
+          reinterpret_cast<const half*>(input_row),
+          int8_scratch,
+          int8_act_block_scales,
+          M, in_features, stream, false);
+        if (quant_err != cudaSuccess) return quant_err;
+
+        // Step 2: Run INT8 GEMM with fused GELU activation
+        return int8_gemm_gelu(
+          int8_scratch,
+          int8_act_block_scales,
+          reinterpret_cast<const int8_t*>(weight),
+          weight_block_scale,
+          reinterpret_cast<half*>(output_row),
+          reinterpret_cast<const half*>(bias),
+          M, out_features, in_features, stream);
+      } else {
+        // Per-column INT8 path with prescale + GELU
+        if (fp8_scratch == nullptr) return cudaErrorInvalidValue;
+        float activation_scale = 1.0f;
+        cudaError_t act = compute_activation_scale(
+          reinterpret_cast<const cutlass::half_t*>(input_row),
+          int64_t(M) * in_features,
+          &activation_scale,
+          stream);
+        if (act != cudaSuccess) return act;
+        auto int8_buf = reinterpret_cast<int8_t*>(fp8_scratch);
+        cudaError_t cvt = convert_half_to_int8(
+          reinterpret_cast<const cutlass::half_t*>(input_row),
+          int8_buf,
+          int64_t(M) * in_features,
+          stream,
+          activation_scale);
+        if (cvt != cudaSuccess) return cvt;
+        if (weight_scale == nullptr) {
+          return cutlass_linear_layer_rcr_int8_gelu(
+            int8_buf,
+            reinterpret_cast<const int8_t*>(weight),
+            reinterpret_cast<const cutlass::half_t*>(bias),
+            reinterpret_cast<cutlass::half_t*>(output_row),
+            M, in_features, out_features, stream, activation_scale);
+        }
+        cudaError_t gemm = cutlass_linear_layer_rcr_int8(
+          int8_buf,
+          reinterpret_cast<const int8_t*>(weight),
+          nullptr,
+          reinterpret_cast<cutlass::half_t*>(output_row),
+          M, in_features, out_features, stream, activation_scale * k_int8_linear_prescale_alpha);
+        if (gemm != cudaSuccess) return gemm;
+        return apply_col_scale_bias_gelu(
+          reinterpret_cast<cutlass::half_t*>(output_row),
+          weight_scale,
+          reinterpret_cast<const cutlass::half_t*>(bias),
+          M, out_features,
+          stream,
+          k_int8_linear_scale_mul);
+      }
+    } else {
+      return cudaErrorNotSupported;
+    }
+  }
+}
+
+template <typename WeightT>
+static inline cudaError_t apply_linear_row_fused_residual(
+    const cutlass::half_t* input_row,
+    const WeightT* weight,
+    const cutlass::half_t* bias,
+    cutlass::half_t* residual_inout,
+    int M, int in_features, int out_features,
+    cudaStream_t stream,
+    cutlass::half_t* fp8_scratch,
+    const cutlass::half_t* weight_scale = nullptr,  // For FP8: per-channel scales
+    cutlass::half_t* temp_out = nullptr,
+    int8_t* int8_scratch = nullptr,
+    float* int8_act_block_scales = nullptr,  // For INT8: activation block scales buffer [M/128, in_features/128]
+    const float* weight_block_scale = nullptr,  // For INT8: weight per-block scales
+    bool use_swizzled_weights = false) {  // For INT8: use swizzled weight format
+
+  if constexpr (std::is_same<WeightT, cutlass::half_t>::value) {
+    return cutlass_linear_layer_rrr_fused_residual(
+      reinterpret_cast<const half*>(input_row),
+      reinterpret_cast<const half*>(weight),
+      reinterpret_cast<const half*>(bias),
+      reinterpret_cast<half*>(residual_inout),
+      M, in_features, out_features, stream);
+  } else if constexpr (std::is_same<WeightT, cutlass::float_e4m3_t>::value) {
+    if (fp8_scratch == nullptr) return cudaErrorInvalidValue;
+    auto fp8_buf = reinterpret_cast<cutlass::float_e4m3_t*>(fp8_scratch);
+    cudaError_t cvt = convert_half_to_fp8_e4m3(
+      reinterpret_cast<const cutlass::half_t*>(input_row),
+      fp8_buf,
+      int64_t(M) * in_features,
+      stream);
+    if (cvt != cudaSuccess) return cvt;
+    if (weight_scale == nullptr) {
+      return cutlass_linear_layer_rcr_fp8_fused_residual(
+        fp8_buf,
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+        reinterpret_cast<const cutlass::half_t*>(bias),
+        reinterpret_cast<cutlass::half_t*>(residual_inout),
+        M, in_features, out_features, stream);
+    }
+    if (temp_out == nullptr) return cudaErrorInvalidValue;
+    cudaError_t gemm = cutlass_linear_layer_rcr_fp8(
+      fp8_buf,
+      reinterpret_cast<const cutlass::float_e4m3_t*>(weight),
+      nullptr,
+      reinterpret_cast<cutlass::half_t*>(temp_out),
+      M, in_features, out_features, stream,
+      k_fp8_linear_prescale_alpha);
+    if (gemm != cudaSuccess) return gemm;
+    return apply_col_scale_bias_residual(
+      reinterpret_cast<const cutlass::half_t*>(temp_out),
+      reinterpret_cast<cutlass::half_t*>(residual_inout),
+      weight_scale,
+      reinterpret_cast<const cutlass::half_t*>(bias),
+      M, out_features,
+      stream,
+      k_fp8_linear_scale_mul);
+  } else {
+    static_assert(std::is_same<WeightT, int8_t>::value || std::is_same<WeightT, cutlass::half_t>::value || std::is_same<WeightT, cutlass::float_e4m3_t>::value,
+                  "Unsupported WeightT");
+    if constexpr (std::is_same<WeightT, int8_t>::value) {
+      if (weight_block_scale != nullptr) {
+        // Per-block (128x128) INT8 quantization + fused residual
+        if (temp_out == nullptr) {
+          printf("[ERROR] apply_linear_row_fused_residual<int8_t>: temp_out is nullptr\n");
+          return cudaErrorInvalidValue;
+        }
+        if (int8_scratch == nullptr) {
+          printf("[ERROR] apply_linear_row_fused_residual<int8_t>: int8_scratch is nullptr\n");
+          return cudaErrorInvalidValue;
+        }
+        if (int8_act_block_scales == nullptr) {
+          printf("[ERROR] apply_linear_row_fused_residual<int8_t>: int8_act_block_scales is nullptr\n");
+          return cudaErrorInvalidValue;
+        }
+        (void)use_swizzled_weights;  // Always uses swizzled path
+
+        // Step 1: Quantize activations to INT8 with per-block scales
+        cudaError_t quant_err = quantize_per_block_128(
+          reinterpret_cast<const half*>(input_row),
+          int8_scratch,
+          int8_act_block_scales,
+          M, in_features, stream, false);
+        if (quant_err != cudaSuccess) return quant_err;
+
+        // Step 2: Run INT8 GEMM with pre-quantized activations
+        cudaError_t gemm_err = int8_gemm(
+          int8_scratch,
+          int8_act_block_scales,
+          reinterpret_cast<const int8_t*>(weight),
+          weight_block_scale,
+          reinterpret_cast<half*>(temp_out),
+          reinterpret_cast<const half*>(bias),
+          M, out_features, in_features, stream);
+        if (gemm_err != cudaSuccess) return gemm_err;
+
+        // Add temp_out to residual: residual_inout += temp_out
+        return add_inplace_half_rr(
+          reinterpret_cast<cutlass::half_t*>(residual_inout),
+          reinterpret_cast<const cutlass::half_t*>(temp_out),
+          int64_t(M) * out_features,
+          stream);
+      } else {
+        // Per-column INT8 path with prescale + fused residual
+        if (fp8_scratch == nullptr) return cudaErrorInvalidValue;
+        float activation_scale = 1.0f;
+        cudaError_t act = compute_activation_scale(
+          reinterpret_cast<const cutlass::half_t*>(input_row),
+          int64_t(M) * in_features,
+          &activation_scale,
+          stream);
+        if (act != cudaSuccess) return act;
+        auto int8_buf = reinterpret_cast<int8_t*>(fp8_scratch);
+        cudaError_t cvt = convert_half_to_int8(
+          reinterpret_cast<const cutlass::half_t*>(input_row),
+          int8_buf,
+          int64_t(M) * in_features,
+          stream,
+          activation_scale);
+        if (cvt != cudaSuccess) return cvt;
+        if (weight_scale == nullptr) {
+          return cutlass_linear_layer_rcr_int8_fused_residual(
+            int8_buf,
+            reinterpret_cast<const int8_t*>(weight),
+            reinterpret_cast<const cutlass::half_t*>(bias),
+            reinterpret_cast<cutlass::half_t*>(residual_inout),
+            M, in_features, out_features, stream, activation_scale);
+        }
+        if (temp_out == nullptr) return cudaErrorInvalidValue;
+        cudaError_t gemm = cutlass_linear_layer_rcr_int8(
+          int8_buf,
+          reinterpret_cast<const int8_t*>(weight),
+          nullptr,
+          reinterpret_cast<cutlass::half_t*>(temp_out),
+          M, in_features, out_features, stream, activation_scale * k_int8_linear_prescale_alpha);
+        if (gemm != cudaSuccess) return gemm;
+        return apply_col_scale_bias_residual(
+          reinterpret_cast<const cutlass::half_t*>(temp_out),
+          reinterpret_cast<cutlass::half_t*>(residual_inout),
+          weight_scale,
+          reinterpret_cast<const cutlass::half_t*>(bias),
+          M, out_features,
+          stream,
+          k_int8_linear_scale_mul);
+      }
+    } else {
+      return cudaErrorNotSupported;
+    }
+  }
+}
+
+// =============================================================================
+// Per-Block INT8 Linear Layer Functions
+// =============================================================================
+
+/**
+ * Apply linear layer with per-block (128x128) INT8 quantization.
+ *
+ * This uses per-block quantization for both activations and weights,
+ * providing better precision than per-tensor quantization.
+ *
+ * @param input FP16 input [M, in_features] (row-major)
+ * @param weight_int8 Pre-quantized INT8 weights [in_features, out_features] (row-major)
+ * @param weight_block_scales Per-block weight scales [in_features/128, out_features/128]
+ * @param bias Optional bias [out_features]
+ * @param output FP16 output [M, out_features] (row-major)
+ * @param int8_scratch Scratch buffer for quantized activations [M, in_features]
+ * @param act_block_scales Scratch buffer for activation scales [M/128, in_features/128]
+ * @param M Number of rows
+ * @param in_features Input feature dimension
+ * @param out_features Output feature dimension
+ * @param stream CUDA stream
+ * @return cudaSuccess on success
+ */
+static inline cudaError_t apply_linear_row_perblock_int8(
+    const cutlass::half_t* input,
+    const int8_t* weight_int8,
+    const float* weight_block_scales,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output,
+    int8_t* int8_scratch,
+    float* act_block_scales,
+    int M, int in_features, int out_features,
+    cudaStream_t stream
+) {
+    if (int8_scratch == nullptr || act_block_scales == nullptr) {
+        printf("[ERROR] apply_linear_row_perblock_int8: scratch buffers are nullptr\n");
+        return cudaErrorInvalidValue;
+    }
+
+    // Step 1: Quantize activations to INT8 with per-block scales
+    cudaError_t quant_err = quantize_per_block_128(
+        reinterpret_cast<const half*>(input),
+        int8_scratch,
+        act_block_scales,
+        M, in_features, stream, false);
+    if (quant_err != cudaSuccess) return quant_err;
+
+    // Step 2: Run INT8 GEMM with pre-quantized activations
+    return int8_gemm(
+        int8_scratch,
+        act_block_scales,
+        weight_int8,
+        weight_block_scales,
+        reinterpret_cast<half*>(output),
+        reinterpret_cast<const half*>(bias),
+        M, out_features, in_features,
+        stream);
+}
+
+/**
+ * Apply linear layer with GELU activation using per-block INT8 quantization.
+ *
+ * Computes: output = GELU(input @ weight + bias)
+ */
+static inline cudaError_t apply_linear_row_gelu_perblock_int8(
+    const cutlass::half_t* input,
+    const int8_t* weight_int8,
+    const float* weight_block_scales,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output,
+    int8_t* int8_scratch,
+    float* act_block_scales,
+    int M, int in_features, int out_features,
+    cudaStream_t stream
+) {
+    // First compute linear layer
+    cudaError_t err = apply_linear_row_perblock_int8(
+        input, weight_int8, weight_block_scales, bias, output,
+        int8_scratch, act_block_scales,
+        M, in_features, out_features, stream);
+    if (err != cudaSuccess) return err;
+
+    // Then apply GELU activation in-place
+    // Note: We need to add a GELU kernel here. For now, we use the existing
+    // path which applies GELU via a separate kernel or fused epilogue.
+    // TODO: Implement fused GELU in the per-block GEMM kernel
+    return cudaSuccess;
+}
+
+/**
+ * Apply linear layer with fused residual using per-block INT8 quantization.
+ *
+ * Computes: residual = residual + (input @ weight + bias)
+ */
+static inline cudaError_t apply_linear_row_fused_residual_perblock_int8(
+    const cutlass::half_t* input,
+    const int8_t* weight_int8,
+    const float* weight_block_scales,
+    const cutlass::half_t* bias,
+    cutlass::half_t* residual_inout,
+    cutlass::half_t* temp_output,  // Temporary buffer for GEMM output
+    int8_t* int8_scratch,
+    float* act_block_scales,
+    int M, int in_features, int out_features,
+    cudaStream_t stream
+) {
+    // First compute linear layer to temp buffer
+    cudaError_t err = apply_linear_row_perblock_int8(
+        input, weight_int8, weight_block_scales, bias, temp_output,
+        int8_scratch, act_block_scales,
+        M, in_features, out_features, stream);
+    if (err != cudaSuccess) return err;
+
+    // TODO: Add residual in-place
+    // This should be fused into the GEMM epilogue for better performance.
+    // For now, the caller must handle residual addition separately.
+    return cudaSuccess;
+}
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/linear_utils.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/linear_utils.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "ops.cuh"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "ops.cuh"
 #include "attention.cuh"
 #include "cosmos_block.cuh"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cu
@@ -1,0 +1,5877 @@
+#include "ops.cuh"
+#include "attention.cuh"
+#include "cosmos_block.cuh"
+#include "workspace.cuh"
+#include "helper.h"
+#include <unordered_map>
+#include <string>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
+#include <cuda_bf16.h>
+#include <cublasLt.h>
+#ifndef OMNIDREAMS_SINGLEVIEW_NO_TORCH
+#include <torch/extension.h>
+#endif
+
+#include "common/profile_config.h"
+#include "common/profiler.h"
+#include <cstdint>
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/device/gemm.h"
+#include "cutlass/gemm/device/gemm_universal_with_broadcast.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/epilogue/thread/linear_combination_silu.h"
+#include "cutlass/epilogue/thread/linear_combination_residual_block.h"
+#include "cutlass/functional.h"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/numeric_types.h"
+
+// CUTLASS 3.x/4.x SM120 (Blackwell GeForce) includes
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+#include "cute/tensor.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/epilogue/fusion/operations.hpp"
+#include "cutlass/epilogue/thread/activation.h"
+#include "cutlass/util/packed_stride.hpp"
+#endif
+
+#include <cutlass/conv/kernel/default_conv2d_fprop.h>
+#include <cutlass/conv/kernel/default_conv3d_fprop.h>
+#include <cutlass/conv/device/implicit_gemm_convolution.h>
+#include <cutlass/conv/conv2d_problem_size.h>
+#include <cutlass/conv/conv3d_problem_size.h>
+
+#define PACK_INPUT_LAYOUT(problem) \
+    cutlass::layout::TensorNDHWC::packed({ \
+        (problem).N, (problem).D, (problem).H, (problem).W, (problem).C})
+
+#define PACK_WEIGHT_LAYOUT(problem) \
+    cutlass::layout::TensorNDHWC::packed({ \
+        (problem).K, (problem).T, (problem).R, (problem).S, (problem).C})
+
+#define PACK_OUTPUT_LAYOUT(problem) \
+    cutlass::layout::TensorNDHWC::packed({ \
+        (problem).N, (problem).Z, (problem).P, (problem).Q, (problem).K})
+
+#define PACK_INPUT_LAYOUT_2D(problem) \
+    cutlass::layout::TensorNHWC::packed({ \
+        (problem).N, (problem).H, (problem).W, (problem).C})
+
+#define PACK_WEIGHT_LAYOUT_2D(problem) \
+    cutlass::layout::TensorNHWC::packed({ \
+        (problem).K, (problem).R, (problem).S, (problem).C})
+
+#define PACK_OUTPUT_LAYOUT_2D(problem) \
+    cutlass::layout::TensorNHWC::packed({ \
+        (problem).N, (problem).P, (problem).Q, (problem).K})
+
+#include <cmath>
+
+namespace omnidreams_singleview {
+
+// Forward declarations for kernels used before definition
+__global__ void gelu_erf_inplace_kernel(half* data, long long numel);
+__global__ void add_pos_embed_img_kernel(half* __restrict__ data,
+                                        const half* __restrict__ pos,
+                                        int N, int img_seq, int K);
+__global__ void add_bias_lastdim_kernel(half* __restrict__ data,
+                                        const half* __restrict__ bias,
+                                        long long total_elems,
+                                        int K);
+__global__ void col_scale_bias_to_bf16_kernel(
+    const cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    cutlass::bfloat16_t* __restrict__ output,
+    float scale_mul,
+    int out_features,
+    long long total_elems);
+__global__ void col_scale_bias_to_bf16_vec2_kernel(
+    const cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    cutlass::bfloat16_t* __restrict__ output,
+    float scale_mul,
+    int out_features,
+    long long total_elems);
+__global__ void col_scale_residual_bf16_kernel(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::bfloat16_t* __restrict__ residual_inout,
+    const cutlass::half_t* __restrict__ scale,
+    float scale_mul,
+    int out_features,
+    long long total_elems);
+__global__ void col_scale_residual_bf16_vec2_kernel(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::bfloat16_t* __restrict__ residual_inout,
+    const cutlass::half_t* __restrict__ scale,
+    float scale_mul,
+    int out_features,
+    long long total_elems);
+cudaError_t apply_col_scale_bias_gelu_to_fp8(
+    const cutlass::half_t* data,
+    cutlass::float_e4m3_t* fp8_out,
+    const cutlass::half_t* scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul,
+    float output_scale);
+static bool ptr_aligned_4(const void* ptr);
+
+// ============================================================================
+// GEMM TILE CONFIGURATION
+// ============================================================================
+
+namespace {
+  // Default threshold: 1024 (original behavior)
+  // Lower values (e.g., 256, 512) use 128x64x64 tiles for smaller M,
+  // which may improve performance for CFG batched workloads.
+  int g_gemm_tile_threshold = 1024;
+}
+
+void set_gemm_tile_threshold(int threshold) {
+  g_gemm_tile_threshold = threshold;
+}
+
+int get_gemm_tile_threshold() {
+  return g_gemm_tile_threshold;
+}
+
+namespace {
+
+bool env_value_is(const char* value, const char* expected) {
+  return value && std::string(value) == expected;
+}
+
+bool byte_ranges_overlap(const void* lhs, size_t lhs_bytes, const void* rhs, size_t rhs_bytes) {
+  if (!lhs || !rhs || lhs_bytes == 0 || rhs_bytes == 0) return false;
+  const auto lhs_begin = reinterpret_cast<std::uintptr_t>(lhs);
+  const auto rhs_begin = reinterpret_cast<std::uintptr_t>(rhs);
+  const auto lhs_end = lhs_begin + lhs_bytes;
+  const auto rhs_end = rhs_begin + rhs_bytes;
+  if (lhs_end < lhs_begin || rhs_end < rhs_begin) return true;
+  return lhs_begin < rhs_end && rhs_begin < lhs_end;
+}
+
+bool valid_cosmos_fp8_linear_tile(const std::string& op_kind, const std::string& tile) {
+  (void)op_kind;
+  if (tile == "m128n128k128" || tile == "m128n64k128") {
+    return true;
+  }
+  if (tile == "m128n32k128") {
+    return true;
+  }
+  return false;
+}
+
+bool valid_cosmos_fp8_gelu_variant(const std::string& variant) {
+  return variant == "default" ||
+         variant == "nosrc_e128n16" ||
+         variant == "nosrc_e128n32" ||
+         variant == "nosrc_e128n64" ||
+         variant == "nosrc_e128n128" ||
+         variant == "nosrc_pingpong_e128n32";
+}
+
+std::string legacy_cosmos_fp8_linear_tile(const std::string& op_kind) {
+  return op_kind == "gelu_fp8" ? "m128n128k128" : "m128n32k128";
+}
+
+std::string preset_540p_cosmos_fp8_linear_tile(
+    const std::string& op_kind,
+    int rows,
+    int in_features,
+    int out_features) {
+  (void)op_kind;
+  (void)rows;
+  (void)in_features;
+  (void)out_features;
+  // 540p autotune winner, 2026-05-06:
+  //   profiles/cosmos_fp8_attention/autotune_540p_20260506_180124_summary.json
+  return "m128n128k128";
+}
+
+std::string preset_540p_cosmos_fp8_gelu_variant(
+    const std::string& op_kind,
+    int rows,
+    int in_features,
+    int out_features) {
+  (void)rows;
+  (void)in_features;
+  (void)out_features;
+  if (op_kind != "gelu_fp8") {
+    return "default";
+  }
+  // 540p autotune winner, 2026-05-06:
+  //   /tmp/native_cutlass_epilogue_exp/autotune_540p_20260506_202601_summary.json
+  // Explicit OMNIDREAMS_DIT_FP8_GELU_VARIANT=default restores the stock CUTLASS epilogue.
+  return "nosrc_pingpong_e128n32";
+}
+
+}  // namespace
+
+CosmosFp8LinearTileSelection select_cosmos_fp8_linear_tile(
+    const std::string& op_kind,
+    int rows,
+    int in_features,
+    int out_features) {
+  CosmosFp8LinearTileSelection selection;
+  selection.op_kind = op_kind;
+
+  const bool known_op =
+      op_kind == "colscale_bf16" || op_kind == "residual_bf16" || op_kind == "gelu_fp8";
+  const std::string normalized_op = known_op ? op_kind : "colscale_bf16";
+
+  const char* preset_env = std::getenv("OMNIDREAMS_DIT_FP8_LINEAR_PRESET");
+  selection.preset = (preset_env && preset_env[0] != '\0') ? std::string(preset_env) : "540p";
+
+  const char* tile_env_name =
+      normalized_op == "gelu_fp8" ? "OMNIDREAMS_DIT_FP8_GELU_TILE" : "OMNIDREAMS_DIT_FP8_LINEAR_TILE";
+  const char* stage_env_name =
+      normalized_op == "gelu_fp8" ? "OMNIDREAMS_DIT_FP8_GELU_STAGE" : "OMNIDREAMS_DIT_FP8_LINEAR_STAGE";
+  const char* variant_env_name = "OMNIDREAMS_DIT_FP8_GELU_VARIANT";
+  const char* tile_env = std::getenv(tile_env_name);
+  const char* stage_env = std::getenv(stage_env_name);
+  const char* variant_env = normalized_op == "gelu_fp8" ? std::getenv(variant_env_name) : nullptr;
+
+  if (tile_env && tile_env[0] != '\0') {
+    std::string requested(tile_env);
+    if (valid_cosmos_fp8_linear_tile(normalized_op, requested)) {
+      selection.tile = requested;
+      selection.tile_env_override = true;
+      selection.reason = std::string(tile_env_name) + "_override";
+    } else {
+      selection.reason = std::string("ignored_invalid_") + tile_env_name;
+    }
+  }
+
+  if (selection.tile.empty()) {
+    if (selection.preset == "legacy" || selection.preset == "env") {
+      selection.tile = legacy_cosmos_fp8_linear_tile(normalized_op);
+      if (selection.reason.empty()) {
+        selection.reason = selection.preset == "env" ? "env_missing_tile_legacy_fallback" : "legacy";
+      }
+    } else {
+      selection.tile = preset_540p_cosmos_fp8_linear_tile(
+          normalized_op, rows, in_features, out_features);
+      if (selection.reason.empty()) {
+        selection.reason = selection.preset == "540p"
+            ? "540p_preset"
+            : "unknown_preset_540p_fallback";
+      }
+    }
+  }
+
+  if (stage_env && stage_env[0] != '\0') {
+    if (env_value_is(stage_env, "2")) {
+      selection.stage = "2";
+      selection.stage_env_override = true;
+    } else if (env_value_is(stage_env, "auto")) {
+      selection.stage = "auto";
+      selection.stage_env_override = true;
+    } else {
+      const bool preset_uses_540p_stage =
+          selection.preset != "legacy" && selection.preset != "env";
+      selection.stage = preset_uses_540p_stage ? "2" : "auto";
+      if (selection.reason.empty() || selection.reason == "540p_preset") {
+        selection.reason = std::string("ignored_invalid_") + stage_env_name;
+      }
+    }
+  } else {
+    const bool preset_uses_540p_stage =
+        selection.preset != "legacy" && selection.preset != "env";
+    selection.stage = preset_uses_540p_stage ? "2" : "auto";
+  }
+
+  if (!known_op) {
+    selection.reason = "unknown_op_colscale_bf16_fallback";
+  }
+  const bool preset_uses_540p_variant =
+      selection.preset != "legacy" && selection.preset != "env";
+  selection.variant = preset_uses_540p_variant
+      ? preset_540p_cosmos_fp8_gelu_variant(normalized_op, rows, in_features, out_features)
+      : "default";
+  if (normalized_op == "gelu_fp8" && variant_env && variant_env[0] != '\0') {
+    std::string requested(variant_env);
+    if (valid_cosmos_fp8_gelu_variant(requested)) {
+      selection.variant = requested;
+      selection.variant_env_override = true;
+    } else if (selection.reason.empty() || selection.reason == "540p_preset") {
+      selection.reason = std::string("ignored_invalid_") + variant_env_name;
+    }
+  }
+  return selection;
+}
+
+// ============================================================================
+// 3D ROTARY POSITION EMBEDDINGS (RoPE)
+// REFERENCE: HuggingFace transformer_wan.py - WanRotaryPosEmbed (lines ~70-120)
+// ============================================================================
+
+/**
+ * Helper: Generate 1D RoPE frequencies
+ * REFERENCE: get_1d_rotary_pos_embed in embeddings.py
+ *
+ * Python equivalent:
+ *   inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2).float() / dim))
+ *   freqs = torch.outer(positions, inv_freq)
+ *   cos = freqs.cos()
+ *   sin = freqs.sin()
+ *
+ * NOTE: RoPE frequencies are duplicated for each even/odd pair.
+ *       For dimension pairs (2i, 2i+1), both positions use the same frequency.
+ */
+__global__ void generate_rope_1d_freq_kernel(
+    float* cos_out,  // [seq_len, dim] - full dimension with duplicates
+    float* sin_out,  // [seq_len, dim] - full dimension with duplicates
+    int seq_len,
+    int dim,         // Must be even
+    float theta,
+    int rope_max_seq_len) {
+
+    int seq_idx = blockIdx.x;
+    int pair_idx = threadIdx.x;
+
+    if (seq_idx >= seq_len || pair_idx >= dim / 2) return;
+
+    // Compute inverse frequency for this dimension pair
+    float freq_exp = float(pair_idx * 2) / float(dim);
+    float inv_freq = 1.0f / powf(theta, freq_exp);
+
+    // Scale position by frequency
+    float angle = float(seq_idx) * inv_freq;
+
+    float cos_val = cosf(angle);
+    float sin_val = sinf(angle);
+
+    // Store at both even and odd positions (for the pair)
+    int even_idx = seq_idx * dim + pair_idx * 2;
+    int odd_idx = even_idx + 1;
+
+    cos_out[even_idx] = cos_val;
+    sin_out[even_idx] = sin_val;
+
+    if (pair_idx * 2 + 1 < dim) {
+        cos_out[odd_idx] = cos_val;
+        sin_out[odd_idx] = sin_val;
+    }
+}
+
+/**
+ * Combine 3 sets of 1D RoPE frequencies (T, H, W) into final 3D RoPE
+ *
+ * REFERENCE: WanRotaryPosEmbed.forward() - actual HF implementation uses unequal splits:
+ * Python (actual):
+ *   split_sizes = [D - 2*(D//3), D//3, D//3]  # e.g., [44, 42, 42] for D=128
+ *   freqs_cos_t, freqs_cos_h, freqs_cos_w = freqs_cos.split(split_sizes, dim=1)
+ *   freqs_cos_f = freqs_cos_t[:ppf].view(ppf, 1, 1, -1).expand(ppf, pph, ppw, -1)
+ *   freqs_cos_h = freqs_cos_h[:pph].view(1, pph, 1, -1).expand(ppf, pph, ppw, -1)
+ *   freqs_cos_w = freqs_cos_w[:ppw].view(1, 1, ppw, -1).expand(ppf, pph, ppw, -1)
+ *   freqs = torch.cat([freqs_cos_f, freqs_cos_h, freqs_cos_w], dim=-1)
+ *
+ * NOTE: Input frequencies are already in full dimension (with even/odd duplicates)
+ */
+__global__ void combine_rope_3d_kernel(
+    const float* cos_t, const float* sin_t,  // [T, D_t] - full dimension
+    const float* cos_h, const float* sin_h,  // [H, D_h] - full dimension
+    const float* cos_w, const float* sin_w,  // [W, D_w] - full dimension
+    float* cos_out, float* sin_out,          // [T*H*W, D] where D = D_t + D_h + D_w
+    int T, int H, int W, int D,
+    int D_t, int D_h, int D_w) {              // Split sizes (full dimensions)
+
+    int total_seq = T * H * W;
+    int seq_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (seq_idx >= total_seq) return;
+
+    // Decompose sequence index to (t, h, w)
+    int w_idx = seq_idx % W;
+    int h_idx = (seq_idx / W) % H;
+    int t_idx = seq_idx / (H * W);
+
+    // Copy temporal frequencies (first D_t elements)
+    for (int d = 0; d < D_t; d++) {
+        cos_out[seq_idx * D + d] = cos_t[t_idx * D_t + d];
+        sin_out[seq_idx * D + d] = sin_t[t_idx * D_t + d];
+    }
+
+    // Copy height frequencies (next D_h elements)
+    for (int d = 0; d < D_h; d++) {
+        cos_out[seq_idx * D + D_t + d] = cos_h[h_idx * D_h + d];
+        sin_out[seq_idx * D + D_t + d] = sin_h[h_idx * D_h + d];
+    }
+
+    // Copy width frequencies (last D_w elements)
+    for (int d = 0; d < D_w; d++) {
+        cos_out[seq_idx * D + D_t + D_h + d] = cos_w[w_idx * D_w + d];
+        sin_out[seq_idx * D + D_t + D_h + d] = sin_w[w_idx * D_w + d];
+    }
+}
+
+cudaError_t generate_rope_3d(
+    float* cos_out,
+    float* sin_out,
+    int post_T, int post_H, int post_W,
+    int head_dim,
+    float theta,
+    int rope_max_seq_len,
+    float* cos_t,
+    float* sin_t,
+    float* cos_h,
+    float* sin_h,
+    float* cos_w,
+    float* sin_w,
+    cudaStream_t stream) {
+
+    // HuggingFace uses unequal split matching this formula:
+    //   h_dim = w_dim = 2 * (attention_head_dim // 6)
+    //   t_dim = attention_head_dim - h_dim - w_dim
+    // For D=128: t_dim=44, h_dim=w_dim=42
+    // For D=64: t_dim=24, h_dim=w_dim=20
+    int D_h_w = 2 * (head_dim / 6);        // Floor division
+    int D_t = head_dim - 2 * D_h_w;        // Remainder goes to temporal
+
+    if (D_t <= 0 || D_h_w <= 0) {
+        return cudaErrorInvalidValue;  // head_dim too small
+    }
+
+    // Generate 1D frequencies for each dimension
+    // Launch with (dim+1)/2 threads to handle odd dimensions properly
+    int threads_t = (D_t + 1) / 2;   // Ceiling division
+    int threads_h = (D_h_w + 1) / 2;
+    int threads_w = (D_h_w + 1) / 2;
+
+    generate_rope_1d_freq_kernel<<<post_T, threads_t, 0, stream>>>(
+        cos_t, sin_t, post_T, D_t, theta, rope_max_seq_len);
+
+    generate_rope_1d_freq_kernel<<<post_H, threads_h, 0, stream>>>(
+        cos_h, sin_h, post_H, D_h_w, theta, rope_max_seq_len);
+
+    generate_rope_1d_freq_kernel<<<post_W, threads_w, 0, stream>>>(
+        cos_w, sin_w, post_W, D_h_w, theta, rope_max_seq_len);
+
+    CUDA_CHECK(cudaGetLastError());
+
+    // Combine into 3D RoPE with proper split sizes
+    int total_seq = post_T * post_H * post_W;
+    int threads = 256;
+    int blocks = (total_seq + threads - 1) / threads;
+
+    combine_rope_3d_kernel<<<blocks, threads, 0, stream>>>(
+        cos_t, sin_t,
+        cos_h, sin_h,
+        cos_w, sin_w,
+        cos_out, sin_out,
+        post_T, post_H, post_W, head_dim,
+        D_t, D_h_w, D_h_w);  // Pass split sizes
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+// ============================================================================
+// TIMESTEP EMBEDDINGS
+// REFERENCE: diffusers.models.embeddings.get_timestep_embedding
+// ============================================================================
+
+/**
+ * Generate sinusoidal timestep embeddings
+ * Python equivalent (with flip_sin_to_cos=True, downscale_freq_shift=0):
+ *   half_dim = embedding_dim // 2
+ *   freq = 10000^(-i/half_dim) for i in [0, half_dim)
+ *   angle = timestep * freq
+ *   output = [cos(angle), sin(angle)]  (concatenated)
+ */
+__global__ void timestep_sinusoidal_embedding_kernel(
+    const int64_t* timesteps,
+    half* embeddings,
+    int num_timesteps,
+    int freq_dim,
+    int max_period) {
+
+    int ts_idx = blockIdx.x;
+    int dim_idx = threadIdx.x;
+
+    if (ts_idx >= num_timesteps || dim_idx >= freq_dim) return;
+
+    int half_dim = freq_dim / 2;
+
+    // Compute frequency for this dimension
+    float emb_scale = logf(float(max_period)) / float(half_dim);
+    float freq;
+
+    if (dim_idx < half_dim) {
+        // Cos component (first half)
+        freq = expf(float(dim_idx) * -emb_scale);
+        float angle = float(timesteps[ts_idx]) * freq;
+        embeddings[ts_idx * freq_dim + dim_idx] = __float2half(cosf(angle));
+    } else {
+        // Sin component (second half)
+        int freq_idx = dim_idx - half_dim;
+        freq = expf(float(freq_idx) * -emb_scale);
+        float angle = float(timesteps[ts_idx]) * freq;
+        embeddings[ts_idx * freq_dim + dim_idx] = __float2half(sinf(angle));
+    }
+}
+
+cudaError_t timestep_sinusoidal_embedding(
+    const int64_t* timesteps,
+    half* embeddings,
+    int num_timesteps,
+    int freq_dim,
+    int max_period,
+    cudaStream_t stream) {
+
+    timestep_sinusoidal_embedding_kernel<<<num_timesteps, freq_dim, 0, stream>>>(
+        timesteps, embeddings, num_timesteps, freq_dim, max_period);
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+// ============================================================================
+// TIMESTEP MLP PROJECTION
+// REFERENCE: HuggingFace embeddings.py - TimestepEmbedding class
+// Structure: Linear -> SiLU -> Linear
+// ============================================================================
+
+/**
+ * SiLU (Swish) activation: x * sigmoid(x)
+ * REFERENCE: activations.py - SiLU/Swish
+ */
+__global__ void silu_activation_kernel(
+    half* data,
+    int64_t total_elements) {
+
+    int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total_elements) return;
+
+    float x = __half2float(data[idx]);
+    // SiLU: x * sigmoid(x) = x / (1 + exp(-x))
+    float result = x / (1.0f + expf(-x));
+    data[idx] = __float2half(result);
+}
+
+cudaError_t apply_silu_inplace(
+    half* data,
+    int64_t total_elements,
+    cudaStream_t stream) {
+
+    int threads = 256;
+    int64_t blocks = (total_elements + threads - 1) / threads;
+
+    silu_activation_kernel<<<blocks, threads, 0, stream>>>(data, total_elements);
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+// ============================================================================
+// SM120 (Blackwell GeForce) FP8 RCR GEMM kernel type definitions
+// Uses CUTLASS 3.x/4.x CollectiveBuilder API with TMA + warp-specialized
+// persistent kernels. SM120 native tensor core: F8F6F4 in TN layout only.
+// ============================================================================
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+
+template <
+    class CtaTileShapeMNK,
+    class EpilogueTile,
+    template <class> class ActivationFn,
+    class ElementOutput,
+    class ElementCompute,
+    class ElementScalar,
+    int AlignmentScalar,
+    cutlass::FloatRoundStyle RoundStyle = cutlass::FloatRoundStyle::round_to_nearest>
+struct CosmosSm120PerColScaleEltActNoSrcCallbacks
+    : cutlass::epilogue::fusion::Sm90EVT<
+          cutlass::epilogue::fusion::Sm90Compute<
+              ActivationFn,
+              ElementOutput,
+              ElementCompute,
+              RoundStyle>,
+          cutlass::epilogue::fusion::Sm90EVT<
+              cutlass::epilogue::fusion::Sm90Compute<
+                  cutlass::multiplies,
+                  ElementCompute,
+                  ElementCompute,
+                  RoundStyle>,
+              cutlass::epilogue::fusion::Sm90RowBroadcast<
+                  0,
+                  CtaTileShapeMNK,
+                  ElementScalar,
+                  ElementCompute,
+                  cute::Stride<cute::_0, bool, int64_t>,
+                  AlignmentScalar>,
+              cutlass::epilogue::fusion::Sm90AccFetch>> {
+    using Impl = cutlass::epilogue::fusion::Sm90EVT<
+        cutlass::epilogue::fusion::Sm90Compute<
+            ActivationFn,
+            ElementOutput,
+            ElementCompute,
+            RoundStyle>,
+        cutlass::epilogue::fusion::Sm90EVT<
+            cutlass::epilogue::fusion::Sm90Compute<
+                cutlass::multiplies,
+                ElementCompute,
+                ElementCompute,
+                RoundStyle>,
+            cutlass::epilogue::fusion::Sm90RowBroadcast<
+                0,
+                CtaTileShapeMNK,
+                ElementScalar,
+                ElementCompute,
+                cute::Stride<cute::_0, bool, int64_t>,
+                AlignmentScalar>,
+            cutlass::epilogue::fusion::Sm90AccFetch>>;
+
+    struct Arguments {
+        ElementScalar alpha = ElementScalar(1);
+        ElementScalar const* alpha_ptr = nullptr;
+
+        using StrideAlpha = cute::Stride<cute::_0, bool, int64_t>;
+        StrideAlpha dAlpha = {cute::_0{}, bool(1), 0};
+
+        using ActivationArguments =
+            typename cutlass::epilogue::fusion::Sm90Compute<
+                ActivationFn,
+                ElementOutput,
+                ElementCompute,
+                RoundStyle>::Arguments;
+        ActivationArguments activation = ActivationArguments();
+
+        operator typename Impl::Arguments() const {
+            return {
+                {
+                    {alpha_ptr, alpha, dAlpha},
+                    {},
+                    {}
+                },
+                activation
+            };
+        }
+    };
+
+    using Impl::Impl;
+};
+
+namespace sm120_fp8_rcr_bias {
+    // D = alpha * (A @ B) + bias
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::half_t;
+    using ElementD = cutlass::half_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+
+    using LayoutA = cutlass::layout::RowMajor;     // TN: A is Row
+    using LayoutB = cutlass::layout::ColumnMajor;   // TN: B is Col
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;  // 16
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;  // 16
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;  // 8
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;  // 8
+
+    using MmaTileShape = Shape<_128, _128, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;  // No multicast on SM120
+
+    using FusionOp = cutlass::epilogue::fusion::LinCombPerRowBias<
+        ElementD, ElementCompute, ElementC, ElementC, ElementCompute>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_bias
+
+namespace sm120_fp8_rcr_bias_gelu {
+    // D = GELU(alpha * (A @ B) + bias)
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::half_t;
+    using ElementD = cutlass::half_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = Shape<_128, _128, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;
+
+    using FusionOp = cutlass::epilogue::fusion::LinCombPerRowBiasEltAct<
+        cutlass::epilogue::thread::GELU,
+        ElementD, ElementCompute, ElementC, ElementC, ElementCompute>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_bias_gelu
+
+namespace sm120_fp8_rcr_colscale_bf16 {
+    // D = (A @ B) * per_column_scale, with BF16 output.
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::bfloat16_t;
+    using ElementD = cutlass::bfloat16_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = Shape<_128, _128, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::Identity,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_colscale_bf16
+
+namespace sm120_fp8_rcr_colscale_bf16_m128n64k128 {
+    // More N-side CTAs for the Cosmos target linears. Kept opt-in for autotune.
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::bfloat16_t;
+    using ElementD = cutlass::bfloat16_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = Shape<_128, _64, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::Identity,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_colscale_bf16_m128n64k128
+
+namespace sm120_fp8_rcr_colscale_bf16_m128n32k128 {
+    // Higher N-side CTA count for Cosmos target linears. Opt-in until measured.
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::bfloat16_t;
+    using ElementD = cutlass::bfloat16_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = Shape<_128, _32, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::Identity,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_colscale_bf16_m128n32k128
+
+namespace sm120_fp8_rcr_colscale_gelu_fp8 {
+    // D = fp8(GELU((A @ B) * per_column_scale)).
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::float_e4m3_t;
+    using ElementD = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = Shape<_128, _128, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::GELU,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_colscale_gelu_fp8
+
+namespace sm120_fp8_rcr_colscale_gelu_fp8_m128n64k128 {
+    // More N-side CTAs for target FFN1 GELU-to-FP8 GEMMs. Kept opt-in until measured.
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::float_e4m3_t;
+    using ElementD = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = Shape<_128, _64, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::GELU,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_colscale_gelu_fp8_m128n64k128
+
+namespace sm120_fp8_rcr_colscale_gelu_fp8_m128n32k128 {
+    // Highest N-side CTA count for FFN1 GELU-to-FP8 GEMMs. Kept selectable for
+    // 540p autotune because GELU epilogue register pressure may prefer more
+    // parallel CTAs on long token sequences.
+    using namespace cute;
+
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::float_e4m3_t;
+    using ElementD = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = Shape<_128, _32, _128>;
+    using ClusterShape = Shape<_1, _1, _1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::GELU,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+} // namespace sm120_fp8_rcr_colscale_gelu_fp8_m128n32k128
+
+template <class TileShape_, int Stages>
+struct Sm120Fp8RcrColscaleBf16StageConfig {
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::bfloat16_t;
+    using ElementD = cutlass::bfloat16_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = TileShape_;
+    using ClusterShape = cute::Shape<cute::_1, cute::_1, cute::_1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::Identity,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCount<Stages>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        cute::Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+template <class TileShape_, int Stages>
+struct Sm120Fp8RcrColscaleGeluFp8StageConfig {
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = cutlass::float_e4m3_t;
+    using ElementD = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using MmaTileShape = TileShape_;
+    using ClusterShape = cute::Shape<cute::_1, cute::_1, cute::_1>;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::GELU,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCount<Stages>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        cute::Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+template <class TileShape_, class EpilogueTile_, int Stages, class KernelScheduleTag>
+struct Sm120Fp8RcrColscaleGeluFp8NoSrcStageConfig {
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = void;
+    using ElementD = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementD>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+    static constexpr int AlignmentScale = 128 / cutlass::sizeof_bits<ElementScale>::value;
+
+    using MmaTileShape = TileShape_;
+    using ClusterShape = cute::Shape<cute::_1, cute::_1, cute::_1>;
+    using EpilogueTile = EpilogueTile_;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::GELU,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale,
+        AlignmentScale,
+        AlignmentScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        EpilogueTile,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCount<Stages>,
+        KernelScheduleTag>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        cute::Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+template <class TileShape_, class EpilogueTile_, class KernelScheduleTag>
+struct Sm120Fp8RcrColscaleGeluFp8NoSrcAutoConfig {
+    using ElementA = cutlass::float_e4m3_t;
+    using ElementB = cutlass::float_e4m3_t;
+    using ElementC = void;
+    using ElementD = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using ElementScale = cutlass::half_t;
+
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    using LayoutD = cutlass::layout::RowMajor;
+
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+    static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementD>::value;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+    static constexpr int AlignmentScale = 128 / cutlass::sizeof_bits<ElementScale>::value;
+
+    using MmaTileShape = TileShape_;
+    using ClusterShape = cute::Shape<cute::_1, cute::_1, cute::_1>;
+    using EpilogueTile = EpilogueTile_;
+
+    using FusionOp = cutlass::epilogue::fusion::PerColLinCombPerColBiasEltAct<
+        cutlass::epilogue::thread::GELU,
+        ElementD,
+        ElementCompute,
+        ElementScale,
+        ElementC,
+        ElementScale,
+        AlignmentScale,
+        AlignmentScale>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        MmaTileShape, ClusterShape,
+        EpilogueTile,
+        ElementAccumulator, ElementCompute,
+        ElementC, LayoutC, AlignmentC,
+        ElementD, LayoutD, AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto,
+        FusionOp>::CollectiveOp;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        ElementA, LayoutA, AlignmentA,
+        ElementB, LayoutB, AlignmentB,
+        ElementAccumulator,
+        MmaTileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        KernelScheduleTag>::CollectiveOp;
+
+    using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+        cute::Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+namespace {
+    void* g_sm120_workspace = nullptr;
+    size_t g_sm120_workspace_size = 0;
+    cublasLtHandle_t g_cublaslt_handle = nullptr;
+    void* g_cublaslt_workspace = nullptr;
+    size_t g_cublaslt_workspace_size = 0;
+    cutlass::half_t* g_cublaslt_half_scratch = nullptr;
+    size_t g_cublaslt_half_scratch_elems = 0;
+
+    void* ensure_sm120_workspace(size_t needed) {
+        if (needed > g_sm120_workspace_size) {
+            if (g_sm120_workspace) cudaFree(g_sm120_workspace);
+            cudaMalloc(&g_sm120_workspace, needed);
+            g_sm120_workspace_size = needed;
+        }
+        return g_sm120_workspace;
+    }
+
+    cudaError_t ensure_cublaslt_handle(cudaStream_t stream) {
+        if (!g_cublaslt_handle) {
+            cublasStatus_t st = cublasLtCreate(&g_cublaslt_handle);
+            if (st != CUBLAS_STATUS_SUCCESS) return cudaErrorUnknown;
+        }
+        (void)stream;
+        return cudaSuccess;
+    }
+
+    void destroy_cublaslt_descs(
+        cublasLtMatmulPreference_t pref,
+        cublasLtMatrixLayout_t d_desc,
+        cublasLtMatrixLayout_t c_desc,
+        cublasLtMatrixLayout_t b_desc,
+        cublasLtMatrixLayout_t a_desc,
+        cublasLtMatmulDesc_t op_desc) {
+        if (pref) cublasLtMatmulPreferenceDestroy(pref);
+        if (d_desc) cublasLtMatrixLayoutDestroy(d_desc);
+        if (c_desc) cublasLtMatrixLayoutDestroy(c_desc);
+        if (b_desc) cublasLtMatrixLayoutDestroy(b_desc);
+        if (a_desc) cublasLtMatrixLayoutDestroy(a_desc);
+        if (op_desc) cublasLtMatmulDescDestroy(op_desc);
+    }
+
+    cudaError_t ensure_cublaslt_workspace(size_t needed) {
+        if (needed > g_cublaslt_workspace_size) {
+            if (g_cublaslt_workspace) cudaFree(g_cublaslt_workspace);
+            cudaError_t err = cudaMalloc(&g_cublaslt_workspace, needed);
+            if (err != cudaSuccess) {
+                g_cublaslt_workspace = nullptr;
+                g_cublaslt_workspace_size = 0;
+                return err;
+            }
+            g_cublaslt_workspace_size = needed;
+        }
+        return cudaSuccess;
+    }
+
+    cudaError_t ensure_cublaslt_half_scratch(size_t elems) {
+        if (elems > g_cublaslt_half_scratch_elems) {
+            if (g_cublaslt_half_scratch) cudaFree(g_cublaslt_half_scratch);
+            cudaError_t err = cudaMalloc(&g_cublaslt_half_scratch, elems * sizeof(cutlass::half_t));
+            if (err != cudaSuccess) {
+                g_cublaslt_half_scratch = nullptr;
+                g_cublaslt_half_scratch_elems = 0;
+                return err;
+            }
+            g_cublaslt_half_scratch_elems = elems;
+        }
+        return cudaSuccess;
+    }
+
+    cudaError_t cublaslt_status_to_cuda(cublasStatus_t st) {
+        if (st == CUBLAS_STATUS_SUCCESS) return cudaSuccess;
+        if (st == CUBLAS_STATUS_NOT_SUPPORTED || st == CUBLAS_STATUS_ARCH_MISMATCH) {
+            return cudaErrorNotSupported;
+        }
+        if (st == CUBLAS_STATUS_INVALID_VALUE) return cudaErrorInvalidValue;
+        return cudaErrorUnknown;
+    }
+
+    // Default-on toggle for the SM120 fused FP8 GEMM + epilogue path. When
+    // enabled, FP8 GEMMs route through the custom CUTLASS SM120 GMMA kernel
+    // with fused col_scale / bias / GELU / residual / FP8-quantize epilogues
+    // (eliminates the cuBLASLt FP8 GEMM + standalone post-op kernel pair).
+    // The path depends on the native TMA-descriptor pool patch in
+    // `cute/atom/copy_traits_sm90_tma.hpp` and `detail/tma_descriptor_pool.hpp`
+    // to work around an nvcc 13.x SM120 __grid_constant__ spill bug.
+    //
+    // Set OMNIDREAMS_DIT_FP8_FUSED_EPILOGUE=0 (or false/no) to fall back to the
+    // legacy cuBLASLt sm89_xmma_gemm_e4m3 + post-op kernel pair (useful for
+    // A/B testing or if a future build environment regresses the SM120 path).
+    bool prefer_sm120_fused_fp8_epilogue() {
+        const char* value = std::getenv("OMNIDREAMS_DIT_FP8_FUSED_EPILOGUE");
+        if (!value || !value[0]) return true;
+        return value[0] != '0' &&
+               value[0] != 'f' &&
+               value[0] != 'F' &&
+               value[0] != 'n' &&
+               value[0] != 'N';
+    }
+
+    bool cosmos_fp8_fused_debug_enabled() {
+        const char* value = std::getenv("OMNIDREAMS_DIT_FP8_FUSED_EPILOGUE_DEBUG");
+        if (!value || !value[0]) return false;
+        return value[0] != '0' &&
+               value[0] != 'f' &&
+               value[0] != 'F' &&
+               value[0] != 'n' &&
+               value[0] != 'N';
+    }
+
+    cudaError_t cublaslt_fp8_rcr_to_half(
+        const cutlass::float_e4m3_t* input_row,
+        const cutlass::float_e4m3_t* weight_fp8,
+        cutlass::half_t* output_row,
+        int M,
+        int K,
+        int N,
+        float alpha,
+        cudaStream_t stream) {
+        if (!input_row || !weight_fp8 || !output_row || M <= 0 || K <= 0 || N <= 0) {
+            return cudaErrorInvalidValue;
+        }
+        cudaError_t err = ensure_cublaslt_handle(stream);
+        if (err != cudaSuccess) return err;
+
+        cublasLtMatmulDesc_t op_desc = nullptr;
+        cublasLtMatrixLayout_t a_desc = nullptr, b_desc = nullptr, c_desc = nullptr, d_desc = nullptr;
+        cublasLtMatmulPreference_t pref = nullptr;
+        cublasLtMatmulHeuristicResult_t heuristic{};
+        int returned_results = 0;
+        constexpr size_t kWorkspaceBytes = 32ull * 1024ull * 1024ull;
+
+        cublasStatus_t st = cublasLtMatmulDescCreate(&op_desc, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+        if (st != CUBLAS_STATUS_SUCCESS) {
+            destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+            return cublaslt_status_to_cuda(st);
+        }
+        cublasOperation_t transa = CUBLAS_OP_N;
+        cublasOperation_t transb = CUBLAS_OP_T;
+        st = cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_TRANSA, &transa, sizeof(transa));
+        if (st == CUBLAS_STATUS_SUCCESS) {
+            st = cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_TRANSB, &transb, sizeof(transb));
+        }
+
+        if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&a_desc, CUDA_R_8F_E4M3, M, K, K);
+        if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&b_desc, CUDA_R_8F_E4M3, N, K, K);
+        if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&c_desc, CUDA_R_16F, M, N, N);
+        if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&d_desc, CUDA_R_16F, M, N, N);
+        cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
+        if (st == CUBLAS_STATUS_SUCCESS) {
+            st = cublasLtMatrixLayoutSetAttribute(a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+        }
+        if (st == CUBLAS_STATUS_SUCCESS) {
+            st = cublasLtMatrixLayoutSetAttribute(b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+        }
+        if (st == CUBLAS_STATUS_SUCCESS) {
+            st = cublasLtMatrixLayoutSetAttribute(c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+        }
+        if (st == CUBLAS_STATUS_SUCCESS) {
+            st = cublasLtMatrixLayoutSetAttribute(d_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+        }
+        if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatmulPreferenceCreate(&pref);
+        if (st == CUBLAS_STATUS_SUCCESS) {
+            size_t workspace_bytes = kWorkspaceBytes;
+            st = cublasLtMatmulPreferenceSetAttribute(
+                pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                &workspace_bytes, sizeof(workspace_bytes));
+        }
+        if (st != CUBLAS_STATUS_SUCCESS) {
+            destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+            return cublaslt_status_to_cuda(st);
+        }
+
+        err = ensure_cublaslt_workspace(kWorkspaceBytes);
+        if (err != cudaSuccess) {
+            destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+            return err;
+        }
+
+        st = cublasLtMatmulAlgoGetHeuristic(
+            g_cublaslt_handle, op_desc, a_desc, b_desc, c_desc, d_desc,
+            pref, 1, &heuristic, &returned_results);
+        if (st != CUBLAS_STATUS_SUCCESS || returned_results == 0) {
+            destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+            return cudaErrorNotSupported;
+        }
+
+        float beta = 0.0f;
+        st = cublasLtMatmul(
+            g_cublaslt_handle,
+            op_desc,
+            &alpha,
+            input_row,
+            a_desc,
+            weight_fp8,
+            b_desc,
+            &beta,
+            output_row,
+            c_desc,
+            output_row,
+            d_desc,
+            &heuristic.algo,
+            g_cublaslt_workspace,
+            kWorkspaceBytes,
+            stream);
+        destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+        return cublaslt_status_to_cuda(st);
+    }
+
+    bool sm120_fp8_stage2(const CosmosFp8LinearTileSelection& selection) {
+        return selection.stage == "2";
+    }
+
+    template <typename Gemm>
+    cudaError_t run_sm120_fp8_colscale_bf16_gemm(
+        const cutlass::float_e4m3_t* input_row,
+        const cutlass::float_e4m3_t* weight_fp8,
+        const cutlass::half_t* weight_scale,
+        cutlass::bfloat16_t* output_row,
+        int N, int in_features, int out_features,
+        cutlass::half_t beta,
+        cudaStream_t stream) {
+        using StrideA = typename Gemm::GemmKernel::StrideA;
+        using StrideB = typename Gemm::GemmKernel::StrideB;
+        using StrideC = typename Gemm::GemmKernel::StrideC;
+        using StrideD = typename Gemm::GemmKernel::StrideD;
+
+        int M = N;
+        int K = in_features;
+        int N_gemm = out_features;
+
+        auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
+        auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N_gemm, K, 1));
+        auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N_gemm, 1));
+        auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N_gemm, 1));
+
+        typename Gemm::Arguments arguments{
+            cutlass::gemm::GemmUniversalMode::kGemm,
+            {M, N_gemm, K, 1},
+            {input_row, stride_A, weight_fp8, stride_B},
+            {{},
+             output_row, stride_C, output_row, stride_D}
+        };
+        arguments.epilogue.thread.alpha_ptr = weight_scale;
+        arguments.epilogue.thread.beta = beta;
+        arguments.epilogue.thread.bias_ptr = nullptr;
+
+        Gemm gemm_op;
+        auto status = gemm_op.can_implement(arguments);
+        if (status != cutlass::Status::kSuccess) return cudaErrorNotSupported;
+
+        size_t ws_size = Gemm::get_workspace_size(arguments);
+        void* ws = ws_size > 0 ? ensure_sm120_workspace(ws_size) : nullptr;
+
+        status = gemm_op.initialize(arguments, ws, stream);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        status = gemm_op.run(stream);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        return cudaGetLastError();
+    }
+
+    template <typename Gemm>
+    cudaError_t run_sm120_fp8_colscale_gelu_fp8_gemm(
+        const cutlass::float_e4m3_t* input_row,
+        const cutlass::float_e4m3_t* weight_fp8,
+        const cutlass::half_t* weight_scale,
+        cutlass::float_e4m3_t* output_fp8,
+        int N, int in_features, int out_features,
+        cudaStream_t stream) {
+        using StrideA = typename Gemm::GemmKernel::StrideA;
+        using StrideB = typename Gemm::GemmKernel::StrideB;
+        using StrideC = typename Gemm::GemmKernel::StrideC;
+        using StrideD = typename Gemm::GemmKernel::StrideD;
+
+        int M = N;
+        int K = in_features;
+        int N_gemm = out_features;
+
+        auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
+        auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N_gemm, K, 1));
+        auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N_gemm, 1));
+        auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N_gemm, 1));
+        using ElementCArg = typename Gemm::ElementC;
+        ElementCArg const* ptr_C = nullptr;
+        if constexpr (!cute::is_void_v<ElementCArg>) {
+            ptr_C = output_fp8;
+        }
+
+        typename Gemm::Arguments arguments{
+            cutlass::gemm::GemmUniversalMode::kGemm,
+            {M, N_gemm, K, 1},
+            {input_row, stride_A, weight_fp8, stride_B},
+            {{},
+             ptr_C, stride_C, output_fp8, stride_D}
+        };
+        arguments.epilogue.thread.alpha_ptr = weight_scale;
+        using ThreadArgs = decltype(arguments.epilogue.thread);
+        if constexpr (requires(ThreadArgs& t) { t.beta; }) {
+            arguments.epilogue.thread.beta = cutlass::half_t(0.0f);
+        }
+        if constexpr (requires(ThreadArgs& t) { t.bias_ptr; }) {
+            arguments.epilogue.thread.bias_ptr = nullptr;
+        }
+
+        Gemm gemm_op;
+        auto status = gemm_op.can_implement(arguments);
+        if (status != cutlass::Status::kSuccess) {
+            if (cosmos_fp8_fused_debug_enabled()) {
+                std::fprintf(stderr,
+                    "[cosmos_fp8_fused] can_implement failed status=%d M=%d N=%d K=%d "
+                    "input=%p weight=%p scale=%p output=%p C=%p\n",
+                    int(status), M, N_gemm, K,
+                    static_cast<const void*>(input_row),
+                    static_cast<const void*>(weight_fp8),
+                    static_cast<const void*>(weight_scale),
+                    static_cast<void*>(output_fp8),
+                    static_cast<const void*>(ptr_C));
+            }
+            return cudaErrorNotSupported;
+        }
+
+        size_t ws_size = Gemm::get_workspace_size(arguments);
+        void* ws = ws_size > 0 ? ensure_sm120_workspace(ws_size) : nullptr;
+        if (cosmos_fp8_fused_debug_enabled()) {
+            std::fprintf(stderr,
+                "[cosmos_fp8_fused] launch M=%d N=%d K=%d workspace=%zu "
+                "input=%p weight=%p scale=%p output=%p C=%p\n",
+                M, N_gemm, K, ws_size,
+                static_cast<const void*>(input_row),
+                static_cast<const void*>(weight_fp8),
+                static_cast<const void*>(weight_scale),
+                static_cast<void*>(output_fp8),
+                static_cast<const void*>(ptr_C));
+        }
+
+        status = gemm_op.initialize(arguments, ws, stream);
+        if (status != cutlass::Status::kSuccess) {
+            if (cosmos_fp8_fused_debug_enabled()) {
+                std::fprintf(stderr, "[cosmos_fp8_fused] initialize failed status=%d\n", int(status));
+            }
+            return cudaErrorUnknown;
+        }
+        status = gemm_op.run(stream);
+        if (status != cutlass::Status::kSuccess) {
+            if (cosmos_fp8_fused_debug_enabled()) {
+                std::fprintf(stderr, "[cosmos_fp8_fused] run failed status=%d\n", int(status));
+            }
+            return cudaErrorUnknown;
+        }
+        cudaError_t launch_err = cudaGetLastError();
+        if (launch_err != cudaSuccess && cosmos_fp8_fused_debug_enabled()) {
+            std::fprintf(stderr,
+                "[cosmos_fp8_fused] cudaGetLastError=%d (%s)\n",
+                int(launch_err), cudaGetErrorString(launch_err));
+        }
+        return launch_err;
+    }
+
+    template <class EpilogueTile, class KernelScheduleTag>
+    cudaError_t run_sm120_fp8_colscale_gelu_fp8_nosrc_variant(
+        const cutlass::float_e4m3_t* input_row,
+        const cutlass::float_e4m3_t* weight_fp8,
+        const cutlass::half_t* weight_scale,
+        cutlass::float_e4m3_t* output_fp8,
+        int N, int in_features, int out_features,
+        const CosmosFp8LinearTileSelection& selection,
+        cudaStream_t stream) {
+        using TileShape = cute::Shape<cute::_128, cute::_128, cute::_128>;
+        if (cosmos_fp8_fused_debug_enabled()) {
+            std::fprintf(stderr,
+                "[cosmos_fp8_fused] variant=%s tile=%s stage=%s reason=%s rows=%d in=%d out=%d\n",
+                selection.variant.c_str(),
+                selection.tile.c_str(),
+                selection.stage.c_str(),
+                selection.reason.c_str(),
+                N, in_features, out_features);
+        }
+        if (sm120_fp8_stage2(selection)) {
+            return run_sm120_fp8_colscale_gelu_fp8_gemm<
+                typename Sm120Fp8RcrColscaleGeluFp8NoSrcStageConfig<
+                    TileShape, EpilogueTile, 2, KernelScheduleTag>::Gemm>(
+                        input_row, weight_fp8, weight_scale, output_fp8,
+                        N, in_features, out_features, stream);
+        }
+        return run_sm120_fp8_colscale_gelu_fp8_gemm<
+            typename Sm120Fp8RcrColscaleGeluFp8NoSrcAutoConfig<
+                TileShape, EpilogueTile, KernelScheduleTag>::Gemm>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, stream);
+    }
+}
+
+#endif // CUTLASS_ARCH_MMA_SM120_SUPPORTED
+
+// Cached runtime SM major version (queried once, reused for all FP8 dispatch).
+namespace {
+    int g_runtime_sm_major = -1;
+    int get_runtime_sm_major() {
+        if (g_runtime_sm_major < 0) {
+            int device = 0;
+            cudaGetDevice(&device);
+            cudaDeviceGetAttribute(&g_runtime_sm_major, cudaDevAttrComputeCapabilityMajor, device);
+        }
+        return g_runtime_sm_major;
+    }
+}
+
+// SM89 fallback for FP8 RCR GEMM (always compiled, used as fallback on non-Blackwell GPUs)
+// Uses 128x64x128 tile (known-working from pre-anahmad-turbo codebase).
+static cudaError_t cutlass_linear_layer_rcr_fp8_sm89(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float alpha) {
+
+    using ElementInputA = cutlass::float_e4m3_t;
+    using ElementInputB = cutlass::float_e4m3_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    const cutlass::half_t* c_ptr = bias ? bias : output_row;
+    int ldc = bias ? 0 : out_features;
+    float beta = bias ? 1.0f : 0.0f;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+        ElementOutput,
+        8,
+        ElementAccumulator,
+        ElementAccumulator>;
+
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA, ElementInputB, LayoutB, ElementOutput, LayoutC, ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm89,
+        cutlass::gemm::GemmShape<128, 64, 128>, cutlass::gemm::GemmShape<64, 32, 128>, cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOp>;
+    Gemm gemm_op;
+    Gemm::Arguments args({N, out_features, in_features},
+                         {input_row, in_features},
+                         {weight_fp8, in_features},
+                         {c_ptr, ldc},
+                         {output_row, out_features},
+                         {alpha, beta});
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+// SM89 fallback for FP8 RCR GEMM + GELU (always compiled)
+// Uses 128x64x128 tile (known-working from pre-anahmad-turbo codebase).
+static cudaError_t cutlass_linear_layer_rcr_fp8_gelu_sm89(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    using ElementInputA = cutlass::float_e4m3_t;
+    using ElementInputB = cutlass::float_e4m3_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    int const kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationGELU<
+        ElementOutput,
+        kElementsPerAccess,
+        ElementAccumulator,
+        float
+    >;
+
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm89,
+        cutlass::gemm::GemmShape<128, 64, 128>,
+        cutlass::gemm::GemmShape<64, 32, 128>,
+        cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOp
+    >;
+    Gemm gemm_op;
+    typename EpilogueOp::Params epilogue_params(1.0f, 1.0f);
+    Gemm::Arguments args(
+        {N, out_features, in_features},
+        {input_row, in_features},
+        {weight_fp8, in_features},
+        {reinterpret_cast<const cutlass::half_t*>(bias), 0},
+        {output_row, out_features},
+        epilogue_params);
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+// Strided-batched BF16 GEMM via cuBLASLt: D[b] = A[b] @ B[b]^T + (bias != null ? C[b] : 0)
+//
+// Used for the AdaLN-LoRA pre-stack path's "up" GEMM. With per-instance
+// (M=B=1, N=3*model_channels=6144, K=lora_dim=256) and batchCount = num_blocks*3,
+// the batch dim fills the GPU even though per-instance M is a vector.
+//
+// Layout matches PyTorch nn.Linear: A is row-major [M, K]; B is row-major
+// [N, K] (PyTorch's [out, in] weight layout); D is row-major [M, N].
+// bias (when non-null) is treated as the C matrix with the supplied stride;
+// pass stride_bias=0 to broadcast a single bias matrix across all batches.
+cudaError_t cublaslt_strided_batched_bf16_gemm(
+    const cutlass::bfloat16_t* a_row,
+    const cutlass::bfloat16_t* b_row,
+    const cutlass::bfloat16_t* bias,
+    cutlass::bfloat16_t* d_row,
+    int M, int K, int N,
+    int batchCount,
+    int64_t stride_a, int64_t stride_b, int64_t stride_d, int64_t stride_bias,
+    cudaStream_t stream) {
+    if (!a_row || !b_row || !d_row || M <= 0 || K <= 0 || N <= 0 || batchCount <= 0) {
+        return cudaErrorInvalidValue;
+    }
+    cudaError_t err = ensure_cublaslt_handle(stream);
+    if (err != cudaSuccess) return err;
+
+    cublasLtMatmulDesc_t op_desc = nullptr;
+    cublasLtMatrixLayout_t a_desc = nullptr, b_desc = nullptr, c_desc = nullptr, d_desc = nullptr;
+    cublasLtMatmulPreference_t pref = nullptr;
+    cublasLtMatmulHeuristicResult_t heuristic{};
+    int returned_results = 0;
+    constexpr size_t kWorkspaceBytes = 32ull * 1024ull * 1024ull;
+
+    cublasStatus_t st = cublasLtMatmulDescCreate(&op_desc, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+    if (st != CUBLAS_STATUS_SUCCESS) {
+        destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+        return cublaslt_status_to_cuda(st);
+    }
+    cublasOperation_t transa = CUBLAS_OP_N;
+    cublasOperation_t transb = CUBLAS_OP_T;
+    st = cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_TRANSA, &transa, sizeof(transa));
+    if (st == CUBLAS_STATUS_SUCCESS) {
+        st = cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_TRANSB, &transb, sizeof(transb));
+    }
+
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&a_desc, CUDA_R_16BF, M, K, K);
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&b_desc, CUDA_R_16BF, N, K, K);
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&c_desc, CUDA_R_16BF, M, N, N);
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutCreate(&d_desc, CUDA_R_16BF, M, N, N);
+    cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(d_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order));
+
+    int32_t batch_count = batchCount;
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(a_desc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(b_desc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(c_desc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(d_desc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count));
+
+    int64_t sa = stride_a, sb = stride_b, sd = stride_d;
+    int64_t sc = (bias != nullptr) ? stride_bias : stride_d;
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(a_desc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &sa, sizeof(sa));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(b_desc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &sb, sizeof(sb));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(c_desc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &sc, sizeof(sc));
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatrixLayoutSetAttribute(d_desc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &sd, sizeof(sd));
+
+    if (st == CUBLAS_STATUS_SUCCESS) st = cublasLtMatmulPreferenceCreate(&pref);
+    if (st == CUBLAS_STATUS_SUCCESS) {
+        size_t workspace_bytes = kWorkspaceBytes;
+        st = cublasLtMatmulPreferenceSetAttribute(
+            pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+            &workspace_bytes, sizeof(workspace_bytes));
+    }
+    if (st != CUBLAS_STATUS_SUCCESS) {
+        destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+        return cublaslt_status_to_cuda(st);
+    }
+
+    err = ensure_cublaslt_workspace(kWorkspaceBytes);
+    if (err != cudaSuccess) {
+        destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+        return err;
+    }
+
+    st = cublasLtMatmulAlgoGetHeuristic(
+        g_cublaslt_handle, op_desc, a_desc, b_desc, c_desc, d_desc,
+        pref, 1, &heuristic, &returned_results);
+    if (st != CUBLAS_STATUS_SUCCESS || returned_results == 0) {
+        destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+        return cudaErrorNotSupported;
+    }
+
+    float alpha_f = 1.0f;
+    float beta_f = (bias != nullptr) ? 1.0f : 0.0f;
+    const cutlass::bfloat16_t* c_ptr = (bias != nullptr) ? bias : d_row;
+    st = cublasLtMatmul(
+        g_cublaslt_handle, op_desc,
+        &alpha_f, a_row, a_desc, b_row, b_desc,
+        &beta_f, c_ptr, c_desc, d_row, d_desc,
+        &heuristic.algo, g_cublaslt_workspace, kWorkspaceBytes,
+        stream);
+    destroy_cublaslt_descs(pref, d_desc, c_desc, b_desc, a_desc, op_desc);
+    return cublaslt_status_to_cuda(st);
+}
+
+cudaError_t cutlass_linear_layer_rcr_fp8(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float alpha) {
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+    if (get_runtime_sm_major() >= 12) {
+        cudaError_t lt_err = cublaslt_fp8_rcr_to_half(
+            input_row, weight_fp8, output_row,
+            N, in_features, out_features, alpha, stream);
+        if (lt_err == cudaSuccess) {
+            if (bias) {
+                int threads = 256;
+                long long total = static_cast<long long>(N) * out_features;
+                long long blocks = (total + threads - 1) / threads;
+                add_bias_lastdim_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+                    reinterpret_cast<half*>(output_row),
+                    reinterpret_cast<const half*>(bias),
+                    total,
+                    out_features);
+                return cudaGetLastError();
+            }
+            return cudaSuccess;
+        }
+#if defined(_WIN32)
+        return cutlass_linear_layer_rcr_fp8_sm89(
+            input_row, weight_fp8, bias, output_row,
+            N, in_features, out_features, stream, alpha);
+#else
+        if (lt_err != cudaErrorNotSupported) return lt_err;
+#endif
+
+        // SM120 Blackwell path: CUTLASS 4.x with TMA + warp-specialized persistent kernel
+        using Gemm = sm120_fp8_rcr_bias::Gemm;
+        using StrideA = typename Gemm::GemmKernel::StrideA;
+        using StrideB = typename Gemm::GemmKernel::StrideB;
+        using StrideC = typename Gemm::GemmKernel::StrideC;
+        using StrideD = typename Gemm::GemmKernel::StrideD;
+
+        int M = N;
+        int K = in_features;
+        int N_gemm = out_features;
+
+        auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
+        auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N_gemm, K, 1));
+        auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N_gemm, 1));
+        auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N_gemm, 1));
+
+        typename Gemm::Arguments arguments{
+            cutlass::gemm::GemmUniversalMode::kGemm,
+            {M, N_gemm, K, 1},
+            {input_row, stride_A, weight_fp8, stride_B},
+            {{},
+             output_row, stride_C, output_row, stride_D}
+        };
+        arguments.epilogue.thread.alpha = alpha;
+        arguments.epilogue.thread.beta = 0.0f;
+        arguments.epilogue.thread.bias_ptr = bias;
+
+        Gemm gemm_op;
+        auto status = gemm_op.can_implement(arguments);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+
+        size_t ws_size = Gemm::get_workspace_size(arguments);
+        void* ws = ws_size > 0 ? ensure_sm120_workspace(ws_size) : nullptr;
+
+        status = gemm_op.initialize(arguments, ws, stream);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        status = gemm_op.run(stream);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        return cudaSuccess;
+    }
+#endif
+    return cutlass_linear_layer_rcr_fp8_sm89(
+        input_row, weight_fp8, bias, output_row,
+        N, in_features, out_features, stream, alpha);
+}
+
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_bf16(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    if (!input_row || !weight_fp8 || !weight_scale || !output_row ||
+        N <= 0 || in_features <= 0 || out_features <= 0) {
+        return cudaErrorInvalidValue;
+    }
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+    if (get_runtime_sm_major() >= 12) {
+        constexpr float prescale_alpha = 1.0f / 128.0f;
+        constexpr float scale_mul = 128.0f;
+        const bool prefer_fused = prefer_sm120_fused_fp8_epilogue();
+        size_t elems = static_cast<size_t>(N) * static_cast<size_t>(out_features);
+        cudaError_t lt_err = prefer_fused ? cudaErrorNotSupported : ensure_cublaslt_half_scratch(elems);
+        if (lt_err == cudaSuccess) {
+            lt_err = cublaslt_fp8_rcr_to_half(
+                input_row, weight_fp8, g_cublaslt_half_scratch,
+                N, in_features, out_features, prescale_alpha, stream);
+        }
+        if (lt_err == cudaSuccess) {
+            int threads = 256;
+            long long total = static_cast<long long>(elems);
+            const bool use_vec2 =
+                (total % 2 == 0) && (out_features % 2 == 0) &&
+                ptr_aligned_4(g_cublaslt_half_scratch) &&
+                ptr_aligned_4(weight_scale) &&
+                ptr_aligned_4(output_row);
+            if (use_vec2) {
+                long long total_h2 = total / 2;
+                long long blocks = (total_h2 + threads - 1) / threads;
+                col_scale_bias_to_bf16_vec2_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+                    g_cublaslt_half_scratch, weight_scale, nullptr, output_row,
+                    scale_mul, out_features, total);
+            } else {
+                long long blocks = (total + threads - 1) / threads;
+                col_scale_bias_to_bf16_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+                    g_cublaslt_half_scratch, weight_scale, nullptr, output_row,
+                    scale_mul, out_features, total);
+            }
+            return cudaGetLastError();
+        }
+#if defined(_WIN32)
+        if (!prefer_fused) return cudaErrorNotSupported;
+#else
+        if (lt_err != cudaErrorNotSupported) return lt_err;
+        if (!prefer_fused) return cudaErrorNotSupported;
+#endif
+
+        const auto selection = select_cosmos_fp8_linear_tile(
+            "colscale_bf16", N, in_features, out_features);
+        if (selection.tile == "m128n32k128") {
+            if (sm120_fp8_stage2(selection)) {
+                cudaError_t err = run_sm120_fp8_colscale_bf16_gemm<
+                    Sm120Fp8RcrColscaleBf16StageConfig<
+                        cute::Shape<cute::_128, cute::_32, cute::_128>, 2>::Gemm>(
+                            input_row, weight_fp8, weight_scale, output_row,
+                            N, in_features, out_features, cutlass::half_t(0.0f), stream);
+                if (err != cudaErrorNotSupported) return err;
+            }
+            return run_sm120_fp8_colscale_bf16_gemm<
+                sm120_fp8_rcr_colscale_bf16_m128n32k128::Gemm>(
+                    input_row, weight_fp8, weight_scale, output_row,
+                    N, in_features, out_features, cutlass::half_t(0.0f), stream);
+        }
+        if (selection.tile == "m128n64k128") {
+            if (sm120_fp8_stage2(selection)) {
+                cudaError_t err = run_sm120_fp8_colscale_bf16_gemm<
+                    Sm120Fp8RcrColscaleBf16StageConfig<
+                        cute::Shape<cute::_128, cute::_64, cute::_128>, 2>::Gemm>(
+                            input_row, weight_fp8, weight_scale, output_row,
+                            N, in_features, out_features, cutlass::half_t(0.0f), stream);
+                if (err != cudaErrorNotSupported) return err;
+            }
+            return run_sm120_fp8_colscale_bf16_gemm<
+                sm120_fp8_rcr_colscale_bf16_m128n64k128::Gemm>(
+                    input_row, weight_fp8, weight_scale, output_row,
+                    N, in_features, out_features, cutlass::half_t(0.0f), stream);
+        }
+        if (sm120_fp8_stage2(selection)) {
+            cudaError_t err = run_sm120_fp8_colscale_bf16_gemm<
+                Sm120Fp8RcrColscaleBf16StageConfig<
+                    cute::Shape<cute::_128, cute::_128, cute::_128>, 2>::Gemm>(
+                        input_row, weight_fp8, weight_scale, output_row,
+                        N, in_features, out_features, cutlass::half_t(0.0f), stream);
+            if (err != cudaErrorNotSupported) return err;
+        }
+        return run_sm120_fp8_colscale_bf16_gemm<sm120_fp8_rcr_colscale_bf16::Gemm>(
+            input_row, weight_fp8, weight_scale, output_row,
+            N, in_features, out_features, cutlass::half_t(0.0f), stream);
+    }
+#endif
+    return cudaErrorNotSupported;
+}
+
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_residual_bf16(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* alpha,
+    cutlass::bfloat16_t* residual_inout,
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    if (!input_row || !weight_fp8 || !alpha || !residual_inout ||
+        N <= 0 || in_features <= 0 || out_features <= 0) {
+        return cudaErrorInvalidValue;
+    }
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+    if (get_runtime_sm_major() >= 12) {
+        constexpr float prescale_alpha = 1.0f / 128.0f;
+        constexpr float scale_mul = 128.0f;
+        const bool prefer_fused = prefer_sm120_fused_fp8_epilogue();
+        size_t elems = static_cast<size_t>(N) * static_cast<size_t>(out_features);
+        cudaError_t lt_err = prefer_fused ? cudaErrorNotSupported : ensure_cublaslt_half_scratch(elems);
+        if (lt_err == cudaSuccess) {
+            lt_err = cublaslt_fp8_rcr_to_half(
+                input_row, weight_fp8, g_cublaslt_half_scratch,
+                N, in_features, out_features, prescale_alpha, stream);
+        }
+        if (lt_err == cudaSuccess) {
+            int threads = 256;
+            long long total = static_cast<long long>(elems);
+            const bool use_vec2 =
+                (total % 2 == 0) && (out_features % 2 == 0) &&
+                ptr_aligned_4(g_cublaslt_half_scratch) &&
+                ptr_aligned_4(alpha) &&
+                ptr_aligned_4(residual_inout);
+            if (use_vec2) {
+                long long total_h2 = total / 2;
+                long long blocks = (total_h2 + threads - 1) / threads;
+                col_scale_residual_bf16_vec2_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+                    g_cublaslt_half_scratch, residual_inout, alpha,
+                    scale_mul, out_features, total);
+            } else {
+                long long blocks = (total + threads - 1) / threads;
+                col_scale_residual_bf16_kernel<<<static_cast<unsigned int>(blocks), threads, 0, stream>>>(
+                    g_cublaslt_half_scratch, residual_inout, alpha,
+                    scale_mul, out_features, total);
+            }
+            return cudaGetLastError();
+        }
+#if defined(_WIN32)
+        if (!prefer_fused) return cudaErrorNotSupported;
+#else
+        if (lt_err != cudaErrorNotSupported) return lt_err;
+        if (!prefer_fused) return cudaErrorNotSupported;
+#endif
+
+        const auto selection = select_cosmos_fp8_linear_tile(
+            "residual_bf16", N, in_features, out_features);
+        if (selection.tile == "m128n32k128") {
+            if (sm120_fp8_stage2(selection)) {
+                cudaError_t err = run_sm120_fp8_colscale_bf16_gemm<
+                    Sm120Fp8RcrColscaleBf16StageConfig<
+                        cute::Shape<cute::_128, cute::_32, cute::_128>, 2>::Gemm>(
+                            input_row, weight_fp8, alpha, residual_inout,
+                            N, in_features, out_features, cutlass::half_t(1.0f), stream);
+                if (err != cudaErrorNotSupported) return err;
+            }
+            return run_sm120_fp8_colscale_bf16_gemm<
+                sm120_fp8_rcr_colscale_bf16_m128n32k128::Gemm>(
+                    input_row, weight_fp8, alpha, residual_inout,
+                    N, in_features, out_features, cutlass::half_t(1.0f), stream);
+        }
+        if (selection.tile == "m128n64k128") {
+            if (sm120_fp8_stage2(selection)) {
+                cudaError_t err = run_sm120_fp8_colscale_bf16_gemm<
+                    Sm120Fp8RcrColscaleBf16StageConfig<
+                        cute::Shape<cute::_128, cute::_64, cute::_128>, 2>::Gemm>(
+                            input_row, weight_fp8, alpha, residual_inout,
+                            N, in_features, out_features, cutlass::half_t(1.0f), stream);
+                if (err != cudaErrorNotSupported) return err;
+            }
+            return run_sm120_fp8_colscale_bf16_gemm<
+                sm120_fp8_rcr_colscale_bf16_m128n64k128::Gemm>(
+                    input_row, weight_fp8, alpha, residual_inout,
+                    N, in_features, out_features, cutlass::half_t(1.0f), stream);
+        }
+        if (sm120_fp8_stage2(selection)) {
+            cudaError_t err = run_sm120_fp8_colscale_bf16_gemm<
+                Sm120Fp8RcrColscaleBf16StageConfig<
+                    cute::Shape<cute::_128, cute::_128, cute::_128>, 2>::Gemm>(
+                        input_row, weight_fp8, alpha, residual_inout,
+                        N, in_features, out_features, cutlass::half_t(1.0f), stream);
+            if (err != cudaErrorNotSupported) return err;
+        }
+        return run_sm120_fp8_colscale_bf16_gemm<sm120_fp8_rcr_colscale_bf16::Gemm>(
+            input_row, weight_fp8, alpha, residual_inout,
+            N, in_features, out_features, cutlass::half_t(1.0f), stream);
+    }
+#endif
+    return cudaErrorNotSupported;
+}
+
+// FP8 GEMM (cuBLASLt) followed by a fused col_scale + residual + LayerNorm
+// + modulate -> FP8 post-op kernel. Replaces the back-to-back pair
+// (col_scale_residual_bf16_vec2 + cosmos_layernorm_modulate_to_fp8_only) that
+// runs after SA-out / CA-out projections in the production FP8 path. The
+// fused post-op keeps the BF16-truncated `x_new` row in shared memory between
+// the residual write and the LN reduce, eliminating the BF16 re-read of x.
+//
+// Falls back to cudaErrorNotSupported when the cuBLASLt half-scratch path
+// can't be set up; callers should run the unfused two-step pair in that case.
+//
+// Layout matches `cutlass_linear_layer_rcr_fp8_colscale_residual_bf16`: alpha
+// is the precomputed per-column (weight_scale * gate * input_scale) FP16
+// vector produced by `cosmos_scale_gate_half`.
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_residual_layernorm_modulate_to_fp8(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* alpha,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* ln_shift,
+    const cutlass::bfloat16_t* ln_scale,
+    cutlass::float_e4m3_t* fp8_out,
+    int N, int in_features, int out_features, int B, float eps,
+    cudaStream_t stream) {
+
+    if (!input_row || !weight_fp8 || !alpha || !residual_inout ||
+        !ln_shift || !ln_scale || !fp8_out ||
+        N <= 0 || in_features <= 0 || out_features <= 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    constexpr float prescale_alpha = 1.0f / 128.0f;
+    constexpr float scale_mul = 128.0f;
+    size_t elems = static_cast<size_t>(N) * static_cast<size_t>(out_features);
+    cudaError_t lt_err = ensure_cublaslt_half_scratch(elems);
+    if (lt_err != cudaSuccess) return lt_err;
+    lt_err = cublaslt_fp8_rcr_to_half(
+        input_row, weight_fp8, g_cublaslt_half_scratch,
+        N, in_features, out_features, prescale_alpha, stream);
+    if (lt_err != cudaSuccess) return lt_err;
+#ifdef OMNIDREAMS_SINGLEVIEW_WITH_COSMOS_MODULATE
+    return cosmos_col_scale_residual_layernorm_modulate_to_fp8_only<cutlass::bfloat16_t>(
+        g_cublaslt_half_scratch, alpha, residual_inout,
+        ln_shift, ln_scale, fp8_out,
+        scale_mul, N, out_features, B, eps, stream);
+#else
+    (void)scale_mul;
+    (void)B;
+    (void)eps;
+    return cudaErrorNotSupported;
+#endif
+}
+
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_gelu_fp8(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* weight_scale,
+    cutlass::float_e4m3_t* output_fp8,
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    if (!input_row || !weight_fp8 || !weight_scale || !output_fp8 ||
+        N <= 0 || in_features <= 0 || out_features <= 0) {
+        return cudaErrorInvalidValue;
+    }
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+    if (get_runtime_sm_major() >= 12) {
+        constexpr float prescale_alpha = 1.0f / 128.0f;
+        constexpr float scale_mul = 128.0f;
+        const size_t input_bytes =
+            static_cast<size_t>(N) * static_cast<size_t>(in_features) * sizeof(*input_row);
+        const size_t output_bytes =
+            static_cast<size_t>(N) * static_cast<size_t>(out_features) * sizeof(*output_fp8);
+        const bool output_overlaps_input =
+            byte_ranges_overlap(input_row, input_bytes, output_fp8, output_bytes);
+        // Some callers reuse FP8 scratch for A and D. The fused GEMM may write
+        // D while it is still reading A, unlike the two-step fallback.
+        const bool prefer_fused = prefer_sm120_fused_fp8_epilogue() && !output_overlaps_input;
+        size_t elems = static_cast<size_t>(N) * static_cast<size_t>(out_features);
+        cudaError_t lt_err = prefer_fused ? cudaErrorNotSupported : ensure_cublaslt_half_scratch(elems);
+        if (lt_err == cudaSuccess) {
+            lt_err = cublaslt_fp8_rcr_to_half(
+                input_row, weight_fp8, g_cublaslt_half_scratch,
+                N, in_features, out_features, prescale_alpha, stream);
+        }
+        if (lt_err == cudaSuccess) {
+            return apply_col_scale_bias_gelu_to_fp8(
+                g_cublaslt_half_scratch, output_fp8, weight_scale, nullptr,
+                N, out_features, stream, scale_mul, 1.0f);
+        }
+#if defined(_WIN32)
+        if (!prefer_fused) return cudaErrorNotSupported;
+#else
+        if (lt_err != cudaErrorNotSupported) return lt_err;
+        if (!prefer_fused) return cudaErrorNotSupported;
+#endif
+
+        const auto selection = select_cosmos_fp8_linear_tile(
+            "gelu_fp8", N, in_features, out_features);
+        using CoopSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+        using PingpongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
+        if (selection.variant == "nosrc_e128n16") {
+            return run_sm120_fp8_colscale_gelu_fp8_nosrc_variant<
+                cute::Shape<cute::_128, cute::_16>, CoopSchedule>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, selection, stream);
+        }
+        if (selection.variant == "nosrc_e128n32") {
+            return run_sm120_fp8_colscale_gelu_fp8_nosrc_variant<
+                cute::Shape<cute::_128, cute::_32>, CoopSchedule>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, selection, stream);
+        }
+        if (selection.variant == "nosrc_e128n64") {
+            return run_sm120_fp8_colscale_gelu_fp8_nosrc_variant<
+                cute::Shape<cute::_128, cute::_64>, CoopSchedule>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, selection, stream);
+        }
+        if (selection.variant == "nosrc_e128n128") {
+            return run_sm120_fp8_colscale_gelu_fp8_nosrc_variant<
+                cute::Shape<cute::_128, cute::_128>, CoopSchedule>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, selection, stream);
+        }
+        if (selection.variant == "nosrc_pingpong_e128n32") {
+            return run_sm120_fp8_colscale_gelu_fp8_nosrc_variant<
+                cute::Shape<cute::_128, cute::_32>, PingpongSchedule>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, selection, stream);
+        }
+        if (selection.tile == "m128n32k128") {
+            if (sm120_fp8_stage2(selection)) {
+                cudaError_t err = run_sm120_fp8_colscale_gelu_fp8_gemm<
+                    Sm120Fp8RcrColscaleGeluFp8StageConfig<
+                        cute::Shape<cute::_128, cute::_32, cute::_128>, 2>::Gemm>(
+                            input_row, weight_fp8, weight_scale, output_fp8,
+                            N, in_features, out_features, stream);
+                if (err != cudaErrorNotSupported) return err;
+            }
+            return run_sm120_fp8_colscale_gelu_fp8_gemm<
+                sm120_fp8_rcr_colscale_gelu_fp8_m128n32k128::Gemm>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, stream);
+        }
+        if (selection.tile == "m128n64k128") {
+            if (sm120_fp8_stage2(selection)) {
+                cudaError_t err = run_sm120_fp8_colscale_gelu_fp8_gemm<
+                    Sm120Fp8RcrColscaleGeluFp8StageConfig<
+                        cute::Shape<cute::_128, cute::_64, cute::_128>, 2>::Gemm>(
+                            input_row, weight_fp8, weight_scale, output_fp8,
+                            N, in_features, out_features, stream);
+                if (err != cudaErrorNotSupported) return err;
+            }
+            return run_sm120_fp8_colscale_gelu_fp8_gemm<
+                sm120_fp8_rcr_colscale_gelu_fp8_m128n64k128::Gemm>(
+                    input_row, weight_fp8, weight_scale, output_fp8,
+                    N, in_features, out_features, stream);
+        }
+        if (sm120_fp8_stage2(selection)) {
+            cudaError_t err = run_sm120_fp8_colscale_gelu_fp8_gemm<
+                Sm120Fp8RcrColscaleGeluFp8StageConfig<
+                    cute::Shape<cute::_128, cute::_128, cute::_128>, 2>::Gemm>(
+                        input_row, weight_fp8, weight_scale, output_fp8,
+                        N, in_features, out_features, stream);
+            if (err != cudaErrorNotSupported) return err;
+        }
+        return run_sm120_fp8_colscale_gelu_fp8_gemm<sm120_fp8_rcr_colscale_gelu_fp8::Gemm>(
+            input_row, weight_fp8, weight_scale, output_fp8,
+            N, in_features, out_features, stream);
+    }
+#endif
+    return cudaErrorNotSupported;
+}
+
+// FP8 A/B (RRR) path with stride-trick bias fusion
+// SM120 only supports TN layout for F8 types; RRR (TT) is not available.
+// Guard out to avoid Sm89 2.x MMA template errors when SM120 headers are active.
+#if !defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+cudaError_t cutlass_linear_layer_rrr_fp8(
+    const cutlass::float_e4m3_t* input_row,   // Row-major [N, in_features] FP8
+    const cutlass::float_e4m3_t* weight_fp8,  // Row-major [in_features, out_features] FP8
+    const cutlass::half_t* bias,              // [out_features] half or nullptr
+    cutlass::half_t* output_row,              // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    using ElementInputA = cutlass::float_e4m3_t;
+    using ElementInputB = cutlass::float_e4m3_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+
+    using LayoutC = cutlass::layout::RowMajor;
+
+    const cutlass::half_t* c_ptr = bias ? bias : output_row;
+    int ldc = bias ? 0 : out_features;
+    float beta = bias ? 1.0f : 0.0f;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+        ElementOutput,
+        8,                      // elements per access (reduce to avoid zero row iterations)
+        ElementAccumulator,
+        ElementAccumulator>;
+
+    // 128x128x128, 8 warps, 16384 output elements/CTA (2x original)
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA, ElementInputB, LayoutB, ElementOutput, LayoutC, ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm89,
+        cutlass::gemm::GemmShape<128, 128, 128>, cutlass::gemm::GemmShape<64, 32, 128>, cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOp>;
+    Gemm gemm_op;
+    Gemm::Arguments args({N, out_features, in_features},
+                         {input_row, in_features},
+                         {weight_fp8, out_features},
+                         {c_ptr, ldc},   // bias broadcast when ldc==0
+                         {output_row, out_features},
+                         {1.0f, beta});
+
+    cutlass::Status status;
+    status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+#endif // !CUTLASS_ARCH_MMA_SM120_SUPPORTED
+
+cudaError_t cutlass_linear_layer_rcr_int8(
+    const int8_t* input_row,
+    const int8_t* weight_int8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float activation_scale) {
+
+    using ElementInputA = int8_t;
+    using ElementInputB = int8_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = int32_t;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    const cutlass::half_t* c_ptr = bias ? bias : output_row;
+    int ldc = bias ? 0 : out_features;
+    float beta = bias ? 1.0f : 0.0f;
+
+    int const kElementsPerAccess = 8; // 8 half values per vectorized access
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+        ElementOutput,
+        kElementsPerAccess,
+        ElementAccumulator,
+        float>;
+
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 64>,
+        cutlass::gemm::GemmShape<64, 64, 64>,
+        cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOp
+    >;
+
+    Gemm gemm_op;
+    Gemm::Arguments args({N, out_features, in_features},
+                         {input_row, in_features},
+                         {weight_int8, in_features},
+                         {c_ptr, ldc},
+                         {output_row, out_features},
+                         {activation_scale, beta});
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+// Row-major GEMM with GELU epilogue: D = GELU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rrr_gelu(
+    const half* input_row,
+    const half* weight_row,
+    const half* bias,
+    half* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    int const kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationGELU<
+        ElementOutput,
+        kElementsPerAccess,
+        ElementAccumulator,
+        float
+    >;
+
+    // Use 256x128x32 tiles to match PyTorch/cuBLAS optimal configuration
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<256, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        EpilogueOp
+    >;
+
+    Gemm gemm_op;
+
+    typename EpilogueOp::Params epilogue_params(1.0f, 1.0f);
+    Gemm::Arguments args(
+        {N, out_features, in_features},
+        {reinterpret_cast<const cutlass::half_t*>(input_row), in_features},
+        {reinterpret_cast<const cutlass::half_t*>(weight_row), out_features},
+        {reinterpret_cast<const cutlass::half_t*>(bias), 0},  // Bias with stride 0
+        {reinterpret_cast<cutlass::half_t*>(output_row), out_features},
+        epilogue_params
+    );
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+// FP8 A/B (RCR) with GELU epilogue: D = GELU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rcr_fp8_gelu(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+    if (get_runtime_sm_major() >= 12) {
+        // SM120 Blackwell path: CUTLASS 4.x with fused GELU epilogue
+        using Gemm = sm120_fp8_rcr_bias_gelu::Gemm;
+        using StrideA = typename Gemm::GemmKernel::StrideA;
+        using StrideB = typename Gemm::GemmKernel::StrideB;
+        using StrideC = typename Gemm::GemmKernel::StrideC;
+        using StrideD = typename Gemm::GemmKernel::StrideD;
+
+        int M = N;
+        int K = in_features;
+        int N_gemm = out_features;
+
+        auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
+        auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N_gemm, K, 1));
+        auto stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N_gemm, 1));
+        auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N_gemm, 1));
+
+        typename Gemm::Arguments arguments{
+            cutlass::gemm::GemmUniversalMode::kGemm,
+            {M, N_gemm, K, 1},
+            {input_row, stride_A, weight_fp8, stride_B},
+            {{},
+             output_row, stride_C, output_row, stride_D}
+        };
+        arguments.epilogue.thread.alpha = 1.0f;
+        arguments.epilogue.thread.beta = 0.0f;
+        arguments.epilogue.thread.bias_ptr = bias;
+
+        Gemm gemm_op;
+        auto status = gemm_op.can_implement(arguments);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+
+        size_t ws_size = Gemm::get_workspace_size(arguments);
+        void* ws = ws_size > 0 ? ensure_sm120_workspace(ws_size) : nullptr;
+
+        status = gemm_op.initialize(arguments, ws, stream);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        status = gemm_op.run(stream);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        return cudaSuccess;
+    }
+#endif
+    return cutlass_linear_layer_rcr_fp8_gelu_sm89(
+        input_row, weight_fp8, bias, output_row,
+        N, in_features, out_features, stream);
+}
+
+// FP8 A/B (RRR) with GELU epilogue: D = GELU(A @ B + bias)
+// SM120 only supports TN layout for F8 types; RRR (TT) is not available.
+#if !defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+cudaError_t cutlass_linear_layer_rrr_fp8_gelu(
+    const cutlass::float_e4m3_t* input_row,   // Row-major [N, in_features] FP8
+    const cutlass::float_e4m3_t* weight_fp8,  // Row-major [in_features, out_features] FP8
+    const cutlass::half_t* bias,              // [out_features] half or nullptr
+    cutlass::half_t* output_row,              // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    using ElementInputA = cutlass::float_e4m3_t;
+    using ElementInputB = cutlass::float_e4m3_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    int const kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationGELU<
+        ElementOutput,
+        kElementsPerAccess,
+        ElementAccumulator,
+        float
+    >;
+
+    // 128x128x128, 8 warps, 16384 output elements/CTA (2x original)
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm89,
+        cutlass::gemm::GemmShape<128, 128, 128>,
+        cutlass::gemm::GemmShape<64, 32, 128>,
+        cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOp
+    >;
+
+    Gemm gemm_op;
+
+    float beta = bias ? 1.0f : 0.0f;
+    typename EpilogueOp::Params epilogue_params(1.0f, beta);
+    const cutlass::half_t* c_ptr = bias ? bias : output_row;
+    int ldc = bias ? 0 : out_features;
+    Gemm::Arguments args(
+        {N, out_features, in_features},
+        {input_row, in_features},
+        {weight_fp8, out_features},
+        {c_ptr, ldc}, // bias broadcast when ldc==0
+        {output_row, out_features},
+        epilogue_params
+    );
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+#endif // !CUTLASS_ARCH_MMA_SM120_SUPPORTED
+
+// INT8 A/B (RCR) with GELU epilogue: D = GELU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rcr_int8_gelu(
+    const int8_t* input_row,
+    const int8_t* weight_int8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float activation_scale) {
+
+    using ElementInputA = int8_t;
+    using ElementInputB = int8_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = int32_t;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    int const kElementsPerAccess = 8;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationGELU<
+        ElementOutput,
+        kElementsPerAccess,
+        ElementAccumulator,
+        float
+    >;
+
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 64>,
+        cutlass::gemm::GemmShape<64, 64, 64>,
+        cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOp
+    >;
+
+    Gemm gemm_op;
+
+    const cutlass::half_t* c_ptr = bias ? bias : output_row;
+    int ldc = bias ? 0 : out_features;
+    float beta = bias ? 1.0f : 0.0f;
+    typename EpilogueOp::Params epilogue_params(activation_scale, beta);
+
+    Gemm::Arguments args(
+        {N, out_features, in_features},
+        {input_row, in_features},
+        {weight_int8, in_features},
+        {c_ptr, ldc},
+        {output_row, out_features},
+        epilogue_params
+    );
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+// ============================================================================
+// Utilities: conversions
+// ============================================================================
+
+__global__ void half_to_fp8_e4m3_kernel(
+    const cutlass::half_t* __restrict__ src,
+    cutlass::float_e4m3_t* __restrict__ dst,
+    int64_t n) {
+  // 4-wide vectorized: each thread processes 4 FP8 elements
+  int64_t base = ((int64_t)blockIdx.x * blockDim.x + threadIdx.x) * 4;
+  if (base >= n) return;
+  const half2* src_h2 = reinterpret_cast<const half2*>(src);
+  half2 v01 = src_h2[base / 2];
+  half2 v23 = (base + 2 < n) ? src_h2[base / 2 + 1] : half2{__float2half(0.f), __float2half(0.f)};
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  dst[base]     = to_fp8(__half2float(v01.x));
+  if (base + 1 < n) dst[base + 1] = to_fp8(__half2float(v01.y));
+  if (base + 2 < n) dst[base + 2] = to_fp8(__half2float(v23.x));
+  if (base + 3 < n) dst[base + 3] = to_fp8(__half2float(v23.y));
+}
+
+cudaError_t convert_half_to_fp8_e4m3(
+    const cutlass::half_t* src,
+    cutlass::float_e4m3_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream) {
+  int threads = 256;
+  int64_t elems_per_block = threads * 4;
+  int64_t blocks = (num_elements + elems_per_block - 1) / elems_per_block;
+  half_to_fp8_e4m3_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(src, dst, num_elements);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+// ============================================================================
+// INT8 QUANTIZATION UTILITIES
+// ============================================================================
+
+// Main's half_to_int8 kernel (host-side scale)
+__global__ void half_to_int8_kernel(
+    const cutlass::half_t* __restrict__ src,
+    int8_t* __restrict__ dst,
+    int64_t n,
+    float inv_scale) {
+  int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float v = to_f32(src[idx]) * inv_scale;
+  float r = nearbyintf(v);
+  r = fminf(fmaxf(r, -128.0f), 127.0f);
+  dst[idx] = static_cast<int8_t>(r);
+}
+
+// Main's atomicMaxFloat (CAS-based, works for all float values)
+__device__ inline void atomicMaxFloat(float* addr, float val) {
+  int* addr_as_i = reinterpret_cast<int*>(addr);
+  int old = *addr_as_i;
+  int assumed;
+  int val_i = __float_as_int(val);
+  while (val_i > old) {
+    assumed = old;
+    old = atomicCAS(addr_as_i, assumed, val_i);
+  }
+}
+
+// Main's absmax_kernel (simple per-thread atomic)
+__global__ void absmax_kernel(
+    const cutlass::half_t* __restrict__ src,
+    float* __restrict__ out,
+    int64_t n) {
+  float local_max = 0.0f;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  for (int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+       idx < n;
+       idx += (int64_t)blockDim.x * gridDim.x) {
+    float v = fabsf(to_f32(src[idx]));
+    if (v > local_max) local_max = v;
+  }
+  atomicMaxFloat(out, local_max);
+}
+
+// Turbo's fast atomic max for non-negative floats (uses atomicMax on uint).
+__device__ inline void atomicMaxFloatNonNeg(float* addr, float val) {
+  val = fmaxf(val, 0.0f);
+  unsigned int* addr_as_ui = reinterpret_cast<unsigned int*>(addr);
+  atomicMax(addr_as_ui, __float_as_uint(val));
+}
+
+// Turbo's warp-level reduction for absmax
+__device__ __forceinline__ float warp_reduce_max(float v) {
+  // Full warp mask
+  unsigned mask = 0xffffffffu;
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    float other = __shfl_down_sync(mask, v, offset);
+    v = fmaxf(v, other);
+  }
+  return v;
+}
+
+// Turbo's optimized absmax kernel (warp + block reduction)
+__global__ void absmax_block_kernel(
+    const cutlass::half_t* __restrict__ src,
+    float* __restrict__ out,
+    int64_t n) {
+  float local_max = 0.0f;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  for (int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+       idx < n;
+       idx += (int64_t)blockDim.x * gridDim.x) {
+    float v = fabsf(to_f32(src[idx]));
+    local_max = fmaxf(local_max, v);
+  }
+
+  // Reduce within warp
+  local_max = warp_reduce_max(local_max);
+
+  // Reduce warp maxima within block
+  __shared__ float warp_max[8]; // supports up to 256 threads (8 warps)
+  int lane = threadIdx.x & 31;
+  int warp = threadIdx.x >> 5;
+  if (lane == 0) warp_max[warp] = local_max;
+  __syncthreads();
+
+  float block_max = 0.0f;
+  if (warp == 0) {
+    block_max = (threadIdx.x < (blockDim.x >> 5)) ? warp_max[lane] : 0.0f;
+    block_max = warp_reduce_max(block_max);
+    if (lane == 0) {
+      atomicMaxFloatNonNeg(out, block_max);
+    }
+  }
+}
+
+// Main's compute_activation_scale (host-side, copies result back to host)
+cudaError_t compute_activation_scale(
+    const cutlass::half_t* src,
+    int64_t num_elements,
+    float* activation_scale_out,
+    cudaStream_t stream) {
+  if (activation_scale_out == nullptr || src == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+  float* d_max = nullptr;
+  CUDA_CHECK(cudaMallocAsync(&d_max, sizeof(float), stream));
+  CUDA_CHECK(cudaMemsetAsync(d_max, 0, sizeof(float), stream));
+  int threads = 256;
+  int64_t blocks = (num_elements + threads - 1) / threads;
+  blocks = blocks > 1024 ? 1024 : blocks;
+  absmax_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(src, d_max, num_elements);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaMemcpyAsync(activation_scale_out, d_max, sizeof(float), cudaMemcpyDeviceToHost, stream));
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  CUDA_CHECK(cudaFreeAsync(d_max, stream));
+  float act = (*activation_scale_out) / 127.0f;
+  if (act < 1.0e-6f) act = 1.0e-6f;
+  *activation_scale_out = act;
+  return cudaSuccess;
+}
+
+// Turbo's compute_activation_scale_device (device-side, result stays on GPU)
+cudaError_t compute_activation_scale_device(
+    const cutlass::half_t* src,
+    int64_t num_elements,
+    float* activation_scale_out_dev,
+    cudaStream_t stream) {
+  if (activation_scale_out_dev == nullptr || src == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+  {
+    cudaError_t e = cudaMemsetAsync(activation_scale_out_dev, 0, sizeof(float), stream);
+    if (e != cudaSuccess) return e;
+  }
+  int threads = 256;
+  int64_t blocks = (num_elements + threads - 1) / threads;
+  blocks = blocks > 1024 ? 1024 : blocks;
+  absmax_block_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(src, activation_scale_out_dev, num_elements);
+  {
+    cudaError_t e = cudaGetLastError();
+    if (e != cudaSuccess) return e;
+  }
+  return cudaGetLastError();
+}
+
+// Main's convert_half_to_int8 (host-side scale)
+cudaError_t convert_half_to_int8(
+    const cutlass::half_t* src,
+    int8_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream,
+    float activation_scale) {
+  int threads = 256;
+  int64_t blocks = (num_elements + threads - 1) / threads;
+  float inv_scale = activation_scale > 0 ? 1.0f / activation_scale : 1.0f;
+  half_to_int8_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(src, dst, num_elements, inv_scale);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+// Turbo's device-scale quantization kernels
+__global__ void half_to_int8_device_scale_kernel(
+    const cutlass::half_t* __restrict__ src,
+    int8_t* __restrict__ dst,
+    int64_t n,
+    const float* __restrict__ scale_dev) {
+  int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  // scale_dev stores activation absmax. Convert to scale = amax/127 with clamp.
+  float amax = *scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  float inv_scale = 127.0f / amax;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float v = to_f32(src[idx]) * inv_scale;
+  int q = __float2int_rn(v);
+  q = max(-128, min(127, q));
+  dst[idx] = static_cast<int8_t>(q);
+}
+
+__global__ void half_to_int8_device_scale_kernel_vec4(
+    const half* __restrict__ src,
+    int8_t* __restrict__ dst,
+    int64_t n,
+    const float* __restrict__ scale_dev) {
+  int64_t base = ((int64_t)blockIdx.x * blockDim.x + threadIdx.x) * 4;
+  if (base >= n) return;
+  // scale_dev stores activation absmax. Convert to inv_scale = 127/amax with clamp.
+  float amax = *scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  float inv_scale = 127.0f / amax;
+
+  // Vectorized path expects n % 4 == 0 and src/dst aligned by the caller.
+  half2 a0 = *reinterpret_cast<const half2*>(src + base + 0);
+  half2 a1 = *reinterpret_cast<const half2*>(src + base + 2);
+
+  float2 f0 = __half22float2(a0);
+  float2 f1 = __half22float2(a1);
+
+  int q0 = __float2int_rn(f0.x * inv_scale);
+  int q1 = __float2int_rn(f0.y * inv_scale);
+  int q2 = __float2int_rn(f1.x * inv_scale);
+  int q3 = __float2int_rn(f1.y * inv_scale);
+
+  q0 = max(-128, min(127, q0));
+  q1 = max(-128, min(127, q1));
+  q2 = max(-128, min(127, q2));
+  q3 = max(-128, min(127, q3));
+
+  char4 packed;
+  packed.x = (char)q0;
+  packed.y = (char)q1;
+  packed.z = (char)q2;
+  packed.w = (char)q3;
+  *reinterpret_cast<char4*>(dst + base) = packed;
+}
+
+// Turbo's convert_half_to_int8_device_scale (device pointer for scale)
+cudaError_t convert_half_to_int8_device_scale(
+    const cutlass::half_t* src,
+    int8_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream,
+    const float* activation_scale_dev) {
+  if (activation_scale_dev == nullptr) return cudaErrorInvalidValue;
+  if (src == nullptr || dst == nullptr) return cudaErrorInvalidValue;
+  int threads = 256;
+
+  // Fast path: vectorize 4 elements per thread when aligned and divisible by 4.
+  uintptr_t src_u = reinterpret_cast<uintptr_t>(src);
+  uintptr_t dst_u = reinterpret_cast<uintptr_t>(dst);
+  bool aligned4 = ((src_u & 3u) == 0u) && ((dst_u & 3u) == 0u);
+  if (aligned4 && (num_elements % 4 == 0)) {
+    int64_t blocks = ((num_elements / 4) + threads - 1) / threads;
+    half_to_int8_device_scale_kernel_vec4<<<(unsigned int)blocks, threads, 0, stream>>>(
+        reinterpret_cast<const half*>(src), dst, num_elements, activation_scale_dev);
+    return cudaGetLastError();
+  }
+
+  // Fallback: scalar
+  int64_t blocks = (num_elements + threads - 1) / threads;
+  half_to_int8_device_scale_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(src, dst, num_elements, activation_scale_dev);
+  return cudaGetLastError();
+}
+
+// Turbo's INT8 to half dequantization kernels (device pointer for scale)
+__global__ void int8_to_half_device_scale_kernel(
+    const int8_t* __restrict__ src,
+    cutlass::half_t* __restrict__ dst,
+    int64_t n,
+    const float* __restrict__ scale_dev) {
+  int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  // scale_dev stores activation absmax. Convert to scale = amax/127 with clamp.
+  float amax = *scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  float scale = amax / 127.0f;
+  float v = static_cast<float>(src[idx]) * scale;
+  dst[idx] = cutlass::half_t(v);
+}
+
+__global__ void int8_to_half_device_scale_kernel_vec4(
+    const int8_t* __restrict__ src,
+    half* __restrict__ dst,
+    int64_t n,
+    const float* __restrict__ scale_dev) {
+  int64_t base = ((int64_t)blockIdx.x * blockDim.x + threadIdx.x) * 4;
+  if (base >= n) return;
+  // scale_dev stores activation absmax. Convert to scale = amax/127 with clamp.
+  float amax = *scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  float scale = amax / 127.0f;
+
+  char4 packed = *reinterpret_cast<const char4*>(src + base);
+  float f0 = (float)packed.x * scale;
+  float f1 = (float)packed.y * scale;
+  float f2 = (float)packed.z * scale;
+  float f3 = (float)packed.w * scale;
+
+  // Store as two half2.
+  half2 h0 = __floats2half2_rn(f0, f1);
+  half2 h1 = __floats2half2_rn(f2, f3);
+  *reinterpret_cast<half2*>(dst + base + 0) = h0;
+  *reinterpret_cast<half2*>(dst + base + 2) = h1;
+}
+
+cudaError_t convert_int8_to_half_device_scale(
+    const int8_t* src,
+    cutlass::half_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream,
+    const float* activation_scale_dev) {
+  if (activation_scale_dev == nullptr) return cudaErrorInvalidValue;
+  if (src == nullptr || dst == nullptr) return cudaErrorInvalidValue;
+  int threads = 256;
+
+  uintptr_t src_u = reinterpret_cast<uintptr_t>(src);
+  uintptr_t dst_u = reinterpret_cast<uintptr_t>(dst);
+  bool aligned4 = ((src_u & 3u) == 0u) && ((dst_u & 3u) == 0u);
+  if (aligned4 && (num_elements % 4 == 0)) {
+    int64_t blocks = ((num_elements / 4) + threads - 1) / threads;
+    int8_to_half_device_scale_kernel_vec4<<<(unsigned int)blocks, threads, 0, stream>>>(
+        src, reinterpret_cast<half*>(dst), num_elements, activation_scale_dev);
+    return cudaGetLastError();
+  }
+
+  int64_t blocks = (num_elements + threads - 1) / threads;
+  int8_to_half_device_scale_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(src, dst, num_elements, activation_scale_dev);
+  return cudaGetLastError();
+}
+
+// ============================================================================
+// INT8/FP16 POST-OPS (column-wise scale/bias)
+// ============================================================================
+
+// Column-wise scale + optional bias on row-major [N, out_features] - half2 vectorized
+__global__ void col_scale_bias_kernel(
+    cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    float scale_mul,
+    int out_features,
+    long long total_elems) {
+  long long idx2 = (long long)blockIdx.x * blockDim.x + threadIdx.x;  // half2 index
+  long long idx = idx2 * 2;
+  if (idx >= total_elems) return;
+  half2* data_h2 = reinterpret_cast<half2*>(data);
+  const half2* scale_h2 = reinterpret_cast<const half2*>(scale);
+  int col = (int)(idx % out_features);
+  int col2 = col / 2;
+  half2 v = data_h2[idx2];
+  half2 s = scale_h2[col2];
+  float v0 = __half2float(v.x) * (__half2float(s.x) * scale_mul);
+  float v1 = __half2float(v.y) * (__half2float(s.y) * scale_mul);
+  if (bias) {
+    const half2* bias_h2 = reinterpret_cast<const half2*>(bias);
+    half2 b = bias_h2[col2];
+    v0 += __half2float(b.x);
+    v1 += __half2float(b.y);
+  }
+  data_h2[idx2] = half2{__float2half(v0), __float2half(v1)};
+}
+
+__global__ void col_scale_bias_to_bf16_kernel(
+    const cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    cutlass::bfloat16_t* __restrict__ output,
+    float scale_mul,
+    int out_features,
+    long long total_elems) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float x = to_f32(data[idx]) * (to_f32(scale[col]) * scale_mul);
+  if (bias) {
+    x += to_f32(bias[col]);
+  }
+  output[idx] = cutlass::bfloat16_t(x);
+}
+
+__global__ void col_scale_bias_to_bf16_vec2_kernel(
+    const cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    cutlass::bfloat16_t* __restrict__ output,
+    float scale_mul,
+    int out_features,
+    long long total_elems) {
+  long long idx2 = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  long long idx = idx2 * 2;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  int col2 = col / 2;
+  const half2* data_h2 = reinterpret_cast<const half2*>(data);
+  const half2* scale_h2 = reinterpret_cast<const half2*>(scale);
+  half2 v = data_h2[idx2];
+  half2 s = scale_h2[col2];
+  float x0 = __half2float(v.x) * (__half2float(s.x) * scale_mul);
+  float x1 = __half2float(v.y) * (__half2float(s.y) * scale_mul);
+  if (bias) {
+    const half2* bias_h2 = reinterpret_cast<const half2*>(bias);
+    half2 b = bias_h2[col2];
+    x0 += __half2float(b.x);
+    x1 += __half2float(b.y);
+  }
+  reinterpret_cast<__nv_bfloat162*>(output)[idx2] =
+      __floats2bfloat162_rn(x0, x1);
+}
+
+// half2-vectorized: col_scale + bias + GELU on row-major [N, out_features]
+__global__ void col_scale_bias_gelu_kernel(
+    cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    float scale_mul,
+    int out_features,
+    long long total_elems) {
+  long long idx2 = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  long long idx = idx2 * 2;
+  if (idx >= total_elems) return;
+  half2* data_h2 = reinterpret_cast<half2*>(data);
+  const half2* scale_h2 = reinterpret_cast<const half2*>(scale);
+  int col = (int)(idx % out_features);
+  int col2 = col / 2;
+  half2 v = data_h2[idx2];
+  half2 s = scale_h2[col2];
+  float x0 = __half2float(v.x) * (__half2float(s.x) * scale_mul);
+  float x1 = __half2float(v.y) * (__half2float(s.y) * scale_mul);
+  if (bias) {
+    const half2* bias_h2 = reinterpret_cast<const half2*>(bias);
+    half2 b = bias_h2[col2];
+    x0 += __half2float(b.x);
+    x1 += __half2float(b.y);
+  }
+  // GELU tanh approximation
+  float c = 0.044715f;
+  float y0 = 0.7978845608028654f * (x0 + c * x0 * x0 * x0);
+  float y1 = 0.7978845608028654f * (x1 + c * x1 * x1 * x1);
+  float g0 = 0.5f * x0 * (1.0f + tanhf(y0));
+  float g1 = 0.5f * x1 * (1.0f + tanhf(y1));
+  data_h2[idx2] = half2{__float2half(g0), __float2half(g1)};
+}
+
+// Fused: col_scale + bias + FP8 conversion for producers that feed another
+// quantized layer directly.
+__global__ void col_scale_bias_to_fp8_kernel(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::float_e4m3_t* __restrict__ fp8_out,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    float scale_mul,
+    float inv_output_scale,
+    int out_features,
+    long long total_elems) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  float x = to_f32(data[idx]) * (to_f32(scale[col]) * scale_mul);
+  if (bias) {
+    x += to_f32(bias[col]);
+  }
+  fp8_out[idx] = to_fp8(x * inv_output_scale);
+}
+
+// Fused: col_scale + bias + GELU + FP8 conversion -- eliminates intermediate FP16 write/read
+// Reads half GEMM output, applies scale+bias+GELU, writes FP8 directly
+__global__ void col_scale_bias_gelu_to_fp8_kernel(
+    const cutlass::half_t* __restrict__ data,        // input: GEMM output [N, out_features]
+    cutlass::float_e4m3_t* __restrict__ fp8_out,     // output: FP8 [N, out_features]
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    float scale_mul,
+    float inv_output_scale,
+    int out_features,
+    long long total_elems) {
+  long long idx2 = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  long long idx = idx2 * 2;
+  if (idx >= total_elems) return;
+  const half2* data_h2 = reinterpret_cast<const half2*>(data);
+  const half2* scale_h2 = reinterpret_cast<const half2*>(scale);
+  int col = (int)(idx % out_features);
+  int col2 = col / 2;
+  half2 v = data_h2[idx2];
+  half2 s = scale_h2[col2];
+  float x0 = __half2float(v.x) * (__half2float(s.x) * scale_mul);
+  float x1 = __half2float(v.y) * (__half2float(s.y) * scale_mul);
+  if (bias) {
+    const half2* bias_h2 = reinterpret_cast<const half2*>(bias);
+    half2 b = bias_h2[col2];
+    x0 += __half2float(b.x);
+    x1 += __half2float(b.y);
+  }
+  // GELU tanh approximation
+  float c = 0.044715f;
+  float y0 = 0.7978845608028654f * (x0 + c * x0 * x0 * x0);
+  float y1 = 0.7978845608028654f * (x1 + c * x1 * x1 * x1);
+  float g0 = 0.5f * x0 * (1.0f + tanhf(y0));
+  float g1 = 0.5f * x1 * (1.0f + tanhf(y1));
+  cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+  fp8_out[idx]     = to_fp8(g0 * inv_output_scale);
+  fp8_out[idx + 1] = to_fp8(g1 * inv_output_scale);
+}
+
+__global__ void col_scale_bias_residual_kernel(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::half_t* __restrict__ residual_inout,
+    const cutlass::half_t* __restrict__ scale,
+    const cutlass::half_t* __restrict__ bias,
+    float scale_mul,
+    int out_features,
+    long long total_elems) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  float acc = __half2float(reinterpret_cast<const half*>(data)[idx]) *
+              (__half2float(reinterpret_cast<const half*>(scale)[col]) * scale_mul);
+  if (bias) {
+    acc += __half2float(reinterpret_cast<const half*>(bias)[col]);
+  }
+  float res = __half2float(reinterpret_cast<half*>(residual_inout)[idx]);
+  reinterpret_cast<half*>(residual_inout)[idx] = __float2half(res + acc);
+}
+
+__global__ void col_scale_residual_bf16_kernel(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::bfloat16_t* __restrict__ residual_inout,
+    const cutlass::half_t* __restrict__ scale,
+    float scale_mul,
+    int out_features,
+    long long total_elems) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  cutlass::NumericConverter<float, cutlass::half_t> half_to_f32;
+  cutlass::NumericConverter<float, cutlass::bfloat16_t> bf16_to_f32;
+  float acc = half_to_f32(data[idx]) * (half_to_f32(scale[col]) * scale_mul);
+  float res = bf16_to_f32(residual_inout[idx]);
+  residual_inout[idx] = cutlass::bfloat16_t(res + acc);
+}
+
+__global__ void col_scale_residual_bf16_vec2_kernel(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::bfloat16_t* __restrict__ residual_inout,
+    const cutlass::half_t* __restrict__ scale,
+    float scale_mul,
+    int out_features,
+    long long total_elems) {
+  long long idx2 = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  long long idx = idx2 * 2;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  int col2 = col / 2;
+  const half2* data_h2 = reinterpret_cast<const half2*>(data);
+  const half2* scale_h2 = reinterpret_cast<const half2*>(scale);
+  half2 v = data_h2[idx2];
+  half2 s = scale_h2[col2];
+  float x0 = __half2float(v.x) * (__half2float(s.x) * scale_mul);
+  float x1 = __half2float(v.y) * (__half2float(s.y) * scale_mul);
+  __nv_bfloat162 r = reinterpret_cast<const __nv_bfloat162*>(residual_inout)[idx2];
+  float2 rf = __bfloat1622float2(r);
+  reinterpret_cast<__nv_bfloat162*>(residual_inout)[idx2] =
+      __floats2bfloat162_rn(rf.x + x0, rf.y + x1);
+}
+
+static bool ptr_aligned_4(const void* ptr) {
+  return (reinterpret_cast<uintptr_t>(ptr) & 0x3) == 0;
+}
+
+cudaError_t apply_col_scale_bias(
+    cutlass::half_t* data,
+    const cutlass::half_t* scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul) {
+  if (scale == nullptr) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  long long total_h2 = total / 2;  // half2 elements
+  int threads = 256;
+  long long blocks = (total_h2 + threads - 1) / threads;
+  col_scale_bias_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(data, scale, bias, scale_mul, out_features, total);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+cudaError_t apply_col_scale_bias_gelu(
+    cutlass::half_t* data,
+    const cutlass::half_t* scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul) {
+  if (scale == nullptr) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  long long total_h2 = total / 2;  // half2 elements
+  int threads = 256;
+  long long blocks = (total_h2 + threads - 1) / threads;
+  col_scale_bias_gelu_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(data, scale, bias, scale_mul, out_features, total);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+cudaError_t apply_col_scale_bias_to_fp8(
+    const cutlass::half_t* data,
+    cutlass::float_e4m3_t* fp8_out,
+    const cutlass::half_t* scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul,
+    float output_scale) {
+  if (scale == nullptr || data == nullptr || fp8_out == nullptr) return cudaErrorInvalidValue;
+  if (!(output_scale > 0.0f) || !std::isfinite(output_scale)) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  int threads = 256;
+  long long blocks = (total + threads - 1) / threads;
+  float inv_output_scale = 1.0f / output_scale;
+  col_scale_bias_to_fp8_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(
+      data, fp8_out, scale, bias, scale_mul, inv_output_scale, out_features, total);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+cudaError_t apply_col_scale_bias_gelu_to_fp8(
+    const cutlass::half_t* data,
+    cutlass::float_e4m3_t* fp8_out,
+    const cutlass::half_t* scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul,
+    float output_scale) {
+  if (scale == nullptr) return cudaErrorInvalidValue;
+  if (!(output_scale > 0.0f) || !std::isfinite(output_scale)) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  long long total_h2 = total / 2;
+  int threads = 256;
+  long long blocks = (total_h2 + threads - 1) / threads;
+  float inv_output_scale = 1.0f / output_scale;
+  col_scale_bias_gelu_to_fp8_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(
+      data, fp8_out, scale, bias, scale_mul, inv_output_scale, out_features, total);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+// GELU + bias kernel (no scaling) - used for per-block INT8 quantization
+__global__ void gelu_bias_kernel(
+    cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ bias,
+    int out_features,
+    long long total_elems) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  float x = __half2float(reinterpret_cast<half*>(data)[idx]);
+  if (bias) {
+    x += __half2float(reinterpret_cast<const half*>(bias)[col]);
+  }
+  // GELU tanh approximation
+  float c = 0.044715f;
+  float y = 0.7978845608028654f * (x + c * x * x * x);
+  float gelu = 0.5f * x * (1.0f + tanhf(y));
+  // Clamp to prevent half overflow
+  gelu = fminf(fmaxf(gelu, -65504.0f), 65504.0f);
+  reinterpret_cast<half*>(data)[idx] = __float2half(gelu);
+}
+
+cudaError_t apply_gelu_bias(
+    cutlass::half_t* data,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream) {
+  long long total = (long long)N * out_features;
+  int threads = 256;
+  long long blocks = (total + threads - 1) / threads;
+  gelu_bias_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(data, bias, out_features, total);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+cudaError_t apply_col_scale_bias_residual(
+    const cutlass::half_t* data,
+    cutlass::half_t* residual_inout,
+    const cutlass::half_t* scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul) {
+  if (scale == nullptr || residual_inout == nullptr) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  int threads = 256;
+  long long blocks = (total + threads - 1) / threads;
+  col_scale_bias_residual_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(data, residual_inout, scale, bias, scale_mul, out_features, total);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+// Simple in-place add kernel: dest += src
+__global__ void add_inplace_kernel(
+    cutlass::half_t* __restrict__ dest,
+    const cutlass::half_t* __restrict__ src,
+    long long total_elems) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  float d = __half2float(reinterpret_cast<half*>(dest)[idx]);
+  float s = __half2float(reinterpret_cast<const half*>(src)[idx]);
+  float result = d + s;
+  // Clamp to prevent half overflow
+  result = fminf(fmaxf(result, -65504.0f), 65504.0f);
+  reinterpret_cast<half*>(dest)[idx] = __float2half(result);
+}
+
+cudaError_t add_inplace_half_rr(
+    cutlass::half_t* dest,
+    const cutlass::half_t* src,
+    long long numel,
+    cudaStream_t stream) {
+  if (dest == nullptr || src == nullptr) return cudaErrorInvalidValue;
+  int threads = 256;
+  long long blocks = (numel + threads - 1) / threads;
+  add_inplace_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(dest, src, numel);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+// ============================================================================
+// INT8 SCALAR-AWARE POST-OPS
+// ============================================================================
+
+__global__ void col_scale_bias_scalar_kernel(
+    cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ weight_scale,
+    const cutlass::half_t* __restrict__ bias,
+    int out_features,
+    long long total_elems,
+    const float* __restrict__ act_scale_dev) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  // act_scale_dev stores activation absmax. Convert to scale = amax/127 with clamp.
+  // NOTE: GEMM output is scaled by 1/127^2 to prevent half overflow, so we need
+  // to compensate by multiplying by 127^2 here. Combined with act_scale and
+  // weight_scale (both are amax/127), we get: 127^2 * (amax_a/127) * (amax_b/127) = amax_a * amax_b.
+  float amax = *act_scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  // Multiply by amax directly (not amax/127) to compensate for GEMM's 1/127^2 scaling
+  float ws = weight_scale ? __half2float(reinterpret_cast<const half*>(weight_scale)[col]) * 127.0f : 1.0f;
+  float b = bias ? __half2float(reinterpret_cast<const half*>(bias)[col]) : 0.0f;
+  float v = __half2float(reinterpret_cast<half*>(data)[idx]);
+  float result = v * (amax * ws) + b;
+  // Clamp to half range to prevent overflow
+  result = fminf(fmaxf(result, -65504.0f), 65504.0f);
+  reinterpret_cast<half*>(data)[idx] = __float2half(result);
+}
+
+__global__ void col_scale_bias_scalar_kernel_h2(
+    cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ weight_scale,
+    const cutlass::half_t* __restrict__ bias,
+    int out_features,
+    long long total_pairs,
+    const float* __restrict__ act_scale_dev) {
+  long long pair_idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (pair_idx >= total_pairs) return;
+
+  // out_features is even for this kernel (enforced by caller), so half2 pairs never cross rows.
+  int col0 = int((pair_idx * 2) % out_features);
+
+  // NOTE: GEMM output is scaled by 1/127^2 to prevent half overflow, so we need
+  // to compensate by multiplying by 127^2 here. Combined with act_scale and
+  // weight_scale (both are amax/127), we get: 127^2 * (amax_a/127) * (amax_b/127) = amax_a * amax_b.
+  float amax = *act_scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  // Use amax directly (not amax/127) to compensate for GEMM's 1/127^2 scaling
+
+  half2 v2 = reinterpret_cast<half2*>(data)[pair_idx];
+  float2 vf = __half22float2(v2);
+
+  float2 wf;
+  if (weight_scale) {
+    half2 w2 = *reinterpret_cast<const half2*>(reinterpret_cast<const half*>(weight_scale) + col0);
+    wf = __half22float2(w2);
+    // Multiply weight_scale by 127 to compensate for GEMM's 1/127^2 scaling
+    wf.x *= 127.0f;
+    wf.y *= 127.0f;
+  } else {
+    wf.x = 1.0f; wf.y = 1.0f;
+  }
+
+  float2 bf;
+  if (bias) {
+    half2 b2 = *reinterpret_cast<const half2*>(reinterpret_cast<const half*>(bias) + col0);
+    bf = __half22float2(b2);
+  } else {
+    bf.x = 0.0f; bf.y = 0.0f;
+  }
+
+  vf.x = vf.x * (amax * wf.x) + bf.x;
+  vf.y = vf.y * (amax * wf.y) + bf.y;
+  // Clamp to half range to prevent overflow
+  vf.x = fminf(fmaxf(vf.x, -65504.0f), 65504.0f);
+  vf.y = fminf(fmaxf(vf.y, -65504.0f), 65504.0f);
+
+  reinterpret_cast<half2*>(data)[pair_idx] = __floats2half2_rn(vf.x, vf.y);
+}
+
+cudaError_t apply_col_scale_bias_scalar(
+    cutlass::half_t* data,
+    const cutlass::half_t* weight_scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    const float* act_scale_dev) {
+  if (data == nullptr || act_scale_dev == nullptr) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  int threads = 256;
+
+  // Fast path: half2 on data/scale/bias when out_features is even (no row-crossing) and pointers are 4-byte aligned.
+  bool even_out = ((out_features & 1) == 0);
+  uintptr_t data_u = reinterpret_cast<uintptr_t>(data);
+  bool aligned = ((data_u & 3u) == 0u);
+  if (even_out && aligned) {
+    long long total_pairs = total / 2;
+    long long blocks = (total_pairs + threads - 1) / threads;
+    col_scale_bias_scalar_kernel_h2<<<(unsigned int)blocks, threads, 0, stream>>>(
+        data, weight_scale, bias, out_features, total_pairs, act_scale_dev);
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+  }
+
+  long long blocks = (total + threads - 1) / threads;
+  col_scale_bias_scalar_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(
+      data, weight_scale, bias, out_features, total, act_scale_dev);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+__global__ void col_scale_bias_gelu_scalar_kernel(
+    cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ weight_scale,
+    const cutlass::half_t* __restrict__ bias,
+    int out_features,
+    long long total_elems,
+    const float* __restrict__ act_scale_dev) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  // NOTE: GEMM output is scaled by 1/127^2 to prevent half overflow.
+  // Compensate by multiplying weight_scale by 127 and using amax directly.
+  float amax = *act_scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  float ws = weight_scale ? __half2float(reinterpret_cast<const half*>(weight_scale)[col]) * 127.0f : 1.0f;
+  float b = bias ? __half2float(reinterpret_cast<const half*>(bias)[col]) : 0.0f;
+  float v = __half2float(reinterpret_cast<half*>(data)[idx]);
+  float x = v * (amax * ws) + b;
+  float c = 0.044715f;
+  float y = 0.7978845608028654f * (x + c * x * x * x);
+  float gelu = 0.5f * x * (1.0f + tanhf(y));
+  // Clamp to half range to prevent overflow
+  gelu = fminf(fmaxf(gelu, -65504.0f), 65504.0f);
+  reinterpret_cast<half*>(data)[idx] = __float2half(gelu);
+}
+
+__global__ void col_scale_bias_gelu_scalar_kernel_h2(
+    cutlass::half_t* __restrict__ data,
+    const cutlass::half_t* __restrict__ weight_scale,
+    const cutlass::half_t* __restrict__ bias,
+    int out_features,
+    long long total_pairs,
+    const float* __restrict__ act_scale_dev) {
+  long long pair_idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (pair_idx >= total_pairs) return;
+  int col0 = int((pair_idx * 2) % out_features);
+
+  // NOTE: GEMM output is scaled by 1/127^2 to prevent half overflow.
+  // Compensate by multiplying weight_scale by 127 and using amax directly.
+  float amax = *act_scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+
+  half2 v2 = reinterpret_cast<half2*>(data)[pair_idx];
+  float2 vf = __half22float2(v2);
+
+  float2 wf;
+  if (weight_scale) {
+    half2 w2 = *reinterpret_cast<const half2*>(reinterpret_cast<const half*>(weight_scale) + col0);
+    wf = __half22float2(w2);
+    wf.x *= 127.0f;
+    wf.y *= 127.0f;
+  } else {
+    wf.x = 1.0f; wf.y = 1.0f;
+  }
+
+  float2 bf;
+  if (bias) {
+    half2 b2 = *reinterpret_cast<const half2*>(reinterpret_cast<const half*>(bias) + col0);
+    bf = __half22float2(b2);
+  } else {
+    bf.x = 0.0f; bf.y = 0.0f;
+  }
+
+  // Apply scale+bias then GELU elementwise.
+  float x0 = vf.x * (amax * wf.x) + bf.x;
+  float x1 = vf.y * (amax * wf.y) + bf.y;
+
+  float c = 0.044715f;
+  float y0 = 0.7978845608028654f * (x0 + c * x0 * x0 * x0);
+  float y1 = 0.7978845608028654f * (x1 + c * x1 * x1 * x1);
+  float g0 = 0.5f * x0 * (1.0f + tanhf(y0));
+  float g1 = 0.5f * x1 * (1.0f + tanhf(y1));
+  // Clamp to half range to prevent overflow
+  g0 = fminf(fmaxf(g0, -65504.0f), 65504.0f);
+  g1 = fminf(fmaxf(g1, -65504.0f), 65504.0f);
+
+  reinterpret_cast<half2*>(data)[pair_idx] = __floats2half2_rn(g0, g1);
+}
+
+cudaError_t apply_col_scale_bias_gelu_scalar(
+    cutlass::half_t* data,
+    const cutlass::half_t* weight_scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    const float* act_scale_dev) {
+  if (data == nullptr || act_scale_dev == nullptr) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  int threads = 256;
+
+  bool even_out = ((out_features & 1) == 0);
+  uintptr_t data_u = reinterpret_cast<uintptr_t>(data);
+  bool aligned = ((data_u & 3u) == 0u);
+  if (even_out && aligned) {
+    long long total_pairs = total / 2;
+    long long blocks = (total_pairs + threads - 1) / threads;
+    col_scale_bias_gelu_scalar_kernel_h2<<<(unsigned int)blocks, threads, 0, stream>>>(
+        data, weight_scale, bias, out_features, total_pairs, act_scale_dev);
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+  }
+
+  long long blocks = (total + threads - 1) / threads;
+  col_scale_bias_gelu_scalar_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(
+      data, weight_scale, bias, out_features, total, act_scale_dev);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+__global__ void col_scale_bias_residual_scalar_kernel(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::half_t* __restrict__ residual_inout,
+    const cutlass::half_t* __restrict__ weight_scale,
+    const cutlass::half_t* __restrict__ bias,
+    int out_features,
+    long long total_elems,
+    const float* __restrict__ act_scale_dev) {
+  long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_elems) return;
+  int col = (int)(idx % out_features);
+  // NOTE: GEMM output is scaled by 1/127^2 to prevent half overflow.
+  // Compensate by multiplying weight_scale by 127 and using amax directly.
+  float amax = *act_scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+  float ws = weight_scale ? __half2float(reinterpret_cast<const half*>(weight_scale)[col]) * 127.0f : 1.0f;
+  float b = bias ? __half2float(reinterpret_cast<const half*>(bias)[col]) : 0.0f;
+  float v = __half2float(reinterpret_cast<const half*>(data)[idx]);
+  float acc = v * (amax * ws) + b;
+  float res = __half2float(reinterpret_cast<half*>(residual_inout)[idx]);
+  float result = res + acc;
+  // Clamp to half range to prevent overflow
+  result = fminf(fmaxf(result, -65504.0f), 65504.0f);
+  reinterpret_cast<half*>(residual_inout)[idx] = __float2half(result);
+}
+
+__global__ void col_scale_bias_residual_scalar_kernel_h2(
+    const cutlass::half_t* __restrict__ data,
+    cutlass::half_t* __restrict__ residual_inout,
+    const cutlass::half_t* __restrict__ weight_scale,
+    const cutlass::half_t* __restrict__ bias,
+    int out_features,
+    long long total_pairs,
+    const float* __restrict__ act_scale_dev) {
+  long long pair_idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+  if (pair_idx >= total_pairs) return;
+  int col0 = int((pair_idx * 2) % out_features);
+
+  // NOTE: GEMM output is scaled by 1/127^2 to prevent half overflow.
+  // Compensate by multiplying weight_scale by 127 and using amax directly.
+  float amax = *act_scale_dev;
+  amax = fmaxf(amax, 127.0f * 1.0e-6f);
+
+  half2 v2 = reinterpret_cast<const half2*>(data)[pair_idx];
+  float2 vf = __half22float2(v2);
+
+  half2 r2 = reinterpret_cast<half2*>(residual_inout)[pair_idx];
+  float2 rf = __half22float2(r2);
+
+  float2 wf;
+  if (weight_scale) {
+    half2 w2 = *reinterpret_cast<const half2*>(reinterpret_cast<const half*>(weight_scale) + col0);
+    wf = __half22float2(w2);
+    wf.x *= 127.0f;
+    wf.y *= 127.0f;
+  } else {
+    wf.x = 1.0f; wf.y = 1.0f;
+  }
+
+  float2 bf;
+  if (bias) {
+    half2 b2 = *reinterpret_cast<const half2*>(reinterpret_cast<const half*>(bias) + col0);
+    bf = __half22float2(b2);
+  } else {
+    bf.x = 0.0f; bf.y = 0.0f;
+  }
+
+  rf.x = rf.x + (vf.x * (amax * wf.x) + bf.x);
+  rf.y = rf.y + (vf.y * (amax * wf.y) + bf.y);
+  // Clamp to half range to prevent overflow
+  rf.x = fminf(fmaxf(rf.x, -65504.0f), 65504.0f);
+  rf.y = fminf(fmaxf(rf.y, -65504.0f), 65504.0f);
+  reinterpret_cast<half2*>(residual_inout)[pair_idx] = __floats2half2_rn(rf.x, rf.y);
+}
+
+cudaError_t apply_col_scale_bias_residual_scalar(
+    const cutlass::half_t* data,
+    cutlass::half_t* residual_inout,
+    const cutlass::half_t* weight_scale,
+    const cutlass::half_t* bias,
+    int N, int out_features,
+    cudaStream_t stream,
+    const float* act_scale_dev) {
+  if (data == nullptr || residual_inout == nullptr || act_scale_dev == nullptr) return cudaErrorInvalidValue;
+  long long total = (long long)N * out_features;
+  int threads = 256;
+
+  bool even_out = ((out_features & 1) == 0);
+  uintptr_t data_u = reinterpret_cast<uintptr_t>(data);
+  uintptr_t res_u = reinterpret_cast<uintptr_t>(residual_inout);
+  bool aligned = ((data_u & 3u) == 0u) && ((res_u & 3u) == 0u);
+  if (even_out && aligned) {
+    long long total_pairs = total / 2;
+    long long blocks = (total_pairs + threads - 1) / threads;
+    col_scale_bias_residual_scalar_kernel_h2<<<(unsigned int)blocks, threads, 0, stream>>>(
+        data, residual_inout, weight_scale, bias, out_features, total_pairs, act_scale_dev);
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+  }
+
+  long long blocks = (total + threads - 1) / threads;
+  col_scale_bias_residual_scalar_kernel<<<(unsigned int)blocks, threads, 0, stream>>>(
+      data, residual_inout, weight_scale, bias, out_features, total, act_scale_dev);
+  CUDA_CHECK(cudaGetLastError());
+  return cudaSuccess;
+}
+
+// ============================================================================
+// INT8 FUSED GEMM WITH SCALE+BIAS VIA CUSTOM EPILOGUE
+// ============================================================================
+
+namespace {
+
+// Epilogue output operator for broadcast GEMM that applies:
+//   out = (act * weight_scale) * accum + beta * C
+// where:
+// - act is derived from a device scalar holding activation absmax (amax): act = max(amax/127, 1e-6)
+// - weight_scale is provided via the broadcast vector V
+// - C is optionally used for bias via stride trick (ldc=0 broadcasts bias)
+template <typename ElementOutput_, int ElementsPerAccess, typename ElementAccumulator_, typename ElementCompute_>
+class LinearCombinationActScaleAmaxPtrTimesVectorPlusC {
+public:
+  using ElementOutput = ElementOutput_;
+  using ElementD = ElementOutput;
+  using ElementC = cutlass::half_t;
+  using ElementAccumulator = ElementAccumulator_;
+  using ElementCompute = ElementCompute_;
+  using ElementScalar = ElementCompute;
+
+  // Broadcast vector element (weight_scale)
+  using ElementVector = cutlass::half_t;
+
+  // Secondary tensor type unused (required by DefaultEpilogueWithBroadcastTensorOp)
+  using ElementZ = ElementOutput;
+  using ElementT = ElementOutput;
+
+  static int const kElementsPerAccess = ElementsPerAccess;
+  static int const kCount = kElementsPerAccess;
+  // EpilogueWithBroadcast has separate implementations for single-source and dual-source.
+  // We only use a single source tensor (C) plus one broadcast vector (V).
+  static bool const kIsSingleSource = true;
+  static bool const kStoreZ = true;
+  static bool const kStoreT = false;
+
+  using FragmentAccumulator = cutlass::Array<ElementAccumulator, kElementsPerAccess>;
+  using FragmentCompute = cutlass::Array<ElementCompute, kElementsPerAccess>;
+  using FragmentC = cutlass::Array<ElementC, kElementsPerAccess>;
+  using FragmentVector = cutlass::Array<ElementVector, kElementsPerAccess>;
+  using FragmentZ = cutlass::Array<ElementZ, kElementsPerAccess>;
+  using FragmentT = cutlass::Array<ElementT, kElementsPerAccess>;
+
+  struct Params {
+    ElementCompute beta;             // scales source tensor C (bias)
+    ElementCompute const* amax_ptr;  // device pointer to activation absmax (amax)
+
+    CUTLASS_HOST_DEVICE
+    Params() : beta(ElementCompute(0)), amax_ptr(nullptr) {}
+
+    CUTLASS_HOST_DEVICE
+    Params(ElementCompute beta_, ElementCompute const* amax_ptr_)
+        : beta(beta_), amax_ptr(amax_ptr_) {}
+  };
+
+private:
+  ElementCompute beta_;
+  ElementCompute const* amax_ptr_;
+
+public:
+  CUTLASS_HOST_DEVICE
+  LinearCombinationActScaleAmaxPtrTimesVectorPlusC(Params const& params)
+      : beta_(params.beta), amax_ptr_(params.amax_ptr) {}
+
+  CUTLASS_HOST_DEVICE
+  bool is_source_needed() const { return beta_ != ElementCompute(0); }
+
+  CUTLASS_HOST_DEVICE
+  void set_k_partition(int, int) {}
+
+  CUTLASS_HOST_DEVICE
+  void operator()(
+      FragmentZ& frag_Z,
+      FragmentT&,
+      FragmentAccumulator const& AB,
+      FragmentC const& frag_C,
+      FragmentCompute const& V) const {
+    // amax_ptr_ points to device scalar, but CUTLASS will dereference it on device.
+    ElementCompute amax = (amax_ptr_ ? *amax_ptr_ : ElementCompute(0));
+    amax = amax < ElementCompute(127.0f * 1.0e-6f) ? ElementCompute(127.0f * 1.0e-6f) : amax;
+    // The INT8 GEMM accumulator is A_int8 @ B_int8, where:
+    //   A_int8 = A_half * 127 / amax_a, B_int8 = B_half * 127 / amax_b
+    // So: A_half @ B_half = accum * amax_a * amax_b / 127^2 = accum * amax * V / 127
+    // where V = weight_scale = amax_b / 127
+    //
+    // IMPORTANT: Scale the accumulator FIRST to prevent overflow in intermediate results.
+    // The accumulator can be very large (up to 127*127*K ≈ 144M for K=8960).
+    // Computing (accum * amax * V) before dividing would overflow.
+    // Instead: (accum / 127) * amax * V keeps values in range.
+    constexpr ElementCompute kInv127 = ElementCompute(1.0f / 127.0f);
+
+    FragmentCompute tmp_Accum =
+        cutlass::NumericArrayConverter<ElementCompute, ElementAccumulator, kElementsPerAccess>()(AB);
+    FragmentCompute tmp_C =
+        cutlass::NumericArrayConverter<ElementCompute, ElementC, kElementsPerAccess>()(frag_C);
+
+    FragmentCompute result;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < kElementsPerAccess; ++i) {
+      // V[i] is weight_scale = amax_b / 127
+      // Scale accumulator first to prevent overflow: (accum / 127) * amax * V
+      ElementCompute scaled_accum = tmp_Accum[i] * kInv127;
+      ElementCompute y = (scaled_accum * amax * V[i]) + (beta_ * tmp_C[i]);
+      result[i] = y;
+    }
+
+    cutlass::NumericArrayConverter<ElementZ, ElementCompute, kElementsPerAccess> convert_z;
+    frag_Z = convert_z(result);
+  }
+
+  CUTLASS_HOST_DEVICE
+  void operator()(
+      FragmentZ& frag_Z,
+      FragmentT& frag_T,
+      FragmentAccumulator const& AB,
+      FragmentCompute const& V) const {
+    // No source C
+    FragmentC zeros;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < kElementsPerAccess; ++i) {
+      zeros[i] = ElementC(0);
+    }
+    (*this)(frag_Z, frag_T, AB, zeros, V);
+  }
+};
+
+} // namespace
+
+cudaError_t cutlass_linear_layer_rcr_int8_scale_bias_dev_amax(
+    const int8_t* input_row,
+    const int8_t* weight_int8,
+    const cutlass::half_t* weight_scale,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    const float* activation_amax_dev) {
+
+  if (input_row == nullptr || weight_int8 == nullptr || weight_scale == nullptr || output_row == nullptr ||
+      activation_amax_dev == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+
+  using ElementInputA = int8_t;
+  using ElementInputB = int8_t;
+  using ElementOutput = cutlass::half_t;
+  using ElementAccumulator = int32_t;
+  using ElementCompute = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+
+  constexpr int kElementsPerAccess = 8;
+
+  using EpilogueOp = LinearCombinationActScaleAmaxPtrTimesVectorPlusC<
+      ElementOutput, kElementsPerAccess, ElementAccumulator, ElementCompute>;
+
+  using DefaultConfig = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalWithBroadcast<
+      ElementInputA, LayoutA,
+      ElementInputB, LayoutB,
+      ElementOutput, LayoutC,
+      ElementAccumulator,
+      cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<128, 128, 64>,
+      DefaultConfig::WarpShape,
+      DefaultConfig::InstructionShape,
+      EpilogueOp,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+      DefaultConfig::kStages,
+      DefaultConfig::kAlignmentA,
+      DefaultConfig::kAlignmentB>;
+
+  Gemm gemm_op;
+
+  // Bias via stride trick: C points to bias vector, ldc=0 broadcasts across rows.
+  const cutlass::half_t* c_ptr = bias ? bias : output_row;
+  int64_t ldc = bias ? int64_t(0) : int64_t(out_features);
+  float beta = bias ? 1.0f : 0.0f;
+
+  typename EpilogueOp::Params epilogue_params(beta, activation_amax_dev);
+
+  Gemm::Arguments args(
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {N, out_features, in_features},
+      1,
+      epilogue_params,
+      input_row,
+      weight_int8,
+      c_ptr,
+      output_row,
+      const_cast<cutlass::half_t*>(weight_scale),
+      nullptr,
+      int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0),
+      int64_t(in_features), int64_t(in_features),
+      ldc,
+      int64_t(out_features),
+      int64_t(0),  // ldr=0 broadcasts weight_scale across rows
+      int64_t(0));
+
+  cutlass::Status status = gemm_op.initialize(args, nullptr);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+  status = gemm_op(stream);
+  if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+
+  return cudaSuccess;
+}
+
+// FP8 A/B with fused residual + optional bias addition, Row-major output (half)
+cudaError_t cutlass_linear_layer_rcr_fp8_fused_residual(
+    const cutlass::float_e4m3_t* input_row,   // Row-major [N, in_features] FP8
+    const cutlass::float_e4m3_t* weight_fp8,  // Column-major [in_features, out_features] FP8
+    const cutlass::half_t* bias,              // [out_features] half or nullptr
+    cutlass::half_t* residual_inout,          // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    using ElementInputA = cutlass::float_e4m3_t;
+    using ElementInputB = cutlass::float_e4m3_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    constexpr int kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationResidualBlock<
+        ElementOutput, ElementAccumulator, ElementCompute, ElementOutput,
+        kElementsPerAccess,
+        cutlass::epilogue::thread::Identity,   // activation on (AB + residual + bias)
+        cutlass::plus,                         // residual add
+        cutlass::epilogue::thread::Identity    // bias identity
+    >;
+
+    using DefaultConfig = cutlass::gemm::device::DefaultGemmConfiguration<
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm89,
+        ElementInputA, ElementInputB, ElementOutput,
+        ElementAccumulator>;
+
+    using Gemm = cutlass::gemm::device::GemmUniversalWithBroadcast<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm89,
+        cutlass::gemm::GemmShape<128, 64, 128>,
+        DefaultConfig::WarpShape,
+        DefaultConfig::InstructionShape,
+        EpilogueOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        DefaultConfig::kStages,
+        DefaultConfig::kAlignmentA,
+        DefaultConfig::kAlignmentB
+    >;
+
+    Gemm gemm_op;
+
+    Gemm::Arguments args(
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {N, out_features, in_features},
+        1,  // batch_count
+        {ElementCompute(1.0f), ElementCompute(1.0f)},   // {alpha, beta} where beta applies residual
+        input_row,
+        weight_fp8,
+        residual_inout,                                  // C = residual
+        residual_inout,                                  // D = residual (in-place)
+        const_cast<cutlass::half_t*>(bias),
+        nullptr,                                         // ptr_Tensor
+        int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0),
+        int64_t(in_features), int64_t(in_features),      // lda, ldb (B is ColumnMajor, ldb=in_features)
+        int64_t(out_features),                           // ldc (residual)
+        int64_t(out_features),                           // ldd (output)
+        int64_t(0),                                      // ldr: 0 => broadcast bias
+        int64_t(0)
+    );
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+
+    return cudaSuccess;
+}
+
+// INT8 A/B with fused residual + optional bias addition, Row-major output (half)
+cudaError_t cutlass_linear_layer_rcr_int8_fused_residual(
+    const int8_t* input_row,              // Row-major [N, in_features] INT8
+    const int8_t* weight_int8,            // Column-major [in_features, out_features] INT8
+    const cutlass::half_t* bias,          // [out_features] half or nullptr
+    cutlass::half_t* residual_inout,      // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float activation_scale) {
+
+    using ElementInputA = int8_t;
+    using ElementInputB = int8_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = int32_t;
+    using ElementCompute = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    constexpr int kElementsPerAccess = 8;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationResidualBlock<
+        ElementOutput, ElementAccumulator, ElementCompute, ElementOutput,
+        kElementsPerAccess,
+        cutlass::epilogue::thread::Identity,
+        cutlass::plus,
+        cutlass::epilogue::thread::Identity
+    >;
+
+    using DefaultConfig = cutlass::gemm::device::DefaultGemmConfiguration<
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        ElementInputA, ElementInputB, ElementOutput,
+        ElementAccumulator>;
+
+    using Gemm = cutlass::gemm::device::GemmUniversalWithBroadcast<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 64>,
+        DefaultConfig::WarpShape,
+        DefaultConfig::InstructionShape,
+        EpilogueOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        DefaultConfig::kStages,
+        DefaultConfig::kAlignmentA,
+        DefaultConfig::kAlignmentB
+    >;
+
+    Gemm gemm_op;
+
+    Gemm::Arguments args(
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {N, out_features, in_features},
+        1,
+        {ElementCompute(activation_scale), ElementCompute(1.0f)},
+        input_row,
+        weight_int8,
+        residual_inout,
+        residual_inout,
+        const_cast<cutlass::half_t*>(bias),
+        nullptr,
+        int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0),
+        int64_t(in_features), int64_t(in_features),
+        int64_t(out_features),
+        int64_t(out_features),
+        int64_t(0),
+        int64_t(0)
+    );
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+
+    return cudaSuccess;
+}
+
+// Row-major A/B/C path with stride-trick bias fusion
+cudaError_t cutlass_linear_layer_rrr(
+    const half* input_row,         // Row-major [N, in_features]
+    const half* weight_row,        // Row-major [in_features, out_features]
+    const half* bias,              // [out_features] or nullptr
+    half* output_row,              // Row-major [N, out_features]
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    const cutlass::half_t* c_ptr = bias ? reinterpret_cast<const cutlass::half_t*>(bias) : reinterpret_cast<const cutlass::half_t*>(output_row);
+    int ldc = bias ? 0 : out_features;
+    cutlass::half_t beta = bias ? cutlass::half_t(1.0f) : cutlass::half_t(0.0f);
+
+    const cutlass::half_t* input_ptr = reinterpret_cast<const cutlass::half_t*>(input_row);
+    const cutlass::half_t* weight_ptr = reinterpret_cast<const cutlass::half_t*>(weight_row);
+    cutlass::half_t* output_ptr = reinterpret_cast<cutlass::half_t*>(output_row);
+
+    cutlass::Status status;
+
+    // Choose tile size based on M dimension for better occupancy
+    // Threshold is configurable via set_gemm_tile_threshold()
+    if (N < g_gemm_tile_threshold) {
+        // Small-M: 128x128x32 for reasonable tile coverage
+        using Gemm = cutlass::gemm::device::Gemm<
+            ElementInputA, LayoutA, ElementInputB, LayoutB, ElementOutput, LayoutC, ElementAccumulator,
+            cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+            cutlass::gemm::GemmShape<128, 128, 32>, cutlass::gemm::GemmShape<64, 64, 32>, cutlass::gemm::GemmShape<16, 8, 16>>;
+        Gemm gemm_op;
+        Gemm::Arguments args({N, out_features, in_features}, {input_ptr, in_features}, {weight_ptr, out_features},
+                             {c_ptr, ldc}, {output_ptr, out_features}, {cutlass::half_t(1.0f), beta});
+        status = gemm_op.initialize(args, nullptr);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        status = gemm_op(stream);
+    } else {
+        // Large-M: 256x128x32 matches PyTorch/cuBLAS optimal configuration
+        // This produces 4x fewer threadblocks than 128x64x64, improving occupancy
+        using Gemm = cutlass::gemm::device::Gemm<
+            ElementInputA, LayoutA, ElementInputB, LayoutB, ElementOutput, LayoutC, ElementAccumulator,
+            cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+            cutlass::gemm::GemmShape<256, 128, 32>, cutlass::gemm::GemmShape<64, 64, 32>, cutlass::gemm::GemmShape<16, 8, 16>>;
+        Gemm gemm_op;
+        Gemm::Arguments args({N, out_features, in_features}, {input_ptr, in_features}, {weight_ptr, out_features},
+                             {c_ptr, ldc}, {output_ptr, out_features}, {cutlass::half_t(1.0f), beta});
+        status = gemm_op.initialize(args, nullptr);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        status = gemm_op(stream);
+    }
+
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+// Row-major GEMM with explicit output leading dimension (row-major stride)
+cudaError_t cutlass_linear_layer_rrr_strided(
+    const half* input_row,         // Row-major [N, in_features]
+    const half* weight_row,        // Row-major [in_features, out_features]
+    const half* bias,              // [out_features] or nullptr
+    half* output_row,              // Row-major with leading dim ld_out
+    int N, int in_features, int out_features,
+    int ld_out,
+    cudaStream_t stream) {
+    if (N <= 0) return cudaSuccess;
+    if (ld_out < out_features) return cudaErrorInvalidValue;
+
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    const cutlass::half_t* c_ptr = bias ? reinterpret_cast<const cutlass::half_t*>(bias)
+                                        : reinterpret_cast<const cutlass::half_t*>(output_row);
+    int ldc = bias ? 0 : ld_out;
+    cutlass::half_t beta = bias ? cutlass::half_t(1.0f) : cutlass::half_t(0.0f);
+
+    const cutlass::half_t* input_ptr = reinterpret_cast<const cutlass::half_t*>(input_row);
+    const cutlass::half_t* weight_ptr = reinterpret_cast<const cutlass::half_t*>(weight_row);
+    cutlass::half_t* output_ptr = reinterpret_cast<cutlass::half_t*>(output_row);
+
+    cutlass::Status status;
+
+    // Match the tile selection heuristic from cutlass_linear_layer_rrr()
+    if (N < 1024) {
+        using Gemm = cutlass::gemm::device::Gemm<
+            ElementInputA, LayoutA, ElementInputB, LayoutB, ElementOutput, LayoutC, ElementAccumulator,
+            cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+            cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<32, 32, 64>, cutlass::gemm::GemmShape<16, 8, 16>>;
+        Gemm gemm_op;
+        Gemm::Arguments args({N, out_features, in_features},
+                             {input_ptr, in_features},
+                             {weight_ptr, out_features},
+                             {c_ptr, ldc},
+                             {output_ptr, ld_out},
+                             {cutlass::half_t(1.0f), beta});
+        status = gemm_op.initialize(args, nullptr);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        status = gemm_op(stream);
+    } else {
+        using Gemm = cutlass::gemm::device::Gemm<
+            ElementInputA, LayoutA, ElementInputB, LayoutB, ElementOutput, LayoutC, ElementAccumulator,
+            cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+            cutlass::gemm::GemmShape<128, 64, 64>, cutlass::gemm::GemmShape<64, 32, 64>, cutlass::gemm::GemmShape<16, 8, 16>>;
+        Gemm gemm_op;
+        Gemm::Arguments args({N, out_features, in_features},
+                             {input_ptr, in_features},
+                             {weight_ptr, out_features},
+                             {c_ptr, ldc},
+                             {output_ptr, ld_out},
+                             {cutlass::half_t(1.0f), beta});
+        status = gemm_op.initialize(args, nullptr);
+        if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        status = gemm_op(stream);
+    }
+
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+// Row-major GEMM with fused residual + bias addition
+// Computes: residual = (A @ B + bias) + residual
+// Uses CUTLASS GemmUniversalWithBroadcast to fuse bias and residual in epilogue
+cudaError_t cutlass_linear_layer_rrr_fused_residual(
+    const half* input_row,         // Row-major [N, in_features]
+    const half* weight_row,        // Row-major [in_features, out_features]
+    const half* bias,              // [out_features] or nullptr
+    half* residual_inout,          // Row-major [N, out_features] - input and output
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+
+    constexpr int kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+    // LinearCombinationResidualBlock epilogue computes: output = (AB + residual) + bias
+    // Uses Identity functors (no activation) and plus for residual addition.
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationResidualBlock<
+        ElementOutput, ElementAccumulator, ElementCompute, ElementOutput,
+        kElementsPerAccess,
+        cutlass::epilogue::thread::Identity,
+        cutlass::plus,
+        cutlass::epilogue::thread::Identity
+    >;
+
+    // Use sm_80 configuration, because it's the only one defined that supports tensor operations.
+    using DefaultConfig = cutlass::gemm::device::DefaultGemmConfiguration<
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        ElementInputA, ElementInputB, ElementOutput,
+        ElementAccumulator>;
+
+    // Use 256x128x32 tiles to match PyTorch/cuBLAS optimal configuration
+    // Note: 128x256x64 caused launch errors, but 256x128x32 should work
+    using Gemm = cutlass::gemm::device::GemmUniversalWithBroadcast<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<256, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        EpilogueOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        DefaultConfig::kStages,
+        DefaultConfig::kAlignmentA,
+        DefaultConfig::kAlignmentB
+    >;
+
+    Gemm gemm_op;
+
+    Gemm::Arguments args(
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {N, out_features, in_features},
+        1,  // batch_count
+        {ElementCompute(1.0f), ElementCompute(1.0f)},   // {alpha, beta}
+        input_row,
+        weight_row,
+        residual_inout,                                 // C = residual
+        residual_inout,                                 // D = residual (in-place)
+        const_cast<half*>(bias),
+        nullptr,                                        // ptr_Tensor
+        int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0), int64_t(0),
+        int64_t(in_features), int64_t(out_features), int64_t(out_features),
+        int64_t(out_features),
+        int64_t(0),                                     // ldr: stride=0 broadcasts bias
+        int64_t(0)
+    );
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+
+    return cudaSuccess;
+}
+
+// Row-major GEMM with fused SiLU activation
+// Computes: D = SiLU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rrr_silu(
+    const half* input_row,         // Row-major [N, in_features]
+    const half* weight_row,        // Row-major [in_features, out_features]
+    const half* bias,              // [out_features] or nullptr
+    half* output_row,              // Row-major [N, out_features]
+    int N, int in_features, int out_features,
+    cudaStream_t stream) {
+
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::RowMajor;
+    using LayoutC = cutlass::layout::RowMajor;
+    int const kElementsPerAccess = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+    using EpilogueOp = cutlass::epilogue::thread::LinearCombinationSilu<
+        ElementOutput,
+        kElementsPerAccess,
+        ElementAccumulator,
+        float
+    >;
+
+    // Use 256x128x32 tiles to match PyTorch/cuBLAS optimal configuration
+    using Gemm = cutlass::gemm::device::Gemm<
+        ElementInputA, LayoutA,
+        ElementInputB, LayoutB,
+        ElementOutput, LayoutC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<256, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        EpilogueOp
+    >;
+
+    Gemm gemm_op;
+
+    // Use stride-trick for bias: provide bias as C with stride 0
+    typename Gemm::Arguments args(
+        {N, out_features, in_features},
+        {reinterpret_cast<const cutlass::half_t*>(input_row), in_features},
+        {reinterpret_cast<const cutlass::half_t*>(weight_row), out_features},
+        {reinterpret_cast<const cutlass::half_t*>(bias), 0},  // Bias with stride 0
+        {reinterpret_cast<cutlass::half_t*>(output_row), out_features},
+        {1.0f, 1.0f}  // alpha=1, beta=1 for bias addition before SiLU
+    );
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+
+    return cudaSuccess;
+}
+
+/**
+ * Timestep MLP: Linear1 -> SiLU -> Linear2
+ * REFERENCE: TimestepEmbedding in embeddings.py
+ */
+cudaError_t timestep_mlp_projection(
+    const half* input,              // [N, freq_dim] row-major
+    half* output,                   // [N, proj_dim] row-major
+    const half* w1_col, const half* b1,  // w1: [freq_dim, hidden_dim] ROW-major (PyTorch tensor)
+    const half* w2_col, const half* b2,  // w2: [hidden_dim, proj_dim] ROW-major (PyTorch tensor)
+    half* hidden_buffer,            // [N, hidden_dim] workspace buffer
+    int N, int freq_dim, int hidden_dim, int proj_dim,
+    cudaStream_t stream) {
+
+    if (N <= 0) {
+        return cudaSuccess;
+    }
+
+    // Stage 1: RowMajor GEMM with fused SiLU activation -> hidden_buffer
+    cudaError_t err = cutlass_linear_layer_rrr_silu(
+        input,
+        w1_col,
+        b1,
+        hidden_buffer,
+        N,
+        freq_dim,
+        hidden_dim,
+        stream);
+    if (err != cudaSuccess) {
+        return err;
+    }
+
+    // Stage 2: RowMajor GEMM with stride-trick bias directly into output
+    err = cutlass_linear_layer_rrr(
+        hidden_buffer,
+        w2_col,
+        b2,
+        output,
+        N,
+        hidden_dim,
+        proj_dim,
+        stream);
+
+    if (err != cudaSuccess) {
+        return err;
+    }
+
+    return cudaSuccess;
+}
+
+// ============================================================================
+// TEXT PROJECTION
+// REFERENCE: HuggingFace embeddings.py - PixArtAlphaTextProjection
+// Structure: Linear (+ optional LayerNorm + act_fn)
+// ============================================================================
+
+/**
+ * LayerNorm kernel (FP32 compute, FP16 output)
+ * Reuses existing implementation pattern from wan_transformer_block.cu
+ */
+__global__ void layernorm_text_kernel(
+    const half* input,
+    half* output,
+    const half* gamma,
+    const half* beta,
+    int N, int seq_len, int dim,
+    float eps) {
+
+    int idx = blockIdx.x * blockDim.y + threadIdx.y;
+    int total = N * seq_len;
+    if (idx >= total) return;
+
+    extern __shared__ float smem[];
+    float* ssum = smem;
+    float* ssum2 = smem + blockDim.x;
+    int tid = threadIdx.x;
+
+    // Compute mean and variance
+    float acc1 = 0.f, acc2 = 0.f;
+    for (int d = tid; d < dim; d += blockDim.x) {
+        float v = __half2float(input[idx * dim + d]);
+        acc1 += v;
+        acc2 += v * v;
+    }
+    ssum[tid] = acc1;
+    ssum2[tid] = acc2;
+    __syncthreads();
+
+    // Reduction
+    for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+        if (tid < off) {
+            ssum[tid] += ssum[tid + off];
+            ssum2[tid] += ssum2[tid + off];
+        }
+        __syncthreads();
+    }
+
+    float mean = ssum[0] / float(dim);
+    float var = ssum2[0] / float(dim) - mean * mean;
+    float inv_std = rsqrtf(var + eps);
+
+    // Normalize and apply affine
+    for (int d = tid; d < dim; d += blockDim.x) {
+        float v = __half2float(input[idx * dim + d]);
+        v = (v - mean) * inv_std;
+        if (gamma) v = v * __half2float(gamma[d]);
+        if (beta) v = v + __half2float(beta[d]);
+        output[idx * dim + d] = __float2half(v);
+    }
+}
+
+cudaError_t text_projection(
+    const half* input,
+    half* output,
+    const half* weight,
+    const half* bias,
+    const half* ln_weight,
+    const half* ln_bias,
+    int N, int seq_len, int text_dim, int model_dim,
+    float eps,
+    cudaStream_t stream) {
+
+    int M = N * seq_len;
+
+    // CUTLASS GEMM: [M, text_dim] x [text_dim, model_dim] -> [M, model_dim]
+    // Mixed layouts: row-major input, column-major weight (from transpose kernel), row-major output
+    {
+        using ElementInputA = cutlass::half_t;
+        using ElementInputB = cutlass::half_t;
+        using ElementOutput = cutlass::half_t;
+        using ElementAccumulator = float;
+        using LayoutA = cutlass::layout::RowMajor;
+        using LayoutB = cutlass::layout::RowMajor;
+        using LayoutC = cutlass::layout::RowMajor;
+        using Gemm = cutlass::gemm::device::Gemm<
+            ElementInputA, LayoutA,
+            ElementInputB, LayoutB,
+            ElementOutput, LayoutC,
+            ElementAccumulator>;
+        Gemm gemm_op;
+        // Use stride trick when bias is present: beta=1, ldc=0, C points to bias vector
+        const cutlass::half_t* c_ptr = bias ? reinterpret_cast<const cutlass::half_t*>(bias) : nullptr;
+        int ldc = bias ? 0 : model_dim;
+        cutlass::half_t beta = bias ? cutlass::half_t(1.0f) : cutlass::half_t(0.0f);
+        Gemm::Arguments args({M, model_dim, text_dim},
+                            {reinterpret_cast<const cutlass::half_t*>(input), text_dim},
+                            {reinterpret_cast<const cutlass::half_t*>(weight), model_dim},
+                            {c_ptr, ldc},
+                            {reinterpret_cast<cutlass::half_t*>(output), model_dim},
+                            {cutlass::half_t(1.0f), beta});
+        cutlass::Status st = gemm_op.initialize(args, nullptr);
+        if (st != cutlass::Status::kSuccess) return cudaErrorUnknown;
+        st = gemm_op(stream);
+        if (st != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    }
+
+    // Apply LayerNorm if requested
+    if (ln_weight) {
+        dim3 block(256, 1);
+        dim3 grid((M + block.y - 1) / block.y);
+        size_t smem = 2 * block.x * sizeof(float);
+
+        layernorm_text_kernel<<<grid, block, smem, stream>>>(
+            output, output, ln_weight, ln_bias, N, seq_len, model_dim, eps);
+
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    return cudaSuccess;
+}
+
+// ============================================================================
+// I2V: Image embedder (WanImageEmbedding)
+// norm1(img_dim) -> MLP(img_dim -> img_dim -> K) -> norm2(K) -> optional pos_embed
+// ============================================================================
+cudaError_t image_embedder_forward(
+    const half* encoder_hidden_states_img,   // [N, img_seq, img_dim]
+    half* out_img_k,                         // [N, img_seq, K]
+    const half* norm1_gamma,                 // [img_dim]
+    const half* norm1_beta,                  // [img_dim]
+    const half* ff0_w,                       // [img_dim, img_dim] (row-major [in, out])
+    const half* ff0_b,                       // [img_dim]
+    const half* ff2_w,                       // [img_dim, K] (row-major [in, out])
+    const half* ff2_b,                       // [K]
+    const half* norm2_gamma,                 // [K]
+    const half* norm2_beta,                  // [K]
+    const half* pos_embed,                   // [1, img_seq, K] or nullptr
+    int N, int img_seq, int img_dim, int K,
+    half* scratch_ln1,                       // [N*img_seq, img_dim]
+    half* scratch_ff0,                       // [N*img_seq, img_dim]
+    cudaStream_t stream) {
+
+    if (!encoder_hidden_states_img || !out_img_k || N <= 0 || img_seq <= 0 || img_dim <= 0 || K <= 0) {
+        return cudaSuccess;
+    }
+
+    // 1) norm1 on raw CLIP embeds: [N*img_seq, img_dim]
+    if (norm1_gamma || norm1_beta) {
+        int M_ln = N * img_seq;
+        dim3 block(256, 1);
+        dim3 grid((M_ln + block.y - 1) / block.y);
+        size_t smem = 2 * block.x * sizeof(float);
+        layernorm_text_kernel<<<grid, block, smem, stream>>>(
+            encoder_hidden_states_img,
+            scratch_ln1,
+            norm1_gamma, norm1_beta,
+            N, img_seq, img_dim, 1e-6f);
+        CUDA_CHECK(cudaGetLastError());
+    } else {
+        size_t bytes = sizeof(half) * (size_t)N * img_seq * img_dim;
+        cudaMemcpyAsync(scratch_ln1, encoder_hidden_states_img, bytes, cudaMemcpyDeviceToDevice, stream);
+    }
+
+    // 2) MLP fc_in: img_dim -> img_dim
+    CUDA_CHECK(cutlass_linear_layer_rrr(
+        scratch_ln1,
+        ff0_w, ff0_b,
+        scratch_ff0,
+        N * img_seq, img_dim, img_dim, stream));
+
+    // 3) GELU exact (erf): matches nn.GELU(approximate="none")
+    {
+        long long numel = (long long)N * img_seq * img_dim;
+        int threads = 256;
+        long long blocks = (numel + threads - 1) / threads;
+        gelu_erf_inplace_kernel<<<blocks, threads, 0, stream>>>(scratch_ff0, numel);
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    // 4) MLP fc_out: img_dim -> K
+    CUDA_CHECK(cutlass_linear_layer_rrr(
+        scratch_ff0,
+        ff2_w, ff2_b,
+        out_img_k,
+        N * img_seq, img_dim, K, stream));
+
+    // 5) norm2 on K
+    if (norm2_gamma || norm2_beta) {
+        int M_ln = N * img_seq;
+        dim3 block(256, 1);
+        dim3 grid((M_ln + block.y - 1) / block.y);
+        size_t smem = 2 * block.x * sizeof(float);
+        layernorm_text_kernel<<<grid, block, smem, stream>>>(
+            out_img_k, out_img_k, norm2_gamma, norm2_beta,
+            N, img_seq, K, 1e-6f);
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    // 6) Optional pos_embed: [1, img_seq, K]
+    if (pos_embed) {
+        long long total = (long long)N * img_seq * K;
+        int threads = 256;
+        long long blocks = (total + threads - 1) / threads;
+        add_pos_embed_img_kernel<<<blocks, threads, 0, stream>>>(out_img_k, pos_embed, N, img_seq, K);
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    return cudaSuccess;
+}
+
+// ============================================================================
+// PATCHIFY OPERATION
+// REFERENCE: Inverse of unpatchify in transformer_wan.py
+// NOTE: In practice, Conv3d with stride=patch_size IS the patchify operation
+//       (it extracts patches AND projects channels in one operation)
+//       This kernel is provided for completeness but not currently used.
+// ============================================================================
+
+/**
+ * Patchify 3D video into non-overlapping patches
+ * Input:  [N, C_in, T, H, W]
+ * Output: [N, post_T*post_H*post_W, C_in*pt*ph*pw]
+ *
+ * Extracts patches with stride=patch_size (non-overlapping)
+ * If needed, can replace Conv3d with: patchify + CUTLASS GEMM for projection
+ */
+__global__ void patchify_3d_kernel(
+    const half* __restrict__ input,   // [N, C_in, T, H, W]
+    half* __restrict__ output,        // [N, M, C_in*patch_vol]
+    int N, int C_in,
+    int T, int H, int W,
+    int pt, int ph, int pw,
+    int post_T, int post_H, int post_W) {
+
+    int n = blockIdx.z;
+    int patch_idx = blockIdx.y * blockDim.y + threadIdx.y;
+    int c_local = blockIdx.x * blockDim.x + threadIdx.x;
+
+    int M = post_T * post_H * post_W;
+    int patch_vol = pt * ph * pw;
+    int C_patch = C_in * patch_vol;
+
+    if (n >= N || patch_idx >= M || c_local >= C_patch) return;
+
+    // Decompose patch_idx to spatial patch position
+    int pw_idx = patch_idx % post_W;
+    int ph_idx = (patch_idx / post_W) % post_H;
+    int pt_idx = patch_idx / (post_H * post_W);
+
+    // Decompose c_local to (channel, t_local, h_local, w_local)
+    int w_local = c_local % pw;
+    int h_local = (c_local / pw) % ph;
+    int t_local = (c_local / (pw * ph)) % pt;
+    int c_in = c_local / patch_vol;
+
+    // Source position in input
+    int t_src = pt_idx * pt + t_local;
+    int h_src = ph_idx * ph + h_local;
+    int w_src = pw_idx * pw + w_local;
+
+    // Input: [N, C_in, T, H, W] layout
+    long long in_idx = ((long long)n * C_in + c_in) * (T * H * W) +
+                       t_src * (H * W) + h_src * W + w_src;
+
+    // Output: [N, M, C_patch] layout
+    long long out_idx = ((long long)n * M + patch_idx) * C_patch + c_local;
+
+    output[out_idx] = input[in_idx];
+}
+
+cudaError_t patchify_3d(
+    const half* input,
+    half* output,
+    int N, int C_in,
+    int T, int H, int W,
+    int pt, int ph, int pw,
+    int post_T, int post_H, int post_W,
+    cudaStream_t stream) {
+
+    int M = post_T * post_H * post_W;
+    int patch_vol = pt * ph * pw;
+    int C_patch = C_in * patch_vol;
+
+    // Launch configuration
+    dim3 block(32, 16);  // x: C_patch elements, y: patches
+    dim3 grid((C_patch + block.x - 1) / block.x,
+              (M + block.y - 1) / block.y,
+              N);
+
+    patchify_3d_kernel<<<grid, block, 0, stream>>>(
+        input, output,
+        N, C_in, T, H, W,
+        pt, ph, pw,
+        post_T, post_H, post_W
+    );
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+/**
+ * Concatenate two tensors along sequence dimension
+ * Used to combine image and text embeddings
+ */
+__global__ void concatenate_seq_kernel(
+    const half* input1, int seq1,
+    const half* input2, int seq2,
+    half* output,
+    int N, int dim) {
+
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = N * (seq1 + seq2) * dim;
+
+    if (idx >= total) return;
+
+    // Decompose index
+    int remaining = idx;
+    int d = remaining % dim; remaining /= dim;
+    int s = remaining % (seq1 + seq2); remaining /= (seq1 + seq2);
+    int n = remaining;
+
+    // Copy from appropriate source
+    if (s < seq1) {
+        // From input1
+        output[idx] = input1[(n * seq1 + s) * dim + d];
+    } else {
+        // From input2
+        output[idx] = input2[(n * seq2 + (s - seq1)) * dim + d];
+    }
+}
+
+cudaError_t concatenate_seq_dim(
+    const half* input1, int seq1,
+    const half* input2, int seq2,
+    half* output,
+    int N, int dim,
+    cudaStream_t stream) {
+
+    int total = N * (seq1 + seq2) * dim;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+
+    concatenate_seq_kernel<<<blocks, threads, 0, stream>>>(
+        input1, seq1, input2, seq2, output, N, dim);
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+/**
+ * Unflatten: [N, M*K] -> [N, M, K]
+ * This is just a memory copy with reshape (no data movement needed)
+ */
+cudaError_t unflatten_dimension(
+    const half* input,
+    half* output,
+    int N, int M, int K,
+    cudaStream_t stream) {
+
+    // Unflatten is a view operation - no kernel needed
+    // Just ensure pointers are correct
+    if (input != output) {
+        size_t total_bytes = sizeof(half) * N * M * K;
+        cudaMemcpyAsync(output, input, total_bytes, cudaMemcpyDeviceToDevice, stream);
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    return cudaSuccess;
+}
+
+// ============================================================================
+// FORMAT CONVERSION KERNELS
+// Support conversion between PyTorch (NCTHW) and CUTLASS (NDHWC) formats
+// ============================================================================
+
+/**
+ * Convert NCTHW -> NDHWC (PyTorch format -> CUTLASS format)
+ * Input:  [N, C, T, H, W] - channels first
+ * Output: [N, T, H, W, C] - channels last
+ */
+__global__ void ncthw_to_ndhwc_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int N, int C, int T, int H, int W) {
+
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * T * H * W * C;
+    if (idx >= total) return;
+
+    // Decompose flat index to NDHWC position
+    int c = idx % C;
+    int w = (idx / C) % W;
+    int h = (idx / (C * W)) % H;
+    int t = (idx / (C * W * H)) % T;
+    int n = idx / (C * W * H * T);
+
+    // Read from NCTHW: [n, c, t, h, w]
+    long long in_idx = ((((long long)n * C + c) * T + t) * H + h) * W + w;
+    output[idx] = input[in_idx];
+}
+
+/**
+ * Convert KCTRS -> KTRSC (PyTorch weight format -> CUTLASS weight format)
+ * Input:  [K, C, T, R, S] - channels second
+ * Output: [K, T, R, S, C] - channels last
+ */
+__global__ void kctrs_to_ktrsc_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int K, int C, int T, int R, int S) {
+
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)K * T * R * S * C;
+    if (idx >= total) return;
+
+    // Decompose flat index to KTRSC position
+    int c = idx % C;
+    int s = (idx / C) % S;
+    int r = (idx / (C * S)) % R;
+    int t = (idx / (C * S * R)) % T;
+    int k = idx / (C * S * R * T);
+
+    // Read from KCTRS: [k, c, t, r, s]
+    long long in_idx = ((((long long)k * C + c) * T + t) * R + r) * S + s;
+    output[idx] = input[in_idx];
+}
+
+/**
+ * Flatten and transpose NDHWC to ColumnMajor
+ * Input:  [N, T, H, W, C] NDHWC (channels last)
+ * Output: [N*T*H*W, C] ColumnMajor
+ *
+ * This is used after patch embedding to prepare data for transformer blocks.
+ */
+__global__ void flatten_transpose_ndhwc_to_colmajor_kernel(
+    const half* __restrict__ in_ndhwc,  // [N, T, H, W, C]
+    half* __restrict__ out_col,          // [M, C] ColumnMajor where M=N*T*H*W
+    int N, int C, int T, int H, int W) {
+
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long M = (long long)N * T * H * W;
+    if (idx >= M) return;
+
+    // Input is already in NDHWC: [N, T, H, W, C]
+    // We just need to copy it to ColumnMajor layout
+    // ColumnMajor [M, C]: element at row i, col c is at i + c*M
+
+    // Copy all channels for this spatial position
+    for (int c = 0; c < C; ++c) {
+        // Read from NDHWC: idx*C + c (sequential in memory)
+        // Write to ColumnMajor: idx + c*M
+        out_col[idx + c * M] = in_ndhwc[idx * C + c];
+    }
+}
+
+cudaError_t convert_ncthw_to_ndhwc(
+    const half* input,
+    half* output,
+    int N, int C, int T, int H, int W,
+    cudaStream_t stream) {
+
+    int threads = 256;
+    long long total = (long long)N * C * T * H * W;
+    long long blocks = (total + threads - 1) / threads;
+
+    ncthw_to_ndhwc_kernel<<<blocks, threads, 0, stream>>>(
+        input, output, N, C, T, H, W);
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+cudaError_t convert_kctrs_to_ktrsc(
+    const half* input,
+    half* output,
+    int K, int C, int T, int R, int S,
+    cudaStream_t stream) {
+
+    int threads = 256;
+    long long total = (long long)K * C * T * R * S;
+    long long blocks = (total + threads - 1) / threads;
+
+    kctrs_to_ktrsc_kernel<<<blocks, threads, 0, stream>>>(
+        input, output, K, C, T, R, S);
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+cudaError_t flatten_transpose_ndhwc_to_colmajor(
+    const half* input,
+    half* output,
+    int N, int C, int T, int H, int W,
+    cudaStream_t stream) {
+
+    int threads = 256;
+    long long M = (long long)N * T * H * W;
+    long long blocks = (M + threads - 1) / threads;
+
+    flatten_transpose_ndhwc_to_colmajor_kernel<<<blocks, threads, 0, stream>>>(
+        input, output, N, C, T, H, W);
+
+    CUDA_CHECK(cudaGetLastError());
+    return cudaSuccess;
+}
+
+// ============================================================================
+// 2D CONVOLUTION HELPER
+// Used when depth dimension is 1
+// ============================================================================
+
+static cudaError_t patch_embedding_conv2d_impl(
+    const half* input,        // [N, H, W, C_in] NHWC format
+    const half* weight,       // [C_out, K_h, K_w, C_in] KRSC format
+    half* output,             // [N, H_out, W_out, C_out] NHWC format
+    int N, int C_in, int C_out,
+    int H, int W,
+    int K_h, int K_w,
+    int stride_h, int stride_w,
+    int pad_h, int pad_w,
+    cudaStream_t stream) {
+
+    // Calculate output dimensions
+    int H_out = (H + 2 * pad_h - K_h) / stride_h + 1;
+    int W_out = (W + 2 * pad_w - K_w) / stride_w + 1;
+
+    // Define CUTLASS 2D convolution kernel (channels-last native)
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+
+    using Conv2dKernel = typename cutlass::conv::kernel::DefaultConv2dFprop<
+        ElementInputA, cutlass::layout::TensorNHWC,
+        ElementInputB, cutlass::layout::TensorNHWC,
+        ElementOutput, cutlass::layout::TensorNHWC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        cutlass::epilogue::thread::LinearCombination<
+            ElementOutput,
+            128 / cutlass::sizeof_bits<ElementOutput>::value,
+            ElementAccumulator,
+            ElementAccumulator
+        >,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        2,  // Stages
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kOptimized,
+        cutlass::conv::StrideSupport::kStrided,
+        4,  // AlignmentA
+        4   // AlignmentB
+    >::Kernel;
+
+    using Conv2dOp = cutlass::conv::device::ImplicitGemmConvolution<Conv2dKernel>;
+
+    // Create problem size
+    cutlass::conv::Conv2dProblemSize problem_size(
+        N,                              // N (batch)
+        H, W,                          // H, W (input spatial)
+        C_in,                          // C (input channels)
+        C_out,                         // K (output channels)
+        K_h, K_w,                      // R, S (filter spatial)
+        H_out, W_out,                  // P, Q (output spatial)
+        pad_h, pad_w,                  // padding
+        stride_h, stride_w,            // stride
+        1, 1,                          // dilation
+        cutlass::conv::Mode::kCrossCorrelation
+    );
+
+    // Configure CUTLASS arguments
+    Conv2dOp conv_op;
+
+    // Create layout objects (must be lvalues for TensorRef constructor)
+    auto layout_A = PACK_INPUT_LAYOUT_2D(problem_size);
+    auto layout_B = PACK_WEIGHT_LAYOUT_2D(problem_size);
+    auto layout_C = PACK_OUTPUT_LAYOUT_2D(problem_size);
+
+    // Create tensor references using kernel-defined types
+    typename Conv2dKernel::TensorRefA ref_A(
+        const_cast<cutlass::half_t*>(reinterpret_cast<const cutlass::half_t*>(input)),
+        layout_A
+    );
+
+    typename Conv2dKernel::TensorRefB ref_B(
+        const_cast<cutlass::half_t*>(reinterpret_cast<const cutlass::half_t*>(weight)),
+        layout_B
+    );
+
+    typename Conv2dKernel::TensorRefC ref_C(
+        reinterpret_cast<cutlass::half_t*>(output),
+        layout_C
+    );
+
+    typename Conv2dKernel::TensorRefC ref_D(
+        reinterpret_cast<cutlass::half_t*>(output),
+        layout_C
+    );
+
+    typename Conv2dKernel::Epilogue::OutputOp::Params epilogue_params(
+        ElementAccumulator(1.0f),  // alpha
+        ElementAccumulator(0.0f)   // beta
+    );
+
+    typename Conv2dOp::Arguments arguments(
+        problem_size,
+        ref_A,
+        ref_B,
+        ref_C,
+        ref_D,
+        epilogue_params,
+        cutlass::conv::SplitKMode::kSerial
+    );
+
+    // Check if kernel can implement this problem
+    cutlass::Status status = conv_op.can_implement(arguments);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorNotSupported;
+    }
+
+    // Initialize and run kernel
+    status = conv_op.initialize(arguments, nullptr, stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorInitializationError;
+    }
+
+    status = conv_op(stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorUnknown;
+    }
+
+    return cudaSuccess;
+}
+
+// ============================================================================
+// 3D CONVOLUTION FOR PATCH EMBEDDING
+// REFERENCE: HuggingFace transformer_wan.py - patch_embedding layer
+// ============================================================================
+
+/**
+ * 3D Convolution with channels-last (NDHWC) format
+ * This is the native CUTLASS format - no internal conversions needed
+ *
+ * @param input [N, T, H, W, C_in] NDHWC format (channels last)
+ * @param weight [C_out, K_d, K_h, K_w, C_in] KTRSC format (channels last)
+ * @param output [N, T_out, H_out, W_out, C_out] NDHWC format (channels last)
+ */
+cudaError_t patch_embedding_conv3d(
+    const half* input,
+    const half* weight,
+    half* output,
+    int N, int C_in, int C_out,
+    int T, int H, int W,
+    int K_d, int K_h, int K_w,
+    int stride_d, int stride_h, int stride_w,
+    int pad_d, int pad_h, int pad_w,
+    cudaStream_t stream) {
+
+    // Optimization / robustness: if the depth dimension is trivial, run a 2D conv per-frame.
+    //
+    // WAN patch embedding almost always uses K_d=1 and stride_d=1. For I2V, C_in can be 36,
+    // and CUTLASS Conv3d kernels may reject some (C_in, C_out, kernel) configurations.
+    //
+    // Because NDHWC is contiguous with channels-last, we can reinterpret:
+    //   [N, T, H, W, C]  as  [N*T, H, W, C]
+    // without any data movement, and run the existing NHWC Conv2d implementation.
+    if (K_d == 1 && stride_d == 1 && pad_d == 0) {
+        int NT = N * T;
+        return patch_embedding_conv2d_impl(
+            input, weight, output,
+            NT, C_in, C_out,
+            H, W,
+            K_h, K_w,
+            stride_h, stride_w,
+            pad_h, pad_w,
+            stream
+        );
+    }
+
+    // Calculate output dimensions
+    int T_out = (T + 2 * pad_d - K_d) / stride_d + 1;
+    int H_out = (H + 2 * pad_h - K_h) / stride_h + 1;
+    int W_out = (W + 2 * pad_w - K_w) / stride_w + 1;
+
+    // Define CUTLASS 3D convolution kernel (channels-last native)
+    using ElementInputA = cutlass::half_t;
+    using ElementInputB = cutlass::half_t;
+    using ElementOutput = cutlass::half_t;
+    using ElementAccumulator = float;
+
+    using Conv3dKernel = typename cutlass::conv::kernel::DefaultConv3dFprop<
+        ElementInputA, cutlass::layout::TensorNDHWC,
+        ElementInputB, cutlass::layout::TensorNDHWC,
+        ElementOutput, cutlass::layout::TensorNDHWC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        cutlass::epilogue::thread::LinearCombination<
+            ElementOutput,
+            128 / cutlass::sizeof_bits<ElementOutput>::value,
+            ElementAccumulator,
+            ElementAccumulator
+        >,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        4,  // Stages
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kOptimized,
+        cutlass::conv::StrideSupport::kStrided
+    >::Kernel;
+
+    using Conv3dOp = cutlass::conv::device::ImplicitGemmConvolution<Conv3dKernel>;
+
+    // Create problem size
+    cutlass::conv::Conv3dProblemSize problem_size(
+        N,                                    // N (batch)
+        T, H, W,                             // D, H, W (input spatial)
+        C_in,                                // C (input channels)
+        C_out,                               // K (output channels)
+        K_d, K_h, K_w,                       // T, R, S (filter spatial)
+        T_out, H_out, W_out,                 // Z, P, Q (output spatial)
+        pad_d, pad_h, pad_w,                 // padding
+        stride_d, stride_h, stride_w,        // stride
+        1, 1, 1,                             // dilation
+        cutlass::conv::Mode::kCrossCorrelation
+    );
+
+    // Configure CUTLASS arguments (all in channels-last format)
+    Conv3dOp conv_op;
+
+    // Create layout objects (must be lvalues for TensorRef constructor)
+    auto layout_A = PACK_INPUT_LAYOUT(problem_size);
+    auto layout_B = PACK_WEIGHT_LAYOUT(problem_size);
+    auto layout_C = PACK_OUTPUT_LAYOUT(problem_size);
+
+    // Create tensor references using kernel-defined types
+    typename Conv3dKernel::TensorRefA ref_A(
+        const_cast<cutlass::half_t*>(reinterpret_cast<const cutlass::half_t*>(input)),
+        layout_A
+    );
+
+    typename Conv3dKernel::TensorRefB ref_B(
+        const_cast<cutlass::half_t*>(reinterpret_cast<const cutlass::half_t*>(weight)),
+        layout_B
+    );
+
+    typename Conv3dKernel::TensorRefC ref_C(
+        reinterpret_cast<cutlass::half_t*>(output),
+        layout_C
+    );
+
+    typename Conv3dKernel::TensorRefC ref_D(
+        reinterpret_cast<cutlass::half_t*>(output),
+        layout_C
+    );
+
+    typename Conv3dKernel::Epilogue::OutputOp::Params epilogue_params(
+        ElementAccumulator(1.0f),  // alpha
+        ElementAccumulator(0.0f)   // beta
+    );
+
+    typename Conv3dOp::Arguments arguments(
+        problem_size,
+        ref_A,
+        ref_B,
+        ref_C,
+        ref_D,
+        epilogue_params,
+        cutlass::conv::SplitKMode::kSerial
+    );
+
+    // Check if kernel can implement this problem
+    cutlass::Status status = conv_op.can_implement(arguments);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorNotSupported;
+    }
+
+    // Initialize and run kernel
+    status = conv_op.initialize(arguments, nullptr, stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorInitializationError;
+    }
+
+    status = conv_op(stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorUnknown;
+    }
+
+    return cudaSuccess;
+}
+
+// ============================================================================
+// Additional helpers for full-model orchestrator
+// ============================================================================
+
+// NDHWC -> row-major [N*M, K] where M=T*H*W
+__global__ void flatten_ndhwc_to_row_kernel(
+    const half* __restrict__ in_ndhwc,
+    half* __restrict__ out_row,
+    int N, int T, int H, int W, int K) {
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total_positions = (long long)N * T * H * W;
+    if (idx >= total_positions) return;
+    int w = idx % W; int tmp = idx / W;
+    int h = tmp % H; tmp /= H;
+    int t = tmp % T; int n = tmp / T;
+    long long in_base = ((((long long)n * T + t) * H + h) * W + w) * K;
+    long long row = ((long long)n * T * H * W) + (t * H * W + h * W + w);
+    for (int c = 0; c < K; ++c) {
+        out_row[row * K + c] = in_ndhwc[in_base + c];
+    }
+}
+
+// Add bias along last dimension for a contiguous NDHWC tensor
+__global__ void add_bias_lastdim_kernel(half* __restrict__ data,
+                                        const half* __restrict__ bias,
+                                        long long total_elems,
+                                        int K) {
+    long long i = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= total_elems) return;
+    int c = (int)(i % K);
+    float v = __half2float(data[i]);
+    float b = __half2float(bias[c]);
+    data[i] = __float2half(v + b);
+}
+
+// Add per-token positional embedding for image tokens.
+// data: [N, img_seq, K] row-major, pos: [1, img_seq, K] row-major (broadcast over batch)
+__global__ void add_pos_embed_img_kernel(half* __restrict__ data,
+                                        const half* __restrict__ pos,
+                                        int N, int img_seq, int K) {
+    long long i = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)N * img_seq * K;
+    if (i >= total) return;
+    int k = (int)(i % K);
+    long long tmp = i / K;
+    int s = (int)(tmp % img_seq);  // token index (within image seq)
+    float v = __half2float(data[i]);
+    float p = __half2float(pos[(long long)s * K + k]);  // broadcast N dimension
+    data[i] = __float2half(v + p);
+}
+
+// GELU tanh approximation in-place
+__global__ void gelu_tanh_inplace_kernel(half* data, long long numel) {
+    long long i = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numel) return;
+    float x = __half2float(data[i]);
+    float c = 0.044715f;
+    float y = 0.7978845608028654f * (x + c * x * x * x);
+    float out = 0.5f * x * (1.0f + tanhf(y));
+    data[i] = __float2half(out);
+}
+
+// Exact GELU (erf) in-place: matches torch.nn.GELU(approximate="none")
+__global__ void gelu_erf_inplace_kernel(half* data, long long numel) {
+    long long i = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numel) return;
+    float x = __half2float(data[i]);
+    // 0.5 * x * (1 + erf(x / sqrt(2)))
+    float out = 0.5f * x * (1.0f + erff(x * 0.7071067811865475244f));
+    data[i] = __float2half(out);
+}
+
+// Expand [N,6,K] to [N*M,6,K] by repeating per sequence token
+__global__ void expand_temb_to_tokens_kernel(const half* __restrict__ temb,
+                                             int N, int M, int K,
+                                             half* __restrict__ temb_out) {
+    long long i = (long long)blockIdx.x * blockDim.x + threadIdx.x; // over N*M*6*K
+    long long total = (long long)N * M * 6 * K;
+    if (i >= total) return;
+    int k = i % K; long long tmp = i / K;
+    int s = tmp % 6; tmp /= 6;
+    int n = tmp / M;
+    long long in_idx = ((long long)n * 6 + s) * K + k;
+    temb_out[i] = temb[in_idx];
+}
+
+// Build per-token scale/shift from table [2,K] and temb [N,K] -> [N*M,K]
+__global__ void build_final_scale_shift_kernel(const half* __restrict__ sst_2k,
+                                               const half* __restrict__ temb_nk,
+                                               float* __restrict__ scale_rm,
+                                               float* __restrict__ shift_rm,
+                                               int N, int M, int K) {
+    int row = blockIdx.y * blockDim.y + threadIdx.y; // [0, N*M)
+    int col = blockIdx.x * blockDim.x + threadIdx.x; // [0, K)
+    if (row >= N * M || col >= K) return;
+    int n = row / (M);
+    float shift_base = __half2float(sst_2k[col]);
+    float scale_base = __half2float(sst_2k[K + col]);
+    float shift_add = __half2float(temb_nk[n * K + col]);
+    float scale_add = __half2float(temb_nk[n * K + col]);
+    shift_rm[row * K + col] = shift_base + shift_add;
+    scale_rm[row * K + col] = scale_base + scale_add;
+}
+
+// Row-major LayerNorm without affine; optional modulation; output row-major half
+__global__ void row_layernorm_modulate_half_kernel(
+    const half* __restrict__ X_row, int M, int K, float eps,
+    const float* __restrict__ scale_rm, const float* __restrict__ shift_rm,
+    half* __restrict__ Y_row) {
+    int row = blockIdx.x; if (row >= M) return;
+    extern __shared__ float s[]; float* ssum = s; float* ssum2 = s + blockDim.x; int tid = threadIdx.x;
+    float acc1 = 0.f, acc2 = 0.f;
+    for (int j = tid; j < K; j += blockDim.x) {
+        float v = __half2float(X_row[(size_t)row * K + j]); acc1 += v; acc2 += v * v;
+    }
+    ssum[tid] = acc1; ssum2[tid] = acc2; __syncthreads();
+    for (int off = blockDim.x >> 1; off > 0; off >>= 1) { if (tid < off) { ssum[tid] += ssum[tid+off]; ssum2[tid] += ssum2[tid+off]; } __syncthreads(); }
+    float mean = ssum[0] / float(K); float var = ssum2[0] / float(K) - mean * mean; float inv = rsqrtf(var + eps);
+    for (int j = tid; j < K; j += blockDim.x) {
+        float v = (__half2float(X_row[(size_t)row * K + j]) - mean) * inv;
+        if (scale_rm && shift_rm) {
+            float s_val = scale_rm[(size_t)row * K + j]; float t_val = shift_rm[(size_t)row * K + j];
+            v = v * (1.f + s_val) + t_val;
+        }
+        Y_row[(size_t)row * K + j] = __float2half(v);
+    }
+}
+
+// Unpatchify: reverse patch embedding to spatial NCTHW
+__global__ void unpatchify_3d_kernel(
+    const half* __restrict__ input,  // [N, M, patch_vol*C]
+    half* __restrict__ output,       // [N, C, T, H, W]
+    int N, int C, int T, int H, int W,
+    int pt, int ph, int pw,
+    int post_T, int post_H, int post_W) {
+    int n = blockIdx.z; int c = blockIdx.y; int thw = blockIdx.x * blockDim.x + threadIdx.x;
+    if (n >= N || c >= C) return; int total_spatial = T * H * W; if (thw >= total_spatial) return;
+    int t = thw / (H * W); int hw = thw % (H * W); int h = hw / W; int w = hw % W;
+    int pt_idx = t / pt; int ph_idx = h / ph; int pw_idx = w / pw;
+    int t_local = t % pt; int h_local = h % ph; int w_local = w % pw;
+    int patch_idx = (pt_idx * post_H + ph_idx) * post_W + pw_idx;
+    int in_c = ((t_local * ph + h_local) * pw + w_local) * C + c;
+    long long in_offset = ((long long)n * (post_T * post_H * post_W) + patch_idx) * ((long long)pt * ph * pw * C) + in_c;
+    long long out_offset = ((long long)n * C + c) * ((long long)T * H * W) + thw;
+    output[out_offset] = input[in_offset];
+}
+
+// Debug helper to print tensor stats
+static void debug_print_tensor_stats(const half* d_tensor, size_t numel, const char* name, cudaStream_t stream) {
+    #ifdef WAN_DEBUG_FORWARD
+    cudaStreamSynchronize(stream);
+    std::vector<half> h_data(numel);
+    cudaMemcpy(h_data.data(), d_tensor, numel * sizeof(half), cudaMemcpyDeviceToHost);
+    float sum = 0, sum2 = 0, minv = 1e30f, maxv = -1e30f;
+    int nan_count = 0, inf_count = 0;
+    for (size_t i = 0; i < numel; ++i) {
+        float v = __half2float(h_data[i]);
+        if (std::isnan(v)) { nan_count++; continue; }
+        if (std::isinf(v)) { inf_count++; continue; }
+        sum += v; sum2 += v * v;
+        minv = std::min(minv, v); maxv = std::max(maxv, v);
+    }
+    float mean = sum / numel;
+    float var = sum2 / numel - mean * mean;
+    float std = std::sqrt(var > 0 ? var : 0);
+    printf("[DEBUG C++] %s: numel=%zu, mean=%.6f, std=%.6f, min=%.6f, max=%.6f, nan=%d, inf=%d\n",
+           name, numel, mean, std, minv, maxv, nan_count, inf_count);
+    #else
+    (void)d_tensor; (void)numel; (void)name; (void)stream;
+    #endif
+}
+
+template <typename WeightT, typename Arch>
+cudaError_t transformer_forward(
+    const TransformerConfig& cfg,
+    const ModelWeightsT<WeightT>& w,
+    const ModelIO& io,
+    ts::Workspace* workspace,
+    cudaStream_t stream) {
+    int N = io.N, C_in = io.C_in, T = io.T, H = io.H, W = io.W;
+    int pt = cfg.patch_t, ph = cfg.patch_h, pw = cfg.patch_w;
+    int post_T = T / pt, post_H = H / ph, post_W = W / pw;
+    int M = post_T * post_H * post_W;
+    int K = cfg.num_attention_heads * cfg.attention_head_dim;
+    int patch_vol = pt * ph * pw;
+
+    if (!workspace) return cudaErrorInvalidValue;
+
+    // Optional coarse profiling (CUDA-event timestamps across major phases)
+    int prof_lvl = g_wan_profile_level.load(std::memory_order_relaxed);
+    bool do_prof = (prof_lvl > 0);
+    // NOTE: these events measure end-to-end GPU time between boundaries, including any idle gaps on the stream.
+    enum {
+        EV_START = 0,
+        EV_AFTER_PATCH,       // after patch embed + flatten
+        EV_AFTER_ROPE,        // after RoPE
+        EV_AFTER_TEMB6K,      // after timestep -> 6K projection
+        EV_AFTER_TEXT,        // after text projection
+        EV_AFTER_IMAGE,       // after image embedder
+        EV_AFTER_TEMB_EXPAND, // after temb expand
+        EV_AFTER_BLOCKS,      // after transformer blocks chain
+        EV_AFTER_FINAL_SHIFT, // after build_final_scale_shift
+        EV_AFTER_SEQ_NORM,    // after final layernorm+modulate
+        EV_AFTER_PROJ_OUT,    // after proj_out GEMM
+        EV_AFTER_UNPATCH,     // after unpatchify
+        EV_COUNT
+    };
+    cudaEvent_t ev[EV_COUNT] = {};
+    if (do_prof) {
+        for (int i = 0; i < EV_COUNT; ++i) {
+            cudaEventCreate(&ev[i]);
+        }
+        cudaEventRecord(ev[EV_START], stream);
+    }
+    auto rec = [&](int idx) {
+        if (do_prof) cudaEventRecord(ev[idx], stream);
+    };
+
+    // 1) Patch embedding
+    half* dInputNDHWC = reinterpret_cast<half*>(workspace->input_ndhwc);
+    CUDA_CHECK(convert_ncthw_to_ndhwc(io.hidden_states_ncthw, dInputNDHWC, N, C_in, T, H, W, stream));
+    half* dPEWeightKTRSC = reinterpret_cast<half*>(workspace->pe_weight_ktrsc);
+    if (w.patch_embedding_weight == nullptr) return cudaErrorInvalidDevicePointer;
+    CUDA_CHECK(convert_kctrs_to_ktrsc(w.patch_embedding_weight, dPEWeightKTRSC, K, C_in, pt, ph, pw, stream));
+    half* dPEOutNDHWC = reinterpret_cast<half*>(workspace->pe_out_ndhwc);
+    CUDA_CHECK(patch_embedding_conv3d(dInputNDHWC, dPEWeightKTRSC, dPEOutNDHWC,
+        N, C_in, K, T, H, W, pt, ph, pw, pt, ph, pw, 0, 0, 0, stream));
+
+    if (w.patch_embedding_bias) {
+        long long total_elems = (long long)N * post_T * post_H * post_W * K;
+        int threads = 256; long long blocks = (total_elems + threads - 1) / threads;
+        add_bias_lastdim_kernel<<<blocks, threads, 0, stream>>>(
+            dPEOutNDHWC, w.patch_embedding_bias, total_elems, K);
+        CUDA_CHECK(cudaGetLastError());
+    }
+
+    // Flatten NDHWC -> row-major [N*M, K]
+    half* dHiddenRM = reinterpret_cast<half*>(workspace->hidden_rm);
+    {
+        long long total_pos = (long long)N * post_T * post_H * post_W;
+        int threads = 256; long long blocks = (total_pos + threads - 1) / threads;
+        flatten_ndhwc_to_row_kernel<<<blocks, threads, 0, stream>>>(dPEOutNDHWC, dHiddenRM, N, post_T, post_H, post_W, K);
+        CUDA_CHECK(cudaGetLastError());
+    }
+    debug_print_tensor_stats(dHiddenRM, (size_t)N * M * K, "1_patch_embed_out", stream);
+    rec(EV_AFTER_PATCH);
+
+    // 2) RoPE
+    float* dCos = workspace->rope_cos;
+    float* dSin = workspace->rope_sin;
+    CUDA_CHECK(generate_rope_3d(dCos, dSin, post_T, post_H, post_W, cfg.attention_head_dim, 10000.0f, cfg.rope_max_seq_len,
+        workspace->rope_cos_t, workspace->rope_sin_t,
+        workspace->rope_cos_h, workspace->rope_sin_h,
+        workspace->rope_cos_w, workspace->rope_sin_w,
+        stream));
+    rec(EV_AFTER_ROPE);
+
+    // 3) Conditioning: timestep -> temb -> SiLU -> final proj to 6K
+    half* dTimestepSin = reinterpret_cast<half*>(workspace->timestep_sin);
+    CUDA_CHECK(timestep_sinusoidal_embedding(io.timesteps, dTimestepSin, N, cfg.freq_dim, 10000, stream));
+    // MLP projection to time_proj_dim
+    // Project sinusoidal -> temb (pre-activation output used later for final modulation)
+    half* dTembPre = reinterpret_cast<half*>(workspace->temb_pre);
+    half* dTembHidden = reinterpret_cast<half*>(workspace->temb_hidden);
+    CUDA_CHECK(timestep_mlp_projection(dTimestepSin, dTembPre,
+        w.time_proj_linear1_w, w.time_proj_linear1_b, w.time_proj_linear2_w, w.time_proj_linear2_b,
+        dTembHidden,
+        N, cfg.freq_dim, cfg.time_hidden_dim, cfg.time_proj_dim, stream));
+    // SiLU applied BEFORE final projection per HF implementation (on a separate buffer)
+    half* dTembAct = reinterpret_cast<half*>(workspace->temb_act);
+    {
+        size_t bytes = sizeof(half) * (size_t)N * cfg.time_proj_dim;
+        cudaMemcpyAsync(dTembAct, dTembPre, bytes, cudaMemcpyDeviceToDevice, stream);
+    }
+    CUDA_CHECK(apply_silu_inplace(dTembAct, (long long)N * cfg.time_proj_dim, stream));
+    // Final projection to 6K
+    half* dTproj6K = reinterpret_cast<half*>(workspace->temb_6k);
+    CUDA_CHECK(cutlass_linear_layer_rrr(dTembAct, w.time_proj_final_w, w.time_proj_final_b,
+        dTproj6K, N, cfg.time_proj_dim, 6 * K, stream));
+    debug_print_tensor_stats(dTproj6K, (size_t)N * 6 * K, "3_temb_6k", stream);
+    // Reshape to [N,6,K] already contiguous in row-major
+    rec(EV_AFTER_TEMB6K);
+
+    // Text projection to K
+    int text_seq = io.text_seq_len;
+    half* dEncTextK = nullptr;
+    if (w.caption_proj_w) {
+        dEncTextK = reinterpret_cast<half*>(workspace->enc_text_k);
+            CUDA_CHECK(text_projection(io.encoder_hidden_states, dEncTextK, w.caption_proj_w, w.caption_proj_b,
+                nullptr, nullptr, N, text_seq, io.text_dim, K, 1e-6f, stream));
+    } else if (w.text_embedder_w1 && w.text_embedder_w2) {
+        int hidden = cfg.text_hidden_dim;
+        half* dH1 = reinterpret_cast<half*>(workspace->text_h1);
+        CUDA_CHECK(cutlass_linear_layer_rrr(io.encoder_hidden_states, w.text_embedder_w1, w.text_embedder_b1,
+            dH1, N * text_seq, io.text_dim, hidden, stream));
+        {
+            long long numel = (long long)N * text_seq * hidden; int threads = 256; long long blocks = (numel + threads - 1) / threads;
+            gelu_tanh_inplace_kernel<<<blocks, threads, 0, stream>>>(dH1, numel);
+            CUDA_CHECK(cudaGetLastError());
+        }
+        dEncTextK = reinterpret_cast<half*>(workspace->enc_text_k);
+        CUDA_CHECK(cutlass_linear_layer_rrr(dH1, w.text_embedder_w2, w.text_embedder_b2,
+            dEncTextK, N * text_seq, hidden, K, stream));
+        debug_print_tensor_stats(dEncTextK, (size_t)N * text_seq * K, "4_text_embed_out", stream);
+    } else {
+        // Assume already in K
+        dEncTextK = nullptr;
+    }
+    rec(EV_AFTER_TEXT);
+
+    // Image projection: run HF-style image_embedder (norm1 -> ff0+GELU -> ff2 -> norm2 [+ pos_embed])
+    int img_seq = io.img_seq_len;
+    half* dEncImgK = nullptr;
+    bool has_img = (io.encoder_hidden_states_img != nullptr && img_seq > 0);
+
+    if (has_img) {
+        dEncImgK = reinterpret_cast<half*>(workspace->enc_img_k); // [N*img_seq, K]
+        half* img_ln1 = reinterpret_cast<half*>(workspace->enc_flat); // [N*img_seq, img_dim]
+        half* img_ff0 = reinterpret_cast<half*>(workspace->enc_cat);  // [N*img_seq, img_dim]
+        CUDA_CHECK(image_embedder_forward(
+            io.encoder_hidden_states_img,
+            dEncImgK,
+            w.image_norm1_gamma, w.image_norm1_beta,
+            w.image_ff0_w, w.image_ff0_b,
+            w.image_ff2_w, w.image_ff2_b,
+            w.image_norm2_gamma, w.image_norm2_beta,
+            w.image_pos_embed,
+            N, img_seq, io.img_dim, K,
+            img_ln1, img_ff0,
+            stream));
+    }
+    rec(EV_AFTER_IMAGE);
+
+    // Prepare encoder pointers (no concatenation)
+    const half* enc_text_ptr = dEncTextK ? dEncTextK : io.encoder_hidden_states;
+    const half* enc_img_ptr = has_img ? dEncImgK : nullptr;
+
+    // temb [N,6,K] -- no longer expanded to [N*M,6,K]; kernels broadcast via temb_row_stride=0
+    const half* dTemb6K = reinterpret_cast<const half*>(dTproj6K);
+    rec(EV_AFTER_TEMB_EXPAND);
+
+    // 4) Transformer blocks chain
+    half* dPing = reinterpret_cast<half*>(workspace->ping);
+    half* dPong = reinterpret_cast<half*>(workspace->pong);
+    // Copy hidden into dPing as current
+    {
+        size_t bytes = sizeof(half) * (size_t)N * M * K; cudaMemcpyAsync(dPing, dHiddenRM, bytes, cudaMemcpyDeviceToDevice, stream);
+    }
+    const half* cur = dPing; half* next = dPong;
+
+    for (int layer = 0; layer < cfg.num_layers; ++layer) {
+        const BlockWeightsT<WeightT>& bw = w.blocks[layer];
+        TransformerBlockParamsT<WeightT> p{};
+        p.B = N; p.Mq = M; p.K = K; p.H = cfg.num_attention_heads; p.D = cfg.attention_head_dim;
+        p.layer_idx = layer;
+        p.Mk = text_seq;
+        p.Mk_img = has_img ? img_seq : 0;
+        p.added_kv_proj_dim = has_img ? K : 0;
+        p.FF = cfg.ffn_dim;
+        p.encoder_batch_size = cfg.encoder_batch_size;
+        p.hidden_states = reinterpret_cast<const cutlass::half_t*>(cur);
+        p.encoder_hidden_states = reinterpret_cast<const cutlass::half_t*>(enc_text_ptr);
+        p.encoder_hidden_states_img = reinterpret_cast<const cutlass::half_t*>(enc_img_ptr);
+        p.rotary_cos = dCos; p.rotary_sin = dSin;
+        p.temb_scale_shift_table = reinterpret_cast<const cutlass::half_t*>(bw.scale_shift_table);
+        p.temb = reinterpret_cast<const cutlass::half_t*>(dTemb6K);
+        p.temb_row_stride = 0;  // broadcast: all rows share the same temb
+        p.sa_w_qkv = reinterpret_cast<const WeightT*>(bw.sa_w_qkv);
+        p.sa_w_qkv_scale = reinterpret_cast<const cutlass::half_t*>(bw.sa_w_qkv_scale);
+        p.sa_b_qkv = reinterpret_cast<const cutlass::half_t*>(bw.sa_b_qkv);
+        p.sa_norm_q_gamma = reinterpret_cast<const cutlass::half_t*>(bw.sa_norm_q);
+        p.sa_norm_k_gamma = reinterpret_cast<const cutlass::half_t*>(bw.sa_norm_k);
+        p.sa_w_out = reinterpret_cast<const WeightT*>(bw.sa_w_out);
+        p.sa_w_out_scale = reinterpret_cast<const cutlass::half_t*>(bw.sa_w_out_scale);
+        p.sa_b_out = reinterpret_cast<const cutlass::half_t*>(bw.sa_b_out);
+        p.ca_w_q = reinterpret_cast<const WeightT*>(bw.ca_w_q);
+        p.ca_w_q_scale = reinterpret_cast<const cutlass::half_t*>(bw.ca_w_q_scale);
+        p.ca_b_q = reinterpret_cast<const cutlass::half_t*>(bw.ca_b_q);
+        p.ca_w_kv = reinterpret_cast<const WeightT*>(bw.ca_w_kv);
+        p.ca_w_kv_scale = reinterpret_cast<const cutlass::half_t*>(bw.ca_w_kv_scale);
+        p.ca_b_kv = reinterpret_cast<const cutlass::half_t*>(bw.ca_b_kv);
+        p.ca_norm_q_gamma = reinterpret_cast<const cutlass::half_t*>(bw.ca_norm_q);
+        p.ca_norm_k_gamma = reinterpret_cast<const cutlass::half_t*>(bw.ca_norm_k);
+        p.ca_w_add_k = reinterpret_cast<const WeightT*>(bw.ca_w_add_k);
+        p.ca_b_add_k = reinterpret_cast<const cutlass::half_t*>(bw.ca_b_add_k);
+        p.ca_w_add_k_scale = reinterpret_cast<const cutlass::half_t*>(bw.ca_w_add_k_scale);
+        p.ca_w_add_v = reinterpret_cast<const WeightT*>(bw.ca_w_add_v);
+        p.ca_b_add_v = reinterpret_cast<const cutlass::half_t*>(bw.ca_b_add_v);
+        p.ca_w_add_v_scale = reinterpret_cast<const cutlass::half_t*>(bw.ca_w_add_v_scale);
+        p.ca_norm_added_k_gamma = reinterpret_cast<const cutlass::half_t*>(bw.ca_norm_added_k);
+        p.ca_w_out = reinterpret_cast<const WeightT*>(bw.ca_w_out);
+        p.ca_w_out_scale = reinterpret_cast<const cutlass::half_t*>(bw.ca_w_out_scale);
+        p.ca_b_out = reinterpret_cast<const cutlass::half_t*>(bw.ca_b_out);
+        p.ln1_gamma = reinterpret_cast<const cutlass::half_t*>(bw.ln1_gamma);
+        p.ln2_gamma = reinterpret_cast<const cutlass::half_t*>(bw.ln2_gamma);
+        p.ln2_bias = reinterpret_cast<const cutlass::half_t*>(bw.ln2_bias);
+        p.ln3_gamma = reinterpret_cast<const cutlass::half_t*>(bw.ln3_gamma);
+        p.ffn_w1 = reinterpret_cast<const WeightT*>(bw.ffn_w1);
+        p.ffn_w1_scale = reinterpret_cast<const cutlass::half_t*>(bw.ffn_w1_scale);
+        p.ffn_b1 = reinterpret_cast<const cutlass::half_t*>(bw.ffn_b1);
+        p.ffn_w2 = reinterpret_cast<const WeightT*>(bw.ffn_w2);
+        p.ffn_w2_scale = reinterpret_cast<const cutlass::half_t*>(bw.ffn_w2_scale);
+        p.ffn_b2 = reinterpret_cast<const cutlass::half_t*>(bw.ffn_b2);
+        // Per-block INT8 weight scales (for INT8 with per-block quantization)
+        p.sa_w_qkv_block_scale = bw.sa_w_qkv_block_scale;
+        p.sa_w_out_block_scale = bw.sa_w_out_block_scale;
+        p.ca_w_q_block_scale = bw.ca_w_q_block_scale;
+        p.ca_w_kv_block_scale = bw.ca_w_kv_block_scale;
+        p.ca_w_out_block_scale = bw.ca_w_out_block_scale;
+        p.ffn_w1_block_scale = bw.ffn_w1_block_scale;
+        p.ffn_w2_block_scale = bw.ffn_w2_block_scale;
+        // Enable per-block quantization mode for INT8
+        p.use_perblock_quant = std::is_same<WeightT, int8_t>::value && bw.sa_w_qkv_block_scale != nullptr;
+        p.out = reinterpret_cast<cutlass::half_t*>(next);
+        p.workspace = workspace;
+        cudaError_t err = run_transformer_block<WeightT, Arch>(p, stream); if (err != cudaSuccess) return err;
+        if (layer < 3) {
+            char buf[64]; snprintf(buf, sizeof(buf), "5_block_%d_out", layer);
+            debug_print_tensor_stats(next, (size_t)N * M * K, buf, stream);
+        }
+        // swap
+        const half* tmp = cur; cur = next; next = const_cast<half*>(tmp);
+    }
+    rec(EV_AFTER_BLOCKS);
+
+    // 5) Final norm + modulation and projection
+    float* dScale = workspace->final_scale;
+    float* dShift = workspace->final_shift;
+    {
+        dim3 tb(32, 32); dim3 gb((K + tb.x - 1) / tb.x, (N * M + tb.y - 1) / tb.y);
+        build_final_scale_shift_kernel<<<gb, tb, 0, stream>>>(w.final_scale_shift_table,
+            dTembPre, dScale, dShift, N, M, K);
+        CUDA_CHECK(cudaGetLastError());
+    }
+    rec(EV_AFTER_FINAL_SHIFT);
+    half* dSeqNorm = reinterpret_cast<half*>(workspace->seq_norm);
+    row_layernorm_modulate_half_kernel<<<N * M, 256, 2 * 256 * sizeof(float), stream>>>(cur, N * M, K, 1e-6f,
+        dScale, dShift, dSeqNorm);
+    CUDA_CHECK(cudaGetLastError());
+    rec(EV_AFTER_SEQ_NORM);
+
+    // Linear to patch_vol*C_out and unpatchify
+    int out_dim = patch_vol * cfg.out_channels;
+    half* dTokens = reinterpret_cast<half*>(workspace->tokens);
+    CUDA_CHECK(cutlass_linear_layer_rrr(dSeqNorm, w.proj_out_w, w.proj_out_b, dTokens, N * M, K, out_dim, stream));
+    rec(EV_AFTER_PROJ_OUT);
+    // Reshape to [N, M, out_dim] and unpatchify
+    {
+        int total_spatial = T * H * W; int threads = 256; int blocks = (total_spatial + threads - 1) / threads;
+        dim3 grid(blocks, cfg.out_channels, N);
+        unpatchify_3d_kernel<<<grid, threads, 0, stream>>>(dTokens, io.out_ncthw, N, cfg.out_channels, T, H, W, pt, ph, pw, post_T, post_H, post_W);
+        CUDA_CHECK(cudaGetLastError());
+    }
+    rec(EV_AFTER_UNPATCH);
+
+    if (do_prof) {
+        cudaEventSynchronize(ev[EV_AFTER_UNPATCH]);
+        auto ms = [&](int a, int b) -> float {
+            float out = 0.0f;
+            cudaEventElapsedTime(&out, ev[a], ev[b]);
+            return out;
+        };
+        float t_patch = ms(EV_START, EV_AFTER_PATCH);
+        float t_rope = ms(EV_AFTER_PATCH, EV_AFTER_ROPE);
+        float t_temb = ms(EV_AFTER_ROPE, EV_AFTER_TEMB6K);
+        float t_text = ms(EV_AFTER_TEMB6K, EV_AFTER_TEXT);
+        float t_img = ms(EV_AFTER_TEXT, EV_AFTER_IMAGE);
+        float t_expand = ms(EV_AFTER_IMAGE, EV_AFTER_TEMB_EXPAND);
+        float t_blocks = ms(EV_AFTER_TEMB_EXPAND, EV_AFTER_BLOCKS);
+        float t_fshift = ms(EV_AFTER_BLOCKS, EV_AFTER_FINAL_SHIFT);
+        float t_seq = ms(EV_AFTER_FINAL_SHIFT, EV_AFTER_SEQ_NORM);
+        float t_proj = ms(EV_AFTER_SEQ_NORM, EV_AFTER_PROJ_OUT);
+        float t_unpatch = ms(EV_AFTER_PROJ_OUT, EV_AFTER_UNPATCH);
+        float t_total = ms(EV_START, EV_AFTER_UNPATCH);
+
+        std::printf(
+            "[transformer_forward][profile] N=%d T=%d H=%d W=%d post=(%d,%d,%d) M=%d K=%d text_seq=%d img_seq=%d | "
+            "patch=%.3f rope=%.3f temb=%.3f text=%.3f img=%.3f expand=%.3f blocks=%.3f final_shift=%.3f seq_norm=%.3f proj_out=%.3f unpatch=%.3f total=%.3f ms\n",
+            N, T, H, W, post_T, post_H, post_W, M, K, io.text_seq_len, io.img_seq_len,
+            t_patch, t_rope, t_temb, t_text, t_img, t_expand, t_blocks, t_fshift, t_seq, t_proj, t_unpatch, t_total
+        );
+
+#ifdef OMNIDREAMS_SINGLEVIEW_PROFILE
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "patch_embed", t_patch);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "rope", t_rope);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "timestep_mlp", t_temb);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "text_proj", t_text);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "image_embed", t_img);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "temb_expand", t_expand);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "blocks_total", t_blocks);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "final_shift", t_fshift);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "seq_norm", t_seq);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "proj_out", t_proj);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "unpatchify", t_unpatch);
+        OMNIDREAMS_SINGLEVIEW_PROF_RECORD("model_forward", "total", t_total);
+#endif
+
+        for (int i = 0; i < EV_COUNT; ++i) {
+            cudaEventDestroy(ev[i]);
+        }
+    }
+
+    return cudaSuccess;
+}
+
+// Explicit instantiations (WeightT x Arch combinations).
+// Currently only WanArchTraits is instantiated; future models add their own lines.
+template cudaError_t transformer_forward<cutlass::half_t, WanArchTraits>(
+    const TransformerConfig& cfg,
+    const ModelWeightsT<cutlass::half_t>& w,
+    const ModelIO& io,
+    ts::Workspace* workspace,
+    cudaStream_t stream
+);
+template cudaError_t transformer_forward<cutlass::float_e4m3_t, WanArchTraits>(
+    const TransformerConfig& cfg,
+    const ModelWeightsT<cutlass::float_e4m3_t>& w,
+    const ModelIO& io,
+    ts::Workspace* workspace,
+    cudaStream_t stream
+);
+template cudaError_t transformer_forward<int8_t, WanArchTraits>(
+    const TransformerConfig& cfg,
+    const ModelWeightsT<int8_t>& w,
+    const ModelIO& io,
+    ts::Workspace* workspace,
+    cudaStream_t stream
+);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cuh
@@ -1,0 +1,875 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include "cutlass/cutlass.h"
+#include "workspace.cuh"
+#include "arch_traits.h"
+
+namespace omnidreams_singleview {
+
+// ============================================================================
+// GEMM TILE CONFIGURATION
+// Controls the M-dimension threshold for switching between tile sizes.
+// For M < threshold: uses 64x64x64 tiles (more threadblocks, better for small M)
+// For M >= threshold: uses 128x64x64 tiles (better arithmetic intensity)
+// ============================================================================
+
+// Set the GEMM tile threshold (default: 1024). Lower values use larger tiles
+// for smaller M, which may improve performance for batched workloads.
+void set_gemm_tile_threshold(int threshold);
+
+// Get the current GEMM tile threshold
+int get_gemm_tile_threshold();
+
+struct CosmosFp8LinearTileSelection {
+    std::string op_kind;
+    std::string preset;
+    std::string tile;
+    std::string stage;
+    std::string variant;
+    std::string reason;
+    bool tile_env_override = false;
+    bool stage_env_override = false;
+    bool variant_env_override = false;
+};
+
+// Select the SM120 FP8 RCR colscale kernel variant for a Cosmos linear shape.
+// Supported op_kind values are "colscale_bf16", "residual_bf16", and
+// "gelu_fp8". Environment overrides are applied at call time so autotune tools
+// can sweep variants without rebuilding.
+CosmosFp8LinearTileSelection select_cosmos_fp8_linear_tile(
+    const std::string& op_kind,
+    int rows,
+    int in_features,
+    int out_features);
+
+// ============================================================================
+// 3D ROTARY POSITION EMBEDDINGS (RoPE)
+// REFERENCE: HuggingFace transformer_wan.py - class WanRotaryPosEmbed
+// ============================================================================
+
+/**
+ * Generate 3D RoPE frequencies for temporal + spatial dimensions
+ *
+ * @param cos_out Output cosine table [seq_len, head_dim]
+ * @param sin_out Output sine table [seq_len, head_dim]
+ * @param post_T Number of patches in temporal dimension
+ * @param post_H Number of patches in height dimension
+ * @param post_W Number of patches in width dimension
+ * @param head_dim Head dimension (must be divisible by 3 for T, H, W)
+ * @param theta RoPE base frequency (typically 10000)
+ * @param rope_max_seq_len Maximum sequence length for RoPE
+ */
+cudaError_t generate_rope_3d(
+    float* cos_out,
+    float* sin_out,
+    int post_T, int post_H, int post_W,
+    int head_dim,
+    float theta,
+    int rope_max_seq_len,
+    float* cos_t,
+    float* sin_t,
+    float* cos_h,
+    float* sin_h,
+    float* cos_w,
+    float* sin_w,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// UNIFIED LINEAR LAYER
+// PyTorch-compatible interface for all linear operations
+// ============================================================================
+
+// Row-major GEMM: A(row) x B(row) -> C(row), optional bias via stride trick
+cudaError_t cutlass_linear_layer_rrr(
+    const half* input_row,
+    const half* weight_row,
+    const half* bias,
+    half* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// Row-major GEMM with explicit output leading dimension (row-major stride).
+// Useful when writing into a submatrix of a larger row-major buffer.
+cudaError_t cutlass_linear_layer_rrr_strided(
+    const half* input_row,         // [N, in_features]
+    const half* weight_row,        // [in_features, out_features]
+    const half* bias,              // [out_features] or nullptr
+    half* output_row,              // points to row-major buffer
+    int N, int in_features, int out_features,
+    int ld_out,                    // row stride (must be >= out_features)
+    cudaStream_t stream
+);
+
+// Row-major GEMM with fused residual addition: residual = (A @ B + bias) + residual
+// Computes output in-place into residual buffer, eliminating intermediate storage
+cudaError_t cutlass_linear_layer_rrr_fused_residual(
+    const half* input_row,
+    const half* weight_row,
+    const half* bias,
+    half* residual_inout,  // Input: existing residual, Output: updated residual
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// Row-major GEMM with fused SiLU activation: D = SiLU(A @ B + bias)
+// Fuses linear layer and SiLU activation into GEMM epilogue, eliminating intermediate storage
+cudaError_t cutlass_linear_layer_rrr_silu(
+    const half* input_row,
+    const half* weight_row,
+    const half* bias,
+    half* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// Row-major variant: A(row) x B(row) -> C(row), optional bias via stride trick
+cudaError_t cutlass_linear_layer_rrr(
+    const half* input_row,
+    const half* weight_row,
+    const half* bias,
+    half* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+cudaError_t cutlass_linear_layer_rcr_fp8(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float alpha = 1.0f
+);
+
+// SM120 FP8 A/B (RCR) linear with per-output-channel scale fused in the
+// epilogue. Writes final BF16 output directly:
+//   output[row, col] = (input_fp8 @ weight_fp8.T)[row, col] * weight_scale[col]
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_bf16(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* weight_scale,
+    cutlass::bfloat16_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// SM120 FP8 A/B (RCR) linear with per-output-channel alpha fused into a BF16
+// residual epilogue:
+//   residual[row, col] += (input_fp8 @ weight_fp8.T)[row, col] * alpha[col]
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_residual_bf16(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* alpha,
+    cutlass::bfloat16_t* residual_inout,
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// FP8 GEMM (cuBLASLt) -> fused col_scale + residual + LayerNorm + modulate -> FP8.
+// Replaces the back-to-back pair (col_scale_residual_bf16 +
+// cosmos_layernorm_modulate_to_fp8_only) on FP8 SA-out / CA-out paths,
+// eliminating one full BF16 re-read of `x`.
+//   residual[row, col] += scale_mul * alpha[col] * (input_fp8 @ weight_fp8.T)[row, col]
+//   fp8_out[row, col]   = fp8(((residual_new - mean) / std) * (1+ln_scale) + ln_shift)
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_residual_layernorm_modulate_to_fp8(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* alpha,
+    cutlass::bfloat16_t* residual_inout,
+    const cutlass::bfloat16_t* ln_shift,
+    const cutlass::bfloat16_t* ln_scale,
+    cutlass::float_e4m3_t* fp8_out,
+    int N, int in_features, int out_features, int B, float eps,
+    cudaStream_t stream
+);
+
+// SM120 FP8 A/B (RCR) linear with per-output-channel scale, GELU, and FP8
+// output fused in the epilogue:
+//   output_fp8[row, col] = fp8(gelu((input_fp8 @ weight_fp8.T)[row, col] * weight_scale[col]))
+cudaError_t cutlass_linear_layer_rcr_fp8_colscale_gelu_fp8(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_fp8,
+    const cutlass::half_t* weight_scale,
+    cutlass::float_e4m3_t* output_fp8,
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// FP8 A/B (RRR) linear: A(row) x B(row) -> C(row), optional bias via stride trick
+cudaError_t cutlass_linear_layer_rrr_fp8(
+    const cutlass::float_e4m3_t* input_row,   // Row-major [N, in_features] FP8
+    const cutlass::float_e4m3_t* weight_fp8,  // Row-major [in_features, out_features] FP8
+    const cutlass::half_t* bias,              // [out_features] half or nullptr
+    cutlass::half_t* output_row,              // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// Row-major GEMM (INT8 inputs/weights) with optional bias via stride trick
+cudaError_t cutlass_linear_layer_rcr_int8(
+    const int8_t* input_row,
+    const int8_t* weight_int8,
+    const cutlass::half_t* bias,
+    cutlass::half_t* output_row,
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float activation_scale = 1.0f
+);
+
+// Row-major GEMM with GELU epilogue: D = GELU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rrr_gelu(
+    const half* input_row,         // Row-major [N, in_features]
+    const half* weight_row,        // Row-major [in_features, out_features]
+    const half* bias,              // [out_features] or nullptr
+    half* output_row,              // Row-major [N, out_features]
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// FP8 A/B (RCR) with GELU epilogue: D = GELU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rcr_fp8_gelu(
+    const cutlass::float_e4m3_t* input_row,   // Row-major [N, in_features] FP8
+    const cutlass::float_e4m3_t* weight_fp8,  // Column-major [in_features, out_features] FP8
+    const cutlass::half_t* bias,              // [out_features] half or nullptr
+    cutlass::half_t* output_row,              // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// FP8 A/B (RRR) with GELU epilogue: D = GELU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rrr_fp8_gelu(
+    const cutlass::float_e4m3_t* input_row,   // Row-major [N, in_features] FP8
+    const cutlass::float_e4m3_t* weight_fp8,  // Row-major [in_features, out_features] FP8
+    const cutlass::half_t* bias,              // [out_features] half or nullptr
+    cutlass::half_t* output_row,              // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+// INT8 A/B (RCR) with GELU epilogue: D = GELU(A @ B + bias)
+cudaError_t cutlass_linear_layer_rcr_int8_gelu(
+    const int8_t* input_row,            // Row-major [N, in_features] INT8
+    const int8_t* weight_int8,          // Column-major [in_features, out_features] INT8
+    const cutlass::half_t* bias,        // [out_features] or nullptr
+    cutlass::half_t* output_row,        // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float activation_scale = 1.0f
+);
+
+// Utilities: type conversions
+cudaError_t convert_half_to_fp8_e4m3(
+    const cutlass::half_t* src,
+    cutlass::float_e4m3_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream
+);
+cudaError_t convert_half_to_int8(
+    const cutlass::half_t* src,
+    int8_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream,
+    float activation_scale = 1.0f
+);
+// Compute activation scale = max(|src|)/127 with floor clamp
+cudaError_t compute_activation_scale(
+    const cutlass::half_t* src,
+    int64_t num_elements,
+    float* activation_scale_out,
+    cudaStream_t stream);
+// Column-wise scale + optional bias on row-major [N, out_features]
+cudaError_t apply_col_scale_bias(
+    cutlass::half_t* data,
+    const cutlass::half_t* scale,   // [out_features]
+    const cutlass::half_t* bias,    // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul = 1.0f
+);
+// Column-wise scale + optional bias + GELU on row-major [N, out_features]
+cudaError_t apply_col_scale_bias_gelu(
+    cutlass::half_t* data,
+    const cutlass::half_t* scale,   // [out_features]
+    const cutlass::half_t* bias,    // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul = 1.0f
+);
+// Fused: col_scale + bias + FP8 conversion
+cudaError_t apply_col_scale_bias_to_fp8(
+    const cutlass::half_t* data,       // GEMM output [N, out_features]
+    cutlass::float_e4m3_t* fp8_out,    // FP8 output [N, out_features]
+    const cutlass::half_t* scale,      // [out_features]
+    const cutlass::half_t* bias,       // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul = 1.0f,
+    float output_scale = 1.0f
+);
+// Fused: col_scale + bias + GELU + FP8 conversion (eliminates intermediate FP16 write/read)
+cudaError_t apply_col_scale_bias_gelu_to_fp8(
+    const cutlass::half_t* data,       // GEMM output [N, out_features]
+    cutlass::float_e4m3_t* fp8_out,    // FP8 output [N, out_features]
+    const cutlass::half_t* scale,      // [out_features]
+    const cutlass::half_t* bias,       // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul = 1.0f,
+    float output_scale = 1.0f
+);
+// Column-wise scale + optional bias + residual add: out = residual + scale*data + bias
+cudaError_t apply_col_scale_bias_residual(
+    const cutlass::half_t* data,          // GEMM output [N, out_features]
+    cutlass::half_t* residual_inout,      // in/out residual buffer [N, out_features]
+    const cutlass::half_t* scale,         // [out_features]
+    const cutlass::half_t* bias,          // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    float scale_mul = 1.0f
+);
+// Row-major GEMM (FP8 inputs/weights) with fused residual addition:
+// Computes: residual = (A @ B + bias) + residual
+cudaError_t cutlass_linear_layer_rcr_fp8_fused_residual(
+    const cutlass::float_e4m3_t* input_row,   // Row-major [N, in_features] FP8
+    const cutlass::float_e4m3_t* weight_fp8,  // Column-major [in_features, out_features] FP8
+    const cutlass::half_t* bias,              // [out_features] (half) or nullptr
+    cutlass::half_t* residual_inout,          // Row-major [N, out_features] (half), in-place
+    int N, int in_features, int out_features,
+    cudaStream_t stream
+);
+
+
+// INT8 A/B (RCR) with fused per-channel scale + optional bias, where activation scale is provided
+// as a device scalar holding activation absmax (amax). The epilogue applies act = max(amax/127, 1e-6).
+// Computes: D = (act * weight_scale[col]) * (A @ B) + bias[col]   (bias optional)
+cudaError_t cutlass_linear_layer_rcr_int8_scale_bias_dev_amax(
+    const int8_t* input_row,             // Row-major [N, in_features] INT8
+    const int8_t* weight_int8,           // Column-major [in_features, out_features] INT8
+    const cutlass::half_t* weight_scale, // [out_features] half (required)
+    const cutlass::half_t* bias,         // [out_features] half or nullptr
+    cutlass::half_t* output_row,         // Row-major [N, out_features] half
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    const float* activation_amax_dev     // device scalar: amax
+);
+
+// Row-major GEMM (INT8 inputs/weights) with fused residual addition:
+// Computes: residual = (A @ B + bias) + residual
+cudaError_t cutlass_linear_layer_rcr_int8_fused_residual(
+    const int8_t* input_row,              // Row-major [N, in_features] INT8
+    const int8_t* weight_int8,            // Column-major [in_features, out_features] INT8
+    const cutlass::half_t* bias,          // [out_features] (half) or nullptr
+    cutlass::half_t* residual_inout,      // Row-major [N, out_features] (half), in-place
+    int N, int in_features, int out_features,
+    cudaStream_t stream,
+    float activation_scale = 1.0f
+);
+
+
+// ============================================================================
+// INT8 QUANTIZATION UTILITIES
+// ============================================================================
+
+// Device-only variant: writes activation absmax to activation_scale_out_dev on device, no host sync.
+cudaError_t compute_activation_scale_device(
+    const cutlass::half_t* src,
+    int64_t num_elements,
+    float* activation_scale_out_dev,
+    cudaStream_t stream);
+
+cudaError_t convert_half_to_int8_device_scale(
+    const cutlass::half_t* src,
+    int8_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream,
+    const float* activation_scale_dev
+);
+cudaError_t convert_int8_to_half_device_scale(
+    const int8_t* src,
+    cutlass::half_t* dst,
+    int64_t num_elements,
+    cudaStream_t stream,
+    const float* activation_scale_dev
+);
+
+// ============================================================================
+// INT8 POST-OPS (scalar-aware versions for activation scale)
+// ============================================================================
+
+// Scalar-aware post-ops for INT8 projection path:
+// - act_scale_dev is a device scalar holding activation absmax (amax). Kernels internally apply amax/127 with clamp.
+// - weight_scale is optional per-output-channel scale (may be nullptr).
+// - bias is optional (may be nullptr).
+cudaError_t apply_col_scale_bias_scalar(
+    cutlass::half_t* data,
+    const cutlass::half_t* weight_scale,   // [out_features] or nullptr
+    const cutlass::half_t* bias,           // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    const float* act_scale_dev
+);
+cudaError_t apply_col_scale_bias_gelu_scalar(
+    cutlass::half_t* data,
+    const cutlass::half_t* weight_scale,   // [out_features] or nullptr
+    const cutlass::half_t* bias,           // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    const float* act_scale_dev
+);
+cudaError_t apply_col_scale_bias_residual_scalar(
+    const cutlass::half_t* data,
+    cutlass::half_t* residual_inout,
+    const cutlass::half_t* weight_scale,   // [out_features] or nullptr
+    const cutlass::half_t* bias,           // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream,
+    const float* act_scale_dev
+);
+
+// Apply GELU activation and add bias (no scaling) on row-major [N, out_features]
+// Used for per-block INT8 quantization where scaling is already handled
+cudaError_t apply_gelu_bias(
+    cutlass::half_t* data,          // [N, out_features] in/out
+    const cutlass::half_t* bias,    // [out_features] or nullptr
+    int N, int out_features,
+    cudaStream_t stream
+);
+
+// Simple in-place add: dest += src (element-wise)
+cudaError_t add_inplace_half_rr(
+    cutlass::half_t* dest,          // [numel] destination (in-place)
+    const cutlass::half_t* src,     // [numel] source to add
+    long long numel,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// TIMESTEP EMBEDDINGS
+// REFERENCE: HuggingFace embeddings.py - class Timesteps, TimestepEmbedding
+// ============================================================================
+
+/**
+ * Generate sinusoidal timestep embeddings
+ *
+ * @param timesteps Input timesteps [N] or [N*seq_len]
+ * @param embeddings Output sinusoidal embeddings [N, freq_dim] or [N*seq_len, freq_dim]
+ * @param num_timesteps Number of timesteps
+ * @param freq_dim Frequency dimension (typically 256)
+ * @param max_period Maximum period for sinusoidal encoding (typically 10000)
+ */
+cudaError_t timestep_sinusoidal_embedding(
+    const int64_t* timesteps,
+    half* embeddings,
+    int num_timesteps,
+    int freq_dim,
+    int max_period,
+    cudaStream_t stream
+);
+
+/**
+ * Timestep MLP projection: Linear -> SiLU -> Linear
+ * Projects sinusoidal embeddings to model dimension
+ *
+ * @param input Sinusoidal embeddings [N, freq_dim] row-major
+ * @param output Projected embeddings [N, proj_dim] row-major
+ * @param w1 First linear weight [freq_dim, hidden_dim] ROW-MAJOR
+ * @param b1 First linear bias [hidden_dim]
+ * @param w2 Second linear weight [hidden_dim, proj_dim] ROW-MAJOR
+ * @param b2 Second linear bias [proj_dim]
+ * @param hidden_buffer Workspace buffer [N, hidden_dim] for intermediate result
+ *
+ * NOTE: Weights must be pre-transposed to column-major by caller
+ */
+cudaError_t timestep_mlp_projection(
+    const half* input,
+    half* output,
+    const half* w1, const half* b1,
+    const half* w2, const half* b2,
+    half* hidden_buffer,
+    int N, int freq_dim, int hidden_dim, int proj_dim,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// TEXT PROJECTION
+// REFERENCE: HuggingFace embeddings.py - class PixArtAlphaTextProjection
+// ============================================================================
+
+/**
+ * Project text embeddings to model dimension
+ * Optional: Linear projection + LayerNorm
+ *
+ * @param input Text embeddings [N, seq_len, text_dim]
+ * @param output Projected text [N, seq_len, model_dim]
+ * @param weight Linear weight [model_dim, text_dim]
+ * @param bias Linear bias [model_dim] (optional)
+ * @param ln_weight LayerNorm weight [model_dim] (optional)
+ * @param ln_bias LayerNorm bias [model_dim] (optional)
+ */
+cudaError_t text_projection(
+    const half* input,
+    half* output,
+    const half* weight,
+    const half* bias,
+    const half* ln_weight,
+    const half* ln_bias,
+    int N, int seq_len, int text_dim, int model_dim,
+    float eps,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// I2V: Image embedder (WanImageEmbedding)
+// norm1(img_dim) -> MLP(img_dim -> img_dim -> K) -> norm2(K) -> optional pos_embed
+// ============================================================================
+cudaError_t image_embedder_forward(
+    const half* encoder_hidden_states_img,   // [N, img_seq, img_dim]
+    half* out_img_k,                         // [N, img_seq, K]
+    const half* norm1_gamma,                 // [img_dim]
+    const half* norm1_beta,                  // [img_dim]
+    const half* ff0_w,                       // [img_dim, img_dim] (row-major [in, out])
+    const half* ff0_b,                       // [img_dim]
+    const half* ff2_w,                       // [img_dim, K] (row-major [in, out])
+    const half* ff2_b,                       // [K]
+    const half* norm2_gamma,                 // [K]
+    const half* norm2_beta,                  // [K]
+    const half* pos_embed,                   // [1, img_seq, K] or nullptr
+    int N, int img_seq, int img_dim, int K,
+    half* scratch_ln1,                       // [N*img_seq, img_dim]
+    half* scratch_ff0,                       // [N*img_seq, img_dim]
+    cudaStream_t stream
+);
+
+// ============================================================================
+// ACTIVATIONS
+// REFERENCE: HuggingFace activations.py
+// ============================================================================
+
+/**
+ * SiLU (Swish) activation: x * sigmoid(x)
+ * Applied element-wise in-place
+ */
+cudaError_t apply_silu_inplace(
+    half* data,
+    int64_t total_elements,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// PATCHIFY / UNPATCHIFY OPERATIONS
+// ============================================================================
+
+/**
+ * Patchify: Extract patches from 3D video tensor
+ * Converts spatial video to sequence of patches
+ *
+ * @param input Video tensor [N, C_in, T, H, W]
+ * @param output Patches [N, post_T*post_H*post_W, C_in*pt*ph*pw]
+ * @param N Batch size
+ * @param C_in Input channels
+ * @param T, H, W Input dimensions
+ * @param pt, ph, pw Patch sizes
+ * @param post_T, post_H, post_W Number of patches in each dimension
+ *
+ * REFERENCE: Inverse of unpatchify operation
+ * Extracts non-overlapping patches with stride=patch_size
+ */
+cudaError_t patchify_3d(
+    const half* input,
+    half* output,
+    int N, int C_in,
+    int T, int H, int W,
+    int pt, int ph, int pw,
+    int post_T, int post_H, int post_W,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+/**
+ * Concatenate two tensors along dimension 1 (sequence dimension)
+ * Used to combine image and text embeddings
+ *
+ * @param input1 First tensor [N, seq1, dim]
+ * @param input2 Second tensor [N, seq2, dim]
+ * @param output Concatenated tensor [N, seq1+seq2, dim]
+ */
+cudaError_t concatenate_seq_dim(
+    const half* input1, int seq1,
+    const half* input2, int seq2,
+    half* output,
+    int N, int dim,
+    cudaStream_t stream
+);
+
+/**
+ * Unflatten tensor dimension: [N, M*K] -> [N, M, K]
+ * Used for reshaping timestep projections
+ */
+cudaError_t unflatten_dimension(
+    const half* input,
+    half* output,
+    int N, int M, int K,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// FORMAT CONVERSION UTILITIES
+// Support conversion between PyTorch (NCTHW) and CUTLASS (NDHWC) formats
+// ============================================================================
+
+/**
+ * Convert NCTHW -> NDHWC (PyTorch channels-first -> CUTLASS channels-last)
+ * Input:  [N, C, T, H, W]
+ * Output: [N, T, H, W, C]
+ */
+cudaError_t convert_ncthw_to_ndhwc(
+    const half* input,
+    half* output,
+    int N, int C, int T, int H, int W,
+    cudaStream_t stream
+);
+
+/**
+ * Convert KCTRS -> KTRSC (PyTorch weight -> CUTLASS weight format)
+ * Input:  [K, C, T, R, S]
+ * Output: [K, T, R, S, C]
+ */
+cudaError_t convert_kctrs_to_ktrsc(
+    const half* input,
+    half* output,
+    int K, int C, int T, int R, int S,
+    cudaStream_t stream
+);
+
+/**
+ * Flatten and transpose NDHWC to ColumnMajor
+ * Input:  [N, T, H, W, C] NDHWC (channels last)
+ * Output: [N*T*H*W, C] ColumnMajor
+ *
+ * Used after patch embedding to prepare data for transformer blocks.
+ */
+cudaError_t flatten_transpose_ndhwc_to_colmajor(
+    const half* input,
+    half* output,
+    int N, int C, int T, int H, int W,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// 3D CONVOLUTION FOR PATCH EMBEDDING
+// REFERENCE: HuggingFace transformer_wan.py - patch_embedding layer
+// ============================================================================
+
+/**
+ * 3D Convolution for patch embedding (channels-last native)
+ * REFERENCE: WAN patch_embedding layer in transformer_wan.py
+ *
+ * This performs the initial spatial-to-sequence conversion in WAN transformer:
+ *   input:  [N, T, H, W, C_in] -> patches -> output: [N, T', H', W', C_out]
+ *
+ * Typical WAN configuration: kernel=(1,2,2), stride=(1,2,2), no padding
+ *   - Reduces spatial dimensions by 2x in H and W
+ *   - Projects channels: 16 -> 1536 (inner_dim)
+ *
+ * @param input [N, T, H, W, C_in] NDHWC format (channels last, CUTLASS native)
+ * @param weight [C_out, K_d, K_h, K_w, C_in] KTRSC format (channels last, CUTLASS native)
+ * @param output [N, T_out, H_out, W_out, C_out] NDHWC format (channels last)
+ * @param N Batch size
+ * @param C_in Input channels
+ * @param C_out Output channels
+ * @param T, H, W Input spatial dimensions
+ * @param K_d, K_h, K_w Kernel dimensions
+ * @param stride_d, stride_h, stride_w Stride for each dimension
+ * @param pad_d, pad_h, pad_w Padding for each dimension
+ *
+ * NOTE: This kernel works natively in channels-last (NDHWC) format.
+ *       Call site is responsible for format conversions from/to PyTorch (NCTHW).
+ */
+cudaError_t patch_embedding_conv3d(
+    const half* input,
+    const half* weight,
+    half* output,
+    int N, int C_in, int C_out,
+    int T, int H, int W,
+    int K_d, int K_h, int K_w,
+    int stride_d, int stride_h, int stride_w,
+    int pad_d, int pad_h, int pad_w,
+    cudaStream_t stream
+);
+
+// ============================================================================
+// Pure C++ CUDA API for full transformer forward (no PyTorch types)
+// ============================================================================
+
+struct TransformerConfig {
+    int num_attention_heads;
+    int attention_head_dim;
+    int num_layers;
+    int ffn_dim;
+    int patch_t;
+    int patch_h;
+    int patch_w;
+    int freq_dim;           // e.g., 256
+    int rope_max_seq_len;   // e.g., 1024
+    int time_hidden_dim;    // hidden dim in timestep MLP
+    int time_proj_dim;      // output dim of timestep MLP (often == K)
+    int text_hidden_dim;    // hidden dim in 2-layer text embedder (if used)
+    int out_channels;       // output latent channels (e.g., 16 for I2V)
+    // Cross-attention KV sharing:
+    // - 0 = default (project KV for each batch item)
+    // - 1 = project KV once and broadcast to all batch items (requires identical encoder tokens across batch)
+    int encoder_batch_size = 0;
+};
+
+template <typename WeightT>
+struct BlockWeightsT {
+    // Self-attention
+    const WeightT* sa_w_qkv = nullptr;    // [3K,K]
+    const half* sa_w_qkv_scale = nullptr; // [3K] per-channel scale (for FP8) or nullptr
+    const float* sa_w_qkv_block_scale = nullptr; // [K/128, 3K/128] per-block scale (for INT8)
+    const half* sa_b_qkv = nullptr;    // [3K]
+    const half* sa_norm_q = nullptr;   // [K]
+    const half* sa_norm_k = nullptr;   // [K]
+    const WeightT* sa_w_out = nullptr;    // [K,K]
+    const half* sa_w_out_scale = nullptr; // [K] per-channel scale or nullptr
+    const float* sa_w_out_block_scale = nullptr; // [K/128, K/128] per-block scale (for INT8)
+    const half* sa_b_out = nullptr;    // [K]
+
+    // Cross-attention (separate Q and KV)
+    const WeightT* ca_w_q = nullptr;      // [K,K]
+    const half* ca_w_q_scale = nullptr;   // [K] per-channel scale or nullptr
+    const float* ca_w_q_block_scale = nullptr; // [K/128, K/128] per-block scale (for INT8)
+    const half* ca_b_q = nullptr;      // [K]
+    const WeightT* ca_w_kv = nullptr;     // [2K,K]
+    const half* ca_w_kv_scale = nullptr;  // [2K] per-channel scale or nullptr
+    const float* ca_w_kv_block_scale = nullptr; // [K/128, 2K/128] per-block scale (for INT8)
+    const half* ca_b_kv = nullptr;     // [2K]
+    const half* ca_norm_q = nullptr;   // [K]
+    const half* ca_norm_k = nullptr;   // [K]
+    // I2V image cross-attention (add_k/add_v projections)
+    const WeightT* ca_w_add_k = nullptr;   // [K, added_kv_proj_dim]
+    const half* ca_b_add_k = nullptr;      // [K]
+    const half* ca_w_add_k_scale = nullptr; // [K] or nullptr
+    const WeightT* ca_w_add_v = nullptr;   // [K, added_kv_proj_dim]
+    const half* ca_b_add_v = nullptr;      // [K]
+    const half* ca_w_add_v_scale = nullptr; // [K] or nullptr
+    const half* ca_norm_added_k = nullptr; // [K]
+    const WeightT* ca_w_out = nullptr;    // [K,K]
+    const half* ca_w_out_scale = nullptr; // [K] per-channel scale or nullptr
+    const float* ca_w_out_block_scale = nullptr; // [K/128, K/128] per-block scale (for INT8)
+    const half* ca_b_out = nullptr;    // [K]
+
+    // Norms
+    const half* ln1_gamma = nullptr;   // [K] optional
+    const half* ln2_gamma = nullptr;   // [K] optional
+    const half* ln2_bias = nullptr;    // [K] optional
+    const half* ln3_gamma = nullptr;   // [K] optional
+
+    // FFN
+    const WeightT* ffn_w1 = nullptr;      // [FF,K]
+    const half* ffn_w1_scale = nullptr;   // [FF] per-channel scale or nullptr
+    const float* ffn_w1_block_scale = nullptr; // [K/128, FF/128] per-block scale (for INT8)
+    const half* ffn_b1 = nullptr;      // [FF]
+    const WeightT* ffn_w2 = nullptr;      // [K,FF]
+    const half* ffn_w2_scale = nullptr;   // [K] per-channel scale or nullptr
+    const float* ffn_w2_block_scale = nullptr; // [FF/128, K/128] per-block scale (for INT8)
+    const half* ffn_b2 = nullptr;      // [K]
+
+    // Per-block scale/shift table [6,K]
+    const half* scale_shift_table = nullptr;
+};
+
+using BlockWeights = BlockWeightsT<cutlass::half_t>;
+
+template <typename WeightT>
+struct ModelWeightsT {
+    // Patch embedding
+    const half* patch_embedding_weight; // [K,C_in,pt,ph,pw] KCTRS
+    const half* patch_embedding_bias;   // [K] optional
+
+    // Timestep embedding MLP
+    const half* time_proj_linear1_w; // [freq_dim, time_hidden_dim]
+    const half* time_proj_linear1_b; // [time_hidden_dim]
+    const half* time_proj_linear2_w; // [time_hidden_dim, time_proj_dim]
+    const half* time_proj_linear2_b; // [time_proj_dim]
+
+    // Final projection to 6*K
+    const half* time_proj_final_w;   // [time_proj_dim, 6*K]
+    const half* time_proj_final_b;   // [6*K]
+
+    // Text projection (one of the two paths may be provided)
+    const half* caption_proj_w;      // [text_dim, K]
+    const half* caption_proj_b;      // [K]
+    // Two-layer embedder
+    const half* text_embedder_w1;    // [text_dim, text_hidden_dim]
+    const half* text_embedder_b1;    // [text_hidden_dim]
+    const half* text_embedder_w2;    // [text_hidden_dim, K]
+    const half* text_embedder_b2;    // [K]
+
+    // Image projection (optional)
+    const half* image_proj_w;        // [img_dim, K] (legacy/simple projection; not used in HF-style image_embedder)
+    const half* image_proj_b;        // [K]
+
+    // HF-style image_embedder (WanImageEmbedding):
+    // norm1(img_dim) -> MLP(img_dim -> img_dim -> K) -> norm2(K) -> optional pos_embed([1,img_seq,K])
+    const half* image_norm1_gamma;   // [img_dim]
+    const half* image_norm1_beta;    // [img_dim]
+    const half* image_ff0_w;         // [img_dim, img_dim]  (MLP fc_in)
+    const half* image_ff0_b;         // [img_dim]
+    const half* image_ff2_w;         // [img_dim, K]        (MLP fc_out)
+    const half* image_ff2_b;         // [K]
+    const half* image_norm2_gamma;   // [K]
+    const half* image_norm2_beta;    // [K]
+    const half* image_pos_embed;     // [1, img_seq, K] optional
+
+    // Transformer blocks
+    const BlockWeightsT<WeightT>* blocks;   // array size num_layers
+
+    // Final scale/shift table and projection
+    const half* final_scale_shift_table; // [2,K]
+    const half* proj_out_w;          // [K, patch_vol*C_in]
+    const half* proj_out_b;          // [patch_vol*C_in] optional
+};
+
+using ModelWeights = ModelWeightsT<cutlass::half_t>;
+struct ModelIO {
+    // Shapes
+    int N, C_in, T, H, W;        // input video
+    int text_seq_len;            // encoder text seq length
+    int img_seq_len;             // encoder image seq length (0 if none)
+    int text_dim;                // encoder text embedding dim
+    int img_dim;                 // encoder image embedding dim (0 if none)
+
+    // Inputs
+    const half* hidden_states_ncthw;       // [N,C,T,H,W]
+    const int64_t* timesteps;              // [N] (long tensor from PyTorch)
+    const half* encoder_hidden_states;     // [N,text_seq,text_dim]
+    const half* encoder_hidden_states_img; // [N,img_seq,img_dim] or nullptr
+
+    // Output
+    half* out_ncthw;                       // [N,C_in,T,H,W]
+};
+
+// Full-model forward orchestrator (templated by block weight type and architecture).
+// Arch defaults to WanArchTraits; callers that don't specify Arch get Wan behavior.
+template <typename WeightT, typename Arch = WanArchTraits>
+cudaError_t transformer_forward(
+    const TransformerConfig& cfg,
+    const ModelWeightsT<WeightT>& w,
+    const ModelIO& io,
+    ts::Workspace* workspace,
+    cudaStream_t stream
+);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/ops.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cstdint>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention.cu
@@ -1,0 +1,1012 @@
+#include "attention.cuh"
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <torch/extension.h>
+
+#include <cuda_fp8.h>
+#include <cutlass/numeric_conversion.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void scaled_fp4_quant(torch::Tensor const& input,
+                      torch::Tensor const& output,
+                      torch::Tensor const& output_sf,
+                      int tensor_layout);
+void scaled_fp4_quant_permute(torch::Tensor const& input,
+                              torch::Tensor const& output,
+                              torch::Tensor const& output_sf,
+                              int tensor_layout);
+void scaled_fp4_quant_trans(torch::Tensor const& input,
+                            torch::Tensor const& output,
+                            torch::Tensor const& output_sf,
+                            int tensor_layout);
+
+std::vector<at::Tensor> mha_fwd(at::Tensor& q,
+                                const at::Tensor& k,
+                                const at::Tensor& v,
+                                const at::Tensor& sfq,
+                                const at::Tensor& sfk,
+                                const at::Tensor& sfv,
+                                const at::Tensor& delta_s,
+                                int unpadded_k,
+                                c10::optional<at::Tensor>& out_,
+                                const float softmax_scale,
+                                bool is_causal,
+                                bool per_block_mean,
+                                bool is_bf16);
+
+namespace omnidreams_singleview {
+namespace {
+
+struct CurrentStreamScope {
+  explicit CurrentStreamScope(cudaStream_t stream, int device)
+      : previous_(c10::cuda::getCurrentCUDAStream(device)),
+        external_(c10::cuda::getStreamFromExternal(stream, device)) {
+    c10::cuda::setCurrentCUDAStream(external_);
+  }
+
+  ~CurrentStreamScope() {
+    c10::cuda::setCurrentCUDAStream(previous_);
+  }
+
+  c10::cuda::CUDAStream previous_;
+  c10::cuda::CUDAStream external_;
+};
+
+int round_up(int x, int multiple) {
+  return ((x + multiple - 1) / multiple) * multiple;
+}
+
+bool env_flag_enabled(const char* name) {
+  const char* v = std::getenv(name);
+  return v && v[0] && v[0] != '0';
+}
+
+constexpr int kFp4EltsPerThread = 16;
+constexpr int kSage3QuantBlockTokens = 128;
+
+inline __device__ float bf16_to_float(cutlass::bfloat16_t value) {
+  return float(value);
+}
+
+// Convert 4 float2 values into 8 e2m1 values packed in one uint32_t. This is
+// the same conversion sequence used by Sage3's BF16/FP16 quantizer.
+inline __device__ uint32_t fp32_vec_to_e2m1_local(float2* array) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0].x), "f"(array[0].y), "f"(array[1].x), "f"(array[1].y),
+        "f"(array[2].x), "f"(array[2].y), "f"(array[3].x), "f"(array[3].y));
+  return val;
+#else
+  return 0;
+#endif
+}
+
+inline __device__ uint8_t fp32_to_e4m3_byte(float value) {
+  uint8_t raw;
+  reinterpret_cast<__nv_fp8_e4m3&>(raw) = __nv_fp8_e4m3(value);
+  return raw;
+}
+
+inline __device__ float e4m3_byte_to_fp32(uint8_t raw) {
+  return float(reinterpret_cast<__nv_fp8_e4m3&>(raw));
+}
+
+inline __device__ uint64_t scaled_floats_to_fp4(float vals[kFp4EltsPerThread],
+                                                uint8_t* sf_raw_out) {
+  float vec_max = 0.0f;
+#pragma unroll
+  for (int i = 0; i < kFp4EltsPerThread; ++i) {
+    vec_max = fmaxf(vec_max, fabsf(vals[i]));
+  }
+
+  float sf_value = vec_max / 6.0f;
+  const uint8_t sf_raw = fp32_to_e4m3_byte(sf_value);
+  sf_value = e4m3_byte_to_fp32(sf_raw);
+  const float sf_inv = (sf_value == 0.0f) ? 0.0f : 1.0f / sf_value;
+  *sf_raw_out = sf_raw;
+
+  float2 fp2_vals[kFp4EltsPerThread / 2];
+#pragma unroll
+  for (int i = 0; i < kFp4EltsPerThread / 2; ++i) {
+    fp2_vals[i].x = vals[2 * i] * sf_inv;
+    fp2_vals[i].y = vals[2 * i + 1] * sf_inv;
+  }
+
+  uint32_t e2m1_vals[kFp4EltsPerThread / 8];
+#pragma unroll
+  for (int i = 0; i < kFp4EltsPerThread / 8; ++i) {
+    e2m1_vals[i] = fp32_vec_to_e2m1_local(fp2_vals + i * 4);
+  }
+  return uint64_t(e2m1_vals[0]) | (uint64_t(e2m1_vals[1]) << 32);
+}
+
+template <int HeadDim, int BlockSize, bool Permute>
+__global__ void fp8_scaled_fp4_quant_kernel(
+    const cutlass::float_e4m3_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    uint8_t* __restrict__ output_sf,
+    int B,
+    int H,
+    int num_tokens,
+    int padded_tokens) {
+  static_assert(BlockSize == kSage3QuantBlockTokens,
+                "Sage3 quantizer assumes 128-token blocks");
+  static_assert(kFp4EltsPerThread == 16,
+                "Sage3 scale layout below assumes 16 FP4 elements/thread");
+  constexpr int kThreadsPerToken = HeadDim / kFp4EltsPerThread;
+
+  const int b = blockIdx.y;
+  const int h = blockIdx.z;
+  const int token_block = blockIdx.x;
+  const int local_token = threadIdx.x / kThreadsPerToken;
+  const int col = threadIdx.x % kThreadsPerToken;
+  const int token_id = token_block * BlockSize + local_token;
+
+  int load_token_id = token_id;
+  if constexpr (Permute) {
+    const int residue = local_token % 32;
+    load_token_id = token_block * BlockSize + (local_token / 32) * 32 +
+                    (residue / 8) * 2 + ((residue % 8) / 2) * 8 +
+                    (residue % 8) % 2;
+  }
+
+  cutlass::NumericConverter<float, cutlass::float_e4m3_t> to_float;
+  float vals[kFp4EltsPerThread];
+#pragma unroll
+  for (int i = 0; i < kFp4EltsPerThread; ++i) {
+    vals[i] = 0.0f;
+  }
+  if (b < B && h < H && load_token_id < num_tokens) {
+    const int d_base = col * kFp4EltsPerThread;
+    const int64_t input_base =
+        ((int64_t(b) * num_tokens + load_token_id) * H + h) * HeadDim + d_base;
+#pragma unroll
+    for (int i = 0; i < kFp4EltsPerThread; ++i) {
+      vals[i] = to_float(input[input_base + i]);
+    }
+  }
+
+  uint8_t sf_raw = 0;
+  const uint64_t packed = scaled_floats_to_fp4(vals, &sf_raw);
+  const int64_t out_offset =
+      ((int64_t(b) * H + h) * padded_tokens + token_id) * (HeadDim / 2) +
+      col * (kFp4EltsPerThread / 2);
+  reinterpret_cast<uint64_t*>(output + out_offset)[0] = packed;
+
+  uint8_t* sf_base =
+      output_sf +
+      ((int64_t(b) * H + h) * padded_tokens + (token_id / 64) * 64) *
+          (HeadDim / kFp4EltsPerThread);
+  const uint32_t token_local = token_id % 64;
+  const uint32_t col_local = col;
+  const uint32_t sf_offset =
+      (col_local / 4) * 256 + (col_local % 4) +
+      (token_local / 16) * 4 + (token_local % 16) * 16;
+  sf_base[sf_offset] = sf_raw;
+}
+
+template <int HeadDim, int BlockSize>
+__global__ void fp8_scaled_fp4_quant_trans_kernel(
+    const cutlass::float_e4m3_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    uint8_t* __restrict__ output_sf,
+    int B,
+    int H,
+    int num_tokens,
+    int padded_tokens) {
+  static_assert(BlockSize == kSage3QuantBlockTokens,
+                "Sage3 quantizer assumes 128-token blocks");
+  static_assert(kFp4EltsPerThread == 16,
+                "Sage3 scale layout below assumes 16 FP4 elements/thread");
+  constexpr int kThreadsPerToken = HeadDim / kFp4EltsPerThread;
+  constexpr int kThreadsPerSeq = BlockSize / kFp4EltsPerThread;
+
+  const int b = blockIdx.y;
+  const int h = blockIdx.z;
+  const int token_block = blockIdx.x;
+  const int local_token = threadIdx.x / kThreadsPerToken;
+  const int col = threadIdx.x % kThreadsPerToken;
+  const int token_id = token_block * BlockSize + local_token;
+  __shared__ uint8_t shared[BlockSize * HeadDim];
+
+  cutlass::NumericConverter<float, cutlass::float_e4m3_t> to_float;
+  const int d_base = col * kFp4EltsPerThread;
+#pragma unroll
+  for (int i = 0; i < kFp4EltsPerThread; ++i) {
+    uint8_t value = 0;
+    if (b < B && h < H && token_id < num_tokens) {
+      const int64_t input_idx =
+          ((int64_t(b) * num_tokens + token_id) * H + h) * HeadDim + d_base + i;
+      value = input[input_idx].storage;
+    }
+    shared[local_token * HeadDim + d_base + i] = value;
+  }
+  __syncthreads();
+
+  const int d = threadIdx.x / kThreadsPerSeq;
+  const int token_group = threadIdx.x % kThreadsPerSeq;
+  float vals[kFp4EltsPerThread];
+#pragma unroll
+  for (int i = 0; i < kFp4EltsPerThread; ++i) {
+    vals[i] = to_float(
+        cutlass::float_e4m3_t::bitcast(
+            shared[(token_group * kFp4EltsPerThread + i) * HeadDim + d]));
+  }
+
+  uint8_t sf_raw = 0;
+  const uint64_t packed = scaled_floats_to_fp4(vals, &sf_raw);
+  const int64_t out_offset =
+      ((int64_t(b) * H + h) * HeadDim + d) * (padded_tokens / 2) +
+      (token_block * BlockSize + token_group * kFp4EltsPerThread) / 2;
+  reinterpret_cast<uint64_t*>(output + out_offset)[0] = packed;
+
+  uint8_t* sf_base =
+      output_sf +
+      ((int64_t(b) * H + h) * HeadDim + (d / 64) * 64) *
+          (padded_tokens / kFp4EltsPerThread);
+  const uint32_t row_local = d % 64;
+  const uint32_t col_local = token_block * BlockSize / kFp4EltsPerThread +
+                             token_group;
+  const uint32_t sf_offset =
+      (col_local / 4) * 256 + (col_local % 4) +
+      (row_local / 16) * 4 + (row_local % 16) * 16;
+  sf_base[sf_offset] = sf_raw;
+}
+
+template <bool Permute>
+cudaError_t launch_fp8_scaled_fp4_quant(
+    const cutlass::float_e4m3_t* input,
+    int B,
+    int num_tokens,
+    int H,
+    int D,
+    int padded_tokens,
+    const at::Tensor& fp4,
+    const at::Tensor& sf,
+    cudaStream_t stream) {
+  if (!input || !fp4.defined() || !sf.defined()) return cudaErrorInvalidValue;
+  if (D != 64 && D != 128) return cudaErrorInvalidValue;
+  if (padded_tokens % kSage3QuantBlockTokens != 0) return cudaErrorInvalidValue;
+
+  const dim3 grid(padded_tokens / kSage3QuantBlockTokens, B, H);
+  if (D == 64) {
+    constexpr int kHeadDim = 64;
+    constexpr int kThreads =
+        kSage3QuantBlockTokens * kHeadDim / kFp4EltsPerThread;
+    fp8_scaled_fp4_quant_kernel<kHeadDim, kSage3QuantBlockTokens, Permute>
+        <<<grid, kThreads, 0, stream>>>(
+            input,
+            fp4.data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(sf.data_ptr()),
+            B, H, num_tokens, padded_tokens);
+  } else {
+    constexpr int kHeadDim = 128;
+    constexpr int kThreads =
+        kSage3QuantBlockTokens * kHeadDim / kFp4EltsPerThread;
+    fp8_scaled_fp4_quant_kernel<kHeadDim, kSage3QuantBlockTokens, Permute>
+        <<<grid, kThreads, 0, stream>>>(
+            input,
+            fp4.data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(sf.data_ptr()),
+            B, H, num_tokens, padded_tokens);
+  }
+  return cudaGetLastError();
+}
+
+cudaError_t launch_fp8_scaled_fp4_quant_trans(
+    const cutlass::float_e4m3_t* input,
+    int B,
+    int num_tokens,
+    int H,
+    int D,
+    int padded_tokens,
+    const at::Tensor& fp4,
+    const at::Tensor& sf,
+    cudaStream_t stream) {
+  if (!input || !fp4.defined() || !sf.defined()) return cudaErrorInvalidValue;
+  if (D != 64 && D != 128) return cudaErrorInvalidValue;
+  if (padded_tokens % kSage3QuantBlockTokens != 0) return cudaErrorInvalidValue;
+
+  const dim3 grid(padded_tokens / kSage3QuantBlockTokens, B, H);
+  if (D == 64) {
+    constexpr int kHeadDim = 64;
+    constexpr int kThreads =
+        kSage3QuantBlockTokens * kHeadDim / kFp4EltsPerThread;
+    fp8_scaled_fp4_quant_trans_kernel<kHeadDim, kSage3QuantBlockTokens>
+        <<<grid, kThreads, 0, stream>>>(
+            input,
+            fp4.data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(sf.data_ptr()),
+            B, H, num_tokens, padded_tokens);
+  } else {
+    constexpr int kHeadDim = 128;
+    constexpr int kThreads =
+        kSage3QuantBlockTokens * kHeadDim / kFp4EltsPerThread;
+    fp8_scaled_fp4_quant_trans_kernel<kHeadDim, kSage3QuantBlockTokens>
+        <<<grid, kThreads, 0, stream>>>(
+            input,
+            fp4.data_ptr<uint8_t>(),
+            reinterpret_cast<uint8_t*>(sf.data_ptr()),
+            B, H, num_tokens, padded_tokens);
+  }
+  return cudaGetLastError();
+}
+
+template <bool ApplyRope>
+__global__ void bf16_q_to_sage3_fp4_kernel(
+    const cutlass::bfloat16_t* __restrict__ input,
+    const cutlass::bfloat16_t* __restrict__ gamma,
+    const cutlass::bfloat16_t* __restrict__ rope_cos,
+    const cutlass::bfloat16_t* __restrict__ rope_sin,
+    uint8_t* __restrict__ output,
+    uint8_t* __restrict__ output_sf,
+    int B,
+    int num_tokens,
+    int H,
+    int D,
+    int input_row_stride,
+    int input_head_offset,
+    int padded_tokens) {
+  const int token_id = blockIdx.x;
+  const int b = blockIdx.y;
+  const int h = blockIdx.z;
+  const int tid = threadIdx.x;
+
+  extern __shared__ float smem[];
+  float acc = 0.0f;
+  if (token_id < num_tokens) {
+    const int64_t input_base =
+        int64_t(b * num_tokens + token_id) * input_row_stride +
+        input_head_offset + h * D;
+    for (int d = tid; d < D; d += blockDim.x) {
+      const float v = bf16_to_float(input[input_base + d]);
+      acc += v * v;
+    }
+  }
+  smem[tid] = acc;
+  __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) smem[tid] += smem[tid + off];
+    __syncthreads();
+  }
+  const float rms = rsqrtf(smem[0] / float(D) + 1e-6f);
+
+  if (tid >= D / kFp4EltsPerThread) return;
+  const int col = tid;
+  const int d_base = col * kFp4EltsPerThread;
+  const int d_half = D / 2;
+  float vals[kFp4EltsPerThread];
+#pragma unroll
+  for (int i = 0; i < kFp4EltsPerThread; ++i) {
+    vals[i] = 0.0f;
+  }
+
+  if (token_id < num_tokens) {
+    const int64_t input_base =
+        int64_t(b * num_tokens + token_id) * input_row_stride +
+        input_head_offset + h * D;
+    const int64_t rope_base = int64_t(token_id) * D;
+#pragma unroll
+    for (int i = 0; i < kFp4EltsPerThread; ++i) {
+      const int d = d_base + i;
+      float q = bf16_to_float(input[input_base + d]) *
+                rms * bf16_to_float(gamma[d]);
+      if constexpr (ApplyRope) {
+        const int d_op = (d < d_half) ? (d + d_half) : (d - d_half);
+        const float q_op =
+            bf16_to_float(input[input_base + d_op]) *
+            rms * bf16_to_float(gamma[d_op]);
+        const float c = bf16_to_float(rope_cos[rope_base + d]);
+        const float s = bf16_to_float(rope_sin[rope_base + d]);
+        const float rot = (d < d_half) ? -q_op : q_op;
+        q = q * c + rot * s;
+      }
+      vals[i] = q;
+    }
+  }
+
+  uint8_t sf_raw = 0;
+  const uint64_t packed = scaled_floats_to_fp4(vals, &sf_raw);
+  const int64_t out_offset =
+      ((int64_t(b) * H + h) * padded_tokens + token_id) * (D / 2) +
+      col * (kFp4EltsPerThread / 2);
+  reinterpret_cast<uint64_t*>(output + out_offset)[0] = packed;
+
+  uint8_t* sf_base =
+      output_sf +
+      ((int64_t(b) * H + h) * padded_tokens + (token_id / 64) * 64) *
+          (D / kFp4EltsPerThread);
+  const uint32_t token_local = token_id % 64;
+  const uint32_t col_local = col;
+  const uint32_t sf_offset =
+      (col_local / 4) * 256 + (col_local % 4) +
+      (token_local / 16) * 4 + (token_local % 16) * 16;
+  sf_base[sf_offset] = sf_raw;
+}
+
+at::Tensor packed_bmhk_view(void* ptr, int B, int M, int H, int D,
+                            int device) {
+  auto opts = at::TensorOptions()
+                  .device(at::kCUDA, device)
+                  .dtype(at::kBFloat16);
+  return torch::from_blob(
+      ptr,
+      {B, H, M, D},
+      {int64_t(M) * H * D, D, int64_t(H) * D, 1},
+      opts);
+}
+
+at::Tensor sage3_fp4_q_or_k_view(const uint8_t* ptr, int B, int H,
+                                  int M_padded, int D, int device) {
+  auto opts = at::TensorOptions().device(at::kCUDA, device).dtype(at::kByte);
+  return torch::from_blob(
+      const_cast<uint8_t*>(ptr),
+      {B, H, M_padded, D / 2},
+      opts);
+}
+
+at::Tensor sage3_fp4_v_view(const uint8_t* ptr, int B, int H,
+                             int M_padded, int D, int device) {
+  auto opts = at::TensorOptions().device(at::kCUDA, device).dtype(at::kByte);
+  return torch::from_blob(
+      const_cast<uint8_t*>(ptr),
+      {B, H, D, M_padded / 2},
+      opts);
+}
+
+at::Tensor sage3_sf_q_or_k_view(const cutlass::float_e4m3_t* ptr, int B, int H,
+                                 int M_padded, int D, int device) {
+  auto opts = at::TensorOptions()
+                  .device(at::kCUDA, device)
+                  .dtype(at::ScalarType::Float8_e4m3fn);
+  return torch::from_blob(
+      const_cast<cutlass::float_e4m3_t*>(ptr),
+      {B, H, M_padded, D / kFp4EltsPerThread},
+      opts);
+}
+
+at::Tensor sage3_sf_v_view(const cutlass::float_e4m3_t* ptr, int B, int H,
+                            int M_padded, int D, int device) {
+  auto opts = at::TensorOptions()
+                  .device(at::kCUDA, device)
+                  .dtype(at::ScalarType::Float8_e4m3fn);
+  return torch::from_blob(
+      const_cast<cutlass::float_e4m3_t*>(ptr),
+      {B, H, D, M_padded / kFp4EltsPerThread},
+      opts);
+}
+
+at::Tensor pad_seq_to_128(const at::Tensor& x) {
+  const int64_t L = x.size(2);
+  const int64_t L_round = round_up(static_cast<int>(L), 128);
+  if (L == L_round) {
+    return x.contiguous();
+  }
+
+  auto out = at::zeros({x.size(0), x.size(1), L_round, x.size(3)}, x.options());
+  out.narrow(2, 0, L).copy_(x);
+  return out;
+}
+
+at::Tensor subtract_group_mean(const at::Tensor& q, at::Tensor* qm_out,
+                               bool per_block_mean) {
+  const int64_t B = q.size(0);
+  const int64_t H = q.size(1);
+  const int64_t L = q.size(2);
+  const int64_t D = q.size(3);
+
+  if (per_block_mean) {
+    TORCH_CHECK(L % 128 == 0, "Sage3 Q length must be padded to 128");
+    const int64_t groups = L / 128;
+    auto q_blocks = q.view({B, H, groups, 128, D});
+    auto qm = q_blocks.mean(/*dim=*/3);
+    auto expanded = qm.unsqueeze(3).expand({B, H, groups, 128, D})
+                        .reshape({B, H, L, D});
+    *qm_out = qm.contiguous();
+    return (q - expanded).contiguous();
+  }
+
+  auto qm = q.mean(/*dim=*/2, /*keepdim=*/true);
+  *qm_out = qm.contiguous();
+  return (q - qm).contiguous();
+}
+
+void quantize_fp4(const at::Tensor& q,
+                  const at::Tensor& k,
+                  const at::Tensor& v,
+                  at::Tensor* q_fp4,
+                  at::Tensor* k_fp4,
+                  at::Tensor* v_fp4,
+                  at::Tensor* q_sf,
+                  at::Tensor* k_sf,
+                  at::Tensor* v_sf) {
+  auto u8_opts = q.options().dtype(at::kByte);
+  auto fp8_opts = q.options().dtype(at::ScalarType::Float8_e4m3fn);
+
+  const int64_t B = q.size(0);
+  const int64_t H = q.size(1);
+  const int64_t QL = q.size(2);
+  const int64_t KL = k.size(2);
+  const int64_t D = q.size(3);
+
+  *q_fp4 = at::empty({B, H, QL, D / 2}, u8_opts);
+  *k_fp4 = at::empty({B, H, KL, D / 2}, u8_opts);
+  *v_fp4 = at::empty({B, H, D, KL / 2}, u8_opts);
+  *q_sf = at::empty({B, H, QL, D / 16}, fp8_opts);
+  *k_sf = at::empty({B, H, KL, D / 16}, fp8_opts);
+  *v_sf = at::empty({B, H, D, KL / 16}, fp8_opts);
+
+  scaled_fp4_quant(q, *q_fp4, *q_sf, 1);
+  scaled_fp4_quant_permute(k, *k_fp4, *k_sf, 1);
+  scaled_fp4_quant_trans(v, *v_fp4, *v_sf, 1);
+}
+
+cudaError_t launch_bf16_q_to_sage3_fp4(
+    const cutlass::bfloat16_t* input,
+    const cutlass::bfloat16_t* gamma,
+    const cutlass::bfloat16_t* rope_cos,
+    const cutlass::bfloat16_t* rope_sin,
+    uint8_t* q_fp4,
+    cutlass::float_e4m3_t* q_sf,
+    int B,
+    int Mq,
+    int H,
+    int D,
+    int input_row_stride,
+    int input_head_offset,
+    bool apply_rope,
+    int padded_mq,
+    cudaStream_t stream) {
+  if (!input || !gamma || !q_fp4 || !q_sf) return cudaErrorInvalidValue;
+  if (apply_rope && (!rope_cos || !rope_sin)) return cudaErrorInvalidValue;
+  if (B <= 0 || Mq <= 0 || H <= 0) return cudaErrorInvalidValue;
+  if (D != 64 && D != 128) return cudaErrorInvalidValue;
+  if (padded_mq < Mq || padded_mq % kSage3QuantBlockTokens != 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  const int threads = (D <= 64) ? 64 : 128;
+  const dim3 grid(padded_mq, B, H);
+  const size_t smem = threads * sizeof(float);
+  if (apply_rope) {
+    bf16_q_to_sage3_fp4_kernel</*ApplyRope=*/true>
+        <<<grid, threads, smem, stream>>>(
+            input, gamma, rope_cos, rope_sin, q_fp4,
+            reinterpret_cast<uint8_t*>(q_sf), B, Mq, H, D,
+            input_row_stride, input_head_offset, padded_mq);
+  } else {
+    bf16_q_to_sage3_fp4_kernel</*ApplyRope=*/false>
+        <<<grid, threads, smem, stream>>>(
+            input, gamma, nullptr, nullptr, q_fp4,
+            reinterpret_cast<uint8_t*>(q_sf), B, Mq, H, D,
+            input_row_stride, input_head_offset, padded_mq);
+  }
+  return cudaGetLastError();
+}
+
+}  // namespace
+
+bool sage3_is_built() {
+  return true;
+}
+
+bool sage3_is_runtime_supported(int device) {
+  if (device < 0) {
+    cudaError_t err = cudaGetDevice(&device);
+    if (err != cudaSuccess) return false;
+  }
+  cudaDeviceProp prop{};
+  cudaError_t err = cudaGetDeviceProperties(&prop, device);
+  if (err != cudaSuccess) return false;
+  if (prop.major != 12 || prop.minor != 0) return false;
+
+  // CUDA reports these devices as compute capability 12.0; it does not expose
+  // the architecture suffix that distinguishes an SM120a target from a generic
+  // SM120 target. Sage3 uses arch-conditional FP4 MMA instructions that must be
+  // compiled for compute_120a/sm_120a, so the default runtime auto-selection is
+  // limited to SM120a devices we have explicitly built and validated. Extend
+  // this allowlist when a new Blackwell SKU is confirmed to run the SM120a path.
+  const std::string name(prop.name);
+  return name.find("GeForce RTX 5090") != std::string::npos ||
+         name.find("RTX PRO 6000") != std::string::npos ||
+         name.find("RTX 6000") != std::string::npos;
+}
+
+cudaError_t sage3_quantize_q_bf16(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* gamma,
+    const cutlass::bfloat16_t* rope_cos,
+    const cutlass::bfloat16_t* rope_sin,
+    uint8_t* Q_fp4,
+    cutlass::float_e4m3_t* Q_sf,
+    int B, int Mq,
+    int H, int D,
+    int input_row_stride,
+    int input_head_offset,
+    bool apply_rope,
+    int padded_mq,
+    cudaStream_t stream) {
+  return launch_bf16_q_to_sage3_fp4(
+      Q, gamma, rope_cos, rope_sin, Q_fp4, Q_sf,
+      B, Mq, H, D, input_row_stride, input_head_offset,
+      apply_rope, padded_mq, stream);
+}
+
+std::vector<at::Tensor> sage3_quantize_cross_kv_bf16(
+    at::Tensor k_bmhd,
+    at::Tensor v_bmhd) {
+  TORCH_CHECK(k_bmhd.is_cuda() && v_bmhd.is_cuda(), "Sage3 K/V inputs must be CUDA tensors");
+  TORCH_CHECK(k_bmhd.device() == v_bmhd.device(),
+              "Sage3 K/V inputs must be on the same CUDA device");
+  TORCH_CHECK(k_bmhd.scalar_type() == at::kBFloat16 &&
+              v_bmhd.scalar_type() == at::kBFloat16,
+              "Sage3 K/V inputs must be bfloat16");
+  TORCH_CHECK(k_bmhd.dim() == 4 && v_bmhd.dim() == 4,
+              "Sage3 K/V inputs must have shape [B, M, H, D]");
+  TORCH_CHECK(k_bmhd.sizes() == v_bmhd.sizes(),
+              "Sage3 K/V inputs must have matching shapes");
+  c10::cuda::CUDAGuard device_guard(k_bmhd.device());
+  at::NoGradGuard no_grad;
+
+  const int64_t B = k_bmhd.size(0);
+  const int64_t M = k_bmhd.size(1);
+  const int64_t H = k_bmhd.size(2);
+  const int64_t D = k_bmhd.size(3);
+  TORCH_CHECK(D == 64 || D == 128, "Sage3 head_dim must be 64 or 128, got ", D);
+
+  auto k = k_bmhd.permute({0, 2, 1, 3}).contiguous();
+  auto v = v_bmhd.permute({0, 2, 1, 3}).contiguous();
+  auto k_padded = pad_seq_to_128(k);
+  auto v_padded = pad_seq_to_128(v);
+  const int64_t Mp = k_padded.size(2);
+
+  auto u8_opts = k.options().dtype(at::kByte);
+  auto fp8_opts = k.options().dtype(at::ScalarType::Float8_e4m3fn);
+  auto k_fp4 = at::empty({B, H, Mp, D / 2}, u8_opts);
+  auto v_fp4 = at::empty({B, H, D, Mp / 2}, u8_opts);
+  auto k_sf = at::empty({B, H, Mp, D / kFp4EltsPerThread}, fp8_opts);
+  auto v_sf = at::empty({B, H, D, Mp / kFp4EltsPerThread}, fp8_opts);
+
+  scaled_fp4_quant_permute(k_padded, k_fp4, k_sf, 1);
+  scaled_fp4_quant_trans(v_padded, v_fp4, v_sf, 1);
+  return {k_fp4, v_fp4, k_sf, v_sf};
+}
+
+cudaError_t run_sage3_fmha_packed_qkv(
+    const cutlass::bfloat16_t* Q,
+    const cutlass::bfloat16_t* K,
+    const cutlass::bfloat16_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream) {
+  if (Mq <= 0 || Mk <= 0) return cudaErrorInvalidValue;
+  if (D != 64 && D != 128) return cudaErrorInvalidValue;
+
+  int device = 0;
+  cudaError_t device_err = cudaGetDevice(&device);
+  if (device_err != cudaSuccess) return device_err;
+
+  c10::cuda::CUDAGuard device_guard(device);
+  CurrentStreamScope stream_scope(stream, device);
+  at::NoGradGuard no_grad;
+
+  auto q_view = packed_bmhk_view(const_cast<cutlass::bfloat16_t*>(Q), B, Mq, H, D, device);
+  auto k_view = packed_bmhk_view(const_cast<cutlass::bfloat16_t*>(K), B, Mk, H, D, device);
+  auto v_view = packed_bmhk_view(const_cast<cutlass::bfloat16_t*>(V), B, Mk, H, D, device);
+  auto o_view = packed_bmhk_view(O, B, Mq, H, D, device);
+
+  constexpr bool per_block_mean = true;
+  auto q_padded = pad_seq_to_128(q_view);
+  auto k_centered = k_view - k_view.mean(/*dim=*/2, /*keepdim=*/true);
+  auto k_padded = pad_seq_to_128(k_centered);
+  auto v_padded = pad_seq_to_128(v_view);
+
+  at::Tensor q_mean;
+  auto q_centered = subtract_group_mean(q_padded, &q_mean, per_block_mean);
+  auto delta_s = at::matmul(q_mean, k_padded.transpose(-2, -1))
+                     .to(at::kFloat)
+                     .contiguous();
+
+  at::Tensor q_fp4, k_fp4, v_fp4, q_sf, k_sf, v_sf;
+  quantize_fp4(q_centered, k_padded.contiguous(), v_padded.contiguous(),
+               &q_fp4, &k_fp4, &v_fp4, &q_sf, &k_sf, &v_sf);
+
+  c10::optional<at::Tensor> out_opt = c10::nullopt;
+  const float softmax_scale = (scale > 0.f) ? scale : (1.0f / std::sqrt(float(D)));
+  auto out = mha_fwd(q_fp4, k_fp4, v_fp4, q_sf, k_sf, v_sf, delta_s,
+                     Mk, out_opt, softmax_scale, causal,
+                     per_block_mean, /*is_bf16=*/true)
+                 .at(0);
+  o_view.copy_(out.narrow(2, 0, Mq));
+  return cudaGetLastError();
+}
+
+static cudaError_t run_sage3_fmha_packed_fp4_impl(
+    const uint8_t* Q_fp4,
+    const uint8_t* K_fp4,
+    const uint8_t* V_fp4,
+    const cutlass::float_e4m3_t* Q_sf,
+    const cutlass::float_e4m3_t* K_sf,
+    const cutlass::float_e4m3_t* V_sf,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    int padded_mq,
+    int padded_mk,
+    cudaStream_t stream) {
+  if (B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0) return cudaErrorInvalidValue;
+  if (D != 64 && D != 128) return cudaErrorInvalidValue;
+  if (!Q_fp4 || !K_fp4 || !V_fp4 || !Q_sf || !K_sf || !V_sf || !O) {
+    return cudaErrorInvalidValue;
+  }
+  if (padded_mq < Mq || padded_mk < Mk ||
+      padded_mq % kSage3QuantBlockTokens != 0 ||
+      padded_mk % kSage3QuantBlockTokens != 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  int device = 0;
+  cudaError_t device_err = cudaGetDevice(&device);
+  if (device_err != cudaSuccess) return device_err;
+
+  c10::cuda::CUDAGuard device_guard(device);
+  CurrentStreamScope stream_scope(stream, device);
+  at::NoGradGuard no_grad;
+
+  auto q_fp4 = sage3_fp4_q_or_k_view(Q_fp4, B, H, padded_mq, D, device);
+  auto k_fp4 = sage3_fp4_q_or_k_view(K_fp4, B, H, padded_mk, D, device);
+  auto v_fp4 = sage3_fp4_v_view(V_fp4, B, H, padded_mk, D, device);
+  auto q_sf = sage3_sf_q_or_k_view(Q_sf, B, H, padded_mq, D, device);
+  auto k_sf = sage3_sf_q_or_k_view(K_sf, B, H, padded_mk, D, device);
+  auto v_sf = sage3_sf_v_view(V_sf, B, H, padded_mk, D, device);
+
+  const int QGroups = padded_mq / kSage3QuantBlockTokens;
+  auto delta_s = at::empty(
+      {B, H, QGroups, padded_mk},
+      at::TensorOptions().device(at::kCUDA, device).dtype(at::kFloat));
+  cudaError_t err = cudaMemsetAsync(delta_s.data_ptr(), 0, delta_s.nbytes(), stream);
+  if (err != cudaSuccess) return err;
+
+  c10::optional<at::Tensor> out_opt = c10::nullopt;
+  const float softmax_scale = (scale > 0.f) ? scale : (1.0f / std::sqrt(float(D)));
+  auto out = mha_fwd(q_fp4, k_fp4, v_fp4, q_sf, k_sf, v_sf, delta_s,
+                     Mk, out_opt, softmax_scale, causal,
+                     /*per_block_mean=*/true, /*is_bf16=*/true)
+                 .at(0);
+  auto o_view = packed_bmhk_view(O, B, Mq, H, D, device);
+  o_view.copy_(out.narrow(2, 0, Mq));
+  return cudaGetLastError();
+}
+
+cudaError_t run_sage3_fmha_packed_qfp4_kvfp8(
+    const uint8_t* Q_fp4,
+    const cutlass::float_e4m3_t* Q_sf,
+    const cutlass::float_e4m3_t* K,
+    const cutlass::float_e4m3_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    int padded_mq,
+    cudaStream_t stream) {
+  if (!Q_fp4 || !Q_sf || !K || !V || !O) return cudaErrorInvalidValue;
+  if (B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0) return cudaErrorInvalidValue;
+  if (D != 64 && D != 128) return cudaErrorInvalidValue;
+  const int padded_mk = round_up(Mk, kSage3QuantBlockTokens);
+
+  int device = 0;
+  cudaError_t device_err = cudaGetDevice(&device);
+  if (device_err != cudaSuccess) return device_err;
+
+  c10::cuda::CUDAGuard device_guard(device);
+  CurrentStreamScope stream_scope(stream, device);
+  at::NoGradGuard no_grad;
+
+  auto opts = at::TensorOptions().device(at::kCUDA, device);
+  auto u8_opts = opts.dtype(at::kByte);
+  auto fp8_opts = opts.dtype(at::ScalarType::Float8_e4m3fn);
+  auto k_fp4 = at::empty({B, H, padded_mk, D / 2}, u8_opts);
+  auto v_fp4 = at::empty({B, H, D, padded_mk / 2}, u8_opts);
+  auto k_sf = at::empty({B, H, padded_mk, D / kFp4EltsPerThread}, fp8_opts);
+  auto v_sf = at::empty({B, H, D, padded_mk / kFp4EltsPerThread}, fp8_opts);
+
+  cudaError_t err = launch_fp8_scaled_fp4_quant</*Permute=*/true>(
+      K, B, Mk, H, D, padded_mk, k_fp4, k_sf, stream);
+  if (err != cudaSuccess) return err;
+  err = launch_fp8_scaled_fp4_quant_trans(
+      V, B, Mk, H, D, padded_mk, v_fp4, v_sf, stream);
+  if (err != cudaSuccess) return err;
+
+  return run_sage3_fmha_packed_fp4_impl(
+      Q_fp4,
+      k_fp4.data_ptr<uint8_t>(),
+      v_fp4.data_ptr<uint8_t>(),
+      Q_sf,
+      reinterpret_cast<const cutlass::float_e4m3_t*>(k_sf.data_ptr()),
+      reinterpret_cast<const cutlass::float_e4m3_t*>(v_sf.data_ptr()),
+      O, B, Mq, Mk, H, D, causal, scale, padded_mq, padded_mk, stream);
+}
+
+cudaError_t run_sage3_fmha_packed_qkv_fp4(
+    const uint8_t* Q_fp4,
+    const uint8_t* K_fp4,
+    const uint8_t* V_fp4,
+    const cutlass::float_e4m3_t* Q_sf,
+    const cutlass::float_e4m3_t* K_sf,
+    const cutlass::float_e4m3_t* V_sf,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    int padded_mq,
+    int padded_mk,
+    cudaStream_t stream) {
+  return run_sage3_fmha_packed_fp4_impl(
+      Q_fp4, K_fp4, V_fp4, Q_sf, K_sf, V_sf, O,
+      B, Mq, Mk, H, D, causal, scale, padded_mq, padded_mk, stream);
+}
+
+cudaError_t run_sage3_fmha_packed_qkv_fp8(
+    const cutlass::float_e4m3_t* Q,
+    const cutlass::float_e4m3_t* K,
+    const cutlass::float_e4m3_t* V,
+    cutlass::bfloat16_t* O,
+    int B, int Mq, int Mk,
+    int H, int D,
+    bool causal,
+    float scale,
+    cudaStream_t stream) {
+  if (B <= 0 || Mq <= 0 || Mk <= 0 || H <= 0) return cudaErrorInvalidValue;
+  if (D != 64 && D != 128) return cudaErrorInvalidValue;
+  if (!Q || !K || !V || !O) return cudaErrorInvalidValue;
+
+  int device = 0;
+  cudaError_t device_err = cudaGetDevice(&device);
+  if (device_err != cudaSuccess) return device_err;
+
+  c10::cuda::CUDAGuard device_guard(device);
+  CurrentStreamScope stream_scope(stream, device);
+  at::NoGradGuard no_grad;
+
+  const bool profile = env_flag_enabled("OMNIDREAMS_DIT_SAGE3_PROFILE");
+  enum {
+    EV_START,
+    EV_AFTER_Q_QUANT,
+    EV_AFTER_K_QUANT,
+    EV_AFTER_V_QUANT,
+    EV_AFTER_DELTA,
+    EV_AFTER_MHA,
+    EV_AFTER_COPY,
+    EV_COUNT,
+  };
+  cudaEvent_t ev[EV_COUNT] = {};
+  auto cleanup_events = [&]() {
+    if (!profile) return;
+    for (int i = 0; i < EV_COUNT; ++i) {
+      if (ev[i]) cudaEventDestroy(ev[i]);
+    }
+  };
+  auto rec = [&](int idx) {
+    if (profile) cudaEventRecord(ev[idx], stream);
+  };
+  if (profile) {
+    for (int i = 0; i < EV_COUNT; ++i) cudaEventCreate(&ev[i]);
+    rec(EV_START);
+  }
+
+  const int QL = round_up(Mq, kSage3QuantBlockTokens);
+  const int KL = round_up(Mk, kSage3QuantBlockTokens);
+  const int QGroups = QL / kSage3QuantBlockTokens;
+  auto opts = at::TensorOptions().device(at::kCUDA, device);
+  auto u8_opts = opts.dtype(at::kByte);
+  auto fp8_opts = opts.dtype(at::ScalarType::Float8_e4m3fn);
+  auto q_fp4 = at::empty({B, H, QL, D / 2}, u8_opts);
+  auto k_fp4 = at::empty({B, H, KL, D / 2}, u8_opts);
+  auto v_fp4 = at::empty({B, H, D, KL / 2}, u8_opts);
+  auto q_sf = at::empty({B, H, QL, D / 16}, fp8_opts);
+  auto k_sf = at::empty({B, H, KL, D / 16}, fp8_opts);
+  auto v_sf = at::empty({B, H, D, KL / 16}, fp8_opts);
+
+  cudaError_t err = launch_fp8_scaled_fp4_quant</*Permute=*/false>(
+      Q, B, Mq, H, D, QL, q_fp4, q_sf, stream);
+  if (err != cudaSuccess) {
+    cleanup_events();
+    return err;
+  }
+  rec(EV_AFTER_Q_QUANT);
+
+  err = launch_fp8_scaled_fp4_quant</*Permute=*/true>(
+      K, B, Mk, H, D, KL, k_fp4, k_sf, stream);
+  if (err != cudaSuccess) {
+    cleanup_events();
+    return err;
+  }
+  rec(EV_AFTER_K_QUANT);
+
+  err = launch_fp8_scaled_fp4_quant_trans(
+      V, B, Mk, H, D, KL, v_fp4, v_sf, stream);
+  if (err != cudaSuccess) {
+    cleanup_events();
+    return err;
+  }
+  rec(EV_AFTER_V_QUANT);
+
+  // This FP8 path intentionally does not recenter Q/K. A zero correction keeps
+  // Sage3's per-block-mean interface equivalent to uncentered attention.
+  auto delta_s = at::empty(
+      {B, H, QGroups, KL},
+      at::TensorOptions().device(at::kCUDA, device).dtype(at::kFloat));
+  err = cudaMemsetAsync(delta_s.data_ptr(), 0, delta_s.nbytes(), stream);
+  if (err != cudaSuccess) {
+    cleanup_events();
+    return err;
+  }
+  rec(EV_AFTER_DELTA);
+
+  c10::optional<at::Tensor> out_opt = c10::nullopt;
+  const float softmax_scale = (scale > 0.f) ? scale : (1.0f / std::sqrt(float(D)));
+  auto out = mha_fwd(q_fp4, k_fp4, v_fp4, q_sf, k_sf, v_sf, delta_s,
+                     Mk, out_opt, softmax_scale, causal,
+                     /*per_block_mean=*/true, /*is_bf16=*/true)
+                 .at(0);
+  rec(EV_AFTER_MHA);
+
+  auto o_view = packed_bmhk_view(O, B, Mq, H, D, device);
+  o_view.copy_(out.narrow(2, 0, Mq));
+  rec(EV_AFTER_COPY);
+
+  err = cudaGetLastError();
+  if (profile) {
+    cudaEventSynchronize(ev[EV_AFTER_COPY]);
+    auto ms = [&](int a, int b) {
+      float out_ms = 0.0f;
+      cudaEventElapsedTime(&out_ms, ev[a], ev[b]);
+      return out_ms;
+    };
+    std::printf(
+        "[sage3-fp8] B=%d Mq=%d Mk=%d H=%d D=%d "
+        "q=%.3f k=%.3f v=%.3f delta=%.3f mha=%.3f copy=%.3f total=%.3f ms\n",
+        B, Mq, Mk, H, D,
+        ms(EV_START, EV_AFTER_Q_QUANT),
+        ms(EV_AFTER_Q_QUANT, EV_AFTER_K_QUANT),
+        ms(EV_AFTER_K_QUANT, EV_AFTER_V_QUANT),
+        ms(EV_AFTER_V_QUANT, EV_AFTER_DELTA),
+        ms(EV_AFTER_DELTA, EV_AFTER_MHA),
+        ms(EV_AFTER_MHA, EV_AFTER_COPY),
+        ms(EV_START, EV_AFTER_COPY));
+    std::fflush(stdout);
+  }
+  cleanup_events();
+  return err;
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "attention.cuh"
 
 #include <ATen/ATen.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention_stub.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention_stub.cu
@@ -1,0 +1,98 @@
+#include "attention.cuh"
+
+#include <torch/extension.h>
+
+namespace omnidreams_singleview {
+
+bool sage3_is_built() {
+  return false;
+}
+
+bool sage3_is_runtime_supported(int /*device*/) {
+  return false;
+}
+
+std::vector<at::Tensor> sage3_quantize_cross_kv_bf16(
+    at::Tensor /*k_bmhd*/,
+    at::Tensor /*v_bmhd*/) {
+  TORCH_CHECK(false, "SageAttention-3 was not built into OmniDreams single-view native extension");
+  return {};
+}
+
+cudaError_t run_sage3_fmha_packed_qkv(
+    const cutlass::bfloat16_t* /*Q*/,
+    const cutlass::bfloat16_t* /*K*/,
+    const cutlass::bfloat16_t* /*V*/,
+    cutlass::bfloat16_t* /*O*/,
+    int /*B*/, int /*Mq*/, int /*Mk*/,
+    int /*H*/, int /*D*/,
+    bool /*causal*/,
+    float /*scale*/,
+    cudaStream_t /*stream*/) {
+  return cudaErrorNotSupported;
+}
+
+cudaError_t run_sage3_fmha_packed_qkv_fp8(
+    const cutlass::float_e4m3_t* /*Q*/,
+    const cutlass::float_e4m3_t* /*K*/,
+    const cutlass::float_e4m3_t* /*V*/,
+    cutlass::bfloat16_t* /*O*/,
+    int /*B*/, int /*Mq*/, int /*Mk*/,
+    int /*H*/, int /*D*/,
+    bool /*causal*/,
+    float /*scale*/,
+    cudaStream_t /*stream*/) {
+  return cudaErrorNotSupported;
+}
+
+cudaError_t run_sage3_fmha_packed_qfp4_kvfp8(
+    const uint8_t* /*Q_fp4*/,
+    const cutlass::float_e4m3_t* /*Q_sf*/,
+    const cutlass::float_e4m3_t* /*K*/,
+    const cutlass::float_e4m3_t* /*V*/,
+    cutlass::bfloat16_t* /*O*/,
+    int /*B*/, int /*Mq*/, int /*Mk*/,
+    int /*H*/, int /*D*/,
+    bool /*causal*/,
+    float /*scale*/,
+    int /*padded_mq*/,
+    cudaStream_t /*stream*/) {
+  return cudaErrorNotSupported;
+}
+
+cudaError_t run_sage3_fmha_packed_qkv_fp4(
+    const uint8_t* /*Q_fp4*/,
+    const uint8_t* /*K_fp4*/,
+    const uint8_t* /*V_fp4*/,
+    const cutlass::float_e4m3_t* /*Q_sf*/,
+    const cutlass::float_e4m3_t* /*K_sf*/,
+    const cutlass::float_e4m3_t* /*V_sf*/,
+    cutlass::bfloat16_t* /*O*/,
+    int /*B*/, int /*Mq*/, int /*Mk*/,
+    int /*H*/, int /*D*/,
+    bool /*causal*/,
+    float /*scale*/,
+    int /*padded_mq*/,
+    int /*padded_mk*/,
+    cudaStream_t /*stream*/) {
+  return cudaErrorNotSupported;
+}
+
+cudaError_t sage3_quantize_q_bf16(
+    const cutlass::bfloat16_t* /*Q*/,
+    const cutlass::bfloat16_t* /*gamma*/,
+    const cutlass::bfloat16_t* /*rope_cos*/,
+    const cutlass::bfloat16_t* /*rope_sin*/,
+    uint8_t* /*Q_fp4*/,
+    cutlass::float_e4m3_t* /*Q_sf*/,
+    int /*B*/, int /*Mq*/,
+    int /*H*/, int /*D*/,
+    int /*input_row_stride*/,
+    int /*input_head_offset*/,
+    bool /*apply_rope*/,
+    int /*padded_mq*/,
+    cudaStream_t /*stream*/) {
+  return cudaErrorNotSupported;
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention_stub.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sage3_attention_stub.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "attention.cuh"
 
 #include <torch/extension.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_kernels.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_kernels.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cuda_runtime.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_kernels.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_kernels.cuh
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cstdint>
+#include <limits>
+
+namespace omnidreams_singleview {
+
+cudaError_t launch_sparge_attention_sm89_hd128(
+    int8_t* Q, int8_t* K, __nv_fp8_e4m3* V, half* O,
+    int32_t* PV_Count, int32_t* __restrict__ Lut, int32_t* __restrict__ Valid_Block_Num,
+    float* __restrict__ PV_Threshold,
+    float* Q_scale, float* K_scale, float* V_scale,
+    const uint32_t batch_size, const uint32_t qo_len, const uint32_t kv_len,
+    const uint32_t num_qo_heads, const uint32_t num_kv_heads,
+    const uint32_t stride_bz_q, const uint32_t stride_seq_q, const uint32_t stride_h_q,
+    const uint32_t stride_bz_k, const uint32_t stride_seq_k, const uint32_t stride_h_k,
+    const uint32_t stride_bz_v, const uint32_t stride_h_v, const uint32_t stride_d_v,
+    const uint32_t stride_bz_o, const uint32_t stride_seq_o, const uint32_t stride_h_o,
+    float sm_scale, cudaStream_t stream);
+
+}  // namespace omnidreams_singleview
+
+namespace sparge_attention {
+
+inline cudaError_t run_sparge_attention_sm89_hd128(
+    int8_t* Q, int8_t* K, __nv_fp8_e4m3* V, half* O,
+    int32_t* lut, int32_t* valid_block_num, float* pv_threshold,
+    float* q_scale, float* k_scale, float* v_scale,
+    int batch_size, int qo_len, int kv_len, int num_qo_heads, int num_kv_heads,
+    int padded_kv_len, float sm_scale, cudaStream_t stream) {
+  constexpr int D = 128;
+
+  if (!Q || !K || !V || !O || !lut || !valid_block_num || !pv_threshold ||
+      !q_scale || !k_scale || !v_scale) {
+    return cudaErrorInvalidValue;
+  }
+  if (batch_size <= 0 || qo_len <= 0 || kv_len <= 0 ||
+      num_qo_heads <= 0 || num_kv_heads <= 0 || padded_kv_len < kv_len) {
+    return cudaErrorInvalidValue;
+  }
+
+  auto to_u32 = [](uint64_t value, uint32_t& out) -> bool {
+    if (value > std::numeric_limits<uint32_t>::max()) {
+      return false;
+    }
+    out = static_cast<uint32_t>(value);
+    return true;
+  };
+
+  uint32_t stride_bz_q = 0;
+  uint32_t stride_seq_q = 0;
+  uint32_t stride_h_q = 0;
+  uint32_t stride_bz_k = 0;
+  uint32_t stride_seq_k = 0;
+  uint32_t stride_h_k = 0;
+  uint32_t stride_bz_v = 0;
+  uint32_t stride_h_v = 0;
+  uint32_t stride_d_v = 0;
+  uint32_t stride_bz_o = 0;
+  uint32_t stride_seq_o = 0;
+  uint32_t stride_h_o = 0;
+
+  if (!to_u32(uint64_t(qo_len) * num_qo_heads * D, stride_bz_q) ||
+      !to_u32(uint64_t(num_qo_heads) * D, stride_seq_q) ||
+      !to_u32(D, stride_h_q) ||
+      !to_u32(uint64_t(kv_len) * num_kv_heads * D, stride_bz_k) ||
+      !to_u32(uint64_t(num_kv_heads) * D, stride_seq_k) ||
+      !to_u32(D, stride_h_k) ||
+      !to_u32(uint64_t(num_kv_heads) * D * padded_kv_len, stride_bz_v) ||
+      !to_u32(uint64_t(D) * padded_kv_len, stride_h_v) ||
+      !to_u32(uint64_t(padded_kv_len), stride_d_v) ||
+      !to_u32(uint64_t(qo_len) * num_qo_heads * D, stride_bz_o) ||
+      !to_u32(uint64_t(num_qo_heads) * D, stride_seq_o) ||
+      !to_u32(D, stride_h_o)) {
+    return cudaErrorInvalidValue;
+  }
+
+  return omnidreams_singleview::launch_sparge_attention_sm89_hd128(
+      Q, K, V, O,
+      nullptr,  // PV_Count is unused by the instantiated return_pv_count=false kernel.
+      lut, valid_block_num, pv_threshold,
+      q_scale, k_scale, v_scale,
+      batch_size, qo_len, kv_len, num_qo_heads, num_kv_heads,
+      stride_bz_q, stride_seq_q, stride_h_q,
+      stride_bz_k, stride_seq_k, stride_h_k,
+      stride_bz_v, stride_h_v, stride_d_v,
+      stride_bz_o, stride_seq_o, stride_h_o,
+      sm_scale, stream);
+}
+
+}  // namespace sparge_attention

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_sm89_inst.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_sm89_inst.cu
@@ -1,0 +1,112 @@
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#include <algorithm>
+#include <atomic>
+
+#include "qattn/qk_int_sv_f8_cuda_sm89.cuh"
+
+namespace omnidreams_singleview {
+
+cudaError_t launch_sparge_attention_sm89_hd128(
+    int8_t* Q,
+    int8_t* K,
+    __nv_fp8_e4m3* V,
+    half* O,
+    int32_t* PV_Count,
+    int32_t* __restrict__ Lut,
+    int32_t* __restrict__ Valid_Block_Num,
+    float* __restrict__ PV_Threshold,
+    float* Q_scale,
+    float* K_scale,
+    float* V_scale,
+    const uint32_t batch_size,
+    const uint32_t qo_len,
+    const uint32_t kv_len,
+    const uint32_t num_qo_heads,
+    const uint32_t num_kv_heads,
+    const uint32_t stride_bz_q,
+    const uint32_t stride_seq_q,
+    const uint32_t stride_h_q,
+    const uint32_t stride_bz_k,
+    const uint32_t stride_seq_k,
+    const uint32_t stride_h_k,
+    const uint32_t stride_bz_v,
+    const uint32_t stride_h_v,
+    const uint32_t stride_d_v,
+    const uint32_t stride_bz_o,
+    const uint32_t stride_seq_o,
+    const uint32_t stride_h_o,
+    float sm_scale,
+    cudaStream_t stream) {
+  if (batch_size == 0 || qo_len == 0 || kv_len == 0 ||
+      num_qo_heads == 0 || num_kv_heads == 0 ||
+      (num_qo_heads % num_kv_heads) != 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  constexpr uint32_t CTA_Q = 128;
+  constexpr uint32_t CTA_K = 64;
+  constexpr uint32_t WARP_Q = 32;
+  constexpr uint32_t WARP_K = 64;
+  constexpr uint32_t kHeadDim = 128;
+  constexpr MaskMode mask_mode = MaskMode::kNone;
+
+  size_t smem_max = std::max(
+      CTA_Q * kHeadDim * sizeof(int8_t) +
+          CTA_K * kHeadDim * sizeof(int8_t) +
+          CTA_K * kHeadDim * sizeof(int8_t),
+      CTA_Q * kHeadDim * sizeof(half));
+  auto kernel_func = qk_int_sv_f8_block_sparse_attn_kernel<
+      CTA_Q, CTA_K, WARP_Q, WARP_K, kHeadDim, DataType::kInt8,
+      QuantGranularity::kPerBlock, QuantGranularity::kPerBlock, float,
+      true, false, PVThresholdMode::kPerBlock, half, ComputeUnit::kCudaCore,
+      mask_mode, true, false>;
+
+  static std::atomic<bool> smem_attr_set{false};
+  if (!smem_attr_set.load(std::memory_order_acquire)) {
+    cudaError_t err = cudaFuncSetAttribute(
+        kernel_func, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_max);
+    if (err != cudaSuccess) {
+      return err;
+    }
+    smem_attr_set.store(true, std::memory_order_release);
+  }
+
+  dim3 grid(div_ceil(qo_len, CTA_Q), num_qo_heads, batch_size);
+  dim3 block(32, (CTA_Q / WARP_Q) * (CTA_K / WARP_K));
+
+  kernel_func<<<grid, block, smem_max, stream>>>(
+      Q,
+      K,
+      reinterpret_cast<int8_t*>(V),
+      O,
+      PV_Count,
+      Lut,
+      Valid_Block_Num,
+      PV_Threshold,
+      Q_scale,
+      K_scale,
+      V_scale,
+      qo_len,
+      kv_len,
+      num_qo_heads / num_kv_heads,
+      stride_bz_q,
+      stride_seq_q,
+      stride_h_q,
+      stride_bz_k,
+      stride_seq_k,
+      stride_h_k,
+      stride_bz_v,
+      stride_h_v,
+      stride_d_v,
+      stride_bz_o,
+      stride_seq_o,
+      stride_h_o,
+      sm_scale);
+
+  return cudaGetLastError();
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_sm89_inst.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/sparge_attention_sm89_inst.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/transformer_block.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/transformer_block.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "workspace.cuh"
 #include "attention.cuh"
 #include "ops.cuh"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/transformer_block.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/transformer_block.cu
@@ -1,0 +1,861 @@
+#include "workspace.cuh"
+#include "attention.cuh"
+#include "ops.cuh"
+#include "linear_utils.cuh"
+#include "dtype_utils.cuh"
+#include "helper.h"
+#include "common/profile_config.h"
+#include "common/profiler.h"
+#include "linear_utils.cuh"
+
+#include "cutlass/cutlass.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/bfloat16.h"
+#include "cutlass/gemm/device/gemm.h"
+#include "cutlass/epilogue/thread/linear_combination_gelu.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+
+#include <cstdio>
+#include <vector>
+#include <type_traits>
+#include <cstdint>
+
+// Debug helper: check for NaN/Inf in a half buffer on device
+// Uncomment `#define FP8_NAN_DEBUG 1` to enable
+// #define FP8_NAN_DEBUG 1
+#ifdef FP8_NAN_DEBUG
+static __global__ void nan_check_kernel(const half* data, int64_t n, int* found_nan, int* found_inf) {
+  int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  float v = __half2float(data[idx]);
+  if (isnan(v)) atomicAdd(found_nan, 1);
+  if (isinf(v)) atomicAdd(found_inf, 1);
+}
+static bool check_nan_inf(const cutlass::half_t* buf, int64_t count, const char* label, cudaStream_t stream) {
+  int h_nan = 0, h_inf = 0;
+  int *d_nan, *d_inf;
+  cudaMallocAsync(&d_nan, sizeof(int), stream);
+  cudaMallocAsync(&d_inf, sizeof(int), stream);
+  cudaMemsetAsync(d_nan, 0, sizeof(int), stream);
+  cudaMemsetAsync(d_inf, 0, sizeof(int), stream);
+  int threads = 256;
+  int blocks = (int)((count + threads - 1) / threads);
+  nan_check_kernel<<<blocks, threads, 0, stream>>>(
+    reinterpret_cast<const half*>(buf), count, d_nan, d_inf);
+  cudaMemcpyAsync(&h_nan, d_nan, sizeof(int), cudaMemcpyDeviceToHost, stream);
+  cudaMemcpyAsync(&h_inf, d_inf, sizeof(int), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+  cudaFreeAsync(d_nan, stream);
+  cudaFreeAsync(d_inf, stream);
+  if (h_nan > 0 || h_inf > 0) {
+    printf("[NAN_DEBUG] %s: %d NaN, %d Inf out of %lld elements\n", label, h_nan, h_inf, (long long)count);
+    return true;
+  }
+  return false;
+}
+#define NAN_CHECK(buf, count, label) check_nan_inf(buf, count, label, stream)
+#else
+#define NAN_CHECK(buf, count, label) false
+#endif
+
+namespace omnidreams_singleview {
+
+// =============================================================================
+// Templated Kernels for dual fp16/bf16 support
+// =============================================================================
+
+// Templated LayerNorm + modulation kernel
+// temb_row_stride: stride between rows in temb. 6*K when expanded [M,6,K], 0 when broadcast [1,6,K].
+template <typename ElementT>
+__global__ void layernorm_modulate_row_kernel(
+    const ElementT* __restrict__ X_row, int M, int K, float eps,
+    const ElementT* __restrict__ scale_shift_table,
+    const ElementT* __restrict__ temb, int temb_row_stride,
+    int scale_idx, int shift_idx,
+    ElementT* __restrict__ Y_row) {
+  int row = blockIdx.x; if (row >= M) return;
+  extern __shared__ float s[];
+  float* ssum = s; float* ssum2 = s + blockDim.x;
+  int tid = threadIdx.x;
+
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(X_row[size_t(row) * K + j]);
+    acc1 += v; acc2 += v * v;
+  }
+  ssum[tid] = acc1; ssum2[tid] = acc2; __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) { ssum[tid] += ssum[tid + off]; ssum2[tid] += ssum2[tid + off]; }
+    __syncthreads();
+  }
+  float mean = ssum[0] / float(K);
+  float var  = ssum2[0] / float(K) - mean * mean;
+  float inv  = rsqrtf(var + eps);
+
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = (omnidreams_singleview::to_float(X_row[size_t(row) * K + j]) - mean) * inv;
+    float base_scale = omnidreams_singleview::to_float(scale_shift_table[scale_idx * K + j]);
+    float base_shift = omnidreams_singleview::to_float(scale_shift_table[shift_idx * K + j]);
+    size_t temb_offset = size_t(row) * temb_row_stride;
+    float add_scale = omnidreams_singleview::to_float(temb[temb_offset + scale_idx * K + j]);
+    float add_shift = omnidreams_singleview::to_float(temb[temb_offset + shift_idx * K + j]);
+    v = v * (1.f + base_scale + add_scale) + (base_shift + add_shift);
+    Y_row[size_t(row) * K + j] = omnidreams_singleview::from_float<ElementT>(v);
+  }
+}
+
+// Templated affine LayerNorm kernel
+template <typename ElementT>
+__global__ void layernorm_affine_row_kernel(
+    const ElementT* __restrict__ X_row, int M, int K, float eps,
+    const ElementT* __restrict__ gamma,
+    const ElementT* __restrict__ beta,
+    ElementT* __restrict__ Y_row) {
+  int row = blockIdx.x; if (row >= M) return;
+  extern __shared__ float smem[];
+  float* ssum = smem; float* ssum2 = smem + blockDim.x;
+  int tid = threadIdx.x;
+
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = omnidreams_singleview::to_float(X_row[size_t(row) * K + j]);
+    acc1 += v; acc2 += v * v;
+  }
+  ssum[tid] = acc1; ssum2[tid] = acc2; __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) { ssum[tid]+=ssum[tid+off]; ssum2[tid]+=ssum2[tid+off]; }
+    __syncthreads();
+  }
+  float mean = ssum[0]/float(K);
+  float var  = ssum2[0]/float(K) - mean*mean;
+  float inv = rsqrtf(var + eps);
+
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = (omnidreams_singleview::to_float(X_row[size_t(row) * K + j]) - mean) * inv;
+    float g = gamma ? omnidreams_singleview::to_float(gamma[j]) : 1.f;
+    float b = beta  ? omnidreams_singleview::to_float(beta[j])  : 0.f;
+    v = v * g + b;
+    Y_row[size_t(row) * K + j] = omnidreams_singleview::from_float<ElementT>(v);
+  }
+}
+
+// Templated residual + gate kernel (in-place)
+// temb_row_stride: stride between rows in temb. 6*K when expanded, 0 when broadcast.
+template <typename ElementT>
+__global__ void residual_gate_add_kernel_rr(
+    ElementT* __restrict__ D_row, int ld_row, int M, int K,
+    const ElementT* __restrict__ S_row, int ld_src,
+    const ElementT* __restrict__ scale_shift_table,
+    const ElementT* __restrict__ temb, int temb_row_stride,
+    int gate_idx) {
+  int i = blockIdx.y * blockDim.y + threadIdx.y;
+  int j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < M && j < K) {
+    size_t pos_dest = size_t(i) * ld_row + j;
+    size_t pos_src  = size_t(i) * ld_src + j;
+    float d_val = omnidreams_singleview::to_float(D_row[pos_dest]);
+    float s_val = omnidreams_singleview::to_float(S_row[pos_src]);
+    float base_gate = omnidreams_singleview::to_float(scale_shift_table[gate_idx * K + j]);
+    size_t temb_offset = size_t(i) * temb_row_stride;
+    float add_gate = omnidreams_singleview::to_float(temb[temb_offset + gate_idx * K + j]);
+    float g_val = base_gate + add_gate;
+    D_row[pos_dest] = omnidreams_singleview::from_float<ElementT>(d_val + s_val * g_val);
+  }
+}
+
+// Templated residual + gate kernel (separate src/dest)
+// temb_row_stride: stride between rows in temb. 6*K when expanded, 0 when broadcast.
+template <typename ElementT>
+__global__ void residual_gate_add_kernel_sr(
+    ElementT* __restrict__ D_dest, int ld_dest, int M, int K,
+    const ElementT* __restrict__ S_row, int ld_src,
+    const ElementT* __restrict__ scale_shift_table,
+    const ElementT* __restrict__ temb, int temb_row_stride,
+    int gate_idx,
+    const ElementT* __restrict__ D_src, int ld_srcD) {
+  int i = blockIdx.y * blockDim.y + threadIdx.y;
+  int j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < M && j < K) {
+    size_t pos_dest = size_t(i) * ld_dest + j;
+    size_t pos_srcD = size_t(i) * ld_srcD + j;
+    size_t pos_srcS = size_t(i) * ld_src + j;
+    float d_val = omnidreams_singleview::to_float(D_src[pos_srcD]);
+    float s_val = omnidreams_singleview::to_float(S_row[pos_srcS]);
+    float base_gate = omnidreams_singleview::to_float(scale_shift_table[gate_idx * K + j]);
+    size_t temb_offset = size_t(i) * temb_row_stride;
+    float add_gate = omnidreams_singleview::to_float(temb[temb_offset + gate_idx * K + j]);
+    float g_val = base_gate + add_gate;
+    D_dest[pos_dest] = omnidreams_singleview::from_float<ElementT>(d_val + s_val * g_val);
+  }
+}
+
+// Note: Templated kernels are implicitly instantiated when called via dispatch functions.
+// CUDA __global__ functions don't support explicit template instantiation syntax.
+
+// =============================================================================
+// Legacy fp16-only kernels (kept for backward compatibility)
+// =============================================================================
+
+// Row-major Affine LayerNorm + on-the-fly modulation, row-major in/out
+// This matches TurboDiffusion: norm(x) * (1 + scale) + shift
+// where norm(x) = (x - mean) * rsqrt(var) * gamma + beta
+// temb_row_stride: stride between rows in temb. 6*K when expanded [M,6,K], 0 when broadcast [1,6,K].
+__global__ void layernorm_affine_modulate_row_rm_to_row_half_kernel(
+    const cutlass::half_t* __restrict__ X_row, int M, int K, float eps,
+    const cutlass::half_t* __restrict__ gamma,  // [K] affine weight (can be nullptr for identity)
+    const cutlass::half_t* __restrict__ beta,   // [K] affine bias (can be nullptr for zero)
+    const cutlass::half_t* __restrict__ scale_shift_table,
+    const cutlass::half_t* __restrict__ temb, int temb_row_stride,
+    int scale_idx, int shift_idx,
+    cutlass::half_t* __restrict__ Y_row) {
+  int row = blockIdx.x; if (row >= M) return;
+  extern __shared__ float s[];
+  float* ssum = s; float* ssum2 = s + blockDim.x;
+  int tid = threadIdx.x;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = to_f32(X_row[size_t(row) * K + j]);
+    acc1 += v; acc2 += v * v;
+  }
+  ssum[tid] = acc1; ssum2[tid] = acc2; __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) { ssum[tid] += ssum[tid + off]; ssum2[tid] += ssum2[tid + off]; }
+    __syncthreads();
+  }
+  float mean = ssum[0] / float(K);
+  float var  = ssum2[0] / float(K) - mean * mean;
+  float inv  = rsqrtf(var + eps);
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = (to_f32(X_row[size_t(row) * K + j]) - mean) * inv;
+    float g = gamma ? to_f32(gamma[j]) : 1.f;
+    float b = beta  ? to_f32(beta[j])  : 0.f;
+    v = v * g + b;
+    float base_scale = to_f32(scale_shift_table[scale_idx * K + j]);
+    float base_shift = to_f32(scale_shift_table[shift_idx * K + j]);
+    size_t temb_offset = size_t(row) * temb_row_stride;
+    float add_scale = to_f32(temb[temb_offset + scale_idx * K + j]);
+    float add_shift = to_f32(temb[temb_offset + shift_idx * K + j]);
+    v = v * (1.f + base_scale + add_scale) + (base_shift + add_shift);
+    Y_row[size_t(row) * K + j] = to_f16(v);
+  }
+}
+
+// Legacy: Row-major LayerNorm without affine + on-the-fly modulation (for backwards compatibility)
+// temb_row_stride: stride between rows in temb. 6*K when expanded [M,6,K], 0 when broadcast [1,6,K].
+__global__ void layernorm_modulate_row_rm_to_row_half_kernel(const cutlass::half_t* __restrict__ X_row, int M, int K,
+                                                            float eps,
+                                                            const cutlass::half_t* __restrict__ scale_shift_table,
+                                                            const cutlass::half_t* __restrict__ temb,
+                                                            int temb_row_stride,
+                                                            int scale_idx, int shift_idx,
+                                                            cutlass::half_t* __restrict__ Y_row) {
+  int row = blockIdx.x; if (row >= M) return;
+  extern __shared__ float s[];
+  float* ssum = s; float* ssum2 = s + blockDim.x;
+  int tid = threadIdx.x;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = to_f32(X_row[size_t(row) * K + j]);
+    acc1 += v; acc2 += v * v;
+  }
+  ssum[tid] = acc1; ssum2[tid] = acc2; __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) {
+    if (tid < off) { ssum[tid] += ssum[tid + off]; ssum2[tid] += ssum2[tid + off]; }
+    __syncthreads();
+  }
+  float mean = ssum[0] / float(K);
+  float var  = ssum2[0] / float(K) - mean * mean;
+  float inv  = rsqrtf(var + eps);
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = (to_f32(X_row[size_t(row) * K + j]) - mean) * inv;
+    float base_scale = to_f32(scale_shift_table[scale_idx * K + j]);
+    float base_shift = to_f32(scale_shift_table[shift_idx * K + j]);
+    size_t temb_offset = size_t(row) * temb_row_stride;
+    float add_scale = to_f32(temb[temb_offset + scale_idx * K + j]);
+    float add_shift = to_f32(temb[temb_offset + shift_idx * K + j]);
+    v = v * (1.f + base_scale + add_scale) + (base_shift + add_shift);
+    Y_row[size_t(row) * K + j] = to_f16(v);
+  }
+}
+
+// Residual add with gate: row-major destination and source with on-the-fly gate calculation
+// temb_row_stride: stride between rows in temb. 6*K when expanded, 0 when broadcast.
+__global__ void residual_gate_add_kernel_half_rr(cutlass::half_t* __restrict__ D_row, int ld_row, int M, int K,
+                                                const cutlass::half_t* __restrict__ S_row, int ld_src,
+                                                const cutlass::half_t* __restrict__ scale_shift_table,
+                                                const cutlass::half_t* __restrict__ temb, int temb_row_stride,
+                                                int gate_idx) {
+  int i = blockIdx.y * blockDim.y + threadIdx.y;
+  int j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < M && j < K) {
+    size_t pos_dest = size_t(i) * ld_row + j;
+    size_t pos_src  = size_t(i) * ld_src + j;
+    cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+    cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+    float d_val = to_f32(D_row[pos_dest]);
+    float s_val = to_f32(S_row[pos_src]);
+    float base_gate = to_f32(scale_shift_table[gate_idx * K + j]);
+    size_t temb_offset = size_t(i) * temb_row_stride;
+    float add_gate = to_f32(temb[temb_offset + gate_idx * K + j]);
+    float g_val = base_gate + add_gate;
+    D_row[pos_dest] = to_f16(d_val + s_val * g_val);
+  }
+}
+
+// Simple row-major residual add: D += S
+__global__ void add_inplace_half_rr(cutlass::half_t* __restrict__ D_row, int ld_row, int M, int K,
+                                    const cutlass::half_t* __restrict__ S_row, int ld_src) {
+  int i = blockIdx.y * blockDim.y + threadIdx.y;
+  int j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < M && j < K) {
+    size_t pos_dest = size_t(i) * ld_row + j;
+    size_t pos_src  = size_t(i) * ld_src + j;
+    cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+    cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+    float d = to_f32(D_row[pos_dest]);
+    float s = to_f32(S_row[pos_src]);
+    D_row[pos_dest] = to_f16(d + s);
+  }
+}
+
+// Residual add with gate: dest = src + S * gate (separate src/dest)
+// temb_row_stride: stride between rows in temb. 6*K when expanded, 0 when broadcast.
+__global__ void residual_gate_add_kernel_half_sr(cutlass::half_t* __restrict__ D_dest, int ld_dest, int M, int K,
+                                                const cutlass::half_t* __restrict__ S_row, int ld_src,
+                                                const cutlass::half_t* __restrict__ scale_shift_table,
+                                                const cutlass::half_t* __restrict__ temb, int temb_row_stride,
+                                                int gate_idx,
+                                                const cutlass::half_t* __restrict__ D_src, int ld_srcD) {
+  int i = blockIdx.y * blockDim.y + threadIdx.y;
+  int j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < M && j < K) {
+    size_t pos_dest = size_t(i) * ld_dest + j;
+    size_t pos_srcD = size_t(i) * ld_srcD + j;
+    size_t pos_srcS = size_t(i) * ld_src + j;
+    cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+    cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+    float d_val = to_f32(D_src[pos_srcD]);
+    float s_val = to_f32(S_row[pos_srcS]);
+    float base_gate = to_f32(scale_shift_table[gate_idx * K + j]);
+    size_t temb_offset = size_t(i) * temb_row_stride;
+    float add_gate = to_f32(temb[temb_offset + gate_idx * K + j]);
+    float g_val = base_gate + add_gate;
+    D_dest[pos_dest] = to_f16(d_val + s_val * g_val);
+  }
+}
+
+// Row-major affine LayerNorm: X_row -> Y_row applying gamma/beta
+__global__ void layernorm_affine_row_to_row_half_kernel(const cutlass::half_t* __restrict__ X_row, int M, int K,
+                                                       float eps,
+                                                       const cutlass::half_t* __restrict__ gamma,
+                                                       const cutlass::half_t* __restrict__ beta,
+                                                       cutlass::half_t* __restrict__ Y_row) {
+  int row = blockIdx.x; if (row >= M) return;
+  extern __shared__ float smem[];
+  float* ssum = smem; float* ssum2 = smem + blockDim.x;
+  int tid = threadIdx.x;
+  cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+  float acc1 = 0.f, acc2 = 0.f;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = to_f32(X_row[size_t(row) * K + j]);
+    acc1 += v; acc2 += v * v;
+  }
+  ssum[tid] = acc1; ssum2[tid] = acc2; __syncthreads();
+  for (int off = blockDim.x >> 1; off > 0; off >>= 1) { if (tid < off) { ssum[tid]+=ssum[tid+off]; ssum2[tid]+=ssum2[tid+off]; } __syncthreads(); }
+  float mean = ssum[0]/float(K);
+  float var  = ssum2[0]/float(K) - mean*mean;
+  float inv = rsqrtf(var + eps);
+  cutlass::NumericConverter<cutlass::half_t, float> to_f16;
+  for (int j = tid; j < K; j += blockDim.x) {
+    float v = (to_f32(X_row[size_t(row) * K + j]) - mean) * inv;
+    float g = gamma ? to_f32(gamma[j]) : 1.f;
+    float b = beta  ? to_f32(beta[j])  : 0.f;
+    v = v * g + b;
+    Y_row[size_t(row) * K + j] = to_f16(v);
+  }
+}
+
+template <typename WeightT, typename Arch>
+cudaError_t run_transformer_block(const TransformerBlockParamsT<WeightT>& p, cudaStream_t stream) {
+  int B = p.B;
+  int Mq = p.Mq;
+  int K = p.K, H = p.H, D = p.D;
+  int M = B * Mq;
+  int Mk_text = p.Mk ? p.Mk : Mq;
+  int Mk_img = p.Mk_img;
+  auto backend = get_attention_backend();
+
+  // Optional fine-grained profiling (level >= 2): per-block breakdown
+  int prof_lvl = g_wan_profile_level.load(std::memory_order_relaxed);
+  int print_every = g_wan_profile_print_every.load(std::memory_order_relaxed);
+  if (print_every < 1) print_every = 1;
+  long long call_idx = 0;
+  bool profile_block = (prof_lvl >= 2);
+  if (profile_block) {
+    call_idx = g_wan_profile_call_idx.fetch_add(1, std::memory_order_relaxed);
+    profile_block = (call_idx % print_every) == 0;
+  }
+  enum {
+    EV_START = 0,
+    EV_AFTER_LN_SA,
+    EV_AFTER_SA,        // after self-attn output projection, before residual gate add
+    EV_AFTER_SA_RES,
+    EV_AFTER_LN_CA,
+    EV_AFTER_CA,
+    EV_AFTER_LN_FFN,    // after FFN pre-norm+mod
+    EV_AFTER_FFN1,
+    EV_AFTER_FFN2_GEMM, // after FFN GEMM2, before residual gate add
+    EV_AFTER_FFN2,
+    EV_COUNT
+  };
+  cudaEvent_t ev[EV_COUNT];
+  auto rec = [&](int idx) {
+    if (profile_block) cudaEventRecord(ev[idx], stream);
+  };
+  if (profile_block) {
+    for (int i = 0; i < EV_COUNT; ++i) { cudaEventCreate(&ev[i]); }
+    rec(EV_START);
+  }
+
+  // Use output buffer as destination for updated hidden state; read from p.hidden_states directly
+  cutlass::half_t* dHiddenR = p.out;
+  cutlass::half_t* scratch_mk_a = p.workspace->scratch_mk_a;
+  cutlass::half_t* scratch_mk_b = p.workspace->scratch_mk_b;
+
+  // 1) Self-attention pre-norm + mod -> row-major
+  //    Arch::kSelfAttnNorm selects RMSNorm (no affine) vs LayerNorm (gamma+beta).
+  cutlass::half_t* dPreSAhRM = scratch_mk_a;
+
+  if constexpr (Arch::kSelfAttnNorm == NormType::RMSNorm) {
+    layernorm_modulate_row_rm_to_row_half_kernel<<<M, 256, 2*256*sizeof(float), stream>>>(
+      p.hidden_states, M, K, 1e-6f, p.temb_scale_shift_table, p.temb, p.temb_row_stride, 1, 0, dPreSAhRM);
+  } else {
+    layernorm_affine_modulate_row_rm_to_row_half_kernel<<<M, 256, 2*256*sizeof(float), stream>>>(
+      p.hidden_states, M, K, 1e-6f, p.ln1_gamma, nullptr,
+      p.temb_scale_shift_table, p.temb, p.temb_row_stride, 1, 0, dPreSAhRM);
+  }
+  { cudaError_t e = cudaGetLastError(); if (e != cudaSuccess) { return e; } }
+  NAN_CHECK(dPreSAhRM, int64_t(M)*K, "after_LN_SA");
+  rec(EV_AFTER_LN_SA);
+
+  // 1b) Run self attention (row-major path)
+  cutlass::half_t* dSAOut = scratch_mk_b;
+  AttentionDeviceParamsT<WeightT> psa{}; psa.B=B; psa.Mq=Mq; psa.K=K; psa.H=H; psa.D=D; psa.hidden_states=dPreSAhRM;
+  psa.w_qkv=p.sa_w_qkv; psa.w_qkv_scale=p.sa_w_qkv_scale; psa.b_qkv=p.sa_b_qkv; psa.norm_q_gamma=p.sa_norm_q_gamma; psa.norm_k_gamma=p.sa_norm_k_gamma;
+  psa.w_out=p.sa_w_out; psa.w_out_scale=p.sa_w_out_scale; psa.b_out=p.sa_b_out; psa.rotary_cos=p.rotary_cos; psa.rotary_sin=p.rotary_sin;
+  // Per-block INT8 quantization scales
+  psa.w_qkv_block_scale=p.sa_w_qkv_block_scale; psa.w_out_block_scale=p.sa_w_out_block_scale;
+  psa.use_perblock_quant=p.use_perblock_quant;
+  psa.workspace = p.workspace;
+
+  // INT8 on Blackwell: fuse gate+residual into output GEMM epilogue
+  // INT8 on Ada: use separate output + residual (fused epilogue crashes in this TU on SM89)
+  if constexpr (std::is_same_v<WeightT, int8_t>) {
+    static int s_gpu_major_sa = -1;
+    if (s_gpu_major_sa < 0) {
+      int dev; cudaGetDevice(&dev);
+      cudaDeviceGetAttribute(&s_gpu_major_sa, cudaDevAttrComputeCapabilityMajor, dev);
+    }
+    if (s_gpu_major_sa >= 10) {
+      // Blackwell: fused gated residual in GEMM epilogue
+      psa.out_after_linear = dHiddenR;
+      psa.gate_sst = p.temb_scale_shift_table;
+      psa.gate_temb = p.temb;
+      psa.gate_temb_row_stride = p.temb_row_stride;
+      psa.gate_idx = 2;
+      psa.residual_src = p.hidden_states;
+    } else {
+      // Ada: separate output projection, residual added below
+      psa.out_after_linear = dSAOut;
+    }
+  } else {
+    psa.out_after_linear = dSAOut;  // non-INT8: separate residual kernel
+  }
+  cudaError_t err = run_self_attention<WeightT>(psa, stream);
+  if (err != cudaSuccess) return err;
+  NAN_CHECK(psa.out_after_linear, int64_t(M)*K, "after_SA_out");
+  rec(EV_AFTER_SA);
+
+  // 1c) Residual with gate into row-major destination
+  // For INT8 on Blackwell, this was fused into the GEMM above. For all others, do it here.
+  {
+    bool need_separate_residual = true;
+    if constexpr (std::is_same_v<WeightT, int8_t>) {
+      static int s_gpu_major_res = -1;
+      if (s_gpu_major_res < 0) {
+        int dev; cudaGetDevice(&dev);
+        cudaDeviceGetAttribute(&s_gpu_major_res, cudaDevAttrComputeCapabilityMajor, dev);
+      }
+      need_separate_residual = (s_gpu_major_res < 10);  // Ada needs separate residual
+    }
+    if (need_separate_residual) {
+      residual_gate_add_kernel_half_sr<<<dim3((K+31)/32,(M+31)/32), dim3(32,32), 0, stream>>>(
+        dHiddenR, K, M, K, dSAOut, K, p.temb_scale_shift_table, p.temb, p.temb_row_stride, 2, p.hidden_states, K);
+      { cudaError_t e = cudaGetLastError(); if (e != cudaSuccess) { return e; } }
+    }
+  }
+  NAN_CHECK(dHiddenR, int64_t(M)*K, "after_SA_residual");
+  rec(EV_AFTER_SA_RES);
+
+  // 2) Cross-attention pre-norm -> row-major (use current hidden state as source)
+  cutlass::half_t* dPreCAhRM = scratch_mk_a;  // Reuse scratch_mk_a
+  layernorm_affine_row_to_row_half_kernel<<<M, 256, 2*256*sizeof(float), stream>>>(
+    dHiddenR, M, K, 1e-6f, p.ln2_gamma, p.ln2_bias, dPreCAhRM);
+  { cudaError_t e = cudaGetLastError(); if (e != cudaSuccess) { return e; } }
+  NAN_CHECK(dPreCAhRM, int64_t(M)*K, "after_LN_CA");
+  rec(EV_AFTER_LN_CA);
+
+  // 2b) Cross attention (I2V: text + optional image branch).
+  //    Arch::kHasImageCrossAttn controls whether the fused I2V path is compiled in.
+  bool has_img_branch = false;
+  if constexpr (Arch::kHasImageCrossAttn) {
+    has_img_branch = (Mk_img > 0) && (p.encoder_hidden_states_img != nullptr) &&
+                     (p.ca_w_add_k != nullptr) && (p.ca_w_add_v != nullptr) &&
+                     (p.ca_norm_added_k_gamma != nullptr);
+  }
+
+  // If image branch is present, prefer the fused I2V path (shared Q, concatenated KV, single attention).
+  // This is supported for:
+  // - CUTLASS backend (half weights)
+  // - cuDNN backend (half and FP8 weights)
+  bool used_fused_i2v = false;
+  if (has_img_branch) {
+    // Only use the fused I2V path when supported by the selected backend:
+    // - CUTLASS fused I2V currently supports B=1 only
+    // - cuDNN fused I2V supports B>=1 (including CFG-batched B=2)
+    if (backend == AttnBackend::CUDNN || B == 1) {
+    CrossAttentionI2VParamsT<WeightT> pi2v{};
+    pi2v.B = B;
+    pi2v.M = Mq; pi2v.K = K; pi2v.H = H; pi2v.D = D;
+    pi2v.Mk_text = Mk_text; pi2v.Mk_img = Mk_img; pi2v.added_kv_proj_dim = p.added_kv_proj_dim;
+    pi2v.hidden_states = dPreCAhRM;
+    pi2v.encoder_hidden_states_text = p.encoder_hidden_states;
+    pi2v.encoder_hidden_states_img  = p.encoder_hidden_states_img;
+    pi2v.w_q = p.ca_w_q; pi2v.b_q = p.ca_b_q; pi2v.w_q_scale = p.ca_w_q_scale;
+    pi2v.w_kv = p.ca_w_kv; pi2v.b_kv = p.ca_b_kv; pi2v.w_kv_scale = p.ca_w_kv_scale;
+    pi2v.w_add_k = p.ca_w_add_k; pi2v.b_add_k = p.ca_b_add_k; pi2v.w_add_k_scale = p.ca_w_add_k_scale;
+    pi2v.w_add_v = p.ca_w_add_v; pi2v.b_add_v = p.ca_b_add_v; pi2v.w_add_v_scale = p.ca_w_add_v_scale;
+    pi2v.norm_q_gamma = p.ca_norm_q_gamma;
+    pi2v.norm_k_gamma = p.ca_norm_k_gamma;
+    pi2v.norm_added_k_gamma = p.ca_norm_added_k_gamma;
+    pi2v.w_out = p.ca_w_out; pi2v.b_out = p.ca_b_out; pi2v.w_out_scale = p.ca_w_out_scale;  // bias applied once
+    pi2v.out_after_linear = dHiddenR;                   // residual inout when fuse_residual=true
+    pi2v.workspace = p.workspace;
+    err = run_cross_attention_i2v<WeightT>(pi2v, /*fuse_residual=*/true, stream);
+    if (err == cudaSuccess) {
+      used_fused_i2v = true;
+    } else if (err != cudaErrorNotSupported) {
+      return err;
+    }
+    }
+  }
+  // For cuDNN, the non-fused fallback does not support the I2V added-KV (image) branch.
+  if (backend == AttnBackend::CUDNN && has_img_branch && !used_fused_i2v) {
+    return cudaErrorNotSupported;
+  }
+  if (!used_fused_i2v) {
+    // Text branch (fuse residual into output projection)
+    AttentionDeviceParamsT<WeightT> pca_text{};
+    pca_text.B = B; pca_text.Mq = Mq; pca_text.K = K; pca_text.H = H; pca_text.D = D;
+    pca_text.Mk = Mk_text; pca_text.Mk_img = 0; pca_text.added_kv_proj_dim = p.added_kv_proj_dim;
+    pca_text.encoder_batch_size = p.encoder_batch_size;
+    pca_text.hidden_states = dPreCAhRM;
+    pca_text.encoder_hidden_states = p.encoder_hidden_states;
+    pca_text.w_q = p.ca_w_q; pca_text.w_q_scale = p.ca_w_q_scale; pca_text.b_q = p.ca_b_q;
+    pca_text.w_kv = p.ca_w_kv; pca_text.w_kv_scale = p.ca_w_kv_scale; pca_text.b_kv = p.ca_b_kv;
+    pca_text.norm_q_gamma = p.ca_norm_q_gamma; pca_text.norm_k_gamma = p.ca_norm_k_gamma;
+    pca_text.w_out = p.ca_w_out; pca_text.w_out_scale = p.ca_w_out_scale; pca_text.b_out = p.ca_b_out;
+    // Per-block INT8 quantization scales
+    pca_text.w_q_block_scale=p.ca_w_q_block_scale; pca_text.w_kv_block_scale=p.ca_w_kv_block_scale;
+    pca_text.w_out_block_scale=p.ca_w_out_block_scale; pca_text.use_perblock_quant=p.use_perblock_quant;
+    pca_text.out_after_linear = dHiddenR;  // residual inout
+    pca_text.workspace = p.workspace;
+    err = run_cross_attention<WeightT>(pca_text, /*fuse_residual=*/true, stream);
+    if (err != cudaSuccess) return err;
+
+    // Optional image branch (bias-less) fused into residual
+    if (has_img_branch) {
+      AttentionDeviceParamsT<WeightT> pca_img{};
+      pca_img.B = B; pca_img.Mq = Mq; pca_img.K = K; pca_img.H = H; pca_img.D = D;
+      pca_img.Mk = 0; pca_img.Mk_img = Mk_img; pca_img.added_kv_proj_dim = p.added_kv_proj_dim;
+      pca_img.encoder_batch_size = p.encoder_batch_size;
+      pca_img.hidden_states = dPreCAhRM;
+      pca_img.encoder_hidden_states = p.encoder_hidden_states_img;
+      pca_img.w_q = p.ca_w_q; pca_img.w_q_scale = p.ca_w_q_scale; pca_img.b_q = p.ca_b_q;
+      pca_img.w_kv = nullptr; pca_img.b_kv = nullptr;
+      pca_img.w_kv_scale = nullptr;
+      pca_img.w_add_k = p.ca_w_add_k; pca_img.b_add_k = p.ca_b_add_k;
+      pca_img.w_add_v = p.ca_w_add_v; pca_img.b_add_v = p.ca_b_add_v;
+      pca_img.w_add_k_scale = p.ca_w_add_k_scale;
+      pca_img.w_add_v_scale = p.ca_w_add_v_scale;
+      pca_img.norm_q_gamma = p.ca_norm_q_gamma; pca_img.norm_k_gamma = nullptr;
+      pca_img.norm_added_k_gamma = p.ca_norm_added_k_gamma;
+      pca_img.w_out = p.ca_w_out; pca_img.w_out_scale = p.ca_w_out_scale; pca_img.b_out = nullptr;  // bias only once (text)
+      // Per-block INT8 quantization scales (image branch shares same out projection)
+      pca_img.w_q_block_scale=p.ca_w_q_block_scale; pca_img.w_out_block_scale=p.ca_w_out_block_scale;
+      pca_img.use_perblock_quant=p.use_perblock_quant;
+      pca_img.out_after_linear = dHiddenR;                  // residual inout
+      pca_img.workspace = p.workspace;
+      err = run_cross_attention<WeightT>(pca_img, /*fuse_residual=*/true, stream);
+      if (err != cudaSuccess) return err;
+    }
+  }
+
+  NAN_CHECK(dHiddenR, int64_t(M)*K, "after_CA_residual");
+  rec(EV_AFTER_CA);
+
+  // 3) FFN pre-norm + mod (row-major)
+  cutlass::half_t* dPreFFh = scratch_mk_a;  // Reuse scratch_mk_a
+  layernorm_modulate_row_rm_to_row_half_kernel<<<M, 256, 2*256*sizeof(float), stream>>>(
+    dHiddenR, M, K, 1e-6f, p.temb_scale_shift_table, p.temb, p.temb_row_stride, 4, 3, dPreFFh);
+  { cudaError_t e3 = cudaGetLastError(); if (e3 != cudaSuccess) { return e3; } }
+  rec(EV_AFTER_LN_FFN);
+
+  // 3b) FFN GEMM1: [M,K] x [FF,K]^T -> [M,FF] with GELU activation
+  int FF = p.FF;
+  {
+    cutlass::half_t* dFF2_row = scratch_mk_b;  // Reuse scratch_mk_b
+
+    if constexpr (std::is_same_v<WeightT, int8_t>) {
+      // Detect GPU arch: SM < 10 = Ada/Ampere, SM >= 10 = Blackwell+
+      static int s_gpu_major = -1;
+      if (s_gpu_major < 0) {
+        int dev; cudaGetDevice(&dev);
+        cudaDeviceGetAttribute(&s_gpu_major, cudaDevAttrComputeCapabilityMajor, dev);
+      }
+      bool use_fused_ffn = (s_gpu_major >= 10);  // Blackwell: fused kernels work
+
+      if (use_fused_ffn) {
+        // Blackwell path: fused GEMM+GELU+requant and GEMM+gated_residual
+        // Step 1: Quantize FFN input [M,K] FP16 -> INT8
+        cudaError_t q_err = quantize_per_block_128(
+          reinterpret_cast<const half*>(dPreFFh),
+          p.workspace->int8_scratch,
+          p.workspace->int8_act_block_scales,
+          M, K, stream, false);
+        if (q_err != cudaSuccess) return q_err;
+
+        // Step 2: FFN up GEMM + GELU with fused requantize epilogue
+        int8_t* ffn_int8_out = reinterpret_cast<int8_t*>(p.workspace->ffn_intermediate);
+        float* ffn_int8_out_scales = reinterpret_cast<float*>(
+          reinterpret_cast<char*>(p.workspace->ffn_intermediate) + (size_t)M * FF);
+
+        cudaError_t err1 = int8_gemm_gelu_requant(
+          p.workspace->int8_scratch,
+          p.workspace->int8_act_block_scales,
+          reinterpret_cast<const int8_t*>(p.ffn_w1),
+          p.ffn_w1_block_scale,
+          ffn_int8_out,
+          ffn_int8_out_scales,
+          reinterpret_cast<const half*>(p.ffn_b1),
+          M, FF, K, stream,
+          reinterpret_cast<half*>(dFF2_row));  // fp16_temp for 2-stage fallback
+        if (err1 != cudaSuccess) return err1;
+
+        rec(EV_AFTER_FFN1);
+
+        // Step 3: FFN down GEMM + gated residual (fused)
+        cudaError_t err2 = int8_gemm_gated_residual(
+          ffn_int8_out,
+          ffn_int8_out_scales,
+          reinterpret_cast<const int8_t*>(p.ffn_w2),
+          p.ffn_w2_block_scale,
+          reinterpret_cast<half*>(dHiddenR),
+          reinterpret_cast<const half*>(p.ffn_b2),
+          reinterpret_cast<const half*>(p.temb_scale_shift_table),
+          reinterpret_cast<const half*>(p.temb),
+          p.temb_row_stride,
+          5,  // gate_idx for FFN
+          M, K, FF, stream);
+        if (err2 != cudaSuccess) return err2;
+
+        rec(EV_AFTER_FFN2_GEMM);
+
+      } else {
+        // Ada/SM89 path: unfused kernels
+        cutlass::half_t* dFF1h = p.workspace->ffn_intermediate;
+
+        cudaError_t q_err = quantize_per_block_128(
+          reinterpret_cast<const half*>(dPreFFh),
+          p.workspace->int8_scratch,
+          p.workspace->int8_act_block_scales,
+          M, K, stream, false);
+        if (q_err != cudaSuccess) return q_err;
+
+        cudaError_t err1 = int8_gemm_gelu(
+          p.workspace->int8_scratch,
+          p.workspace->int8_act_block_scales,
+          reinterpret_cast<const int8_t*>(p.ffn_w1),
+          p.ffn_w1_block_scale,
+          reinterpret_cast<half*>(dFF1h),
+          reinterpret_cast<const half*>(p.ffn_b1),
+          M, FF, K, stream);
+        if (err1 != cudaSuccess) return err1;
+
+        rec(EV_AFTER_FFN1);
+
+        cudaError_t rq_err = quantize_per_block_128(
+          reinterpret_cast<const half*>(dFF1h),
+          p.workspace->int8_scratch,
+          p.workspace->int8_act_block_scales,
+          M, FF, stream, false);
+        if (rq_err != cudaSuccess) return rq_err;
+
+        cudaError_t err2 = int8_gemm(
+          p.workspace->int8_scratch,
+          p.workspace->int8_act_block_scales,
+          reinterpret_cast<const int8_t*>(p.ffn_w2),
+          p.ffn_w2_block_scale,
+          reinterpret_cast<half*>(dFF2_row),
+          reinterpret_cast<const half*>(p.ffn_b2),
+          M, K, FF, stream);
+        if (err2 != cudaSuccess) return err2;
+
+        rec(EV_AFTER_FFN2_GEMM);
+
+        residual_gate_add_kernel_half_rr<<<dim3((K+31)/32,(M+31)/32), dim3(32,32), 0, stream>>>(
+          dHiddenR, K, M, K, dFF2_row, K, p.temb_scale_shift_table, p.temb, p.temb_row_stride, 5);
+        { cudaError_t e4 = cudaGetLastError(); if (e4 != cudaSuccess) { return e4; } }
+      }
+
+    } else {
+      // FP16/FP8 path: separate GEMM1 + quantize + GEMM2
+      cutlass::half_t* dFF1h = p.workspace->ffn_intermediate;
+      // For FP8 with per-channel scales: fuse GELU output -> FP8 conversion for GEMM2 input,
+      // eliminating intermediate FP16 write/read between FFN up and FFN down.
+      cutlass::half_t* ffn2_fp8_scratch = p.workspace->cudnn.sa_qkv_row;
+      constexpr bool is_fp8 = std::is_same<WeightT, cutlass::float_e4m3_t>::value;
+      cutlass::float_e4m3_t* fp8_next = nullptr;
+      if constexpr (is_fp8) {
+        if (p.ffn_w1_scale != nullptr) {
+          fp8_next = reinterpret_cast<cutlass::float_e4m3_t*>(ffn2_fp8_scratch);
+        }
+      }
+      cudaError_t err1 = apply_linear_row_gelu<WeightT>(
+        dPreFFh,
+        p.ffn_w1,
+        p.ffn_b1,
+        dFF1h,
+        M, K, FF, stream,
+        scratch_mk_b,  // fp8_scratch
+        p.ffn_w1_scale,  // weight_scale (for FP8 with per-channel scales)
+        p.workspace->int8_scratch,  // int8_scratch
+        p.workspace->int8_act_block_scales,  // int8_act_block_scales (for per-block INT8)
+        p.ffn_w1_block_scale,  // weight_block_scale (for per-block INT8)
+        false,  // use_swizzled_weights
+        fp8_next);  // fused GELU->FP8 output (nullptr for non-FP8 or no weight_scale)
+      if (err1 != cudaSuccess) return err1;
+
+      NAN_CHECK(dFF1h, int64_t(M)*FF, "after_FFN1_gelu");
+      rec(EV_AFTER_FFN1);
+
+      // 3c) FFN GEMM2: [M,FF] x [K,FF]^T -> [M,K]
+      // When fp8_next was set, the fused kernel already wrote FP8 data to ffn2_fp8_scratch,
+      // so skip the input quantization step in apply_linear_row.
+      bool skip_quant = (fp8_next != nullptr);
+      cudaError_t err2 = apply_linear_row<WeightT>(
+        dFF1h,
+        p.ffn_w2,
+        p.ffn_b2,
+        dFF2_row,
+        M, FF, K, stream,
+        ffn2_fp8_scratch,  // fp8_scratch (has FP8 data if fused, else used as scratch)
+        p.ffn_w2_scale,  // weight_scale (for FP8)
+        p.workspace->int8_scratch,  // int8_scratch
+        p.workspace->int8_act_block_scales,  // int8_act_block_scales
+        p.ffn_w2_block_scale,  // weight_block_scale
+        false,  // use_swizzled_weights
+        skip_quant);  // fp8_input_preconverted
+      if (err2 != cudaSuccess) return err2;
+
+      NAN_CHECK(dFF2_row, int64_t(M)*K, "after_FFN2_gemm");
+      // 3d) Residual with gate (FP16/FP8 path only -- INT8 path fuses this into GEMM)
+      //    Arch::kFFNGateStyle: 1 = gated residual from scale_shift_table, 0 = plain residual add
+      rec(EV_AFTER_FFN2_GEMM);
+      if constexpr (Arch::kFFNGateStyle == 1) {
+        residual_gate_add_kernel_half_rr<<<dim3((K+31)/32,(M+31)/32), dim3(32,32), 0, stream>>>(
+          dHiddenR, K, M, K, dFF2_row, K, p.temb_scale_shift_table, p.temb, p.temb_row_stride, 5);
+      } else {
+        add_inplace_half_rr<<<dim3((K+31)/32,(M+31)/32), dim3(32,32), 0, stream>>>(
+          dHiddenR, K, M, K, dFF2_row, K);
+      }
+      { cudaError_t e4 = cudaGetLastError(); if (e4 != cudaSuccess) { return e4; } }
+    }
+  }
+
+  NAN_CHECK(dHiddenR, int64_t(M)*K, "after_FFN_residual");
+  rec(EV_AFTER_FFN2);
+
+  if (profile_block) {
+    cudaEventSynchronize(ev[EV_AFTER_FFN2]);
+    auto ms = [&](int a, int b) -> float {
+      float out = 0.f;
+      cudaEventElapsedTime(&out, ev[a], ev[b]);
+      return out;
+    };
+    float t_ln1   = ms(EV_START, EV_AFTER_LN_SA);
+    float t_self  = ms(EV_AFTER_LN_SA, EV_AFTER_SA_RES);
+    float t_ln2   = ms(EV_AFTER_SA_RES, EV_AFTER_LN_CA);
+    float t_cross = ms(EV_AFTER_LN_CA, EV_AFTER_CA);
+    float t_ffn1  = ms(EV_AFTER_CA, EV_AFTER_FFN1);
+    float t_ffn2  = ms(EV_AFTER_FFN1, EV_AFTER_FFN2);
+    float t_total = ms(EV_START, EV_AFTER_FFN2);
+
+    std::printf(
+      "[wan_block][L=%d][call=%lld] M=%d K=%d H=%d D=%d Mk_text=%d Mk_img=%d | ln1=%.3f self=%.3f ln2=%.3f cross=%.3f ffn1=%.3f ffn2=%.3f total=%.3f ms\n",
+      p.layer_idx, call_idx, M, K, H, D, Mk_text, Mk_img,
+      t_ln1, t_self, t_ln2, t_cross, t_ffn1, t_ffn2, t_total
+    );
+
+#ifdef OMNIDREAMS_SINGLEVIEW_PROFILE
+    OMNIDREAMS_SINGLEVIEW_PROF_RECORD("block_detail", "ln1", t_ln1);
+    OMNIDREAMS_SINGLEVIEW_PROF_RECORD("block_detail", "self_attn", t_self);
+    OMNIDREAMS_SINGLEVIEW_PROF_RECORD("block_detail", "ln2", t_ln2);
+    OMNIDREAMS_SINGLEVIEW_PROF_RECORD("block_detail", "cross_attn", t_cross);
+    OMNIDREAMS_SINGLEVIEW_PROF_RECORD("block_detail", "ffn1", t_ffn1);
+    OMNIDREAMS_SINGLEVIEW_PROF_RECORD("block_detail", "ffn2", t_ffn2);
+    OMNIDREAMS_SINGLEVIEW_PROF_RECORD("block_detail", "total", t_total);
+#endif
+
+    if (prof_lvl >= 3) {
+      float t_sa_attn = ms(EV_AFTER_LN_SA, EV_AFTER_SA);
+      float t_sa_res  = ms(EV_AFTER_SA, EV_AFTER_SA_RES);
+      float t_ffn_ln  = ms(EV_AFTER_CA, EV_AFTER_LN_FFN);
+      float t_ffn_g1  = ms(EV_AFTER_LN_FFN, EV_AFTER_FFN1);
+      float t_ffn_g2  = ms(EV_AFTER_FFN1, EV_AFTER_FFN2_GEMM);
+      float t_ffn_res = ms(EV_AFTER_FFN2_GEMM, EV_AFTER_FFN2);
+      std::printf(
+        "[wan_block_detail][L=%d][call=%lld] sa_attn=%.3f sa_res=%.3f | ffn_ln=%.3f ffn_g1=%.3f ffn_g2=%.3f ffn_res=%.3f ms\n",
+        p.layer_idx, call_idx,
+        t_sa_attn, t_sa_res,
+        t_ffn_ln, t_ffn_g1, t_ffn_g2, t_ffn_res
+      );
+    }
+
+    for (int i = 0; i < EV_COUNT; ++i) { cudaEventDestroy(ev[i]); }
+  }
+
+  return cudaSuccess;
+}
+
+// Explicit template instantiations (WeightT x Arch combinations).
+// Currently only WanArchTraits is instantiated; future models add their own lines.
+template cudaError_t run_transformer_block<cutlass::half_t, WanArchTraits>(
+  const TransformerBlockParamsT<cutlass::half_t>& p,
+  cudaStream_t stream
+);
+template cudaError_t run_transformer_block<cutlass::float_e4m3_t, WanArchTraits>(
+  const TransformerBlockParamsT<cutlass::float_e4m3_t>& p,
+  cudaStream_t stream
+);
+template cudaError_t run_transformer_block<int8_t, WanArchTraits>(
+  const TransformerBlockParamsT<int8_t>& p,
+  cudaStream_t stream
+);
+
+} // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/workspace.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/workspace.cuh
@@ -1,0 +1,564 @@
+#pragma once
+
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/util/device_memory.h>
+#include <cuda_runtime.h>
+#include <algorithm>
+#include "common/workspace_alloc.h"
+
+// cuDNN SDPA workspace is backend/shape dependent. We allocate it dynamically in Workspace.
+
+namespace ts {
+
+// CUTLASS Flash Attention workspace pointers
+// Contains buffers specific to the CUTLASS Flash Attention implementation
+struct CutlassFlashAttentionWorkspace {
+    // Self-attention workspace (BMHK packed format for Flash Attention)
+    cutlass::half_t* sa_qkv_row;        // M×3K - QKV projection output
+    cutlass::half_t* sa_q_bmhk;         // M×H×D - Packed Q
+    cutlass::half_t* sa_k_bmhk;         // M×H×D - Packed K
+    cutlass::half_t* sa_v_bmhk;         // M×H×D - Packed V
+    cutlass::half_t* sa_o_bmhk;         // M×H×D - FMHA output (reuses sa_q_bmhk)
+    cutlass::half_t* sa_out_row;        // M×K - Unpacked output (reuses portion of sa_qkv_row)
+
+    // Cross-attention workspace (BMHK packed format for Flash Attention)
+    cutlass::half_t* ca_q_bmhk;         // M×H×D - Packed Q
+    cutlass::half_t* ca_k_bmhk;         // Mk×H×D - Packed K
+    cutlass::half_t* ca_v_bmhk;         // Mk×H×D - Packed V
+    cutlass::half_t* ca_o_bmhk;         // M×H×D - FMHA output (reuses ca_q_bmhk)
+    cutlass::half_t* ca_q_row;          // M×K - Q projection (reuses portion of sa_qkv_row)
+    cutlass::half_t* ca_kv_row;         // Mk×2K - KV projection
+
+    static size_t calculate_size(int M, int K, int H, int D, int Mk_max) {
+        size_t mhd = size_t(M) * H * D;
+        size_t mk_max_hd = size_t(Mk_max) * H * D;
+        size_t mk_max_2k = size_t(Mk_max) * 2 * K;
+
+        size_t total = 0;
+        total += size_t(M) * 3 * K; // sa_qkv_row
+        total += mhd;               // sa_q_bmhk
+        total += mhd;               // sa_k_bmhk
+        total += mhd;               // sa_v_bmhk
+        total += mhd;               // ca_q_bmhk
+        total += mk_max_hd;         // ca_k_bmhk
+        total += mk_max_hd;         // ca_v_bmhk
+        total += mk_max_2k;         // ca_kv_row
+
+        return total * sizeof(cutlass::half_t);
+    }
+
+    void initialize(cutlass::half_t* ptr, int M, int K, int H, int D, int Mk_max) {
+        size_t budget = calculate_size(M, K, H, D, Mk_max);
+        ts::WorkspaceAllocator ws(ptr, budget, "cutlass_flash");
+
+        sa_qkv_row = ws.alloc<cutlass::half_t>(size_t(M) * 3 * K);
+        sa_out_row = sa_qkv_row;   // alias: reuses beginning of sa_qkv_row
+        ca_q_row   = sa_qkv_row;   // alias: reuses beginning of sa_qkv_row
+
+        sa_q_bmhk = ws.alloc<cutlass::half_t>(size_t(M) * H * D);
+        sa_o_bmhk = sa_q_bmhk;     // alias: output overwrites Q in-place
+
+        sa_k_bmhk = ws.alloc<cutlass::half_t>(size_t(M) * H * D);
+        sa_v_bmhk = ws.alloc<cutlass::half_t>(size_t(M) * H * D);
+
+        ca_q_bmhk = ws.alloc<cutlass::half_t>(size_t(M) * H * D);
+        ca_o_bmhk = ca_q_bmhk;     // alias: output overwrites Q in-place
+
+        ca_k_bmhk = ws.alloc<cutlass::half_t>(size_t(Mk_max) * H * D);
+        ca_v_bmhk = ws.alloc<cutlass::half_t>(size_t(Mk_max) * H * D);
+        ca_kv_row = ws.alloc<cutlass::half_t>(size_t(Mk_max) * 2 * K);
+    }
+};
+
+// cuDNN Attention workspace pointers
+// Contains buffers specific to the cuDNN attention implementation
+struct CudnnAttentionWorkspace {
+    // Self-attention workspace
+    cutlass::half_t* sa_qkv_row;        // M×3K - QKV projection output
+    cutlass::half_t* sa_q_bmhk;         // 1×H×M×D - Q in BHSD format
+    cutlass::half_t* sa_k_bmhk;         // 1×H×M×D - K in BHSD format
+    cutlass::half_t* sa_v_bmhk;         // 1×H×M×D - V in BHSD format
+    cutlass::half_t* sa_o_bmhk;         // 1×H×M×D - Output in BHSD format
+
+    // Cross-attention workspace
+    cutlass::half_t* ca_q_row;          // M×K - Q projection
+    cutlass::half_t* ca_kv_row;         // Mk×2K - KV projection
+    cutlass::half_t* ca_q_bmhk;         // 1×H×M×D - Q in BHSD format
+    cutlass::half_t* ca_k_bmhk;         // 1×H×Mk×D - K in BHSD format
+    cutlass::half_t* ca_v_bmhk;         // 1×H×Mk×D - V in BHSD format
+    cutlass::half_t* ca_o_bmhk;         // 1×H×M×D - Output in BHSD format
+
+    // cuDNN workspace (for cuDNN internal use)
+    void* cudnn_workspace;
+
+    static size_t calculate_size(int M, int K, int H, int D, int Mk_max) {
+        size_t total = 0;
+
+        // Self-attention buffers
+        total += size_t(M) * 3 * K;     // sa_qkv_row
+        total += size_t(M) * K;         // sa_q_bmhk (reinterpreted as M×K)
+        total += size_t(M) * K;         // sa_k_bmhk
+        total += size_t(M) * K;         // sa_v_bmhk
+        total += size_t(M) * K;         // sa_o_bmhk
+
+        // Cross-attention buffers
+        total += size_t(M) * K;         // ca_q_row
+        total += size_t(Mk_max) * 2 * K; // ca_kv_row
+        total += size_t(M) * K;         // ca_q_bmhk
+        total += size_t(Mk_max) * K;    // ca_k_bmhk
+        total += size_t(Mk_max) * K;    // ca_v_bmhk
+        total += size_t(M) * K;         // ca_o_bmhk
+
+        // Convert to bytes (cuDNN SDPA workspace is allocated dynamically elsewhere)
+        return total * sizeof(cutlass::half_t);
+    }
+
+    void initialize(cutlass::half_t* ptr, int M, int K, int H, int D, int Mk_max) {
+        size_t budget = calculate_size(M, K, H, D, Mk_max);
+        ts::WorkspaceAllocator ws(ptr, budget, "cudnn_attn");
+
+        sa_qkv_row = ws.alloc<cutlass::half_t>(size_t(M) * 3 * K);
+        sa_q_bmhk  = ws.alloc<cutlass::half_t>(size_t(M) * K);
+        sa_k_bmhk  = ws.alloc<cutlass::half_t>(size_t(M) * K);
+        sa_v_bmhk  = ws.alloc<cutlass::half_t>(size_t(M) * K);
+        sa_o_bmhk  = ws.alloc<cutlass::half_t>(size_t(M) * K);
+
+        ca_q_row   = ws.alloc<cutlass::half_t>(size_t(M) * K);
+        ca_kv_row  = ws.alloc<cutlass::half_t>(size_t(Mk_max) * 2 * K);
+        ca_q_bmhk  = ws.alloc<cutlass::half_t>(size_t(M) * K);
+        ca_k_bmhk  = ws.alloc<cutlass::half_t>(size_t(Mk_max) * K);
+        ca_v_bmhk  = ws.alloc<cutlass::half_t>(size_t(Mk_max) * K);
+        ca_o_bmhk  = ws.alloc<cutlass::half_t>(size_t(M) * K);
+
+        cudnn_workspace = nullptr;
+    }
+};
+
+// Unified workspace for WAN model and transformer blocks
+// Supports both full model forward pass and individual block testing
+struct Workspace {
+    // === Dimensions ===
+
+    // Block-level dimensions (always used)
+    int M;           // Sequence length (for blocks: N*post_T*post_H*post_W)
+    int K;           // Inner dimension
+    int H;           // Number of heads
+    int D;           // Head dimension
+    int FF;          // FFN intermediate dimension
+    int Mk_max;      // Maximum encoder sequence length
+
+    // Model-level dimensions (0 if block-only mode)
+    int N;           // Batch size
+    int C_in;        // Input channels
+    int T, H_in, W;  // Input spatial dimensions
+    int pt, ph, pw;  // Patch sizes
+    int post_T, post_H, post_W;  // Post-patch spatial dimensions
+    int freq_dim;    // Timestep embedding frequency dimension
+    int time_hidden_dim;  // Timestep MLP hidden dimension
+    int time_proj_dim;    // Timestep projection dimension
+    int text_hidden_dim;  // Text embedder hidden dimension (if used)
+    int text_dim;    // Text input dimension
+    int img_dim;     // Image input dimension (if used)
+    int img_seq;     // Image sequence length (if used)
+
+    // Monolithic allocation
+    cutlass::DeviceAllocation<uint8_t> memory_pool;
+    // Separate cuDNN SDPA workspace (safe to grow without invalidating other pointers)
+    cutlass::DeviceAllocation<uint8_t> cudnn_workspace_pool;
+    size_t cudnn_workspace_capacity_bytes = 0;
+
+    // === Transformer Block Buffers (always allocated) ===
+
+    cutlass::half_t* hidden_persistent;  // M×K - persistent hidden state
+    cutlass::half_t* scratch_mk_a;      // M×K - reused for pre-norm inputs
+    cutlass::half_t* scratch_mk_b;      // M×K - reused for attention outputs
+    cutlass::half_t* ffn_intermediate;  // M×FF - FFN GEMM1 output
+
+    // INT8 quantization scratch buffers (allocated when quant_linear is enabled)
+    int8_t* int8_scratch;               // M×max(K,FF) - INT8 activation scratch
+    float* int8_act_amax;               // Device scalar for activation amax (per-tensor mode)
+
+    // Per-block INT8 quantization buffers (allocated when quant_linear_perblock is enabled)
+    // These enable per-128x128-block quantization for better precision
+    float* int8_act_block_scales;       // [M/128, max(K,FF)/128] - per-block activation scales
+    int int8_act_block_scales_m_blocks; // Number of M blocks for current allocation
+    int int8_act_block_scales_k_blocks; // Number of K blocks for current allocation
+
+    // Attention-specific workspace (backend-dependent)
+    // Both backends can coexist - they store pointers to the same underlying memory
+    CutlassFlashAttentionWorkspace cutlass_flash;
+    CudnnAttentionWorkspace cudnn;
+
+    // === Model-Level Buffers (nullptr if block-only mode) ===
+
+    // Patch embedding
+    cutlass::half_t* input_ndhwc;           // N×T×H×W×C_in
+    cutlass::half_t* pe_weight_ktrsc;       // K×pt×ph×pw×C_in
+    cutlass::half_t* pe_out_ndhwc;          // N×post_T×post_H×post_W×K
+    cutlass::half_t* hidden_rm;             // N×M×K - hidden states (row-major)
+
+    // RoPE buffers (float precision)
+    float* rope_cos;                        // M×D - RoPE cosine table
+    float* rope_sin;                        // M×D - RoPE sine table
+    float* rope_cos_t;                      // post_T×D_t - temporal RoPE cosine
+    float* rope_sin_t;                      // post_T×D_t - temporal RoPE sine
+    float* rope_cos_h;                      // post_H×D_h - height RoPE cosine
+    float* rope_sin_h;                      // post_H×D_h - height RoPE sine
+    float* rope_cos_w;                      // post_W×D_w - width RoPE cosine
+    float* rope_sin_w;                      // post_W×D_w - width RoPE sine
+
+    // Timestep embedding buffers
+    cutlass::half_t* timestep_sin;          // N×freq_dim
+    cutlass::half_t* temb_hidden;           // N×time_hidden_dim - intermediate MLP buffer
+    cutlass::half_t* temb_pre;              // N×time_proj_dim
+    cutlass::half_t* temb_act;              // N×time_proj_dim
+    cutlass::half_t* temb_6k;               // N×6×K
+    // temb_expanded removed: kernels now broadcast via temb_row_stride=0 (saves N*M*6*K*2 bytes)
+
+    // Text encoder buffers
+    cutlass::half_t* enc_text_k;            // N×text_seq×K
+    cutlass::half_t* text_h1;               // N×text_seq×text_hidden_dim
+
+    // Image encoder buffers (optional)
+    cutlass::half_t* enc_img_k;             // N×img_seq×K
+    cutlass::half_t* enc_cat;               // N×enc_seq×K
+    cutlass::half_t* enc_flat;              // N×enc_seq×K
+
+    // Transformer block ping-pong buffers
+    cutlass::half_t* ping;                  // N×M×K
+    cutlass::half_t* pong;                  // N×M×K
+
+    // Final projection buffers
+    float* final_scale;                     // N×M×K
+    float* final_shift;                     // N×M×K
+    cutlass::half_t* seq_norm;              // N×M×K
+    cutlass::half_t* tokens;                // N×M×(patch_vol×C_in)
+    cutlass::half_t* output_ndhwc;          // N×T×H×W×C_in
+
+    // Helper to calculate transformer block workspace size.
+    static size_t calculate_block_size(
+        int M,
+        int K,
+        int H,
+        int D,
+        int FF,
+        int Mk_max,
+        bool quant_linear = false) {
+        size_t mk = size_t(M) * K;
+        size_t mff = size_t(M) * FF;
+
+        size_t total = 0;
+        total += mk;              // hidden_persistent
+        total += mk;              // scratch_mk_a
+        total += mk;              // scratch_mk_b
+        total += mff;             // ffn_intermediate
+
+        // Convert to bytes before adding attention workspace size
+        size_t total_bytes = total * sizeof(cutlass::half_t);
+
+        // INT8 quantization buffers (when quant_linear is enabled)
+        if (quant_linear) {
+            size_t max_features = std::max(size_t(K), size_t(FF));
+            total_bytes += size_t(M) * max_features * sizeof(int8_t);  // int8_scratch
+            total_bytes = (total_bytes + 255) & ~255;  // Align for int8_act_amax
+            total_bytes += sizeof(float);  // int8_act_amax (device scalar for per-tensor mode)
+            total_bytes = (total_bytes + 255) & ~255;  // Align for block scales
+
+            // Per-block INT8 quantization scales
+            // Shape: [M/128, max(K,FF)/128] float32
+            int num_m_blocks = (M + 127) / 128;
+            int num_k_blocks = (max_features + 127) / 128;
+            total_bytes += size_t(num_m_blocks) * num_k_blocks * sizeof(float);  // int8_act_block_scales
+            total_bytes = (total_bytes + 255) & ~255;  // Align for attention workspace
+        }
+
+        // CUTLASS and cuDNN can share memory (mutual exclusion at runtime)
+        size_t cutlass_size = CutlassFlashAttentionWorkspace::calculate_size(M, K, H, D, Mk_max);
+        size_t cudnn_size = CudnnAttentionWorkspace::calculate_size(M, K, H, D, Mk_max);
+        size_t shared_attn_size = std::max(cutlass_size, cudnn_size);
+        total_bytes += shared_attn_size;
+
+        return total_bytes;
+    }
+
+    // Helper to calculate full model workspace size
+    static size_t calculate_model_size(
+            int N, int M, int K, int H, int D, int FF, int enc_seq,
+            int C_in, int T, int H_in, int W, int pt, int ph, int pw,
+            int post_T, int post_H, int post_W,
+            int freq_dim, int time_hidden_dim, int time_proj_dim,
+            int text_hidden_dim, int text_dim, int text_seq,
+            int img_dim, int img_seq,
+            bool quant_linear = false) {
+
+        size_t total_half = 0;
+        size_t total_float = 0;
+        size_t total_bytes = 0;  // For mixed-type allocations (block-level)
+
+        int patch_vol = pt * ph * pw;
+
+        // Block-level buffers (includes INT8 scratch when quant_linear=true)
+        // For true batched attention, cross-attn KV workspace must accommodate all batch items:
+        // total_kv_rows = N * enc_seq (not just enc_seq).
+        // NOTE: calculate_block_size returns bytes, so add directly to total_bytes
+        total_bytes += calculate_block_size(N * M, K, H, D, FF, N * enc_seq, quant_linear);
+
+        // Patch embedding
+        total_half += size_t(N) * T * H_in * W * C_in;
+        total_half += size_t(K) * pt * ph * pw * C_in;
+        total_half += size_t(N) * post_T * post_H * post_W * K;
+        total_half += size_t(N) * M * K;
+
+        // RoPE buffers
+        total_float += size_t(M) * D * 2;  // cos + sin
+        size_t rope_temp = std::max({size_t(post_T) * D, size_t(post_H) * D, size_t(post_W) * D});
+        total_float += rope_temp * 6;
+
+        // Timestep embedding
+        total_half += size_t(N) * freq_dim;
+        total_half += size_t(N) * time_hidden_dim;  // temb_hidden
+        total_half += size_t(N) * time_proj_dim * 2;  // temb_pre, temb_act
+        total_half += size_t(N) * 6 * K;
+        // temb_expanded removed (was N*M*6*K)
+
+        // Text encoder
+        total_half += size_t(N) * text_seq * K;
+        if (text_hidden_dim > 0) {
+            total_half += size_t(N) * text_seq * text_hidden_dim;
+        }
+
+        // Image encoder
+        if (img_seq > 0) {
+            total_half += size_t(N) * img_seq * K;
+            total_half += size_t(N) * enc_seq * K * 2;
+        }
+
+        // Ping-pong + final projection
+        total_half += size_t(N) * M * K * 2;
+        total_float += size_t(N) * M * K * 2;
+        total_half += size_t(N) * M * K;
+        total_half += size_t(N) * M * patch_vol * C_in;
+        total_half += size_t(N) * T * H_in * W * C_in;
+
+        return total_bytes + total_half * sizeof(cutlass::half_t) + total_float * sizeof(float);
+    }
+
+    // Initialize for block-only testing (no model-level buffers)
+    void initialize_for_blocks(int M_, int K_, int H_, int D_, int FF_, int Mk_max_, bool quant_linear_ = false) {
+        M = M_; K = K_; H = H_; D = D_; FF = FF_; Mk_max = Mk_max_;
+        N = 0;  // Indicates block-only mode
+        quant_linear = quant_linear_;
+
+        size_t total_size = calculate_block_size(M, K, H, D, FF, Mk_max, quant_linear);
+        memory_pool.reset(total_size);
+
+        WorkspaceAllocator ws(memory_pool.get(), total_size, "block_workspace");
+        initialize_block_pointers(ws, M);
+
+        // Null out model-level pointers
+        input_ndhwc = pe_weight_ktrsc = pe_out_ndhwc = hidden_rm = nullptr;
+        rope_cos = rope_sin = rope_cos_t = rope_sin_t = nullptr;
+        rope_cos_h = rope_sin_h = rope_cos_w = rope_sin_w = nullptr;
+        timestep_sin = temb_hidden = temb_pre = temb_act = temb_6k = nullptr;
+        enc_text_k = text_h1 = enc_img_k = enc_cat = enc_flat = nullptr;
+        ping = pong = seq_norm = tokens = output_ndhwc = nullptr;
+        final_scale = final_shift = nullptr;
+    }
+
+    // Initialize for full model forward pass
+    void initialize_for_model(
+            int N_, int M_, int K_, int H_, int D_, int FF_, int enc_seq_,
+            int C_in_, int T_, int H_in_, int W_, int pt_, int ph_, int pw_,
+            int post_T_, int post_H_, int post_W_,
+            int freq_dim_, int time_hidden_dim_, int time_proj_dim_,
+            int text_hidden_dim_, int text_dim_, int text_seq,
+            int img_dim_, int img_seq_,
+            bool quant_linear_ = false) {
+
+        N = N_; M = M_; K = K_; H = H_; D = D_; FF = FF_;
+        // For true batched attention, Mk_max is the total encoder tokens across batch.
+        Mk_max = N_ * enc_seq_;
+        C_in = C_in_; T = T_; H_in = H_in_; W = W_;
+        pt = pt_; ph = ph_; pw = pw_;
+        post_T = post_T_; post_H = post_H_; post_W = post_W_;
+        freq_dim = freq_dim_; time_hidden_dim = time_hidden_dim_; time_proj_dim = time_proj_dim_;
+        text_hidden_dim = text_hidden_dim_; text_dim = text_dim_;
+        img_dim = img_dim_; img_seq = img_seq_;
+        quant_linear = quant_linear_;
+
+        size_t total_bytes = calculate_model_size(N, M, K, H, D, FF, enc_seq_,
+                C_in, T, H_in, W, pt, ph, pw, post_T, post_H, post_W,
+                freq_dim, time_hidden_dim, time_proj_dim, text_hidden_dim,
+                text_dim, text_seq, img_dim, img_seq, quant_linear);
+
+        memory_pool.reset(total_bytes);
+        WorkspaceAllocator ws(memory_pool.get(), total_bytes, "model_workspace");
+        int patch_vol = pt * ph * pw;
+
+        // Patch embedding
+        input_ndhwc     = ws.alloc<cutlass::half_t>(size_t(N) * T * H_in * W * C_in);
+        pe_weight_ktrsc = ws.alloc<cutlass::half_t>(size_t(K) * pt * ph * pw * C_in);
+        pe_out_ndhwc    = ws.alloc<cutlass::half_t>(size_t(N) * post_T * post_H * post_W * K);
+        hidden_rm       = ws.alloc<cutlass::half_t>(size_t(N) * M * K);
+
+        // RoPE buffers
+        rope_cos   = ws.alloc<float>(size_t(M) * D);
+        rope_sin   = ws.alloc<float>(size_t(M) * D);
+        rope_cos_t = ws.alloc<float>(size_t(post_T) * D);
+        rope_sin_t = ws.alloc<float>(size_t(post_T) * D);
+        rope_cos_h = ws.alloc<float>(size_t(post_H) * D);
+        rope_sin_h = ws.alloc<float>(size_t(post_H) * D);
+        rope_cos_w = ws.alloc<float>(size_t(post_W) * D);
+        rope_sin_w = ws.alloc<float>(size_t(post_W) * D);
+
+        // Timestep embedding
+        timestep_sin = ws.alloc<cutlass::half_t>(size_t(N) * freq_dim);
+        temb_hidden  = ws.alloc<cutlass::half_t>(size_t(N) * time_hidden_dim);
+        temb_pre     = ws.alloc<cutlass::half_t>(size_t(N) * time_proj_dim);
+        temb_act     = ws.alloc<cutlass::half_t>(size_t(N) * time_proj_dim);
+        temb_6k      = ws.alloc<cutlass::half_t>(size_t(N) * 6 * K);
+
+        // Text encoder
+        enc_text_k = ws.alloc<cutlass::half_t>(size_t(N) * text_seq * K);
+        if (text_hidden_dim > 0) {
+            text_h1 = ws.alloc<cutlass::half_t>(size_t(N) * text_seq * text_hidden_dim);
+        } else {
+            text_h1 = nullptr;
+        }
+
+        // Image encoder
+        if (img_seq > 0) {
+            enc_img_k = ws.alloc<cutlass::half_t>(size_t(N) * img_seq * K);
+            enc_cat   = ws.alloc<cutlass::half_t>(size_t(N) * enc_seq_ * K);
+            enc_flat  = ws.alloc<cutlass::half_t>(size_t(N) * enc_seq_ * K);
+        } else {
+            enc_img_k = enc_cat = enc_flat = nullptr;
+        }
+
+        // Ping-pong buffers
+        ping = ws.alloc<cutlass::half_t>(size_t(N) * M * K);
+        pong = ws.alloc<cutlass::half_t>(size_t(N) * M * K);
+
+        // Final projection
+        final_scale  = ws.alloc<float>(size_t(N) * M * K);
+        final_shift  = ws.alloc<float>(size_t(N) * M * K);
+        seq_norm     = ws.alloc<cutlass::half_t>(size_t(N) * M * K);
+        tokens       = ws.alloc<cutlass::half_t>(size_t(N) * M * patch_vol * C_in);
+        output_ndhwc = ws.alloc<cutlass::half_t>(size_t(N) * T * H_in * W * C_in);
+
+        // Initialize block-level pointers (model mode uses N*M for effective batch*sequence)
+        //
+        // IMPORTANT: The transformer block implementation operates on a flattened row dimension:
+        //   M_block = B * Mq = N * (post_T * post_H * post_W).
+        // All block scratch/attention workspace buffers must be sized for M_block rows.
+        initialize_block_pointers(ws, N * M);
+    }
+
+    // Release workspace
+    void release() {
+        memory_pool.release();
+        cudnn_workspace_pool.release();
+        cudnn_workspace_capacity_bytes = 0;
+    }
+
+    // Get total allocated size in bytes
+    size_t size_bytes() const {
+        return memory_pool.size();
+    }
+
+    // Get total allocated size in MB
+    float size_mb() const {
+        return size_bytes() / (1024.0f * 1024.0f);
+    }
+
+    // INT8 linear quantization flag (set before calling initialize)
+    bool quant_linear = false;
+
+    // Validate INT8 buffers are properly allocated (returns true if valid)
+    bool validate_int8_buffers() const {
+        if (!quant_linear) return true;  // Not using INT8, no validation needed
+        bool valid = true;
+        if (int8_scratch == nullptr) {
+            printf("[ERROR] Workspace::validate_int8_buffers: int8_scratch is nullptr despite quant_linear=true\n");
+            valid = false;
+        }
+        if (int8_act_amax == nullptr) {
+            printf("[ERROR] Workspace::validate_int8_buffers: int8_act_amax is nullptr despite quant_linear=true\n");
+            valid = false;
+        }
+        if (int8_act_block_scales == nullptr) {
+            printf("[ERROR] Workspace::validate_int8_buffers: int8_act_block_scales is nullptr despite quant_linear=true\n");
+            valid = false;
+        }
+        if (valid) {
+            printf("[OK] Workspace::validate_int8_buffers: All INT8 buffers valid\n");
+        }
+        return valid;
+    }
+
+    // Ensure cuDNN SDPA workspace exists with at least `bytes` capacity.
+    // This can be called between kernel launches and does not invalidate pointers in `memory_pool`.
+    void ensure_cudnn_workspace(size_t bytes) {
+        if (bytes == 0) {
+            // Still keep pointer null; callers should handle zero-size workspace.
+            cudnn_workspace_capacity_bytes = 0;
+            cudnn.cudnn_workspace = nullptr;
+            return;
+        }
+        if (cudnn_workspace_capacity_bytes >= bytes && cudnn_workspace_pool.get() != nullptr) {
+            cudnn.cudnn_workspace = cudnn_workspace_pool.get();
+            return;
+        }
+        // Round up to reduce realloc churn (256KB granularity)
+        size_t rounded = (bytes + (256 * 1024 - 1)) & ~(size_t(256 * 1024 - 1));
+        cudnn_workspace_pool.reset(rounded);
+        cudnn_workspace_capacity_bytes = rounded;
+        cudnn.cudnn_workspace = cudnn_workspace_pool.get();
+    }
+
+private:
+    // Helper to initialize block-level pointers using bounds-checked allocator.
+    // effective_M is the actual number of rows to process (N*M for model forward, M for block-only).
+    void initialize_block_pointers(WorkspaceAllocator& ws, int effective_M) {
+        hidden_persistent = ws.alloc<cutlass::half_t>(size_t(effective_M) * K);
+        scratch_mk_a      = ws.alloc<cutlass::half_t>(size_t(effective_M) * K);
+        scratch_mk_b      = ws.alloc<cutlass::half_t>(size_t(effective_M) * K);
+        ffn_intermediate   = ws.alloc<cutlass::half_t>(size_t(effective_M) * FF);
+
+        // INT8 quantization buffers (when enabled)
+        if (quant_linear) {
+            size_t max_features = std::max(size_t(K), size_t(FF));
+            int8_scratch = ws.alloc<int8_t>(size_t(effective_M) * max_features);
+            ws.align_to(256);
+            int8_act_amax = ws.alloc<float>(1);
+            ws.align_to(256);
+
+            int num_m_blocks = (effective_M + 127) / 128;
+            int num_k_blocks = (max_features + 127) / 128;
+            int8_act_block_scales = ws.alloc<float>(size_t(num_m_blocks) * num_k_blocks);
+            int8_act_block_scales_m_blocks = num_m_blocks;
+            int8_act_block_scales_k_blocks = num_k_blocks;
+            ws.align_to(256);
+        } else {
+            int8_scratch = nullptr;
+            int8_act_amax = nullptr;
+            int8_act_block_scales = nullptr;
+            int8_act_block_scales_m_blocks = 0;
+            int8_act_block_scales_k_blocks = 0;
+        }
+
+        // CUTLASS and cuDNN share the same underlying buffer (mutual exclusion at runtime).
+        // Carve out the larger of the two as a shared region.
+        size_t cutlass_size = CutlassFlashAttentionWorkspace::calculate_size(effective_M, K, H, D, Mk_max);
+        size_t cudnn_size = CudnnAttentionWorkspace::calculate_size(effective_M, K, H, D, Mk_max);
+        size_t shared_attn_size = std::max(cutlass_size, cudnn_size);
+        WorkspaceAllocator attn_sub = ws.sub(shared_attn_size, "shared_attn");
+        auto* attn_base = reinterpret_cast<cutlass::half_t*>(attn_sub.current());
+        cutlass_flash.initialize(attn_base, effective_M, K, H, D, Mk_max);
+        cudnn.initialize(attn_base, effective_M, K, H, D, Mk_max);
+
+    }
+};
+
+} // namespace ts

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/workspace.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/workspace.cuh
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cutlass/cutlass.h>

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/workspace.cuh
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/kernels/workspace.cuh
@@ -5,11 +5,122 @@
 #include <cutlass/util/device_memory.h>
 #include <cuda_runtime.h>
 #include <algorithm>
+#include <cstdint>
+#include <stdexcept>
 #include "common/workspace_alloc.h"
 
 // cuDNN SDPA workspace is backend/shape dependent. We allocate it dynamically in Workspace.
 
 namespace ts {
+
+struct SpargeAttentionWorkspace {
+    cutlass::half_t* pooled_q;          // [num_q_blocks, H, D]
+    cutlass::half_t* pooled_k;          // [num_k_blocks, H, D]
+    float* pooled_scores;               // [num_q_blocks, num_k_blocks, H]
+    int32_t* sparse_map;                // [H, num_q_blocks, num_k_blocks]
+    int32_t* lut;                       // [H, num_q_blocks, num_k_blocks]
+    int32_t* valid_block_num;           // [H, num_q_blocks]
+    int32_t* topk_indices;              // [H, num_q_blocks, topk]
+
+    int8_t* q_int8;                     // [padded_q_len, H, D]
+    int8_t* k_int8;                     // [padded_k_len, H, D]
+    float* q_scale;                     // [H, num_q_blocks]
+    float* k_scale;                     // [H, num_k_blocks]
+
+    cutlass::float_e4m3_t* v_fp8;       // [H, D, padded_kv_len]
+    float* v_scale;                     // [H, D]
+    cutlass::half_t* o_sparse;          // [padded_q_len, H, D]
+    uint8_t* reserved_tail;              // preserves the optimized sparse workspace footprint
+
+    int BLKQ;
+    int BLKK;
+    float topk_ratio;
+
+    static size_t calculate_size(
+            int Mq, int Mk, int K, int H, int D, int BLKQ, int BLKK,
+            float topk_ratio) {
+        (void)K;
+        if (BLKQ <= 0 || BLKK <= 0) {
+            throw std::invalid_argument("SpargeAttentionWorkspace block sizes must be positive");
+        }
+        int num_q_blocks = (Mq + BLKQ - 1) / BLKQ;
+        int num_k_blocks = (Mk + BLKK - 1) / BLKK;
+        int topk = std::max(1, std::min(num_k_blocks, int(topk_ratio * num_k_blocks)));
+        int padded_q_len = num_q_blocks * BLKQ;
+        int padded_k_len = num_k_blocks * BLKK;
+        int padded_kv_len = ((Mk + 127) / 128) * 128;
+
+        size_t total = 0;
+        total += size_t(H) * num_q_blocks * D * sizeof(cutlass::half_t);
+        total += size_t(H) * num_k_blocks * D * sizeof(cutlass::half_t);
+        total += size_t(H) * num_q_blocks * num_k_blocks * sizeof(float);
+        total += size_t(H) * num_q_blocks * num_k_blocks * sizeof(int32_t);
+        total += size_t(H) * num_q_blocks * num_k_blocks * sizeof(int32_t);
+        total += size_t(H) * num_q_blocks * sizeof(int32_t);
+        total += size_t(H) * num_q_blocks * topk * sizeof(int32_t);
+        total += size_t(H) * padded_q_len * D * sizeof(int8_t);
+        total += size_t(H) * padded_k_len * D * sizeof(int8_t);
+        total += size_t(H) * num_q_blocks * sizeof(float);
+        total += size_t(H) * num_k_blocks * sizeof(float);
+        total += size_t(H) * D * padded_kv_len * sizeof(cutlass::float_e4m3_t);
+        total += size_t(H) * D * sizeof(float);
+        total += size_t(H) * padded_q_len * D * sizeof(cutlass::half_t);
+        total += reserved_tail_size(Mq, Mk, H, D);
+        return total;
+    }
+
+    void initialize(
+            uint8_t* ptr, int Mq, int Mk, int K, int H, int D, int BLKQ_,
+            int BLKK_, float topk_ratio_) {
+        BLKQ = BLKQ_;
+        BLKK = BLKK_;
+        topk_ratio = topk_ratio_;
+        if (BLKQ <= 0 || BLKK <= 0) {
+            throw std::invalid_argument("SpargeAttentionWorkspace block sizes must be positive");
+        }
+
+        size_t budget = calculate_size(Mq, Mk, K, H, D, BLKQ, BLKK, topk_ratio);
+        WorkspaceAllocator ws(ptr, budget, "sparge");
+
+        int num_q_blocks = (Mq + BLKQ - 1) / BLKQ;
+        int num_k_blocks = (Mk + BLKK - 1) / BLKK;
+        int topk = std::max(1, std::min(num_k_blocks, int(topk_ratio * num_k_blocks)));
+        int padded_q_len = num_q_blocks * BLKQ;
+        int padded_k_len = num_k_blocks * BLKK;
+        int padded_kv_len = ((Mk + 127) / 128) * 128;
+
+        pooled_q = ws.alloc<cutlass::half_t>(size_t(H) * num_q_blocks * D);
+        pooled_k = ws.alloc<cutlass::half_t>(size_t(H) * num_k_blocks * D);
+        pooled_scores = ws.alloc<float>(size_t(H) * num_q_blocks * num_k_blocks);
+        sparse_map = ws.alloc<int32_t>(size_t(H) * num_q_blocks * num_k_blocks);
+        lut = ws.alloc<int32_t>(size_t(H) * num_q_blocks * num_k_blocks);
+        valid_block_num = ws.alloc<int32_t>(size_t(H) * num_q_blocks);
+        topk_indices = ws.alloc<int32_t>(size_t(H) * num_q_blocks * topk);
+
+        q_int8 = ws.alloc<int8_t>(size_t(H) * padded_q_len * D);
+        k_int8 = ws.alloc<int8_t>(size_t(H) * padded_k_len * D);
+        q_scale = ws.alloc<float>(size_t(H) * num_q_blocks);
+        k_scale = ws.alloc<float>(size_t(H) * num_k_blocks);
+
+        v_fp8 = ws.alloc<cutlass::float_e4m3_t>(size_t(H) * D * padded_kv_len);
+        v_scale = ws.alloc<float>(size_t(H) * D);
+        o_sparse = ws.alloc<cutlass::half_t>(size_t(H) * padded_q_len * D);
+        reserved_tail = ws.alloc<uint8_t>(reserved_tail_size(Mq, Mk, H, D));
+    }
+
+private:
+    static size_t reserved_tail_size(int Mq, int Mk, int H, int D) {
+        const size_t half_bytes = sizeof(cutlass::half_t);
+        size_t total = 0;
+        total += size_t(H) * Mq * D * half_bytes;
+        total += size_t(H) * Mk * D * half_bytes;
+        total += size_t(H) * D * D * half_bytes;
+        total += size_t(H) * D * half_bytes;
+        total += size_t(H) * Mq * D * half_bytes;
+        total += size_t(H) * Mq * D * half_bytes;
+        return total;
+    }
+};
 
 // CUTLASS Flash Attention workspace pointers
 // Contains buffers specific to the CUTLASS Flash Attention implementation
@@ -189,6 +300,10 @@ struct Workspace {
     // Both backends can coexist - they store pointers to the same underlying memory
     CutlassFlashAttentionWorkspace cutlass_flash;
     CudnnAttentionWorkspace cudnn;
+    // SpargeAttentionWorkspace is intentionally not part of this legacy shared
+    // attention workspace. The optimized DiT streaming bridge owns its lifetime
+    // via the caller-provided `sparge_workspace` byte tensor and initializes
+    // CosmosBlockBuffers::sparge directly.
 
     // === Model-Level Buffers (nullptr if block-only mode) ===
 

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_blackwell_api_shim.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_blackwell_api_shim.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include <torch/python.h>
 
 // Build SageAttention-3's Blackwell kernel implementation into OmniDreams single-view native extension

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_blackwell_api_shim.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_blackwell_api_shim.cu
@@ -1,0 +1,11 @@
+#include <torch/python.h>
+
+// Build SageAttention-3's Blackwell kernel implementation into OmniDreams single-view native extension
+// without registering Sage's standalone pybind module.
+#undef PYBIND11_MODULE
+#define PYBIND11_MODULE(name, variable) \
+  static void native_sage3_blackwell_pybind_stub(pybind11::module_& variable)
+
+#include "sageattention3_blackwell/sageattn3/blackwell/api.cu"
+
+#undef PYBIND11_MODULE

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_fp4_quant_shim.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_fp4_quant_shim.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include <torch/python.h>
 
 // Build SageAttention-3's FP4 quantization kernels into OmniDreams single-view native extension without

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_fp4_quant_shim.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/sage3_fp4_quant_shim.cu
@@ -1,0 +1,11 @@
+#include <torch/python.h>
+
+// Build SageAttention-3's FP4 quantization kernels into OmniDreams single-view native extension without
+// registering Sage's standalone pybind module.
+#undef PYBIND11_MODULE
+#define PYBIND11_MODULE(name, variable) \
+  static void native_sage3_fp4_quant_pybind_stub(pybind11::module_& variable)
+
+#include "sageattention3_blackwell/sageattn3/quantization/fp4_quantization_4d.cu"
+
+#undef PYBIND11_MODULE

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.cu
@@ -1596,8 +1596,20 @@ torch::Tensor optimized_dit_forward(
     std::string linear_backend_name = lower_ascii(cs("cosmos_linear_backend", "auto"));
     std::string attention_backend_name = lower_ascii(cs("cosmos_attention_backend", "cudnn_bf16"));
     std::string kv_cache_backend_name = lower_ascii(cs("cosmos_kv_cache_backend", "bf16"));
+    float sparge_topk_ratio = cf("cosmos_sparge_topk_ratio", 0.25f);
+    int sparge_hybrid_period = ci("cosmos_sparge_hybrid_period", 0);
+    int sparge_hybrid_phase = ci("cosmos_sparge_hybrid_phase", 0);
+    bool sparge_attention_sink = cb("cosmos_sparge_attention_sink", true);
     bool quantized_prepared = cb("cosmos_quantized_prepared", false);
     bool quantized_prepared_strict = cb("cosmos_quantized_prepared_strict", quantized_prepared);
+    TORCH_CHECK(sparge_topk_ratio > 0.0f && sparge_topk_ratio <= 1.0f,
+                "cosmos_sparge_topk_ratio must be in (0, 1], got ", sparge_topk_ratio);
+    TORCH_CHECK(sparge_hybrid_period >= 0,
+                "cosmos_sparge_hybrid_period must be non-negative, got ",
+                sparge_hybrid_period);
+    TORCH_CHECK(sparge_hybrid_phase >= 0,
+                "cosmos_sparge_hybrid_phase must be non-negative, got ",
+                sparge_hybrid_phase);
     // Shape: x_new is [B, V, T, HW, D_in]. For FlashDreams' single-view DiT V=1;
     // we flatten (V, T, HW) into a single L dimension for the transformer math.
     int B = (int)x_new.size(0);
@@ -1922,6 +1934,8 @@ torch::Tensor optimized_dit_forward(
         attention_backend = omnidreams_singleview::CosmosAttentionBackend::FP8_DENSE_REF;
     } else if (attention_backend_name == "fp8_cudnn") {
         attention_backend = omnidreams_singleview::CosmosAttentionBackend::FP8_CUDNN;
+    } else if (attention_backend_name == "sparge") {
+        attention_backend = omnidreams_singleview::CosmosAttentionBackend::SPARGE;
     } else if (attention_backend_name == "sage3") {
         attention_backend = omnidreams_singleview::CosmosAttentionBackend::SAGE3;
     } else if (attention_backend_name == "sage3_fp8") {
@@ -1929,8 +1943,36 @@ torch::Tensor optimized_dit_forward(
     } else {
         TORCH_CHECK(false,
                     "unsupported cosmos_attention_backend '", attention_backend_name,
-                    "'. Expected one of: cudnn_bf16, bf16, fp8_dense_ref, fp8_cudnn, sage3, sage3_fp8");
+                    "'. Expected one of: cudnn_bf16, bf16, fp8_dense_ref, fp8_cudnn, sparge, sage3, sage3_fp8");
     }
+    const bool sparge_hybrid_enabled =
+        attention_backend == omnidreams_singleview::CosmosAttentionBackend::SPARGE &&
+        sparge_hybrid_period > 0;
+    const int sparge_hybrid_phase_mod =
+        sparge_hybrid_enabled ? (sparge_hybrid_phase % sparge_hybrid_period) : 0;
+    bool schedule_uses_sparge =
+        attention_backend == omnidreams_singleview::CosmosAttentionBackend::SPARGE &&
+        !sparge_hybrid_enabled;
+    bool schedule_uses_sage3_fp8 =
+        attention_backend == omnidreams_singleview::CosmosAttentionBackend::SAGE3_FP8;
+    if (sparge_hybrid_enabled) {
+        int sparge_block_count = 0;
+        for (int bi = 0; bi < num_blocks; ++bi) {
+            if ((bi % sparge_hybrid_period) == sparge_hybrid_phase_mod) {
+                schedule_uses_sparge = true;
+                ++sparge_block_count;
+            } else {
+                schedule_uses_sage3_fp8 = true;
+            }
+        }
+        TORCH_CHECK(sparge_block_count > 0,
+                    "cosmos_sparge_hybrid_period/phase do not select any SPARGE blocks for num_blocks=",
+                    num_blocks);
+    }
+    TORCH_CHECK(!schedule_uses_sage3_fp8 || fp8_kv_cache_enabled,
+                "Sage3 FP8 attention requires cosmos_kv_cache_backend='fp8'");
+    TORCH_CHECK(!schedule_uses_sage3_fp8 || sage3_cross_fp4_enabled,
+                "Sage3 FP8 attention requires Sage3 FP4 cross-attention caches");
     // ── 5a. One-shot setup outside the per-block loop ─────────────────────────
     //
     // (i) RoPE cos/sin: callers may precompute these for fixed-shape replay.
@@ -1992,8 +2034,9 @@ torch::Tensor optimized_dit_forward(
         config.contains("cosmos_write_bf16_kv_cache")
             ? py::cast<bool>(config["cosmos_write_bf16_kv_cache"])
             : true;
-    TORCH_CHECK(write_bf16_self_kv_cache || fp8_kv_cache_enabled,
-                "cosmos_write_bf16_kv_cache=false requires cosmos_kv_cache_backend='fp8'");
+    TORCH_CHECK(write_bf16_self_kv_cache || fp8_kv_cache_enabled || schedule_uses_sparge,
+                "cosmos_write_bf16_kv_cache=false requires cosmos_kv_cache_backend='fp8' "
+                "unless the selected attention schedule forces BF16 self-KV writes");
     auto workspace_tensor = [&](const char* name,
                                 std::vector<int64_t> shape,
                                 at::ScalarType dtype) -> torch::Tensor {
@@ -2141,8 +2184,7 @@ torch::Tensor optimized_dit_forward(
     auto attn_k_bhmd_fp8 = workspace_tensor("attn_k_bhmd_fp8", {B, H, max_attn_tokens, D}, at::kByte);
     auto attn_v_bhmd_fp8 = workspace_tensor("attn_v_bhmd_fp8", {B, H, max_attn_tokens, D}, at::kByte);
     auto attn_v_bhdm_fp8 = workspace_tensor("attn_v_bhdm_fp8", {B, H, D, max_attn_tokens}, at::kByte);
-    const bool needs_sage3_fp8_attention_scratch =
-        attention_backend == omnidreams_singleview::CosmosAttentionBackend::SAGE3_FP8;
+    const bool needs_sage3_fp8_attention_scratch = schedule_uses_sage3_fp8;
     torch::Tensor attn_q_sage3_fp4;
     torch::Tensor attn_q_sage3_sf;
     if (needs_sage3_fp8_attention_scratch) {
@@ -2166,6 +2208,19 @@ torch::Tensor optimized_dit_forward(
     auto attn_o_half = workspace_tensor("attn_o_half", {B, M, H, D}, at::kHalf);
     const int64_t attn_tc_scale_elems = 12;
     auto attn_tc_scale = workspace_tensor("attn_tc_scale", {attn_tc_scale_elems}, at::kFloat);
+
+    torch::Tensor sparge_workspace;
+    const bool needs_sparge_workspace = schedule_uses_sparge;
+    if (needs_sparge_workspace) {
+        TORCH_CHECK(D == 128,
+                    "cosmos_attention_backend='sparge' requires head_dim=128, got ", D);
+        size_t sparge_workspace_bytes = ts::SpargeAttentionWorkspace::calculate_size(
+            M, max_attn_tokens, K, H, D, 128, 64, sparge_topk_ratio);
+        sparge_workspace = workspace_tensor(
+            "sparge_workspace",
+            {static_cast<int64_t>(sparge_workspace_bytes)},
+            at::kByte);
+    }
 
     omnidreams_singleview::CosmosBlockBuffers buf{};
     buf.qkv_row           = reinterpret_cast<cutlass::bfloat16_t*>(qkv_row.data_ptr<at::BFloat16>());
@@ -2211,6 +2266,12 @@ torch::Tensor optimized_dit_forward(
     buf.attn_tc_scale = attn_tc_scale.data_ptr<float>();
     buf.attn_tc_scale_elems = attn_tc_scale_elems;
     buf.attn_tc_scale_is_ones = attn_tc_scale_is_ones;
+    if (needs_sparge_workspace) {
+        buf.sparge.initialize(
+            sparge_workspace.data_ptr<uint8_t>(),
+            M, max_attn_tokens, K, H, D,
+            128, 64, sparge_topk_ratio);
+    }
     rec(EV_AFTER_ROPE_SCRATCH);
 
     // ── 5a. AdaLN-LoRA pre-stack + global down + batched up GEMMs ──────────
@@ -2780,6 +2841,16 @@ torch::Tensor optimized_dit_forward(
         }
 
         omnidreams_singleview::CosmosAttentionBackend block_attention_backend = attention_backend;
+        if (sparge_hybrid_enabled) {
+            const bool use_sparge_block =
+                (i % sparge_hybrid_period) == sparge_hybrid_phase_mod;
+            block_attention_backend = use_sparge_block
+                ? omnidreams_singleview::CosmosAttentionBackend::SPARGE
+                : omnidreams_singleview::CosmosAttentionBackend::SAGE3_FP8;
+        }
+        const bool block_write_bf16_self_kv_cache =
+            write_bf16_self_kv_cache ||
+            block_attention_backend == omnidreams_singleview::CosmosAttentionBackend::SPARGE;
 
         omnidreams_singleview::CosmosBlockParams bp{};
         bp.B  = B;
@@ -2795,7 +2866,9 @@ torch::Tensor optimized_dit_forward(
         bp.linear_backend = linear_backend;
         bp.attention_backend = block_attention_backend;
         bp.fp8_kv_cache_enabled = fp8_kv_cache_enabled;
-        bp.write_bf16_self_kv_cache = write_bf16_self_kv_cache;
+        bp.write_bf16_self_kv_cache = block_write_bf16_self_kv_cache;
+        bp.sparge_topk_ratio = sparge_topk_ratio;
+        bp.sparge_attention_sink = sparge_attention_sink;
         if (trace_enabled) {
             auto* trace_base = reinterpret_cast<cutlass::bfloat16_t*>(
                 trace_tensor.data_ptr<at::BFloat16>());
@@ -2854,6 +2927,12 @@ torch::Tensor optimized_dit_forward(
         bp.v_cross_fp8_bhdm = fp8_cross_tc_layout_cache_enabled && !v_cross_fp8_bhdm_caches.empty()
             ? reinterpret_cast<const cutlass::float_e4m3_t*>(v_cross_fp8_bhdm_caches[i].data_ptr<uint8_t>())
             : nullptr;
+        bp.k_cross_fp8_bhmd_tokens = bp.k_cross_fp8_bhmd
+            ? (int)k_cross_fp8_bhmd_caches[i].size(2)
+            : 0;
+        bp.v_cross_fp8_bhmd_tokens = bp.v_cross_fp8_bhmd
+            ? (int)v_cross_fp8_bhmd_caches[i].size(2)
+            : 0;
         bp.k_cross_sage3_fp4 = sage3_cross_fp4_enabled
             ? k_cross_sage3_fp4_caches[i].data_ptr<uint8_t>()
             : nullptr;

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.cu
@@ -1,0 +1,3030 @@
+#include "streaming_dit_bridge.h"
+#include "../kernels/attention.cuh"
+#include "../kernels/cosmos_block.cuh"
+#include "../kernels/cosmos_fp8_flash.cuh"
+#include "../kernels/cosmos_fp8_tc_probe.cuh"
+#include "../kernels/linear_utils.cuh"
+#include "../kernels/ops.cuh"
+#include "cutlass/gemm/device/gemm_batched.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/numeric_conversion.h"
+#include <torch/nn/functional.h>
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cfloat>
+#include <cmath>
+#include <cstdlib>
+#include <cstdio>
+#include <string>
+
+// streaming_dit_bridge.cu — full Cosmos DiT forward using native CUTLASS GEMMs
+// + cuDNN FMHA.
+//
+// Streaming forward (optimized_dit_forward): the per-block hot path is
+// implemented in `omnidreams_singleview::cosmos_run_transformer_block_streaming` (see
+// `kernels/cosmos_block.cu`), which fuses ln+modulate, runs three bf16
+// CUTLASS GEMMs for Q/K/V, packs+rotate-half-RoPE in one kernel, calls
+// cuDNN FMHA, then drives the SA/CA out projections and FFN through bf16
+// CUTLASS GEMMs with separate gated-residual kernels. One-shot pieces
+// (x_embedder, timestep+sin embedding, adaln-LoRA, t_embedding_norm,
+// final layer) stay in ATen because they run once per forward, not per
+// layer.
+//
+// DDPM forward (cosmos_forward): full-sequence training-style forward,
+// kept on the original ATen + cuDNN-FMHA path -- only the streaming
+// path lands on the alpadreams pipeline and is therefore the perf
+// hotspot.
+//
+// RoPE note: Cosmos uses rotate_half convention (negate second half, swap halves);
+// native's built-in QKV+RoPE kernel (used by WAN) bakes adjacent-pair
+// rotation in. The streaming orchestrator uses a custom rotate-half pack+RoPE
+// kernel; the DDPM `cosmos_forward` keeps RoPE in ATen.
+
+namespace F = torch::nn::functional;
+
+static bool cosmos_profile_enabled() {
+    const char* v = std::getenv("OMNIDREAMS_DIT_PROFILE");
+    return v && v[0] && v[0] != '0';
+}
+
+__global__ void cosmos_add_inplace_kernel(
+    cutlass::bfloat16_t* __restrict__ dst,
+    const cutlass::bfloat16_t* __restrict__ src,
+    int64_t n)
+{
+    int64_t i = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    dst[i] = cutlass::bfloat16_t(float(dst[i]) + float(src[i]));
+}
+
+static cudaError_t cosmos_add_inplace(
+    cutlass::bfloat16_t* dst,
+    const cutlass::bfloat16_t* src,
+    int64_t n,
+    cudaStream_t stream)
+{
+    int threads = 256;
+    int64_t blocks = (n + threads - 1) / threads;
+    cosmos_add_inplace_kernel<<<blocks, threads, 0, stream>>>(dst, src, n);
+    return cudaGetLastError();
+}
+
+struct CosmosStreamingScratch {
+    int B = 0, M = 0, K = 0, H = 0, D = 0, FF = 0, lora_dim = 0;
+    c10::Device device = c10::Device(c10::DeviceType::CPU);
+    c10::ScalarType dtype = c10::ScalarType::Undefined;
+
+    torch::Tensor qkv_row;
+    torch::Tensor q_row;
+    torch::Tensor k_row;
+    torch::Tensor v_row;
+    torch::Tensor q_bmhk;
+    torch::Tensor k_bmhk;
+    torch::Tensor o_bmhk;
+    torch::Tensor normed;
+    torch::Tensor ffn_intermediate;
+    torch::Tensor lora_hidden_sa;
+    torch::Tensor lora_hidden_ca;
+    torch::Tensor lora_hidden_mlp;
+    torch::Tensor mods_sa;
+    torch::Tensor mods_ca;
+    torch::Tensor mods_mlp;
+    torch::Tensor fl_hidden;
+    torch::Tensor fl_mods;
+
+    bool matches(int b, int m, int k, int h, int d, int ff, int lora,
+                 const c10::Device& dev, c10::ScalarType dt) const {
+        return qkv_row.defined() && B == b && M == m && K == k && H == h &&
+               D == d && FF == ff && lora_dim == lora && device == dev && dtype == dt;
+    }
+
+    void ensure(int b, int m, int k, int h, int d, int ff, int lora,
+                const c10::Device& dev, c10::ScalarType dt,
+                const torch::TensorOptions& opts) {
+        if (matches(b, m, k, h, d, ff, lora, dev, dt)) return;
+        B = b; M = m; K = k; H = h; D = d; FF = ff; lora_dim = lora;
+        device = dev; dtype = dt;
+        qkv_row = torch::empty({M, 3 * K}, opts);
+        q_row = torch::empty({M, K}, opts);
+        k_row = torch::empty({M, K}, opts);
+        v_row = torch::empty({M, K}, opts);
+        q_bmhk = torch::empty({M, H, D}, opts);
+        k_bmhk = torch::empty({M, H, D}, opts);
+        o_bmhk = torch::empty({M, H, D}, opts);
+        normed = torch::empty({M, K}, opts);
+        ffn_intermediate = torch::empty({M, FF}, opts);
+        lora_hidden_sa = torch::empty({B, lora_dim}, opts);
+        lora_hidden_ca = torch::empty({B, lora_dim}, opts);
+        lora_hidden_mlp = torch::empty({B, lora_dim}, opts);
+        mods_sa = torch::empty({B, 3 * K}, opts);
+        mods_ca = torch::empty({B, 3 * K}, opts);
+        mods_mlp = torch::empty({B, 3 * K}, opts);
+        fl_hidden = torch::empty({B, lora_dim}, opts);
+        fl_mods = torch::empty({B, 2 * K}, opts);
+    }
+};
+
+thread_local CosmosStreamingScratch g_cosmos_streaming_scratch;
+
+static __global__ void cosmos_softmax_batched_half_to_fp8_kernel(
+    const cutlass::half_t* __restrict__ scores,
+    cutlass::float_e4m3_t* __restrict__ probs,
+    int groups,
+    int rows,
+    int cols,
+    bool causal)
+{
+    int row = blockIdx.x;
+    int group = blockIdx.y;
+    if (group >= groups || row >= rows) return;
+
+    int tid = threadIdx.x;
+    extern __shared__ float smem[];
+    cutlass::NumericConverter<float, cutlass::half_t> to_f32;
+    cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+
+    const size_t group_offset = static_cast<size_t>(group) * rows * cols;
+    const cutlass::half_t* score_row = scores + group_offset + static_cast<size_t>(row) * cols;
+    cutlass::float_e4m3_t* prob_row = probs + group_offset + static_cast<size_t>(row) * cols;
+
+    float max_val = -FLT_MAX;
+    for (int col = tid; col < cols; col += blockDim.x) {
+        bool valid = !causal || col <= row;
+        if (valid) {
+            float v = to_f32(score_row[col]);
+            max_val = fmaxf(max_val, v);
+        }
+    }
+    smem[tid] = max_val;
+    __syncthreads();
+    for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+        if (tid < offset) smem[tid] = fmaxf(smem[tid], smem[tid + offset]);
+        __syncthreads();
+    }
+    max_val = smem[0];
+
+    float sum = 0.0f;
+    for (int col = tid; col < cols; col += blockDim.x) {
+        bool valid = !causal || col <= row;
+        if (valid) {
+            float v = to_f32(score_row[col]);
+            sum += expf(v - max_val);
+        }
+    }
+    smem[tid] = sum;
+    __syncthreads();
+    for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+        if (tid < offset) smem[tid] += smem[tid + offset];
+        __syncthreads();
+    }
+    sum = smem[0];
+
+    for (int col = tid; col < cols; col += blockDim.x) {
+        bool valid = !causal || col <= row;
+        float p = 0.0f;
+        if (valid) {
+            float v = to_f32(score_row[col]);
+            p = expf(v - max_val) / sum;
+        }
+        prob_row[col] = to_fp8(p);
+    }
+}
+
+static __global__ void cosmos_test_bf16_to_fp8_kernel(
+    const cutlass::bfloat16_t* __restrict__ src,
+    cutlass::float_e4m3_t* __restrict__ dst,
+    int64_t n)
+{
+    int64_t idx = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    cutlass::NumericConverter<float, cutlass::bfloat16_t> to_float;
+    cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+    dst[idx] = to_fp8(to_float(src[idx]));
+}
+
+namespace {
+
+using CosmosFp8BatchedRcrGemm = cutlass::gemm::device::GemmBatched<
+    cutlass::float_e4m3_t,
+    cutlass::layout::RowMajor,
+    cutlass::float_e4m3_t,
+    cutlass::layout::ColumnMajor,
+    cutlass::half_t,
+    cutlass::layout::RowMajor,
+    float,
+    cutlass::arch::OpClassTensorOp,
+    cutlass::arch::Sm89,
+    cutlass::gemm::GemmShape<128, 64, 128>,
+    cutlass::gemm::GemmShape<64, 32, 128>,
+    cutlass::gemm::GemmShape<16, 8, 32>,
+    cutlass::epilogue::thread::LinearCombination<cutlass::half_t, 8, float, float>,
+    cutlass::gemm::threadblock::GemmBatchedIdentityThreadblockSwizzle,
+    3>;
+
+static cudaError_t cosmos_fp8_batched_rcr_gemm(
+    const cutlass::float_e4m3_t* input_row,
+    const cutlass::float_e4m3_t* weight_col,
+    cutlass::half_t* output_row,
+    int batch_count,
+    int m,
+    int k,
+    int n,
+    int64_t batch_stride_a,
+    int64_t batch_stride_b,
+    int64_t batch_stride_c,
+    float alpha,
+    cudaStream_t stream)
+{
+    CosmosFp8BatchedRcrGemm gemm_op;
+    CosmosFp8BatchedRcrGemm::Arguments args(
+        {m, n, k},
+        {input_row, k},
+        batch_stride_a,
+        {weight_col, k},
+        batch_stride_b,
+        {output_row, n},
+        batch_stride_c,
+        {output_row, n},
+        batch_stride_c,
+        {alpha, 0.0f},
+        batch_count);
+
+    cutlass::Status status = gemm_op.initialize(args, nullptr, stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    status = gemm_op(stream);
+    if (status != cutlass::Status::kSuccess) return cudaErrorUnknown;
+    return cudaSuccess;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static torch::Tensor get_w(const py::dict& d, const std::string& key) {
+    TORCH_CHECK(d.contains(key.c_str()),
+        "cosmos_forward: missing weight key '", key, "'");
+    return py::cast<torch::Tensor>(d[key.c_str()]).contiguous();
+}
+
+torch::Tensor cosmos_test_linear_fp8(
+    torch::Tensor input,
+    torch::Tensor weight_fp8_u8,
+    c10::optional<torch::Tensor> weight_scale_opt,
+    c10::optional<torch::Tensor> bias_opt,
+    bool gelu)
+{
+    TORCH_CHECK(input.is_cuda(), "input must be CUDA");
+    TORCH_CHECK(weight_fp8_u8.is_cuda(), "weight_fp8_u8 must be CUDA");
+    TORCH_CHECK(input.scalar_type() == at::kHalf, "input must be torch.float16");
+    TORCH_CHECK(weight_fp8_u8.scalar_type() == at::kByte, "weight_fp8_u8 must be torch.uint8");
+    TORCH_CHECK(input.dim() == 2, "input must be [N, in_features]");
+    TORCH_CHECK(weight_fp8_u8.dim() == 2, "weight_fp8_u8 must be [out_features, in_features]");
+
+    input = input.contiguous();
+    weight_fp8_u8 = weight_fp8_u8.contiguous();
+    const int N = static_cast<int>(input.size(0));
+    const int in_features = static_cast<int>(input.size(1));
+    const int out_features = static_cast<int>(weight_fp8_u8.size(0));
+    TORCH_CHECK(weight_fp8_u8.size(1) == in_features,
+                "weight_fp8_u8 shape mismatch: expected second dim ", in_features,
+                ", got ", weight_fp8_u8.size(1));
+
+    torch::Tensor weight_scale;
+    const cutlass::half_t* weight_scale_ptr = nullptr;
+    if (weight_scale_opt.has_value() && weight_scale_opt.value().defined()) {
+        weight_scale = weight_scale_opt.value().to(torch::kFloat16).contiguous();
+        TORCH_CHECK(weight_scale.is_cuda(), "weight_scale must be CUDA");
+        TORCH_CHECK(weight_scale.dim() == 1 && weight_scale.size(0) == out_features,
+                    "weight_scale must be [out_features]");
+        weight_scale_ptr = reinterpret_cast<const cutlass::half_t*>(weight_scale.data_ptr<at::Half>());
+    }
+
+    torch::Tensor bias;
+    const cutlass::half_t* bias_ptr = nullptr;
+    if (bias_opt.has_value() && bias_opt.value().defined()) {
+        bias = bias_opt.value().to(torch::kFloat16).contiguous();
+        TORCH_CHECK(bias.is_cuda(), "bias must be CUDA");
+        TORCH_CHECK(bias.dim() == 1 && bias.size(0) == out_features,
+                    "bias must be [out_features]");
+        bias_ptr = reinterpret_cast<const cutlass::half_t*>(bias.data_ptr<at::Half>());
+    }
+
+    auto out = torch::empty({N, out_features}, input.options());
+    auto fp8_scratch = torch::empty({N, in_features},
+                                    torch::TensorOptions().dtype(torch::kUInt8).device(input.device()));
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+    cudaError_t err = cudaSuccess;
+    if (gelu) {
+        err = omnidreams_singleview::apply_linear_row_gelu<cutlass::float_e4m3_t>(
+            reinterpret_cast<const cutlass::half_t*>(input.data_ptr<at::Half>()),
+            reinterpret_cast<const cutlass::float_e4m3_t*>(weight_fp8_u8.data_ptr<uint8_t>()),
+            bias_ptr,
+            reinterpret_cast<cutlass::half_t*>(out.data_ptr<at::Half>()),
+            N, in_features, out_features,
+            stream,
+            reinterpret_cast<cutlass::half_t*>(fp8_scratch.data_ptr<uint8_t>()),
+            weight_scale_ptr);
+    } else {
+        err = omnidreams_singleview::apply_linear_row<cutlass::float_e4m3_t>(
+            reinterpret_cast<const cutlass::half_t*>(input.data_ptr<at::Half>()),
+            reinterpret_cast<const cutlass::float_e4m3_t*>(weight_fp8_u8.data_ptr<uint8_t>()),
+            bias_ptr,
+            reinterpret_cast<cutlass::half_t*>(out.data_ptr<at::Half>()),
+            N, in_features, out_features,
+            stream,
+            reinterpret_cast<cutlass::half_t*>(fp8_scratch.data_ptr<uint8_t>()),
+            weight_scale_ptr);
+    }
+    TORCH_CHECK(err == cudaSuccess, "cosmos_test_linear_fp8 failed: ", cudaGetErrorString(err));
+    return out;
+}
+
+torch::Tensor cosmos_test_linear_fp8_out_fp8(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor weight_scale)
+{
+    TORCH_CHECK(input_bf16.is_cuda(), "input_bf16 must be CUDA");
+    TORCH_CHECK(weight_fp8_u8.is_cuda(), "weight_fp8_u8 must be CUDA");
+    TORCH_CHECK(weight_scale.is_cuda(), "weight_scale must be CUDA");
+    TORCH_CHECK(input_bf16.scalar_type() == at::kBFloat16, "input_bf16 must be torch.bfloat16");
+    TORCH_CHECK(weight_fp8_u8.scalar_type() == at::kByte, "weight_fp8_u8 must be torch.uint8");
+    TORCH_CHECK(input_bf16.dim() == 2, "input_bf16 must be [N, in_features]");
+    TORCH_CHECK(weight_fp8_u8.dim() == 2, "weight_fp8_u8 must be [out_features, in_features]");
+
+    input_bf16 = input_bf16.contiguous();
+    weight_fp8_u8 = weight_fp8_u8.contiguous();
+    weight_scale = weight_scale.to(torch::kFloat16).contiguous();
+
+    const int N = static_cast<int>(input_bf16.size(0));
+    const int in_features = static_cast<int>(input_bf16.size(1));
+    const int out_features = static_cast<int>(weight_fp8_u8.size(0));
+    TORCH_CHECK(weight_fp8_u8.size(1) == in_features,
+                "weight_fp8_u8 shape mismatch: expected second dim ", in_features,
+                ", got ", weight_fp8_u8.size(1));
+    TORCH_CHECK(weight_scale.dim() == 1 && weight_scale.size(0) == out_features,
+                "weight_scale must be [out_features]");
+
+    auto u8_opts = torch::TensorOptions().dtype(torch::kUInt8).device(input_bf16.device());
+    auto h_opts = torch::TensorOptions().dtype(torch::kFloat16).device(input_bf16.device());
+    auto input_fp8 = torch::empty({N, in_features}, u8_opts);
+    auto half_scratch = torch::empty({N, out_features}, h_opts);
+    auto output_fp8 = torch::empty({N, out_features}, u8_opts);
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    constexpr int threads = 256;
+    int64_t in_elems = int64_t(N) * in_features;
+    cosmos_test_bf16_to_fp8_kernel<<<static_cast<unsigned int>((in_elems + threads - 1) / threads), threads, 0, stream>>>(
+        reinterpret_cast<const cutlass::bfloat16_t*>(input_bf16.data_ptr<at::BFloat16>()),
+        reinterpret_cast<cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+        in_elems);
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "input BF16->FP8 quantization failed: ", cudaGetErrorString(err));
+
+    constexpr float prescale_alpha = 1.0f / 128.0f;
+    constexpr float output_scale_mul = 128.0f;
+    err = omnidreams_singleview::cutlass_linear_layer_rcr_fp8(
+        reinterpret_cast<const cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight_fp8_u8.data_ptr<uint8_t>()),
+        nullptr,
+        reinterpret_cast<cutlass::half_t*>(half_scratch.data_ptr<at::Half>()),
+        N, in_features, out_features, stream,
+        prescale_alpha);
+    TORCH_CHECK(err == cudaSuccess, "FP8 linear for out-FP8 probe failed: ", cudaGetErrorString(err));
+
+    err = omnidreams_singleview::apply_col_scale_bias_to_fp8(
+        reinterpret_cast<const cutlass::half_t*>(half_scratch.data_ptr<at::Half>()),
+        reinterpret_cast<cutlass::float_e4m3_t*>(output_fp8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::half_t*>(weight_scale.data_ptr<at::Half>()),
+        nullptr,
+        N, out_features, stream,
+        output_scale_mul);
+    TORCH_CHECK(err == cudaSuccess, "output half->FP8 quantization failed: ", cudaGetErrorString(err));
+    return output_fp8;
+}
+
+torch::Tensor cosmos_test_linear_fp8_gelu_out_fp8(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor weight_scale,
+    double output_scale,
+    bool alias_output)
+{
+    TORCH_CHECK(input_bf16.is_cuda(), "input_bf16 must be CUDA");
+    TORCH_CHECK(weight_fp8_u8.is_cuda(), "weight_fp8_u8 must be CUDA");
+    TORCH_CHECK(weight_scale.is_cuda(), "weight_scale must be CUDA");
+    TORCH_CHECK(input_bf16.scalar_type() == at::kBFloat16, "input_bf16 must be torch.bfloat16");
+    TORCH_CHECK(weight_fp8_u8.scalar_type() == at::kByte, "weight_fp8_u8 must be torch.uint8");
+    TORCH_CHECK(output_scale > 0.0 && std::isfinite(output_scale), "output_scale must be positive and finite");
+    TORCH_CHECK(input_bf16.dim() == 2, "input_bf16 must be [N, in_features]");
+    TORCH_CHECK(weight_fp8_u8.dim() == 2, "weight_fp8_u8 must be [out_features, in_features]");
+
+    input_bf16 = input_bf16.contiguous();
+    weight_fp8_u8 = weight_fp8_u8.contiguous();
+    weight_scale = weight_scale.to(torch::kFloat16).contiguous();
+
+    const int N = static_cast<int>(input_bf16.size(0));
+    const int in_features = static_cast<int>(input_bf16.size(1));
+    const int out_features = static_cast<int>(weight_fp8_u8.size(0));
+    TORCH_CHECK(weight_fp8_u8.size(1) == in_features,
+                "weight_fp8_u8 shape mismatch: expected second dim ", in_features,
+                ", got ", weight_fp8_u8.size(1));
+    TORCH_CHECK(weight_scale.dim() == 1 && weight_scale.size(0) == out_features,
+                "weight_scale must be [out_features]");
+    TORCH_CHECK(!alias_output || output_scale == 1.0,
+                "alias_output is only supported on the fused output_scale=1 path");
+
+    auto u8_opts = torch::TensorOptions().dtype(torch::kUInt8).device(input_bf16.device());
+    torch::Tensor scratch_fp8;
+    torch::Tensor input_fp8;
+    torch::Tensor output_fp8;
+    if (alias_output) {
+        const int scratch_features = std::max(in_features, out_features);
+        scratch_fp8 = torch::empty({int64_t(N) * scratch_features}, u8_opts);
+        input_fp8 = scratch_fp8;
+        output_fp8 = scratch_fp8.narrow(0, 0, int64_t(N) * out_features).view({N, out_features});
+    } else {
+        input_fp8 = torch::empty({N, in_features}, u8_opts);
+        output_fp8 = torch::empty({N, out_features}, u8_opts);
+    }
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    constexpr int threads = 256;
+    int64_t in_elems = int64_t(N) * in_features;
+    cosmos_test_bf16_to_fp8_kernel<<<static_cast<unsigned int>((in_elems + threads - 1) / threads), threads, 0, stream>>>(
+        reinterpret_cast<const cutlass::bfloat16_t*>(input_bf16.data_ptr<at::BFloat16>()),
+        reinterpret_cast<cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+        in_elems);
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "input BF16->FP8 quantization failed: ", cudaGetErrorString(err));
+
+    if (output_scale == 1.0) {
+        err = omnidreams_singleview::cutlass_linear_layer_rcr_fp8_colscale_gelu_fp8(
+            reinterpret_cast<const cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+            reinterpret_cast<const cutlass::float_e4m3_t*>(weight_fp8_u8.data_ptr<uint8_t>()),
+            reinterpret_cast<const cutlass::half_t*>(weight_scale.data_ptr<at::Half>()),
+            reinterpret_cast<cutlass::float_e4m3_t*>(output_fp8.data_ptr<uint8_t>()),
+            N, in_features, out_features, stream);
+        TORCH_CHECK(err == cudaSuccess, "fused GELU FP8-output linear failed: ", cudaGetErrorString(err));
+    } else {
+        auto half_scratch = torch::empty(
+            {N, out_features},
+            torch::TensorOptions().dtype(torch::kFloat16).device(input_bf16.device()));
+        constexpr float prescale_alpha = 1.0f / 128.0f;
+        constexpr float output_scale_mul = 128.0f;
+        err = omnidreams_singleview::cutlass_linear_layer_rcr_fp8(
+            reinterpret_cast<const cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+            reinterpret_cast<const cutlass::float_e4m3_t*>(weight_fp8_u8.data_ptr<uint8_t>()),
+            nullptr,
+            reinterpret_cast<cutlass::half_t*>(half_scratch.data_ptr<at::Half>()),
+            N, in_features, out_features, stream,
+            prescale_alpha);
+        TORCH_CHECK(err == cudaSuccess, "FP8 linear for scaled GELU FP8-output probe failed: ", cudaGetErrorString(err));
+        err = omnidreams_singleview::apply_col_scale_bias_gelu_to_fp8(
+            reinterpret_cast<const cutlass::half_t*>(half_scratch.data_ptr<at::Half>()),
+            reinterpret_cast<cutlass::float_e4m3_t*>(output_fp8.data_ptr<uint8_t>()),
+            reinterpret_cast<const cutlass::half_t*>(weight_scale.data_ptr<at::Half>()),
+            nullptr,
+            N, out_features, stream,
+            output_scale_mul,
+            static_cast<float>(output_scale));
+        TORCH_CHECK(err == cudaSuccess, "scaled GELU output half->FP8 quantization failed: ", cudaGetErrorString(err));
+    }
+    return output_fp8;
+}
+
+torch::Tensor cosmos_test_linear_fp8_scaled_bf16(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor weight_scale)
+{
+    TORCH_CHECK(input_bf16.is_cuda(), "input_bf16 must be CUDA");
+    TORCH_CHECK(weight_fp8_u8.is_cuda(), "weight_fp8_u8 must be CUDA");
+    TORCH_CHECK(weight_scale.is_cuda(), "weight_scale must be CUDA");
+    TORCH_CHECK(input_bf16.scalar_type() == at::kBFloat16, "input_bf16 must be torch.bfloat16");
+    TORCH_CHECK(weight_fp8_u8.scalar_type() == at::kByte, "weight_fp8_u8 must be torch.uint8");
+    TORCH_CHECK(input_bf16.dim() == 2, "input_bf16 must be [N, in_features]");
+    TORCH_CHECK(weight_fp8_u8.dim() == 2, "weight_fp8_u8 must be [out_features, in_features]");
+
+    input_bf16 = input_bf16.contiguous();
+    weight_fp8_u8 = weight_fp8_u8.contiguous();
+    weight_scale = weight_scale.to(torch::kFloat16).contiguous();
+
+    const int N = static_cast<int>(input_bf16.size(0));
+    const int in_features = static_cast<int>(input_bf16.size(1));
+    const int out_features = static_cast<int>(weight_fp8_u8.size(0));
+    TORCH_CHECK(weight_fp8_u8.size(1) == in_features,
+                "weight_fp8_u8 shape mismatch: expected second dim ", in_features,
+                ", got ", weight_fp8_u8.size(1));
+    TORCH_CHECK(weight_scale.dim() == 1 && weight_scale.size(0) == out_features,
+                "weight_scale must be [out_features]");
+
+    auto u8_opts = torch::TensorOptions().dtype(torch::kUInt8).device(input_bf16.device());
+    auto bf16_opts = torch::TensorOptions().dtype(torch::kBFloat16).device(input_bf16.device());
+    auto input_fp8 = torch::empty({N, in_features}, u8_opts);
+    auto output_bf16 = torch::empty({N, out_features}, bf16_opts);
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    constexpr int threads = 256;
+    int64_t in_elems = int64_t(N) * in_features;
+    cosmos_test_bf16_to_fp8_kernel<<<static_cast<unsigned int>((in_elems + threads - 1) / threads), threads, 0, stream>>>(
+        reinterpret_cast<const cutlass::bfloat16_t*>(input_bf16.data_ptr<at::BFloat16>()),
+        reinterpret_cast<cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+        in_elems);
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "input BF16->FP8 quantization failed: ", cudaGetErrorString(err));
+
+    err = omnidreams_singleview::cutlass_linear_layer_rcr_fp8_colscale_bf16(
+        reinterpret_cast<const cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight_fp8_u8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::half_t*>(weight_scale.data_ptr<at::Half>()),
+        reinterpret_cast<cutlass::bfloat16_t*>(output_bf16.data_ptr<at::BFloat16>()),
+        N, in_features, out_features, stream);
+    TORCH_CHECK(err == cudaSuccess, "fused scaled BF16 FP8 linear failed: ", cudaGetErrorString(err));
+    return output_bf16;
+}
+
+torch::Tensor cosmos_test_linear_fp8_residual_scaled_bf16(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor alpha,
+    torch::Tensor residual_bf16)
+{
+    TORCH_CHECK(input_bf16.is_cuda(), "input_bf16 must be CUDA");
+    TORCH_CHECK(weight_fp8_u8.is_cuda(), "weight_fp8_u8 must be CUDA");
+    TORCH_CHECK(alpha.is_cuda(), "alpha must be CUDA");
+    TORCH_CHECK(residual_bf16.is_cuda(), "residual_bf16 must be CUDA");
+    TORCH_CHECK(input_bf16.scalar_type() == at::kBFloat16, "input_bf16 must be torch.bfloat16");
+    TORCH_CHECK(weight_fp8_u8.scalar_type() == at::kByte, "weight_fp8_u8 must be torch.uint8");
+    TORCH_CHECK(residual_bf16.scalar_type() == at::kBFloat16, "residual_bf16 must be torch.bfloat16");
+    TORCH_CHECK(input_bf16.dim() == 2, "input_bf16 must be [N, in_features]");
+    TORCH_CHECK(weight_fp8_u8.dim() == 2, "weight_fp8_u8 must be [out_features, in_features]");
+    TORCH_CHECK(residual_bf16.dim() == 2, "residual_bf16 must be [N, out_features]");
+
+    input_bf16 = input_bf16.contiguous();
+    weight_fp8_u8 = weight_fp8_u8.contiguous();
+    alpha = alpha.to(torch::kFloat16).contiguous();
+    auto output_bf16 = residual_bf16.contiguous().clone();
+
+    const int N = static_cast<int>(input_bf16.size(0));
+    const int in_features = static_cast<int>(input_bf16.size(1));
+    const int out_features = static_cast<int>(weight_fp8_u8.size(0));
+    TORCH_CHECK(weight_fp8_u8.size(1) == in_features,
+                "weight_fp8_u8 shape mismatch: expected second dim ", in_features,
+                ", got ", weight_fp8_u8.size(1));
+    TORCH_CHECK(output_bf16.size(0) == N && output_bf16.size(1) == out_features,
+                "residual_bf16 must be [N, out_features]");
+    TORCH_CHECK(alpha.dim() == 1 && alpha.size(0) == out_features,
+                "alpha must be [out_features]");
+
+    auto u8_opts = torch::TensorOptions().dtype(torch::kUInt8).device(input_bf16.device());
+    auto input_fp8 = torch::empty({N, in_features}, u8_opts);
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    constexpr int threads = 256;
+    int64_t in_elems = int64_t(N) * in_features;
+    cosmos_test_bf16_to_fp8_kernel<<<static_cast<unsigned int>((in_elems + threads - 1) / threads), threads, 0, stream>>>(
+        reinterpret_cast<const cutlass::bfloat16_t*>(input_bf16.data_ptr<at::BFloat16>()),
+        reinterpret_cast<cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+        in_elems);
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "input BF16->FP8 quantization failed: ", cudaGetErrorString(err));
+
+    err = omnidreams_singleview::cutlass_linear_layer_rcr_fp8_colscale_residual_bf16(
+        reinterpret_cast<const cutlass::float_e4m3_t*>(input_fp8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::float_e4m3_t*>(weight_fp8_u8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::half_t*>(alpha.data_ptr<at::Half>()),
+        reinterpret_cast<cutlass::bfloat16_t*>(output_bf16.data_ptr<at::BFloat16>()),
+        N, in_features, out_features, stream);
+    TORCH_CHECK(err == cudaSuccess, "fused residual BF16 FP8 linear failed: ", cudaGetErrorString(err));
+    return output_bf16;
+}
+
+py::dict cosmos_test_fp8_linear_tile_selection(
+    std::string op_kind,
+    int64_t rows,
+    int64_t in_features,
+    int64_t out_features)
+{
+    auto selection = omnidreams_singleview::select_cosmos_fp8_linear_tile(
+        op_kind,
+        static_cast<int>(rows),
+        static_cast<int>(in_features),
+        static_cast<int>(out_features));
+    py::dict out;
+    out["op_kind"] = selection.op_kind;
+    out["preset"] = selection.preset;
+    out["tile"] = selection.tile;
+    out["stage"] = selection.stage;
+    out["variant"] = selection.variant;
+    out["reason"] = selection.reason;
+    out["tile_env_override"] = selection.tile_env_override;
+    out["stage_env_override"] = selection.stage_env_override;
+    out["variant_env_override"] = selection.variant_env_override;
+    return out;
+}
+
+py::dict cosmos_test_fp8_sdpa_selection(
+    int64_t B,
+    int64_t Mq,
+    int64_t Mk,
+    int64_t H,
+    int64_t D)
+{
+    auto selection = omnidreams_singleview::select_cosmos_fp8_sdpa(
+        static_cast<int>(B),
+        static_cast<int>(Mq),
+        static_cast<int>(Mk),
+        static_cast<int>(H),
+        static_cast<int>(D));
+    py::dict out;
+    out["preset"] = selection.preset;
+    out["layout"] = selection.layout;
+    out["heuristics"] = selection.heuristics;
+    out["plan"] = selection.plan;
+    out["reason"] = selection.reason;
+    out["layout_env_override"] = selection.layout_env_override;
+    out["heuristics_env_override"] = selection.heuristics_env_override;
+    out["plan_env_override"] = selection.plan_env_override;
+    return out;
+}
+
+torch::Tensor cosmos_test_fp8_dense_ref_sdpa(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8,
+    torch::Tensor v_fp8_u8,
+    bool causal)
+{
+    TORCH_CHECK(q_fp8_u8.is_cuda() && k_fp8_u8.is_cuda() && v_fp8_u8.is_cuda(),
+                "q/k/v must be CUDA tensors");
+    TORCH_CHECK(q_fp8_u8.scalar_type() == at::kByte &&
+                k_fp8_u8.scalar_type() == at::kByte &&
+                v_fp8_u8.scalar_type() == at::kByte,
+                "q/k/v must be raw FP8 bytes as torch.uint8");
+    TORCH_CHECK(q_fp8_u8.dim() == 4 && k_fp8_u8.dim() == 4 && v_fp8_u8.dim() == 4,
+                "q/k/v must be [B, S, H, D]");
+    TORCH_CHECK(q_fp8_u8.size(0) == k_fp8_u8.size(0) &&
+                q_fp8_u8.size(1) == k_fp8_u8.size(1) &&
+                q_fp8_u8.size(2) == k_fp8_u8.size(2) &&
+                q_fp8_u8.size(3) == k_fp8_u8.size(3) &&
+                q_fp8_u8.size(0) == v_fp8_u8.size(0) &&
+                q_fp8_u8.size(1) == v_fp8_u8.size(1) &&
+                q_fp8_u8.size(2) == v_fp8_u8.size(2) &&
+                q_fp8_u8.size(3) == v_fp8_u8.size(3),
+                "FP8 dense reference SDPA currently requires self-attention q/k/v shape equality");
+
+    int B = static_cast<int>(q_fp8_u8.size(0));
+    int S = static_cast<int>(q_fp8_u8.size(1));
+    int H = static_cast<int>(q_fp8_u8.size(2));
+    int D = static_cast<int>(q_fp8_u8.size(3));
+    TORCH_CHECK(S > 0 && D > 0, "S and D must be positive");
+
+    auto q_bhsd = q_fp8_u8.permute({0, 2, 1, 3}).contiguous();
+    auto k_bhsd = k_fp8_u8.permute({0, 2, 1, 3}).contiguous();
+    auto v_bhds = v_fp8_u8.permute({0, 2, 3, 1}).contiguous();
+
+    auto u8_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q_fp8_u8.device());
+    auto h_opts = torch::TensorOptions().dtype(torch::kFloat16).device(q_fp8_u8.device());
+    auto scores = torch::empty({B * H, S, S}, h_opts);
+    auto probs = torch::empty({B * H, S, S}, u8_opts);
+    auto out_bhsd = torch::empty({B, H, S, D}, h_opts);
+
+    auto* q_ptr = reinterpret_cast<const cutlass::float_e4m3_t*>(q_bhsd.data_ptr<uint8_t>());
+    auto* k_ptr = reinterpret_cast<const cutlass::float_e4m3_t*>(k_bhsd.data_ptr<uint8_t>());
+    auto* v_ptr = reinterpret_cast<const cutlass::float_e4m3_t*>(v_bhds.data_ptr<uint8_t>());
+    auto* score_ptr = reinterpret_cast<cutlass::half_t*>(scores.data_ptr<at::Half>());
+    auto* prob_ptr = reinterpret_cast<cutlass::float_e4m3_t*>(probs.data_ptr<uint8_t>());
+    auto* out_ptr = reinterpret_cast<cutlass::half_t*>(out_bhsd.data_ptr<at::Half>());
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    const float attn_scale = 1.0f / std::sqrt(static_cast<float>(D));
+    const int groups = B * H;
+    const size_t qkv_group_elems = static_cast<size_t>(S) * D;
+    const size_t score_group_elems = static_cast<size_t>(S) * S;
+
+    cudaError_t err = cosmos_fp8_batched_rcr_gemm(
+        q_ptr, k_ptr, score_ptr,
+        groups,
+        S, D, S,
+        static_cast<int64_t>(qkv_group_elems),
+        static_cast<int64_t>(qkv_group_elems),
+        static_cast<int64_t>(score_group_elems),
+        attn_scale,
+        stream);
+    TORCH_CHECK(err == cudaSuccess,
+                "FP8 dense reference SDPA batched QK GEMM failed: ", cudaGetErrorString(err));
+
+    cosmos_softmax_batched_half_to_fp8_kernel<<<dim3(S, groups), 256, 256 * sizeof(float), stream>>>(
+        score_ptr, prob_ptr, groups, S, S, causal);
+    err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess,
+                "FP8 dense reference SDPA batched softmax kernel failed: ", cudaGetErrorString(err));
+
+    err = cosmos_fp8_batched_rcr_gemm(
+        prob_ptr, v_ptr, out_ptr,
+        groups,
+        S, S, D,
+        static_cast<int64_t>(score_group_elems),
+        static_cast<int64_t>(qkv_group_elems),
+        static_cast<int64_t>(qkv_group_elems),
+        1.0f,
+        stream);
+    TORCH_CHECK(err == cudaSuccess,
+                "FP8 dense reference SDPA batched PV GEMM failed: ", cudaGetErrorString(err));
+
+    return out_bhsd.permute({0, 2, 1, 3}).contiguous();
+}
+
+torch::Tensor cosmos_test_fp8_cudnn_sdpa(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8,
+    torch::Tensor v_fp8_u8,
+    bool causal)
+{
+    TORCH_CHECK(q_fp8_u8.is_cuda() && k_fp8_u8.is_cuda() && v_fp8_u8.is_cuda(),
+                "q/k/v must be CUDA tensors");
+    TORCH_CHECK(q_fp8_u8.scalar_type() == at::kByte &&
+                k_fp8_u8.scalar_type() == at::kByte &&
+                v_fp8_u8.scalar_type() == at::kByte,
+                "q/k/v must be raw FP8 bytes as torch.uint8");
+    TORCH_CHECK(q_fp8_u8.dim() == 4 && k_fp8_u8.dim() == 4 && v_fp8_u8.dim() == 4,
+                "q/k/v must be [B, S, H, D]");
+    TORCH_CHECK(q_fp8_u8.size(0) == k_fp8_u8.size(0) &&
+                q_fp8_u8.size(0) == v_fp8_u8.size(0),
+                "q/k/v batch sizes must match");
+    TORCH_CHECK(k_fp8_u8.size(1) == v_fp8_u8.size(1),
+                "k/v sequence lengths must match");
+    TORCH_CHECK(q_fp8_u8.size(2) == k_fp8_u8.size(2) &&
+                q_fp8_u8.size(2) == v_fp8_u8.size(2),
+                "q/k/v head counts must match");
+    TORCH_CHECK(q_fp8_u8.size(3) == k_fp8_u8.size(3) &&
+                q_fp8_u8.size(3) == v_fp8_u8.size(3),
+                "q/k/v head dims must match");
+
+    q_fp8_u8 = q_fp8_u8.contiguous();
+    k_fp8_u8 = k_fp8_u8.contiguous();
+    v_fp8_u8 = v_fp8_u8.contiguous();
+
+    const int B = static_cast<int>(q_fp8_u8.size(0));
+    const int Mq = static_cast<int>(q_fp8_u8.size(1));
+    const int Mk = static_cast<int>(k_fp8_u8.size(1));
+    const int H = static_cast<int>(q_fp8_u8.size(2));
+    const int D = static_cast<int>(q_fp8_u8.size(3));
+    TORCH_CHECK(D == 128,
+                "cuDNN FP8 SDPA probe currently specializes D=128; got unsupported head dim ", D);
+    const auto selection = omnidreams_singleview::select_cosmos_fp8_sdpa(B, Mq, Mk, H, D);
+
+    auto byte_opts = torch::TensorOptions().dtype(torch::kUInt8).device(q_fp8_u8.device());
+    auto fp32_opts = torch::TensorOptions().dtype(torch::kFloat32).device(q_fp8_u8.device());
+    auto out = torch::empty({B, Mq, H, D}, byte_opts);
+    auto one = torch::ones({1, 1, 1, 1}, fp32_opts);
+    auto amax_s = torch::empty({1, 1, 1, 1}, fp32_opts);
+    auto amax_o = torch::empty({1, 1, 1, 1}, fp32_opts);
+    torch::Tensor q_for_cudnn = q_fp8_u8;
+    torch::Tensor k_for_cudnn = k_fp8_u8;
+    torch::Tensor v_for_cudnn = v_fp8_u8;
+    if (selection.layout == "bhmd") {
+        q_for_cudnn = q_fp8_u8.permute({0, 2, 1, 3}).contiguous();
+        k_for_cudnn = k_fp8_u8.permute({0, 2, 1, 3}).contiguous();
+        v_for_cudnn = v_fp8_u8.permute({0, 2, 1, 3}).contiguous();
+    }
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    cudaError_t err = omnidreams_singleview::run_cudnn_fmha_packed_qkv_fp8(
+        reinterpret_cast<const cutlass::float_e4m3_t*>(q_for_cudnn.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::float_e4m3_t*>(k_for_cudnn.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::float_e4m3_t*>(v_for_cudnn.data_ptr<uint8_t>()),
+        reinterpret_cast<cutlass::float_e4m3_t*>(out.data_ptr<uint8_t>()),
+        one.data_ptr<float>(),
+        one.data_ptr<float>(),
+        one.data_ptr<float>(),
+        one.data_ptr<float>(),
+        one.data_ptr<float>(),
+        one.data_ptr<float>(),
+        amax_s.data_ptr<float>(),
+        amax_o.data_ptr<float>(),
+        B, Mq, Mk, H, D, causal, 0.0f, stream);
+    TORCH_CHECK(err == cudaSuccess,
+                "cuDNN FP8 SDPA probe failed: ", cudaGetErrorString(err));
+    return out;
+}
+
+torch::Tensor cosmos_test_fp8_tc_probe_qk(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8)
+{
+    TORCH_CHECK(q_fp8_u8.is_cuda() && k_fp8_u8.is_cuda(),
+                "q/k must be CUDA tensors");
+    TORCH_CHECK(q_fp8_u8.scalar_type() == at::kByte &&
+                k_fp8_u8.scalar_type() == at::kByte,
+                "q/k must be raw FP8 bytes as torch.uint8");
+    TORCH_CHECK(q_fp8_u8.dim() == 2 && k_fp8_u8.dim() == 2,
+                "q/k must be 2D raw E4M3 tensors: q [Mq, D], k [Mk, D]");
+    TORCH_CHECK(q_fp8_u8.size(1) == k_fp8_u8.size(1),
+                "q/k inner dims must match");
+
+    q_fp8_u8 = q_fp8_u8.contiguous();
+    k_fp8_u8 = k_fp8_u8.contiguous();
+    const int Mq = static_cast<int>(q_fp8_u8.size(0));
+    const int Mk = static_cast<int>(k_fp8_u8.size(0));
+    const int D = static_cast<int>(q_fp8_u8.size(1));
+    TORCH_CHECK(Mq > 0 && Mk > 0 && D > 0, "q/k dimensions must be positive");
+    TORCH_CHECK((Mq % 128) == 0 && (Mk % 128) == 0 && (D % 128) == 0,
+                "SM120 FP8 tensor-core probe currently requires Mq, Mk, and D to be multiples of 128");
+
+    auto opts_bf16 = torch::TensorOptions().dtype(torch::kBFloat16).device(q_fp8_u8.device());
+    auto opts_f32 = torch::TensorOptions().dtype(torch::kFloat32).device(q_fp8_u8.device());
+    auto out = torch::empty({Mq, Mk}, opts_bf16);
+    auto c_scratch = torch::empty({Mq, Mk}, opts_bf16);
+    auto q_scale = torch::ones({std::max<int64_t>(1, int64_t(Mq) * D)}, opts_f32);
+    auto k_scale = torch::ones({std::max<int64_t>(1, int64_t(Mk) * D)}, opts_f32);
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    cudaError_t err = omnidreams_singleview::run_cosmos_fp8_tc_probe_qk(
+        reinterpret_cast<const cutlass::float_e4m3_t*>(q_fp8_u8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::float_e4m3_t*>(k_fp8_u8.data_ptr<uint8_t>()),
+        q_scale.data_ptr<float>(),
+        k_scale.data_ptr<float>(),
+        reinterpret_cast<const cutlass::bfloat16_t*>(c_scratch.data_ptr<at::BFloat16>()),
+        reinterpret_cast<cutlass::bfloat16_t*>(out.data_ptr<at::BFloat16>()),
+        Mq, Mk, D, stream);
+    TORCH_CHECK(err == cudaSuccess,
+                "SM120 FP8 tensor-core QK probe failed: ", cudaGetErrorString(err));
+    return out;
+}
+
+torch::Tensor cosmos_test_fp8_tc_probe_pv(
+    torch::Tensor probs_fp8_u8,
+    torch::Tensor v_fp8_u8)
+{
+    TORCH_CHECK(probs_fp8_u8.is_cuda() && v_fp8_u8.is_cuda(),
+                "probs/v must be CUDA tensors");
+    TORCH_CHECK(probs_fp8_u8.scalar_type() == at::kByte &&
+                v_fp8_u8.scalar_type() == at::kByte,
+                "probs/v must be raw FP8 bytes as torch.uint8");
+    TORCH_CHECK(probs_fp8_u8.dim() == 2 && v_fp8_u8.dim() == 2,
+                "probs/v must be 2D raw E4M3 tensors: probs [Mq, Mk], v [Mk, D]");
+    TORCH_CHECK(probs_fp8_u8.size(1) == v_fp8_u8.size(0),
+                "probs second dim must match v rows");
+
+    probs_fp8_u8 = probs_fp8_u8.contiguous();
+    v_fp8_u8 = v_fp8_u8.contiguous();
+    const int Mq = static_cast<int>(probs_fp8_u8.size(0));
+    const int Mk = static_cast<int>(probs_fp8_u8.size(1));
+    const int D = static_cast<int>(v_fp8_u8.size(1));
+    TORCH_CHECK(Mq > 0 && Mk > 0 && D > 0, "probs/v dimensions must be positive");
+    TORCH_CHECK((Mq % 128) == 0 && (Mk % 128) == 0 && (D % 128) == 0,
+                "SM120 FP8 tensor-core probe currently requires Mq, Mk, and D to be multiples of 128");
+
+    auto opts_bf16 = torch::TensorOptions().dtype(torch::kBFloat16).device(probs_fp8_u8.device());
+    auto opts_f32 = torch::TensorOptions().dtype(torch::kFloat32).device(probs_fp8_u8.device());
+    auto out = torch::empty({Mq, D}, opts_bf16);
+    auto c_scratch = torch::empty({Mq, D}, opts_bf16);
+    auto probs_scale = torch::ones({std::max<int64_t>(1, int64_t(Mq) * Mk)}, opts_f32);
+    auto v_scale = torch::ones({std::max<int64_t>(1, int64_t(Mk) * D)}, opts_f32);
+    // CUTLASS SM120 blockwise FP8 builder currently exposes the TN path only.
+    // Accept raw Cosmos V as [Mk, D], then provide the tensor-core probe its
+    // required [D, Mk] row-major storage.
+    auto v_for_tc = v_fp8_u8.t().contiguous();
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    cudaError_t err = omnidreams_singleview::run_cosmos_fp8_tc_probe_pv(
+        reinterpret_cast<const cutlass::float_e4m3_t*>(probs_fp8_u8.data_ptr<uint8_t>()),
+        reinterpret_cast<const cutlass::float_e4m3_t*>(v_for_tc.data_ptr<uint8_t>()),
+        probs_scale.data_ptr<float>(),
+        v_scale.data_ptr<float>(),
+        reinterpret_cast<const cutlass::bfloat16_t*>(c_scratch.data_ptr<at::BFloat16>()),
+        reinterpret_cast<cutlass::bfloat16_t*>(out.data_ptr<at::BFloat16>()),
+        Mq, Mk, D, stream);
+    TORCH_CHECK(err == cudaSuccess,
+                "SM120 FP8 tensor-core PV probe failed: ", cudaGetErrorString(err));
+    return out;
+}
+
+std::vector<torch::Tensor> cosmos_test_fp8_attention_backend(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8,
+    torch::Tensor v_fp8_u8,
+    bool causal,
+    std::string backend)
+{
+    if (backend == "fp8_dense_ref") {
+        auto out = cosmos_test_fp8_dense_ref_sdpa(
+            q_fp8_u8, k_fp8_u8, v_fp8_u8, causal);
+        auto backend_id = torch::empty({1},
+            torch::TensorOptions().dtype(torch::kInt32).device(out.device()));
+        backend_id.fill_(1);
+        return {out, backend_id};
+    }
+
+    if (backend == "fp8_cudnn") {
+        auto out = cosmos_test_fp8_cudnn_sdpa(
+            q_fp8_u8, k_fp8_u8, v_fp8_u8, causal);
+        auto backend_id = torch::empty({1},
+            torch::TensorOptions().dtype(torch::kInt32).device(out.device()));
+        backend_id.fill_(8);
+        return {out, backend_id};
+    }
+
+    TORCH_CHECK(false,
+        "unknown Cosmos FP8 attention backend '", backend,
+        "'. Expected one of: fp8_dense_ref, fp8_cudnn");
+}
+
+// RMSNorm: x * rsqrt(mean(x²) + eps) * gamma
+// Works on any trailing shape; gamma must match last dim of x.
+static torch::Tensor rms_norm(const torch::Tensor& x,
+                               const torch::Tensor& gamma,
+                               float eps = 1e-6f) {
+    auto xf = x.to(torch::kFloat32);
+    auto inv = torch::rsqrt(xf.pow(2).mean(-1, /*keepdim=*/true) + eps);
+    return (xf * inv * gamma.to(torch::kFloat32)).to(x.dtype());
+}
+
+// LayerNorm with no learnable parameters (elementwise_affine=False, eps=1e-6).
+static torch::Tensor layernorm_no_affine(const torch::Tensor& x, float eps = 1e-6f) {
+    return torch::layer_norm(x, {x.size(-1)}, /*weight=*/{}, /*bias=*/{}, eps);
+}
+
+// rotate_half: [..., D] → [-x2, x1] (second half negated, first half kept).
+static torch::Tensor rotate_half(const torch::Tensor& x) {
+    int64_t half = x.size(-1) / 2;
+    return torch::cat({-x.slice(-1, half), x.slice(-1, 0, half)}, -1);
+}
+
+// Cosmos VideoRopePosition3DEmb.generate_embeddings():
+// returns [S, 1, 1, head_dim] float32 raw angles on the same device as `device_ref`.
+static torch::Tensor compute_cosmos_rope_emb(
+    int pT, int pH, int pW, int head_dim,
+    float h_ratio, float w_ratio, float t_ratio,
+    const torch::Device& device)
+{
+    int dim_h = (head_dim / 6) * 2;
+    int dim_w = dim_h;
+    int dim_t = head_dim - 2 * dim_h;
+
+    float h_ntk = (dim_h > 2) ? std::pow(h_ratio, float(dim_h) / float(dim_h - 2)) : 1.0f;
+    float w_ntk = (dim_w > 2) ? std::pow(w_ratio, float(dim_w) / float(dim_w - 2)) : 1.0f;
+    float t_ntk = (dim_t > 2) ? std::pow(t_ratio, float(dim_t) / float(dim_t - 2)) : 1.0f;
+
+    auto cpu = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCPU);
+
+    auto h_range = torch::arange(0, dim_h, 2, cpu).narrow(0, 0, dim_h / 2) / float(dim_h);
+    auto w_range = torch::arange(0, dim_w, 2, cpu).narrow(0, 0, dim_w / 2) / float(dim_w);
+    auto t_range = torch::arange(0, dim_t, 2, cpu).narrow(0, 0, dim_t / 2) / float(dim_t);
+
+    auto h_freqs = 1.f / torch::pow(10000.f * h_ntk, h_range);  // [dim_h/2]
+    auto w_freqs = 1.f / torch::pow(10000.f * w_ntk, w_range);
+    auto t_freqs = 1.f / torch::pow(10000.f * t_ntk, t_range);
+
+    auto half_h = torch::outer(torch::arange(pH, cpu).to(torch::kFloat32), h_freqs); // [pH, dim_h/2]
+    auto half_w = torch::outer(torch::arange(pW, cpu).to(torch::kFloat32), w_freqs);
+    auto half_t = torch::outer(torch::arange(pT, cpu).to(torch::kFloat32), t_freqs);
+
+    // Broadcast to [pT, pH, pW, dim/2]
+    auto emb_t = half_t.unsqueeze(1).unsqueeze(1).expand({pT, pH, pW, dim_t / 2});
+    auto emb_h = half_h.unsqueeze(0).unsqueeze(2).expand({pT, pH, pW, dim_h / 2});
+    auto emb_w = half_w.unsqueeze(0).unsqueeze(1).expand({pT, pH, pW, dim_w / 2});
+
+    // Cat [emb_t, emb_h, emb_w] × 2 to get [pT, pH, pW, head_dim]
+    auto em = torch::cat({emb_t, emb_h, emb_w, emb_t, emb_h, emb_w}, -1);
+
+    int S = pT * pH * pW;
+    return em.reshape({S, 1, 1, head_dim}).to(device);
+}
+
+// Apply Cosmos rotate_half RoPE.
+// q, k: [B, Mq, H, D]; rope_emb: [Mq, 1, 1, D] float32 raw angles.
+static std::pair<torch::Tensor, torch::Tensor> apply_cosmos_rope(
+    const torch::Tensor& q, const torch::Tensor& k,
+    const torch::Tensor& rope_emb)
+{
+    // [Mq, 1, 1, D] → [1, Mq, 1, D]
+    auto rope = rope_emb.permute({1, 0, 2, 3});
+    auto cos  = torch::cos(rope).to(q.dtype());
+    auto sin  = torch::sin(rope).to(q.dtype());
+    return {q * cos + rotate_half(q) * sin,
+            k * cos + rotate_half(k) * sin};
+}
+
+// Run CUTLASS FMHA on pre-packed q/k/v (bfloat16).
+// Input shape: [B, Mq/Mk, H, D] bf16. Returns [B, Mq, H, D] bf16.
+static torch::Tensor fmha(
+    const torch::Tensor& q, const torch::Tensor& k, const torch::Tensor& v,
+    bool causal, cudaStream_t stream)
+{
+    auto qb = q.to(torch::kBFloat16).contiguous();
+    auto kb = k.to(torch::kBFloat16).contiguous();
+    auto vb = v.to(torch::kBFloat16).contiguous();
+
+    int B = (int)qb.size(0), Mq = (int)qb.size(1), H = (int)qb.size(2), D = (int)qb.size(3);
+    int Mk = (int)kb.size(1);
+
+    auto ob = torch::empty({B * Mq, H, D}, qb.options());
+    auto qf = qb.reshape({B * Mq, H, D});
+    auto kf = kb.reshape({B * Mk, H, D});
+    auto vf = vb.reshape({B * Mk, H, D});
+
+    cudaError_t err = omnidreams_singleview::run_cudnn_fmha_packed_qkv(
+        reinterpret_cast<const cutlass::bfloat16_t*>(qf.data_ptr<at::BFloat16>()),
+        reinterpret_cast<const cutlass::bfloat16_t*>(kf.data_ptr<at::BFloat16>()),
+        reinterpret_cast<const cutlass::bfloat16_t*>(vf.data_ptr<at::BFloat16>()),
+        reinterpret_cast<cutlass::bfloat16_t*>(ob.data_ptr<at::BFloat16>()),
+        B, Mq, Mk, H, D, causal, /*scale=*/0.f, stream);
+
+    TORCH_CHECK(err == cudaSuccess,
+        "run_cudnn_fmha_packed_qkv failed: ", cudaGetErrorString(err));
+
+    return ob.reshape({B, Mq, H, D});
+}
+
+// adaln-LoRA modulation for one sub-layer.
+// emb:  [B, L, D] — post-norm timestep embedding
+// down: weight at ".1.weight" — [lora_dim, D]
+// up:   weight at ".2.weight" — [out_dim, lora_dim]
+// Returns [B, L, out_dim] = SiLU(emb) @ down.T @ up.T
+static torch::Tensor adaln_lora_proj(
+    const torch::Tensor& emb,
+    const torch::Tensor& down,   // [lora_dim, D]
+    const torch::Tensor& up)     // [out_dim, lora_dim]
+{
+    auto h = torch::silu(emb);                     // [B, L, D]
+    auto h2 = torch::matmul(h, down.t());          // [B, L, lora_dim]
+    return torch::matmul(h2, up.t());              // [B, L, out_dim]
+}
+
+// GELU FFN: layer2(gelu(layer1(x)))
+// w1: [FF, D], w2: [D, FF]  (PyTorch weight layout)
+static torch::Tensor gelu_ffn(const torch::Tensor& x,
+                               const torch::Tensor& w1,
+                               const torch::Tensor& w2) {
+    return torch::matmul(torch::gelu(torch::matmul(x, w1.t())), w2.t());
+}
+
+// Sinusoidal embedding matching Cosmos Timesteps module.
+// ts: [N] float32 → [N, num_channels]
+static torch::Tensor sinusoidal_emb(const torch::Tensor& ts, int num_channels) {
+    int half = num_channels / 2;
+    auto dev_opts = torch::TensorOptions().dtype(torch::kFloat32).device(ts.device());
+    // Matches reference: exponent = arange(half_dim) / (half_dim - 0.0) = arange(half) / half
+    auto exp = -std::log(10000.0) * torch::arange(half, dev_opts) / float(half);
+    auto freqs = torch::exp(exp);                              // [half]
+    auto angles = ts.unsqueeze(1) * freqs.unsqueeze(0);        // [N, half]
+    return torch::cat({torch::cos(angles), torch::sin(angles)}, -1);  // [N, num_channels]
+}
+
+// Patch embedding: rearrange [B, C, T, H, W] → linear → [B, pT, pH, pW, D_out].
+static torch::Tensor patch_embed(const torch::Tensor& x, const torch::Tensor& w,
+                                  int pt, int ph, int pw) {
+    int B = (int)x.size(0), C = (int)x.size(1);
+    int T = (int)x.size(2), H = (int)x.size(3), W = (int)x.size(4);
+    int pT = T / pt, pH = H / ph, pW = W / pw;
+
+    // [B, C, pT, pt, pH, ph, pW, pw]
+    auto r = x.reshape({B, C, pT, pt, pH, ph, pW, pw});
+    // [B, pT, pH, pW, C, pt, ph, pw]
+    r = r.permute({0, 2, 4, 6, 1, 3, 5, 7}).contiguous();
+    // [B, pT, pH, pW, C*pt*ph*pw]
+    r = r.reshape({B, pT, pH, pW, C * pt * ph * pw});
+    return torch::matmul(r, w.t());  // [B, pT, pH, pW, D_out]
+}
+
+// ---------------------------------------------------------------------------
+// Per-sub-block residual helpers
+//
+// Each residual helper takes the running `x`, normalizes a copy, applies an
+// adaln-modulated linear / attention / FFN path, and returns `x + gate * out`.
+//
+// They are factored out of `cosmos_block_forward` so the streaming forward
+// (Phase 2) can reuse them with different attention semantics (non-causal
+// self-attn against a KV cache, pre-computed cross-attn K/V) while keeping
+// Michael's full-sequence DDPM path bit-identical to the original code.
+// ---------------------------------------------------------------------------
+
+static std::string block_prefix(int block_idx) {
+    return "blocks." + std::to_string(block_idx) + ".";
+}
+
+// Compute (shift, scale, gate) for one adaln-LoRA modulation sub-layer.
+// t_emb:          [B, L, D]            post-norm timestep embedding
+// adaln_lora_3d:  [B, L, 3*D]          adaln-LoRA component from t_embedder
+// Returns three tensors each of shape [B, L, D].
+static std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> compute_adaln_mods(
+    const torch::Tensor& t_emb,
+    const torch::Tensor& adaln_lora_3d,
+    const py::dict& weights,
+    int block_idx,
+    const std::string& mod_name)
+{
+    const std::string pfx = block_prefix(block_idx) + mod_name;
+    auto down = get_w(weights, pfx + ".1.weight");  // [lora_dim, D]
+    auto up   = get_w(weights, pfx + ".2.weight");  // [3*D, lora_dim]
+    auto mods = adaln_lora_proj(t_emb, down, up) + adaln_lora_3d;
+    auto chunks = mods.chunk(3, -1);
+    return {chunks[0], chunks[1], chunks[2]};
+}
+
+// Self-attention residual block.
+//   x + gate * OutProj( FMHA( QKVProj( norm(x) * (1+scale) + shift ) ) )
+// `causal` selects the top-left causal mask (true for full-sequence DDPM
+// training forward; false for streaming with KV cache where causality is
+// enforced implicitly by only caching past tokens).
+static torch::Tensor self_attn_residual(
+    const torch::Tensor& x,              // [B, L, D]
+    const torch::Tensor& shift,
+    const torch::Tensor& scale,
+    const torch::Tensor& gate,
+    const py::dict& weights,
+    int block_idx,
+    const torch::Tensor& rope_emb,       // [L, 1, 1, Dh] float32 raw angles
+    int num_heads,
+    bool causal,
+    cudaStream_t stream)
+{
+    int B = (int)x.size(0), L = (int)x.size(1), D = (int)x.size(2);
+    int H = num_heads, Dh = D / H;
+    const std::string pfx = block_prefix(block_idx) + "self_attn.";
+
+    auto normed = layernorm_no_affine(x) * (1.f + scale) + shift;
+
+    auto wq = get_w(weights, pfx + "q_proj.weight");         // [D, D]
+    auto wk = get_w(weights, pfx + "k_proj.weight");
+    auto wv = get_w(weights, pfx + "v_proj.weight");
+    auto wo = get_w(weights, pfx + "output_proj.weight");
+
+    auto gq = get_w(weights, pfx + "q_norm.weight");         // [Dh]
+    auto gk = get_w(weights, pfx + "k_norm.weight");
+
+    // [B, L, D] → [B, L, H, Dh]
+    auto q = torch::matmul(normed, wq.t()).reshape({B, L, H, Dh});
+    auto k = torch::matmul(normed, wk.t()).reshape({B, L, H, Dh});
+    auto v = torch::matmul(normed, wv.t()).reshape({B, L, H, Dh});
+
+    q = rms_norm(q, gq);
+    k = rms_norm(k, gk);
+
+    auto [q_rot, k_rot] = apply_cosmos_rope(q, k, rope_emb);
+
+    auto attn_out = fmha(q_rot, k_rot, v, causal, stream);
+    return x + gate * torch::matmul(attn_out.reshape({B, L, D}), wo.t());
+}
+
+// Cross-attention residual block (full — computes K/V from `ctx` on the fly).
+// Streaming path will add a variant that takes pre-computed K/V caches.
+static torch::Tensor cross_attn_residual(
+    const torch::Tensor& x,              // [B, L,  D]
+    const torch::Tensor& shift,
+    const torch::Tensor& scale,
+    const torch::Tensor& gate,
+    const py::dict& weights,
+    int block_idx,
+    const torch::Tensor& ctx,            // [B, Lc, Dc]
+    int num_heads,
+    cudaStream_t stream)
+{
+    int B = (int)x.size(0), L = (int)x.size(1), D = (int)x.size(2);
+    int Lc = (int)ctx.size(1);
+    int H = num_heads, Dh = D / H;
+    const std::string pfx = block_prefix(block_idx) + "cross_attn.";
+
+    auto normed = layernorm_no_affine(x) * (1.f + scale) + shift;
+
+    auto wq = get_w(weights, pfx + "q_proj.weight");         // [D, D]
+    auto wk = get_w(weights, pfx + "k_proj.weight");         // [D, Dc]
+    auto wv = get_w(weights, pfx + "v_proj.weight");         // [D, Dc]
+    auto wo = get_w(weights, pfx + "output_proj.weight");
+
+    auto gq = get_w(weights, pfx + "q_norm.weight");
+    auto gk = get_w(weights, pfx + "k_norm.weight");
+
+    auto q = torch::matmul(normed, wq.t()).reshape({B, L,  H, Dh});
+    auto k = torch::matmul(ctx,    wk.t()).reshape({B, Lc, H, Dh});
+    auto v = torch::matmul(ctx,    wv.t()).reshape({B, Lc, H, Dh});
+
+    q = rms_norm(q, gq);
+    k = rms_norm(k, gk);
+    // No RoPE for cross-attention
+
+    auto attn_out = fmha(q, k, v, /*causal=*/false, stream);
+    return x + gate * torch::matmul(attn_out.reshape({B, L, D}), wo.t());
+}
+
+// MLP (GELU FFN) residual block.
+static torch::Tensor mlp_residual(
+    const torch::Tensor& x,              // [B, L, D]
+    const torch::Tensor& shift,
+    const torch::Tensor& scale,
+    const torch::Tensor& gate,
+    const py::dict& weights,
+    int block_idx)
+{
+    const std::string pfx = block_prefix(block_idx) + "mlp.";
+    auto normed = layernorm_no_affine(x) * (1.f + scale) + shift;
+    auto w1 = get_w(weights, pfx + "layer1.weight");  // [FF, D]
+    auto w2 = get_w(weights, pfx + "layer2.weight");  // [D, FF]
+    return x + gate * gelu_ffn(normed, w1, w2);
+}
+
+// ---------------------------------------------------------------------------
+// Single transformer block (full-sequence DDPM forward)
+// ---------------------------------------------------------------------------
+
+static torch::Tensor cosmos_block_forward(
+    const torch::Tensor& x,              // [B, L, D]
+    const torch::Tensor& t_emb,          // [B, L, D]     post-norm timestep emb
+    const torch::Tensor& adaln_lora_3d,  // [B, L, 3*D]   from t_embedder
+    const torch::Tensor& ctx,            // [B, Lc, Dc]   cross-attn context
+    const torch::Tensor& rope_emb,       // [L, 1, 1, Dh] float32 raw angles
+    const py::dict& weights,
+    int block_idx, int num_heads, cudaStream_t stream)
+{
+    auto [shift_sa,  scale_sa,  gate_sa]  = compute_adaln_mods(
+        t_emb, adaln_lora_3d, weights, block_idx, "adaln_modulation_self_attn");
+    auto [shift_ca,  scale_ca,  gate_ca]  = compute_adaln_mods(
+        t_emb, adaln_lora_3d, weights, block_idx, "adaln_modulation_cross_attn");
+    auto [shift_mlp, scale_mlp, gate_mlp] = compute_adaln_mods(
+        t_emb, adaln_lora_3d, weights, block_idx, "adaln_modulation_mlp");
+
+    auto cur = x;
+    cur = self_attn_residual (cur, shift_sa,  scale_sa,  gate_sa,
+                              weights, block_idx, rope_emb, num_heads,
+                              /*causal=*/true, stream);
+    cur = cross_attn_residual(cur, shift_ca,  scale_ca,  gate_ca,
+                              weights, block_idx, ctx, num_heads, stream);
+    cur = mlp_residual       (cur, shift_mlp, scale_mlp, gate_mlp,
+                              weights, block_idx);
+    return cur;
+}
+
+// ---------------------------------------------------------------------------
+// Main forward
+// ---------------------------------------------------------------------------
+
+torch::Tensor cosmos_forward(
+    torch::Tensor x,
+    torch::Tensor condition_mask,
+    torch::Tensor padding_mask,
+    torch::Tensor timesteps,
+    torch::Tensor crossattn_emb,
+    torch::Tensor hdmap,
+    py::dict weights,
+    py::dict config)
+{
+    TORCH_CHECK(x.is_cuda(),            "x must be a CUDA tensor");
+    TORCH_CHECK(x.dim() == 5,           "x must be 5D [B, C, T, H, W]");
+    TORCH_CHECK(x.size(1) == 16,        "x channel dim must be 16");
+    TORCH_CHECK(condition_mask.is_cuda() && condition_mask.dim() == 5);
+    TORCH_CHECK(crossattn_emb.is_cuda() && crossattn_emb.dim() == 3);
+    TORCH_CHECK(hdmap.is_cuda() && hdmap.dim() == 5);
+
+    auto orig_dtype = x.dtype();
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+    // ── Config ───────────────────────────────────────────────────────────────
+    auto ci = [&](const char* k, int d)   { return config.contains(k) ? py::cast<int>(config[k]) : d; };
+    auto cf = [&](const char* k, float d) { return config.contains(k) ? py::cast<float>(config[k]) : d; };
+    auto cb = [&](const char* k, bool d)  { return config.contains(k) ? py::cast<bool>(config[k]) : d; };
+
+    int   num_blocks     = ci("num_blocks",      28);
+    int   num_heads      = ci("num_heads",        16);
+    int   model_channels = ci("model_channels",  2048);
+    int   pt = ci("patch_temporal", 1),  ph = ci("patch_spatial", 2),  pw = ci("patch_spatial", 2);
+    float ts_scale       = cf("timestep_scale",  0.001f);
+    float h_ratio        = cf("rope_h_extrapolation_ratio", 3.0f);
+    float w_ratio        = cf("rope_w_extrapolation_ratio", 3.0f);
+    float t_ratio        = cf("rope_t_extrapolation_ratio", 1.0f);
+    bool  concat_pm      = cb("concat_padding_mask", true);
+
+    int head_dim = model_channels / num_heads;
+    int B = (int)x.size(0), T = (int)x.size(2), H = (int)x.size(3), W = (int)x.size(4);
+
+    // ── 1. Concat condition mask ─────────────────────────────────────────────
+    // [B, 16+1, T, H, W]
+    auto x_in = torch::cat({x, condition_mask.to(orig_dtype)}, 1);
+
+    // ── 2. Scale timesteps ───────────────────────────────────────────────────
+    auto ts = timesteps.to(torch::kFloat32) * ts_scale;  // [B, T]
+
+    // ── 3. Concat padding mask ───────────────────────────────────────────────
+    if (concat_pm) {
+        auto pm = padding_mask.to(orig_dtype);
+        if (pm.size(-2) != H || pm.size(-1) != W) {
+            pm = F::interpolate(
+                pm.to(torch::kFloat32),
+                F::InterpolateFuncOptions()
+                    .size(std::vector<int64_t>{H, W})
+                    .mode(torch::kNearest)
+            ).to(orig_dtype);
+        }
+        // [B, 1, H, W] → [B, 1, 1, H, W] → [B, 1, T, H, W]
+        x_in = torch::cat({x_in, pm.unsqueeze(2).expand({B, 1, T, H, W})}, 1);
+    }
+
+    // ── 4. Patch embedding ───────────────────────────────────────────────────
+    auto w_pe = get_w(weights, "x_embedder.proj.1.weight");       // [D, C_in*pt*ph*pw]
+    auto x_emb = patch_embed(x_in, w_pe, pt, ph, pw);             // [B, pT, pH, pW, D]
+
+    int pT = T / pt, pHs = H / ph, pWs = W / pw;
+
+    // ── 5. Additional patch embedding (hdmap) ────────────────────────────────
+    {
+        auto w_h = get_w(weights, "additional_patch_embedding.proj.1.weight");
+        x_emb = x_emb + patch_embed(hdmap.to(orig_dtype), w_h, pt, ph, pw);
+    }
+
+    // ── 6. RoPE embeddings ───────────────────────────────────────────────────
+    // [S=pT*pHs*pWs, 1, 1, head_dim] float32 raw angles
+    auto rope_emb = compute_cosmos_rope_emb(pT, pHs, pWs, head_dim,
+                                            h_ratio, w_ratio, t_ratio, x.device());
+
+    // ── 7. Timestep embedding ────────────────────────────────────────────────
+    auto ts_flat = ts.flatten().to(torch::kFloat32);           // [B*T]
+    auto t_sin   = sinusoidal_emb(ts_flat, model_channels).to(orig_dtype); // [B*T, D]
+
+    // TimestepEmbedding (use_adaln_lora=True): linear_1 has no bias
+    auto w1 = get_w(weights, "t_embedder.1.linear_1.weight");  // [D, D]
+    auto t_h = torch::silu(torch::matmul(t_sin, w1.t()));      // [B*T, D]
+
+    auto w2 = get_w(weights, "t_embedder.1.linear_2.weight");  // [3*D, D]
+    auto adaln_lora_BT3D = torch::matmul(t_h, w2.t());          // [B*T, 3*D]
+
+    // When use_adaln_lora=True, emb_B_T_D = sample = t_sin (raw sinusoidal)
+    auto t_emb_BT = t_sin;  // [B*T, D]
+
+    // t_embedding_norm (RMSNorm)
+    auto norm_gamma = get_w(weights, "t_embedding_norm.weight");
+    t_emb_BT = rms_norm(t_emb_BT, norm_gamma);  // [B*T, D]
+
+    // Reshape to [B, T, ...]
+    auto t_emb_BTD  = t_emb_BT.reshape({B, T, model_channels});
+    auto adaln_lora_BTD = adaln_lora_BT3D.reshape({B, T, 3 * model_channels});
+
+    // Expand from [B, T, *] to [B, L, *] by repeating each frame pHs*pWs times
+    int frame_seqlen = pHs * pWs;
+    int L = pT * pHs * pWs;
+
+    auto t_emb_BLD  = t_emb_BTD.repeat_interleave(frame_seqlen, 1);    // [B, L, D]
+    auto adaln_BL3D = adaln_lora_BTD.repeat_interleave(frame_seqlen, 1); // [B, L, 3*D]
+
+    // ── 8. Flatten x to [B, L, D] ────────────────────────────────────────────
+    auto cur = x_emb.reshape({B, L, model_channels}).to(orig_dtype);
+
+    // ── 9. Optional crossattn projection ─────────────────────────────────────
+    auto ctx = crossattn_emb.to(orig_dtype);
+    if (weights.contains("crossattn_proj.0.weight")) {
+        auto wp = get_w(weights, "crossattn_proj.0.weight");  // [1024, in_ch]
+        auto bp = get_w(weights, "crossattn_proj.0.bias");    // [1024]
+        ctx = torch::gelu(torch::matmul(ctx, wp.t()) + bp);
+    }
+
+    // ── 10. Transformer blocks ───────────────────────────────────────────────
+    for (int i = 0; i < num_blocks; ++i) {
+        cur = cosmos_block_forward(
+            cur, t_emb_BLD, adaln_BL3D, ctx, rope_emb,
+            weights, i, num_heads, stream);
+    }
+
+    // ── 11. Final layer ──────────────────────────────────────────────────────
+    // Reshape to [B, pT, pHs, pWs, D]
+    auto x_out = cur.reshape({B, pT, pHs, pWs, model_channels});
+
+    {
+        // final_layer.adaln_modulation: SiLU → Linear(D, lora_dim) → Linear(lora_dim, 2*D)
+        auto fl_down = get_w(weights, "final_layer.adaln_modulation.1.weight"); // [lora_dim, D]
+        auto fl_up   = get_w(weights, "final_layer.adaln_modulation.2.weight"); // [2*D, lora_dim]
+
+        // adaln_lora_B_T_3D[:, :, :2*D] is the lora component for the final layer
+        auto fl_lora  = adaln_lora_BTD.slice(2, 0, 2 * model_channels);    // [B, T, 2*D]
+        auto fl_mods  = adaln_lora_proj(t_emb_BTD, fl_down, fl_up) + fl_lora;  // [B, T, 2*D]
+        auto fl_chunks = fl_mods.chunk(2, -1);
+        // Broadcast [B, T, D] → [B, T, 1, 1, D] for spatial dims
+        auto shift = fl_chunks[0].unsqueeze(2).unsqueeze(3);
+        auto scale = fl_chunks[1].unsqueeze(2).unsqueeze(3);
+
+        x_out = layernorm_no_affine(x_out) * (1.f + scale) + shift;
+
+        auto w_fl = get_w(weights, "final_layer.linear.weight");  // [out_ch*pt*ph*pw, D]
+        x_out = torch::matmul(x_out, w_fl.t());  // [B, pT, pHs, pWs, pt*ph*pw*out_ch]
+    }
+
+    // ── 12. Unpatchify ───────────────────────────────────────────────────────
+    // [B, pT, pHs, pWs, pt*ph*pw*out_ch] → [B, out_ch, T, H, W]
+    int out_channels = 16;
+    // [B, pT, pHs, pWs, pt, ph, pw, out_ch]
+    x_out = x_out.reshape({B, pT, pHs, pWs, pt, ph, pw, out_channels});
+    // → [B, out_ch, pT, pt, pHs, ph, pWs, pw]
+    x_out = x_out.permute({0, 7, 1, 4, 2, 5, 3, 6}).contiguous();
+    // → [B, out_ch, T, H, W]
+    x_out = x_out.reshape({B, out_channels, T, H, W});
+
+    return x_out.to(orig_dtype);
+}
+
+
+// ===========================================================================
+// STREAMING (KV-cached autoregressive) forward
+//
+// Mirrors FlashDreams' CosmosDiTNetwork.forward. All the heavy math (adaln,
+// FFN, RMSNorm, LayerNorm) is reused from the DDPM path via the residual
+// helpers above; the only new pieces are the two streaming sub-block helpers
+// that (a) write new K/V into a ring-buffer cache and (b) skip K/V
+// projection for cross-attention because those are pre-computed by
+// FlashDreams' CrossAttention.initialize_cache.
+// ===========================================================================
+
+// Self-attention residual (streaming).
+// Identical math to `self_attn_residual(causal=false)` except it ALSO writes
+// the post-RoPE, post-RMSNorm K and post-V-proj V into external cache tensors
+// at `[write_start : write_start + L_new)`, then reads the valid prefix
+// `[0 : write_start + L_new)` as the attention context. This matches
+// `FlashDreams.SelfAttention.forward` line-for-line.
+static torch::Tensor self_attn_residual_streaming(
+    const torch::Tensor& x,              // [B, L_new, D]
+    const torch::Tensor& shift,          // [B, 1, D]
+    const torch::Tensor& scale,
+    const torch::Tensor& gate,
+    const py::dict& weights,
+    int block_idx,
+    const torch::Tensor& rope_emb,       // [L_new, 1, 1, Dh] fp32
+    int num_heads,
+    torch::Tensor& k_cache,              // [B, cache_cap, H, Dh]  MUTATED IN PLACE
+    torch::Tensor& v_cache,              // [B, cache_cap, H, Dh]  MUTATED IN PLACE
+    int64_t write_start,
+    cudaStream_t stream)
+{
+    int B = (int)x.size(0), L = (int)x.size(1), D = (int)x.size(2);
+    int H = num_heads, Dh = D / H;
+    const std::string pfx = block_prefix(block_idx) + "self_attn.";
+
+    auto normed = layernorm_no_affine(x) * (1.f + scale) + shift;
+
+    auto wq = get_w(weights, pfx + "q_proj.weight");
+    auto wk = get_w(weights, pfx + "k_proj.weight");
+    auto wv = get_w(weights, pfx + "v_proj.weight");
+    auto wo = get_w(weights, pfx + "output_proj.weight");
+
+    auto gq = get_w(weights, pfx + "q_norm.weight");
+    auto gk = get_w(weights, pfx + "k_norm.weight");
+
+    auto q = torch::matmul(normed, wq.t()).reshape({B, L, H, Dh});
+    auto k = torch::matmul(normed, wk.t()).reshape({B, L, H, Dh});
+    auto v = torch::matmul(normed, wv.t()).reshape({B, L, H, Dh});
+
+    q = rms_norm(q, gq);
+    k = rms_norm(k, gk);
+
+    auto [q_rot, k_rot] = apply_cosmos_rope(q, k, rope_emb);
+
+    // In-place write into the ring-buffer caches. The Python side is
+    // responsible for rolling the buffers via BlockKVCache.before_update
+    // prior to this call, so `write_start` is simply the tail of the valid
+    // region to append to.
+    const int64_t L_new = (int64_t)L;
+    const int64_t read_end = write_start + L_new;
+    TORCH_CHECK(read_end <= k_cache.size(1),
+        "self-attn write_start+L_new exceeds cache capacity");
+
+    k_cache.slice(/*dim=*/1, write_start, read_end).copy_(k_rot.to(k_cache.dtype()));
+    v_cache.slice(/*dim=*/1, write_start, read_end).copy_(v    .to(v_cache.dtype()));
+
+    auto cached_k = k_cache.slice(/*dim=*/1, 0, read_end);
+    auto cached_v = v_cache.slice(/*dim=*/1, 0, read_end);
+
+    // Non-causal FMHA against the historical cache + just-written tokens.
+    auto attn_out = fmha(q_rot, cached_k, cached_v, /*causal=*/false, stream);
+
+    return x + gate * torch::matmul(attn_out.reshape({B, L, D}), wo.t());
+}
+
+// Cross-attention residual (streaming) — text K/V are already pre-computed
+// by FlashDreams.CrossAttention.initialize_cache (post-k_norm K, raw V), so we
+// only need Q projection + q_norm + FMHA + output projection.
+static torch::Tensor cross_attn_residual_streaming(
+    const torch::Tensor& x,              // [B, L_new, D]
+    const torch::Tensor& shift,          // [B, 1, D]
+    const torch::Tensor& scale,
+    const torch::Tensor& gate,
+    const py::dict& weights,
+    int block_idx,
+    const torch::Tensor& k_cached,       // [B, Lc, H, Dh]  post-k_norm text K
+    const torch::Tensor& v_cached,       // [B, Lc, H, Dh]  raw text V
+    int num_heads,
+    cudaStream_t stream)
+{
+    int B = (int)x.size(0), L = (int)x.size(1), D = (int)x.size(2);
+    int H = num_heads, Dh = D / H;
+    const std::string pfx = block_prefix(block_idx) + "cross_attn.";
+
+    auto normed = layernorm_no_affine(x) * (1.f + scale) + shift;
+
+    auto wq = get_w(weights, pfx + "q_proj.weight");
+    auto wo = get_w(weights, pfx + "output_proj.weight");
+    auto gq = get_w(weights, pfx + "q_norm.weight");
+
+    auto q = torch::matmul(normed, wq.t()).reshape({B, L, H, Dh});
+    q = rms_norm(q, gq);
+
+    auto attn_out = fmha(q, k_cached, v_cached, /*causal=*/false, stream);
+    return x + gate * torch::matmul(attn_out.reshape({B, L, D}), wo.t());
+}
+
+// ---------------------------------------------------------------------------
+// Streaming main forward
+// ---------------------------------------------------------------------------
+
+torch::Tensor optimized_dit_forward(
+    torch::Tensor x_new,
+    torch::Tensor condition_mask_patched,
+    torch::Tensor hdmap_patched,
+    torch::Tensor timesteps,
+    torch::Tensor rope_emb,
+    std::vector<torch::Tensor> k_cross_caches,
+    std::vector<torch::Tensor> v_cross_caches,
+    std::vector<torch::Tensor> k_self_caches,
+    std::vector<torch::Tensor> v_self_caches,
+    int64_t self_attn_write_start,
+    py::dict weights,
+    py::dict config)
+{
+    TORCH_CHECK(x_new.is_cuda(),            "x_new must be a CUDA tensor");
+    TORCH_CHECK(x_new.dim() == 5,           "x_new must be 5D [B, V, T, HW, D_in]");
+    TORCH_CHECK(condition_mask_patched.is_cuda() && condition_mask_patched.dim() == 5,
+                "condition_mask_patched must be CUDA 5D");
+
+    auto orig_dtype = x_new.dtype();
+    auto orig_scalar_type = x_new.scalar_type();
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    bool prof = cosmos_profile_enabled();
+    enum {
+        EV_START = 0,
+        EV_AFTER_INPUT_EMBED,
+        EV_AFTER_TEMB,
+        EV_AFTER_ROPE_SCRATCH,
+        EV_AFTER_BLOCKS,
+        EV_AFTER_FINAL,
+        EV_COUNT
+    };
+    cudaEvent_t ev[EV_COUNT];
+    auto rec = [&](int idx) {
+        if (prof) cudaEventRecord(ev[idx], stream);
+    };
+    if (prof) {
+        for (int i = 0; i < EV_COUNT; ++i) cudaEventCreate(&ev[i]);
+        rec(EV_START);
+    }
+
+    // ── Config ───────────────────────────────────────────────────────────────
+    auto ci = [&](const char* k, int d)   { return config.contains(k) ? py::cast<int>(config[k]) : d; };
+    auto cf = [&](const char* k, float d) { return config.contains(k) ? py::cast<float>(config[k]) : d; };
+    auto cb = [&](const char* k, bool d)  { return config.contains(k) ? py::cast<bool>(config[k]) : d; };
+    auto cs = [&](const char* k, const char* d) {
+        return config.contains(k) ? py::cast<std::string>(config[k]) : std::string(d);
+    };
+    auto lower_ascii = [](std::string s) {
+        for (char& ch : s) ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+        return s;
+    };
+
+    int   num_blocks     = ci("num_blocks",     28);
+    int   num_heads      = ci("num_heads",      16);
+    int   model_channels = ci("model_channels", 2048);
+    float ts_scale       = cf("timestep_scale", 0.001f);
+    std::string linear_backend_name = lower_ascii(cs("cosmos_linear_backend", "auto"));
+    std::string attention_backend_name = lower_ascii(cs("cosmos_attention_backend", "cudnn_bf16"));
+    std::string kv_cache_backend_name = lower_ascii(cs("cosmos_kv_cache_backend", "bf16"));
+    bool quantized_prepared = cb("cosmos_quantized_prepared", false);
+    bool quantized_prepared_strict = cb("cosmos_quantized_prepared_strict", quantized_prepared);
+    // Shape: x_new is [B, V, T, HW, D_in]. For FlashDreams' single-view DiT V=1;
+    // we flatten (V, T, HW) into a single L dimension for the transformer math.
+    int B = (int)x_new.size(0);
+    int V = (int)x_new.size(1);
+    int T = (int)x_new.size(2);
+    int HW = (int)x_new.size(3);
+    TORCH_CHECK(V == 1, "optimized_dit_forward currently supports V==1 only (got V=",
+                V, "); multi-view support is a future extension.");
+    int L = V * T * HW;
+
+    TORCH_CHECK((int)k_cross_caches.size() == num_blocks && (int)v_cross_caches.size() == num_blocks,
+                "k_cross_caches and v_cross_caches must have length num_blocks=", num_blocks);
+    TORCH_CHECK((int)k_self_caches.size()  == num_blocks && (int)v_self_caches.size()  == num_blocks,
+                "k_self_caches and v_self_caches must have length num_blocks=", num_blocks);
+
+    torch::Tensor hdmap_embed;
+    if (config.contains("cosmos_hdmap_embed")) {
+        hdmap_embed = py::cast<torch::Tensor>(config["cosmos_hdmap_embed"]);
+        TORCH_CHECK(hdmap_embed.is_cuda(), "config['cosmos_hdmap_embed'] must be a CUDA tensor");
+        TORCH_CHECK(hdmap_embed.device() == x_new.device(),
+                    "config['cosmos_hdmap_embed'] must be on device ", x_new.device());
+        TORCH_CHECK(hdmap_embed.scalar_type() == orig_scalar_type,
+                    "config['cosmos_hdmap_embed'] has dtype ", hdmap_embed.scalar_type(),
+                    ", expected ", orig_scalar_type);
+        TORCH_CHECK(hdmap_embed.dim() == 3 &&
+                    hdmap_embed.size(0) == B &&
+                    hdmap_embed.size(1) == L &&
+                    hdmap_embed.size(2) == model_channels,
+                    "config['cosmos_hdmap_embed'] must have shape [", B, ", ", L, ", ",
+                    model_channels, "]");
+        TORCH_CHECK(hdmap_embed.is_contiguous(), "config['cosmos_hdmap_embed'] must be contiguous");
+    }
+
+    // ── 1. Concat condition_mask along last dim (both pre-patchified) ────────
+    auto x_cat = torch::cat({x_new, condition_mask_patched.to(orig_dtype)}, -1);
+    // [B, V, T, HW, D_in + D_cond] → [B, L, D_in + D_cond]
+    auto x_flat = x_cat.reshape({B, L, -1}).contiguous();
+
+    // ── 2. x_embedder (already fused: padding mask channel baked out) ────────
+    auto w_xe = get_w(weights, "x_embedder.proj.1.weight");  // [D, D_in+D_cond]
+    auto cur = torch::matmul(x_flat, w_xe.t());              // [B, L, D]
+
+    // ── 3. Additional patch embedding (HD-map bbox control) ──────────────────
+    if (hdmap_embed.defined()) {
+        cur = cur + hdmap_embed;
+    } else if (hdmap_patched.defined() && hdmap_patched.numel() > 0) {
+        TORCH_CHECK(hdmap_patched.dim() == 5, "hdmap_patched must be 5D [B, V, T, HW, D_hdmap]");
+        auto hdmap_flat = hdmap_patched.to(orig_dtype).reshape({B, L, -1}).contiguous();
+        auto w_hd = get_w(weights, "additional_patch_embedding.proj.1.weight");
+        cur = cur + torch::matmul(hdmap_flat, w_hd.t());
+    }
+    rec(EV_AFTER_INPUT_EMBED);
+
+    // ── 4. Timestep embedding (single timestep per batch item) ───────────────
+    // timesteps: [B]  (not [B, T] as in the DDPM path). Fixed scheduler-step
+    // replay can provide these tensors to avoid per-forward ATen setup.
+    torch::Tensor t_emb_BD;
+    torch::Tensor t_emb_silu;
+    torch::Tensor adaln_lora_BD;
+    auto validate_timestep_cache = [&](const torch::Tensor& t, const char* name, int cols) {
+        TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+        TORCH_CHECK(t.device() == x_new.device(), name, " must be on device ", x_new.device());
+        TORCH_CHECK(t.scalar_type() == orig_scalar_type,
+                    name, " has dtype ", t.scalar_type(), ", expected ", orig_scalar_type);
+        TORCH_CHECK(t.dim() == 2 && (int)t.size(0) == B && (int)t.size(1) == cols,
+                    name, " must have shape [", B, ", ", cols, "], got [",
+                    t.dim() > 0 ? t.size(0) : 0, ", ", t.dim() > 1 ? t.size(1) : 0, "]");
+        TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+    };
+    if (config.contains("cosmos_t_emb") ||
+        config.contains("cosmos_t_emb_silu") ||
+        config.contains("cosmos_adaln_lora")) {
+        TORCH_CHECK(config.contains("cosmos_t_emb") &&
+                    config.contains("cosmos_t_emb_silu") &&
+                    config.contains("cosmos_adaln_lora"),
+                    "precomputed timestep embedding requires config['cosmos_t_emb'], "
+                    "config['cosmos_t_emb_silu'], and config['cosmos_adaln_lora']");
+        t_emb_BD = py::cast<torch::Tensor>(config["cosmos_t_emb"]);
+        t_emb_silu = py::cast<torch::Tensor>(config["cosmos_t_emb_silu"]);
+        adaln_lora_BD = py::cast<torch::Tensor>(config["cosmos_adaln_lora"]);
+        validate_timestep_cache(t_emb_BD, "config['cosmos_t_emb']", model_channels);
+        validate_timestep_cache(t_emb_silu, "config['cosmos_t_emb_silu']", model_channels);
+        validate_timestep_cache(adaln_lora_BD, "config['cosmos_adaln_lora']", 3 * model_channels);
+    } else {
+        auto ts = timesteps.to(torch::kFloat32) * ts_scale;             // [B]
+        auto t_sin = sinusoidal_emb(ts, model_channels).to(orig_dtype); // [B, D]
+
+        // TimestepEmbedding (use_adaln_lora=True): linear_1 has no bias.
+        auto w_t1 = get_w(weights, "t_embedder.1.linear_1.weight");     // [D, D]
+        auto t_h  = torch::silu(torch::matmul(t_sin, w_t1.t()));        // [B, D]
+
+        auto w_t2 = get_w(weights, "t_embedder.1.linear_2.weight");     // [3D, D]
+        adaln_lora_BD = torch::matmul(t_h, w_t2.t());                   // [B, 3D]
+
+        // use_adaln_lora=True -> emb_B_D = raw sinusoidal (sample)
+        t_emb_BD = t_sin;                                               // [B, D]
+
+        // t_embedding_norm (RMSNorm)
+        auto norm_gamma = get_w(weights, "t_embedding_norm.weight");
+        t_emb_BD = rms_norm(t_emb_BD, norm_gamma);                      // [B, D]
+        t_emb_silu = t_emb_BD.clone();                                  // [B, D]
+        cudaError_t e = omnidreams_singleview::cosmos_silu_inplace<cutlass::bfloat16_t>(
+            reinterpret_cast<cutlass::bfloat16_t*>(t_emb_silu.data_ptr<at::BFloat16>()),
+            int64_t(B) * model_channels, stream);
+        TORCH_CHECK(e == cudaSuccess, "cosmos_silu_inplace failed: ", cudaGetErrorString(e));
+    }
+    rec(EV_AFTER_TEMB);
+
+    // ── 5. Transformer blocks (28): CUTLASS GEMM fusion path ──────────────────
+    //
+    // Replaces the previous ATen-heavy block loop (~14 ATen ops per sub-layer
+    // × 3 sub-layers per block × 28 blocks = ~1180 ATen launches/forward) with
+    // one C++ call per block. Each block call runs:
+    //
+    //   - 3x adaln-LoRA (SiLU pre-applied; 2 GEMMs each + add) via
+    //     `cosmos_adaln_lora_split`
+    //   - Self-attn residual: ln+modulate (1 kernel), 3 bf16 CUTLASS GEMMs
+    //     (Q/K/V), per-head RMSNorm Q/K (2 kernels), pack+rotate-half RoPE
+    //     (2 kernels), KV-cache append (2 small copy kernels), cuDNN FMHA,
+    //     out GEMM, gated_residual (1 kernel)
+    //   - Cross-attn residual (Q only; KV pre-cached): ln+modulate, Q GEMM,
+    //     per-head RMSNorm Q, cuDNN FMHA, out GEMM, gated_residual
+    //   - FFN residual: ln+modulate, GEMM1+GELU (fused epilogue), GEMM2,
+    //     gated_residual
+    //
+    // Force bf16 throughout to match FlashDreams' CosmosDiTNetwork dtype.
+    // The orchestrator + bf16 GEMM kernels handle this end-to-end; no fp16
+    // down-cast.
+    TORCH_CHECK(orig_dtype == torch::kBFloat16,
+                "optimized_dit_forward requires bf16 inputs (matches "
+                "FlashDreams' CosmosDiTNetwork dtype); got dtype=", orig_dtype);
+    TORCH_CHECK(B == 1,
+                "optimized_dit_forward Phase-1 CUTLASS path supports B=1 "
+                "only (got B=", B, "); CFG-batched B=2 will fall back when "
+                "FlashDreams enables it. The previous ATen path supported B>1.");
+
+    int K = model_channels;
+    int H = num_heads;
+    TORCH_CHECK(K % H == 0,
+                "model_channels (", K, ") must be divisible by num_heads (", H, ")");
+    int D = K / H;
+    auto opts = torch::TensorOptions().dtype(orig_scalar_type).device(x_new.device());
+
+    bool fp8_kv_cache_enabled = false;
+    std::vector<torch::Tensor> k_cross_fp8_caches;
+    std::vector<torch::Tensor> v_cross_fp8_caches;
+    std::vector<torch::Tensor> k_self_fp8_caches;
+    std::vector<torch::Tensor> v_self_fp8_caches;
+    std::vector<torch::Tensor> k_cross_fp8_bhmd_caches;
+    std::vector<torch::Tensor> v_cross_fp8_bhmd_caches;
+    std::vector<torch::Tensor> v_cross_fp8_bhdm_caches;
+    std::vector<torch::Tensor> k_self_fp8_bhmd_caches;
+    std::vector<torch::Tensor> v_self_fp8_bhmd_caches;
+    std::vector<torch::Tensor> v_self_fp8_bhdm_caches;
+    std::vector<torch::Tensor> k_cross_sage3_fp4_caches;
+    std::vector<torch::Tensor> v_cross_sage3_fp4_caches;
+    std::vector<torch::Tensor> k_cross_sage3_sf_caches;
+    std::vector<torch::Tensor> v_cross_sage3_sf_caches;
+    bool fp8_cross_tc_layout_cache_enabled = false;
+    bool fp8_self_tc_layout_cache_enabled = false;
+    const bool sage3_cross_fp4_enabled =
+        config.contains("k_cross_sage3_fp4_caches") ||
+        config.contains("v_cross_sage3_fp4_caches") ||
+        config.contains("k_cross_sage3_sf_caches") ||
+        config.contains("v_cross_sage3_sf_caches");
+    auto config_tensor_vector = [&](const char* key) {
+        TORCH_CHECK(config.contains(key),
+                    "cosmos_kv_cache_backend=fp8 requires config['", key, "']");
+        try {
+            return py::cast<std::vector<torch::Tensor>>(config[key]);
+        } catch (const py::cast_error&) {
+            TORCH_CHECK(false, "config['", key, "'] must be a list of CUDA tensors");
+            return std::vector<torch::Tensor>{};
+        }
+    };
+    auto optional_config_tensor_vector = [&](const char* key) {
+        if (!config.contains(key)) {
+            return std::vector<torch::Tensor>{};
+        }
+        try {
+            return py::cast<std::vector<torch::Tensor>>(config[key]);
+        } catch (const py::cast_error&) {
+            TORCH_CHECK(false, "config['", key, "'] must be a list of CUDA tensors");
+            return std::vector<torch::Tensor>{};
+        }
+    };
+    if (kv_cache_backend_name == "bf16" || kv_cache_backend_name == "none") {
+        fp8_kv_cache_enabled = false;
+    } else if (kv_cache_backend_name == "fp8" || kv_cache_backend_name == "shadow_fp8") {
+        fp8_kv_cache_enabled = true;
+        if (!sage3_cross_fp4_enabled) {
+            k_cross_fp8_caches = config_tensor_vector("k_cross_fp8_caches");
+            v_cross_fp8_caches = config_tensor_vector("v_cross_fp8_caches");
+        }
+        k_self_fp8_caches = config_tensor_vector("k_self_fp8_caches");
+        v_self_fp8_caches = config_tensor_vector("v_self_fp8_caches");
+        TORCH_CHECK((sage3_cross_fp4_enabled ||
+                     ((int)k_cross_fp8_caches.size() == num_blocks &&
+                      (int)v_cross_fp8_caches.size() == num_blocks)) &&
+                    (int)k_self_fp8_caches.size() == num_blocks &&
+                    (int)v_self_fp8_caches.size() == num_blocks,
+                    "FP8 shadow KV cache lists must all have length num_blocks=", num_blocks);
+        k_cross_fp8_bhmd_caches = optional_config_tensor_vector("k_cross_fp8_bhmd_caches");
+        v_cross_fp8_bhmd_caches = optional_config_tensor_vector("v_cross_fp8_bhmd_caches");
+        v_cross_fp8_bhdm_caches = optional_config_tensor_vector("v_cross_fp8_bhdm_caches");
+        k_self_fp8_bhmd_caches = optional_config_tensor_vector("k_self_fp8_bhmd_caches");
+        v_self_fp8_bhmd_caches = optional_config_tensor_vector("v_self_fp8_bhmd_caches");
+        v_self_fp8_bhdm_caches = optional_config_tensor_vector("v_self_fp8_bhdm_caches");
+        fp8_cross_tc_layout_cache_enabled =
+            !k_cross_fp8_bhmd_caches.empty() || !v_cross_fp8_bhmd_caches.empty() ||
+            !v_cross_fp8_bhdm_caches.empty();
+        fp8_self_tc_layout_cache_enabled =
+            !k_self_fp8_bhmd_caches.empty() || !v_self_fp8_bhmd_caches.empty() ||
+            !v_self_fp8_bhdm_caches.empty();
+        if (fp8_cross_tc_layout_cache_enabled) {
+            TORCH_CHECK((int)k_cross_fp8_bhmd_caches.size() == num_blocks &&
+                        (int)v_cross_fp8_bhmd_caches.size() == num_blocks,
+                        "FP8 cuDNN-layout cross KV cache lists k/v k_cross_fp8_bhmd_caches and "
+                        "v_cross_fp8_bhmd_caches must both have length num_blocks=",
+                        num_blocks);
+            TORCH_CHECK(v_cross_fp8_bhdm_caches.empty() || (int)v_cross_fp8_bhdm_caches.size() == num_blocks,
+                        "v_cross_fp8_bhdm_caches must be omitted or have length num_blocks=", num_blocks);
+        }
+        if (fp8_self_tc_layout_cache_enabled) {
+            TORCH_CHECK((int)k_self_fp8_bhmd_caches.size() == num_blocks &&
+                        (int)v_self_fp8_bhmd_caches.size() == num_blocks,
+                        "FP8 cuDNN-layout self KV cache lists k/v k_self_fp8_bhmd_caches and "
+                        "v_self_fp8_bhmd_caches must both have length num_blocks=",
+                        num_blocks);
+            TORCH_CHECK(v_self_fp8_bhdm_caches.empty() || (int)v_self_fp8_bhdm_caches.size() == num_blocks,
+                        "v_self_fp8_bhdm_caches must be omitted or have length num_blocks=", num_blocks);
+        }
+    } else {
+        TORCH_CHECK(false,
+                    "unsupported cosmos_kv_cache_backend '", kv_cache_backend_name,
+                    "'. Expected one of: bf16, fp8");
+    }
+    if (sage3_cross_fp4_enabled) {
+        TORCH_CHECK(config.contains("k_cross_sage3_fp4_caches") &&
+                    config.contains("v_cross_sage3_fp4_caches") &&
+                    config.contains("k_cross_sage3_sf_caches") &&
+                    config.contains("v_cross_sage3_sf_caches"),
+                    "Sage3 cross-attention FP4 caches require k/v fp4 and k/v scale cache lists");
+        k_cross_sage3_fp4_caches = config_tensor_vector("k_cross_sage3_fp4_caches");
+        v_cross_sage3_fp4_caches = config_tensor_vector("v_cross_sage3_fp4_caches");
+        k_cross_sage3_sf_caches = config_tensor_vector("k_cross_sage3_sf_caches");
+        v_cross_sage3_sf_caches = config_tensor_vector("v_cross_sage3_sf_caches");
+        TORCH_CHECK((int)k_cross_sage3_fp4_caches.size() == num_blocks &&
+                    (int)v_cross_sage3_fp4_caches.size() == num_blocks &&
+                    (int)k_cross_sage3_sf_caches.size() == num_blocks &&
+                    (int)v_cross_sage3_sf_caches.size() == num_blocks,
+                    "Sage3 cross FP4 cache lists must all have length num_blocks=", num_blocks);
+    }
+
+    // FFN inner dim is fixed by the checkpoint (4 * K for cosmos production);
+    // we can read it off the actual ffn weight tensor rather than relying on
+    // a config knob (avoids a config mismatch hazard).
+    auto ffn_w1_probe = get_w(weights, "blocks.0.mlp.layer1.weight");           // [FF, K]
+    int FF = (int)ffn_w1_probe.size(0);
+    auto adaln_down_probe = get_w(weights, "blocks.0.adaln_modulation_self_attn.1.weight"); // [lora_dim, K]
+    int lora_dim = (int)adaln_down_probe.size(0);
+
+    const std::array<std::string, 8> block_linear_rel_keys = {
+        "self_attn.q_proj.weight",
+        "self_attn.k_proj.weight",
+        "self_attn.v_proj.weight",
+        "self_attn.output_proj.weight",
+        "cross_attn.q_proj.weight",
+        "cross_attn.output_proj.weight",
+        "mlp.layer1.weight",
+        "mlp.layer2.weight",
+    };
+    bool any_block_linear_fp8 = false;
+    bool any_block_linear_bf16 = false;
+    for (int i = 0; i < num_blocks; ++i) {
+        const std::string p = block_prefix(i);
+        const bool has_fused_qkv =
+            weights.contains(py::str(p + "self_attn.qkv_proj.weight")) &&
+            get_w(weights, p + "self_attn.qkv_proj.weight").scalar_type() == at::kByte;
+        for (const std::string& rel_key : block_linear_rel_keys) {
+            if (has_fused_qkv &&
+                (rel_key == "self_attn.q_proj.weight" ||
+                 rel_key == "self_attn.k_proj.weight" ||
+                 rel_key == "self_attn.v_proj.weight")) {
+                any_block_linear_fp8 = true;
+                continue;
+            }
+            auto t = get_w(weights, p + rel_key);
+            if (t.scalar_type() == at::kByte) {
+                any_block_linear_fp8 = true;
+            } else if (t.scalar_type() == at::kBFloat16) {
+                any_block_linear_bf16 = true;
+            } else {
+                TORCH_CHECK(false, p + rel_key,
+                            " must be torch.bfloat16 or torch.uint8 raw E4M3 bytes; got ",
+                            t.scalar_type());
+            }
+        }
+    }
+    omnidreams_singleview::CosmosLinearBackend linear_backend = omnidreams_singleview::CosmosLinearBackend::BF16;
+    if (linear_backend_name == "auto") {
+        linear_backend = any_block_linear_fp8
+            ? (any_block_linear_bf16 ? omnidreams_singleview::CosmosLinearBackend::MIXED
+                                     : omnidreams_singleview::CosmosLinearBackend::FP8)
+            : omnidreams_singleview::CosmosLinearBackend::BF16;
+    } else if (linear_backend_name == "bf16" || linear_backend_name == "cudnn") {
+        linear_backend = omnidreams_singleview::CosmosLinearBackend::BF16;
+    } else if (linear_backend_name == "fp8") {
+        linear_backend = omnidreams_singleview::CosmosLinearBackend::FP8;
+    } else if (linear_backend_name == "mixed") {
+        linear_backend = omnidreams_singleview::CosmosLinearBackend::MIXED;
+    } else {
+        TORCH_CHECK(false,
+                    "unsupported cosmos_linear_backend '", linear_backend_name,
+                    "'. Expected one of: auto, bf16, fp8, mixed");
+    }
+
+    omnidreams_singleview::CosmosAttentionBackend attention_backend = omnidreams_singleview::CosmosAttentionBackend::CUDNN_BF16;
+    if (attention_backend_name == "cudnn_bf16" || attention_backend_name == "bf16") {
+        attention_backend = omnidreams_singleview::CosmosAttentionBackend::CUDNN_BF16;
+    } else if (attention_backend_name == "fp8_dense_ref") {
+        attention_backend = omnidreams_singleview::CosmosAttentionBackend::FP8_DENSE_REF;
+    } else if (attention_backend_name == "fp8_cudnn") {
+        attention_backend = omnidreams_singleview::CosmosAttentionBackend::FP8_CUDNN;
+    } else if (attention_backend_name == "sage3") {
+        attention_backend = omnidreams_singleview::CosmosAttentionBackend::SAGE3;
+    } else if (attention_backend_name == "sage3_fp8") {
+        attention_backend = omnidreams_singleview::CosmosAttentionBackend::SAGE3_FP8;
+    } else {
+        TORCH_CHECK(false,
+                    "unsupported cosmos_attention_backend '", attention_backend_name,
+                    "'. Expected one of: cudnn_bf16, bf16, fp8_dense_ref, fp8_cudnn, sage3, sage3_fp8");
+    }
+    // ── 5a. One-shot setup outside the per-block loop ─────────────────────────
+    //
+    // (i) RoPE cos/sin: callers may precompute these for fixed-shape replay.
+    //      rope_emb is fp32 [L_new, 1, 1, D]; the block path consumes bf16
+    //      [L_new, D] cos/sin.
+    torch::Tensor rope_cos;
+    torch::Tensor rope_sin;
+    auto validate_rope_cache = [&](const torch::Tensor& t, const char* name) {
+        TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+        TORCH_CHECK(t.device() == x_new.device(), name, " must be on device ", x_new.device());
+        TORCH_CHECK(t.scalar_type() == orig_scalar_type,
+                    name, " has dtype ", t.scalar_type(), ", expected ", orig_scalar_type);
+        TORCH_CHECK(t.dim() == 2 && (int)t.size(0) == L && (int)t.size(1) == D,
+                    name, " must have shape [", L, ", ", D, "], got [",
+                    t.dim() > 0 ? t.size(0) : 0, ", ", t.dim() > 1 ? t.size(1) : 0, "]");
+        TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+    };
+    if (config.contains("cosmos_rope_cos") || config.contains("cosmos_rope_sin")) {
+        TORCH_CHECK(config.contains("cosmos_rope_cos") && config.contains("cosmos_rope_sin"),
+                    "precomputed RoPE requires both config['cosmos_rope_cos'] and config['cosmos_rope_sin']");
+        rope_cos = py::cast<torch::Tensor>(config["cosmos_rope_cos"]);
+        rope_sin = py::cast<torch::Tensor>(config["cosmos_rope_sin"]);
+        validate_rope_cache(rope_cos, "config['cosmos_rope_cos']");
+        validate_rope_cache(rope_sin, "config['cosmos_rope_sin']");
+    } else {
+        auto rope_view = rope_emb.permute({1, 0, 2, 3}).reshape({L, model_channels / num_heads});
+        rope_cos = torch::cos(rope_view).to(orig_dtype).contiguous();           // [L, D] bf16
+        rope_sin = torch::sin(rope_view).to(orig_dtype).contiguous();           // [L, D] bf16
+    }
+
+    // (iii) Block-shared scratch buffers. These are sized once and reused
+    //       across all 28 blocks. The PyTorch caching allocator amortises
+    //       the cost across forwards of the same shape.
+    int M = L;  // per-call query length (B==1)
+    int sage3_q_padded = ((M + 127) / 128) * 128;
+    int max_attn_tokens = M;
+    for (int i = 0; i < num_blocks; ++i) {
+        max_attn_tokens = std::max(max_attn_tokens, (int)k_cross_caches[i].size(1));
+        max_attn_tokens = std::max(max_attn_tokens, (int)k_self_caches[i].size(1));
+    }
+    int linear_scratch_features = std::max(std::max(K, FF), 3 * K);
+    py::dict workspace_dict;
+    bool use_external_workspace = false;
+    if (config.contains("cosmos_workspace")) {
+        try {
+            workspace_dict = py::cast<py::dict>(config["cosmos_workspace"]);
+            use_external_workspace = true;
+        } catch (const py::cast_error&) {
+            TORCH_CHECK(false, "config['cosmos_workspace'] must be a dict of preallocated CUDA tensors");
+        }
+    }
+    const bool attn_tc_scale_is_ones =
+        config.contains("cosmos_attn_tc_scale_is_ones")
+            ? py::cast<bool>(config["cosmos_attn_tc_scale_is_ones"])
+            : false;
+    TORCH_CHECK(!attn_tc_scale_is_ones || use_external_workspace,
+                "cosmos_attn_tc_scale_is_ones=true requires config['cosmos_workspace']");
+    bool write_bf16_self_kv_cache =
+        config.contains("cosmos_write_bf16_kv_cache")
+            ? py::cast<bool>(config["cosmos_write_bf16_kv_cache"])
+            : true;
+    TORCH_CHECK(write_bf16_self_kv_cache || fp8_kv_cache_enabled,
+                "cosmos_write_bf16_kv_cache=false requires cosmos_kv_cache_backend='fp8'");
+    auto workspace_tensor = [&](const char* name,
+                                std::vector<int64_t> shape,
+                                at::ScalarType dtype) -> torch::Tensor {
+        if (!use_external_workspace) {
+            return torch::empty(c10::IntArrayRef(shape), torch::TensorOptions().dtype(dtype).device(x_new.device()));
+        }
+        TORCH_CHECK(workspace_dict.contains(name),
+                    "config['cosmos_workspace'] is missing scratch tensor '", name, "'");
+        auto t = py::cast<torch::Tensor>(workspace_dict[name]);
+        TORCH_CHECK(t.is_cuda(), "cosmos_workspace['", name, "'] must be CUDA");
+        TORCH_CHECK(t.device() == x_new.device(),
+                    "cosmos_workspace['", name, "'] must be on device ", x_new.device());
+        TORCH_CHECK(t.scalar_type() == dtype,
+                    "cosmos_workspace['", name, "'] has dtype ", t.scalar_type(),
+                    ", expected ", dtype);
+        TORCH_CHECK(t.dim() == static_cast<int64_t>(shape.size()),
+                    "cosmos_workspace['", name, "'] has dim ", t.dim(),
+                    ", expected ", shape.size());
+        for (size_t dim = 0; dim < shape.size(); ++dim) {
+            TORCH_CHECK(t.size(static_cast<int64_t>(dim)) == shape[dim],
+                        "cosmos_workspace['", name, "'] shape mismatch at dim ", dim,
+                        ": got ", t.size(static_cast<int64_t>(dim)),
+                        ", expected ", shape[dim]);
+        }
+        TORCH_CHECK(t.is_contiguous(), "cosmos_workspace['", name, "'] must be contiguous");
+        return t;
+    };
+    auto workspace_tensor_singleton_or_shape = [&](const char* name,
+                                                   std::vector<int64_t> shape,
+                                                   at::ScalarType dtype,
+                                                   bool allow_singleton) -> torch::Tensor {
+        if (!use_external_workspace) {
+            if (allow_singleton) {
+                return torch::empty({1}, torch::TensorOptions().dtype(dtype).device(x_new.device()));
+            }
+            return workspace_tensor(name, shape, dtype);
+        }
+        if (!allow_singleton) {
+            return workspace_tensor(name, shape, dtype);
+        }
+        TORCH_CHECK(workspace_dict.contains(name),
+                    "config['cosmos_workspace'] is missing scratch tensor '", name, "'");
+        auto t = py::cast<torch::Tensor>(workspace_dict[name]);
+        TORCH_CHECK(t.is_cuda(), "cosmos_workspace['", name, "'] must be CUDA");
+        TORCH_CHECK(t.device() == x_new.device(),
+                    "cosmos_workspace['", name, "'] must be on device ", x_new.device());
+        TORCH_CHECK(t.scalar_type() == dtype,
+                    "cosmos_workspace['", name, "'] has dtype ", t.scalar_type(),
+                    ", expected ", dtype);
+        bool exact = t.dim() == static_cast<int64_t>(shape.size());
+        if (exact) {
+            for (size_t dim = 0; dim < shape.size(); ++dim) {
+                exact = exact && t.size(static_cast<int64_t>(dim)) == shape[dim];
+            }
+        }
+        bool singleton = t.numel() == 1;
+        TORCH_CHECK(exact || singleton,
+                    "cosmos_workspace['", name, "'] must have shape [",
+                    shape.size() > 0 ? shape[0] : 0,
+                    shape.size() > 1 ? ", ..." : "",
+                    "] or be a singleton placeholder for this backend");
+        TORCH_CHECK(t.is_contiguous(), "cosmos_workspace['", name, "'] must be contiguous");
+        return t;
+    };
+
+    torch::Tensor qkv_row;
+    torch::Tensor q_row;
+    torch::Tensor k_row;
+    torch::Tensor v_row;
+    torch::Tensor q_bmhk;
+    torch::Tensor k_bmhk;
+    torch::Tensor o_bmhk;
+    torch::Tensor normed;
+    torch::Tensor ffn_intermediate;
+    torch::Tensor lora_hidden_sa;
+    torch::Tensor lora_hidden_ca;
+    torch::Tensor lora_hidden_mlp;
+    torch::Tensor mods_sa;
+    torch::Tensor mods_ca;
+    torch::Tensor mods_mlp;
+    // AdaLN-LoRA pre-stack scratch (Phase 1 of the AdaLN-LoRA pre-stack +
+    // strided-batched up GEMM optimization). Optional in workspace; required
+    // only when OMNIDREAMS_DIT_ADALN_PRECOMPUTE is enabled (default on).
+    torch::Tensor lora_hidden_all;
+    torch::Tensor mods_all;
+    torch::Tensor fl_hidden_scratch;
+    torch::Tensor fl_mods_scratch;
+    if (!use_external_workspace) {
+        g_cosmos_streaming_scratch.ensure(
+            B, M, K, H, D, FF, lora_dim, x_new.device(), x_new.scalar_type(), opts);
+        auto& scratch = g_cosmos_streaming_scratch;
+        qkv_row = scratch.qkv_row;
+        q_row = scratch.q_row;
+        k_row = scratch.k_row;
+        v_row = scratch.v_row;
+        q_bmhk = scratch.q_bmhk;
+        k_bmhk = scratch.k_bmhk;
+        o_bmhk = scratch.o_bmhk;
+        normed = scratch.normed;
+        ffn_intermediate = scratch.ffn_intermediate;
+        lora_hidden_sa = scratch.lora_hidden_sa;
+        lora_hidden_ca = scratch.lora_hidden_ca;
+        lora_hidden_mlp = scratch.lora_hidden_mlp;
+        mods_sa = scratch.mods_sa;
+        mods_ca = scratch.mods_ca;
+        mods_mlp = scratch.mods_mlp;
+        fl_hidden_scratch = scratch.fl_hidden;
+        fl_mods_scratch = scratch.fl_mods;
+    } else {
+        qkv_row = workspace_tensor("qkv_row", {M, 3 * K}, orig_scalar_type);
+        q_row = workspace_tensor("q_row", {M, K}, orig_scalar_type);
+        k_row = workspace_tensor("k_row", {M, K}, orig_scalar_type);
+        v_row = workspace_tensor("v_row", {M, K}, orig_scalar_type);
+        q_bmhk = workspace_tensor("q_bmhk", {M, H, D}, orig_scalar_type);
+        k_bmhk = workspace_tensor("k_bmhk", {M, H, D}, orig_scalar_type);
+        o_bmhk = workspace_tensor("o_bmhk", {M, H, D}, orig_scalar_type);
+        normed = workspace_tensor("normed", {M, K}, orig_scalar_type);
+        ffn_intermediate = workspace_tensor("ffn_intermediate", {M, FF}, orig_scalar_type);
+        lora_hidden_sa = workspace_tensor("lora_hidden_sa", {B, lora_dim}, orig_scalar_type);
+        lora_hidden_ca = workspace_tensor("lora_hidden_ca", {B, lora_dim}, orig_scalar_type);
+        lora_hidden_mlp = workspace_tensor("lora_hidden_mlp", {B, lora_dim}, orig_scalar_type);
+        mods_sa = workspace_tensor("mods_sa", {B, 3 * K}, orig_scalar_type);
+        mods_ca = workspace_tensor("mods_ca", {B, 3 * K}, orig_scalar_type);
+        mods_mlp = workspace_tensor("mods_mlp", {B, 3 * K}, orig_scalar_type);
+        // Optional AdaLN-LoRA pre-stack scratch buffers. Validate only if
+        // present in the workspace; the bridge falls back to per-block
+        // cosmos_adaln_lora_split when these are missing.
+        if (workspace_dict.contains("lora_hidden_all")) {
+            lora_hidden_all = workspace_tensor(
+                "lora_hidden_all", {num_blocks * 3, B, lora_dim}, orig_scalar_type);
+        }
+        if (workspace_dict.contains("mods_all")) {
+            mods_all = workspace_tensor(
+                "mods_all", {num_blocks * 3, B, 3 * K}, orig_scalar_type);
+        }
+    }
+    // v_bmhk aliases v_row inside the orchestrator (V has no transformation,
+    // and [M, K] / [M, H, D] are byte-equivalent for K = H*D).
+    auto linear_fp8_scratch = workspace_tensor("linear_fp8_scratch", {M, linear_scratch_features}, at::kByte);
+    auto linear_half_scratch = workspace_tensor("linear_half_scratch", {M, linear_scratch_features}, at::kHalf);
+    auto attn_q_fp8 = workspace_tensor("attn_q_fp8", {B, M, H, D}, at::kByte);
+    auto attn_k_fp8 = workspace_tensor("attn_k_fp8", {B, max_attn_tokens, H, D}, at::kByte);
+    auto attn_v_fp8 = workspace_tensor("attn_v_fp8", {B, max_attn_tokens, H, D}, at::kByte);
+    auto attn_q_bhmd_fp8 = workspace_tensor("attn_q_bhmd_fp8", {B, H, M, D}, at::kByte);
+    auto attn_k_bhmd_fp8 = workspace_tensor("attn_k_bhmd_fp8", {B, H, max_attn_tokens, D}, at::kByte);
+    auto attn_v_bhmd_fp8 = workspace_tensor("attn_v_bhmd_fp8", {B, H, max_attn_tokens, D}, at::kByte);
+    auto attn_v_bhdm_fp8 = workspace_tensor("attn_v_bhdm_fp8", {B, H, D, max_attn_tokens}, at::kByte);
+    const bool needs_sage3_fp8_attention_scratch =
+        attention_backend == omnidreams_singleview::CosmosAttentionBackend::SAGE3_FP8;
+    torch::Tensor attn_q_sage3_fp4;
+    torch::Tensor attn_q_sage3_sf;
+    if (needs_sage3_fp8_attention_scratch) {
+        attn_q_sage3_fp4 = workspace_tensor("attn_q_sage3_fp4", {B, H, sage3_q_padded, D / 2}, at::kByte);
+        attn_q_sage3_sf = workspace_tensor(
+            "attn_q_sage3_sf", {B, H, sage3_q_padded, D / 16}, at::ScalarType::Float8_e4m3fn);
+    }
+    const bool needs_dense_attention_scratch =
+        attention_backend == omnidreams_singleview::CosmosAttentionBackend::FP8_DENSE_REF;
+    auto attn_scores_half = workspace_tensor_singleton_or_shape(
+        "attn_scores_half", {B * H, M, max_attn_tokens}, at::kHalf, !needs_dense_attention_scratch);
+    auto attn_scores_bf16 = workspace_tensor_singleton_or_shape(
+        "attn_scores_bf16", {B * H, M, max_attn_tokens}, at::kBFloat16, !needs_dense_attention_scratch);
+    auto attn_score_c_bf16 = workspace_tensor_singleton_or_shape(
+        "attn_score_c_bf16", {B * H, M, max_attn_tokens}, at::kBFloat16, !needs_dense_attention_scratch);
+    auto attn_probs_fp8 = workspace_tensor_singleton_or_shape(
+        "attn_probs_fp8", {B * H, M, max_attn_tokens}, at::kByte, !needs_dense_attention_scratch);
+    auto attn_o_bhmd_half = workspace_tensor("attn_o_bhmd_half", {B, H, M, D}, at::kHalf);
+    auto attn_o_bhmd_bf16 = workspace_tensor("attn_o_bhmd_bf16", {B, H, M, D}, at::kBFloat16);
+    auto attn_o_c_bf16 = workspace_tensor("attn_o_c_bf16", {B, H, M, D}, at::kBFloat16);
+    auto attn_o_half = workspace_tensor("attn_o_half", {B, M, H, D}, at::kHalf);
+    const int64_t attn_tc_scale_elems = 12;
+    auto attn_tc_scale = workspace_tensor("attn_tc_scale", {attn_tc_scale_elems}, at::kFloat);
+
+    omnidreams_singleview::CosmosBlockBuffers buf{};
+    buf.qkv_row           = reinterpret_cast<cutlass::bfloat16_t*>(qkv_row.data_ptr<at::BFloat16>());
+    buf.q_row             = reinterpret_cast<cutlass::bfloat16_t*>(q_row.data_ptr<at::BFloat16>());
+    buf.k_row             = reinterpret_cast<cutlass::bfloat16_t*>(k_row.data_ptr<at::BFloat16>());
+    buf.v_row             = reinterpret_cast<cutlass::bfloat16_t*>(v_row.data_ptr<at::BFloat16>());
+    buf.q_bmhk            = reinterpret_cast<cutlass::bfloat16_t*>(q_bmhk.data_ptr<at::BFloat16>());
+    buf.k_bmhk            = reinterpret_cast<cutlass::bfloat16_t*>(k_bmhk.data_ptr<at::BFloat16>());
+    buf.v_bmhk            = nullptr;  // aliased to v_row inside orchestrator
+    buf.o_bmhk            = reinterpret_cast<cutlass::bfloat16_t*>(o_bmhk.data_ptr<at::BFloat16>());
+    buf.attn_out_row      = nullptr;  // aliased to o_bmhk inside orchestrator
+    buf.normed            = reinterpret_cast<cutlass::bfloat16_t*>(normed.data_ptr<at::BFloat16>());
+    buf.ffn_intermediate  = reinterpret_cast<cutlass::bfloat16_t*>(ffn_intermediate.data_ptr<at::BFloat16>());
+    buf.lora_hidden_sa    = reinterpret_cast<cutlass::bfloat16_t*>(lora_hidden_sa.data_ptr<at::BFloat16>());
+    buf.lora_hidden_ca    = reinterpret_cast<cutlass::bfloat16_t*>(lora_hidden_ca.data_ptr<at::BFloat16>());
+    buf.lora_hidden_mlp   = reinterpret_cast<cutlass::bfloat16_t*>(lora_hidden_mlp.data_ptr<at::BFloat16>());
+    buf.mods_sa           = reinterpret_cast<cutlass::bfloat16_t*>(mods_sa.data_ptr<at::BFloat16>());
+    buf.mods_ca           = reinterpret_cast<cutlass::bfloat16_t*>(mods_ca.data_ptr<at::BFloat16>());
+    buf.mods_mlp          = reinterpret_cast<cutlass::bfloat16_t*>(mods_mlp.data_ptr<at::BFloat16>());
+    buf.linear_fp8_scratch = reinterpret_cast<cutlass::float_e4m3_t*>(linear_fp8_scratch.data_ptr<uint8_t>());
+    buf.linear_half_scratch = reinterpret_cast<cutlass::half_t*>(linear_half_scratch.data_ptr<at::Half>());
+    buf.attn_q_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_q_fp8.data_ptr<uint8_t>());
+    buf.attn_k_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_k_fp8.data_ptr<uint8_t>());
+    buf.attn_v_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_v_fp8.data_ptr<uint8_t>());
+    buf.attn_q_bhmd_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_q_bhmd_fp8.data_ptr<uint8_t>());
+    buf.attn_k_bhmd_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_k_bhmd_fp8.data_ptr<uint8_t>());
+    buf.attn_v_bhmd_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_v_bhmd_fp8.data_ptr<uint8_t>());
+    buf.attn_v_bhdm_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_v_bhdm_fp8.data_ptr<uint8_t>());
+    buf.attn_q_sage3_fp4 = needs_sage3_fp8_attention_scratch
+        ? attn_q_sage3_fp4.data_ptr<uint8_t>()
+        : nullptr;
+    buf.attn_q_sage3_sf = needs_sage3_fp8_attention_scratch
+        ? reinterpret_cast<cutlass::float_e4m3_t*>(attn_q_sage3_sf.data_ptr())
+        : nullptr;
+    buf.attn_scores_half = reinterpret_cast<cutlass::half_t*>(attn_scores_half.data_ptr<at::Half>());
+    buf.attn_scores_bf16 = reinterpret_cast<cutlass::bfloat16_t*>(attn_scores_bf16.data_ptr<at::BFloat16>());
+    buf.attn_score_c_bf16 = reinterpret_cast<cutlass::bfloat16_t*>(attn_score_c_bf16.data_ptr<at::BFloat16>());
+    buf.attn_probs_fp8 = reinterpret_cast<cutlass::float_e4m3_t*>(attn_probs_fp8.data_ptr<uint8_t>());
+    buf.attn_o_bhmd_half = reinterpret_cast<cutlass::half_t*>(attn_o_bhmd_half.data_ptr<at::Half>());
+    buf.attn_o_bhmd_bf16 = reinterpret_cast<cutlass::bfloat16_t*>(attn_o_bhmd_bf16.data_ptr<at::BFloat16>());
+    buf.attn_o_c_bf16 = reinterpret_cast<cutlass::bfloat16_t*>(attn_o_c_bf16.data_ptr<at::BFloat16>());
+    buf.attn_o_half = reinterpret_cast<cutlass::half_t*>(attn_o_half.data_ptr<at::Half>());
+    buf.attn_tc_scale = attn_tc_scale.data_ptr<float>();
+    buf.attn_tc_scale_elems = attn_tc_scale_elems;
+    buf.attn_tc_scale_is_ones = attn_tc_scale_is_ones;
+    rec(EV_AFTER_ROPE_SCRATCH);
+
+    // ── 5a. AdaLN-LoRA pre-stack + global down + batched up GEMMs ──────────
+    //
+    // Replaces 168 launch-bound CUTLASS BF16 GEMVs (84 down + 84 up) per
+    // forward with one wide BF16 GEMM (down) + one strided-batched BF16
+    // GEMM (up). All 28 blocks share the same SiLU(t_emb) and adaln_lora_3D,
+    // so the whole AdaLN-LoRA stage collapses to two launches at the top
+    // of the forward.
+    //
+    // Gated by OMNIDREAMS_DIT_ADALN_PRECOMPUTE (default ON). Falls back to the
+    // per-block cosmos_adaln_lora_split path when:
+    //   - workspace doesn't include lora_hidden_all / mods_all
+    //   - first call happens during graph capture (cudaMalloc unsafe; the
+    //     persistent stacks are allocated in eager warmup before capture)
+    //   - cuBLASLt doesn't support the strided-batched bias broadcast we
+    //     request (heuristic returns no algo): we set the flag false and
+    //     the per-block path runs in this forward.
+    //
+    // The stacked weight buffers (`g_adaln_down_stack`, `g_adaln_up_stack`)
+    // are persistent across forwards. They are (re)populated only when
+    // (num_blocks, K, lora_dim, weight_pointer_fingerprint) changes — i.e.
+    // exactly once per process for typical inference.
+    static cutlass::bfloat16_t* g_adaln_down_stack = nullptr;
+    static cutlass::bfloat16_t* g_adaln_up_stack = nullptr;
+    static int g_adaln_num_blocks = 0;
+    static int g_adaln_K = 0;
+    static int g_adaln_lora_dim = 0;
+    static const cutlass::bfloat16_t* g_adaln_fingerprint_down = nullptr;
+
+    auto adaln_precompute_env_enabled = []() {
+        const char* v = std::getenv("OMNIDREAMS_DIT_ADALN_PRECOMPUTE");
+        if (!v || !v[0]) return true;
+        return v[0] != '0' && v[0] != 'f' && v[0] != 'F' && v[0] != 'n' && v[0] != 'N';
+    };
+    bool adaln_precompute_enabled =
+        adaln_precompute_env_enabled() &&
+        lora_hidden_all.defined() &&
+        mods_all.defined();
+
+    if (adaln_precompute_enabled) {
+        cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+        cudaError_t cap_err = cudaStreamIsCapturing(stream, &capture_status);
+        const bool capturing = (cap_err == cudaSuccess) &&
+                               (capture_status != cudaStreamCaptureStatusNone);
+
+        const cutlass::bfloat16_t* fingerprint = reinterpret_cast<const cutlass::bfloat16_t*>(
+            get_w(weights, "blocks.0.adaln_modulation_self_attn.1.weight").data_ptr<at::BFloat16>());
+        const bool shape_changed =
+            (g_adaln_num_blocks != num_blocks) ||
+            (g_adaln_K != K) ||
+            (g_adaln_lora_dim != lora_dim) ||
+            (g_adaln_fingerprint_down != fingerprint);
+
+        if (shape_changed) {
+            if (capturing) {
+                adaln_precompute_enabled = false;
+            } else {
+                if (g_adaln_down_stack || g_adaln_up_stack) {
+                    cudaStreamSynchronize(stream);
+                }
+                size_t down_bytes = size_t(num_blocks) * 3 * lora_dim * K * sizeof(cutlass::bfloat16_t);
+                size_t up_bytes   = size_t(num_blocks) * 3 * 3 * K * lora_dim * sizeof(cutlass::bfloat16_t);
+                if (g_adaln_down_stack) cudaFree(g_adaln_down_stack);
+                if (g_adaln_up_stack)   cudaFree(g_adaln_up_stack);
+                g_adaln_down_stack = nullptr;
+                g_adaln_up_stack = nullptr;
+                cudaError_t a1 = cudaMalloc(reinterpret_cast<void**>(&g_adaln_down_stack), down_bytes);
+                cudaError_t a2 = cudaMalloc(reinterpret_cast<void**>(&g_adaln_up_stack), up_bytes);
+                TORCH_CHECK(a1 == cudaSuccess && a2 == cudaSuccess,
+                            "AdaLN-LoRA stack cudaMalloc failed: ",
+                            cudaGetErrorString(a1 != cudaSuccess ? a1 : a2));
+
+                static const std::array<const char*, 3> sublayer_names = {
+                    "self_attn", "cross_attn", "mlp",
+                };
+                size_t per_instance_down_bytes = size_t(lora_dim) * K * sizeof(cutlass::bfloat16_t);
+                size_t per_instance_up_bytes   = size_t(3) * K * lora_dim * sizeof(cutlass::bfloat16_t);
+                for (int bi = 0; bi < num_blocks; ++bi) {
+                    const std::string p_b = block_prefix(bi);
+                    for (int sj = 0; sj < 3; ++sj) {
+                        std::string down_key = p_b + "adaln_modulation_" + sublayer_names[sj] + ".1.weight";
+                        std::string up_key   = p_b + "adaln_modulation_" + sublayer_names[sj] + ".2.weight";
+                        auto down_t = get_w(weights, down_key);
+                        auto up_t   = get_w(weights, up_key);
+                        TORCH_CHECK(down_t.scalar_type() == at::kBFloat16 &&
+                                    up_t.scalar_type() == at::kBFloat16,
+                                    "AdaLN-LoRA weights must be torch.bfloat16; got ",
+                                    down_t.scalar_type(), "/", up_t.scalar_type());
+                        TORCH_CHECK((int)down_t.size(0) == lora_dim &&
+                                    (int)down_t.size(1) == K,
+                                    "Expected adaln down weight shape [", lora_dim, ", ", K,
+                                    "], got [", down_t.size(0), ", ", down_t.size(1), "]");
+                        TORCH_CHECK((int)up_t.size(0) == 3 * K &&
+                                    (int)up_t.size(1) == lora_dim,
+                                    "Expected adaln up weight shape [", 3 * K, ", ", lora_dim,
+                                    "], got [", up_t.size(0), ", ", up_t.size(1), "]");
+                        int instance = bi * 3 + sj;
+                        cudaMemcpyAsync(
+                            g_adaln_down_stack + size_t(instance) * lora_dim * K,
+                            down_t.data_ptr<at::BFloat16>(),
+                            per_instance_down_bytes,
+                            cudaMemcpyDeviceToDevice, stream);
+                        cudaMemcpyAsync(
+                            g_adaln_up_stack + size_t(instance) * 3 * K * lora_dim,
+                            up_t.data_ptr<at::BFloat16>(),
+                            per_instance_up_bytes,
+                            cudaMemcpyDeviceToDevice, stream);
+                    }
+                }
+                g_adaln_num_blocks = num_blocks;
+                g_adaln_K = K;
+                g_adaln_lora_dim = lora_dim;
+                g_adaln_fingerprint_down = fingerprint;
+            }
+        }
+
+        if (adaln_precompute_enabled) {
+            cutlass::bfloat16_t* lora_hidden_base =
+                reinterpret_cast<cutlass::bfloat16_t*>(lora_hidden_all.data_ptr<at::BFloat16>());
+            cutlass::bfloat16_t* mods_base =
+                reinterpret_cast<cutlass::bfloat16_t*>(mods_all.data_ptr<at::BFloat16>());
+            const cutlass::bfloat16_t* silu_emb_ptr =
+                reinterpret_cast<const cutlass::bfloat16_t*>(t_emb_silu.data_ptr<at::BFloat16>());
+            const cutlass::bfloat16_t* lora_3d_ptr =
+                reinterpret_cast<const cutlass::bfloat16_t*>(adaln_lora_BD.data_ptr<at::BFloat16>());
+
+            int N_down = num_blocks * 3 * lora_dim;
+            cudaError_t e_down = omnidreams_singleview::cutlass_linear_layer_rrr_bf16(
+                silu_emb_ptr, g_adaln_down_stack, /*bias=*/nullptr,
+                lora_hidden_base, B, K, N_down, stream);
+            TORCH_CHECK(e_down == cudaSuccess,
+                        "AdaLN-LoRA global down GEMM failed: ", cudaGetErrorString(e_down));
+
+            int batchCount = num_blocks * 3;
+            int64_t stride_a    = int64_t(B) * lora_dim;
+            int64_t stride_b    = int64_t(3) * K * lora_dim;
+            int64_t stride_d    = int64_t(B) * 3 * K;
+            int64_t stride_bias = 0;
+            cudaError_t e_up = omnidreams_singleview::cublaslt_strided_batched_bf16_gemm(
+                lora_hidden_base, g_adaln_up_stack, lora_3d_ptr, mods_base,
+                B, lora_dim, 3 * K,
+                batchCount,
+                stride_a, stride_b, stride_d, stride_bias,
+                stream);
+            if (e_up != cudaSuccess) {
+                std::fprintf(stderr,
+                    "[OmniDreams single-view native extension] AdaLN-LoRA batched up GEMM failed (%s); "
+                    "falling back to per-block path for this forward.\n",
+                    cudaGetErrorString(e_up));
+                adaln_precompute_enabled = false;
+            }
+        }
+    }
+
+    // x is updated in place block-by-block. Make `cur` contiguous and own
+    // its own storage (the residual updates are in-place writes). cur
+    // currently holds [B, L, K] from x_embedder + hdmap.
+    cur = cur.contiguous();
+
+    torch::Tensor trace_tensor;
+    bool trace_enabled = false;
+    if (config.contains("cosmos_trace_tensor")) {
+        trace_tensor = py::cast<torch::Tensor>(config["cosmos_trace_tensor"]);
+        TORCH_CHECK(trace_tensor.is_cuda(), "config['cosmos_trace_tensor'] must be CUDA");
+        TORCH_CHECK(trace_tensor.device() == x_new.device(),
+                    "config['cosmos_trace_tensor'] must be on device ", x_new.device());
+        TORCH_CHECK(trace_tensor.scalar_type() == at::kBFloat16,
+                    "config['cosmos_trace_tensor'] must be torch.bfloat16; got ",
+                    trace_tensor.scalar_type());
+        TORCH_CHECK(trace_tensor.dim() == 5 &&
+                    trace_tensor.size(0) == num_blocks &&
+                    trace_tensor.size(1) == 4 &&
+                    trace_tensor.size(2) == B &&
+                    trace_tensor.size(3) == M &&
+                    trace_tensor.size(4) == K,
+                    "config['cosmos_trace_tensor'] must have shape [num_blocks, 4, B, M, K] = [",
+                    num_blocks, ", 4, ", B, ", ", M, ", ", K, "]");
+        TORCH_CHECK(trace_tensor.is_contiguous(), "config['cosmos_trace_tensor'] must be contiguous");
+        trace_enabled = true;
+    }
+
+    torch::Tensor block_mods_sa;
+    torch::Tensor block_mods_ca;
+    torch::Tensor block_mods_mlp;
+    bool block_mod_cache_enabled = false;
+    if (config.contains("cosmos_block_mods_sa") ||
+        config.contains("cosmos_block_mods_ca") ||
+        config.contains("cosmos_block_mods_mlp")) {
+        TORCH_CHECK(config.contains("cosmos_block_mods_sa") &&
+                    config.contains("cosmos_block_mods_ca") &&
+                    config.contains("cosmos_block_mods_mlp"),
+                    "precomputed block AdaLN requires config['cosmos_block_mods_sa'], "
+                    "config['cosmos_block_mods_ca'], and config['cosmos_block_mods_mlp']");
+        auto validate_block_mod_cache = [&](const torch::Tensor& t, const char* name) {
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.device() == x_new.device(), name, " must be on device ", x_new.device());
+            TORCH_CHECK(t.scalar_type() == orig_scalar_type,
+                        name, " has dtype ", t.scalar_type(), ", expected ", orig_scalar_type);
+            TORCH_CHECK(t.dim() == 3 &&
+                        (int)t.size(0) == num_blocks &&
+                        (int)t.size(1) == B &&
+                        (int)t.size(2) == 3 * K,
+                        name, " must have shape [", num_blocks, ", ", B, ", ", 3 * K,
+                        "], got [",
+                        t.dim() > 0 ? t.size(0) : 0, ", ",
+                        t.dim() > 1 ? t.size(1) : 0, ", ",
+                        t.dim() > 2 ? t.size(2) : 0, "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        block_mods_sa = py::cast<torch::Tensor>(config["cosmos_block_mods_sa"]);
+        block_mods_ca = py::cast<torch::Tensor>(config["cosmos_block_mods_ca"]);
+        block_mods_mlp = py::cast<torch::Tensor>(config["cosmos_block_mods_mlp"]);
+        validate_block_mod_cache(block_mods_sa, "config['cosmos_block_mods_sa']");
+        validate_block_mod_cache(block_mods_ca, "config['cosmos_block_mods_ca']");
+        validate_block_mod_cache(block_mods_mlp, "config['cosmos_block_mods_mlp']");
+        block_mod_cache_enabled = true;
+    }
+
+    auto validate_fp8_activation_tensor_shape = [&](const torch::Tensor& tensor, const char* name) {
+        TORCH_CHECK(tensor.scalar_type() == at::kFloat, name, " must be torch.float32; got ", tensor.scalar_type());
+        TORCH_CHECK(tensor.dim() == 2 &&
+                    tensor.size(0) == num_blocks &&
+                    tensor.size(1) == omnidreams_singleview::kCosmosFp8ActivationScaleSites,
+                    name, " must have shape [num_blocks, ",
+                    omnidreams_singleview::kCosmosFp8ActivationScaleSites, "] = [",
+                    num_blocks, ", ", omnidreams_singleview::kCosmosFp8ActivationScaleSites, "]");
+        TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+    };
+    torch::Tensor fp8_activation_scales_host;
+    bool fp8_activation_scales_enabled = false;
+    if (config.contains("cosmos_fp8_activation_scales")) {
+        auto fp8_activation_scales = py::cast<torch::Tensor>(config["cosmos_fp8_activation_scales"]);
+        validate_fp8_activation_tensor_shape(fp8_activation_scales, "config['cosmos_fp8_activation_scales']");
+        if (fp8_activation_scales.is_cuda()) {
+            TORCH_CHECK(fp8_activation_scales.device() == x_new.device(),
+                        "config['cosmos_fp8_activation_scales'] must be on device ", x_new.device(),
+                        " when CUDA");
+        }
+        fp8_activation_scales_host = fp8_activation_scales.to(torch::kCPU).contiguous();
+        fp8_activation_scales_enabled = true;
+    }
+    torch::Tensor fp8_activation_amax_tensor;
+    bool fp8_activation_amax_enabled = false;
+    if (config.contains("cosmos_fp8_activation_amax_tensor")) {
+        fp8_activation_amax_tensor = py::cast<torch::Tensor>(config["cosmos_fp8_activation_amax_tensor"]);
+        TORCH_CHECK(fp8_activation_amax_tensor.is_cuda(),
+                    "config['cosmos_fp8_activation_amax_tensor'] must be CUDA");
+        TORCH_CHECK(fp8_activation_amax_tensor.device() == x_new.device(),
+                    "config['cosmos_fp8_activation_amax_tensor'] must be on device ", x_new.device());
+        validate_fp8_activation_tensor_shape(fp8_activation_amax_tensor, "config['cosmos_fp8_activation_amax_tensor']");
+        fp8_activation_amax_enabled = true;
+    }
+
+    // ── 5b. Per-block loop: one C++ orchestrator call per block ──────────────
+    for (int i = 0; i < num_blocks; ++i) {
+        const std::string p = block_prefix(i);
+
+        auto get_block_linear_weight = [&](const std::string& rel_key) {
+            std::string key = p + rel_key;
+            auto canonical = get_w(weights, key);
+            auto t = canonical;
+            if (quantized_prepared && canonical.scalar_type() == at::kByte) {
+                std::string prepared_key = key + "_fp8_prepared";
+                if (weights.contains(py::str(prepared_key))) {
+                    t = get_w(weights, prepared_key);
+                    TORCH_CHECK(t.scalar_type() == at::kByte,
+                                prepared_key, " must be torch.uint8 raw E4M3 bytes; got ",
+                                t.scalar_type());
+                    TORCH_CHECK(t.dim() == canonical.dim(),
+                                prepared_key, " must have the same rank as ", key);
+                    for (int64_t dim = 0; dim < canonical.dim(); ++dim) {
+                        TORCH_CHECK(t.size(dim) == canonical.size(dim),
+                                    prepared_key, " must have the same shape as ", key);
+                    }
+                    TORCH_CHECK(t.is_contiguous(), prepared_key, " must be contiguous");
+                    t = t.contiguous();
+                } else if (quantized_prepared_strict) {
+                    TORCH_CHECK(false,
+                                "missing FP8 prepared alias ", prepared_key,
+                                " while cosmos_quantized_prepared_strict=True");
+                }
+            }
+            if (linear_backend == omnidreams_singleview::CosmosLinearBackend::FP8) {
+                TORCH_CHECK(t.scalar_type() == at::kByte,
+                            key, " must be torch.uint8 raw E4M3 bytes when cosmos_linear_backend=fp8; got ",
+                            t.scalar_type());
+            } else if (linear_backend == omnidreams_singleview::CosmosLinearBackend::BF16) {
+                TORCH_CHECK(t.scalar_type() == at::kBFloat16,
+                            key, " must be torch.bfloat16 when cosmos_linear_backend=bf16; got ",
+                            t.scalar_type());
+            } else {
+                TORCH_CHECK(t.scalar_type() == at::kByte || t.scalar_type() == at::kBFloat16,
+                            key, " must be torch.bfloat16 or torch.uint8 raw E4M3 bytes "
+                            "when cosmos_linear_backend=mixed; got ", t.scalar_type());
+            }
+            return t;
+        };
+        auto has_block_weight = [&](const std::string& rel_key) {
+            std::string key = p + rel_key;
+            return weights.contains(py::str(key));
+        };
+        auto get_block_linear_scale = [&](const std::string& rel_key, const torch::Tensor& weight) {
+            if (weight.scalar_type() != at::kByte) {
+                return torch::Tensor();
+            }
+            std::string canonical_key = p + rel_key + "_scale";
+            std::string key = canonical_key;
+            bool using_prepared_scale = false;
+            if (quantized_prepared) {
+                std::string prepared_key = p + rel_key + "_fp8_prepared_scale";
+                if (weights.contains(py::str(prepared_key))) {
+                    key = prepared_key;
+                    using_prepared_scale = true;
+                } else if (quantized_prepared_strict) {
+                    TORCH_CHECK(false,
+                                "missing FP8 prepared scale alias ", prepared_key,
+                                " while cosmos_quantized_prepared_strict=True");
+                }
+            }
+            auto s = get_w(weights, key);
+            if (using_prepared_scale) {
+                TORCH_CHECK(s.scalar_type() == at::kHalf,
+                            key, " must be torch.float16; got ", s.scalar_type());
+            }
+            if (s.scalar_type() != at::kHalf) {
+                s = s.to(torch::kFloat16);
+            }
+            TORCH_CHECK(s.dim() == 1, key, " must be [out_features]");
+            TORCH_CHECK(s.numel() == weight.size(0),
+                        key, " must have ", weight.size(0), " elements, got ", s.numel());
+            TORCH_CHECK(s.is_contiguous(), key, " must be contiguous");
+            return s.contiguous();
+        };
+        auto linear_weight_ptr = [&](const torch::Tensor& t) -> const void* {
+            if (t.scalar_type() == at::kByte) {
+                return t.data_ptr<uint8_t>();
+            }
+            return t.data_ptr<at::BFloat16>();
+        };
+        auto scale_ptr = [](const torch::Tensor& t) -> const cutlass::half_t* {
+            return t.defined()
+                ? reinterpret_cast<const cutlass::half_t*>(t.data_ptr<at::Half>())
+                : nullptr;
+        };
+        auto optional_prepared_weight = [&](const std::string& rel_key,
+                                            int rows,
+                                            int cols) -> torch::Tensor {
+            std::string key = p + rel_key + "_prepared";
+            if (!weights.contains(py::str(key))) {
+                return torch::Tensor();
+            }
+            auto t = get_w(weights, key);
+            TORCH_CHECK(t.scalar_type() == at::kBFloat16,
+                        key, " must be torch.bfloat16; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 2 && (int)t.size(0) == rows && (int)t.size(1) == cols,
+                        key, " must have shape [", rows, ", ", cols, "], got [",
+                        t.dim() > 0 ? t.size(0) : 0, ", ",
+                        t.dim() > 1 ? t.size(1) : 0, "]");
+            return t;
+        };
+        auto prepared_ptr = [](const torch::Tensor& t) -> const cutlass::bfloat16_t* {
+            return t.defined()
+                ? reinterpret_cast<const cutlass::bfloat16_t*>(t.data_ptr<at::BFloat16>())
+                : nullptr;
+        };
+
+        const bool use_fused_sa_qkv =
+            has_block_weight("self_attn.qkv_proj.weight") &&
+            get_w(weights, p + "self_attn.qkv_proj.weight").scalar_type() == at::kByte;
+        torch::Tensor sa_w_qkv_t;
+        torch::Tensor sa_w_qkv_scale_t;
+        if (use_fused_sa_qkv) {
+            sa_w_qkv_t = get_block_linear_weight("self_attn.qkv_proj.weight");
+            sa_w_qkv_scale_t = get_block_linear_scale("self_attn.qkv_proj.weight", sa_w_qkv_t);
+            TORCH_CHECK(sa_w_qkv_t.dim() == 2 && (int)sa_w_qkv_t.size(0) == 3 * K &&
+                        (int)sa_w_qkv_t.size(1) == K,
+                        p, "self_attn.qkv_proj.weight must have shape [", 3 * K, ", ", K,
+                        "], got [", sa_w_qkv_t.dim() > 0 ? sa_w_qkv_t.size(0) : 0,
+                        ", ", sa_w_qkv_t.dim() > 1 ? sa_w_qkv_t.size(1) : 0, "]");
+            TORCH_CHECK(sa_w_qkv_scale_t.numel() == 3 * K,
+                        p, "self_attn.qkv_proj.weight_scale must have ", 3 * K,
+                        " elements, got ", sa_w_qkv_scale_t.numel());
+        }
+        auto sa_w_q_t = use_fused_sa_qkv ? torch::Tensor() : get_block_linear_weight("self_attn.q_proj.weight");
+        auto sa_w_k_t = use_fused_sa_qkv ? torch::Tensor() : get_block_linear_weight("self_attn.k_proj.weight");
+        auto sa_w_v_t = use_fused_sa_qkv ? torch::Tensor() : get_block_linear_weight("self_attn.v_proj.weight");
+        auto sa_w_out_t = get_block_linear_weight("self_attn.output_proj.weight");
+        auto ca_w_q_t = get_block_linear_weight("cross_attn.q_proj.weight");
+        auto ca_w_out_t = get_block_linear_weight("cross_attn.output_proj.weight");
+        auto ffn_w1_t = get_block_linear_weight("mlp.layer1.weight");
+        auto ffn_w2_t = get_block_linear_weight("mlp.layer2.weight");
+
+        auto sa_w_q_scale_t = use_fused_sa_qkv ? torch::Tensor() : get_block_linear_scale("self_attn.q_proj.weight", sa_w_q_t);
+        auto sa_w_k_scale_t = use_fused_sa_qkv ? torch::Tensor() : get_block_linear_scale("self_attn.k_proj.weight", sa_w_k_t);
+        auto sa_w_v_scale_t = use_fused_sa_qkv ? torch::Tensor() : get_block_linear_scale("self_attn.v_proj.weight", sa_w_v_t);
+        auto sa_w_out_scale_t = get_block_linear_scale("self_attn.output_proj.weight", sa_w_out_t);
+        auto ca_w_q_scale_t = get_block_linear_scale("cross_attn.q_proj.weight", ca_w_q_t);
+        auto ca_w_out_scale_t = get_block_linear_scale("cross_attn.output_proj.weight", ca_w_out_t);
+        auto ffn_w1_scale_t = get_block_linear_scale("mlp.layer1.weight", ffn_w1_t);
+        auto ffn_w2_scale_t = get_block_linear_scale("mlp.layer2.weight", ffn_w2_t);
+        auto sa_w_qkv_prepared_t = optional_prepared_weight("self_attn.qkv_proj.weight", K, 3 * K);
+        auto sa_w_out_prepared_t = optional_prepared_weight("self_attn.output_proj.weight", K, K);
+        auto ca_w_q_prepared_t = optional_prepared_weight("cross_attn.q_proj.weight", K, K);
+        auto ca_w_out_prepared_t = optional_prepared_weight("cross_attn.output_proj.weight", K, K);
+        auto ffn_w1_prepared_t = optional_prepared_weight("mlp.layer1.weight", K, FF);
+        auto ffn_w2_prepared_t = optional_prepared_weight("mlp.layer2.weight", FF, K);
+
+        omnidreams_singleview::CosmosBlockWeights bw{};
+        bw.sa_w_qkv        = use_fused_sa_qkv ? linear_weight_ptr(sa_w_qkv_t) : nullptr;
+        bw.sa_w_q          = use_fused_sa_qkv ? nullptr : linear_weight_ptr(sa_w_q_t);
+        bw.sa_w_k          = use_fused_sa_qkv ? nullptr : linear_weight_ptr(sa_w_k_t);
+        bw.sa_w_v          = use_fused_sa_qkv ? nullptr : linear_weight_ptr(sa_w_v_t);
+        bw.sa_w_out        = linear_weight_ptr(sa_w_out_t);
+        bw.sa_w_qkv_scale  = use_fused_sa_qkv ? scale_ptr(sa_w_qkv_scale_t) : nullptr;
+        bw.sa_w_q_scale    = scale_ptr(sa_w_q_scale_t);
+        bw.sa_w_k_scale    = scale_ptr(sa_w_k_scale_t);
+        bw.sa_w_v_scale    = scale_ptr(sa_w_v_scale_t);
+        bw.sa_w_out_scale  = scale_ptr(sa_w_out_scale_t);
+        bw.sa_w_qkv_prepared = prepared_ptr(sa_w_qkv_prepared_t);
+        bw.sa_w_out_prepared = prepared_ptr(sa_w_out_prepared_t);
+        bw.sa_q_norm       = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "self_attn.q_norm.weight").data_ptr<at::BFloat16>());
+        bw.sa_k_norm       = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "self_attn.k_norm.weight").data_ptr<at::BFloat16>());
+        bw.ca_w_q          = linear_weight_ptr(ca_w_q_t);
+        bw.ca_w_out        = linear_weight_ptr(ca_w_out_t);
+        bw.ca_w_q_scale    = scale_ptr(ca_w_q_scale_t);
+        bw.ca_w_out_scale  = scale_ptr(ca_w_out_scale_t);
+        bw.ca_w_q_prepared = prepared_ptr(ca_w_q_prepared_t);
+        bw.ca_w_out_prepared = prepared_ptr(ca_w_out_prepared_t);
+        bw.ca_q_norm       = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "cross_attn.q_norm.weight").data_ptr<at::BFloat16>());
+        bw.ffn_w1          = linear_weight_ptr(ffn_w1_t);
+        bw.ffn_w2          = linear_weight_ptr(ffn_w2_t);
+        bw.ffn_w1_scale    = scale_ptr(ffn_w1_scale_t);
+        bw.ffn_w2_scale    = scale_ptr(ffn_w2_scale_t);
+        bw.ffn_w1_prepared = prepared_ptr(ffn_w1_prepared_t);
+        bw.ffn_w2_prepared = prepared_ptr(ffn_w2_prepared_t);
+        bw.adaln_sa_down   = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "adaln_modulation_self_attn.1.weight").data_ptr<at::BFloat16>());
+        bw.adaln_sa_up     = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "adaln_modulation_self_attn.2.weight").data_ptr<at::BFloat16>());
+        bw.adaln_ca_down   = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "adaln_modulation_cross_attn.1.weight").data_ptr<at::BFloat16>());
+        bw.adaln_ca_up     = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "adaln_modulation_cross_attn.2.weight").data_ptr<at::BFloat16>());
+        bw.adaln_mlp_down  = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "adaln_modulation_mlp.1.weight").data_ptr<at::BFloat16>());
+        bw.adaln_mlp_up    = reinterpret_cast<const cutlass::bfloat16_t*>(get_w(weights, p + "adaln_modulation_mlp.2.weight").data_ptr<at::BFloat16>());
+
+        // Cross-attn KV caches: FlashDreams stores them as [B*V, Mk_c, H, D].
+        // With V==1 this is [B, Mk_c, H, D]. Self-attn caches: [B*V, cap, H, D].
+        TORCH_CHECK(k_cross_caches[i].is_cuda() && k_cross_caches[i].dim() == 4);
+        TORCH_CHECK(v_cross_caches[i].is_cuda() && v_cross_caches[i].dim() == 4);
+        TORCH_CHECK(k_self_caches[i].is_cuda()  && k_self_caches[i].dim() == 4);
+        TORCH_CHECK(v_self_caches[i].is_cuda()  && v_self_caches[i].dim() == 4);
+        int Mk_c = (int)k_cross_caches[i].size(1);
+        int cap  = (int)k_self_caches[i].size(1);
+        auto validate_fp8_cache = [&](const torch::Tensor& t, const char* name, int tokens) {
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.scalar_type() == at::kByte,
+                        name, " must be torch.uint8 raw E4M3 bytes; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 4,
+                        name, " must be 4D [B, tokens, H, D]; got dim=", t.dim());
+            TORCH_CHECK((int)t.size(0) == B && (int)t.size(1) >= tokens &&
+                        (int)t.size(2) == H && (int)t.size(3) == D,
+                        name, " must have shape [", B, ", >= ", tokens, ", ", H, ", ", D,
+                        "], got [", t.size(0), ", ", t.size(1), ", ", t.size(2), ", ", t.size(3), "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        auto validate_fp8_k_bhmd_cache = [&](const torch::Tensor& t, const char* name, int tokens) {
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.scalar_type() == at::kByte,
+                        name, " must be torch.uint8 raw E4M3 bytes; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 4,
+                        name, " must be 4D [B, H, tokens, D]; got dim=", t.dim());
+            TORCH_CHECK((int)t.size(0) == B && (int)t.size(1) == H &&
+                        (int)t.size(2) >= tokens && (int)t.size(3) == D,
+                        name, " must have shape [", B, ", ", H, ", >= ", tokens, ", ", D,
+                        "], got [", t.size(0), ", ", t.size(1), ", ", t.size(2), ", ", t.size(3), "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        auto validate_fp8_v_bhdm_cache = [&](const torch::Tensor& t, const char* name, int tokens) {
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.scalar_type() == at::kByte,
+                        name, " must be torch.uint8 raw E4M3 bytes; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 4,
+                        name, " must be 4D [B, H, D, tokens]; got dim=", t.dim());
+            TORCH_CHECK((int)t.size(0) == B && (int)t.size(1) == H &&
+                        (int)t.size(2) == D && (int)t.size(3) >= tokens,
+                        name, " must have shape [", B, ", ", H, ", ", D, ", >= ", tokens,
+                        "], got [", t.size(0), ", ", t.size(1), ", ", t.size(2), ", ", t.size(3), "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        auto validate_sage3_k_fp4_cache = [&](const torch::Tensor& t, const char* name, int tokens) {
+            int padded = ((tokens + 127) / 128) * 128;
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.scalar_type() == at::kByte,
+                        name, " must be torch.uint8 Sage3 FP4 bytes; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 4,
+                        name, " must be 4D [B, H, padded_tokens, D/2]; got dim=", t.dim());
+            TORCH_CHECK((int)t.size(0) == B && (int)t.size(1) == H &&
+                        (int)t.size(2) == padded && (int)t.size(3) == D / 2,
+                        name, " must have shape [", B, ", ", H, ", ", padded, ", ", D / 2,
+                        "], got [", t.size(0), ", ", t.size(1), ", ", t.size(2), ", ", t.size(3), "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        auto validate_sage3_v_fp4_cache = [&](const torch::Tensor& t, const char* name, int tokens) {
+            int padded = ((tokens + 127) / 128) * 128;
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.scalar_type() == at::kByte,
+                        name, " must be torch.uint8 Sage3 FP4 bytes; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 4,
+                        name, " must be 4D [B, H, D, padded_tokens/2]; got dim=", t.dim());
+            TORCH_CHECK((int)t.size(0) == B && (int)t.size(1) == H &&
+                        (int)t.size(2) == D && (int)t.size(3) == padded / 2,
+                        name, " must have shape [", B, ", ", H, ", ", D, ", ", padded / 2,
+                        "], got [", t.size(0), ", ", t.size(1), ", ", t.size(2), ", ", t.size(3), "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        auto validate_sage3_k_sf_cache = [&](const torch::Tensor& t, const char* name, int tokens) {
+            int padded = ((tokens + 127) / 128) * 128;
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.scalar_type() == at::ScalarType::Float8_e4m3fn,
+                        name, " must be torch.float8_e4m3fn Sage3 scale bytes; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 4,
+                        name, " must be 4D [B, H, padded_tokens, D/16]; got dim=", t.dim());
+            TORCH_CHECK((int)t.size(0) == B && (int)t.size(1) == H &&
+                        (int)t.size(2) == padded && (int)t.size(3) == D / 16,
+                        name, " must have shape [", B, ", ", H, ", ", padded, ", ", D / 16,
+                        "], got [", t.size(0), ", ", t.size(1), ", ", t.size(2), ", ", t.size(3), "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        auto validate_sage3_v_sf_cache = [&](const torch::Tensor& t, const char* name, int tokens) {
+            int padded = ((tokens + 127) / 128) * 128;
+            TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+            TORCH_CHECK(t.scalar_type() == at::ScalarType::Float8_e4m3fn,
+                        name, " must be torch.float8_e4m3fn Sage3 scale bytes; got ", t.scalar_type());
+            TORCH_CHECK(t.dim() == 4,
+                        name, " must be 4D [B, H, D, padded_tokens/16]; got dim=", t.dim());
+            TORCH_CHECK((int)t.size(0) == B && (int)t.size(1) == H &&
+                        (int)t.size(2) == D && (int)t.size(3) == padded / 16,
+                        name, " must have shape [", B, ", ", H, ", ", D, ", ", padded / 16,
+                        "], got [", t.size(0), ", ", t.size(1), ", ", t.size(2), ", ", t.size(3), "]");
+            TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        };
+        if (fp8_kv_cache_enabled) {
+            if (!sage3_cross_fp4_enabled) {
+                validate_fp8_cache(k_cross_fp8_caches[i], "k_cross_fp8_caches[i]", Mk_c);
+                validate_fp8_cache(v_cross_fp8_caches[i], "v_cross_fp8_caches[i]", Mk_c);
+            }
+            validate_fp8_cache(k_self_fp8_caches[i], "k_self_fp8_caches[i]", cap);
+            validate_fp8_cache(v_self_fp8_caches[i], "v_self_fp8_caches[i]", cap);
+            if (fp8_cross_tc_layout_cache_enabled) {
+                validate_fp8_k_bhmd_cache(k_cross_fp8_bhmd_caches[i], "k_cross_fp8_bhmd_caches[i]", Mk_c);
+                validate_fp8_k_bhmd_cache(v_cross_fp8_bhmd_caches[i], "v_cross_fp8_bhmd_caches[i]", Mk_c);
+                if (!v_cross_fp8_bhdm_caches.empty()) {
+                    validate_fp8_v_bhdm_cache(v_cross_fp8_bhdm_caches[i], "v_cross_fp8_bhdm_caches[i]", Mk_c);
+                }
+            }
+            if (fp8_self_tc_layout_cache_enabled) {
+                validate_fp8_k_bhmd_cache(k_self_fp8_bhmd_caches[i], "k_self_fp8_bhmd_caches[i]", cap);
+                validate_fp8_k_bhmd_cache(v_self_fp8_bhmd_caches[i], "v_self_fp8_bhmd_caches[i]", cap);
+                if (!v_self_fp8_bhdm_caches.empty()) {
+                    validate_fp8_v_bhdm_cache(v_self_fp8_bhdm_caches[i], "v_self_fp8_bhdm_caches[i]", cap);
+                }
+            }
+        }
+        if (sage3_cross_fp4_enabled) {
+            validate_sage3_k_fp4_cache(k_cross_sage3_fp4_caches[i], "k_cross_sage3_fp4_caches[i]", Mk_c);
+            validate_sage3_v_fp4_cache(v_cross_sage3_fp4_caches[i], "v_cross_sage3_fp4_caches[i]", Mk_c);
+            validate_sage3_k_sf_cache(k_cross_sage3_sf_caches[i], "k_cross_sage3_sf_caches[i]", Mk_c);
+            validate_sage3_v_sf_cache(v_cross_sage3_sf_caches[i], "v_cross_sage3_sf_caches[i]", Mk_c);
+        }
+
+        omnidreams_singleview::CosmosAttentionBackend block_attention_backend = attention_backend;
+
+        omnidreams_singleview::CosmosBlockParams bp{};
+        bp.B  = B;
+        bp.M  = M;
+        bp.K  = K;
+        bp.H  = H;
+        bp.D  = D;
+        bp.FF = FF;
+        bp.lora_dim = lora_dim;
+        bp.Mk_cross = Mk_c;
+        bp.self_attn_cache_cap   = cap;
+        bp.self_attn_write_start = (int)self_attn_write_start;
+        bp.linear_backend = linear_backend;
+        bp.attention_backend = block_attention_backend;
+        bp.fp8_kv_cache_enabled = fp8_kv_cache_enabled;
+        bp.write_bf16_self_kv_cache = write_bf16_self_kv_cache;
+        if (trace_enabled) {
+            auto* trace_base = reinterpret_cast<cutlass::bfloat16_t*>(
+                trace_tensor.data_ptr<at::BFloat16>());
+            const int64_t trace_elems = static_cast<int64_t>(B) * M * K;
+            auto* block_trace = trace_base + static_cast<int64_t>(i) * 4 * trace_elems;
+            bp.trace_sa_out = block_trace;
+            bp.trace_ca_out = block_trace + trace_elems;
+            bp.trace_ffn_out = block_trace + 2 * trace_elems;
+            bp.trace_block_out = block_trace + 3 * trace_elems;
+            bp.trace_elems = trace_elems;
+        }
+        if (fp8_activation_scales_enabled) {
+            bp.fp8_activation_scales =
+                fp8_activation_scales_host.data_ptr<float>() +
+                static_cast<int64_t>(i) * omnidreams_singleview::kCosmosFp8ActivationScaleSites;
+        }
+        if (fp8_activation_amax_enabled) {
+            bp.fp8_activation_amax_out =
+                fp8_activation_amax_tensor.data_ptr<float>() +
+                static_cast<int64_t>(i) * omnidreams_singleview::kCosmosFp8ActivationScaleSites;
+        }
+        bp.x = reinterpret_cast<cutlass::bfloat16_t*>(cur.data_ptr<at::BFloat16>());
+        bp.t_emb         = reinterpret_cast<const cutlass::bfloat16_t*>(t_emb_silu.data_ptr<at::BFloat16>());
+        bp.adaln_lora_3D = reinterpret_cast<const cutlass::bfloat16_t*>(adaln_lora_BD.data_ptr<at::BFloat16>());
+        if (block_mod_cache_enabled) {
+            const int64_t block_mod_stride = static_cast<int64_t>(B) * 3 * K;
+            bp.precomputed_mods_sa = reinterpret_cast<const cutlass::bfloat16_t*>(
+                block_mods_sa.data_ptr<at::BFloat16>()) + static_cast<int64_t>(i) * block_mod_stride;
+            bp.precomputed_mods_ca = reinterpret_cast<const cutlass::bfloat16_t*>(
+                block_mods_ca.data_ptr<at::BFloat16>()) + static_cast<int64_t>(i) * block_mod_stride;
+            bp.precomputed_mods_mlp = reinterpret_cast<const cutlass::bfloat16_t*>(
+                block_mods_mlp.data_ptr<at::BFloat16>()) + static_cast<int64_t>(i) * block_mod_stride;
+        }
+        bp.k_cross = reinterpret_cast<const cutlass::bfloat16_t*>(k_cross_caches[i].data_ptr<at::BFloat16>());
+        bp.v_cross = reinterpret_cast<const cutlass::bfloat16_t*>(v_cross_caches[i].data_ptr<at::BFloat16>());
+        bp.k_self_cache = reinterpret_cast<cutlass::bfloat16_t*>(k_self_caches[i].data_ptr<at::BFloat16>());
+        bp.v_self_cache = reinterpret_cast<cutlass::bfloat16_t*>(v_self_caches[i].data_ptr<at::BFloat16>());
+        bp.k_cross_fp8 = fp8_kv_cache_enabled && !k_cross_fp8_caches.empty()
+            ? reinterpret_cast<const cutlass::float_e4m3_t*>(k_cross_fp8_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.v_cross_fp8 = fp8_kv_cache_enabled && !v_cross_fp8_caches.empty()
+            ? reinterpret_cast<const cutlass::float_e4m3_t*>(v_cross_fp8_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.k_self_cache_fp8 = fp8_kv_cache_enabled
+            ? reinterpret_cast<cutlass::float_e4m3_t*>(k_self_fp8_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.v_self_cache_fp8 = fp8_kv_cache_enabled
+            ? reinterpret_cast<cutlass::float_e4m3_t*>(v_self_fp8_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.k_cross_fp8_bhmd = fp8_cross_tc_layout_cache_enabled
+            ? reinterpret_cast<const cutlass::float_e4m3_t*>(k_cross_fp8_bhmd_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.v_cross_fp8_bhmd = fp8_cross_tc_layout_cache_enabled && !v_cross_fp8_bhmd_caches.empty()
+            ? reinterpret_cast<const cutlass::float_e4m3_t*>(v_cross_fp8_bhmd_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.v_cross_fp8_bhdm = fp8_cross_tc_layout_cache_enabled && !v_cross_fp8_bhdm_caches.empty()
+            ? reinterpret_cast<const cutlass::float_e4m3_t*>(v_cross_fp8_bhdm_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.k_cross_sage3_fp4 = sage3_cross_fp4_enabled
+            ? k_cross_sage3_fp4_caches[i].data_ptr<uint8_t>()
+            : nullptr;
+        bp.v_cross_sage3_fp4 = sage3_cross_fp4_enabled
+            ? v_cross_sage3_fp4_caches[i].data_ptr<uint8_t>()
+            : nullptr;
+        bp.k_cross_sage3_sf = sage3_cross_fp4_enabled
+            ? reinterpret_cast<const cutlass::float_e4m3_t*>(k_cross_sage3_sf_caches[i].data_ptr())
+            : nullptr;
+        bp.v_cross_sage3_sf = sage3_cross_fp4_enabled
+            ? reinterpret_cast<const cutlass::float_e4m3_t*>(v_cross_sage3_sf_caches[i].data_ptr())
+            : nullptr;
+        bp.Mk_cross_sage3_padded = sage3_cross_fp4_enabled
+            ? ((Mk_c + 127) / 128) * 128
+            : 0;
+        bp.k_self_cache_fp8_bhmd = fp8_self_tc_layout_cache_enabled
+            ? reinterpret_cast<cutlass::float_e4m3_t*>(k_self_fp8_bhmd_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.v_self_cache_fp8_bhmd = fp8_self_tc_layout_cache_enabled && !v_self_fp8_bhmd_caches.empty()
+            ? reinterpret_cast<cutlass::float_e4m3_t*>(v_self_fp8_bhmd_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.v_self_cache_fp8_bhdm = fp8_self_tc_layout_cache_enabled && !v_self_fp8_bhdm_caches.empty()
+            ? reinterpret_cast<cutlass::float_e4m3_t*>(v_self_fp8_bhdm_caches[i].data_ptr<uint8_t>())
+            : nullptr;
+        bp.rope_cos = reinterpret_cast<const cutlass::bfloat16_t*>(rope_cos.data_ptr<at::BFloat16>());
+        bp.rope_sin = reinterpret_cast<const cutlass::bfloat16_t*>(rope_sin.data_ptr<at::BFloat16>());
+        bp.w   = bw;
+        bp.buf = buf;
+
+        // Phase 1 AdaLN-LoRA pre-stack path: when `adaln_precompute_enabled`
+        // is true, the global down + batched up GEMMs at the top of the
+        // forward have already populated `mods_all` for all 28 blocks. Each
+        // block's per-sub-layer (shift, scale, gate) views are slices of
+        // `mods_all`. Setting bp.adaln_precomputed = true tells
+        // cosmos_run_transformer_block_streaming to skip the three
+        // cosmos_adaln_lora_split calls.
+        if (adaln_precompute_enabled) {
+            cutlass::bfloat16_t* lora_hidden_base =
+                reinterpret_cast<cutlass::bfloat16_t*>(lora_hidden_all.data_ptr<at::BFloat16>());
+            cutlass::bfloat16_t* mods_base =
+                reinterpret_cast<cutlass::bfloat16_t*>(mods_all.data_ptr<at::BFloat16>());
+            int64_t lora_inst = int64_t(i) * 3;
+            int64_t lora_step = int64_t(B) * lora_dim;
+            int64_t mods_step = int64_t(B) * 3 * K;
+            bp.buf.lora_hidden_sa  = lora_hidden_base + (lora_inst + 0) * lora_step;
+            bp.buf.lora_hidden_ca  = lora_hidden_base + (lora_inst + 1) * lora_step;
+            bp.buf.lora_hidden_mlp = lora_hidden_base + (lora_inst + 2) * lora_step;
+            bp.buf.mods_sa  = mods_base + (lora_inst + 0) * mods_step;
+            bp.buf.mods_ca  = mods_base + (lora_inst + 1) * mods_step;
+            bp.buf.mods_mlp = mods_base + (lora_inst + 2) * mods_step;
+            bp.adaln_precomputed = true;
+        } else {
+            bp.adaln_precomputed = false;
+        }
+
+        cudaEvent_t block_start, block_end;
+        if (prof) {
+            cudaEventCreate(&block_start);
+            cudaEventCreate(&block_end);
+            cudaEventRecord(block_start, stream);
+        }
+        cudaError_t e = omnidreams_singleview::cosmos_run_transformer_block_streaming(bp, stream);
+        if (prof) {
+            cudaEventRecord(block_end, stream);
+            cudaEventSynchronize(block_end);
+            float block_ms = 0.f;
+            cudaEventElapsedTime(&block_ms, block_start, block_end);
+            std::printf("[cosmos_stream][block=%d] total=%.3f ms\n", i, block_ms);
+            cudaEventDestroy(block_start);
+            cudaEventDestroy(block_end);
+        }
+        TORCH_CHECK(e == cudaSuccess,
+                    "cosmos_run_transformer_block_streaming failed at block ", i,
+                    ": ", cudaGetErrorString(e));
+    }
+    rec(EV_AFTER_BLOCKS);
+
+    // ── 6. Final layer (matches FlashDreams FinalLayer, n_adaln_chunks=2) ───
+    // adaln_lora_BD[..., :2D] is the lora component for the final layer (fused
+    // state_dict uses 2*D output for FinalLayer.adaln_modulation).
+    //
+    {
+        torch::Tensor shift_2d;
+        torch::Tensor scale_2d;
+        torch::Tensor fl_mods;
+        if (config.contains("cosmos_final_shift") || config.contains("cosmos_final_scale")) {
+            TORCH_CHECK(config.contains("cosmos_final_shift") && config.contains("cosmos_final_scale"),
+                        "precomputed final AdaLN requires both config['cosmos_final_shift'] "
+                        "and config['cosmos_final_scale']");
+            shift_2d = py::cast<torch::Tensor>(config["cosmos_final_shift"]);
+            scale_2d = py::cast<torch::Tensor>(config["cosmos_final_scale"]);
+            validate_timestep_cache(shift_2d, "config['cosmos_final_shift']", model_channels);
+            validate_timestep_cache(scale_2d, "config['cosmos_final_scale']", model_channels);
+        } else {
+            auto fl_hidden = fl_hidden_scratch.defined()
+                ? fl_hidden_scratch
+                : torch::empty({B, lora_dim}, opts);
+            fl_mods = fl_mods_scratch.defined()
+                ? fl_mods_scratch
+                : torch::empty({B, 2 * K}, opts);
+            auto fl_down = get_w(weights, "final_layer.adaln_modulation.1.weight");
+            auto fl_up = get_w(weights, "final_layer.adaln_modulation.2.weight");
+            cudaError_t gemm_err = omnidreams_singleview::cutlass_linear_layer_rrr_bf16(
+                reinterpret_cast<const cutlass::bfloat16_t*>(t_emb_silu.data_ptr<at::BFloat16>()),
+                reinterpret_cast<const cutlass::bfloat16_t*>(fl_down.data_ptr<at::BFloat16>()),
+                /*bias=*/nullptr,
+                reinterpret_cast<cutlass::bfloat16_t*>(fl_hidden.data_ptr<at::BFloat16>()),
+                B, K, lora_dim, stream);
+            TORCH_CHECK(gemm_err == cudaSuccess, "final AdaLN down GEMM failed: ", cudaGetErrorString(gemm_err));
+            gemm_err = omnidreams_singleview::cutlass_linear_layer_rrr_bf16(
+                reinterpret_cast<const cutlass::bfloat16_t*>(fl_hidden.data_ptr<at::BFloat16>()),
+                reinterpret_cast<const cutlass::bfloat16_t*>(fl_up.data_ptr<at::BFloat16>()),
+                /*bias=*/nullptr,
+                reinterpret_cast<cutlass::bfloat16_t*>(fl_mods.data_ptr<at::BFloat16>()),
+                B, lora_dim, 2 * K, stream);
+            TORCH_CHECK(gemm_err == cudaSuccess, "final AdaLN up GEMM failed: ", cudaGetErrorString(gemm_err));
+            cudaError_t final_add_err = cosmos_add_inplace(
+                reinterpret_cast<cutlass::bfloat16_t*>(fl_mods.data_ptr<at::BFloat16>()),
+                reinterpret_cast<const cutlass::bfloat16_t*>(adaln_lora_BD.data_ptr<at::BFloat16>()),
+                int64_t(B) * 2 * K, stream);
+            TORCH_CHECK(final_add_err == cudaSuccess, "final AdaLN add failed: ", cudaGetErrorString(final_add_err));
+            shift_2d = fl_mods.slice(-1, 0, K);
+            scale_2d = fl_mods.slice(-1, K, 2 * K);
+        }
+
+        shift_2d = shift_2d.contiguous();
+        scale_2d = scale_2d.contiguous();
+        auto final_normed = torch::empty({B, L, K}, opts);
+        cudaError_t final_ln_err = omnidreams_singleview::cosmos_layernorm_modulate<cutlass::bfloat16_t>(
+            reinterpret_cast<const cutlass::bfloat16_t*>(cur.data_ptr<at::BFloat16>()),
+            reinterpret_cast<const cutlass::bfloat16_t*>(shift_2d.data_ptr<at::BFloat16>()),
+            reinterpret_cast<const cutlass::bfloat16_t*>(scale_2d.data_ptr<at::BFloat16>()),
+            reinterpret_cast<cutlass::bfloat16_t*>(final_normed.data_ptr<at::BFloat16>()),
+            B * L, K, B, 1e-6f, stream);
+        TORCH_CHECK(final_ln_err == cudaSuccess, "final layernorm_modulate failed: ", cudaGetErrorString(final_ln_err));
+
+        auto w_fl = get_w(weights, "final_layer.linear.weight");
+        int final_D_out = (int)w_fl.size(0);
+        auto final_out = torch::empty({B, L, final_D_out}, opts);
+        cudaError_t gemm_err = omnidreams_singleview::cutlass_linear_layer_rrr_bf16(
+            reinterpret_cast<const cutlass::bfloat16_t*>(final_normed.data_ptr<at::BFloat16>()),
+            reinterpret_cast<const cutlass::bfloat16_t*>(w_fl.data_ptr<at::BFloat16>()),
+            /*bias=*/nullptr,
+            reinterpret_cast<cutlass::bfloat16_t*>(final_out.data_ptr<at::BFloat16>()),
+            B * L, K, final_D_out, stream);
+        TORCH_CHECK(gemm_err == cudaSuccess, "final projection GEMM failed: ", cudaGetErrorString(gemm_err));
+        cur = final_out;
+    }
+    rec(EV_AFTER_FINAL);
+
+    if (prof) {
+        cudaEventSynchronize(ev[EV_AFTER_FINAL]);
+        auto ms = [&](int a, int b) -> float {
+            float out = 0.f;
+            cudaEventElapsedTime(&out, ev[a], ev[b]);
+            return out;
+        };
+        std::printf(
+            "[cosmos_stream] input=%.3f temb=%.3f rope_scratch=%.3f blocks=%.3f final=%.3f total=%.3f ms\n",
+            ms(EV_START, EV_AFTER_INPUT_EMBED),
+            ms(EV_AFTER_INPUT_EMBED, EV_AFTER_TEMB),
+            ms(EV_AFTER_TEMB, EV_AFTER_ROPE_SCRATCH),
+            ms(EV_AFTER_ROPE_SCRATCH, EV_AFTER_BLOCKS),
+            ms(EV_AFTER_BLOCKS, EV_AFTER_FINAL),
+            ms(EV_START, EV_AFTER_FINAL));
+        for (int i = 0; i < EV_COUNT; ++i) cudaEventDestroy(ev[i]);
+    }
+
+    // ── 7. Reshape back to [B, V, T, HW, D_out] — no unpatchify here;
+    //      FlashDreams unpatchify_and_maybe_gather_cp handles that on the
+    //      Python side, matching the existing contract of CosmosDiTNetwork. ──
+    int D_out = (int)cur.size(-1);
+    return cur.reshape({B, V, T, HW, D_out}).to(orig_dtype).contiguous();
+}

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.cu
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "streaming_dit_bridge.h"
 #include "../kernels/attention.cuh"
 #include "../kernels/cosmos_block.cuh"

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 // streaming_dit_bridge.h — bridge declarations for OmniDreams single-view native extension CUDA extension.

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/pyext/streaming_dit_bridge.h
@@ -1,0 +1,194 @@
+#pragma once
+
+// streaming_dit_bridge.h — bridge declarations for OmniDreams single-view native extension CUDA extension.
+
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <string>
+
+#include "../kernels/attention.cuh"
+
+namespace omnidreams_singleview {
+bool sage3_is_built();
+bool sage3_is_runtime_supported(int device);
+std::vector<torch::Tensor> sage3_quantize_cross_kv_bf16(
+    torch::Tensor k_bmhd,
+    torch::Tensor v_bmhd);
+}
+
+// Full model forward pass using native CUTLASS FMHA for attention blocks.
+//
+// Args (matching CosmosCausalHdmapDiT._forward_train):
+//   x              — [B, 16, T, H, W] latent video input (bf16 or fp16)
+//   condition_mask — [B, 1, T, H, W] conditioning video mask
+//   padding_mask   — [B, 1, H, W] spatial padding mask (all-ones = fully valid)
+//   timesteps      — [B, T] per-frame diffusion timesteps (float32 or model dtype)
+//   crossattn_emb  — [B, Lc, 1024] cross-attention context (text)
+//   hdmap          — [B, 16, T, H, W] HDmap control input
+//   weights        — dict[str, Tensor] model parameters by name
+//   config         — dict with integer/float hyper-parameters
+//
+// Returns: [B, 16, T, H, W] denoised output (same dtype as x).
+torch::Tensor cosmos_forward(
+    torch::Tensor x,
+    torch::Tensor condition_mask,
+    torch::Tensor padding_mask,
+    torch::Tensor timesteps,
+    torch::Tensor crossattn_emb,
+    torch::Tensor hdmap,
+    py::dict weights,
+    py::dict config
+);
+
+
+// ---------------------------------------------------------------------------
+// Streaming forward — mirrors FlashDreams' CosmosDiTNetwork.forward.
+//
+// Unlike `cosmos_forward` above (full-sequence DDPM, causal SA over Mq==Mk),
+// this entry point runs streaming autoregressive inference with a KV cache
+// that is fed fresh Q tokens (L_new) attending over a larger cached K/V
+// buffer (up to `sink_size + local_attn_size * tokens_per_frame`). Causality
+// is enforced implicitly by only caching past tokens, so the FMHA call runs
+// with `causal=false` and Mq != Mk.
+//
+// Inputs (all CUDA tensors; dtype = bf16 unless noted):
+//   x_new                    [B, V, T, HW, D_in]       pre-patchified tokens
+//                            (output of FlashDreams patchify_and_maybe_split_cp)
+//   condition_mask_patched   [B, V, T, HW, D_cond]     pre-patchified condition mask
+//   hdmap_patched            [B, V, T, HW, D_hdmap]    pre-patchified HD-map bbox control
+//                            (pass `torch::Tensor()` to disable)
+//   timesteps                [B] (bf16/fp32)           ONE timestep per batch item
+//                            (FlashDreams uses a scalar timestep for the whole block,
+//                             unlike cosmos_forward which takes [B, T] per-frame)
+//   rope_emb                 [L_new, 1, 1, Dh] fp32    RoPE angles, pre-shifted to
+//                            `chunk_idx * num_latents_per_block` by the caller
+//   k_cross_caches           list[num_blocks] of [B*V, Lc, H, Dh]
+//                            pre-computed text K (post-k_norm, no RoPE)
+//   v_cross_caches           list[num_blocks] of [B*V, Lc, H, Dh]
+//                            pre-computed text V (raw v_proj, no norm)
+//   k_self_caches            list[num_blocks] of [B*V, cache_cap, H, Dh]  MUTABLE
+//                            self-attn K ring buffer (post-RoPE + k_norm)
+//   v_self_caches            list[num_blocks] of [B*V, cache_cap, H, Dh]  MUTABLE
+//                            self-attn V ring buffer (raw)
+//   self_attn_write_start    int — write new K/V at cache[:, write_start:write_start+L_new]
+//                            (caller is responsible for rolling the ring buffer via
+//                             BlockKVCache.before_update(...) before this call;
+//                             write_start == _n_cached in non-steady state, or
+//                             cache_cap - L_new once the cache saturates)
+//   weights                  dict  model parameters, same keys as FlashDreams state_dict
+//                            (x_embedder must be post-`_fuse_padding_mask_into_patch_embed`,
+//                            final_layer.linear must be post-`_fuse_shuffle_op_into_last_layer`)
+//   config                   dict  num_blocks, num_heads, model_channels,
+//                                  timestep_scale, (no padding / rope ratios — those
+//                                  are baked into the pre-computed rope_emb and weights).
+//                                  Optional invariant-cache tensors include
+//                                  cosmos_t_emb/cosmos_t_emb_silu/cosmos_adaln_lora,
+//                                  cosmos_final_shift/cosmos_final_scale,
+//                                  cosmos_rope_cos/cosmos_rope_sin, and
+//                                  cosmos_block_mods_sa/ca/mlp, and
+//                                  cosmos_hdmap_embed.
+//
+// Returns: [B, V, T, HW, D_out] (pre-unpatchify); caller applies
+//          FlashDreams unpatchify_and_maybe_gather_cp afterwards.
+torch::Tensor optimized_dit_forward(
+    torch::Tensor x_new,
+    torch::Tensor condition_mask_patched,
+    torch::Tensor hdmap_patched,
+    torch::Tensor timesteps,
+    torch::Tensor rope_emb,
+    std::vector<torch::Tensor> k_cross_caches,
+    std::vector<torch::Tensor> v_cross_caches,
+    std::vector<torch::Tensor> k_self_caches,
+    std::vector<torch::Tensor> v_self_caches,
+    int64_t self_attn_write_start,
+    py::dict weights,
+    py::dict config
+);
+
+// Test/bring-up hook for the Cosmos FP8 RCR linear contract:
+//   input [N, in] fp16
+//   weight_fp8_u8 [out, in] raw E4M3 bytes in PyTorch Linear layout
+//   weight_scale [out] optional per-output-channel dequant scale
+// Returns [N, out] fp16.
+torch::Tensor cosmos_test_linear_fp8(
+    torch::Tensor input,
+    torch::Tensor weight_fp8_u8,
+    c10::optional<torch::Tensor> weight_scale,
+    c10::optional<torch::Tensor> bias,
+    bool gelu
+);
+
+torch::Tensor cosmos_test_linear_fp8_out_fp8(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor weight_scale
+);
+
+torch::Tensor cosmos_test_linear_fp8_gelu_out_fp8(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor weight_scale,
+    double output_scale = 1.0,
+    bool alias_output = false
+);
+
+torch::Tensor cosmos_test_linear_fp8_scaled_bf16(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor weight_scale
+);
+
+torch::Tensor cosmos_test_linear_fp8_residual_scaled_bf16(
+    torch::Tensor input_bf16,
+    torch::Tensor weight_fp8_u8,
+    torch::Tensor alpha,
+    torch::Tensor residual_bf16
+);
+
+py::dict cosmos_test_fp8_linear_tile_selection(
+    std::string op_kind,
+    int64_t rows,
+    int64_t in_features,
+    int64_t out_features
+);
+
+py::dict cosmos_test_fp8_sdpa_selection(
+    int64_t B,
+    int64_t Mq,
+    int64_t Mk,
+    int64_t H,
+    int64_t D
+);
+
+torch::Tensor cosmos_test_fp8_dense_ref_sdpa(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8,
+    torch::Tensor v_fp8_u8,
+    bool causal
+);
+
+torch::Tensor cosmos_test_fp8_cudnn_sdpa(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8,
+    torch::Tensor v_fp8_u8,
+    bool causal
+);
+
+torch::Tensor cosmos_test_fp8_tc_probe_qk(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8
+);
+
+torch::Tensor cosmos_test_fp8_tc_probe_pv(
+    torch::Tensor probs_fp8_u8,
+    torch::Tensor v_fp8_u8
+);
+
+std::vector<torch::Tensor> cosmos_test_fp8_attention_backend(
+    torch::Tensor q_fp8_u8,
+    torch::Tensor k_fp8_u8,
+    torch::Tensor v_fp8_u8,
+    bool causal,
+    std::string backend
+);

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/streaming_dit_bindings.cpp
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/streaming_dit_bindings.cpp
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "streaming_dit_bindings.h"
+
+#include "pyext/streaming_dit_bridge.h"
+
+namespace py = pybind11;
+
+namespace omnidreams_singleview {
+
+void bind_optimized_dit(py::module_& module) {
+  module.def(
+      "optimized_dit_forward",
+      &::optimized_dit_forward,
+      py::arg("x_new"),
+      py::arg("condition_mask_patched"),
+      py::arg("hdmap_patched"),
+      py::arg("timesteps"),
+      py::arg("rope_emb"),
+      py::arg("k_cross_caches"),
+      py::arg("v_cross_caches"),
+      py::arg("k_self_caches"),
+      py::arg("v_self_caches"),
+      py::arg("self_attn_write_start"),
+      py::arg("weights"),
+      py::arg("config"));
+  module.def(
+      "sage3_quantize_cross_kv_bf16",
+      &sage3_quantize_cross_kv_bf16,
+      py::arg("k_bmhd"),
+      py::arg("v_bmhd"));
+  module.def("sage3_is_built", &sage3_is_built);
+  module.def("sage3_is_runtime_supported", &sage3_is_runtime_supported, py::arg("device"));
+  module.def("optimized_dit_supports_block_mod_cache", []() { return true; });
+  module.def("optimized_dit_supports_hdmap_cache", []() { return true; });
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/streaming_dit_bindings.cpp
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/streaming_dit_bindings.cpp
@@ -6,6 +6,7 @@
 #include "streaming_dit_bindings.h"
 
 #include "pyext/streaming_dit_bridge.h"
+#include <cuda_runtime.h>
 
 namespace py = pybind11;
 
@@ -34,6 +35,36 @@ void bind_optimized_dit(py::module_& module) {
       py::arg("v_bmhd"));
   module.def("sage3_is_built", &sage3_is_built);
   module.def("sage3_is_runtime_supported", &sage3_is_runtime_supported, py::arg("device"));
+  module.def("sparge_is_built", []() {
+#ifdef OMNIDREAMS_SINGLEVIEW_HAS_SPARGE
+    return true;
+#else
+    return false;
+#endif
+  });
+  module.def("sparge_is_runtime_supported", [](int device) {
+#ifdef OMNIDREAMS_SINGLEVIEW_HAS_SPARGE
+    if (device < -1) {
+      return false;
+    }
+    if (device == -1) {
+      cudaError_t err = cudaGetDevice(&device);
+      if (err != cudaSuccess) {
+        return false;
+      }
+    }
+    cudaDeviceProp prop{};
+    cudaError_t err = cudaGetDeviceProperties(&prop, device);
+    if (err != cudaSuccess) {
+      return false;
+    }
+    return (prop.major == 8 && prop.minor == 9) ||
+           (prop.major == 12 && prop.minor == 0);
+#else
+    (void)device;
+    return false;
+#endif
+  }, py::arg("device") = -1);
   module.def("optimized_dit_supports_block_mod_cache", []() { return true; });
   module.def("optimized_dit_supports_hdmap_cache", []() { return true; });
 }

--- a/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/streaming_dit_bindings.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/dit_streaming/streaming_dit_bindings.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace omnidreams_singleview {
+
+void bind_optimized_dit(pybind11::module_& module);
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/omnidreams_singleview_ext.cpp
+++ b/integrations/omnidreams/omnidreams_singleview/src/omnidreams_singleview_ext.cpp
@@ -17,6 +17,7 @@
 
 #include <torch/extension.h>
 
+#include "dit_streaming/streaming_dit_bindings.h"
 #include "native_primitives.h"
 
 #ifndef OMNIDREAMS_SINGLEVIEW_WITH_CUDA
@@ -87,4 +88,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
   module.def("is_available", &is_available);
   module.def("build_info", &build_info);
   omnidreams_singleview::bind_native_primitives(module);
+  omnidreams_singleview::bind_optimized_dit(module);
 }

--- a/integrations/omnidreams/omnidreams_singleview/thirdparty_sources.json
+++ b/integrations/omnidreams/omnidreams_singleview/thirdparty_sources.json
@@ -29,6 +29,12 @@
       "directory": "SageAttention"
     },
     {
+      "name": "SpargeAttn",
+      "repo": "https://github.com/thu-ml/SpargeAttn.git",
+      "commit": "bfd980b781784c04ad6a53e7ee657c0645d99171",
+      "directory": "SpargeAttn"
+    },
+    {
       "name": "cudnn-frontend",
       "repo": "https://github.com/NVIDIA/cudnn-frontend.git",
       "commit": "deda80e5372d50e925d7bf4f76c5db779be3fbd5",

--- a/integrations/omnidreams/omnidreams_singleview/thirdparty_sources.json
+++ b/integrations/omnidreams/omnidreams_singleview/thirdparty_sources.json
@@ -29,10 +29,10 @@
       "directory": "SageAttention"
     },
     {
-      "name": "SpargeAttn",
-      "repo": "https://github.com/thu-ml/SpargeAttn.git",
-      "commit": "bfd980b781784c04ad6a53e7ee657c0645d99171",
-      "directory": "SpargeAttn"
+      "name": "cudnn-frontend",
+      "repo": "https://github.com/NVIDIA/cudnn-frontend.git",
+      "commit": "deda80e5372d50e925d7bf4f76c5db779be3fbd5",
+      "directory": "cudnn-frontend"
     }
   ]
 }

--- a/integrations/omnidreams/omnidreams_singleview/tools/native_build.py
+++ b/integrations/omnidreams/omnidreams_singleview/tools/native_build.py
@@ -31,7 +31,6 @@ ROOT = Path(__file__).resolve().parents[1]
 THIRDPARTY_DIR = ROOT / "3rdparty"
 CUTLASS_DIR = THIRDPARTY_DIR / "cutlass"
 SAGE_ATTENTION_DIR = THIRDPARTY_DIR / "SageAttention"
-SPARGE_ATTN_DIR = THIRDPARTY_DIR / "SpargeAttn"
 SYNC_THIRDPARTY_PATH = ROOT / "tools" / "sync_thirdparty.py"
 STAMP_NAME = ".flashdreams_source.json"
 

--- a/integrations/omnidreams/tests/test_omnidreams_pipeline.py
+++ b/integrations/omnidreams/tests/test_omnidreams_pipeline.py
@@ -215,6 +215,7 @@ def test_bidirectional_transformer_requires_and_wires_negative_embeddings(
     transformer.network = cast(Any, fake_network)
     transformer._output_height = None
     transformer._output_width = None
+    transformer._optimized_dit_executor = None
     # ``Transformer.device`` is a property reading from ``self.parameters()``;
     # register a placeholder so it resolves to CPU instead of asserting.
     transformer.register_parameter(
@@ -250,6 +251,49 @@ def test_bidirectional_transformer_requires_and_wires_negative_embeddings(
 
     assert cache.network_cache_uncond is not None
     assert fake_network.cache_kwargs[-1]["context"] is negative_text_embeddings
+
+
+@pytest.mark.ci_cpu
+def test_cosmos_transformer_checkpoint_path_none_keeps_random_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeNetwork(torch.nn.Module):
+        def __init__(self, config: object) -> None:
+            super().__init__()
+            self.config = config
+            self.updated_after_load = False
+
+        def set_context_parallel_group(self, **kwargs: object) -> None:
+            del kwargs
+
+        def load_state_dict(
+            self,
+            state_dict: object,
+            *args: object,
+            **kwargs: object,
+        ) -> object:
+            del state_dict, args, kwargs
+            raise AssertionError("load_state_dict should not run without a checkpoint")
+
+        def update_parameters_after_loading_checkpoint(self) -> None:
+            self.updated_after_load = True
+
+    monkeypatch.setattr(
+        omnidreams_transformer_module,
+        "CosmosDiTNetwork",
+        FakeNetwork,
+    )
+
+    transformer = CosmosTransformer(
+        CosmosTransformerConfig(
+            checkpoint_path=None,
+            compile_network=False,
+            use_cuda_graph=False,
+        )
+    )
+
+    assert isinstance(transformer.network, FakeNetwork)
+    assert transformer.network.updated_after_load is True
 
 
 @pytest.mark.ci_cpu

--- a/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
@@ -53,7 +53,9 @@ def _fake_extension_module(**attrs: object) -> ModuleType:
 
 def _fake_thirdparty_info(tmp_path: Path) -> dict[str, dict[str, object]]:
     cutlass = tmp_path / "cutlass"
+    cudnn_frontend = tmp_path / "cudnn-frontend"
     (cutlass / "include").mkdir(parents=True)
+    (cudnn_frontend / "include").mkdir(parents=True)
     return {
         "cutlass": {
             "name": "cutlass",
@@ -81,6 +83,15 @@ def _fake_thirdparty_info(tmp_path: Path) -> dict[str, dict[str, object]]:
             "source_sha256": "sparge-source-hash",
             "tree_sha256": "sparge-tree-hash",
             "stamp_path": str(tmp_path / "SpargeAttn" / ".flashdreams_source.json"),
+        },
+        "cudnn-frontend": {
+            "name": "cudnn-frontend",
+            "path": str(cudnn_frontend),
+            "repo": "https://github.com/NVIDIA/cudnn-frontend.git",
+            "commit": "cudnn-frontend-test-sha",
+            "source_sha256": "cudnn-frontend-source-hash",
+            "tree_sha256": "cudnn-frontend-tree-hash",
+            "stamp_path": str(cudnn_frontend / ".flashdreams_source.json"),
         },
     }
 
@@ -144,6 +155,7 @@ def test_load_extension_uses_build_root_for_torch_cache(
     monkeypatch.setattr(native, "validate_thirdparty", lambda: thirdparty_info)
     monkeypatch.setattr(cpp_extension, "load", fake_load_torch_extension)
     monkeypatch.setattr(native.os, "cpu_count", lambda: 48)
+    monkeypatch.setattr(native, "_python_package_dir", lambda package: None)
     monkeypatch.delenv("MAX_JOBS", raising=False)
 
     extension = native.load_extension(build_root=build_root)
@@ -153,26 +165,72 @@ def test_load_extension_uses_build_root_for_torch_cache(
     assert captured["build_directory"] == str(
         build_root / "torch_extensions" / str(extension_name)
     )
+    cutlass_dir = Path(str(thirdparty_info["cutlass"]["path"]))
+    sage_attention_dir = Path(str(thirdparty_info["SageAttention"]["path"]))
+    sparge_attn_csrc = Path(str(thirdparty_info["SpargeAttn"]["path"])) / "csrc"
+    cudnn_frontend_include = (
+        Path(str(thirdparty_info["cudnn-frontend"]["path"])) / "include"
+    )
     assert captured["extra_include_paths"] == [
         str(native._SOURCE_DIR),
-        str(Path(str(thirdparty_info["cutlass"]["path"])) / "include"),
+        str(native._DIT_STREAMING_DIR),
+        str(native._DIT_STREAMING_KERNEL_DIR),
+        str(native._DIT_STREAMING_PYEXT_DIR),
+        str(native._DIT_STREAMING_COMMON_DIR),
+        str(cutlass_dir / "include"),
+        str(cutlass_dir / "tools" / "util" / "include"),
+        str(cutlass_dir / "examples" / "common"),
+        str(cutlass_dir / "examples" / "41_fused_multi_head_attention"),
+        str(sage_attention_dir),
+        str(sage_attention_dir / "sageattention3_blackwell" / "sageattn3"),
+        str(
+            sage_attention_dir / "sageattention3_blackwell" / "sageattn3" / "blackwell"
+        ),
+        str(
+            sage_attention_dir
+            / "sageattention3_blackwell"
+            / "sageattn3"
+            / "quantization"
+        ),
+        str(sparge_attn_csrc),
+        str(sparge_attn_csrc / "qattn"),
+        str(sparge_attn_csrc / "fused"),
+        str(cudnn_frontend_include),
     ]
     sources = [Path(str(source)).name for source in captured["sources"]]
     assert sources == [
         "omnidreams_singleview_ext.cpp",
         "native_primitives.cpp",
         "native_primitives_cuda.cu",
+        "streaming_dit_bindings.cpp",
+        "streaming_dit_bridge.cu",
+        "sage3_blackwell_api_shim.cu",
+        "sage3_fp4_quant_shim.cu",
+        "attention.cu",
+        "block_quant.cu",
+        "cosmos_adaln_lora.cu",
+        "cosmos_block.cu",
+        "cosmos_fp8_flash.cu",
+        "cosmos_fp8_flash_tc.cu",
+        "cosmos_fp8_tc_probe.cu",
+        "cosmos_fp8_two_gemm.cu",
+        "cosmos_gemm_bf16.cu",
+        "cosmos_modulate.cu",
+        "ops.cu",
+        "sage3_attention.cu",
+        "sparge_attention_sm89_inst.cu",
+        "transformer_block.cu",
     ]
     fingerprint_sources = {
-        source.relative_to(native._SOURCE_DIR).as_posix()
+        source.relative_to(native._ROOT).as_posix()
         for source in native._extension_fingerprint_sources()
     }
     assert {
-        "native_common/macros.h",
-        "native_common/scalar_types.h",
-        "native_common/tensor_ref.h",
-        "native_common/tensor_ref_torch.h",
-        "native_common/workspace_allocator.h",
+        "src/native_common/macros.h",
+        "src/native_common/scalar_types.h",
+        "src/native_common/tensor_ref.h",
+        "src/native_common/tensor_ref_torch.h",
+        "src/native_common/workspace_allocator.h",
     }.issubset(fingerprint_sources)
     assert "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA" in captured["extra_cflags"]
     assert (
@@ -203,13 +261,13 @@ def test_load_extension_uses_build_root_for_torch_cache(
         '-DOMNIDREAMS_SINGLEVIEW_SPARGE_ATTN_SHA=\\"sparge-test-sha\\"'
         in captured["extra_cflags"]
     )
+    assert "-DOMNIDREAMS_SINGLEVIEW_HAS_SPARGE=1" in captured["extra_cflags"]
     assert (
         '-DOMNIDREAMS_SINGLEVIEW_CUDA_ARCH_LIST=\\"12.0a\\"' in captured["extra_cflags"]
     )
-    assert captured["extra_cuda_cflags"] == [
-        "-O3",
-        "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA",
-    ]
+    assert "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA" in captured["extra_cuda_cflags"]
+    assert "-DOMNIDREAMS_SINGLEVIEW_HAS_SAGE3=1" in captured["extra_cuda_cflags"]
+    assert "-DOMNIDREAMS_SINGLEVIEW_HAS_SPARGE=1" in captured["extra_cuda_cflags"]
     assert captured["with_cuda"] is True
     assert captured["max_jobs_env"] == "8"
     assert captured["cuda_arch_list_env"] == "12.0a"
@@ -546,6 +604,69 @@ def test_optimized_dit_shape_ops_preserves_configured_dtype() -> None:
 
 
 @pytest.mark.ci_cpu
+def test_optimized_dit_sparge_period_one_is_pure_sparge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimized_dit = native.load_python_module("optimized_dit")
+    monkeypatch.setattr(
+        optimized_dit.OptimizedDiTExecutor,
+        "_sage3_status",
+        lambda self, device=None: (False, "Sage3 unavailable in test"),
+    )
+    monkeypatch.setattr(
+        optimized_dit.OptimizedDiTExecutor,
+        "_sparge_status",
+        lambda self, device=None: (True, ""),
+    )
+    transformer = SimpleNamespace(
+        config=SimpleNamespace(
+            network=SimpleNamespace(
+                num_blocks=28,
+                num_heads=16,
+                model_channels=2048,
+                adaln_lora_dim=256,
+                timestep_scale=0.001,
+            ),
+            num_views=1,
+            use_cuda_graph=False,
+            cuda_graph_warmup_iters=0,
+        ),
+        network=SimpleNamespace(),
+    )
+    extension = SimpleNamespace(
+        optimized_dit_forward=lambda *args, **kwargs: None,
+        optimized_dit_supports_block_mod_cache=lambda: True,
+        optimized_dit_supports_hdmap_cache=lambda: True,
+    )
+
+    executor = optimized_dit.OptimizedDiTExecutor(
+        transformer,
+        extension,
+        dit_backend="fp8_kvcache_cudnn",
+        attention_backend="auto",
+        sparge_hybrid_period=1,
+    )
+    executor._resolve_runtime_attention_backend(torch.device("cuda:0"))
+
+    assert executor._attention_backend == "sparge"
+    assert executor._sparge_hybrid_period == 0
+    assert executor._sparge_hybrid_phase == 0
+    assert executor._sparge_topk == optimized_dit._DEFAULT_SPARGE_TOPK
+
+    auto_executor = optimized_dit.OptimizedDiTExecutor(
+        transformer,
+        extension,
+        dit_backend="fp8_kvcache_cudnn",
+        attention_backend="auto",
+    )
+    auto_executor._resolve_runtime_attention_backend(torch.device("cuda:0"))
+
+    assert auto_executor._attention_backend == "sparge"
+    assert auto_executor._sparge_hybrid_period == 0
+    assert auto_executor._sparge_topk == optimized_dit._DEFAULT_SPARGE_TOPK
+
+
+@pytest.mark.ci_cpu
 @pytest.mark.skipif(
     os.environ.get("OMNIDREAMS_SINGLEVIEW_RUN_THIRDPARTY_VERIFY") != "1",
     reason="Set OMNIDREAMS_SINGLEVIEW_RUN_THIRDPARTY_VERIFY=1 to verify downloaded sources.",
@@ -553,7 +674,7 @@ def test_optimized_dit_shape_ops_preserves_configured_dtype() -> None:
 def test_real_thirdparty_sources_verify() -> None:
     info = native.validate_thirdparty()
 
-    assert set(info) == {"cutlass", "SageAttention", "SpargeAttn"}
+    assert set(info) == {"cutlass", "SageAttention", "SpargeAttn", "cudnn-frontend"}
 
 
 @pytest.mark.ci_gpu

--- a/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
@@ -534,6 +534,18 @@ def test_native_workspace_requests_allocate_named_workspaces() -> None:
 
 
 @pytest.mark.ci_cpu
+def test_optimized_dit_shape_ops_preserves_configured_dtype() -> None:
+    optimized_dit = native.load_python_module("optimized_dit")
+    shape_ops = optimized_dit._CosmosNetworkShapeOps(
+        SimpleNamespace(patch_temporal=1, patch_spatial=2),
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+
+    assert next(shape_ops.parameters()).dtype == torch.bfloat16
+
+
+@pytest.mark.ci_cpu
 @pytest.mark.skipif(
     os.environ.get("OMNIDREAMS_SINGLEVIEW_RUN_THIRDPARTY_VERIFY") != "1",
     reason="Set OMNIDREAMS_SINGLEVIEW_RUN_THIRDPARTY_VERIFY=1 to verify downloaded sources.",

--- a/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import pytest
@@ -736,7 +736,11 @@ def test_optimized_dit_hybrid_sends_fp8_only_default_cache_config(
 
     assert executor._attention_backend == "sparge"
     assert executor._sparge_hybrid_period == optimized_dit._DEFAULT_SPARGE_HYBRID_PERIOD
+    assert executor._sparge_topk == optimized_dit._DEFAULT_SPARGE_HYBRID_TOPK
     assert runtime["cosmos_write_bf16_kv_cache"] is False
+    assert (
+        runtime["cosmos_sparge_topk_ratio"] == optimized_dit._DEFAULT_SPARGE_HYBRID_TOPK
+    )
 
 
 @pytest.mark.ci_cpu

--- a/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
@@ -667,6 +667,79 @@ def test_optimized_dit_sparge_period_one_is_pure_sparge(
 
 
 @pytest.mark.ci_cpu
+def test_optimized_dit_hybrid_sends_fp8_only_default_cache_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimized_dit = native.load_python_module("optimized_dit")
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch.float8_e4m3fn is required for fp8 runtime setup")
+
+    monkeypatch.setattr(
+        optimized_dit,
+        "_make_cosmos_streaming_workspace",
+        lambda **_: {"workspace": torch.empty(1, dtype=torch.uint8)},
+    )
+    monkeypatch.setattr(
+        optimized_dit.OptimizedDiTExecutor,
+        "_sage3_status",
+        lambda self, device=None: (True, ""),
+    )
+    monkeypatch.setattr(
+        optimized_dit.OptimizedDiTExecutor,
+        "_sparge_status",
+        lambda self, device=None: (True, ""),
+    )
+
+    transformer = SimpleNamespace(
+        config=SimpleNamespace(
+            network=SimpleNamespace(
+                num_blocks=2,
+                num_heads=16,
+                model_channels=2048,
+                adaln_lora_dim=256,
+                timestep_scale=0.001,
+            ),
+            num_views=1,
+            use_cuda_graph=False,
+            cuda_graph_warmup_iters=0,
+        ),
+        network=SimpleNamespace(),
+    )
+    extension = SimpleNamespace(
+        optimized_dit_forward=lambda *args, **kwargs: None,
+        optimized_dit_supports_block_mod_cache=lambda: True,
+        optimized_dit_supports_hdmap_cache=lambda: True,
+        sage3_quantize_cross_kv_bf16=lambda k, v: (
+            torch.empty(1, dtype=torch.uint8),
+            torch.empty(1, dtype=torch.uint8),
+            torch.empty(1, dtype=torch.uint8),
+            torch.empty(1, dtype=torch.uint8),
+        ),
+    )
+    executor = optimized_dit.OptimizedDiTExecutor(
+        transformer,
+        extension,
+        dit_backend="fp8_kvcache_cudnn",
+        attention_backend="auto",
+    )
+    monkeypatch.setattr(executor, "_release_network_after_fp8_snapshot", lambda: None)
+
+    k_cache = torch.zeros((1, 4, 16, 128), dtype=torch.bfloat16)
+    runtime = executor._ensure_fp8_runtime(
+        k_cross=[k_cache],
+        v_cross=[k_cache],
+        k_self=[k_cache],
+        v_self=[k_cache],
+        tokens=4,
+        cache=SimpleNamespace(),
+    )
+
+    assert executor._attention_backend == "sparge"
+    assert executor._sparge_hybrid_period == optimized_dit._DEFAULT_SPARGE_HYBRID_PERIOD
+    assert runtime["cosmos_write_bf16_kv_cache"] is False
+
+
+@pytest.mark.ci_cpu
 @pytest.mark.skipif(
     os.environ.get("OMNIDREAMS_SINGLEVIEW_RUN_THIRDPARTY_VERIFY") != "1",
     reason="Set OMNIDREAMS_SINGLEVIEW_RUN_THIRDPARTY_VERIFY=1 to verify downloaded sources.",

--- a/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
@@ -604,6 +604,60 @@ def test_optimized_dit_shape_ops_preserves_configured_dtype() -> None:
 
 
 @pytest.mark.ci_cpu
+def test_cosmos_transformer_config_defaults_to_auto_native_attention() -> None:
+    from omnidreams.transformer import CosmosTransformerConfig
+
+    config = CosmosTransformerConfig()
+
+    assert config.native_dit_backend == "fp8_kvcache_cudnn"
+    assert config.native_dit_attention_backend == "auto"
+
+
+@pytest.mark.ci_cpu
+def test_optimized_dit_default_attention_backend_uses_cudnn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimized_dit = native.load_python_module("optimized_dit")
+    monkeypatch.setattr(
+        optimized_dit.OptimizedDiTExecutor,
+        "_sage3_status",
+        lambda self, device=None: (True, ""),
+    )
+    monkeypatch.setattr(
+        optimized_dit.OptimizedDiTExecutor,
+        "_sparge_status",
+        lambda self, device=None: (True, ""),
+    )
+    transformer = SimpleNamespace(
+        config=SimpleNamespace(
+            network=SimpleNamespace(
+                num_blocks=28,
+                num_heads=16,
+                model_channels=2048,
+                adaln_lora_dim=256,
+                timestep_scale=0.001,
+            ),
+            num_views=1,
+            use_cuda_graph=False,
+            cuda_graph_warmup_iters=0,
+        ),
+        network=SimpleNamespace(),
+    )
+    extension = SimpleNamespace(
+        optimized_dit_forward=lambda *args, **kwargs: None,
+        optimized_dit_supports_block_mod_cache=lambda: True,
+        optimized_dit_supports_hdmap_cache=lambda: True,
+    )
+
+    executor = optimized_dit.OptimizedDiTExecutor(transformer, extension)
+    executor._resolve_runtime_attention_backend(torch.device("cuda:0"))
+
+    assert executor._requested_attention_backend == "auto"
+    assert executor._attention_backend == "cudnn"
+    assert executor._sparge_hybrid_period == 0
+
+
+@pytest.mark.ci_cpu
 def test_optimized_dit_sparge_period_one_is_pure_sparge(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -643,7 +697,7 @@ def test_optimized_dit_sparge_period_one_is_pure_sparge(
         transformer,
         extension,
         dit_backend="fp8_kvcache_cudnn",
-        attention_backend="auto",
+        attention_backend="sparge",
         sparge_hybrid_period=1,
     )
     executor._resolve_runtime_attention_backend(torch.device("cuda:0"))
@@ -661,13 +715,13 @@ def test_optimized_dit_sparge_period_one_is_pure_sparge(
     )
     auto_executor._resolve_runtime_attention_backend(torch.device("cuda:0"))
 
-    assert auto_executor._attention_backend == "sparge"
+    assert auto_executor._attention_backend == "cudnn"
     assert auto_executor._sparge_hybrid_period == 0
     assert auto_executor._sparge_topk == optimized_dit._DEFAULT_SPARGE_TOPK
 
 
 @pytest.mark.ci_cpu
-def test_optimized_dit_hybrid_sends_fp8_only_default_cache_config(
+def test_optimized_dit_explicit_sparge_hybrid_sends_fp8_only_cache_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     optimized_dit = native.load_python_module("optimized_dit")
@@ -720,7 +774,8 @@ def test_optimized_dit_hybrid_sends_fp8_only_default_cache_config(
         transformer,
         extension,
         dit_backend="fp8_kvcache_cudnn",
-        attention_backend="auto",
+        attention_backend="sparge",
+        sparge_hybrid_period=optimized_dit._DEFAULT_SPARGE_HYBRID_PERIOD,
     )
     monkeypatch.setattr(executor, "_release_network_after_fp8_snapshot", lambda: None)
 


### PR DESCRIPTION
## Summary
- Adds the optimized OmniDreams single-view DiT native execution path and dispatch wiring.
- Ports FP8/Sage3/Sparge attention support with fallback handling.
- Adds targeted CPU coverage for native configuration and hybrid BF16 cache behavior.

## Validation
- .venv/bin/python -m py_compile integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
- .venv/bin/python -m pytest integrations/omnidreams/tests/test_omnidreams_singleview_native.py -m ci_cpu -q
- git diff --check origin/dev/mchock/omnidreams-native-source-build-scaffold..HEAD
- git show --check --stat --oneline HEAD
- Local CodeRabbit branch review connected but hung without actionable findings; stopped as best-effort.

## Notes
- Draft because the diff is large and should get CI/review coverage before publishing.
