### PR TITLE
Fix extrinsics (stale custom .proto extension) in omnidreams

### DIFF
--- a/integrations/omnidreams/omnidreams/grpc/protos/camera.proto
+++ b/integrations/omnidreams/omnidreams/grpc/protos/camera.proto
@@ -17,8 +17,6 @@ syntax = "proto3";
 
 package omnidreams.camera;
 
-import "omnidreams/grpc/protos/common.proto";
-
 enum ShutterType {
     UNKNOWN = 0; // Unknown shutter type
     ROLLING_TOP_TO_BOTTOM = 1; // Rolling shutter from top to bottom of the imager
@@ -126,8 +124,4 @@ message CameraSpec {
     oneof external_distortion {
         BivariateWindshieldModelParameters bivariate_windshield_model_param = 10;
     }
-
-    // Pose of camera relative to the ego rig frame.
-    // Identity (default/unset) means the camera is at the rig origin.
-    common.Pose rig_to_camera = 11;
 }

--- a/integrations/omnidreams/omnidreams/grpc/protos/camera_pb2.py
+++ b/integrations/omnidreams/omnidreams/grpc/protos/camera_pb2.py
@@ -22,32 +22,31 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
-from omnidreams.grpc.protos import common_pb2 as omnidreams_dot_grpc_dot_protos_dot_common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#omnidreams/grpc/protos/camera.proto\x12\x11omnidreams.camera\x1a#omnidreams/grpc/protos/common.proto\"A\n\tLinearCde\x12\x10\n\x08linear_c\x18\x01 \x01(\x01\x12\x10\n\x08linear_d\x18\x02 \x01(\x01\x12\x10\n\x08linear_e\x18\x03 \x01(\x01\"\xec\x02\n\x11\x46thetaCameraParam\x12\x19\n\x11principal_point_x\x18\x01 \x01(\x01\x12\x19\n\x11principal_point_y\x18\x02 \x01(\x01\x12K\n\x0ereference_poly\x18\x03 \x01(\x0e\x32\x33.omnidreams.camera.FthetaCameraParam.PolynomialType\x12\x1f\n\x17pixeldist_to_angle_poly\x18\x04 \x03(\x01\x12\x1f\n\x17\x61ngle_to_pixeldist_poly\x18\x05 \x03(\x01\x12\x11\n\tmax_angle\x18\x06 \x01(\x01\x12\x30\n\nlinear_cde\x18\x07 \x01(\x0b\x32\x1c.omnidreams.camera.LinearCde\"M\n\x0ePolynomialType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x16\n\x12PIXELDIST_TO_ANGLE\x10\x01\x12\x16\n\x12\x41NGLE_TO_PIXELDIST\x10\x02\"\xcd\x01\n\x18OpenCVPinholeCameraParam\x12\x19\n\x11principal_point_x\x18\x01 \x01(\x01\x12\x19\n\x11principal_point_y\x18\x02 \x01(\x01\x12\x16\n\x0e\x66ocal_length_x\x18\x03 \x01(\x01\x12\x16\n\x0e\x66ocal_length_y\x18\x04 \x01(\x01\x12\x15\n\rradial_coeffs\x18\x05 \x03(\x01\x12\x19\n\x11tangential_coeffs\x18\x06 \x03(\x01\x12\x19\n\x11thin_prism_coeffs\x18\x07 \x03(\x01\"\xaa\x01\n\x18OpenCVFisheyeCameraParam\x12\x19\n\x11principal_point_x\x18\x01 \x01(\x01\x12\x19\n\x11principal_point_y\x18\x02 \x01(\x01\x12\x16\n\x0e\x66ocal_length_x\x18\x03 \x01(\x01\x12\x16\n\x0e\x66ocal_length_y\x18\x04 \x01(\x01\x12\x15\n\rradial_coeffs\x18\x05 \x03(\x01\x12\x11\n\tmax_angle\x18\x06 \x01(\x01\"\xa9\x02\n\"BivariateWindshieldModelParameters\x12\x61\n\x0ereference_poly\x18\x01 \x01(\x0e\x32I.omnidreams.camera.BivariateWindshieldModelParameters.ReferencePolynomial\x12\x17\n\x0fhorizontal_poly\x18\x02 \x03(\x01\x12\x15\n\rvertical_poly\x18\x03 \x03(\x01\x12\x1f\n\x17horizontal_poly_inverse\x18\x04 \x03(\x01\x12\x1d\n\x15vertical_poly_inverse\x18\x05 \x03(\x01\"0\n\x13ReferencePolynomial\x12\x0b\n\x07\x46ORWARD\x10\x00\x12\x0c\n\x08\x42\x41\x43KWARD\x10\x01\"\x94\x04\n\nCameraSpec\x12<\n\x0c\x66theta_param\x18\x02 \x01(\x0b\x32$.omnidreams.camera.FthetaCameraParamH\x00\x12K\n\x14opencv_pinhole_param\x18\x03 \x01(\x0b\x32+.omnidreams.camera.OpenCVPinholeCameraParamH\x00\x12K\n\x14opencv_fisheye_param\x18\x04 \x01(\x0b\x32+.omnidreams.camera.OpenCVFisheyeCameraParamH\x00\x12\x12\n\nlogical_id\x18\x05 \x01(\t\x12\x14\n\x0cresolution_h\x18\x07 \x01(\r\x12\x14\n\x0cresolution_w\x18\x08 \x01(\r\x12\x34\n\x0cshutter_type\x18\t \x01(\x0e\x32\x1e.omnidreams.camera.ShutterType\x12\x61\n bivariate_windshield_model_param\x18\n \x01(\x0b\x32\x35.omnidreams.camera.BivariateWindshieldModelParametersH\x01\x12.\n\rrig_to_camera\x18\x0b \x01(\x0b\x32\x17.omnidreams.common.PoseB\x0e\n\x0c\x63\x61mera_paramB\x15\n\x13\x65xternal_distortion*\x92\x01\n\x0bShutterType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x19\n\x15ROLLING_TOP_TO_BOTTOM\x10\x01\x12\x19\n\x15ROLLING_LEFT_TO_RIGHT\x10\x02\x12\x19\n\x15ROLLING_BOTTOM_TO_TOP\x10\x03\x12\x19\n\x15ROLLING_RIGHT_TO_LEFT\x10\x04\x12\n\n\x06GLOBAL\x10\x05\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#omnidreams/grpc/protos/camera.proto\x12\x11omnidreams.camera\"A\n\tLinearCde\x12\x10\n\x08linear_c\x18\x01 \x01(\x01\x12\x10\n\x08linear_d\x18\x02 \x01(\x01\x12\x10\n\x08linear_e\x18\x03 \x01(\x01\"\xec\x02\n\x11\x46thetaCameraParam\x12\x19\n\x11principal_point_x\x18\x01 \x01(\x01\x12\x19\n\x11principal_point_y\x18\x02 \x01(\x01\x12K\n\x0ereference_poly\x18\x03 \x01(\x0e\x32\x33.omnidreams.camera.FthetaCameraParam.PolynomialType\x12\x1f\n\x17pixeldist_to_angle_poly\x18\x04 \x03(\x01\x12\x1f\n\x17\x61ngle_to_pixeldist_poly\x18\x05 \x03(\x01\x12\x11\n\tmax_angle\x18\x06 \x01(\x01\x12\x30\n\nlinear_cde\x18\x07 \x01(\x0b\x32\x1c.omnidreams.camera.LinearCde\"M\n\x0ePolynomialType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x16\n\x12PIXELDIST_TO_ANGLE\x10\x01\x12\x16\n\x12\x41NGLE_TO_PIXELDIST\x10\x02\"\xcd\x01\n\x18OpenCVPinholeCameraParam\x12\x19\n\x11principal_point_x\x18\x01 \x01(\x01\x12\x19\n\x11principal_point_y\x18\x02 \x01(\x01\x12\x16\n\x0e\x66ocal_length_x\x18\x03 \x01(\x01\x12\x16\n\x0e\x66ocal_length_y\x18\x04 \x01(\x01\x12\x15\n\rradial_coeffs\x18\x05 \x03(\x01\x12\x19\n\x11tangential_coeffs\x18\x06 \x03(\x01\x12\x19\n\x11thin_prism_coeffs\x18\x07 \x03(\x01\"\xaa\x01\n\x18OpenCVFisheyeCameraParam\x12\x19\n\x11principal_point_x\x18\x01 \x01(\x01\x12\x19\n\x11principal_point_y\x18\x02 \x01(\x01\x12\x16\n\x0e\x66ocal_length_x\x18\x03 \x01(\x01\x12\x16\n\x0e\x66ocal_length_y\x18\x04 \x01(\x01\x12\x15\n\rradial_coeffs\x18\x05 \x03(\x01\x12\x11\n\tmax_angle\x18\x06 \x01(\x01\"\xa9\x02\n\"BivariateWindshieldModelParameters\x12\x61\n\x0ereference_poly\x18\x01 \x01(\x0e\x32I.omnidreams.camera.BivariateWindshieldModelParameters.ReferencePolynomial\x12\x17\n\x0fhorizontal_poly\x18\x02 \x03(\x01\x12\x15\n\rvertical_poly\x18\x03 \x03(\x01\x12\x1f\n\x17horizontal_poly_inverse\x18\x04 \x03(\x01\x12\x1d\n\x15vertical_poly_inverse\x18\x05 \x03(\x01\"0\n\x13ReferencePolynomial\x12\x0b\n\x07\x46ORWARD\x10\x00\x12\x0c\n\x08\x42\x41\x43KWARD\x10\x01\"\xe4\x03\n\nCameraSpec\x12<\n\x0c\x66theta_param\x18\x02 \x01(\x0b\x32$.omnidreams.camera.FthetaCameraParamH\x00\x12K\n\x14opencv_pinhole_param\x18\x03 \x01(\x0b\x32+.omnidreams.camera.OpenCVPinholeCameraParamH\x00\x12K\n\x14opencv_fisheye_param\x18\x04 \x01(\x0b\x32+.omnidreams.camera.OpenCVFisheyeCameraParamH\x00\x12\x12\n\nlogical_id\x18\x05 \x01(\t\x12\x14\n\x0cresolution_h\x18\x07 \x01(\r\x12\x14\n\x0cresolution_w\x18\x08 \x01(\r\x12\x34\n\x0cshutter_type\x18\t \x01(\x0e\x32\x1e.omnidreams.camera.ShutterType\x12\x61\n bivariate_windshield_model_param\x18\n \x01(\x0b\x32\x35.omnidreams.camera.BivariateWindshieldModelParametersH\x01\x42\x0e\n\x0c\x63\x61mera_paramB\x15\n\x13\x65xternal_distortion*\x92\x01\n\x0bShutterType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x19\n\x15ROLLING_TOP_TO_BOTTOM\x10\x01\x12\x19\n\x15ROLLING_LEFT_TO_RIGHT\x10\x02\x12\x19\n\x15ROLLING_BOTTOM_TO_TOP\x10\x03\x12\x19\n\x15ROLLING_RIGHT_TO_LEFT\x10\x04\x12\n\n\x06GLOBAL\x10\x05\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'omnidreams.grpc.protos.camera_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_SHUTTERTYPE']._serialized_start=1746
-  _globals['_SHUTTERTYPE']._serialized_end=1892
-  _globals['_LINEARCDE']._serialized_start=95
-  _globals['_LINEARCDE']._serialized_end=160
-  _globals['_FTHETACAMERAPARAM']._serialized_start=163
-  _globals['_FTHETACAMERAPARAM']._serialized_end=527
-  _globals['_FTHETACAMERAPARAM_POLYNOMIALTYPE']._serialized_start=450
-  _globals['_FTHETACAMERAPARAM_POLYNOMIALTYPE']._serialized_end=527
-  _globals['_OPENCVPINHOLECAMERAPARAM']._serialized_start=530
-  _globals['_OPENCVPINHOLECAMERAPARAM']._serialized_end=735
-  _globals['_OPENCVFISHEYECAMERAPARAM']._serialized_start=738
-  _globals['_OPENCVFISHEYECAMERAPARAM']._serialized_end=908
-  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS']._serialized_start=911
-  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS']._serialized_end=1208
-  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS_REFERENCEPOLYNOMIAL']._serialized_start=1160
-  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS_REFERENCEPOLYNOMIAL']._serialized_end=1208
-  _globals['_CAMERASPEC']._serialized_start=1211
-  _globals['_CAMERASPEC']._serialized_end=1743
+  _globals['_SHUTTERTYPE']._serialized_start=1661
+  _globals['_SHUTTERTYPE']._serialized_end=1807
+  _globals['_LINEARCDE']._serialized_start=58
+  _globals['_LINEARCDE']._serialized_end=123
+  _globals['_FTHETACAMERAPARAM']._serialized_start=126
+  _globals['_FTHETACAMERAPARAM']._serialized_end=490
+  _globals['_FTHETACAMERAPARAM_POLYNOMIALTYPE']._serialized_start=413
+  _globals['_FTHETACAMERAPARAM_POLYNOMIALTYPE']._serialized_end=490
+  _globals['_OPENCVPINHOLECAMERAPARAM']._serialized_start=493
+  _globals['_OPENCVPINHOLECAMERAPARAM']._serialized_end=698
+  _globals['_OPENCVFISHEYECAMERAPARAM']._serialized_start=701
+  _globals['_OPENCVFISHEYECAMERAPARAM']._serialized_end=871
+  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS']._serialized_start=874
+  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS']._serialized_end=1171
+  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS_REFERENCEPOLYNOMIAL']._serialized_start=1123
+  _globals['_BIVARIATEWINDSHIELDMODELPARAMETERS_REFERENCEPOLYNOMIAL']._serialized_end=1171
+  _globals['_CAMERASPEC']._serialized_start=1174
+  _globals['_CAMERASPEC']._serialized_end=1658
 # @@protoc_insertion_point(module_scope)

--- a/integrations/omnidreams/omnidreams/grpc/protos/camera_pb2.pyi
+++ b/integrations/omnidreams/omnidreams/grpc/protos/camera_pb2.pyi
@@ -1,4 +1,3 @@
-from omnidreams.grpc.protos import common_pb2 as _common_pb2
 from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
@@ -114,7 +113,7 @@ class BivariateWindshieldModelParameters(_message.Message):
     def __init__(self, reference_poly: _Optional[_Union[BivariateWindshieldModelParameters.ReferencePolynomial, str]] = ..., horizontal_poly: _Optional[_Iterable[float]] = ..., vertical_poly: _Optional[_Iterable[float]] = ..., horizontal_poly_inverse: _Optional[_Iterable[float]] = ..., vertical_poly_inverse: _Optional[_Iterable[float]] = ...) -> None: ...
 
 class CameraSpec(_message.Message):
-    __slots__ = ("ftheta_param", "opencv_pinhole_param", "opencv_fisheye_param", "logical_id", "resolution_h", "resolution_w", "shutter_type", "bivariate_windshield_model_param", "rig_to_camera")
+    __slots__ = ("ftheta_param", "opencv_pinhole_param", "opencv_fisheye_param", "logical_id", "resolution_h", "resolution_w", "shutter_type", "bivariate_windshield_model_param")
     FTHETA_PARAM_FIELD_NUMBER: _ClassVar[int]
     OPENCV_PINHOLE_PARAM_FIELD_NUMBER: _ClassVar[int]
     OPENCV_FISHEYE_PARAM_FIELD_NUMBER: _ClassVar[int]
@@ -123,7 +122,6 @@ class CameraSpec(_message.Message):
     RESOLUTION_W_FIELD_NUMBER: _ClassVar[int]
     SHUTTER_TYPE_FIELD_NUMBER: _ClassVar[int]
     BIVARIATE_WINDSHIELD_MODEL_PARAM_FIELD_NUMBER: _ClassVar[int]
-    RIG_TO_CAMERA_FIELD_NUMBER: _ClassVar[int]
     ftheta_param: FthetaCameraParam
     opencv_pinhole_param: OpenCVPinholeCameraParam
     opencv_fisheye_param: OpenCVFisheyeCameraParam
@@ -132,5 +130,4 @@ class CameraSpec(_message.Message):
     resolution_w: int
     shutter_type: ShutterType
     bivariate_windshield_model_param: BivariateWindshieldModelParameters
-    rig_to_camera: _common_pb2.Pose
-    def __init__(self, ftheta_param: _Optional[_Union[FthetaCameraParam, _Mapping]] = ..., opencv_pinhole_param: _Optional[_Union[OpenCVPinholeCameraParam, _Mapping]] = ..., opencv_fisheye_param: _Optional[_Union[OpenCVFisheyeCameraParam, _Mapping]] = ..., logical_id: _Optional[str] = ..., resolution_h: _Optional[int] = ..., resolution_w: _Optional[int] = ..., shutter_type: _Optional[_Union[ShutterType, str]] = ..., bivariate_windshield_model_param: _Optional[_Union[BivariateWindshieldModelParameters, _Mapping]] = ..., rig_to_camera: _Optional[_Union[_common_pb2.Pose, _Mapping]] = ...) -> None: ...
+    def __init__(self, ftheta_param: _Optional[_Union[FthetaCameraParam, _Mapping]] = ..., opencv_pinhole_param: _Optional[_Union[OpenCVPinholeCameraParam, _Mapping]] = ..., opencv_fisheye_param: _Optional[_Union[OpenCVFisheyeCameraParam, _Mapping]] = ..., logical_id: _Optional[str] = ..., resolution_h: _Optional[int] = ..., resolution_w: _Optional[int] = ..., shutter_type: _Optional[_Union[ShutterType, str]] = ..., bivariate_windshield_model_param: _Optional[_Union[BivariateWindshieldModelParameters, _Mapping]] = ...) -> None: ...

--- a/integrations/omnidreams/omnidreams/grpc/protos/video_model.proto
+++ b/integrations/omnidreams/omnidreams/grpc/protos/video_model.proto
@@ -89,7 +89,7 @@ message SessionRequest {
     DebugOptions debug_options = 3;      // Optional debug output options
     repeated camera.CameraSpec camera_specs = 4;  // One per view
     repeated Image initial_frames = 5;            // One conditioning frame per view
-    repeated common.Pose rig_to_camera = 6; // Rig-to-camera extrinsics (one per view)
+    repeated common.Pose rig_to_camera = 6; // Rig-to-camera extrinsics (one per camera_spec)
     fixed64 random_seed = 7;  // Optional random seed for deterministic generation (0 = server chooses)
 }
 

--- a/integrations/omnidreams/omnidreams/grpc/server.py
+++ b/integrations/omnidreams/omnidreams/grpc/server.py
@@ -68,7 +68,7 @@ from omnidreams.grpc.utils import (
     dynamic_state_to_ludus_cube_pool,
     encode_image,
     load_static_world_from_zip_bytes,
-    parse_rig_to_camera,
+    parse_rig_to_camera_transforms,
     proto_to_dict,
     trajectory_to_camera_poses,
 )
@@ -858,7 +858,7 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
         profiler = get_profiler()
         _ = profiler.get_chunk_idx(session_id)
 
-        # 1. Parse camera specs list — extract names, intrinsics, rig_to_camera
+        # 1. Parse camera specs list — extract names and intrinsics
         camera_specs_raw = list(request.camera_specs)
         if not camera_specs_raw:
             raise ValueError(
@@ -867,8 +867,6 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
 
         camera_names: list[str] = []
         camera_models_from_client: dict[str, FThetaCamera] = {}
-        rig_to_camera_transforms: dict[str, np.ndarray] = {}
-
         for i, spec in enumerate(camera_specs_raw):
             spec_dict = proto_to_dict(spec)
             cam_name = spec_dict.get("logical_id", f"camera_{i}")
@@ -883,9 +881,12 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
             if has_camera_model:
                 camera_models_from_client[cam_name] = camera_spec_to_ftheta(spec_dict)
 
-            # Parse rig_to_camera (FLU convention from client → convert to RDF)
-            rig_to_cam_flu = parse_rig_to_camera(spec_dict)
-            rig_to_camera_transforms[cam_name] = rig_to_cam_flu
+        # Parse rig-to-camera extrinsics from SessionRequest, one pose per
+        # camera_spec in the same order. The client and Ludus renderer use FLU.
+        rig_to_camera_transforms = parse_rig_to_camera_transforms(
+            list(request.rig_to_camera),
+            camera_names,
+        )
 
         logger.info(f"Parsed {len(camera_names)} camera specs: {camera_names}")
         assert len(camera_names) == len(camera_models_from_client), (
@@ -1029,7 +1030,7 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
             chunk_size = self.conditioning_wrapper.frame_chunk_size
             logger.info(f"Continuation chunk: expecting {chunk_size} poses")
 
-        # 3. Parse rig trajectory (FLU → RDF) and derive per-camera poses
+        # 3. Parse rig trajectory (FLU) and derive per-camera poses
         # FIXME: do this on GPU ... should not do this actually ...
         with profiler.measure(
             "parse_trajectory", session_id=session_id, chunk_idx=chunk_idx
@@ -1189,7 +1190,7 @@ class SessionState:
         self.session_id = session_id
         self.camera_names = camera_names  # Ordered list of camera logical IDs
         self.rig_to_camera_transforms = (
-            rig_to_camera_transforms  # cam_name → 4×4 rig_to_camera (RDF or FLU)
+            rig_to_camera_transforms  # cam_name → 4×4 rig_to_camera (FLU)
         )
         self.scene_data = scene_data
         self.renderer = renderer  # Created in start_session

--- a/integrations/omnidreams/omnidreams/grpc/utils.py
+++ b/integrations/omnidreams/omnidreams/grpc/utils.py
@@ -599,21 +599,20 @@ def dynamic_state_to_ludus_cube_pool(
 # =============================================================================
 
 
-def parse_rig_to_camera(camera_spec_dict: dict) -> np.ndarray:
+def parse_rig_to_camera(rig_to_camera_dict: dict) -> np.ndarray:
     """
-    Extract the rig_to_camera 4x4 transformation matrix from a CameraSpec dict.
+    Convert a rig-to-camera Pose dict to a 4x4 transformation matrix.
 
-    If the ``rig_to_camera`` field is absent or contains the default (zero)
-    values, an identity matrix is returned — meaning the camera coincides
+    An absent or empty pose is treated as identity, meaning the camera coincides
     with the rig origin.
 
     Args:
-        camera_spec_dict: Dict representation of a ``CameraSpec`` proto message.
+        rig_to_camera_dict: Dict representation of a ``common.Pose`` proto message.
 
     Returns:
         4x4 rig_to_camera transformation matrix (float32).
     """
-    rig_to_cam = camera_spec_dict.get("rig_to_camera", {})
+    rig_to_cam = rig_to_camera_dict
     if not rig_to_cam:
         return np.eye(4, dtype=np.float32)
 
@@ -633,6 +632,24 @@ def parse_rig_to_camera(camera_spec_dict: dict) -> np.ndarray:
     )
 
     return pose_to_matrix(translation, quat_wxyz)
+
+
+def parse_rig_to_camera_transforms(
+    rig_to_camera_messages: list[object],
+    camera_names: list[str],
+) -> dict[str, np.ndarray]:
+    """Parse SessionRequest.rig_to_camera into a per-camera transform map."""
+    if len(rig_to_camera_messages) != len(camera_names):
+        raise ValueError(
+            "SessionRequest.rig_to_camera must contain exactly one Pose per "
+            f"camera_spec; got {len(rig_to_camera_messages)} poses for "
+            f"{len(camera_names)} camera_specs."
+        )
+
+    return {
+        cam_name: parse_rig_to_camera(proto_to_dict(rig_to_camera))
+        for cam_name, rig_to_camera in zip(camera_names, rig_to_camera_messages)
+    }
 
 
 def compute_camera_poses_from_rig(

--- a/integrations/omnidreams/tests/test_grpc_camera_extrinsics.py
+++ b/integrations/omnidreams/tests/test_grpc_camera_extrinsics.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from omnidreams.grpc.protos import common_pb2
+from omnidreams.grpc.utils import (
+    compute_camera_poses_from_rig,
+    parse_rig_to_camera_transforms,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def _pose(x: float, y: float, z: float) -> common_pb2.Pose:
+    return common_pb2.Pose(
+        vec=common_pb2.Vec3(x=x, y=y, z=z),
+        quat=common_pb2.Quat(w=1.0, x=0.0, y=0.0, z=0.0),
+    )
+
+
+def test_session_rig_to_camera_transforms_are_mapped_by_camera_order() -> None:
+    transforms = parse_rig_to_camera_transforms(
+        [_pose(1.0, 2.0, 3.0), _pose(4.0, 5.0, 6.0)],
+        ["front", "rear"],
+    )
+
+    front = np.eye(4, dtype=np.float32)
+    front[:3, 3] = [1.0, 2.0, 3.0]
+    rear = np.eye(4, dtype=np.float32)
+    rear[:3, 3] = [4.0, 5.0, 6.0]
+
+    assert list(transforms) == ["front", "rear"]
+    np.testing.assert_allclose(transforms["front"], front)
+    np.testing.assert_allclose(transforms["rear"], rear)
+
+
+def test_session_rig_to_camera_count_must_match_camera_specs() -> None:
+    with pytest.raises(ValueError, match="exactly one Pose per camera_spec"):
+        parse_rig_to_camera_transforms([_pose(1.0, 0.0, 0.0)], ["front", "rear"])
+
+
+def test_camera_pose_uses_session_rig_to_camera_transform() -> None:
+    rig_poses = np.eye(4, dtype=np.float32)[None, ...]
+    transforms = parse_rig_to_camera_transforms(
+        [_pose(1.0, 2.0, 3.0)],
+        ["front"],
+    )
+
+    camera_poses = compute_camera_poses_from_rig(rig_poses, transforms["front"])
+
+    expected = np.eye(4, dtype=np.float32)[None, ...]
+    expected[0, :3, 3] = [1.0, 2.0, 3.0]
+    np.testing.assert_allclose(camera_poses, expected)

--- a/integrations/omnidreams/tests/test_grpc_server_integration.py
+++ b/integrations/omnidreams/tests/test_grpc_server_integration.py
@@ -67,10 +67,6 @@ def _build_camera_spec(
             angle_to_pixeldist_poly=[focal],
             linear_cde=camera_pb2.LinearCde(linear_c=1.0, linear_d=0.0, linear_e=0.0),
         ),
-        rig_to_camera=common_pb2.Pose(
-            vec=common_pb2.Vec3(x=0.0, y=0.0, z=0.0),
-            quat=common_pb2.Quat(w=1.0, x=0.0, y=0.0, z=0.0),
-        ),
     )
 
 
@@ -244,6 +240,12 @@ def test_grpc_server_start_render_close_roundtrip(
                             width=resolution_w,
                         ),
                         format=video_model_pb2.ImageFormat.PNG,
+                    )
+                ],
+                rig_to_camera=[
+                    common_pb2.Pose(
+                        vec=common_pb2.Vec3(x=0.0, y=0.0, z=0.0),
+                        quat=common_pb2.Quat(w=1.0, x=0.0, y=0.0, z=0.0),
                     )
                 ],
                 random_seed=42,


### PR DESCRIPTION
The previous [MR](https://github.com/NVIDIA/flashdreams/pull/178) removing legacy `.proto` defs forgot to remove a non-standard extension of `camera.proto` and incorrectly depended on it. This patch removes the field and depends on the properly supported location for this data.