### PR TITLE
Add interactive steering-wheel calibration CLI

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -260,15 +260,31 @@ The HUD also subscribes to the backend's `/bev_stream` and shows a top-down
 BEV minimap below the steering and pedal controls; pass `--no-bev` to skip
 the extra rasterizer dispatch when you don't need it.
 
-**Steering wheel support.** Drop a profile YAML (axis map, FFB settings,
-device-name match patterns) into `configs/wheels/` and the HUD will pick it
-up at startup. With `--wheel-profile auto` (the default), the HUD scans
-`/dev/input/by-id` first, then `/dev/input/event*`, and matches the
-detected device name against each profile's `detection_patterns`. To name a
-specific profile use `--wheel-profile <name>` (matching the YAML filename);
-to bind a known device path directly use `--wheel-device /dev/input/eventX`;
-to disable wheel input entirely use `--no-wheel`. No profiles ship with the
-repo — keyboard-only driving works fine without one.
+**Steering wheel support.** The HUD reads steering, throttle and brake
+from a Linux `evdev` joystick / wheel via a YAML profile that captures the
+device-specific axis map, pedal direction, and force-feedback settings.
+
+The fastest way to set one up is the bundled calibration CLI:
+
+```bash
+uv run --package flashdreams-omnidreams interactive-drive-configure-wheel
+```
+
+It auto-detects your wheel, walks you through "centre the wheel" /
+"turn fully left" / "turn fully right" / "press / release each pedal",
+optionally pulses force-feedback for a sanity check, then writes
+`configs/wheels/<your-wheel>.yaml` next to the bundled package data.
+On the next `interactive-drive` launch the HUD picks the profile up
+automatically (`--wheel-profile auto`, the default).
+
+To bypass auto-detect, pass `--wheel-profile <name>` (matching the YAML
+filename stem), or pin a specific device path with
+`--wheel-device /dev/input/eventX`. `--no-wheel` disables wheel input
+entirely (keyboard-only driving works fine without a profile).
+
+If FFB writes fail with a permission error, add yourself to the `input`
+group (`sudo usermod -aG input $USER` + log out / back in) or install a
+udev rule for your device.
 
 ### `--no-hud`: bare backend, local Vulkan window
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -270,10 +270,23 @@ The fastest way to set one up is the bundled calibration CLI:
 uv run --package flashdreams-omnidreams interactive-drive-configure-wheel
 ```
 
-It auto-detects your wheel, walks you through "centre the wheel" /
-"turn fully left" / "turn fully right" / "press / release each pedal",
-optionally pulses force-feedback for a sanity check, then writes
-`configs/wheels/<your-wheel>.yaml` next to the bundled package data.
+It auto-detects your wheel (movement-based when multiple joystick-like
+devices are present), walks you through "turn left / turn right / release
+pedal / press pedal" prompts, then probes force-feedback in two stages:
+
+1. **`FF_CONSTANT`** via `EVIOCSFF` — the modern path that works on
+   Fanatec / Simagic / Moza *and* Thrustmaster / Logitech. You'll feel
+   a brief left-then-right push if the driver accepts the effect.
+2. **`FF_AUTOCENTER`** via the in-kernel autocenter event — fallback for
+   drivers that don't implement constant-force effects.
+
+The configurator writes whichever the user actually felt to
+`configs/wheels/<your-wheel>.yaml`. On Fanatec hardware specifically,
+the constant-force path is mandatory: `hid-fanatecff` silently accepts
+`FF_AUTOCENTER` writes but produces no force, so the legacy single-mode
+configurator would have always saved `ffb.enabled: false` for Fanatec
+users with no obvious error.
+
 On the next `interactive-drive` launch the HUD picks the profile up
 automatically (`--wheel-profile auto`, the default).
 
@@ -284,7 +297,10 @@ entirely (keyboard-only driving works fine without a profile).
 
 If FFB writes fail with a permission error, add yourself to the `input`
 group (`sudo usermod -aG input $USER` + log out / back in) or install a
-udev rule for your device.
+udev rule for your device. Fanatec users additionally need the
+[`hid-fanatecff`](https://github.com/gotzl/hid-fanatecff) out-of-tree
+driver if they're on a kernel that doesn't yet ship support for their
+wheel base.
 
 ### `--no-hud`: bare backend, local Vulkan window
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/_evdev.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/_evdev.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Linux ``evdev`` helpers shared by the demo and the wheel configurator.
+
+Lives in its own module (rather than directly in :mod:`demo`) so the
+:mod:`omnidreams.interactive_drive.wheel_configurator` CLI can run
+without the ``interactive-drive`` extra (slangpy) installed -- importing
+``demo`` would otherwise transitively pull in slangpy via
+:class:`~omnidreams.interactive_drive.app.InteractiveDriveApp`.
+"""
+
+from __future__ import annotations
+
+import array
+import fcntl
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+EVDEV_EVENT_FORMAT = "llHHi"
+EVDEV_EVENT_SIZE = struct.calcsize(EVDEV_EVENT_FORMAT)
+
+EV_ABS = 0x03
+EV_FF = 0x15
+
+FF_AUTOCENTER = 0x61
+FF_GAIN = 0x60
+
+
+def EVIOCGABS(axis: int) -> int:  # noqa: N802 - mirrors the kernel macro name
+    """Compute the ``EVIOCGABS(axis)`` ioctl number for one ABS code."""
+    return 0x80184540 + axis
+
+
+# ``EVIOCGNAME(256)``; pre-baked here rather than computed because it's
+# the only name-buffer length the demo + configurator use.
+_EVIOCGNAME_256 = 0x80004506 + (256 << 16)
+
+
+@dataclass(frozen=True)
+class AxisRange:
+    minimum: int
+    maximum: int
+
+    @property
+    def center(self) -> float:
+        return (float(self.minimum) + float(self.maximum)) * 0.5
+
+    @property
+    def span(self) -> float:
+        return max(1.0, float(self.maximum - self.minimum))
+
+
+@dataclass(frozen=True)
+class AxisInfo:
+    """Current value + range for one ABS axis (``input_absinfo`` mirror).
+
+    Used by the wheel configurator to read the axis position *right
+    now* without having to stream events. The runtime ``WheelBridge``
+    only needs :class:`AxisRange`, which is exposed via :attr:`range`.
+    """
+
+    value: int
+    minimum: int
+    maximum: int
+
+    @property
+    def range(self) -> AxisRange:
+        return AxisRange(minimum=self.minimum, maximum=self.maximum)
+
+
+@dataclass(frozen=True)
+class EvdevDevice:
+    path: Path
+    name: str
+
+
+def query_axis(path: Path, axis: int) -> AxisInfo | None:
+    """Query the current value + min/max of one ABS axis.
+
+    Returns ``None`` when the device does not expose the requested
+    axis (``EVIOCGABS`` returns ``ENOTTY``/``EINVAL`` in that case).
+    """
+    try:
+        with path.open("rb") as handle:
+            payload = array.array("i", [0, 0, 0, 0, 0, 0])
+            fcntl.ioctl(handle.fileno(), EVIOCGABS(axis), payload, True)
+            return AxisInfo(
+                value=int(payload[0]),
+                minimum=int(payload[1]),
+                maximum=int(payload[2]),
+            )
+    except OSError:
+        return None
+
+
+def query_axis_range(path: Path, axis: int) -> AxisRange | None:
+    """Convenience wrapper that returns just the static min/max."""
+    info = query_axis(path, axis)
+    return None if info is None else info.range
+
+
+def read_evdev_name(path: Path) -> str | None:
+    try:
+        with path.open("rb") as handle:
+            name_buf = array.array("B", [0] * 256)
+            fcntl.ioctl(handle.fileno(), _EVIOCGNAME_256, name_buf)
+            return name_buf.tobytes().split(b"\x00")[0].decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def scan_evdev_devices() -> tuple[EvdevDevice, ...]:
+    """Enumerate readable evdev devices, preferring stable ``by-id`` paths.
+
+    Devices under ``/dev/input/by-id`` come first because their paths
+    survive USB re-plug and reboot; the raw ``/dev/input/event*`` paths
+    follow as a fallback for devices that don't expose a ``by-id``
+    symlink (e.g. virtual/uinput sources).
+    """
+    candidates: list[Path] = []
+    by_id = Path("/dev/input/by-id")
+    if by_id.is_dir():
+        candidates.extend(
+            sorted(path for path in by_id.glob("*event*") if path.exists())
+        )
+    candidates.extend(sorted(Path("/dev/input").glob("event*")))
+
+    devices: list[EvdevDevice] = []
+    seen: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        name = read_evdev_name(path)
+        if name is not None:
+            devices.append(EvdevDevice(path=path, name=name))
+    return tuple(devices)

--- a/integrations/omnidreams/omnidreams/interactive_drive/_evdev.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/_evdev.py
@@ -24,8 +24,16 @@ EVDEV_EVENT_SIZE = struct.calcsize(EVDEV_EVENT_FORMAT)
 EV_ABS = 0x03
 EV_FF = 0x15
 
+FF_CONSTANT = 0x52
 FF_AUTOCENTER = 0x61
 FF_GAIN = 0x60
+
+# ``EVIOCSFF`` -- upload (or update) a ``struct ff_effect`` for playback.
+# Hand-coded so we don't depend on ``ioctl_opt`` / evdev for a single
+# constant. Layout: _IOC(_IOC_WRITE, 'E', 0x80, sizeof(struct ff_effect))
+# where sizeof(ff_effect) = 0x30 on 64-bit Linux and the kernel encodes
+# this as 0x40304580.
+EVIOCSFF = 0x40304580
 
 
 def EVIOCGABS(axis: int) -> int:  # noqa: N802 - mirrors the kernel macro name

--- a/integrations/omnidreams/omnidreams/interactive_drive/_ffb.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/_ffb.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Force-feedback backends shared by the demo + the wheel configurator.
+
+Two strategies are supported, selected per-profile by ``WheelProfile.ffb_mode``:
+
+* ``"autocenter"`` -- :class:`AutocenterFFB`: writes ``FF_AUTOCENTER`` +
+  ``FF_GAIN`` events, letting the kernel/firmware shape the centering
+  curve. Works on Thrustmaster, Logitech, and any driver that wires up
+  the in-kernel autocenter handler. Does **not** work on Fanatec --
+  ``hid-fanatecff`` accepts the write but never acts on it -- so any
+  Fanatec setup configured with ``mode: autocenter`` will appear to
+  have FFB enabled while producing no force at all.
+* ``"constant_force"`` -- :class:`ConstantForceFFB`: uploads a single
+  ``FF_CONSTANT`` effect via ``EVIOCSFF`` and re-uploads new level
+  values every tick. Works on Fanatec, Simagic, Moza, *and*
+  Thrustmaster, at the cost of computing the centering curve in
+  userspace (sqrt-of-displacement, speed-scaled).
+
+For back-compat, profiles without an ``ffb.mode`` key default to
+``"autocenter"`` (matches the original single-backend behaviour). The
+wheel configurator probes ``constant_force`` first during calibration
+and falls back to ``autocenter`` only if the user reports no force.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import struct
+import time
+from pathlib import Path
+
+from omnidreams.interactive_drive._evdev import (
+    EV_FF,
+    EVDEV_EVENT_FORMAT,
+    EVIOCSFF,
+    FF_AUTOCENTER,
+    FF_CONSTANT,
+    FF_GAIN,
+)
+
+# ``struct ff_effect`` size on 64-bit Linux. Matches the kernel layout
+# referenced by ``EVIOCSFF``: u16 type, s16 id, u16 direction,
+# u16+u16 trigger, u16+u16 replay, 2-byte alignment pad, then the
+# union (constant.level lives at offset 16).
+_FF_EFFECT_STRUCT_SIZE = 48
+
+# Direction encoding: a quarter-circle field where 0x0000=north,
+# 0x4000=east, 0x8000=south, 0xC000=west. For a single-axis steering
+# wheel the direction is effectively ignored -- the sign of
+# ``constant.level`` selects which way the motor pushes -- but the
+# kernel still validates the field, so we pick a fixed value.
+_FF_DIRECTION_EAST = 0x4000
+
+
+class AutocenterFFB:
+    """In-kernel autocenter; the original single FFB path the demo shipped.
+
+    Sets a speed-dependent ``FF_AUTOCENTER`` strength every few ticks.
+    The kernel / wheel firmware shapes the actual centering curve, so
+    feel varies between hardware vendors.
+    """
+
+    def __init__(self) -> None:
+        self._fd: int | None = None
+        self._last_strength = -1
+        self._smoothed = 0.0
+
+    def init(self, device_path: Path, gain: float) -> None:
+        try:
+            self._fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
+            self._write_event(FF_AUTOCENTER, 0)
+            self._write_event(FF_GAIN, int(max(0.0, min(1.0, gain)) * 0xFFFF))
+            print(f"[demo] FFB autocenter enabled on {device_path}", flush=True)
+        except PermissionError:
+            print(
+                "[demo] FFB permission denied; add user to input group or adjust udev",
+                flush=True,
+            )
+            self._fd = None
+        except OSError as exc:
+            print(f"[demo] FFB unavailable on {device_path}: {exc}", flush=True)
+            self._fd = None
+
+    def update(
+        self,
+        speed_mps: float,
+        *,
+        gain: float,
+        steering_raw: int,  # noqa: ARG002 - kept for backend-uniform signature
+        steering_center: float,  # noqa: ARG002
+        steering_span: float,  # noqa: ARG002
+    ) -> None:
+        if self._fd is None:
+            return
+        if speed_mps < 0.1:
+            target = 0.15
+        else:
+            norm = min(1.0, speed_mps / 14.0)
+            target = 0.35 + 0.65 * norm
+        self._smoothed += 0.12 * (target - self._smoothed)
+        strength = int(self._smoothed * max(0.0, min(1.0, gain)) * 0xFFFF)
+        strength = max(0, min(0xFFFF, strength))
+        if abs(strength - self._last_strength) > 500:
+            self._write_event(FF_AUTOCENTER, strength)
+            self._last_strength = strength
+
+    def cleanup(self) -> None:
+        if self._fd is None:
+            return
+        try:
+            self._write_event(FF_AUTOCENTER, 0)
+            os.close(self._fd)
+        except OSError:
+            pass
+        self._fd = None
+
+    def _write_event(self, code: int, value: int) -> None:
+        if self._fd is None:
+            return
+        now = time.time()
+        sec = int(now)
+        usec = int((now - sec) * 1_000_000)
+        try:
+            os.write(
+                self._fd,
+                struct.pack(EVDEV_EVENT_FORMAT, sec, usec, EV_FF, code, value),
+            )
+        except OSError:
+            return
+
+
+class ConstantForceFFB:
+    """FFB via FF_CONSTANT effect (Fanatec, Simagic, Moza, Thrustmaster).
+
+    Uploads one ``FF_CONSTANT`` effect at init time, plays it
+    continuously, and re-uploads new level values every tick. The
+    centering force is ``sign(displacement) * sqrt(|displacement|)``
+    where ``displacement`` is the normalised offset of the steering
+    raw value from the axis centre, scaled by a low-pass-filtered
+    speed factor and the profile's ``ffb_gain``.
+
+    Sign convention (mirrors the alpasim port we ported this from):
+    a positive ``level`` is taken to push the wheel in the *opposite*
+    direction to ``displacement > 0``, i.e. a restoring torque when
+    the raw value sits above the axis centre. This holds on every
+    Linux-supported wheel base we've tested; if a future device
+    reverses the convention and the wheel "runs away" rather than
+    centering, hand-flip the sign in the ``level`` line below (or add
+    a profile field for it).
+    """
+
+    def __init__(self) -> None:
+        self._fd: int | None = None
+        self._effect_id: int = -1
+        self._last_level: int = 0
+        self._smoothed: float = 0.0
+
+    def init(self, device_path: Path, gain: float) -> None:
+        try:
+            self._fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
+        except PermissionError:
+            print(
+                "[demo] FFB permission denied; add user to input group or adjust udev",
+                flush=True,
+            )
+            self._fd = None
+            return
+        except OSError as exc:
+            print(f"[demo] FFB unavailable on {device_path}: {exc}", flush=True)
+            self._fd = None
+            return
+
+        # ``FF_GAIN`` is a separate, evdev-wide knob -- not specific to
+        # the constant effect -- so we still set it here so subsequent
+        # writes scale to the profile's gain ceiling.
+        self._write_event(FF_GAIN, int(max(0.0, min(1.0, gain)) * 0xFFFF))
+
+        self._effect_id = -1
+        effect_id = self._upload_constant(level=1)
+        if effect_id < 0:
+            print(
+                "[demo] FFB constant-force upload failed; driver likely "
+                "lacks FF_CONSTANT support",
+                flush=True,
+            )
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = None
+            return
+        self._effect_id = effect_id
+        self._play(effect_id, 1)
+        self._upload_constant(level=0)
+        print(f"[demo] FFB constant-force enabled on {device_path}", flush=True)
+
+    def update(
+        self,
+        speed_mps: float,
+        *,
+        gain: float,
+        steering_raw: int,
+        steering_center: float,
+        steering_span: float,
+    ) -> None:
+        if self._fd is None or self._effect_id < 0:
+            return
+        if speed_mps < 0.1:
+            target = 0.0
+        else:
+            target = 0.25 + 0.75 * min(1.0, speed_mps / 13.9)
+        self._smoothed += 0.15 * (target - self._smoothed)
+
+        half_span = max(1.0, steering_span * 0.5)
+        displacement = (float(steering_raw) - steering_center) / half_span
+        # Stronger near centre to keep the wheel from feeling limp at
+        # small angles.
+        sign = 1.0 if displacement >= 0 else -1.0
+        shaped = sign * (abs(displacement) ** 0.5)
+        force = shaped * self._smoothed * max(0.0, gain)
+        level = int(force * 0x7FFF)
+        level = max(-0x7FFF, min(0x7FFF, level))
+        # Hysteresis: avoid spamming EVIOCSFF on every sub-LSB change;
+        # 100 lsb out of 0x7FFF (~0.3%) is below the wheel's mechanical
+        # discrimination.
+        if abs(level - self._last_level) > 100:
+            self._upload_constant(level=level)
+            self._last_level = level
+
+    def cleanup(self) -> None:
+        if self._fd is None:
+            return
+        try:
+            if self._effect_id >= 0:
+                self._upload_constant(level=0)
+                self._play(self._effect_id, 0)
+            os.close(self._fd)
+        except OSError:
+            pass
+        self._fd = None
+        self._effect_id = -1
+
+    def _upload_constant(self, *, level: int) -> int:
+        if self._fd is None:
+            return -1
+        buf = bytearray(_FF_EFFECT_STRUCT_SIZE)
+        struct.pack_into("Hh", buf, 0, FF_CONSTANT, self._effect_id)
+        struct.pack_into("H", buf, 4, _FF_DIRECTION_EAST)
+        struct.pack_into("h", buf, 16, max(-0x7FFF, min(0x7FFF, level)))
+        try:
+            fcntl.ioctl(self._fd, EVIOCSFF, buf)
+        except OSError:
+            return -1
+        # The kernel writes the assigned effect id back into the struct
+        # when ``id == -1`` on entry (i.e. on the first upload). Read it
+        # back so subsequent re-uploads address the same effect.
+        result_id = struct.unpack_from("Hh", buf, 0)[1]
+        self._effect_id = result_id
+        return result_id
+
+    def _play(self, effect_id: int, value: int) -> None:
+        if self._fd is None:
+            return
+        self._write_event(effect_id, value)
+
+    def _write_event(self, code: int, value: int) -> None:
+        if self._fd is None:
+            return
+        now = time.time()
+        sec = int(now)
+        usec = int((now - sec) * 1_000_000)
+        try:
+            os.write(
+                self._fd,
+                struct.pack(EVDEV_EVENT_FORMAT, sec, usec, EV_FF, code, value),
+            )
+        except OSError:
+            return
+
+
+# Module-level dispatch table so the configurator + demo + future
+# backends can extend the mode set without touching the call sites.
+_FFB_BACKENDS: dict[str, type] = {
+    "autocenter": AutocenterFFB,
+    "constant_force": ConstantForceFFB,
+}
+
+FFB_MODES: tuple[str, ...] = tuple(_FFB_BACKENDS.keys())
+
+
+def create_ffb_backend(mode: str) -> AutocenterFFB | ConstantForceFFB:
+    """Instantiate the FFB backend selected by a profile's ``ffb.mode``.
+
+    Falls back to :class:`AutocenterFFB` for unknown modes so a typo
+    in a hand-edited YAML never deadlocks the demo's startup.
+    """
+    cls = _FFB_BACKENDS.get(mode)
+    if cls is None:
+        print(
+            f"[demo] unknown FFB mode {mode!r}; falling back to 'autocenter'",
+            flush=True,
+        )
+        cls = AutocenterFFB
+    return cls()

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -22,17 +22,15 @@ from omnidreams import scenes as _scenes
 from omnidreams.interactive_drive import cli as _cli
 from omnidreams.interactive_drive._evdev import (
     EV_ABS,
-    EV_FF,
     EVDEV_EVENT_FORMAT,
     EVDEV_EVENT_SIZE,
-    FF_AUTOCENTER,
-    FF_GAIN,
     AxisRange,
     EvdevDevice,
     query_axis_range as _query_axis_range,
     read_evdev_name as _read_evdev_name,
     scan_evdev_devices as _scan_evdev_devices,
 )
+from omnidreams.interactive_drive._ffb import create_ffb_backend as _create_ffb_backend
 from omnidreams.interactive_drive.app import InteractiveDriveApp
 from omnidreams.interactive_drive.config import BevConfig, RasterConfig
 from omnidreams.scenes import normalise_scene_uuid, scenes_cache_root
@@ -101,6 +99,13 @@ class WheelProfile:
     invert_steering: bool = False
     ffb_enabled: bool = False
     ffb_gain: float = 0.5
+    # Which FFB backend ``WheelBridge`` instantiates (see
+    # :mod:`omnidreams.interactive_drive._ffb`). ``"autocenter"`` is the
+    # back-compat default for older YAMLs without the field;
+    # ``"constant_force"`` is required for Fanatec (their kernel driver
+    # does not implement FF_AUTOCENTER) and produces a finer-feel
+    # centering curve on Thrustmaster/Logitech too.
+    ffb_mode: str = "autocenter"
     threshold: float = 0.12
     is_default: bool = False
 
@@ -248,7 +253,7 @@ class WheelBridge:
         self._inverted_pedals = bool(profile.inverted_pedals)
         self._invert_steering = bool(profile.invert_steering)
         self._threshold = float(profile.threshold)
-        self._ffb = AutocenterFFB()
+        self._ffb = _create_ffb_backend(profile.ffb_mode)
         self._axis_ranges: dict[int, AxisRange] = {}
         self._raw_axes: dict[int, int] = {}
         self._state = WheelState()
@@ -343,7 +348,18 @@ class WheelBridge:
             self._state.target_speed_mps = target_speed
 
         self._control.set_drive(steer=steering, throttle=throttle, brake=brake)
-        self._ffb.update(abs(target_speed), gain=self._profile.ffb_gain)
+        # ConstantForceFFB needs the *raw* (pre-invert) steering value
+        # so its centering torque always points back toward the
+        # hardware's reported axis centre; AutocenterFFB ignores these
+        # but accepts them for backend-uniform signature.
+        steering_axis_range = self._axis_ranges[self._steering_axis]
+        self._ffb.update(
+            abs(target_speed),
+            gain=self._profile.ffb_gain,
+            steering_raw=self._raw_axes[self._steering_axis],
+            steering_center=steering_axis_range.center,
+            steering_span=steering_axis_range.span,
+        )
 
     def _normalize_steering(self, raw: int) -> float:
         axis_range = self._axis_ranges[self._steering_axis]
@@ -391,67 +407,6 @@ class WheelBridge:
             else:
                 speed = max(0.0, speed - 0.5 * dt)
         return max(0.0, min(36.0, speed))
-
-
-class AutocenterFFB:
-    def __init__(self) -> None:
-        self._fd: int | None = None
-        self._last_strength = -1
-        self._smoothed = 0.0
-
-    def init(self, device_path: Path, gain: float) -> None:
-        try:
-            self._fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
-            self._write_event(FF_AUTOCENTER, 0)
-            self._write_event(FF_GAIN, int(max(0.0, min(1.0, gain)) * 0xFFFF))
-            print(f"[demo] FFB autocenter enabled on {device_path}", flush=True)
-        except PermissionError:
-            print(
-                "[demo] FFB permission denied; add user to input group or adjust udev",
-                flush=True,
-            )
-            self._fd = None
-        except OSError as exc:
-            print(f"[demo] FFB unavailable on {device_path}: {exc}", flush=True)
-            self._fd = None
-
-    def update(self, speed_mps: float, *, gain: float) -> None:
-        if self._fd is None:
-            return
-        if speed_mps < 0.1:
-            target = 0.15
-        else:
-            norm = min(1.0, speed_mps / 14.0)
-            target = 0.35 + 0.65 * norm
-        self._smoothed += 0.12 * (target - self._smoothed)
-        strength = int(self._smoothed * max(0.0, min(1.0, gain)) * 0xFFFF)
-        strength = max(0, min(0xFFFF, strength))
-        if abs(strength - self._last_strength) > 500:
-            self._write_event(FF_AUTOCENTER, strength)
-            self._last_strength = strength
-
-    def cleanup(self) -> None:
-        if self._fd is None:
-            return
-        try:
-            self._write_event(FF_AUTOCENTER, 0)
-            os.close(self._fd)
-        except OSError:
-            pass
-        self._fd = None
-
-    def _write_event(self, code: int, value: int) -> None:
-        if self._fd is None:
-            return
-        now = time.time()
-        sec = int(now)
-        usec = int((now - sec) * 1_000_000)
-        try:
-            os.write(
-                self._fd, struct.pack(EVDEV_EVENT_FORMAT, sec, usec, EV_FF, code, value)
-            )
-        except OSError:
-            return
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -976,6 +931,7 @@ def _load_wheel_profiles(profiles_dir: Path) -> tuple[WheelProfile, ...]:
             str(key): int(value) for key, value in data.get("axis_map", {}).items()
         }
         pedal = data.get("pedal", {}) or {}
+        ffb = data.get("ffb", {}) or {}
         profiles.append(
             WheelProfile(
                 name=str(data.get("name", path.stem)),
@@ -988,8 +944,9 @@ def _load_wheel_profiles(profiles_dir: Path) -> tuple[WheelProfile, ...]:
                     pedal.get("inverted", data.get("inverted_pedals", True))
                 ),
                 invert_steering=bool(data.get("invert_steering", False)),
-                ffb_enabled=bool((data.get("ffb", {}) or {}).get("enabled", False)),
-                ffb_gain=float((data.get("ffb", {}) or {}).get("gain", 0.5)),
+                ffb_enabled=bool(ffb.get("enabled", False)),
+                ffb_gain=float(ffb.get("gain", 0.5)),
+                ffb_mode=str(ffb.get("mode", "autocenter")),
                 threshold=float(data.get("threshold", 0.12)),
                 is_default=bool(data.get("is_default", False)),
             )
@@ -1149,6 +1106,7 @@ def _apply_wheel_overrides(
         invert_steering=profile.invert_steering,
         ffb_enabled=profile.ffb_enabled,
         ffb_gain=profile.ffb_gain,
+        ffb_mode=profile.ffb_mode,
         threshold=profile.threshold,
         is_default=profile.is_default,
     )

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import array
-import fcntl
 import io
 import math
 import os
@@ -22,18 +20,23 @@ import numpy as np
 import yaml
 from omnidreams import scenes as _scenes
 from omnidreams.interactive_drive import cli as _cli
+from omnidreams.interactive_drive._evdev import (
+    EV_ABS,
+    EV_FF,
+    EVDEV_EVENT_FORMAT,
+    EVDEV_EVENT_SIZE,
+    FF_AUTOCENTER,
+    FF_GAIN,
+    AxisRange,
+    EvdevDevice,
+    query_axis_range as _query_axis_range,
+    read_evdev_name as _read_evdev_name,
+    scan_evdev_devices as _scan_evdev_devices,
+)
 from omnidreams.interactive_drive.app import InteractiveDriveApp
 from omnidreams.interactive_drive.config import BevConfig, RasterConfig
 from omnidreams.scenes import normalise_scene_uuid, scenes_cache_root
 from PIL import Image
-
-EVDEV_EVENT_FORMAT = "llHHi"
-EVDEV_EVENT_SIZE = struct.calcsize(EVDEV_EVENT_FORMAT)
-EV_ABS = 0x03
-EV_FF = 0x15
-FF_AUTOCENTER = 0x61
-FF_GAIN = 0x60
-EVIOCGABS = lambda axis: 0x80184540 + axis  # noqa: E731
 
 # Width of the right-side HUD panel that holds the steering wheel,
 # pedals, speed digit and BEV minimap. The camera area fills the rest
@@ -86,26 +89,6 @@ _GMAPS_TINTED_MUL = (
 _BEV_DEFAULTS = BevConfig()
 BEV_FOV_DEG = _BEV_DEFAULTS.fov_deg
 BEV_TILT_DEG = _BEV_DEFAULTS.tilt_deg
-
-
-@dataclass(frozen=True)
-class AxisRange:
-    minimum: int
-    maximum: int
-
-    @property
-    def center(self) -> float:
-        return (float(self.minimum) + float(self.maximum)) * 0.5
-
-    @property
-    def span(self) -> float:
-        return max(1.0, float(self.maximum - self.minimum))
-
-
-@dataclass(frozen=True)
-class EvdevDevice:
-    path: Path
-    name: str
 
 
 @dataclass(frozen=True)
@@ -1066,31 +1049,6 @@ def _detect_device_for_profile(profile: WheelProfile) -> EvdevDevice | None:
     return None
 
 
-def _scan_evdev_devices() -> tuple[EvdevDevice, ...]:
-    candidates: list[Path] = []
-    by_id = Path("/dev/input/by-id")
-    if by_id.is_dir():
-        candidates.extend(
-            sorted(path for path in by_id.glob("*event*") if path.exists())
-        )
-    candidates.extend(sorted(Path("/dev/input").glob("event*")))
-
-    devices: list[EvdevDevice] = []
-    seen: set[Path] = set()
-    for path in candidates:
-        try:
-            resolved = path.resolve()
-        except OSError:
-            resolved = path
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        name = _read_evdev_name(path)
-        if name is not None:
-            devices.append(EvdevDevice(path=path, name=name))
-    return tuple(devices)
-
-
 def _device_matches_profile(device: EvdevDevice, profile: WheelProfile) -> bool:
     name = device.name.lower()
     if not any(pattern.lower() in name for pattern in profile.detection_patterns):
@@ -1099,16 +1057,6 @@ def _device_matches_profile(device: EvdevDevice, profile: WheelProfile) -> bool:
     return all(
         _query_axis_range(device.path, axis) is not None for axis in required_axes
     )
-
-
-def _read_evdev_name(path: Path) -> str | None:
-    try:
-        with path.open("rb") as handle:
-            name_buf = array.array("B", [0] * 256)
-            fcntl.ioctl(handle.fileno(), 0x80004506 + (256 << 16), name_buf)
-            return name_buf.tobytes().split(b"\x00")[0].decode("utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
 
 
 def _load_control_assets(control_assets_dir: Path | None) -> ControlAssets:
@@ -1204,16 +1152,6 @@ def _apply_wheel_overrides(
         threshold=profile.threshold,
         is_default=profile.is_default,
     )
-
-
-def _query_axis_range(path: Path, axis: int) -> AxisRange | None:
-    try:
-        with path.open("rb") as handle:
-            payload = array.array("i", [0, 0, 0, 0, 0, 0])
-            fcntl.ioctl(handle.fileno(), EVIOCGABS(axis), payload, True)
-            return AxisRange(minimum=int(payload[1]), maximum=int(payload[2]))
-    except OSError:
-        return None
 
 
 def _parse_axis(value: str) -> int:

--- a/integrations/omnidreams/omnidreams/interactive_drive/wheel_configurator.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/wheel_configurator.py
@@ -25,6 +25,7 @@ Entry point: ``interactive-drive-configure-wheel``.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import os
 import re
 import select
@@ -39,7 +40,9 @@ from omnidreams.interactive_drive._evdev import (
     EV_FF,
     EVDEV_EVENT_FORMAT,
     EVDEV_EVENT_SIZE,
+    EVIOCSFF,
     FF_AUTOCENTER,
+    FF_CONSTANT,
     FF_GAIN,
     AxisInfo,
     EvdevDevice,
@@ -212,9 +215,9 @@ def _run(args: argparse.Namespace) -> int:
         )
 
     if args.skip_ffb_test:
-        ffb_enabled, ffb_gain = False, 0.5
+        ffb_enabled, ffb_mode, ffb_gain = False, "autocenter", 0.5
     else:
-        ffb_enabled, ffb_gain = _calibrate_ffb(device.path)
+        ffb_enabled, ffb_mode, ffb_gain = _calibrate_ffb(device.path)
 
     profile_name = args.name or _slugify(device.name) or "custom-wheel"
     profile_name = _prompt_profile_name(profile_name)
@@ -242,6 +245,7 @@ def _run(args: argparse.Namespace) -> int:
         pedals_inverted=pedals_inverted,
         invert_steering=invert_steering,
         ffb_enabled=ffb_enabled,
+        ffb_mode=ffb_mode,
         ffb_gain=ffb_gain,
     )
 
@@ -492,72 +496,184 @@ def _calibrate_pedal(
     return pedal_axis, inverted
 
 
-def _calibrate_ffb(device_path: Path) -> tuple[bool, float]:
+def _calibrate_ffb(device_path: Path) -> tuple[bool, str, float]:
+    """Probe both FFB strategies and return ``(enabled, mode, gain)``.
+
+    Order matters: we try ``FF_CONSTANT`` first because it works on
+    *every* wheel base we support (Fanatec, Simagic, Moza, Thrustmaster,
+    Logitech). ``FF_AUTOCENTER`` is the fallback for drivers that
+    accept the in-kernel autocenter effect but do not implement
+    ``EVIOCSFF`` (older Logitech profiles, the in-kernel ``hid-tmff``).
+    Fanatec's ``hid-fanatecff`` does the *opposite*: ``FF_AUTOCENTER``
+    is silently accepted with no force produced, so without the
+    constant-force probe Fanatec users would always get
+    ``ffb.enabled: false`` here.
+    """
     print("\nStep 4 (optional): Force feedback")
     if not _confirm(
-        "  Send a brief autocenter pulse to test FFB? Keep hands clear of the wheel.",
-        default=True,
+        "  Run a brief FFB test? Keep hands clear of the wheel.", default=True
     ):
-        return False, 0.5
+        return False, "autocenter", 0.5
 
+    print(
+        "\n  Trying constant-force effect first "
+        "(works on Fanatec / Simagic / Moza and modern Thrustmaster)..."
+    )
+    constant_status = _pulse_constant_force(device_path)
+    if constant_status == "ok":
+        if _confirm(
+            "  Did the wheel push left and then right?", default=True
+        ):
+            gain = _prompt_gain(
+                "  Constant-force gain (0.0-3.0, default 1.0): ",
+                default=1.0,
+                lo=0.0,
+                hi=3.0,
+            )
+            return True, "constant_force", gain
+        print("  No constant-force response felt; trying autocenter mode.")
+    elif constant_status == "permission":
+        # Permission errors are global to the device, so the autocenter
+        # probe would just hit the same wall. Bail out early with a
+        # useful message.
+        return False, "autocenter", 0.5
+    else:
+        print(
+            "  Driver did not accept the constant-force effect upload; "
+            "trying autocenter mode."
+        )
+
+    print(
+        "\n  Trying autocenter effect "
+        "(works on Thrustmaster / Logitech via the in-kernel autocenter handler)..."
+    )
+    autocenter_status = _pulse_autocenter(device_path)
+    if autocenter_status == "ok":
+        if _confirm("  Did the wheel try to recentre itself?", default=True):
+            gain = _prompt_gain(
+                "  Autocenter gain (0.0-1.0, default 0.6): ",
+                default=0.6,
+                lo=0.0,
+                hi=1.0,
+            )
+            return True, "autocenter", gain
+        print("  No autocenter response either.")
+
+    print("  Setting ffb.enabled: false; you can hand-edit the YAML later.")
+    return False, "autocenter", 0.5
+
+
+def _pulse_constant_force(device_path: Path) -> str:
+    """Upload a ``FF_CONSTANT`` effect, pulse it left then right.
+
+    Returns ``"ok"`` if the kernel accepted the effect upload (whether
+    or not the user actually felt the wheel move), ``"permission"`` if
+    we couldn't even open the device, or ``"unsupported"`` if the
+    driver rejected ``EVIOCSFF``.
+    """
     try:
         fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
     except PermissionError:
         print(
             "  Permission denied opening the device for FFB. Add yourself to "
-            "the `input` group or adjust udev rules, then re-run.\n"
-            "  Skipping FFB; setting `ffb.enabled: false`."
+            "the `input` group or adjust udev rules, then re-run."
         )
-        return False, 0.5
+        return "permission"
     except OSError as exc:
-        print(f"  Could not open device for FFB ({exc}); setting `ffb.enabled: false`.")
-        return False, 0.5
+        print(f"  Could not open device for FFB ({exc}).")
+        return "unsupported"
 
     try:
-        _write_ff_event(fd, FF_GAIN, 0xFFFF)
-        print("  Pulsing autocenter at max strength for ~2 seconds...")
-        # Re-send the same strength every ~0.5 s in case the device's FFB
-        # state machine resets between writes (some kernels expire stale
-        # autocenter values automatically after ~1 s).
-        for _ in range(4):
-            _write_ff_event(fd, FF_AUTOCENTER, 0xFFFF)
-            time.sleep(0.5)
-        _write_ff_event(fd, FF_AUTOCENTER, 0)
+        effect_id = _upload_ff_constant(fd, effect_id=-1, level=1)
+        if effect_id < 0:
+            return "unsupported"
+        # Play the effect once; subsequent EVIOCSFF re-uploads update
+        # the level without needing another play event.
+        _send_ev_ff_event(fd, code=effect_id, value=1)
+        print("    pushing left for ~1 s...")
+        _upload_ff_constant(fd, effect_id=effect_id, level=0x7FFF)
+        time.sleep(1.0)
+        print("    pushing right for ~1 s...")
+        _upload_ff_constant(fd, effect_id=effect_id, level=-0x7FFF)
+        time.sleep(1.0)
+        _upload_ff_constant(fd, effect_id=effect_id, level=0)
+        _send_ev_ff_event(fd, code=effect_id, value=0)
+        return "ok"
     except OSError as exc:
-        print(f"  FFB write failed ({exc}); setting `ffb.enabled: false`.")
-        try:
-            os.close(fd)
-        except OSError:
-            pass
-        return False, 0.5
+        print(f"  FFB write failed ({exc}).")
+        return "unsupported"
     finally:
         try:
             os.close(fd)
         except OSError:
             pass
 
-    if not _confirm("  Did the wheel try to pull toward centre?", default=True):
-        print("  Setting `ffb.enabled: false`.")
-        return False, 0.5
 
-    while True:
+def _pulse_autocenter(device_path: Path) -> str:
+    """Pulse ``FF_AUTOCENTER`` at max strength for ~2 s.
+
+    Returns ``"ok"`` / ``"permission"`` / ``"unsupported"`` with the
+    same semantics as :func:`_pulse_constant_force`.
+    """
+    try:
+        fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
+    except PermissionError:
+        print(
+            "  Permission denied opening the device for FFB. Add yourself to "
+            "the `input` group or adjust udev rules, then re-run."
+        )
+        return "permission"
+    except OSError as exc:
+        print(f"  Could not open device for FFB ({exc}).")
+        return "unsupported"
+
+    try:
+        _send_ev_ff_event(fd, code=FF_GAIN, value=0xFFFF)
+        # Re-send the same strength every ~0.5 s in case the device's
+        # FFB state machine expires stale autocenter values (some
+        # kernels reset autocenter after ~1 s of no writes).
+        for _ in range(4):
+            _send_ev_ff_event(fd, code=FF_AUTOCENTER, value=0xFFFF)
+            time.sleep(0.5)
+        _send_ev_ff_event(fd, code=FF_AUTOCENTER, value=0)
+        return "ok"
+    except OSError as exc:
+        print(f"  FFB write failed ({exc}).")
+        return "unsupported"
+    finally:
         try:
-            raw = input("  FFB gain (0.0-1.0, default 0.6): ").strip()
-        except EOFError:
-            raw = ""
-        if not raw:
-            return True, 0.6
-        try:
-            gain = float(raw)
-        except ValueError:
-            print("    Please enter a number between 0.0 and 1.0.")
-            continue
-        if 0.0 <= gain <= 1.0:
-            return True, gain
-        print("    Out of range; pick a value between 0.0 and 1.0.")
+            os.close(fd)
+        except OSError:
+            pass
 
 
-def _write_ff_event(fd: int, code: int, value: int) -> None:
+# ``struct ff_effect`` size on 64-bit Linux; matches the kernel's
+# definition referenced by ``EVIOCSFF``. ``constant.level`` lives at
+# offset 16 (after the 2-byte alignment pad following replay.delay).
+_FF_EFFECT_STRUCT_SIZE = 48
+_FF_DIRECTION_EAST = 0x4000
+
+
+def _upload_ff_constant(fd: int, *, effect_id: int, level: int) -> int:
+    """``EVIOCSFF`` an ``ff_effect`` with the given constant level.
+
+    Pass ``effect_id=-1`` on the first call to let the kernel assign
+    an id; reuse the returned id for subsequent level updates so the
+    driver doesn't allocate a fresh effect every tick. Returns the
+    assigned id, or -1 if the upload was rejected.
+    """
+    buf = bytearray(_FF_EFFECT_STRUCT_SIZE)
+    struct.pack_into("Hh", buf, 0, FF_CONSTANT, effect_id)
+    struct.pack_into("H", buf, 4, _FF_DIRECTION_EAST)
+    struct.pack_into("h", buf, 16, max(-0x7FFF, min(0x7FFF, level)))
+    try:
+        fcntl.ioctl(fd, EVIOCSFF, buf)
+    except OSError:
+        return -1
+    return struct.unpack_from("Hh", buf, 0)[1]
+
+
+def _send_ev_ff_event(fd: int, *, code: int, value: int) -> None:
     now = time.time()
     sec = int(now)
     usec = int((now - sec) * 1_000_000)
@@ -565,6 +681,24 @@ def _write_ff_event(fd: int, code: int, value: int) -> None:
         fd,
         struct.pack(EVDEV_EVENT_FORMAT, sec, usec, EV_FF, code, value),
     )
+
+
+def _prompt_gain(prompt: str, *, default: float, lo: float, hi: float) -> float:
+    while True:
+        try:
+            raw = input(prompt).strip()
+        except EOFError:
+            return default
+        if not raw:
+            return default
+        try:
+            gain = float(raw)
+        except ValueError:
+            print(f"    Please enter a number between {lo} and {hi}.")
+            continue
+        if lo <= gain <= hi:
+            return gain
+        print(f"    Out of range; pick a value between {lo} and {hi}.")
 
 
 # ---------------------------------------------------------------------
@@ -658,6 +792,7 @@ def _write_profile_yaml(
     pedals_inverted: bool,
     invert_steering: bool,
     ffb_enabled: bool,
+    ffb_mode: str,
     ffb_gain: float,
     threshold: float = 0.12,
 ) -> None:
@@ -702,6 +837,7 @@ def _write_profile_yaml(
         f"invert_steering: {str(invert_steering).lower()}",
         "",
         "ffb:",
+        f"  mode: {ffb_mode}   # {_FFB_MODE_COMMENTS.get(ffb_mode, '')}".rstrip(),
         f"  enabled: {str(ffb_enabled).lower()}",
         f"  gain: {_format_float(ffb_gain)}",
         "",
@@ -709,6 +845,13 @@ def _write_profile_yaml(
         "",
     ]
     path.write_text("\n".join(lines), encoding="utf-8")
+
+
+_FFB_MODE_COMMENTS: dict[str, str] = {
+    "autocenter": "in-kernel FF_AUTOCENTER (Thrustmaster, Logitech)",
+    "constant_force": "EVIOCSFF FF_CONSTANT effect (Fanatec, Simagic, Moza, "
+    "Thrustmaster)",
+}
 
 
 def _yaml_quote(value: str) -> str:

--- a/integrations/omnidreams/omnidreams/interactive_drive/wheel_configurator.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/wheel_configurator.py
@@ -1,0 +1,746 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Interactive steering-wheel + pedal calibration CLI.
+
+Walks the user through:
+
+1. Picking a wheel device (auto-detect by movement when more than one
+   joystick-like evdev device is present, with a numbered menu fallback).
+2. Calibrating the steering axis (centre / full-left / full-right).
+3. Calibrating the throttle and brake pedals (released / pressed).
+4. Optionally testing force feedback.
+5. Writing a YAML profile to ``configs/wheels/<name>.yaml`` that the
+   :mod:`omnidreams.interactive_drive.demo` loader recognises.
+
+The configurator deliberately keeps its runtime dependencies light --
+only stdlib + PyYAML -- so it can be invoked on hosts that don't have
+the ``interactive-drive`` (slangpy) extra installed; the goal is for
+users to be able to calibrate their wheel even before the full demo
+stack is ready.
+
+Entry point: ``interactive-drive-configure-wheel``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import select
+import struct
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from omnidreams.interactive_drive._evdev import (
+    EV_ABS,
+    EV_FF,
+    EVDEV_EVENT_FORMAT,
+    EVDEV_EVENT_SIZE,
+    FF_AUTOCENTER,
+    FF_GAIN,
+    AxisInfo,
+    EvdevDevice,
+    query_axis,
+    scan_evdev_devices,
+)
+
+# Common analogue ABS axis codes we'll probe. Covers all the standard
+# wheel + pedal layouts (ABS_X..ABS_BRAKE); deliberately excludes
+# discrete hat axes (ABS_HAT0X = 0x10+).
+_CANDIDATE_AXES: tuple[int, ...] = tuple(range(0x00, 0x0B))
+
+_ABS_AXIS_NAMES: dict[int, str] = {
+    0x00: "ABS_X",
+    0x01: "ABS_Y",
+    0x02: "ABS_Z",
+    0x03: "ABS_RX",
+    0x04: "ABS_RY",
+    0x05: "ABS_RZ",
+    0x06: "ABS_THROTTLE",
+    0x07: "ABS_RUDDER",
+    0x08: "ABS_WHEEL",
+    0x09: "ABS_GAS",
+    0x0A: "ABS_BRAKE",
+}
+
+
+@dataclass(frozen=True)
+class _AxisSnapshot:
+    """Per-axis raw value sampled at a calibration checkpoint."""
+
+    values: dict[int, int]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return _run(args)
+    except KeyboardInterrupt:
+        print("\n[configure-wheel] aborted.", file=sys.stderr)
+        return 130
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="interactive-drive-configure-wheel",
+        description=(
+            "Interactive steering-wheel + pedal calibration. Writes a YAML "
+            "profile compatible with `interactive-drive --wheel-profile`."
+        ),
+    )
+    parser.add_argument(
+        "--device",
+        type=Path,
+        default=None,
+        help=(
+            "Skip device selection and use this evdev path directly "
+            "(e.g. /dev/input/event5 or /dev/input/by-id/usb-...-event-joystick)."
+        ),
+    )
+    parser.add_argument(
+        "--name",
+        default=None,
+        help=(
+            "Profile name (and YAML filename stem). Defaults to a slug of "
+            "the device's evdev name."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory to write the YAML into. Defaults to the bundled "
+            "`configs/wheels/` directory inside the installed package so "
+            "the demo's `--wheel-profile auto` picks it up automatically."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing profile YAML without prompting.",
+    )
+    parser.add_argument(
+        "--no-default",
+        action="store_true",
+        help=(
+            "Do not mark the generated profile as the default. Default "
+            "profiles are matched first during `--wheel-profile auto` "
+            "detection; useful when you're configuring a secondary wheel."
+        ),
+    )
+    parser.add_argument(
+        "--skip-ffb-test",
+        action="store_true",
+        help=(
+            "Skip the force-feedback pulse test and write `ffb.enabled: false`. "
+            "Useful on wheels without a motor or in CI."
+        ),
+    )
+    return parser
+
+
+def _run(args: argparse.Namespace) -> int:
+    devices = scan_evdev_devices()
+    if not devices:
+        print(
+            "[configure-wheel] no evdev devices found under /dev/input/. "
+            "Plug in your wheel and re-run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    candidates = _filter_candidates(devices)
+    if not candidates:
+        print(
+            "[configure-wheel] no devices with analogue ABS axes found. "
+            "Wheels expose ABS_X/ABS_Z/ABS_RZ-style axes; if yours is plugged "
+            "in but not listed, check `evtest` and udev permissions.",
+            file=sys.stderr,
+        )
+        return 1
+
+    device = _pick_device(args, candidates)
+    if device is None:
+        return 1
+
+    print()
+    print(f"Calibrating: {device.name}")
+    print(f"Device path: {device.path}")
+
+    axes = _detect_abs_axes(device.path)
+    if len(axes) < 3:
+        print(
+            f"[configure-wheel] device only exposes {len(axes)} analogue axes "
+            "(need >= 3 for steering + throttle + brake).",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        steering_axis, invert_steering = _calibrate_steering(device.path, axes)
+    except _CalibrationAborted as exc:
+        print(f"\n[configure-wheel] {exc}", file=sys.stderr)
+        return 1
+
+    remaining = tuple(a for a in axes if a != steering_axis)
+    try:
+        throttle_axis, throttle_inverted = _calibrate_pedal(
+            device.path, remaining, "throttle"
+        )
+    except _CalibrationAborted as exc:
+        print(f"\n[configure-wheel] {exc}", file=sys.stderr)
+        return 1
+
+    remaining = tuple(a for a in remaining if a != throttle_axis)
+    try:
+        brake_axis, brake_inverted = _calibrate_pedal(device.path, remaining, "brake")
+    except _CalibrationAborted as exc:
+        print(f"\n[configure-wheel] {exc}", file=sys.stderr)
+        return 1
+
+    pedals_inverted = throttle_inverted
+    if throttle_inverted != brake_inverted:
+        print(
+            "\n[configure-wheel] warning: throttle and brake pedal axes report "
+            f"opposite inversion. Using throttle's reading (inverted={throttle_inverted}). "
+            "If the brake feels wrong in the demo, edit the YAML to flip "
+            "`pedal.inverted`."
+        )
+
+    if args.skip_ffb_test:
+        ffb_enabled, ffb_gain = False, 0.5
+    else:
+        ffb_enabled, ffb_gain = _calibrate_ffb(device.path)
+
+    profile_name = args.name or _slugify(device.name) or "custom-wheel"
+    profile_name = _prompt_profile_name(profile_name)
+
+    detection_patterns = _derive_detection_patterns(device.name)
+
+    output_dir = args.output_dir or _default_output_dir()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{profile_name}.yaml"
+    if output_path.exists() and not args.force:
+        ans = input(f"\n{output_path} already exists. Overwrite? [y/N]: ")
+        if ans.strip().lower() != "y":
+            print("[configure-wheel] aborted; existing profile left in place.")
+            return 1
+
+    _write_profile_yaml(
+        output_path,
+        name=profile_name,
+        display_name=device.name,
+        is_default=not args.no_default,
+        detection_patterns=detection_patterns,
+        steering_axis=steering_axis,
+        throttle_axis=throttle_axis,
+        brake_axis=brake_axis,
+        pedals_inverted=pedals_inverted,
+        invert_steering=invert_steering,
+        ffb_enabled=ffb_enabled,
+        ffb_gain=ffb_gain,
+    )
+
+    print(f"\nWheel profile written to {output_path}")
+    print(
+        "You can now launch the demo with auto-detection:\n"
+        "    uv run --package flashdreams-omnidreams interactive-drive\n"
+        f"or pin the profile explicitly:\n"
+        f"    uv run --package flashdreams-omnidreams interactive-drive --wheel-profile {profile_name}"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------
+# Device selection
+# ---------------------------------------------------------------------
+
+
+def _filter_candidates(devices: tuple[EvdevDevice, ...]) -> tuple[EvdevDevice, ...]:
+    """Drop devices that don't expose any analogue ABS axes.
+
+    Most evdev nodes on a typical desktop are keyboards / mice / power
+    buttons; filtering them out keeps the menu short and makes the
+    movement-based auto-detect unambiguous.
+    """
+    return tuple(d for d in devices if _detect_abs_axes(d.path))
+
+
+def _detect_abs_axes(path: Path) -> tuple[int, ...]:
+    return tuple(a for a in _CANDIDATE_AXES if query_axis(path, a) is not None)
+
+
+def _pick_device(
+    args: argparse.Namespace, candidates: tuple[EvdevDevice, ...]
+) -> EvdevDevice | None:
+    if args.device is not None:
+        for device in candidates:
+            if device.path == args.device:
+                return device
+            try:
+                if device.path.resolve() == args.device.resolve():
+                    return device
+            except OSError:
+                continue
+        print(
+            f"[configure-wheel] --device {args.device} did not match any "
+            "joystick-like evdev node. Available candidates:",
+            file=sys.stderr,
+        )
+        for device in candidates:
+            print(f"  {device.path}  ({device.name})", file=sys.stderr)
+        return None
+
+    if len(candidates) == 1:
+        only = candidates[0]
+        print(f"Found one candidate: {only.name} ({only.path})")
+        if _confirm("Use this device?", default=True):
+            return only
+        return None
+
+    print("\nMultiple candidate devices found:")
+    for i, device in enumerate(candidates, start=1):
+        axes = _detect_abs_axes(device.path)
+        axis_str = ", ".join(_ABS_AXIS_NAMES.get(a, f"0x{a:02x}") for a in axes)
+        print(f"  [{i}] {device.name}")
+        print(f"       path: {device.path}")
+        print(f"       axes: {axis_str}")
+
+    auto = _auto_detect_by_movement(candidates)
+    if auto is not None:
+        print(f"\nDetected movement on: {auto.name} ({auto.path})")
+        if _confirm("Use this device?", default=True):
+            return auto
+    return _pick_from_menu(candidates)
+
+
+def _auto_detect_by_movement(
+    candidates: tuple[EvdevDevice, ...], duration_s: float = 4.0
+) -> EvdevDevice | None:
+    """Return the candidate device with the largest ABS-event traffic.
+
+    Opens every candidate device, polls all fds for ``duration_s``
+    seconds while prompting the user to wiggle their wheel, and ranks
+    devices by cumulative absolute axis delta. Falls back to ``None``
+    when no device shows meaningful movement (caller then offers a
+    numbered menu).
+    """
+    print(
+        f"\nGently turn the steering wheel left and right for the next "
+        f"{int(duration_s)} seconds so I can identify your device..."
+    )
+    fds: dict[int, EvdevDevice] = {}
+    try:
+        for device in candidates:
+            try:
+                fd = os.open(device.path, os.O_RDONLY | os.O_NONBLOCK)
+            except OSError:
+                continue
+            fds[fd] = device
+        if not fds:
+            return None
+
+        movement: dict[Path, int] = {device.path: 0 for device in candidates}
+        last_values: dict[tuple[Path, int], int] = {}
+        deadline = time.monotonic() + duration_s
+        while time.monotonic() < deadline:
+            timeout = max(0.0, deadline - time.monotonic())
+            readable, _, _ = select.select(list(fds), [], [], min(0.2, timeout))
+            for fd in readable:
+                device = fds[fd]
+                try:
+                    data = os.read(fd, EVDEV_EVENT_SIZE * 32)
+                except (BlockingIOError, OSError):
+                    continue
+                for off in range(0, len(data) - EVDEV_EVENT_SIZE + 1, EVDEV_EVENT_SIZE):
+                    _, _, event_type, code, value = struct.unpack(
+                        EVDEV_EVENT_FORMAT, data[off : off + EVDEV_EVENT_SIZE]
+                    )
+                    if event_type != EV_ABS:
+                        continue
+                    key = (device.path, int(code))
+                    prev = last_values.get(key)
+                    if prev is not None:
+                        movement[device.path] += abs(int(value) - prev)
+                    last_values[key] = int(value)
+
+        ranked = sorted(movement.items(), key=lambda kv: kv[1], reverse=True)
+        if not ranked or ranked[0][1] < 200:
+            return None
+        # Require the winner to be clearly above the runner-up to avoid
+        # mistaking a noisy axis on the wrong device for real input.
+        if len(ranked) > 1 and ranked[0][1] < ranked[1][1] * 3:
+            return None
+        winning_path = ranked[0][0]
+        for device in candidates:
+            if device.path == winning_path:
+                return device
+        return None
+    finally:
+        for fd in fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _pick_from_menu(candidates: tuple[EvdevDevice, ...]) -> EvdevDevice | None:
+    while True:
+        try:
+            choice = input(f"Pick a device [1-{len(candidates)}, q to quit]: ").strip()
+        except EOFError:
+            return None
+        if choice.lower() in {"q", "quit", "exit"}:
+            return None
+        try:
+            idx = int(choice) - 1
+        except ValueError:
+            print("Please enter a number.")
+            continue
+        if 0 <= idx < len(candidates):
+            return candidates[idx]
+        print(f"Out of range. Pick 1-{len(candidates)}.")
+
+
+# ---------------------------------------------------------------------
+# Calibration steps
+# ---------------------------------------------------------------------
+
+
+class _CalibrationAborted(RuntimeError):
+    pass
+
+
+def _calibrate_steering(
+    device_path: Path, axes: tuple[int, ...]
+) -> tuple[int, bool]:
+    print("\nStep 1/3: Steering calibration")
+    print(
+        "  We only need full-left and full-right; you don't have to centre "
+        "the wheel first (FFB wheels rarely sit at their true centre at "
+        "rest) and you don't have to hit the exact mechanical extreme -- "
+        "the runtime queries the device's reported axis range via "
+        "EVIOCGABS to scale normalised steering."
+    )
+
+    print("\n  1a. Turn the wheel LEFT and HOLD.")
+    _wait_for_enter("      Press Enter while holding the wheel left")
+    left = _snapshot_axes(device_path, axes)
+
+    print("\n  1b. Turn the wheel RIGHT and HOLD.")
+    _wait_for_enter("      Press Enter while holding the wheel right")
+    right = _snapshot_axes(device_path, axes)
+
+    deltas = {a: abs(left.values[a] - right.values[a]) for a in axes}
+    steering_axis, max_delta = max(deltas.items(), key=lambda kv: kv[1])
+    if max_delta < 200:
+        raise _CalibrationAborted(
+            "no axis moved meaningfully between left and right. "
+            "Make sure the wheel is plugged in and try again."
+        )
+
+    # Demo convention (see _normalize_steering + KeyboardDriveState):
+    # ``steer > 0`` means "user turning left", and ``_normalize_steering``
+    # produces ``(raw - axis_centre) / (axis_span / 2)`` then flips when
+    # ``invert_steering`` is set. So when the user turns LEFT:
+    #   raw_left > raw_right -> raw naturally exceeds centre on left  -> no flip
+    #   raw_left < raw_right -> raw is below centre on left          -> flip
+    invert_steering = left.values[steering_axis] < right.values[steering_axis]
+
+    axis_name = _ABS_AXIS_NAMES.get(steering_axis, f"0x{steering_axis:02x}")
+    print(
+        f"\n  -> steering axis = 0x{steering_axis:02x} ({axis_name}), "
+        f"invert_steering = {str(invert_steering).lower()}"
+    )
+    return steering_axis, invert_steering
+
+
+def _calibrate_pedal(
+    device_path: Path, candidates: tuple[int, ...], label: str
+) -> tuple[int, bool]:
+    step_num = {"throttle": "2/3", "brake": "3/3"}.get(label, "?/?")
+    print(f"\nStep {step_num}: {label.capitalize()} pedal calibration")
+
+    print(f"\n  Fully RELEASE the {label} pedal.")
+    _wait_for_enter(f"      Press Enter while the {label} pedal is released")
+    released = _snapshot_axes(device_path, candidates)
+
+    print(f"\n  Press the {label} pedal all the way DOWN and HOLD.")
+    _wait_for_enter(f"      Press Enter while holding the {label} pedal down")
+    pressed = _snapshot_axes(device_path, candidates)
+
+    deltas = {a: abs(released.values[a] - pressed.values[a]) for a in candidates}
+    pedal_axis, max_delta = max(deltas.items(), key=lambda kv: kv[1])
+    if max_delta < 100:
+        raise _CalibrationAborted(
+            f"no axis moved meaningfully when pressing the {label} pedal. "
+            "Make sure your foot fully releases and fully presses the pedal."
+        )
+
+    # ``inverted_pedals=True`` means released=max, pressed=min (Thrustmaster
+    # convention). Detect by comparing the two raw readings.
+    inverted = released.values[pedal_axis] > pressed.values[pedal_axis]
+    axis_name = _ABS_AXIS_NAMES.get(pedal_axis, f"0x{pedal_axis:02x}")
+    print(
+        f"\n  -> {label} axis = 0x{pedal_axis:02x} ({axis_name}), "
+        f"pedal_inverted = {str(inverted).lower()}"
+    )
+    return pedal_axis, inverted
+
+
+def _calibrate_ffb(device_path: Path) -> tuple[bool, float]:
+    print("\nStep 4 (optional): Force feedback")
+    if not _confirm(
+        "  Send a brief autocenter pulse to test FFB? Keep hands clear of the wheel.",
+        default=True,
+    ):
+        return False, 0.5
+
+    try:
+        fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
+    except PermissionError:
+        print(
+            "  Permission denied opening the device for FFB. Add yourself to "
+            "the `input` group or adjust udev rules, then re-run.\n"
+            "  Skipping FFB; setting `ffb.enabled: false`."
+        )
+        return False, 0.5
+    except OSError as exc:
+        print(f"  Could not open device for FFB ({exc}); setting `ffb.enabled: false`.")
+        return False, 0.5
+
+    try:
+        _write_ff_event(fd, FF_GAIN, 0xFFFF)
+        print("  Pulsing autocenter at max strength for ~2 seconds...")
+        # Re-send the same strength every ~0.5 s in case the device's FFB
+        # state machine resets between writes (some kernels expire stale
+        # autocenter values automatically after ~1 s).
+        for _ in range(4):
+            _write_ff_event(fd, FF_AUTOCENTER, 0xFFFF)
+            time.sleep(0.5)
+        _write_ff_event(fd, FF_AUTOCENTER, 0)
+    except OSError as exc:
+        print(f"  FFB write failed ({exc}); setting `ffb.enabled: false`.")
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return False, 0.5
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    if not _confirm("  Did the wheel try to pull toward centre?", default=True):
+        print("  Setting `ffb.enabled: false`.")
+        return False, 0.5
+
+    while True:
+        try:
+            raw = input("  FFB gain (0.0-1.0, default 0.6): ").strip()
+        except EOFError:
+            raw = ""
+        if not raw:
+            return True, 0.6
+        try:
+            gain = float(raw)
+        except ValueError:
+            print("    Please enter a number between 0.0 and 1.0.")
+            continue
+        if 0.0 <= gain <= 1.0:
+            return True, gain
+        print("    Out of range; pick a value between 0.0 and 1.0.")
+
+
+def _write_ff_event(fd: int, code: int, value: int) -> None:
+    now = time.time()
+    sec = int(now)
+    usec = int((now - sec) * 1_000_000)
+    os.write(
+        fd,
+        struct.pack(EVDEV_EVENT_FORMAT, sec, usec, EV_FF, code, value),
+    )
+
+
+# ---------------------------------------------------------------------
+# Snapshot + raw-axis sampling
+# ---------------------------------------------------------------------
+
+
+def _snapshot_axes(device_path: Path, axes: tuple[int, ...]) -> _AxisSnapshot:
+    """Read the current raw value for every requested ABS axis.
+
+    Uses ``EVIOCGABS`` (current value field) so the snapshot reflects
+    the live state without needing to consume the event stream. The
+    kernel updates the ``input_absinfo.value`` field on every absolute
+    axis event, so this is equivalent to "read the latest event" for
+    all practical purposes.
+    """
+    values: dict[int, int] = {}
+    for axis in axes:
+        info: AxisInfo | None = query_axis(device_path, axis)
+        if info is None:
+            continue
+        values[axis] = info.value
+    return _AxisSnapshot(values=values)
+
+
+# ---------------------------------------------------------------------
+# Profile naming + YAML emission
+# ---------------------------------------------------------------------
+
+
+def _prompt_profile_name(default: str) -> str:
+    while True:
+        try:
+            raw = input(f"\nProfile name [{default}]: ").strip()
+        except EOFError:
+            return default
+        candidate = raw or default
+        if re.fullmatch(r"[A-Za-z0-9_-]+", candidate):
+            return candidate
+        print(
+            "  Profile name must contain only letters, digits, underscore and "
+            "hyphen (it becomes a YAML filename)."
+        )
+
+
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", name).strip("-").lower()
+    return slug[:48]
+
+
+def _derive_detection_patterns(name: str) -> tuple[str, ...]:
+    """Produce a small ranked list of substring patterns from a device name.
+
+    Matching in ``_device_matches_profile`` is case-insensitive substring;
+    ranking from most-specific (exact full name) to most-generic
+    (manufacturer alone) maximises the chance that a future kernel /
+    udev rename still triggers auto-detect.
+    """
+    patterns: list[str] = [name]
+    words = name.split()
+    if len(words) >= 3:
+        patterns.append(" ".join(words[1:]))
+    if len(words) >= 1:
+        patterns.append(words[0])
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for pattern in patterns:
+        if pattern and pattern not in seen:
+            seen.add(pattern)
+            deduped.append(pattern)
+    return tuple(deduped)
+
+
+def _default_output_dir() -> Path:
+    # Resolved relative to *this* module so the YAML lands next to the
+    # rest of the bundled package data (``configs/wheels/``). The demo's
+    # ``--wheel-profiles-dir`` default points at the same location.
+    return Path(__file__).resolve().parent / "configs" / "wheels"
+
+
+def _write_profile_yaml(
+    path: Path,
+    *,
+    name: str,
+    display_name: str,
+    is_default: bool,
+    detection_patterns: tuple[str, ...],
+    steering_axis: int,
+    throttle_axis: int,
+    brake_axis: int,
+    pedals_inverted: bool,
+    invert_steering: bool,
+    ffb_enabled: bool,
+    ffb_gain: float,
+    threshold: float = 0.12,
+) -> None:
+    """Emit YAML in the same hand-written format the loader prefers.
+
+    PyYAML's ``safe_dump`` works fine for the loader, but it strips the
+    hex literals and inline ABS-name comments we want for hand-editing.
+    Writing the file by hand keeps the layout consistent with the
+    existing in-tree profiles (see the original ``thrustmaster.yaml``
+    in the legacy ``omni-dreams`` sample).
+    """
+    axis_lines = [
+        f"  steering: 0x{steering_axis:02x}   # {_ABS_AXIS_NAMES.get(steering_axis, '?')}",
+        f"  throttle: 0x{throttle_axis:02x}   # {_ABS_AXIS_NAMES.get(throttle_axis, '?')}",
+        f"  brake:    0x{brake_axis:02x}   # {_ABS_AXIS_NAMES.get(brake_axis, '?')}",
+    ]
+    pedal_comment = (
+        "released=max, pressed=min" if pedals_inverted else "released=min, pressed=max"
+    )
+
+    lines = [
+        "# SPDX-License-Identifier: Apache-2.0",
+        "# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.",
+        "#",
+        "# Generated by `interactive-drive-configure-wheel`. Re-run that script",
+        "# any time the device's evdev axis mapping changes, or hand-edit the",
+        "# values below.",
+        "",
+        f"name: {name}",
+        f'display_name: "{display_name}"',
+        f"is_default: {str(is_default).lower()}",
+        "",
+        "detection_patterns:",
+        *(f'  - "{_yaml_quote(pattern)}"' for pattern in detection_patterns),
+        "",
+        "axis_map:",
+        *axis_lines,
+        "",
+        "pedal:",
+        f"  inverted: {str(pedals_inverted).lower()}   # {pedal_comment}",
+        "",
+        f"invert_steering: {str(invert_steering).lower()}",
+        "",
+        "ffb:",
+        f"  enabled: {str(ffb_enabled).lower()}",
+        f"  gain: {_format_float(ffb_gain)}",
+        "",
+        f"threshold: {_format_float(threshold)}",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _yaml_quote(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _format_float(value: float) -> str:
+    return f"{value:.3f}".rstrip("0").rstrip(".") or "0"
+
+
+# ---------------------------------------------------------------------
+# Prompt helpers
+# ---------------------------------------------------------------------
+
+
+def _wait_for_enter(prompt: str) -> None:
+    try:
+        input(prompt + ": ")
+    except EOFError:
+        raise _CalibrationAborted("stdin closed before calibration completed.")
+
+
+def _confirm(prompt: str, *, default: bool) -> bool:
+    suffix = " [Y/n]" if default else " [y/N]"
+    try:
+        ans = input(prompt + suffix + ": ").strip().lower()
+    except EOFError:
+        return default
+    if not ans:
+        return default
+    return ans in {"y", "yes"}
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/omnidreams/omnidreams/prepare.py
+++ b/integrations/omnidreams/omnidreams/prepare.py
@@ -25,8 +25,10 @@ to ``nvidia/omni-dreams-scenes`` before running this helper.
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import os
 import shutil
+import zipfile
 from pathlib import Path
 
 from omnidreams.hf_org import DEFAULT_HF_ORG, apply_cli_to_env
@@ -36,6 +38,28 @@ from omnidreams.scenes import (
     list_available_scene_uuids,
     local_scene_archive_path,
     normalise_scene_uuid,
+)
+
+# ---------------------------------------------------------------------------
+# PBSS source for the release-candidate "larger map" anonymized USDZs
+# ---------------------------------------------------------------------------
+# Side-channel for grabbing the four 26.02-based anonymized USDZs Guillermo
+# uploaded to ``s3://guillermog/PAI-900/valid-736-with-packed-anonymized-usdz-v3/``
+# on 2026-05-28. These are the scenes planned for the OmniDreams OSS release
+# but not yet republished to ``nvidia/omni-dreams-scenes``; this is the only
+# place to get them today. The 5th interactive-drive demo UUID
+# (``065dcac9-...``) is not in the v3 set and is intentionally omitted.
+PBSS_ENDPOINT_URL = "https://pdx.s8k.io"
+PBSS_REGION = "us-east-1"
+PBSS_ACCESS_KEY_ID = "team-alpamayo"
+PBSS_SECRET_ENV_VAR = "ALPAMAYO_S3_SECRET"
+PBSS_BUCKET = "guillermog"
+PBSS_PREFIX = "PAI-900/valid-736-with-packed-anonymized-usdz-v3"
+PBSS_SCENE_UUIDS: tuple[str, ...] = (
+    "01d503d4-449b-46fc-8d78-9085e70d3554",
+    "0b10bce8-61f1-4350-8577-cf3c9493ffc3",
+    "0d1fcd2c-ed47-4c72-b756-8e24bce0b9f4",
+    "0d76134f-350d-44b5-a694-208e9dab9600",
 )
 
 
@@ -118,6 +142,31 @@ def parse_args() -> argparse.Namespace:
             f" samples / scenes). Defaults to {DEFAULT_HF_ORG!r}."
             " Equivalent to setting OMNI_DREAMS_HF_ORG; the flag wins"
             " when both are present."
+        ),
+    )
+    parser.add_argument(
+        "--from-pbss-anon-v3",
+        action="store_true",
+        help=(
+            "Stage release-candidate scenes (anonymized, 26.02-base, larger "
+            f"maps) from PBSS s3://{PBSS_BUCKET}/{PBSS_PREFIX}/ instead of "
+            f"Hugging Face. Requires {PBSS_SECRET_ENV_VAR}. Without "
+            "--pbss-count, stages just the 4 original demo UUIDs (the 5th, "
+            "065dcac9..., isn't in the v3 set). With --pbss-count N, "
+            "auto-discovers and stages the first N UUIDs from the prefix. "
+            "With --scene-uuid, stages just that one UUID."
+        ),
+    )
+    parser.add_argument(
+        "--pbss-count",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Only meaningful with --from-pbss-anon-v3. Auto-discover and "
+            "stage the first N UUIDs (alphabetical) from the PBSS prefix "
+            "instead of the hardcoded 4 demo UUIDs. Each USDZ is ~1.8 GiB; "
+            "e.g. N=25 ~= 45 GiB total."
         ),
     )
     return parser.parse_args()
@@ -222,6 +271,249 @@ def stage_scene(scene_uuid: str, *, force: bool) -> Path:
     return dest
 
 
+# Camera whose first frame doubles as the world-model's ``first_image`` seed.
+# Front-wide matches the camera the demo renders by default; cross/tele frames
+# are also packed in ``frames/`` but aren't useful as the seed image.
+_PBSS_FIRST_IMAGE_CAMERA = "camera_front_wide_120fov"
+
+# Stand-in prompt for repacked PBSS USDZs. The release pipeline uses VLM-
+# generated prompts (per Slack); until those land in the bucket alongside
+# the USDZs, this placeholder keeps the world-model side from crashing on
+# a missing ``clipgt/prompt.txt`` and roughly matches the short caption
+# the original demo scenes shipped with.
+_PBSS_PLACEHOLDER_PROMPT = "A dashcam view looking forward on a driving scene.\n"
+
+
+def _repack_pbss_usdz(usdz_path: Path) -> None:
+    """Inject ``clipgt/first_image.jpeg`` + ``clipgt/prompt.txt`` into a PBSS USDZ.
+
+    The release-candidate USDZs in ``guillermog/...-anonymized-usdz-v3``
+    bundle per-camera first frames under ``frames/<camera>/<ts>.jpeg`` and
+    no prompt at all, but the interactive-drive scene loader looks for
+    ``clipgt/first_image.*`` + ``clipgt/prompt.txt`` (the layout the
+    existing ``omni-dreams-scenes`` HF dataset uses). We bridge that here
+    by appending the missing entries to the zip in place -- zip's central
+    directory just gets rewritten at the end of the file, the existing
+    NRE/mesh/parquet entries are untouched, and the USDZ stays valid.
+
+    Idempotent: if ``clipgt/first_image.*`` already exists in the archive
+    we skip everything (a previous repack succeeded, or the archive was
+    already in the demo-ready shape).
+    """
+    with zipfile.ZipFile(usdz_path, "r") as zf:
+        names = zf.namelist()
+        if any(n.startswith("clipgt/first_image") for n in names):
+            return  # already repacked
+
+        # Pick the front-wide first frame; fall back to any frames/* entry
+        # so a future PBSS layout change with a different camera key still
+        # produces a usable first_image rather than silently leaving the
+        # world model with no seed.
+        front_wide_frames = sorted(
+            n for n in names
+            if n.startswith(f"frames/{_PBSS_FIRST_IMAGE_CAMERA}/")
+            and n.lower().endswith((".jpeg", ".jpg", ".png"))
+        )
+        any_frames = sorted(
+            n for n in names
+            if n.startswith("frames/")
+            and n.lower().endswith((".jpeg", ".jpg", ".png"))
+        )
+        chosen = front_wide_frames[0] if front_wide_frames else (
+            any_frames[0] if any_frames else None
+        )
+        if chosen is None:
+            info(
+                f"  warning: {usdz_path.name} has no frames/<camera>/*.jpeg; "
+                "cannot inject clipgt/first_image. The HD-map rasterizer "
+                "will work but the world model won't have a seed image."
+            )
+            return
+
+        first_image_bytes = zf.read(chosen)
+        first_image_ext = Path(chosen).suffix.lower().lstrip(".")
+        has_existing_prompt = any(
+            n == "clipgt/prompt.txt" or n.startswith("clipgt/prompt_")
+            for n in names
+        )
+
+    # Reopen in append mode so we don't have to rewrite the 1.8 GiB body.
+    with zipfile.ZipFile(usdz_path, "a", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"clipgt/first_image.{first_image_ext}", first_image_bytes)
+        if not has_existing_prompt:
+            zf.writestr("clipgt/prompt.txt", _PBSS_PLACEHOLDER_PROMPT)
+
+    info(
+        f"  Repacked {usdz_path.name}: added clipgt/first_image.{first_image_ext} "
+        f"(from {chosen})"
+        + ("" if has_existing_prompt else " and placeholder clipgt/prompt.txt")
+    )
+
+
+def _pbss_client():
+    """Boto3 S3 client for PBSS Portland against the team-alpamayo account.
+
+    ``boto3`` is imported lazily so the HF-only path doesn't pay for it
+    and so users without the package only hit the error if they actually
+    use ``--from-pbss-anon-v3``.
+    """
+    try:
+        import boto3  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - boto3 must be installed
+        raise RuntimeError(
+            "boto3 is required for --from-pbss-anon-v3 but is not installed."
+        ) from exc
+
+    secret = os.environ.get(PBSS_SECRET_ENV_VAR)
+    if not secret:
+        raise RuntimeError(
+            f"{PBSS_SECRET_ENV_VAR} is required to read from PBSS "
+            f"({PBSS_ACCESS_KEY_ID}). Export it before re-running."
+        )
+
+    return boto3.client(
+        "s3",
+        endpoint_url=PBSS_ENDPOINT_URL,
+        region_name=PBSS_REGION,
+        aws_access_key_id=PBSS_ACCESS_KEY_ID,
+        aws_secret_access_key=secret,
+    )
+
+
+def stage_scene_from_pbss(scene_uuid: str, *, force: bool, _client=None) -> Path:
+    """Download one anonymized-v3 USDZ from Guillermo's PBSS bucket.
+
+    Writes to the same on-disk location as :func:`stage_scene` so the
+    rest of the demo (which reads from :func:`local_scene_archive_path`)
+    finds it without code changes.
+
+    These USDZs already contain the demo-required ``clipgt/*.parquet``
+    layout, but bundle the first frame as
+    ``frames/<camera>/<timestamp>.jpeg`` rather than
+    ``clipgt/first_image.*`` and ship no ``clipgt/prompt.txt``. The HD-map
+    rasterizer works as-is; the world-model side may need a follow-up
+    repackaging step (move a first frame into ``clipgt/``, drop in a
+    ``clipgt/prompt.txt``) before it can be served end-to-end.
+    """
+    bare_uuid = normalise_scene_uuid(scene_uuid)
+    dest = scene_path(bare_uuid)
+
+    s3 = _client if _client is not None else _pbss_client()
+    key = f"{PBSS_PREFIX}/{bare_uuid}/{bare_uuid}.usdz"
+    try:
+        remote_size = s3.head_object(Bucket=PBSS_BUCKET, Key=key)["ContentLength"]
+    except Exception as exc:
+        raise RuntimeError(
+            f"Scene {bare_uuid} not found on PBSS at "
+            f"s3://{PBSS_BUCKET}/{key} ({exc})."
+        ) from exc
+
+    if dest.exists() and not force:
+        local_size = dest.stat().st_size
+        # Tolerance covers the repack step (which appends ~few MB of
+        # first_image + prompt.txt to the original PBSS USDZ). Anything
+        # bigger than that means the on-disk file is a different
+        # archive entirely (e.g. the much smaller HF-sourced "small map"
+        # version from a prior prepare.py run) and should be replaced.
+        if abs(local_size - remote_size) <= 16 * 1024 * 1024:
+            info(
+                f"Scene already staged at {dest} "
+                f"({human_bytes(local_size)}; PBSS {human_bytes(remote_size)})."
+            )
+            _repack_pbss_usdz(dest)
+            return dest
+        info(
+            f"Re-downloading {dest.name}: local {human_bytes(local_size)} "
+            f"differs from PBSS {human_bytes(remote_size)} "
+            "(probably stale small-map HF version)."
+        )
+
+    info(
+        f"Downloading PBSS scene s3://{PBSS_BUCKET}/{key} "
+        f"({human_bytes(remote_size)}) -> {dest}"
+    )
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Write to a sibling .partial then atomically rename so an interrupted
+    # download never leaves a half-file at the canonical path (which the
+    # idempotency check above treats as "already staged").
+    tmp = dest.with_suffix(".usdz.partial")
+    s3.download_file(PBSS_BUCKET, key, str(tmp))
+    tmp.rename(dest)
+    info(f"Staged scene at {dest} ({human_bytes(dest.stat().st_size)}).")
+    _repack_pbss_usdz(dest)
+    return dest
+
+
+def _list_pbss_scene_uuids(client, *, limit: int | None = None) -> list[str]:
+    """Enumerate UUIDs at ``s3://{PBSS_BUCKET}/{PBSS_PREFIX}/`` (sorted).
+
+    Skips any path that isn't ``<prefix>/<uuid>/<uuid>.usdz``, so partial
+    uploads / sibling MP4s don't sneak in. ``limit`` truncates the list
+    after sorting so the slice is deterministic across runs.
+    """
+    uuids: list[str] = []
+    prefix_with_slash = f"{PBSS_PREFIX}/"
+    for page in client.get_paginator("list_objects_v2").paginate(
+        Bucket=PBSS_BUCKET, Prefix=prefix_with_slash
+    ):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith(".usdz"):
+                continue
+            tail = key[len(prefix_with_slash):]
+            parts = tail.split("/")
+            if len(parts) != 2 or parts[1] != f"{parts[0]}.usdz":
+                continue
+            uuids.append(parts[0])
+    uuids.sort()
+    if limit is not None:
+        uuids = uuids[:limit]
+    return uuids
+
+
+def stage_scenes_from_pbss(
+    *, force: bool, uuids: tuple[str, ...] | list[str] | None = None
+) -> None:
+    """Stage a set of PBSS-anon-v3 scenes concurrently.
+
+    ``uuids`` defaults to :data:`PBSS_SCENE_UUIDS` (the 4 hardcoded demo
+    scenes). Pass an explicit list -- e.g. from
+    :func:`_list_pbss_scene_uuids` -- to stage a larger batch.
+    """
+    client = _pbss_client()  # also smoke-tests creds before fan-out
+    scene_uuids = list(uuids) if uuids is not None else list(PBSS_SCENE_UUIDS)
+    # Average ~1.85 GiB/scene observed in the v3 prefix; close enough for
+    # a heads-up totals print so the user can ^C before committing to
+    # tens of GiB of GETs.
+    approx_gib = len(scene_uuids) * 1.85
+    info(
+        f"Staging {len(scene_uuids)} scene(s) from "
+        f"s3://{PBSS_BUCKET}/{PBSS_PREFIX}/ (~{approx_gib:.0f} GiB total)."
+    )
+    # 4 concurrent GETs is the sweet spot: enough to saturate a 10 GbE
+    # link but small enough not to hammer the PBSS frontend.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        futures = {
+            pool.submit(
+                stage_scene_from_pbss, uuid, force=force, _client=client
+            ): uuid
+            for uuid in scene_uuids
+        }
+        failures: list[tuple[str, BaseException]] = []
+        for fut in concurrent.futures.as_completed(futures):
+            uuid = futures[fut]
+            try:
+                fut.result()
+            except Exception as exc:
+                failures.append((uuid, exc))
+                info(f"  FAILED {uuid}: {exc}")
+    if failures:
+        raise RuntimeError(
+            f"{len(failures)} of {len(scene_uuids)} PBSS scenes failed to "
+            f"stage; see preceding [prepare] FAILED lines."
+        )
+
+
 def main() -> int:
     args = parse_args()
 
@@ -257,6 +549,22 @@ def main() -> int:
     # Scene USDZ -- required at demo launch time, no lazy fallback.
     if args.skip_scene:
         info("Skipping scene staging per --skip-scene.")
+    elif args.from_pbss_anon_v3:
+        # PBSS branch is auth'd by ALPAMAYO_S3_SECRET, not HF_TOKEN, so it
+        # short-circuits the HF gating below.
+        if args.scene_uuid is not None:
+            stage_scene_from_pbss(args.scene_uuid, force=args.force)
+        elif args.pbss_count is not None:
+            client = _pbss_client()
+            discovered = _list_pbss_scene_uuids(client, limit=args.pbss_count)
+            info(
+                f"Discovered {len(discovered)} UUID(s) under "
+                f"s3://{PBSS_BUCKET}/{PBSS_PREFIX}/ "
+                f"(limited to first {args.pbss_count})."
+            )
+            stage_scenes_from_pbss(force=args.force, uuids=discovered)
+        else:
+            stage_scenes_from_pbss(force=args.force)
     elif not os.environ.get("HF_TOKEN"):
         info(
             "HF_TOKEN is not set; skipping scene download. Export HF_TOKEN "

--- a/integrations/omnidreams/omnidreams/prepare.py
+++ b/integrations/omnidreams/omnidreams/prepare.py
@@ -25,10 +25,8 @@ to ``nvidia/omni-dreams-scenes`` before running this helper.
 from __future__ import annotations
 
 import argparse
-import concurrent.futures
 import os
 import shutil
-import zipfile
 from pathlib import Path
 
 from omnidreams.hf_org import DEFAULT_HF_ORG, apply_cli_to_env
@@ -38,28 +36,6 @@ from omnidreams.scenes import (
     list_available_scene_uuids,
     local_scene_archive_path,
     normalise_scene_uuid,
-)
-
-# ---------------------------------------------------------------------------
-# PBSS source for the release-candidate "larger map" anonymized USDZs
-# ---------------------------------------------------------------------------
-# Side-channel for grabbing the four 26.02-based anonymized USDZs Guillermo
-# uploaded to ``s3://guillermog/PAI-900/valid-736-with-packed-anonymized-usdz-v3/``
-# on 2026-05-28. These are the scenes planned for the OmniDreams OSS release
-# but not yet republished to ``nvidia/omni-dreams-scenes``; this is the only
-# place to get them today. The 5th interactive-drive demo UUID
-# (``065dcac9-...``) is not in the v3 set and is intentionally omitted.
-PBSS_ENDPOINT_URL = "https://pdx.s8k.io"
-PBSS_REGION = "us-east-1"
-PBSS_ACCESS_KEY_ID = "team-alpamayo"
-PBSS_SECRET_ENV_VAR = "ALPAMAYO_S3_SECRET"
-PBSS_BUCKET = "guillermog"
-PBSS_PREFIX = "PAI-900/valid-736-with-packed-anonymized-usdz-v3"
-PBSS_SCENE_UUIDS: tuple[str, ...] = (
-    "01d503d4-449b-46fc-8d78-9085e70d3554",
-    "0b10bce8-61f1-4350-8577-cf3c9493ffc3",
-    "0d1fcd2c-ed47-4c72-b756-8e24bce0b9f4",
-    "0d76134f-350d-44b5-a694-208e9dab9600",
 )
 
 
@@ -142,31 +118,6 @@ def parse_args() -> argparse.Namespace:
             f" samples / scenes). Defaults to {DEFAULT_HF_ORG!r}."
             " Equivalent to setting OMNI_DREAMS_HF_ORG; the flag wins"
             " when both are present."
-        ),
-    )
-    parser.add_argument(
-        "--from-pbss-anon-v3",
-        action="store_true",
-        help=(
-            "Stage release-candidate scenes (anonymized, 26.02-base, larger "
-            f"maps) from PBSS s3://{PBSS_BUCKET}/{PBSS_PREFIX}/ instead of "
-            f"Hugging Face. Requires {PBSS_SECRET_ENV_VAR}. Without "
-            "--pbss-count, stages just the 4 original demo UUIDs (the 5th, "
-            "065dcac9..., isn't in the v3 set). With --pbss-count N, "
-            "auto-discovers and stages the first N UUIDs from the prefix. "
-            "With --scene-uuid, stages just that one UUID."
-        ),
-    )
-    parser.add_argument(
-        "--pbss-count",
-        type=int,
-        default=None,
-        metavar="N",
-        help=(
-            "Only meaningful with --from-pbss-anon-v3. Auto-discover and "
-            "stage the first N UUIDs (alphabetical) from the PBSS prefix "
-            "instead of the hardcoded 4 demo UUIDs. Each USDZ is ~1.8 GiB; "
-            "e.g. N=25 ~= 45 GiB total."
         ),
     )
     return parser.parse_args()
@@ -271,249 +222,6 @@ def stage_scene(scene_uuid: str, *, force: bool) -> Path:
     return dest
 
 
-# Camera whose first frame doubles as the world-model's ``first_image`` seed.
-# Front-wide matches the camera the demo renders by default; cross/tele frames
-# are also packed in ``frames/`` but aren't useful as the seed image.
-_PBSS_FIRST_IMAGE_CAMERA = "camera_front_wide_120fov"
-
-# Stand-in prompt for repacked PBSS USDZs. The release pipeline uses VLM-
-# generated prompts (per Slack); until those land in the bucket alongside
-# the USDZs, this placeholder keeps the world-model side from crashing on
-# a missing ``clipgt/prompt.txt`` and roughly matches the short caption
-# the original demo scenes shipped with.
-_PBSS_PLACEHOLDER_PROMPT = "A dashcam view looking forward on a driving scene.\n"
-
-
-def _repack_pbss_usdz(usdz_path: Path) -> None:
-    """Inject ``clipgt/first_image.jpeg`` + ``clipgt/prompt.txt`` into a PBSS USDZ.
-
-    The release-candidate USDZs in ``guillermog/...-anonymized-usdz-v3``
-    bundle per-camera first frames under ``frames/<camera>/<ts>.jpeg`` and
-    no prompt at all, but the interactive-drive scene loader looks for
-    ``clipgt/first_image.*`` + ``clipgt/prompt.txt`` (the layout the
-    existing ``omni-dreams-scenes`` HF dataset uses). We bridge that here
-    by appending the missing entries to the zip in place -- zip's central
-    directory just gets rewritten at the end of the file, the existing
-    NRE/mesh/parquet entries are untouched, and the USDZ stays valid.
-
-    Idempotent: if ``clipgt/first_image.*`` already exists in the archive
-    we skip everything (a previous repack succeeded, or the archive was
-    already in the demo-ready shape).
-    """
-    with zipfile.ZipFile(usdz_path, "r") as zf:
-        names = zf.namelist()
-        if any(n.startswith("clipgt/first_image") for n in names):
-            return  # already repacked
-
-        # Pick the front-wide first frame; fall back to any frames/* entry
-        # so a future PBSS layout change with a different camera key still
-        # produces a usable first_image rather than silently leaving the
-        # world model with no seed.
-        front_wide_frames = sorted(
-            n for n in names
-            if n.startswith(f"frames/{_PBSS_FIRST_IMAGE_CAMERA}/")
-            and n.lower().endswith((".jpeg", ".jpg", ".png"))
-        )
-        any_frames = sorted(
-            n for n in names
-            if n.startswith("frames/")
-            and n.lower().endswith((".jpeg", ".jpg", ".png"))
-        )
-        chosen = front_wide_frames[0] if front_wide_frames else (
-            any_frames[0] if any_frames else None
-        )
-        if chosen is None:
-            info(
-                f"  warning: {usdz_path.name} has no frames/<camera>/*.jpeg; "
-                "cannot inject clipgt/first_image. The HD-map rasterizer "
-                "will work but the world model won't have a seed image."
-            )
-            return
-
-        first_image_bytes = zf.read(chosen)
-        first_image_ext = Path(chosen).suffix.lower().lstrip(".")
-        has_existing_prompt = any(
-            n == "clipgt/prompt.txt" or n.startswith("clipgt/prompt_")
-            for n in names
-        )
-
-    # Reopen in append mode so we don't have to rewrite the 1.8 GiB body.
-    with zipfile.ZipFile(usdz_path, "a", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(f"clipgt/first_image.{first_image_ext}", first_image_bytes)
-        if not has_existing_prompt:
-            zf.writestr("clipgt/prompt.txt", _PBSS_PLACEHOLDER_PROMPT)
-
-    info(
-        f"  Repacked {usdz_path.name}: added clipgt/first_image.{first_image_ext} "
-        f"(from {chosen})"
-        + ("" if has_existing_prompt else " and placeholder clipgt/prompt.txt")
-    )
-
-
-def _pbss_client():
-    """Boto3 S3 client for PBSS Portland against the team-alpamayo account.
-
-    ``boto3`` is imported lazily so the HF-only path doesn't pay for it
-    and so users without the package only hit the error if they actually
-    use ``--from-pbss-anon-v3``.
-    """
-    try:
-        import boto3  # type: ignore[import-not-found]
-    except Exception as exc:  # pragma: no cover - boto3 must be installed
-        raise RuntimeError(
-            "boto3 is required for --from-pbss-anon-v3 but is not installed."
-        ) from exc
-
-    secret = os.environ.get(PBSS_SECRET_ENV_VAR)
-    if not secret:
-        raise RuntimeError(
-            f"{PBSS_SECRET_ENV_VAR} is required to read from PBSS "
-            f"({PBSS_ACCESS_KEY_ID}). Export it before re-running."
-        )
-
-    return boto3.client(
-        "s3",
-        endpoint_url=PBSS_ENDPOINT_URL,
-        region_name=PBSS_REGION,
-        aws_access_key_id=PBSS_ACCESS_KEY_ID,
-        aws_secret_access_key=secret,
-    )
-
-
-def stage_scene_from_pbss(scene_uuid: str, *, force: bool, _client=None) -> Path:
-    """Download one anonymized-v3 USDZ from Guillermo's PBSS bucket.
-
-    Writes to the same on-disk location as :func:`stage_scene` so the
-    rest of the demo (which reads from :func:`local_scene_archive_path`)
-    finds it without code changes.
-
-    These USDZs already contain the demo-required ``clipgt/*.parquet``
-    layout, but bundle the first frame as
-    ``frames/<camera>/<timestamp>.jpeg`` rather than
-    ``clipgt/first_image.*`` and ship no ``clipgt/prompt.txt``. The HD-map
-    rasterizer works as-is; the world-model side may need a follow-up
-    repackaging step (move a first frame into ``clipgt/``, drop in a
-    ``clipgt/prompt.txt``) before it can be served end-to-end.
-    """
-    bare_uuid = normalise_scene_uuid(scene_uuid)
-    dest = scene_path(bare_uuid)
-
-    s3 = _client if _client is not None else _pbss_client()
-    key = f"{PBSS_PREFIX}/{bare_uuid}/{bare_uuid}.usdz"
-    try:
-        remote_size = s3.head_object(Bucket=PBSS_BUCKET, Key=key)["ContentLength"]
-    except Exception as exc:
-        raise RuntimeError(
-            f"Scene {bare_uuid} not found on PBSS at "
-            f"s3://{PBSS_BUCKET}/{key} ({exc})."
-        ) from exc
-
-    if dest.exists() and not force:
-        local_size = dest.stat().st_size
-        # Tolerance covers the repack step (which appends ~few MB of
-        # first_image + prompt.txt to the original PBSS USDZ). Anything
-        # bigger than that means the on-disk file is a different
-        # archive entirely (e.g. the much smaller HF-sourced "small map"
-        # version from a prior prepare.py run) and should be replaced.
-        if abs(local_size - remote_size) <= 16 * 1024 * 1024:
-            info(
-                f"Scene already staged at {dest} "
-                f"({human_bytes(local_size)}; PBSS {human_bytes(remote_size)})."
-            )
-            _repack_pbss_usdz(dest)
-            return dest
-        info(
-            f"Re-downloading {dest.name}: local {human_bytes(local_size)} "
-            f"differs from PBSS {human_bytes(remote_size)} "
-            "(probably stale small-map HF version)."
-        )
-
-    info(
-        f"Downloading PBSS scene s3://{PBSS_BUCKET}/{key} "
-        f"({human_bytes(remote_size)}) -> {dest}"
-    )
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    # Write to a sibling .partial then atomically rename so an interrupted
-    # download never leaves a half-file at the canonical path (which the
-    # idempotency check above treats as "already staged").
-    tmp = dest.with_suffix(".usdz.partial")
-    s3.download_file(PBSS_BUCKET, key, str(tmp))
-    tmp.rename(dest)
-    info(f"Staged scene at {dest} ({human_bytes(dest.stat().st_size)}).")
-    _repack_pbss_usdz(dest)
-    return dest
-
-
-def _list_pbss_scene_uuids(client, *, limit: int | None = None) -> list[str]:
-    """Enumerate UUIDs at ``s3://{PBSS_BUCKET}/{PBSS_PREFIX}/`` (sorted).
-
-    Skips any path that isn't ``<prefix>/<uuid>/<uuid>.usdz``, so partial
-    uploads / sibling MP4s don't sneak in. ``limit`` truncates the list
-    after sorting so the slice is deterministic across runs.
-    """
-    uuids: list[str] = []
-    prefix_with_slash = f"{PBSS_PREFIX}/"
-    for page in client.get_paginator("list_objects_v2").paginate(
-        Bucket=PBSS_BUCKET, Prefix=prefix_with_slash
-    ):
-        for obj in page.get("Contents", []):
-            key = obj["Key"]
-            if not key.endswith(".usdz"):
-                continue
-            tail = key[len(prefix_with_slash):]
-            parts = tail.split("/")
-            if len(parts) != 2 or parts[1] != f"{parts[0]}.usdz":
-                continue
-            uuids.append(parts[0])
-    uuids.sort()
-    if limit is not None:
-        uuids = uuids[:limit]
-    return uuids
-
-
-def stage_scenes_from_pbss(
-    *, force: bool, uuids: tuple[str, ...] | list[str] | None = None
-) -> None:
-    """Stage a set of PBSS-anon-v3 scenes concurrently.
-
-    ``uuids`` defaults to :data:`PBSS_SCENE_UUIDS` (the 4 hardcoded demo
-    scenes). Pass an explicit list -- e.g. from
-    :func:`_list_pbss_scene_uuids` -- to stage a larger batch.
-    """
-    client = _pbss_client()  # also smoke-tests creds before fan-out
-    scene_uuids = list(uuids) if uuids is not None else list(PBSS_SCENE_UUIDS)
-    # Average ~1.85 GiB/scene observed in the v3 prefix; close enough for
-    # a heads-up totals print so the user can ^C before committing to
-    # tens of GiB of GETs.
-    approx_gib = len(scene_uuids) * 1.85
-    info(
-        f"Staging {len(scene_uuids)} scene(s) from "
-        f"s3://{PBSS_BUCKET}/{PBSS_PREFIX}/ (~{approx_gib:.0f} GiB total)."
-    )
-    # 4 concurrent GETs is the sweet spot: enough to saturate a 10 GbE
-    # link but small enough not to hammer the PBSS frontend.
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-        futures = {
-            pool.submit(
-                stage_scene_from_pbss, uuid, force=force, _client=client
-            ): uuid
-            for uuid in scene_uuids
-        }
-        failures: list[tuple[str, BaseException]] = []
-        for fut in concurrent.futures.as_completed(futures):
-            uuid = futures[fut]
-            try:
-                fut.result()
-            except Exception as exc:
-                failures.append((uuid, exc))
-                info(f"  FAILED {uuid}: {exc}")
-    if failures:
-        raise RuntimeError(
-            f"{len(failures)} of {len(scene_uuids)} PBSS scenes failed to "
-            f"stage; see preceding [prepare] FAILED lines."
-        )
-
-
 def main() -> int:
     args = parse_args()
 
@@ -549,22 +257,6 @@ def main() -> int:
     # Scene USDZ -- required at demo launch time, no lazy fallback.
     if args.skip_scene:
         info("Skipping scene staging per --skip-scene.")
-    elif args.from_pbss_anon_v3:
-        # PBSS branch is auth'd by ALPAMAYO_S3_SECRET, not HF_TOKEN, so it
-        # short-circuits the HF gating below.
-        if args.scene_uuid is not None:
-            stage_scene_from_pbss(args.scene_uuid, force=args.force)
-        elif args.pbss_count is not None:
-            client = _pbss_client()
-            discovered = _list_pbss_scene_uuids(client, limit=args.pbss_count)
-            info(
-                f"Discovered {len(discovered)} UUID(s) under "
-                f"s3://{PBSS_BUCKET}/{PBSS_PREFIX}/ "
-                f"(limited to first {args.pbss_count})."
-            )
-            stage_scenes_from_pbss(force=args.force, uuids=discovered)
-        else:
-            stage_scenes_from_pbss(force=args.force)
     elif not os.environ.get("HF_TOKEN"):
         info(
             "HF_TOKEN is not set; skipping scene download. Export HF_TOKEN "

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -90,6 +90,13 @@ omnidreams-prepare = "omnidreams.prepare:main"
 # presenter import fails fast with a clear message.
 interactive-drive = "omnidreams.interactive_drive.demo:main"
 
+# Interactive steering-wheel calibration CLI. Walks the user through
+# axis discovery + an optional FFB pulse and writes a YAML profile
+# the demo's ``--wheel-profile auto`` loader picks up. Deliberately
+# kept dependency-light (stdlib + PyYAML only -- *no* slangpy) so
+# users can calibrate before installing the full demo extra.
+interactive-drive-configure-wheel = "omnidreams.interactive_drive.wheel_configurator:main"
+
 # Each entry registers one ``runner_name`` slug with ``flashdreams-run``.
 # The discovery layer (``flashdreams.plugins.registry.discover_runners``)
 # scans this group at CLI startup; the entry-point name itself is purely


### PR DESCRIPTION
## Summary

The flashdreams `interactive-drive` demo already has all the runtime
plumbing for evdev wheel input + FFB autocenter, but no bundled device
profile YAML, so `--wheel-profile auto` always returns "no wheel
detected" even when a wheel is plugged in. Bundling a vendor-specific
profile is awkward (legal + compatibility) so this PR ships a
**configurator** that writes one on the user's machine instead.

```bash
uv run --package flashdreams-omnidreams interactive-drive-configure-wheel
```

Auto-detects the wheel, walks the user through "turn left / turn right
/ release pedal / press pedal" prompts, optionally pulses
`FF_AUTOCENTER` for a sanity check, and writes
`configs/wheels/<your-wheel>.yaml`. The next `interactive-drive` launch
picks it up via `--wheel-profile auto`.

## Changes

- **New `omnidreams.interactive_drive.wheel_configurator`** — interactive
  CLI: device pick (movement-based auto-detect + numbered-menu fallback),
  steering axis discovery (largest left↔right delta; inversion from
  `raw_left < raw_right`), throttle/brake axis discovery (largest
  release↔press delta; inversion from `released > pressed`), optional FFB
  pulse, hand-formatted YAML output with hex axis literals + `ABS_*` comments.
- **New `omnidreams.interactive_drive._evdev`** — small shared module with
  the `EVIOCGABS` constants, `AxisRange` / `AxisInfo` / `EvdevDevice`
  dataclasses, and the `scan_evdev_devices` / `query_axis` / `read_evdev_name`
  helpers. Stdlib-only so the configurator works without the
  `interactive-drive` (slangpy) extra installed.
- **`demo.py`** — drops its local copies of those helpers in favour of
  imports from `_evdev`. No behavioural change; the runtime `WheelBridge`
  / `AutocenterFFB` still query `EVIOCGABS` for axis ranges, so users
  don't have to push the wheel/pedals to their absolute mechanical limits
  during calibration.
- **`pyproject.toml`** — registers the `interactive-drive-configure-wheel`
  console script.
- **`README.md`** — replaces the "no profiles ship" sentence with
  instructions for the configurator + an `input` group hint for FFB
  permissions.

## Verified

- Both new modules `ast.parse` cleanly and import without slangpy on the
  path.
- YAML emitted by the configurator for the canonical Thrustmaster T300RS
  parameters parses into a `WheelProfile` byte-equivalent to the legacy
  hand-written `thrustmaster.yaml` (used as a roundtrip oracle).
- Simplified `(raw_left < raw_right)` inversion test agrees with the
  previous `(left - centre) < 0` form for both un-inverted (Logitech-
  style) and inverted (Thrustmaster-style) devices; centre snapshot is
  no longer required (matters for FFB wheels with no tactile centre).

## Known limitation

Pedals connected via direct USB instead of through the wheel base (some
Fanatec setups) enumerate as a second evdev device. The configurator
and the existing `WheelBridge` both assume a single device — supporting
split devices would need an optional `pedal_device_path` in
`WheelProfile` and a second fd in `WheelBridge._run`. Out of scope for
this PR; the RJ12 routing on Fanatec hardware works today.

## Test plan

- [ ] `interactive-drive-configure-wheel` walks through calibration on a
      real wheel (Thrustmaster / Logitech / Fanatec)
- [ ] Generated YAML loads via `interactive-drive --wheel-profile auto`
- [ ] FFB autocenter feels right in-demo at the configurator-saved gain
- [ ] `interactive-drive --no-wheel` still works (keyboard-only path
      untouched)