### PR TITLE
Wire skip_finalize_kv_cache to interactive demo

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model.yaml
+++ b/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model.yaml
@@ -17,6 +17,7 @@ compile_net: false
 light_vae: true
 encode_with_pixel_shuffle: false
 local_attn_size: 6
+skip_finalize_kv_cache: false
 sink_size: 0
 denoising_steps: [1000, 500]
 upsampling_enabled: false

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -99,7 +99,10 @@ def _build_pipeline_config(
             enable_sync_and_profile=bool(profile.enabled),
             diffusion_model=dict(
                 seed=seed,
-                transformer=dict(compile_network=manifest.compile_net),
+                transformer=dict(
+                    compile_network=manifest.compile_net,
+                    skip_finalize_kv_cache=manifest.skip_finalize_kv_cache,
+                ),
                 scheduler=dict(
                     denoising_timesteps=list(manifest.denoising_steps),
                     num_inference_steps=len(manifest.denoising_steps),
@@ -114,7 +117,10 @@ def _build_pipeline_config(
             enable_sync_and_profile=bool(profile.enabled),
             diffusion_model=dict(
                 seed=seed,
-                transformer=dict(compile_network=manifest.compile_net),
+                transformer=dict(
+                    compile_network=manifest.compile_net,
+                    skip_finalize_kv_cache=manifest.skip_finalize_kv_cache,
+                ),
             ),
         )
         scheduler_uses_manifest_steps = False
@@ -139,6 +145,15 @@ def _build_pipeline_config(
             f"{config_name} uses flashdreams default denoising steps [1000, 450]; "
             f"got {manifest.denoising_steps}."
         )
+    transformer_config = getattr(config.diffusion_model, "transformer", None)
+    print(
+        "[flashdreams-session] config "
+        f"recipe={config_name} "
+        f"manifest_skip_finalize_kv_cache={manifest.skip_finalize_kv_cache} "
+        "transformer_skip_finalize_kv_cache="
+        f"{getattr(transformer_config, 'skip_finalize_kv_cache', '<missing>')}",
+        flush=True,
+    )
     return config
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
@@ -105,6 +105,7 @@ class WorldModelManifest:
     light_vae: bool = True
     encode_with_pixel_shuffle: bool = False
     local_attn_size: int = 6
+    skip_finalize_kv_cache: bool = False
     sink_size: int = 0
     denoising_steps: list[int] = field(default_factory=lambda: [1000, 500])
     upsampling_enabled: bool = False
@@ -148,6 +149,7 @@ def load_world_model_manifest(path: str | Path) -> WorldModelManifest:
         light_vae=bool(data.get("light_vae", True)),
         encode_with_pixel_shuffle=bool(data.get("encode_with_pixel_shuffle", False)),
         local_attn_size=int(data.get("local_attn_size", 6)),
+        skip_finalize_kv_cache=bool(data.get("skip_finalize_kv_cache", False)),
         sink_size=int(data.get("sink_size", 0)),
         denoising_steps=[int(x) for x in data.get("denoising_steps", [1000, 500])],
         upsampling_enabled=bool(data.get("upsampling_enabled", False)),


### PR DESCRIPTION
This change adds `skip_finalize_kv_cache` to the demo's config file.
By default it's False so it's not changing the current behavior. 