### PR TITLE
interactive-drive: support 16-aligned demo resolutions

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -331,6 +331,15 @@ def prepare_config_and_backend(
             manifest = replace(
                 manifest, debug_condition_frame_dir=args.official_hdmap_dir.resolve()
             )
+        if config.raster.resolution_wh != manifest.resolution_wh:
+            config = replace(
+                config,
+                raster=replace(
+                    config.raster,
+                    width=manifest.resolution_wh[0],
+                    height=manifest.resolution_wh[1],
+                ),
+            )
         backend = WorldModelRenderBackend(
             manifest=manifest,
             chunk=config.chunk,

--- a/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model.yaml
+++ b/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model.yaml
@@ -7,7 +7,13 @@
 # Flashdreams owns checkpoint selection and cache layout for the selected
 # recipe; this manifest keeps the interactive demo's runtime shape and
 # performance knobs in one place.
-
+#
+# Default is 1280x704. You can try smaller resolutions as long as both width
+# and height are multiples of 16; examples with roughly similar aspect ratio:
+#   - [1168, 640]
+#   - [1024, 560]
+#   - [896, 496]
+#   - [640, 352]
 resolution_wh: [1280, 704]
 fps: 30
 num_frames_per_block: 8

--- a/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
@@ -110,7 +110,7 @@ class _LudusConditionRasterizerImpl:
         self.ctx.set_msaa_samples(4)
         self.ctx.set_max_tessellation_levels(cube=0)
         # Use thinner BEV linework so the small map panel doesn't get
-        # swallowed by 12-pixel polylines designed for the 1280x704 main view.
+        # swallowed by the heavier polylines designed for the main view.
         bev_line_width = max(2.0, float(raster.line_width_px) * 0.4)
         bev_pole_width = max(2.0, float(raster.pole_width_px) * 0.6)
         self.ctx.set_line_widths(

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
@@ -20,6 +20,8 @@ _HF_URL_PATTERN = re.compile(
     r"^https?://(?:www\.)?huggingface\.co/[^/]+/[^/]+/(?:blob|resolve)/[^/]+/.+$",
     re.IGNORECASE,
 )
+_DEFAULT_RESOLUTION_WH = (1280, 704)
+_RESOLUTION_ALIGNMENT_PX = 16
 
 
 def _is_hf_url(raw: str) -> bool:
@@ -95,10 +97,26 @@ def _resolve_manifest_path(raw_path: str | None, *, manifest_dir: Path) -> Path 
     return path
 
 
+def _parse_resolution_wh(raw: object) -> tuple[int, int]:
+    if raw is None:
+        return _DEFAULT_RESOLUTION_WH
+    if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+        raise ValueError(f"resolution_wh must be [width, height], got {raw!r}")
+    width, height = int(raw[0]), int(raw[1])
+    if width <= 0 or height <= 0:
+        raise ValueError(f"resolution_wh must be positive, got {(width, height)!r}")
+    if width % _RESOLUTION_ALIGNMENT_PX or height % _RESOLUTION_ALIGNMENT_PX:
+        raise ValueError(
+            "resolution_wh must be divisible by "
+            f"{_RESOLUTION_ALIGNMENT_PX}, got {(width, height)!r}"
+        )
+    return (width, height)
+
+
 @dataclass(frozen=True)
 class WorldModelManifest:
     debug_condition_frame_dir: Path | None = None
-    resolution_wh: tuple[int, int] = (1280, 704)
+    resolution_wh: tuple[int, int] = _DEFAULT_RESOLUTION_WH
     fps: int = 30
     num_frames_per_block: int = 8
     compile_net: bool = True
@@ -134,14 +152,14 @@ def load_world_model_manifest(path: str | Path) -> WorldModelManifest:
                 flush=True,
             )
         raw_yaml = rewritten
-    data = yaml.safe_load(raw_yaml)
-    resolution = tuple(data.get("resolution_wh", [1280, 704]))
+    data = yaml.safe_load(raw_yaml) or {}
+    resolution = _parse_resolution_wh(data.get("resolution_wh"))
     return WorldModelManifest(
         debug_condition_frame_dir=_resolve_manifest_path(
             data.get("debug_condition_frame_dir"),
             manifest_dir=manifest_dir,
         ),
-        resolution_wh=(int(resolution[0]), int(resolution[1])),
+        resolution_wh=resolution,
         fps=int(data.get("fps", 30)),
         num_frames_per_block=int(data.get("num_frames_per_block", 8)),
         compile_net=bool(data.get("compile_net", True)),

--- a/integrations/omnidreams/omnidreams/pipeline.py
+++ b/integrations/omnidreams/omnidreams/pipeline.py
@@ -60,6 +60,23 @@ OmnidreamsPipelineCache: TypeAlias = StreamInferencePipelineCache[
 ]
 
 
+def _validate_pixel_resolution_alignment(
+    pixel_height: int,
+    pixel_width: int,
+    *,
+    spatial_compression_ratio: int,
+    patch_spatial: int,
+) -> None:
+    required_alignment = int(spatial_compression_ratio) * int(patch_spatial)
+    if pixel_height % required_alignment or pixel_width % required_alignment:
+        raise ValueError(
+            "image pixel size "
+            f"({pixel_width}, {pixel_height}) must be divisible by "
+            f"{required_alignment} so the VAE latent is divisible by "
+            f"patch_spatial={patch_spatial}."
+        )
+
+
 @dataclass(kw_only=True)
 class OmnidreamsPipelineConfig(StreamInferencePipelineConfig):
     """Config for the Omnidreams pipeline.
@@ -188,6 +205,7 @@ class OmnidreamsPipeline(
         assert isinstance(text, list) and len(text) > 0 and isinstance(text[0], list), (
             f"text must be a [B, V] nested list of prompts, got {type(text)}"
         )
+        self._validate_image_resolution(image)
 
         text_embeddings = torch.stack(
             [self.text_encoder(t) for t in text], dim=0
@@ -309,6 +327,7 @@ class OmnidreamsPipeline(
         assert isinstance(text, list) and len(text) > 0 and isinstance(text[0], list), (
             f"text must be a [B, V] nested list of prompts, got {type(text)}"
         )
+        self._validate_image_resolution(image)
         text_embeddings = torch.stack(
             [self.text_encoder(t) for t in text], dim=0
         )  # [B, V, L, D]
@@ -330,6 +349,24 @@ class OmnidreamsPipeline(
             "image_embeddings": image_embeddings.cpu(),
             "negative_text_embeddings": negative_text_embeddings,
         }
+
+    def _validate_image_resolution(self, image: Tensor) -> None:
+        transformer = self.diffusion_model.transformer
+        assert isinstance(transformer, CosmosTransformer), (
+            "OmnidreamsPipeline requires a Cosmos transformer; "
+            f"got {type(transformer).__name__}."
+        )
+        decoder = self.decoder
+        assert isinstance(decoder, (WanVAEDecoder, TeahvVAEDecoder)), (
+            "OmnidreamsPipeline requires a Wan or Taehv VAE decoder; "
+            f"got {type(decoder).__name__}."
+        )
+        _validate_pixel_resolution_alignment(
+            int(image.shape[-2]),
+            int(image.shape[-1]),
+            spatial_compression_ratio=int(decoder.spatial_compression_ratio),
+            patch_spatial=int(transformer.config.network.patch_spatial),
+        )
 
     def release_oneshot_encoders(self) -> None:
         """Free the per-rollout text and first-frame image encoders.

--- a/integrations/omnidreams/tests/interactive_drive/test_manifest.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_manifest.py
@@ -28,6 +28,20 @@ class WorldModelManifestTest(unittest.TestCase):
             self.assertEqual(manifest.denoising_steps, [1000, 500])
             self.assertEqual(manifest.resolution_wh, (1280, 704))
 
+    def test_rejects_unaligned_resolution(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.yaml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    resolution_wh: [1164, 640]
+                    """
+                ).strip(),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "divisible by 16"):
+                load_world_model_manifest(path)
+
     def test_resolves_relative_paths_from_manifest_location(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/integrations/omnidreams/tests/test_omnidreams_pipeline.py
+++ b/integrations/omnidreams/tests/test_omnidreams_pipeline.py
@@ -146,6 +146,16 @@ def test_omnidreams_initialize_cache_encodes_cfg_negative_prompt(
         captured_embeddings["negative_text_embeddings"] = negative_text_embeddings
         return object()
 
+    def skip_validate_image_resolution(
+        self: OmnidreamsPipeline, image: torch.Tensor
+    ) -> None:
+        del self, image
+
+    monkeypatch.setattr(
+        OmnidreamsPipeline,
+        "_validate_image_resolution",
+        skip_validate_image_resolution,
+    )
     monkeypatch.setattr(
         OmnidreamsPipeline,
         "initialize_cache_from_embeddings",

--- a/integrations/omnidreams/tests/test_omnidreams_pipeline.py
+++ b/integrations/omnidreams/tests/test_omnidreams_pipeline.py
@@ -24,7 +24,10 @@ from omnidreams.config import (
     SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE,
 )
 from omnidreams.constants import NEGATIVE_PROMPT
-from omnidreams.pipeline import OmnidreamsPipeline
+from omnidreams.pipeline import (
+    OmnidreamsPipeline,
+    _validate_pixel_resolution_alignment,
+)
 from omnidreams.transformer import (
     CosmosTransformer,
     CosmosTransformerConfig,
@@ -50,6 +53,23 @@ def _make_uninitialized_omnidreams_pipeline() -> OmnidreamsPipeline:
     )
     pipeline.V_group = None
     return pipeline
+
+
+@pytest.mark.ci_cpu
+def test_validate_pixel_resolution_alignment_requires_vae_and_patch_multiple() -> None:
+    _validate_pixel_resolution_alignment(
+        640,
+        1168,
+        spatial_compression_ratio=8,
+        patch_spatial=2,
+    )
+    with pytest.raises(ValueError, match="divisible by 16"):
+        _validate_pixel_resolution_alignment(
+            640,
+            1164,
+            spatial_compression_ratio=8,
+            patch_spatial=2,
+        )
 
 
 @pytest.mark.ci_cpu


### PR DESCRIPTION
- Keep interactive-drive default resolution at `1280x704`.
- Allow `example_world_model.yaml` to document smaller 16-aligned resolutions.
- Add manifest and pipeline validation so invalid resolutions fail early.
