### PR TITLE
docs(omnidreams): add interactive-drive section + WebRTC troubleshooting; fix internal-GitLab link and --no-instantiate flag order

### DIFF
--- a/docs/source/api/cli.rst
+++ b/docs/source/api/cli.rst
@@ -51,7 +51,7 @@ Resolve config only (no model instantiation):
 
 .. code-block:: bash
 
-   uv run flashdreams-run self-forcing-wan2.1-t2v-1.3b-taehv --no-instantiate
+   uv run flashdreams-run --no-instantiate self-forcing-wan2.1-t2v-1.3b-taehv
 
 See also
 --------

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -21,7 +21,7 @@ OmniDreams
    <div class="model-link-row">
      <a class="model-link-button" href="https://research.nvidia.com/labs/sil/projects/omnidreams-blog/" target="_blank" rel="noopener noreferrer">Blog page</a>
      <a class="model-link-button" href="https://huggingface.co/nvidia/omni-dreams-models/" target="_blank" rel="noopener noreferrer">Model page</a>
-     <a class="model-link-button" href="https://gitlab-master.nvidia.com/sil/omni-dreams/" target="_blank" rel="noopener noreferrer">Official code</a>
+     <a class="model-link-button" href="https://github.com/NVIDIA/flashdreams/tree/main/integrations/omnidreams" target="_blank" rel="noopener noreferrer">Official code</a>
    </div>
 
 OmniDreams is an HDMap-conditioned world model for single-view and multi-view
@@ -157,6 +157,51 @@ When successfully connected, the browser-based UI looks like this:
       Your browser does not support the video tag.
     </video>
   </div>
+
+.. note::
+
+   If ``/request_session`` loads but the video never appears, the
+   browser is likely obfuscating local IPs in WebRTC ICE candidates
+   (replacing them with mDNS ``.local`` hostnames), which prevents the
+   peer connection from completing. Disable the setting and reload:
+
+   - **Chrome / Edge:** ``chrome://flags/#enable-webrtc-hide-local-ips-with-mdns`` → **Disabled**, then restart the browser.
+   - **Brave:** ``brave://settings/privacy/security`` → *WebRTC IP handling policy* → **Default public and private interfaces**.
+   - **Firefox:** ``about:config`` → ``media.peerconnection.ice.obfuscate_host_addresses`` → **false**.
+
+Run the desktop demo
+--------------------
+
+``interactive-drive`` runs the OmniDreams single-view pipeline in a
+local Vulkan window with keyboard or steering-wheel input. Requires
+access to `NVIDIA/flashdreams <https://github.com/NVIDIA/flashdreams>`_
+and an ``HF_TOKEN`` with read access to
+`nvidia/omni-dreams-scenes <https://huggingface.co/datasets/nvidia/omni-dreams-scenes>`_
+(scene USDZs) and
+`nvidia/omni-dreams-models <https://huggingface.co/nvidia/omni-dreams-models>`_
+(world-model checkpoints).
+
+First-time setup:
+
+.. code-block:: bash
+
+   git clone git@github.com:NVIDIA/flashdreams.git
+   cd flashdreams
+   export HF_TOKEN=<your-hf-token>
+   uv sync --package flashdreams-omnidreams --extra interactive-drive
+
+Optionally pre-download scenes and checkpoints so the first launch
+isn't blocked on network I/O:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams omnidreams-prepare
+
+Run the demo:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams interactive-drive
 
 Performance table
 -----------------

--- a/flashdreams/flashdreams/scripts/cli.py
+++ b/flashdreams/flashdreams/scripts/cli.py
@@ -26,7 +26,7 @@ Usage::
     flashdreams-run wan21-t2v-1.3b-480p --help        # show overridable fields
     flashdreams-run wan21-t2v-1.3b-480p --prompt "A cat surfing."
     flashdreams-run wan21-i2v-14b-480p --prompt "..." --image-path frame.png
-    flashdreams-run template-offline --no-instantiate # resolve config only
+    flashdreams-run --no-instantiate template-offline # resolve config only
 
     # Multi-GPU via context-parallelism (integration transformers auto-detect
     # CP size from the launcher's WORLD group). ``--no-python`` tells


### PR DESCRIPTION
## Summary

- Adds a new **Run the desktop demo** section to the OmniDreams page documenting `interactive-drive` (clone → `uv sync --extra interactive-drive` → optional `omnidreams-prepare` → `interactive-drive`).
- Adds a **troubleshooting note** under *Launch the interactive server* explaining the most common WebRTC failure mode: modern browsers obfuscate local IPs in ICE candidates with mDNS `.local` hostnames, so the page loads but the video stream never starts. Includes the exact toggle for Chrome/Edge, Brave, and Firefox.
- Fixes two pre-existing doc bugs that surfaced while writing the above:
  - **Internal-only GitLab URL on the OmniDreams page** — the *Official code* link button pointed at `https://gitlab-master.nvidia.com/sil/omni-dreams/`, which is unreachable for external readers. Repointed to `https://github.com/NVIDIA/flashdreams/tree/main/integrations/omnidreams`.
  - **`--no-instantiate` flag order wrong** — `--no-instantiate` is a top-level field of the parent dataclass in `flashdreams/scripts/cli.py`; tyro requires it before the runner subcommand. Both `docs/source/api/cli.rst` and the `cli.py` module docstring (also surfaced via `flashdreams-run --help`) showed it *after* the slug, which doesn't parse. Swapped to `flashdreams-run --no-instantiate <runner-slug>`.

## Files changed

- `docs/source/models/omnidreams.rst` — new section + note + URL fix.
- `docs/source/api/cli.rst` — `--no-instantiate` flag order.
- `flashdreams/scripts/cli.py` — same fix in the module docstring.

The new content matches the existing page's style: short imperative intros ending in `:`, no bold-text pseudo-headers, no bullet lists for requirements (mentioned inline in prose), no new sub-section levels.