### PR TITLE
Add opt-in native FP8 LightVAE encoder path for OmniDreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ compile_commands.json
 *.dump
 
 outputs/
+artifacts/
 data_local/
 credentials/*.secret
 

--- a/integrations/omnidreams/omnidreams/config.py
+++ b/integrations/omnidreams/omnidreams/config.py
@@ -25,8 +25,10 @@ registration is performed here.
 
 from __future__ import annotations
 
+import os
 from typing import cast
 
+import torch
 from omnidreams.encoder.pixel_shuffle import (
     PixelShuffleVAEEncoderConfig,
 )
@@ -37,6 +39,9 @@ from omnidreams.runner import OmnidreamsRunnerConfig
 from omnidreams.transformer import CosmosTransformerConfig
 from omnidreams.transformer.impl.network import (
     CosmosDiTNetworkConfig,
+)
+from omnidreams.vae_native import (
+    OmnidreamsWanVAEEncoderConfig as WanVAEEncoderConfig,
 )
 
 from flashdreams.core.io.internal import use_internal_storage
@@ -59,7 +64,6 @@ from flashdreams.recipes.taehv import (
 from flashdreams.recipes.wan.autoencoder.vae import (
     AVAILABLE_WAN_VAE_CHECKPOINT_PATHS,
     WanVAEDecoderConfig,
-    WanVAEEncoderConfig,
 )
 
 _INTERNAL_OMNIDREAMS_CHECKPOINT_PATHS: dict[str, str] = {
@@ -91,6 +95,13 @@ AVAILABLE_OMNIDREAMS_CHECKPOINT_PATHS: dict[str, str] = (
     }
 )
 """Resolved at module import; set ``FLASHDREAMS_INTERNAL_STORAGE`` first."""
+
+_LIGHTVAE_FP8_STATE_ENV = "OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH"
+
+
+def _lightvae_fp8_state_path() -> str | None:
+    return os.environ.get(_LIGHTVAE_FP8_STATE_ENV)
+
 
 SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE = OmnidreamsPipelineConfig(
     name="omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae",
@@ -159,6 +170,35 @@ SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF = cast(
 )  # ty:ignore[redundant-cast]
 """Performance-tuned variant: enable ``use_compile`` / ``use_cuda_graph``
 on the image encoder, the per-AR-step encoder, and the decoder."""
+
+SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF = cast(
+    OmnidreamsPipelineConfig,
+    derive_config(
+        SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF,
+        name="omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf",
+        image_encoder=dict(
+            dtype=torch.float16,
+            use_compile=False,
+            use_cuda_graph=False,
+            native_vae_acceleration="required",
+            native_vae_backend="fp8",
+            native_vae_fp8_state_path=_lightvae_fp8_state_path(),
+        ),
+        encoder=dict(
+            dtype=torch.float16,
+            use_compile=False,
+            use_cuda_graph=False,
+            native_vae_acceleration="required",
+            native_vae_backend="fp8",
+            native_vae_fp8_state_path=_lightvae_fp8_state_path(),
+        ),
+    ),
+)  # ty:ignore[redundant-cast]
+"""Native VAE perf variant: LightVAE FP8 encoder with PyTorch LightTAE decoder.
+
+Set ``OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH`` before setup to provide the
+calibrated FP8 LightVAE state required by the native encoder.
+"""
 
 SV_2STEPS_CHUNK2_LOC6_VAE_VAE = cast(
     OmnidreamsPipelineConfig,
@@ -399,6 +439,7 @@ OMNIDREAMS_CONFIGS: dict[str, OmnidreamsPipelineConfig] = {
     for cfg in (
         SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE,
         SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF,
+        SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF,
         SV_2STEPS_CHUNK2_LOC6_VAE_VAE,
         SV_2STEPS_CHUNK3_LOC6_VAE_VAE,
         SV_2STEPS_CHUNK4_LOC8_PSHUFFLE_LIGHTTAE,
@@ -448,6 +489,16 @@ RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF = OmnidreamsRunnerConfig(
         "Single-view chunk2 perf preset (compile + CUDA graphs across all stages)."
     ),
     pipeline=SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF,
+    prompt=_DEFAULT_PROMPT_1V,
+)
+
+RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF = OmnidreamsRunnerConfig(
+    runner_name=SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF.name,
+    description=(
+        "Single-view chunk2 native VAE perf preset "
+        "(LightVAE FP8 encoder + PyTorch LightTAE decoder)."
+    ),
+    pipeline=SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF,
     prompt=_DEFAULT_PROMPT_1V,
 )
 
@@ -545,6 +596,7 @@ OMNIDREAMS_RUNNERS: dict[str, RunnerConfig] = {
     for cfg in (
         RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE,
         RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF,
+        RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF,
         RUNNER_SV_2STEPS_CHUNK2_LOC6_VAE_VAE,
         RUNNER_SV_2STEPS_CHUNK3_LOC6_VAE_VAE,
         RUNNER_SV_2STEPS_CHUNK4_LOC8_PSHUFFLE_LIGHTTAE,

--- a/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
+++ b/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
@@ -47,6 +47,7 @@ _DIT_STREAMING_DIR = _SOURCE_DIR / "dit_streaming"
 _DIT_STREAMING_KERNEL_DIR = _DIT_STREAMING_DIR / "kernels"
 _DIT_STREAMING_PYEXT_DIR = _DIT_STREAMING_DIR / "pyext"
 _DIT_STREAMING_COMMON_DIR = _DIT_STREAMING_DIR / "common"
+_VAE_STREAMING_DIR = _SOURCE_DIR / "vae_streaming"
 _PYTORCH_MAX_JOBS_ENV = "MAX_JOBS"
 _DEFAULT_MAX_JOBS_CAP = 8
 _NATIVE_CUDA_ARCH_LIST_ENV = "OMNIDREAMS_SINGLEVIEW_CUDA_ARCH_LIST"
@@ -155,6 +156,12 @@ def _extension_sources() -> list[Path]:
         _NATIVE_PRIMITIVES_SOURCE,
         _NATIVE_PRIMITIVES_CUDA_SOURCE,
         _DIT_STREAMING_DIR / "streaming_dit_bindings.cpp",
+        _VAE_STREAMING_DIR / "vae_streaming_bindings.cpp",
+        _VAE_STREAMING_DIR / "lightvae_ops.cu",
+        _VAE_STREAMING_DIR / "lightvae_fp8_ops.cu",
+        _VAE_STREAMING_DIR / "lightvae_fp8_direct_stages.cu",
+        _VAE_STREAMING_DIR / "lightvae_fp8_warp_mma_stages.cu",
+        _VAE_STREAMING_DIR / "lightvae_fp8_attention.cu",
         _DIT_STREAMING_PYEXT_DIR / "streaming_dit_bridge.cu",
         _DIT_STREAMING_PYEXT_DIR / "sage3_blackwell_api_shim.cu",
         _DIT_STREAMING_PYEXT_DIR / "sage3_fp4_quant_shim.cu",
@@ -182,6 +189,8 @@ def _extension_fingerprint_sources() -> list[Path]:
         *sorted(_DIT_STREAMING_DIR.rglob("*.h")),
         *sorted(_DIT_STREAMING_DIR.rglob("*.cuh")),
         *sorted(_DIT_STREAMING_DIR.rglob("*.hpp")),
+        *sorted(_VAE_STREAMING_DIR.rglob("*.h")),
+        *sorted(_VAE_STREAMING_DIR.rglob("*.hpp")),
         *sorted(_PYTHON_DIR.glob("*.py")),
     ]
 
@@ -356,6 +365,7 @@ def load_extension(
                         str(_DIT_STREAMING_KERNEL_DIR),
                         str(_DIT_STREAMING_PYEXT_DIR),
                         str(_DIT_STREAMING_COMMON_DIR),
+                        str(_VAE_STREAMING_DIR),
                         str(cutlass_include),
                         str(cutlass_dir / "tools" / "util" / "include"),
                         str(cutlass_dir / "examples" / "common"),

--- a/integrations/omnidreams/omnidreams/pipeline.py
+++ b/integrations/omnidreams/omnidreams/pipeline.py
@@ -28,6 +28,7 @@ from omnidreams.transformer import (
     CosmosTransformerCache,
     CosmosTransformerConfig,
 )
+from omnidreams.vae_native import OmnidreamsWanVAEEncoderConfig
 from torch import Tensor
 
 from flashdreams.core.distributed.context_parallel import (
@@ -50,7 +51,6 @@ from flashdreams.recipes.taehv import TeahvVAEDecoder
 from flashdreams.recipes.wan.autoencoder.vae import (
     WanVAEDecoder,
     WanVAEEncoder,
-    WanVAEEncoderConfig,
 )
 
 OmnidreamsPipelineCache: TypeAlias = StreamInferencePipelineCache[
@@ -96,8 +96,8 @@ class OmnidreamsPipelineConfig(StreamInferencePipelineConfig):
     and use ``initialize_cache_from_embeddings`` with precomputed embeddings
     to skip loading it."""
 
-    image_encoder: WanVAEEncoderConfig | None = field(
-        default_factory=WanVAEEncoderConfig
+    image_encoder: OmnidreamsWanVAEEncoderConfig | None = field(
+        default_factory=OmnidreamsWanVAEEncoderConfig
     )
     """One-shot Wan VAE first-frame encoder. Pin its checkpoint to the
     VAE the network was trained against. ``None`` skips loading."""

--- a/integrations/omnidreams/omnidreams/transformer/__init__.py
+++ b/integrations/omnidreams/omnidreams/transformer/__init__.py
@@ -420,6 +420,7 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
     def patchify_and_maybe_split_cp(self, x: Tensor) -> Tensor:
         # x expected to be [B, V, T, C, H, W]
         assert x.ndim == 6, f"x must be a 6D tensor, but got shape {x.shape}"
+        x = x.to(device=self.device, dtype=self.config.dtype)
 
         if self.flatten_thw:
             return self.network.patchify_and_maybe_split_cp(
@@ -504,6 +505,13 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         # ``unpatchify_and_maybe_gather_cp`` and the network-cache /
         # RoPE setup below all read these.
         cfg = self.config
+        text_embeddings = text_embeddings.to(device=self.device, dtype=cfg.dtype)
+        image_embeddings = image_embeddings.to(device=self.device, dtype=cfg.dtype)
+        if negative_text_embeddings is not None:
+            negative_text_embeddings = negative_text_embeddings.to(
+                device=self.device, dtype=cfg.dtype
+            )
+
         kt = cfg.network.patch_temporal
         kh = kw = cfg.network.patch_spatial
         assert height % kh == 0 and width % kw == 0, (

--- a/integrations/omnidreams/omnidreams/vae_native.py
+++ b/integrations/omnidreams/omnidreams/vae_native.py
@@ -19,26 +19,17 @@ from __future__ import annotations
 
 import math
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Literal, get_args
 
 import torch
-from torch import Tensor
-
-from flashdreams.recipes.wan.autoencoder.vae import (
-    TEMPORAL_WINDOW,
-    WanVAECache,
-    WanVAEEncoder,
-    WanVAEEncoderConfig,
-)
 from omnidreams.native import omnidreams_singleview
 from omnidreams.native.acceleration import (
     NativeAccelerationConfig,
     NativeAccelerationMode,
     NativeAccelerationUnavailable,
-    NativeAvailabilityCheck,
     NativeBackendSelection,
     require_extension_symbols,
 )
@@ -46,6 +37,14 @@ from omnidreams.native.primitives import (
     NativePrepError,
     NativeTensorSpec,
     prepare_tensor_for_native,
+)
+from torch import Tensor
+
+from flashdreams.recipes.wan.autoencoder.vae import (
+    TEMPORAL_WINDOW,
+    WanVAECache,
+    WanVAEEncoder,
+    WanVAEEncoderConfig,
 )
 
 NativeVAEBackend = Literal["fp8"]
@@ -91,7 +90,7 @@ def _native_vae_availability_check(
     backend: NativeVAEBackend,
     run_symbol: str,
     setup_symbols: tuple[str, ...] = (),
-) -> NativeAvailabilityCheck:
+) -> Callable[[ModuleType], tuple[bool, str]]:
     symbol_check = require_extension_symbols(
         "omnidreams_vae_backend_status",
         run_symbol,
@@ -99,7 +98,16 @@ def _native_vae_availability_check(
     )
 
     def check(extension: ModuleType) -> tuple[bool, str]:
-        ok, reason = symbol_check(extension)
+        symbol_result = symbol_check(extension)
+        if isinstance(symbol_result, tuple):
+            ok, reason = symbol_result
+        else:
+            ok = bool(symbol_result)
+            reason = (
+                "required native symbols are available"
+                if ok
+                else "required native symbols are unavailable"
+            )
         if not ok:
             return ok, reason
 
@@ -413,7 +421,9 @@ class _NativeWanVAEEncoderExecutor(_NativeVAEExecutor):
         t = x.shape[2]
         body = (t // TEMPORAL_WINDOW) * TEMPORAL_WINDOW
         for i in range(0, body, TEMPORAL_WINDOW):
-            outs.append(self._encode_chunk(native_encoder, x[:, :, i : i + TEMPORAL_WINDOW]))
+            outs.append(
+                self._encode_chunk(native_encoder, x[:, :, i : i + TEMPORAL_WINDOW])
+            )
         if body < t:
             outs.append(self._encode_chunk(native_encoder, x[:, :, body:]))
 
@@ -446,8 +456,8 @@ class OmnidreamsWanVAEEncoder(WanVAEEncoder):
                     selection=self._native_vae_selection,
                     backend=config.native_vae_backend,
                 )
-                self._native_vae_executor._fp8_state_path = (
-                    _native_vae_fp8_state_path(config)
+                self._native_vae_executor._fp8_state_path = _native_vae_fp8_state_path(
+                    config
                 )
 
     @property
@@ -489,6 +499,7 @@ class OmnidreamsWanVAEEncoder(WanVAEEncoder):
 
         z = self.vae.encode(input_bcthw, cache=cache).transpose(1, 2)
         return z.reshape(*batch_shape, *z.shape[1:])
+
 
 __all__ = [
     "NativeVAEBackend",

--- a/integrations/omnidreams/omnidreams/vae_native.py
+++ b/integrations/omnidreams/omnidreams/vae_native.py
@@ -1,0 +1,497 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OmniDreams VAE native acceleration wrappers."""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Literal, get_args
+
+import torch
+from torch import Tensor
+
+from flashdreams.recipes.wan.autoencoder.vae import (
+    TEMPORAL_WINDOW,
+    WanVAECache,
+    WanVAEEncoder,
+    WanVAEEncoderConfig,
+)
+from omnidreams.native import omnidreams_singleview
+from omnidreams.native.acceleration import (
+    NativeAccelerationConfig,
+    NativeAccelerationMode,
+    NativeAccelerationUnavailable,
+    NativeAvailabilityCheck,
+    NativeBackendSelection,
+    require_extension_symbols,
+)
+from omnidreams.native.primitives import (
+    NativePrepError,
+    NativeTensorSpec,
+    prepare_tensor_for_native,
+)
+
+NativeVAEBackend = Literal["fp8"]
+NATIVE_LIGHTVAE_FP8_STATE_ENV = "OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH"
+
+
+@dataclass(kw_only=True)
+class OmnidreamsWanVAEEncoderConfig(WanVAEEncoderConfig):
+    """Wan VAE encoder config with OmniDreams native acceleration knobs."""
+
+    _target: type = field(default_factory=lambda: OmnidreamsWanVAEEncoder)
+
+    native_vae_acceleration: NativeAccelerationMode = "disabled"
+    native_vae_build_root: str | None = None
+    native_vae_max_jobs: int | str | None = None
+    native_vae_verbose_build: bool = False
+    native_vae_backend: NativeVAEBackend = "fp8"
+    native_vae_fp8_state_path: str | None = None
+
+
+def _native_acceleration_config(
+    config: OmnidreamsWanVAEEncoderConfig,
+) -> NativeAccelerationConfig:
+    return NativeAccelerationConfig(
+        mode=config.native_vae_acceleration,
+        build_root=config.native_vae_build_root,
+        max_jobs=config.native_vae_max_jobs,
+        verbose_build=config.native_vae_verbose_build,
+    )
+
+
+def _native_vae_fp8_state_path(
+    config: OmnidreamsWanVAEEncoderConfig,
+) -> str | None:
+    return config.native_vae_fp8_state_path or os.environ.get(
+        NATIVE_LIGHTVAE_FP8_STATE_ENV
+    )
+
+
+def _native_vae_availability_check(
+    *,
+    component: str,
+    backend: NativeVAEBackend,
+    run_symbol: str,
+    setup_symbols: tuple[str, ...] = (),
+) -> NativeAvailabilityCheck:
+    symbol_check = require_extension_symbols(
+        "omnidreams_vae_backend_status",
+        run_symbol,
+        *setup_symbols,
+    )
+
+    def check(extension: ModuleType) -> tuple[bool, str]:
+        ok, reason = symbol_check(extension)
+        if not ok:
+            return ok, reason
+
+        status = extension.omnidreams_vae_backend_status(component, backend)
+        if not isinstance(status, Mapping):
+            return False, "omnidreams_vae_backend_status did not return a mapping"
+
+        available = bool(status.get("available", False))
+        status_reason = str(
+            status.get(
+                "reason",
+                "native VAE backend is available"
+                if available
+                else "native VAE backend is unavailable",
+            )
+        )
+        return available, status_reason
+
+    return check
+
+
+def _native_vae_preflight_reason(
+    *,
+    component: str,
+    config: OmnidreamsWanVAEEncoderConfig,
+) -> str | None:
+    if config.native_vae_backend not in get_args(NativeVAEBackend):
+        return (
+            f"native VAE backend must be one of {get_args(NativeVAEBackend)}, "
+            f"got {config.native_vae_backend!r}"
+        )
+    if (
+        component == "vae_encoder"
+        and config.native_vae_backend == "fp8"
+        and not _native_vae_fp8_state_path(config)
+    ):
+        return (
+            "native LightVAE fp8 backend requires native_vae_fp8_state_path "
+            f"or {NATIVE_LIGHTVAE_FP8_STATE_ENV}"
+        )
+    return None
+
+
+def _unavailable_native_vae_selection(
+    *,
+    component: str,
+    config: OmnidreamsWanVAEEncoderConfig,
+    reason: str,
+) -> NativeBackendSelection:
+    if config.native_vae_acceleration == "required":
+        raise NativeAccelerationUnavailable(reason)
+    return NativeBackendSelection(
+        component=component,
+        mode=config.native_vae_acceleration,
+        enabled=False,
+        reason=reason,
+    )
+
+
+def _select_native_vae_backend(
+    *,
+    component: str,
+    config: OmnidreamsWanVAEEncoderConfig,
+    run_symbol: str,
+    setup_symbols: tuple[str, ...] = (),
+) -> NativeBackendSelection:
+    reason = _native_vae_preflight_reason(component=component, config=config)
+    if reason is not None:
+        return _unavailable_native_vae_selection(
+            component=component,
+            config=config,
+            reason=reason,
+        )
+    return omnidreams_singleview.select_backend(
+        component,
+        _native_acceleration_config(config),
+        availability_check=_native_vae_availability_check(
+            component=component,
+            backend=config.native_vae_backend,
+            run_symbol=run_symbol,
+            setup_symbols=setup_symbols,
+        ),
+    )
+
+
+def _wan_encoder_symbols(backend: NativeVAEBackend) -> tuple[str, tuple[str, ...]]:
+    suffix = backend
+    return (
+        f"omnidreams_vae_encode_wan_{suffix}",
+        (
+            f"omnidreams_vae_create_wan_encoder_{suffix}",
+            f"omnidreams_vae_reset_wan_encoder_{suffix}",
+        ),
+    )
+
+
+class _NativeVAEExecutor:
+    def __init__(
+        self,
+        *,
+        selection: NativeBackendSelection,
+        backend: NativeVAEBackend,
+    ) -> None:
+        self.selection = selection
+        self.extension = selection.require_extension()
+        self.backend = backend
+
+    @property
+    def _required(self) -> bool:
+        return self.selection.mode == "required"
+
+    def _fallback_or_raise(self, exc: Exception) -> None:
+        if self._required:
+            raise NativeAccelerationUnavailable(str(exc)) from exc
+
+    def after_initialize_autoregressive_cache(self, cache: object) -> None:
+        hook = getattr(
+            self.extension,
+            "omnidreams_vae_after_initialize_autoregressive_cache",
+            None,
+        )
+        if callable(hook):
+            hook(self.selection.component, cache)
+
+
+class _NativeWanVAEEncoderExecutor(_NativeVAEExecutor):
+    _FP8_INPUT_SPEC = NativeTensorSpec(
+        name="wan_vae_encoder_input",
+        layout="B C T H W",
+        shape=(1, 3, None, None, None),
+        dtypes=(torch.float16,),
+        axis_divisibility=(("H", 8), ("W", 8)),
+    )
+
+    def __init__(
+        self,
+        *,
+        selection: NativeBackendSelection,
+        backend: NativeVAEBackend,
+    ) -> None:
+        super().__init__(selection=selection, backend=backend)
+        self._helper: ModuleType | None = None
+        self._native_encoder: object | None = None
+        self._native_encoder_model_id: int | None = None
+        self._native_encoder_device: torch.device | None = None
+        self._fp8_state_path: str | None = None
+        self._fp8_state: Mapping[str, Tensor] | None = None
+        self._fp8_state_loaded_path: str | None = None
+        self._cache_id: int | None = None
+        self._cache_is_empty = True
+
+    @classmethod
+    def from_config(
+        cls,
+        config: OmnidreamsWanVAEEncoderConfig,
+    ) -> "_NativeWanVAEEncoderExecutor | None":
+        run_symbol, setup_symbols = _wan_encoder_symbols(config.native_vae_backend)
+        selection = _select_native_vae_backend(
+            component="vae_encoder",
+            config=config,
+            run_symbol=run_symbol,
+            setup_symbols=setup_symbols,
+        )
+        if not selection.enabled:
+            return None
+        executor = cls(selection=selection, backend=config.native_vae_backend)
+        executor._fp8_state_path = _native_vae_fp8_state_path(config)
+        return executor
+
+    def _helper_module(self) -> ModuleType:
+        if self._helper is None:
+            self._helper = omnidreams_singleview.load_python_module("vae_weights")
+        return self._helper
+
+    def _load_fp8_state(self, helper: ModuleType) -> Mapping[str, Tensor]:
+        if self._fp8_state_path is None:
+            raise NativeAccelerationUnavailable(
+                "native LightVAE fp8 backend requires native_vae_fp8_state_path "
+                f"or {NATIVE_LIGHTVAE_FP8_STATE_ENV}"
+            )
+        if (
+            self._fp8_state is not None
+            and self._fp8_state_loaded_path == self._fp8_state_path
+        ):
+            return self._fp8_state
+        state = helper.load_lightvae_fp8_state(self._fp8_state_path)
+        self._fp8_state = state
+        self._fp8_state_loaded_path = self._fp8_state_path
+        return state
+
+    def _get_native_encoder(self, model: object, device: torch.device) -> object | None:
+        model_id = id(model)
+        if (
+            self._native_encoder is not None
+            and self._native_encoder_model_id == model_id
+            and self._native_encoder_device == device
+        ):
+            return self._native_encoder
+
+        try:
+            helper = self._helper_module()
+            if self.backend == "fp8":
+                fp8_state = self._load_fp8_state(helper)
+                state = helper.build_lightvae_encoder_fp8_staged_state(
+                    model,
+                    fp8_state,
+                    self.extension,
+                )
+                native_encoder = self.extension.omnidreams_vae_create_wan_encoder_fp8(
+                    state,
+                )
+            else:
+                raise NativeAccelerationUnavailable(
+                    f"unsupported native LightVAE encoder backend {self.backend!r}"
+                )
+        except Exception as exc:
+            self._fallback_or_raise(exc)
+            return None
+
+        self._native_encoder = native_encoder
+        self._native_encoder_model_id = model_id
+        self._native_encoder_device = device
+        self._cache_is_empty = True
+        return native_encoder
+
+    def _bind_cache(self, cache: WanVAECache) -> None:
+        cache_id = id(cache)
+        if self._cache_id == cache_id:
+            return
+        self._cache_id = cache_id
+        self._cache_is_empty = True
+        if self._native_encoder is not None:
+            self._reset_native_encoder()
+
+    def after_initialize_autoregressive_cache(self, cache: object) -> None:
+        if self._native_encoder is not None:
+            self._reset_native_encoder()
+        self._cache_id = id(cache)
+        self._cache_is_empty = True
+
+    def _reset_native_encoder(self) -> None:
+        reset = getattr(
+            self.extension,
+            f"omnidreams_vae_reset_wan_encoder_{self.backend}",
+        )
+        reset(self._native_encoder)
+
+    def _encode_chunk(self, native_encoder: object, input_bcthw: Tensor) -> Tensor:
+        encode = getattr(
+            self.extension,
+            f"omnidreams_vae_encode_wan_{self.backend}",
+        )
+        return encode(
+            native_encoder,
+            input_bcthw,
+            True,
+        )
+
+    def try_encode(
+        self,
+        model: object,
+        input_bcthw: Tensor,
+        cache: WanVAECache,
+    ) -> Tensor | None:
+        if cache.enc_state and self._cache_id != id(cache):
+            exc = NativeAccelerationUnavailable(
+                "native LightVAE encoder cannot attach to a WanVAE cache that "
+                "was already advanced by the Python encoder"
+            )
+            if self._required:
+                raise exc
+            return None
+
+        try:
+            prepared = prepare_tensor_for_native(input_bcthw, self._FP8_INPUT_SPEC)
+        except NativePrepError as exc:
+            if self._cache_id == id(cache) and not self._cache_is_empty:
+                raise NativeAccelerationUnavailable(
+                    "native LightVAE encoder cannot fall back after its internal "
+                    "streaming cache has advanced"
+                ) from exc
+            self._fallback_or_raise(exc)
+            return None
+
+        self._bind_cache(cache)
+        native_encoder = self._get_native_encoder(model, prepared.tensor.device)
+        if native_encoder is None:
+            return None
+
+        x = prepared.tensor
+        outs: list[Tensor] = []
+        if self._cache_is_empty:
+            outs.append(self._encode_chunk(native_encoder, x[:, :, :1]))
+            x = x[:, :, 1:]
+        else:
+            try:
+                if x.shape[2] % TEMPORAL_WINDOW != 0:
+                    raise NativePrepError(
+                        "Streaming LightVAE encode after the first chunk requires "
+                        f"T % {TEMPORAL_WINDOW} == 0; got T={x.shape[2]}"
+                    )
+            except NativePrepError as exc:
+                if not self._cache_is_empty:
+                    raise NativeAccelerationUnavailable(
+                        "native LightVAE encoder cannot fall back after its "
+                        "internal streaming cache has advanced"
+                    ) from exc
+                self._fallback_or_raise(exc)
+                return None
+
+        t = x.shape[2]
+        body = (t // TEMPORAL_WINDOW) * TEMPORAL_WINDOW
+        for i in range(0, body, TEMPORAL_WINDOW):
+            outs.append(self._encode_chunk(native_encoder, x[:, :, i : i + TEMPORAL_WINDOW]))
+        if body < t:
+            outs.append(self._encode_chunk(native_encoder, x[:, :, body:]))
+
+        self._cache_is_empty = False
+        if len(outs) == 1:
+            return outs[0]
+        return torch.cat(outs, dim=2)
+
+
+class OmnidreamsWanVAEEncoder(WanVAEEncoder):
+    """Wan VAE encoder with optional OmniDreams native dispatch."""
+
+    config: OmnidreamsWanVAEEncoderConfig
+
+    def __init__(self, config: OmnidreamsWanVAEEncoderConfig) -> None:
+        super().__init__(config)
+        self.config = config
+        self._native_vae_selection: NativeBackendSelection | None = None
+        self._native_vae_executor: _NativeWanVAEEncoderExecutor | None = None
+        if config.native_vae_acceleration != "disabled":
+            run_symbol, setup_symbols = _wan_encoder_symbols(config.native_vae_backend)
+            self._native_vae_selection = _select_native_vae_backend(
+                component="vae_encoder",
+                config=config,
+                run_symbol=run_symbol,
+                setup_symbols=setup_symbols,
+            )
+            if self._native_vae_selection.enabled:
+                self._native_vae_executor = _NativeWanVAEEncoderExecutor(
+                    selection=self._native_vae_selection,
+                    backend=config.native_vae_backend,
+                )
+                self._native_vae_executor._fp8_state_path = (
+                    _native_vae_fp8_state_path(config)
+                )
+
+    @property
+    def native_vae_selection(self) -> NativeBackendSelection | None:
+        return self._native_vae_selection
+
+    def initialize_autoregressive_cache(self) -> WanVAECache:
+        cache = self.vae.prepare_cache()
+        if self._native_vae_executor is not None:
+            self._native_vae_executor.after_initialize_autoregressive_cache(cache)
+        return cache
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input: Tensor,
+        autoregressive_index: int = 0,
+        cache: WanVAECache | None = None,
+    ) -> Tensor:
+        if cache is None:
+            cache = self.initialize_autoregressive_cache()
+
+        assert input.ndim >= 4, "Expected input to have shape [..., T, C, H, W]"
+
+        *batch_shape, _t, _c, _h, _w = input.shape
+        batch_size = math.prod(batch_shape)
+        x = input.reshape(batch_size, *input.shape[-4:]).to(dtype=self.config.dtype)
+        input_bcthw = x.transpose(1, 2)
+
+        if self._native_vae_executor is not None:
+            native_z = self._native_vae_executor.try_encode(
+                self.vae,
+                input_bcthw,
+                cache,
+            )
+            if native_z is not None:
+                z = native_z.transpose(1, 2)
+                return z.reshape(*batch_shape, *z.shape[1:])
+
+        z = self.vae.encode(input_bcthw, cache=cache).transpose(1, 2)
+        return z.reshape(*batch_shape, *z.shape[1:])
+
+__all__ = [
+    "NativeVAEBackend",
+    "OmnidreamsWanVAEEncoder",
+    "OmnidreamsWanVAEEncoderConfig",
+]

--- a/integrations/omnidreams/omnidreams_singleview/python/vae_weights.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/vae_weights.py
@@ -1,0 +1,1001 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Weight-layout builders for OmniDreams native VAE kernels."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+
+
+def _unwrap_module(module: torch.nn.Module) -> torch.nn.Module:
+    orig = getattr(module, "_orig_mod", None)
+    return orig if isinstance(orig, torch.nn.Module) else module
+
+
+def _module_device(module: torch.nn.Module) -> torch.device:
+    for tensor in module.parameters():
+        return tensor.device
+    for tensor in module.buffers():
+        return tensor.device
+    raise ValueError(f"{module.__class__.__name__} has no parameters or buffers")
+
+
+def _pad_1d(tensor: torch.Tensor, size: int, *, device: torch.device) -> torch.Tensor:
+    src = tensor.detach().to(device=device, dtype=torch.float16).flatten().contiguous()
+    if src.numel() == size:
+        return src
+    out = torch.zeros((size,), device=device, dtype=torch.float16)
+    out[: src.numel()].copy_(src)
+    return out.contiguous()
+
+
+def _lightvae_gamma(
+    norm: torch.nn.Module,
+    real_c: int,
+    pad_c: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    gamma = norm.gamma.detach().reshape(real_c).to(
+        device=device,
+        dtype=torch.float16,
+    )
+    if pad_c == real_c:
+        return gamma.contiguous()
+    out = torch.zeros((pad_c,), device=device, dtype=torch.float16)
+    out[:real_c].copy_(gamma)
+    return out.contiguous()
+
+
+def _lightvae_causal3_weight(
+    conv: torch.nn.Conv3d,
+    *,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
+    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    kt, kh, kw = int(w.shape[2]), int(w.shape[3]), int(w.shape[4])
+    if (kt, kh, kw) != (3, 3, 3):
+        raise ValueError(f"expected LightVAE 3x3x3 weight, got {tuple(w.shape)}")
+    packed = torch.zeros((out_pad, 3, 3, 3 * in_pad), device=device, dtype=torch.float16)
+    packed3d = torch.zeros((out_pad, 3, 3, 3, in_pad), device=device, dtype=torch.float16)
+    for dt in range(3):
+        wt = w[:out_real, :in_real, dt].permute(0, 2, 3, 1).contiguous()
+        packed[:out_real, :, :, dt * in_pad : dt * in_pad + in_real].copy_(wt)
+        packed3d[:out_real, dt, :, :, :in_real].copy_(wt)
+    return packed.contiguous(), _pad_1d(b[:out_real], out_pad, device=device), packed3d.contiguous()
+
+
+def _lightvae_spatial3_weight(
+    conv: torch.nn.Conv2d,
+    *,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
+    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    packed = torch.zeros((out_pad, 3, 3, in_pad), device=device, dtype=torch.float16)
+    packed[:out_real, :, :, :in_real].copy_(w[:out_real, :in_real].permute(0, 2, 3, 1))
+    return packed.contiguous(), _pad_1d(b[:out_real], out_pad, device=device)
+
+
+def _lightvae_temporal3_weight(
+    conv: torch.nn.Conv3d,
+    *,
+    channels: int,
+    real_channels: int | None = None,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
+    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    real = int(real_channels if real_channels is not None else channels)
+    if real > channels:
+        raise ValueError(f"real_channels {real} cannot exceed padded channels {channels}")
+    packed = torch.zeros((channels, 3 * channels), device=device, dtype=torch.float16)
+    for dt in range(3):
+        packed[:real, dt * channels : dt * channels + real].copy_(w[:real, :real, dt, 0, 0])
+    return packed.contiguous(), _pad_1d(b[:real], channels, device=device)
+
+
+def _lightvae_conv1_weight(
+    conv: torch.nn.Module,
+    *,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
+    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    if w.dim() == 5:
+        w = w[:, :, 0, 0, 0]
+    elif w.dim() == 4:
+        w = w[:, :, 0, 0]
+    packed = torch.zeros((out_pad, in_pad), device=device, dtype=torch.float16)
+    packed[:out_real, :in_real].copy_(w[:out_real, :in_real])
+    return packed.contiguous(), _pad_1d(b[:out_real], out_pad, device=device)
+
+
+def _lightvae_resblock_state(
+    block: torch.nn.Module,
+    *,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    device: torch.device,
+) -> dict[str, Any]:
+    residual = block.residual
+    conv1_w, conv1_b, conv1_w3d = _lightvae_causal3_weight(
+        residual[2],
+        in_real=in_real,
+        in_pad=in_pad,
+        out_real=out_real,
+        out_pad=out_pad,
+        device=device,
+    )
+    conv2_w, conv2_b, conv2_w3d = _lightvae_causal3_weight(
+        residual[6],
+        in_real=out_real,
+        in_pad=out_pad,
+        out_real=out_real,
+        out_pad=out_pad,
+        device=device,
+    )
+    shortcut_w = shortcut_b = None
+    if not isinstance(block.shortcut, torch.nn.Identity):
+        shortcut_w, shortcut_b = _lightvae_conv1_weight(
+            block.shortcut,
+            in_real=in_real,
+            in_pad=in_pad,
+            out_real=out_real,
+            out_pad=out_pad,
+            device=device,
+        )
+    return {
+        "in_real": in_real,
+        "in_pad": in_pad,
+        "out_real": out_real,
+        "out_pad": out_pad,
+        "norm1_gamma": _lightvae_gamma(residual[0], in_real, in_pad, device=device),
+        "conv1_w": conv1_w,
+        "conv1_w3d": conv1_w3d,
+        "conv1_b": conv1_b,
+        "norm2_gamma": _lightvae_gamma(residual[3], out_real, out_pad, device=device),
+        "conv2_w": conv2_w,
+        "conv2_w3d": conv2_w3d,
+        "conv2_b": conv2_b,
+        "shortcut_w": shortcut_w,
+        "shortcut_b": shortcut_b,
+    }
+
+
+def _require_lightvae_layout(model: torch.nn.Module) -> None:
+    if not hasattr(model, "encoder") or not hasattr(model, "conv1"):
+        raise TypeError("native LightVAE encoder requires a WanVAE encoder model")
+    enc = _unwrap_module(model.encoder)
+    if len(enc.downsamples) != 11:
+        raise ValueError(
+            "native LightVAE encoder supports the pruned Wan LightVAE layout only "
+            f"(expected 11 downsample blocks, got {len(enc.downsamples)})"
+        )
+    if enc.conv1.out_channels != 24:
+        raise ValueError(
+            "native LightVAE encoder supports the lightvae checkpoint only "
+            f"(encoder.conv1.out_channels={enc.conv1.out_channels})"
+        )
+
+_LIGHTVAE_FP8_STAGED_STATE_CACHE: dict[tuple[int, int, int, str], dict[str, Any]] = {}
+
+
+def load_lightvae_fp8_state(path: str) -> dict[str, torch.Tensor]:
+    """Load a LightVAE FP8 calibration state from a local torch checkpoint."""
+
+    obj = torch.load(path, map_location="cpu")
+    if isinstance(obj, Mapping) and "fp8_state" in obj:
+        obj = obj["fp8_state"]
+    if not isinstance(obj, Mapping):
+        raise TypeError(
+            "native LightVAE fp8 state must be a mapping or contain an 'fp8_state' mapping"
+        )
+
+    state: dict[str, torch.Tensor] = {}
+    for key, value in obj.items():
+        if isinstance(value, torch.Tensor):
+            state[str(key)] = value.detach()
+    if not state:
+        raise ValueError("native LightVAE fp8 state did not contain tensor entries")
+    return state
+
+
+def _ds_key(idx: int, suffix: str) -> str:
+    return f"encoder.downsamples.{idx}{suffix}"
+
+
+def _mid_key(idx: int, suffix: str) -> str:
+    return f"encoder.middle.{idx}{suffix}"
+
+
+def _pad_scale_tensor(
+    scale: torch.Tensor,
+    real_channels: int,
+    padded_channels: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    s = scale.detach().to(device=device, dtype=torch.float16).flatten().contiguous()
+    if s.numel() in (1, padded_channels):
+        return s
+    if s.numel() != real_channels:
+        raise ValueError(
+            f"scale has {s.numel()} channels, expected 1, {real_channels}, or {padded_channels}"
+        )
+    out = torch.ones((padded_channels,), device=device, dtype=torch.float16)
+    out[:real_channels].copy_(s)
+    return out.contiguous()
+
+
+def _repeat_scale_tensor(scale: torch.Tensor, copies: int) -> torch.Tensor:
+    if scale.numel() == 1 or copies == 1:
+        return scale.contiguous()
+    return scale.repeat(copies).contiguous()
+
+
+def _scale_ratio(numerator: torch.Tensor, denominator: torch.Tensor) -> torch.Tensor:
+    return (
+        numerator.float() / denominator.float().clamp_min(1.0e-12)
+    ).to(dtype=torch.float16).contiguous()
+
+
+def _bias_over_scale(
+    bias: torch.Tensor | None,
+    output_scale: torch.Tensor,
+) -> torch.Tensor | None:
+    if bias is None:
+        return None
+    if output_scale.numel() == 1:
+        return (
+            bias.float() / output_scale.flatten()[0].float().clamp_min(1.0e-12)
+        ).to(dtype=torch.float16).contiguous()
+    if bias.numel() != output_scale.numel():
+        raise ValueError(
+            f"bias has {bias.numel()} values, expected {output_scale.numel()} for scaled FP8 epilogue"
+        )
+    return _scale_ratio(bias, output_scale)
+
+
+def _scale_prefix(scale: torch.Tensor, real_channels: int) -> torch.Tensor:
+    if scale.numel() == 1 or scale.numel() == real_channels:
+        return scale.contiguous()
+    if scale.numel() < real_channels:
+        raise ValueError(f"scale has {scale.numel()} values, expected at least {real_channels}")
+    return scale[:real_channels].contiguous()
+
+
+def _scale_prefix_float(scale: torch.Tensor, real_channels: int) -> torch.Tensor:
+    return _scale_prefix(scale, real_channels).to(dtype=torch.float32).contiguous()
+
+
+def _state_scale_any(
+    fp8_state: Mapping[str, torch.Tensor],
+    keys: tuple[str, ...],
+    real_channels: int,
+    padded_channels: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    for key in keys:
+        scale = fp8_state.get(key)
+        if scale is not None:
+            return _pad_scale_tensor(scale, real_channels, padded_channels, device=device)
+    raise KeyError(f"LightVAE fp8 state missing scale. Tried: {', '.join(keys)}")
+
+
+def _activation_scale_any(
+    fp8_state: Mapping[str, torch.Tensor],
+    keys: tuple[str, ...],
+    real_channels: int,
+    padded_channels: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    return _state_scale_any(fp8_state, keys, real_channels, padded_channels, device=device)
+
+
+def _activation_scale_scalar_any(
+    fp8_state: Mapping[str, torch.Tensor],
+    keys: tuple[str, ...],
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    for key in keys:
+        scale = fp8_state.get(key)
+        if scale is not None:
+            return (
+                scale.detach()
+                .to(device=device, dtype=torch.float32)
+                .flatten()
+                .amax()
+                .reshape(1)
+                .to(torch.float16)
+                .contiguous()
+            )
+    raise KeyError(f"LightVAE fp8 state missing scalar activation_scale. Tried: {', '.join(keys)}")
+
+
+def _float_scalar(scale: torch.Tensor, *, device: torch.device) -> torch.Tensor:
+    return scale.detach().to(device=device, dtype=torch.float32).flatten().amax().reshape(1).contiguous()
+
+
+def _inverse_float_scalar(scale: torch.Tensor, *, device: torch.device) -> torch.Tensor:
+    return (1.0 / _float_scalar(scale, device=device).clamp(min=1.0e-12)).contiguous()
+
+
+def _weight_scale_any(
+    fp8_state: Mapping[str, torch.Tensor],
+    key: str,
+    real_channels: int,
+    padded_channels: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    return _state_scale_any(fp8_state, (key,), real_channels, padded_channels, device=device)
+
+
+def _lightvae_fp8_prepare_krsc(
+    native_ext: Any,
+    weight_krsc: torch.Tensor,
+    input_scale: torch.Tensor,
+    output_scale: torch.Tensor,
+) -> torch.Tensor:
+    return native_ext.lightvae_fp8_prepare_conv2d_weight_krsc(
+        weight_krsc.contiguous(),
+        input_scale.contiguous(),
+        output_scale.contiguous(),
+    )
+
+
+def _lightvae_fp8_prepare_conv1(
+    native_ext: Any,
+    weight_kc: torch.Tensor,
+    input_scale: torch.Tensor,
+    output_scale: torch.Tensor,
+) -> torch.Tensor:
+    return _lightvae_fp8_prepare_krsc(
+        native_ext,
+        weight_kc.reshape(weight_kc.shape[0], 1, 1, weight_kc.shape[1]).contiguous(),
+        input_scale,
+        output_scale,
+    )
+
+
+def _lightvae_fp8_causal_weight(
+    native_ext: Any,
+    conv: torch.nn.Conv3d,
+    *,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    input_scale: torch.Tensor,
+    output_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    warp_mma_scaled_epilogue: bool,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    weight, bias, _weight3d = _lightvae_causal3_weight(
+        conv,
+        in_real=in_real,
+        in_pad=in_pad,
+        out_real=out_real,
+        out_pad=out_pad,
+        device=device,
+    )
+    if warp_mma_scaled_epilogue:
+        return (
+            _lightvae_fp8_prepare_krsc(
+                native_ext,
+                weight,
+                _repeat_scale_tensor(input_scale, 3),
+                weight_scale,
+            ),
+            bias,
+            weight_scale,
+            _scale_ratio(weight_scale, output_scale),
+            _bias_over_scale(bias, output_scale),
+        )
+    return (
+        _lightvae_fp8_prepare_krsc(
+            native_ext,
+            weight,
+            _repeat_scale_tensor(input_scale, 3),
+            output_scale,
+        ),
+        bias,
+        None,
+        None,
+        None,
+    )
+
+
+def _lightvae_fp8_spatial_weight(
+    native_ext: Any,
+    conv: torch.nn.Conv2d,
+    *,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    input_scale: torch.Tensor,
+    output_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    warp_mma_scaled_epilogue: bool,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    weight, bias = _lightvae_spatial3_weight(
+        conv,
+        in_real=in_real,
+        in_pad=in_pad,
+        out_real=out_real,
+        out_pad=out_pad,
+        device=device,
+    )
+    if warp_mma_scaled_epilogue:
+        return (
+            _lightvae_fp8_prepare_krsc(native_ext, weight, input_scale, weight_scale),
+            bias,
+            _scale_ratio(weight_scale, output_scale),
+            _bias_over_scale(bias, output_scale),
+        )
+    return _lightvae_fp8_prepare_krsc(native_ext, weight, input_scale, output_scale), bias, None, None
+
+
+def _lightvae_fp8_temporal_weight(
+    native_ext: Any,
+    conv: torch.nn.Conv3d,
+    *,
+    channels: int,
+    real_channels: int | None = None,
+    input_scale: torch.Tensor,
+    output_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    weight, bias = _lightvae_temporal3_weight(
+        conv,
+        channels=channels,
+        real_channels=real_channels,
+        device=device,
+    )
+    _ = weight_scale
+    return (
+        _lightvae_fp8_prepare_conv1(
+            native_ext,
+            weight,
+            _repeat_scale_tensor(input_scale, 3),
+            output_scale,
+        ),
+        bias,
+    )
+
+
+def _lightvae_fp8_conv1_weight(
+    native_ext: Any,
+    conv: torch.nn.Module,
+    *,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    input_scale: torch.Tensor,
+    output_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    weight, bias = _lightvae_conv1_weight(
+        conv,
+        in_real=in_real,
+        in_pad=in_pad,
+        out_real=out_real,
+        out_pad=out_pad,
+        device=device,
+    )
+    _ = weight_scale
+    return _lightvae_fp8_prepare_conv1(native_ext, weight, input_scale, output_scale), bias
+
+
+def _build_lightvae_fp8_resblock_state(
+    native_ext: Any,
+    block: torch.nn.Module,
+    *,
+    path: str,
+    input_scale: torch.Tensor,
+    norm1_scale: torch.Tensor,
+    conv1_scale: torch.Tensor,
+    conv1_weight_scale: torch.Tensor,
+    norm2_scale: torch.Tensor,
+    conv2_weight_scale: torch.Tensor,
+    shortcut_scale: torch.Tensor | None,
+    shortcut_weight_scale: torch.Tensor | None,
+    output_scale: torch.Tensor,
+    in_real: int,
+    in_pad: int,
+    out_real: int,
+    out_pad: int,
+    warp_mma_scaled_epilogue: bool,
+    device: torch.device,
+) -> dict[str, Any]:
+    residual = block.residual
+    conv1_w, conv1_b, conv1_source_scale, conv1_epilogue_scale, conv1_bias_scaled = _lightvae_fp8_causal_weight(
+        native_ext,
+        residual[2],
+        in_real=in_real,
+        in_pad=in_pad,
+        out_real=out_real,
+        out_pad=out_pad,
+        input_scale=norm1_scale,
+        output_scale=conv1_scale,
+        weight_scale=conv1_weight_scale,
+        warp_mma_scaled_epilogue=warp_mma_scaled_epilogue,
+        device=device,
+    )
+    conv2_w, conv2_b, conv2_source_scale, conv2_epilogue_scale, conv2_bias_scaled = _lightvae_fp8_causal_weight(
+        native_ext,
+        residual[6],
+        in_real=out_real,
+        in_pad=out_pad,
+        out_real=out_real,
+        out_pad=out_pad,
+        input_scale=norm2_scale,
+        output_scale=output_scale,
+        weight_scale=conv2_weight_scale,
+        warp_mma_scaled_epilogue=warp_mma_scaled_epilogue,
+        device=device,
+    )
+    shortcut = None
+    if not isinstance(block.shortcut, torch.nn.Identity):
+        if shortcut_scale is None:
+            raise ValueError(f"{path} shortcut requires shortcut_scale")
+        sw, sb = _lightvae_fp8_conv1_weight(
+            native_ext,
+            block.shortcut,
+            in_real=in_real,
+            in_pad=in_pad,
+            out_real=out_real,
+            out_pad=out_pad,
+            input_scale=input_scale,
+            output_scale=shortcut_scale,
+            weight_scale=shortcut_weight_scale
+            if shortcut_weight_scale is not None
+            else shortcut_scale,
+            device=device,
+        )
+        shortcut = {"w": sw, "b": sb, "scale": shortcut_scale}
+    return {
+        "path": path,
+        "in_real": in_real,
+        "out_real": out_real,
+        "input_scale": input_scale,
+        "input_scale_rms": _scale_prefix_float(input_scale, in_real),
+        "norm1_scale": norm1_scale,
+        "norm1_scale_rms": _scale_prefix_float(norm1_scale, in_real),
+        "conv1_scale": conv1_scale,
+        "conv1_scale_rms": _scale_prefix_float(conv1_scale, out_real),
+        "norm2_scale": norm2_scale,
+        "norm2_scale_rms": _scale_prefix_float(norm2_scale, out_real),
+        "output_scale": output_scale,
+        "norm1_gamma": _lightvae_gamma(residual[0], in_real, in_pad, device=device),
+        "norm2_gamma": _lightvae_gamma(residual[3], out_real, out_pad, device=device),
+        "conv1_w": conv1_w,
+        "conv1_b": conv1_b,
+        "conv1_source_scale": conv1_source_scale,
+        "conv1_epilogue_scale": conv1_epilogue_scale,
+        "conv1_bias_scaled": conv1_bias_scaled,
+        "conv2_w": conv2_w,
+        "conv2_b": conv2_b,
+        "conv2_source_scale": conv2_source_scale,
+        "conv2_epilogue_scale": conv2_epilogue_scale,
+        "conv2_bias_scaled": conv2_bias_scaled,
+        "shortcut": shortcut,
+    }
+
+
+def build_lightvae_encoder_fp8_staged_state(
+    model: torch.nn.Module,
+    fp8_state: Mapping[str, torch.Tensor],
+    native_ext: Any,
+) -> dict[str, Any]:
+    """Return the prepared TIN16 FP8 LightVAE encoder state."""
+
+    _require_lightvae_layout(model)
+    required_prepare = getattr(native_ext, "lightvae_fp8_prepare_conv2d_weight_krsc", None)
+    if not callable(required_prepare):
+        raise TypeError(
+            "native extension missing lightvae_fp8_prepare_conv2d_weight_krsc"
+        )
+
+    device = _module_device(model)
+    state_key = (id(model), id(fp8_state), id(native_ext), str(device))
+    cached = _LIGHTVAE_FP8_STAGED_STATE_CACHE.get(state_key)
+    if cached is not None:
+        return cached
+
+    enc = _unwrap_module(model.encoder).eval()
+    downs = enc.downsamples
+    middle = enc.middle
+    head = enc.head
+    fs = {str(k): v for k, v in fp8_state.items()}
+    use_warp_mma_scaled_epilogue_causal_conv3 = True
+    use_warp_mma_scaled_epilogue_spatial_conv3 = True
+
+    def act(keys: tuple[str, ...], real: int, pad: int) -> torch.Tensor:
+        return _activation_scale_any(fs, keys, real, pad, device=device)
+
+    def ws(key: str, real: int, pad: int) -> torch.Tensor:
+        return _weight_scale_any(fs, key, real, pad, device=device)
+
+    scale_input = act((
+        "encoder.conv1.input.activation_scale",
+        "encoder.input.activation_scale",
+        "input.activation_scale",
+    ), 3, 32)
+    scale_conv1 = act(("encoder.conv1.activation_scale",), 24, 32)
+
+    scale_s0_0_n1 = act((_ds_key(0, ".residual.1.activation_scale"), _ds_key(0, ".residual.0.activation_scale")), 24, 32)
+    scale_s0_0_c1 = act((_ds_key(0, ".residual.2.activation_scale"),), 24, 32)
+    scale_s0_0_n2 = act((_ds_key(0, ".residual.4.activation_scale"), _ds_key(0, ".residual.3.activation_scale")), 24, 32)
+    scale_s0_0 = act((_ds_key(0, ".activation_scale"),), 24, 32)
+    scale_s0_1_n1 = act((_ds_key(1, ".residual.1.activation_scale"), _ds_key(1, ".residual.0.activation_scale")), 24, 32)
+    scale_s0_1_c1 = act((_ds_key(1, ".residual.2.activation_scale"),), 24, 32)
+    scale_s0_1_n2 = act((_ds_key(1, ".residual.4.activation_scale"), _ds_key(1, ".residual.3.activation_scale")), 24, 32)
+    scale_s0_1 = act((_ds_key(1, ".activation_scale"),), 24, 32)
+    scale_ds0 = act((_ds_key(2, ".activation_scale"), _ds_key(2, ".resample.1.activation_scale")), 24, 32)
+
+    scale_s1_0_n1 = act((_ds_key(3, ".residual.1.activation_scale"), _ds_key(3, ".residual.0.activation_scale")), 24, 32)
+    scale_s1_0_c1 = act((_ds_key(3, ".residual.2.activation_scale"),), 48, 64)
+    scale_s1_0_n2 = act((_ds_key(3, ".residual.4.activation_scale"), _ds_key(3, ".residual.3.activation_scale")), 48, 64)
+    scale_s1_0_short = act((_ds_key(3, ".shortcut.activation_scale"),), 48, 64)
+    scale_s1_0 = act((_ds_key(3, ".activation_scale"),), 48, 64)
+    scale_s1_1_n1 = act((_ds_key(4, ".residual.1.activation_scale"), _ds_key(4, ".residual.0.activation_scale")), 48, 64)
+    scale_s1_1_c1 = act((_ds_key(4, ".residual.2.activation_scale"),), 48, 64)
+    scale_s1_1_n2 = act((_ds_key(4, ".residual.4.activation_scale"), _ds_key(4, ".residual.3.activation_scale")), 48, 64)
+    scale_s1_1 = act((_ds_key(4, ".activation_scale"),), 48, 64)
+    scale_ds1_spatial = act((_ds_key(5, ".resample.1.activation_scale"),), 48, 64)
+    scale_ds1 = act((_ds_key(5, ".activation_scale"), _ds_key(5, ".time_conv.activation_scale")), 48, 64)
+
+    scale_s2_0_n1 = act((_ds_key(6, ".residual.1.activation_scale"), _ds_key(6, ".residual.0.activation_scale")), 48, 64)
+    scale_s2_0_c1 = act((_ds_key(6, ".residual.2.activation_scale"),), 96, 96)
+    scale_s2_0_n2 = act((_ds_key(6, ".residual.4.activation_scale"), _ds_key(6, ".residual.3.activation_scale")), 96, 96)
+    scale_s2_0_short = act((_ds_key(6, ".shortcut.activation_scale"),), 96, 96)
+    scale_s2_0 = act((_ds_key(6, ".activation_scale"),), 96, 96)
+    scale_s2_1_n1 = act((_ds_key(7, ".residual.1.activation_scale"), _ds_key(7, ".residual.0.activation_scale")), 96, 96)
+    scale_s2_1_c1 = act((_ds_key(7, ".residual.2.activation_scale"),), 96, 96)
+    scale_s2_1_n2 = act((_ds_key(7, ".residual.4.activation_scale"), _ds_key(7, ".residual.3.activation_scale")), 96, 96)
+    scale_s2_1 = act((_ds_key(7, ".activation_scale"),), 96, 96)
+    scale_ds2_spatial = act((_ds_key(8, ".resample.1.activation_scale"),), 96, 96)
+    scale_ds2 = act((_ds_key(8, ".activation_scale"), _ds_key(8, ".time_conv.activation_scale")), 96, 96)
+
+    scale_s3_0_n1 = act((_ds_key(9, ".residual.1.activation_scale"), _ds_key(9, ".residual.0.activation_scale")), 96, 96)
+    scale_s3_0_c1 = act((_ds_key(9, ".residual.2.activation_scale"),), 96, 96)
+    scale_s3_0_n2 = act((_ds_key(9, ".residual.4.activation_scale"), _ds_key(9, ".residual.3.activation_scale")), 96, 96)
+    scale_s3_0 = act((_ds_key(9, ".activation_scale"),), 96, 96)
+    scale_s3_1_n1 = act((_ds_key(10, ".residual.1.activation_scale"), _ds_key(10, ".residual.0.activation_scale")), 96, 96)
+    scale_s3_1_c1 = act((_ds_key(10, ".residual.2.activation_scale"),), 96, 96)
+    scale_s3_1_n2 = act((_ds_key(10, ".residual.4.activation_scale"), _ds_key(10, ".residual.3.activation_scale")), 96, 96)
+    scale_s3_1 = act((_ds_key(10, ".activation_scale"),), 96, 96)
+
+    scale_mid0_n1 = act((_mid_key(0, ".residual.1.activation_scale"), _mid_key(0, ".residual.0.activation_scale")), 96, 96)
+    scale_mid0_c1 = act((_mid_key(0, ".residual.2.activation_scale"),), 96, 96)
+    scale_mid0_n2 = act((_mid_key(0, ".residual.4.activation_scale"), _mid_key(0, ".residual.3.activation_scale")), 96, 96)
+    scale_mid0 = act((_mid_key(0, ".activation_scale"),), 96, 96)
+    scale_mid_attn_norm = act((
+        _mid_key(1, ".norm.activation_scale"),
+        _mid_key(1, ".to_qkv.input.activation_scale"),
+        _mid_key(0, ".activation_scale"),
+    ), 96, 96)
+    scale_mid_qkv = _activation_scale_scalar_any(fs, (
+        _mid_key(1, ".to_qkv.activation_scale"),
+        _mid_key(1, ".qkv.activation_scale"),
+        _mid_key(1, ".activation_scale"),
+        _mid_key(0, ".activation_scale"),
+    ), device=device)
+    scale_mid_sdpa = _activation_scale_scalar_any(fs, (
+        _mid_key(1, ".sdpa.activation_scale"),
+        _mid_key(1, ".attention.activation_scale"),
+        _mid_key(1, ".to_qkv.activation_scale"),
+        _mid_key(1, ".activation_scale"),
+        _mid_key(0, ".activation_scale"),
+    ), device=device)
+    scale_mid_attn = act((_mid_key(1, ".activation_scale"), _mid_key(0, ".activation_scale")), 96, 96)
+    scale_mid1_n1 = act((_mid_key(2, ".residual.1.activation_scale"), _mid_key(2, ".residual.0.activation_scale")), 96, 96)
+    scale_mid1_c1 = act((_mid_key(2, ".residual.2.activation_scale"),), 96, 96)
+    scale_mid1_n2 = act((_mid_key(2, ".residual.4.activation_scale"), _mid_key(2, ".residual.3.activation_scale")), 96, 96)
+    scale_mid1 = act((_mid_key(2, ".activation_scale"),), 96, 96)
+    scale_head_norm = act(("encoder.head.1.activation_scale", "encoder.head.0.activation_scale"), 96, 96)
+    scale_head_conv = act(("encoder.head.2.activation_scale",), 32, 32)
+    scale_post = act(("conv1.activation_scale",), 32, 32)
+
+    conv1_w, conv1_b, conv1_source_scale, conv1_epilogue_scale, conv1_bias_scaled = _lightvae_fp8_causal_weight(
+        native_ext,
+        enc.conv1,
+        in_real=3,
+        in_pad=32,
+        out_real=24,
+        out_pad=32,
+        input_scale=scale_input,
+        output_scale=scale_conv1,
+        weight_scale=ws("encoder.conv1.weight_scale", 24, 32),
+        warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
+        device=device,
+    )
+
+    def rb(
+        idx: int,
+        block: torch.nn.Module,
+        in_real: int,
+        in_pad: int,
+        out_real: int,
+        out_pad: int,
+        input_scale: torch.Tensor,
+        n1: torch.Tensor,
+        c1: torch.Tensor,
+        n2: torch.Tensor,
+        output_scale: torch.Tensor,
+        shortcut_scale: torch.Tensor | None = None,
+    ) -> dict[str, Any]:
+        path = _ds_key(idx, "")
+        shortcut_weight_scale = (
+            ws(f"{path}.shortcut.weight_scale", out_real, out_pad)
+            if shortcut_scale is not None
+            else None
+        )
+        return _build_lightvae_fp8_resblock_state(
+            native_ext,
+            block,
+            path=path,
+            input_scale=input_scale,
+            norm1_scale=n1,
+            conv1_scale=c1,
+            conv1_weight_scale=ws(f"{path}.residual.2.weight_scale", out_real, out_pad),
+            norm2_scale=n2,
+            conv2_weight_scale=ws(f"{path}.residual.6.weight_scale", out_real, out_pad),
+            shortcut_scale=shortcut_scale,
+            shortcut_weight_scale=shortcut_weight_scale,
+            output_scale=output_scale,
+            in_real=in_real,
+            in_pad=in_pad,
+            out_real=out_real,
+            out_pad=out_pad,
+            warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
+            device=device,
+        )
+
+    def mid_rb(
+        idx: int,
+        block: torch.nn.Module,
+        input_scale: torch.Tensor,
+        n1: torch.Tensor,
+        c1: torch.Tensor,
+        n2: torch.Tensor,
+        output_scale: torch.Tensor,
+    ) -> dict[str, Any]:
+        path = _mid_key(idx, "")
+        return _build_lightvae_fp8_resblock_state(
+            native_ext,
+            block,
+            path=path,
+            input_scale=input_scale,
+            norm1_scale=n1,
+            conv1_scale=c1,
+            conv1_weight_scale=ws(f"{path}.residual.2.weight_scale", 96, 96),
+            norm2_scale=n2,
+            conv2_weight_scale=ws(f"{path}.residual.6.weight_scale", 96, 96),
+            shortcut_scale=None,
+            shortcut_weight_scale=None,
+            output_scale=output_scale,
+            in_real=96,
+            in_pad=96,
+            out_real=96,
+            out_pad=96,
+            warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
+            device=device,
+        )
+
+    ds0_w, ds0_b, ds0_epilogue_scale, ds0_bias_scaled = _lightvae_fp8_spatial_weight(
+        native_ext,
+        downs[2].resample[1],
+        in_real=24,
+        in_pad=32,
+        out_real=24,
+        out_pad=32,
+        input_scale=scale_s0_1,
+        output_scale=scale_ds0,
+        weight_scale=ws(_ds_key(2, ".resample.1.weight_scale"), 24, 32),
+        warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_spatial_conv3,
+        device=device,
+    )
+    ds1_w, ds1_b, ds1_epilogue_scale, ds1_bias_scaled = _lightvae_fp8_spatial_weight(
+        native_ext,
+        downs[5].resample[1],
+        in_real=48,
+        in_pad=64,
+        out_real=48,
+        out_pad=64,
+        input_scale=scale_s1_1,
+        output_scale=scale_ds1_spatial,
+        weight_scale=ws(_ds_key(5, ".resample.1.weight_scale"), 48, 64),
+        warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_spatial_conv3,
+        device=device,
+    )
+    ds1_tw, ds1_tb = _lightvae_fp8_temporal_weight(
+        native_ext,
+        downs[5].time_conv,
+        channels=64,
+        real_channels=48,
+        input_scale=scale_ds1_spatial,
+        output_scale=scale_ds1,
+        weight_scale=ws(_ds_key(5, ".time_conv.weight_scale"), 48, 64),
+        device=device,
+    )
+    ds2_w, ds2_b, ds2_epilogue_scale, ds2_bias_scaled = _lightvae_fp8_spatial_weight(
+        native_ext,
+        downs[8].resample[1],
+        in_real=96,
+        in_pad=96,
+        out_real=96,
+        out_pad=96,
+        input_scale=scale_s2_1,
+        output_scale=scale_ds2_spatial,
+        weight_scale=ws(_ds_key(8, ".resample.1.weight_scale"), 96, 96),
+        warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_spatial_conv3,
+        device=device,
+    )
+    ds2_tw, ds2_tb = _lightvae_fp8_temporal_weight(
+        native_ext,
+        downs[8].time_conv,
+        channels=96,
+        input_scale=scale_ds2_spatial,
+        output_scale=scale_ds2,
+        weight_scale=ws(_ds_key(8, ".time_conv.weight_scale"), 96, 96),
+        device=device,
+    )
+    head_w, head_b, head_source_scale, head_epilogue_scale, head_bias_scaled = _lightvae_fp8_causal_weight(
+        native_ext,
+        head[2],
+        in_real=96,
+        in_pad=96,
+        out_real=32,
+        out_pad=32,
+        input_scale=scale_head_norm,
+        output_scale=scale_head_conv,
+        weight_scale=ws("encoder.head.2.weight_scale", 32, 32),
+        warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
+        device=device,
+    )
+    post_w, post_b = _lightvae_fp8_conv1_weight(
+        native_ext,
+        model.conv1,
+        in_real=32,
+        in_pad=32,
+        out_real=32,
+        out_pad=32,
+        input_scale=scale_head_conv,
+        output_scale=scale_post,
+        weight_scale=ws("conv1.weight_scale", 32, 32),
+        device=device,
+    )
+    mid_attn_qkv_w, mid_attn_qkv_b = _lightvae_fp8_conv1_weight(
+        native_ext,
+        middle[1].to_qkv,
+        in_real=96,
+        in_pad=96,
+        out_real=288,
+        out_pad=288,
+        input_scale=scale_mid_attn_norm,
+        output_scale=scale_mid_qkv,
+        weight_scale=ws(_mid_key(1, ".to_qkv.weight_scale"), 288, 288),
+        device=device,
+    )
+    mid_attn_proj_w, mid_attn_proj_b = _lightvae_fp8_conv1_weight(
+        native_ext,
+        middle[1].proj,
+        in_real=96,
+        in_pad=96,
+        out_real=96,
+        out_pad=96,
+        input_scale=scale_mid_sdpa,
+        output_scale=scale_mid_attn,
+        weight_scale=ws(_mid_key(1, ".proj.weight_scale"), 96, 96),
+        device=device,
+    )
+
+    mean = model.mean.detach().to(device=device, dtype=torch.float16).reshape(-1).contiguous()
+    inv_std = model.inv_std.detach().to(device=device, dtype=torch.float16).reshape(-1).contiguous()
+    if mean.numel() != 16 or inv_std.numel() != 16:
+        raise ValueError("native LightVAE fp8 encoder expects 16 latent mean/std channels")
+
+    staged = {
+        "warp_mma_scaled_epilogue": use_warp_mma_scaled_epilogue_causal_conv3 and use_warp_mma_scaled_epilogue_spatial_conv3,
+        "warp_mma_scaled_epilogue_causal_conv3": use_warp_mma_scaled_epilogue_causal_conv3,
+        "warp_mma_scaled_epilogue_spatial_conv3": use_warp_mma_scaled_epilogue_spatial_conv3,
+        "scale_input": scale_input,
+        "scale_conv1": scale_conv1,
+        "conv1_w": conv1_w,
+        "conv1_b": conv1_b,
+        "conv1_source_scale": conv1_source_scale,
+        "conv1_epilogue_scale": conv1_epilogue_scale,
+        "conv1_bias_scaled": conv1_bias_scaled,
+        "blocks": [
+            rb(0, downs[0], 24, 32, 24, 32, scale_conv1, scale_s0_0_n1, scale_s0_0_c1, scale_s0_0_n2, scale_s0_0),
+            rb(1, downs[1], 24, 32, 24, 32, scale_s0_0, scale_s0_1_n1, scale_s0_1_c1, scale_s0_1_n2, scale_s0_1),
+            rb(3, downs[3], 24, 32, 48, 64, scale_ds0, scale_s1_0_n1, scale_s1_0_c1, scale_s1_0_n2, scale_s1_0, scale_s1_0_short),
+            rb(4, downs[4], 48, 64, 48, 64, scale_s1_0, scale_s1_1_n1, scale_s1_1_c1, scale_s1_1_n2, scale_s1_1),
+            rb(6, downs[6], 48, 64, 96, 96, scale_ds1, scale_s2_0_n1, scale_s2_0_c1, scale_s2_0_n2, scale_s2_0, scale_s2_0_short),
+            rb(7, downs[7], 96, 96, 96, 96, scale_s2_0, scale_s2_1_n1, scale_s2_1_c1, scale_s2_1_n2, scale_s2_1),
+            rb(9, downs[9], 96, 96, 96, 96, scale_ds2, scale_s3_0_n1, scale_s3_0_c1, scale_s3_0_n2, scale_s3_0),
+            rb(10, downs[10], 96, 96, 96, 96, scale_s3_0, scale_s3_1_n1, scale_s3_1_c1, scale_s3_1_n2, scale_s3_1),
+            mid_rb(0, middle[0], scale_s3_1, scale_mid0_n1, scale_mid0_c1, scale_mid0_n2, scale_mid0),
+            mid_rb(2, middle[2], scale_mid_attn, scale_mid1_n1, scale_mid1_c1, scale_mid1_n2, scale_mid1),
+        ],
+        "ds0": {"w": ds0_w, "b": ds0_b, "scale": scale_ds0, "epilogue_scale": ds0_epilogue_scale, "bias_scaled": ds0_bias_scaled, "real": 24},
+        "ds1": {"spatial_w": ds1_w, "spatial_b": ds1_b, "spatial_scale": scale_ds1_spatial, "spatial_epilogue_scale": ds1_epilogue_scale, "spatial_bias_scaled": ds1_bias_scaled, "temporal_w": ds1_tw, "temporal_b": ds1_tb, "scale": scale_ds1, "real": 48},
+        "ds2": {"spatial_w": ds2_w, "spatial_b": ds2_b, "spatial_scale": scale_ds2_spatial, "spatial_epilogue_scale": ds2_epilogue_scale, "spatial_bias_scaled": ds2_bias_scaled, "temporal_w": ds2_tw, "temporal_b": ds2_tb, "scale": scale_ds2, "real": 96},
+        "scale_mid0": scale_mid0,
+        "scale_mid_attn": scale_mid_attn,
+        "mid_attn": {
+            "input_scale_rms": _scale_prefix_float(scale_mid0, 96),
+            "norm_gamma": _lightvae_gamma(middle[1].norm, 96, 96, device=device),
+            "norm_scale": scale_mid_attn_norm,
+            "norm_scale_rms": _scale_prefix_float(scale_mid_attn_norm, 96),
+            "qkv_w": mid_attn_qkv_w,
+            "qkv_b": mid_attn_qkv_b,
+            "qkv_scale": scale_mid_qkv,
+            "qkv_scale_float": _float_scalar(scale_mid_qkv, device=device),
+            "sdpa_inverse_scale_float": _inverse_float_scalar(scale_mid_sdpa, device=device),
+            "unit_float": torch.ones((1,), device=device, dtype=torch.float32).contiguous(),
+            "proj_w": mid_attn_proj_w,
+            "proj_b": mid_attn_proj_b,
+        },
+        "scale_mid1": scale_mid1,
+        "scale_mid1_rms": _scale_prefix_float(scale_mid1, 96),
+        "head_norm_gamma": _lightvae_gamma(head[0], 96, 96, device=device),
+        "scale_head_norm": scale_head_norm,
+        "scale_head_norm_rms": _scale_prefix_float(scale_head_norm, 96),
+        "scale_head_conv": scale_head_conv,
+        "head_w": head_w,
+        "head_b": head_b,
+        "head_source_scale": head_source_scale,
+        "head_epilogue_scale": head_epilogue_scale,
+        "head_bias_scaled": head_bias_scaled,
+        "scale_post": scale_post,
+        "post_w": post_w,
+        "post_b": post_b,
+        "mean": mean,
+        "inv_std": inv_std,
+    }
+    _LIGHTVAE_FP8_STAGED_STATE_CACHE[state_key] = staged
+    return staged

--- a/integrations/omnidreams/omnidreams_singleview/python/vae_weights.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/vae_weights.py
@@ -36,6 +36,41 @@ def _module_device(module: torch.nn.Module) -> torch.device:
     raise ValueError(f"{module.__class__.__name__} has no parameters or buffers")
 
 
+def _module_attr(obj: object, name: str) -> torch.nn.Module:
+    value = getattr(obj, name)
+    if not isinstance(value, torch.nn.Module):
+        raise TypeError(f"{obj.__class__.__name__}.{name} must be a torch module")
+    return value
+
+
+def _conv3d_attr(obj: object, name: str) -> torch.nn.Conv3d:
+    value = getattr(obj, name)
+    if not isinstance(value, torch.nn.Conv3d):
+        raise TypeError(f"{obj.__class__.__name__}.{name} must be a Conv3d module")
+    return value
+
+
+def _tensor_attr(obj: object, name: str) -> torch.Tensor:
+    value = getattr(obj, name)
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"{obj.__class__.__name__}.{name} must be a tensor")
+    return value
+
+
+def _sequence_attr(obj: object, name: str) -> Any:
+    value = getattr(obj, name)
+    if not hasattr(value, "__getitem__") or not hasattr(value, "__len__"):
+        raise TypeError(f"{obj.__class__.__name__}.{name} must be an indexed sequence")
+    return value
+
+
+def _conv_bias(conv: torch.nn.Conv2d | torch.nn.Conv3d) -> torch.Tensor:
+    bias = conv.bias
+    if bias is None:
+        raise ValueError(f"{conv.__class__.__name__} must have a bias tensor")
+    return bias
+
+
 def _pad_1d(tensor: torch.Tensor, size: int, *, device: torch.device) -> torch.Tensor:
     src = tensor.detach().to(device=device, dtype=torch.float16).flatten().contiguous()
     if src.numel() == size:
@@ -52,9 +87,14 @@ def _lightvae_gamma(
     *,
     device: torch.device,
 ) -> torch.Tensor:
-    gamma = norm.gamma.detach().reshape(real_c).to(
-        device=device,
-        dtype=torch.float16,
+    gamma = (
+        _tensor_attr(norm, "gamma")
+        .detach()
+        .reshape(real_c)
+        .to(
+            device=device,
+            dtype=torch.float16,
+        )
     )
     if pad_c == real_c:
         return gamma.contiguous()
@@ -73,17 +113,25 @@ def _lightvae_causal3_weight(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
-    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    b = _conv_bias(conv).detach().to(device=device, dtype=torch.float16).contiguous()
     kt, kh, kw = int(w.shape[2]), int(w.shape[3]), int(w.shape[4])
     if (kt, kh, kw) != (3, 3, 3):
         raise ValueError(f"expected LightVAE 3x3x3 weight, got {tuple(w.shape)}")
-    packed = torch.zeros((out_pad, 3, 3, 3 * in_pad), device=device, dtype=torch.float16)
-    packed3d = torch.zeros((out_pad, 3, 3, 3, in_pad), device=device, dtype=torch.float16)
+    packed = torch.zeros(
+        (out_pad, 3, 3, 3 * in_pad), device=device, dtype=torch.float16
+    )
+    packed3d = torch.zeros(
+        (out_pad, 3, 3, 3, in_pad), device=device, dtype=torch.float16
+    )
     for dt in range(3):
         wt = w[:out_real, :in_real, dt].permute(0, 2, 3, 1).contiguous()
         packed[:out_real, :, :, dt * in_pad : dt * in_pad + in_real].copy_(wt)
         packed3d[:out_real, dt, :, :, :in_real].copy_(wt)
-    return packed.contiguous(), _pad_1d(b[:out_real], out_pad, device=device), packed3d.contiguous()
+    return (
+        packed.contiguous(),
+        _pad_1d(b[:out_real], out_pad, device=device),
+        packed3d.contiguous(),
+    )
 
 
 def _lightvae_spatial3_weight(
@@ -96,7 +144,7 @@ def _lightvae_spatial3_weight(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
-    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    b = _conv_bias(conv).detach().to(device=device, dtype=torch.float16).contiguous()
     packed = torch.zeros((out_pad, 3, 3, in_pad), device=device, dtype=torch.float16)
     packed[:out_real, :, :, :in_real].copy_(w[:out_real, :in_real].permute(0, 2, 3, 1))
     return packed.contiguous(), _pad_1d(b[:out_real], out_pad, device=device)
@@ -110,13 +158,17 @@ def _lightvae_temporal3_weight(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
-    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    b = _conv_bias(conv).detach().to(device=device, dtype=torch.float16).contiguous()
     real = int(real_channels if real_channels is not None else channels)
     if real > channels:
-        raise ValueError(f"real_channels {real} cannot exceed padded channels {channels}")
+        raise ValueError(
+            f"real_channels {real} cannot exceed padded channels {channels}"
+        )
     packed = torch.zeros((channels, 3 * channels), device=device, dtype=torch.float16)
     for dt in range(3):
-        packed[:real, dt * channels : dt * channels + real].copy_(w[:real, :real, dt, 0, 0])
+        packed[:real, dt * channels : dt * channels + real].copy_(
+            w[:real, :real, dt, 0, 0]
+        )
     return packed.contiguous(), _pad_1d(b[:real], channels, device=device)
 
 
@@ -129,8 +181,10 @@ def _lightvae_conv1_weight(
     out_pad: int,
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    w = conv.weight.detach().to(device=device, dtype=torch.float16).contiguous()
-    b = conv.bias.detach().to(device=device, dtype=torch.float16).contiguous()
+    w = _tensor_attr(conv, "weight").detach().to(device=device, dtype=torch.float16)
+    w = w.contiguous()
+    b = _tensor_attr(conv, "bias").detach().to(device=device, dtype=torch.float16)
+    b = b.contiguous()
     if w.dim() == 5:
         w = w[:, :, 0, 0, 0]
     elif w.dim() == 4:
@@ -149,7 +203,7 @@ def _lightvae_resblock_state(
     out_pad: int,
     device: torch.device,
 ) -> dict[str, Any]:
-    residual = block.residual
+    residual = _sequence_attr(block, "residual")
     conv1_w, conv1_b, conv1_w3d = _lightvae_causal3_weight(
         residual[2],
         in_real=in_real,
@@ -167,9 +221,10 @@ def _lightvae_resblock_state(
         device=device,
     )
     shortcut_w = shortcut_b = None
-    if not isinstance(block.shortcut, torch.nn.Identity):
+    shortcut = _module_attr(block, "shortcut")
+    if not isinstance(shortcut, torch.nn.Identity):
         shortcut_w, shortcut_b = _lightvae_conv1_weight(
-            block.shortcut,
+            shortcut,
             in_real=in_real,
             in_pad=in_pad,
             out_real=out_real,
@@ -197,17 +252,21 @@ def _lightvae_resblock_state(
 def _require_lightvae_layout(model: torch.nn.Module) -> None:
     if not hasattr(model, "encoder") or not hasattr(model, "conv1"):
         raise TypeError("native LightVAE encoder requires a WanVAE encoder model")
-    enc = _unwrap_module(model.encoder)
-    if len(enc.downsamples) != 11:
+    enc = _unwrap_module(_module_attr(model, "encoder"))
+    downs = _sequence_attr(enc, "downsamples")
+    if len(downs) != 11:
         raise ValueError(
             "native LightVAE encoder supports the pruned Wan LightVAE layout only "
-            f"(expected 11 downsample blocks, got {len(enc.downsamples)})"
+            f"(expected 11 downsample blocks, got {len(downs)})"
         )
-    if enc.conv1.out_channels != 24:
+    conv1 = _module_attr(enc, "conv1")
+    conv1_out_channels = getattr(conv1, "out_channels", None)
+    if conv1_out_channels != 24:
         raise ValueError(
             "native LightVAE encoder supports the lightvae checkpoint only "
-            f"(encoder.conv1.out_channels={enc.conv1.out_channels})"
+            f"(encoder.conv1.out_channels={conv1_out_channels})"
         )
+
 
 _LIGHTVAE_FP8_STAGED_STATE_CACHE: dict[tuple[int, int, int, str], dict[str, Any]] = {}
 
@@ -267,8 +326,10 @@ def _repeat_scale_tensor(scale: torch.Tensor, copies: int) -> torch.Tensor:
 
 def _scale_ratio(numerator: torch.Tensor, denominator: torch.Tensor) -> torch.Tensor:
     return (
-        numerator.float() / denominator.float().clamp_min(1.0e-12)
-    ).to(dtype=torch.float16).contiguous()
+        (numerator.float() / denominator.float().clamp_min(1.0e-12))
+        .to(dtype=torch.float16)
+        .contiguous()
+    )
 
 
 def _bias_over_scale(
@@ -279,8 +340,10 @@ def _bias_over_scale(
         return None
     if output_scale.numel() == 1:
         return (
-            bias.float() / output_scale.flatten()[0].float().clamp_min(1.0e-12)
-        ).to(dtype=torch.float16).contiguous()
+            (bias.float() / output_scale.flatten()[0].float().clamp_min(1.0e-12))
+            .to(dtype=torch.float16)
+            .contiguous()
+        )
     if bias.numel() != output_scale.numel():
         raise ValueError(
             f"bias has {bias.numel()} values, expected {output_scale.numel()} for scaled FP8 epilogue"
@@ -292,7 +355,9 @@ def _scale_prefix(scale: torch.Tensor, real_channels: int) -> torch.Tensor:
     if scale.numel() == 1 or scale.numel() == real_channels:
         return scale.contiguous()
     if scale.numel() < real_channels:
-        raise ValueError(f"scale has {scale.numel()} values, expected at least {real_channels}")
+        raise ValueError(
+            f"scale has {scale.numel()} values, expected at least {real_channels}"
+        )
     return scale[:real_channels].contiguous()
 
 
@@ -311,7 +376,9 @@ def _state_scale_any(
     for key in keys:
         scale = fp8_state.get(key)
         if scale is not None:
-            return _pad_scale_tensor(scale, real_channels, padded_channels, device=device)
+            return _pad_scale_tensor(
+                scale, real_channels, padded_channels, device=device
+            )
     raise KeyError(f"LightVAE fp8 state missing scale. Tried: {', '.join(keys)}")
 
 
@@ -323,7 +390,9 @@ def _activation_scale_any(
     *,
     device: torch.device,
 ) -> torch.Tensor:
-    return _state_scale_any(fp8_state, keys, real_channels, padded_channels, device=device)
+    return _state_scale_any(
+        fp8_state, keys, real_channels, padded_channels, device=device
+    )
 
 
 def _activation_scale_scalar_any(
@@ -344,11 +413,20 @@ def _activation_scale_scalar_any(
                 .to(torch.float16)
                 .contiguous()
             )
-    raise KeyError(f"LightVAE fp8 state missing scalar activation_scale. Tried: {', '.join(keys)}")
+    raise KeyError(
+        f"LightVAE fp8 state missing scalar activation_scale. Tried: {', '.join(keys)}"
+    )
 
 
 def _float_scalar(scale: torch.Tensor, *, device: torch.device) -> torch.Tensor:
-    return scale.detach().to(device=device, dtype=torch.float32).flatten().amax().reshape(1).contiguous()
+    return (
+        scale.detach()
+        .to(device=device, dtype=torch.float32)
+        .flatten()
+        .amax()
+        .reshape(1)
+        .contiguous()
+    )
 
 
 def _inverse_float_scalar(scale: torch.Tensor, *, device: torch.device) -> torch.Tensor:
@@ -363,7 +441,9 @@ def _weight_scale_any(
     *,
     device: torch.device,
 ) -> torch.Tensor:
-    return _state_scale_any(fp8_state, (key,), real_channels, padded_channels, device=device)
+    return _state_scale_any(
+        fp8_state, (key,), real_channels, padded_channels, device=device
+    )
 
 
 def _lightvae_fp8_prepare_krsc(
@@ -406,7 +486,13 @@ def _lightvae_fp8_causal_weight(
     weight_scale: torch.Tensor,
     warp_mma_scaled_epilogue: bool,
     device: torch.device,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
     weight, bias, _weight3d = _lightvae_causal3_weight(
         conv,
         in_real=in_real,
@@ -471,7 +557,12 @@ def _lightvae_fp8_spatial_weight(
             _scale_ratio(weight_scale, output_scale),
             _bias_over_scale(bias, output_scale),
         )
-    return _lightvae_fp8_prepare_krsc(native_ext, weight, input_scale, output_scale), bias, None, None
+    return (
+        _lightvae_fp8_prepare_krsc(native_ext, weight, input_scale, output_scale),
+        bias,
+        None,
+        None,
+    )
 
 
 def _lightvae_fp8_temporal_weight(
@@ -525,7 +616,9 @@ def _lightvae_fp8_conv1_weight(
         device=device,
     )
     _ = weight_scale
-    return _lightvae_fp8_prepare_conv1(native_ext, weight, input_scale, output_scale), bias
+    return _lightvae_fp8_prepare_conv1(
+        native_ext, weight, input_scale, output_scale
+    ), bias
 
 
 def _build_lightvae_fp8_resblock_state(
@@ -549,40 +642,45 @@ def _build_lightvae_fp8_resblock_state(
     warp_mma_scaled_epilogue: bool,
     device: torch.device,
 ) -> dict[str, Any]:
-    residual = block.residual
-    conv1_w, conv1_b, conv1_source_scale, conv1_epilogue_scale, conv1_bias_scaled = _lightvae_fp8_causal_weight(
-        native_ext,
-        residual[2],
-        in_real=in_real,
-        in_pad=in_pad,
-        out_real=out_real,
-        out_pad=out_pad,
-        input_scale=norm1_scale,
-        output_scale=conv1_scale,
-        weight_scale=conv1_weight_scale,
-        warp_mma_scaled_epilogue=warp_mma_scaled_epilogue,
-        device=device,
+    residual = _sequence_attr(block, "residual")
+    conv1_w, conv1_b, conv1_source_scale, conv1_epilogue_scale, conv1_bias_scaled = (
+        _lightvae_fp8_causal_weight(
+            native_ext,
+            residual[2],
+            in_real=in_real,
+            in_pad=in_pad,
+            out_real=out_real,
+            out_pad=out_pad,
+            input_scale=norm1_scale,
+            output_scale=conv1_scale,
+            weight_scale=conv1_weight_scale,
+            warp_mma_scaled_epilogue=warp_mma_scaled_epilogue,
+            device=device,
+        )
     )
-    conv2_w, conv2_b, conv2_source_scale, conv2_epilogue_scale, conv2_bias_scaled = _lightvae_fp8_causal_weight(
-        native_ext,
-        residual[6],
-        in_real=out_real,
-        in_pad=out_pad,
-        out_real=out_real,
-        out_pad=out_pad,
-        input_scale=norm2_scale,
-        output_scale=output_scale,
-        weight_scale=conv2_weight_scale,
-        warp_mma_scaled_epilogue=warp_mma_scaled_epilogue,
-        device=device,
+    conv2_w, conv2_b, conv2_source_scale, conv2_epilogue_scale, conv2_bias_scaled = (
+        _lightvae_fp8_causal_weight(
+            native_ext,
+            residual[6],
+            in_real=out_real,
+            in_pad=out_pad,
+            out_real=out_real,
+            out_pad=out_pad,
+            input_scale=norm2_scale,
+            output_scale=output_scale,
+            weight_scale=conv2_weight_scale,
+            warp_mma_scaled_epilogue=warp_mma_scaled_epilogue,
+            device=device,
+        )
     )
     shortcut = None
-    if not isinstance(block.shortcut, torch.nn.Identity):
+    shortcut_module = _module_attr(block, "shortcut")
+    if not isinstance(shortcut_module, torch.nn.Identity):
         if shortcut_scale is None:
             raise ValueError(f"{path} shortcut requires shortcut_scale")
         sw, sb = _lightvae_fp8_conv1_weight(
             native_ext,
-            block.shortcut,
+            shortcut_module,
             in_real=in_real,
             in_pad=in_pad,
             out_real=out_real,
@@ -632,7 +730,9 @@ def build_lightvae_encoder_fp8_staged_state(
     """Return the prepared TIN16 FP8 LightVAE encoder state."""
 
     _require_lightvae_layout(model)
-    required_prepare = getattr(native_ext, "lightvae_fp8_prepare_conv2d_weight_krsc", None)
+    required_prepare = getattr(
+        native_ext, "lightvae_fp8_prepare_conv2d_weight_krsc", None
+    )
     if not callable(required_prepare):
         raise TypeError(
             "native extension missing lightvae_fp8_prepare_conv2d_weight_krsc"
@@ -644,10 +744,11 @@ def build_lightvae_encoder_fp8_staged_state(
     if cached is not None:
         return cached
 
-    enc = _unwrap_module(model.encoder).eval()
-    downs = enc.downsamples
-    middle = enc.middle
-    head = enc.head
+    enc = _unwrap_module(_module_attr(model, "encoder")).eval()
+    enc_conv1 = _conv3d_attr(enc, "conv1")
+    downs = _sequence_attr(enc, "downsamples")
+    middle = _sequence_attr(enc, "middle")
+    head = _sequence_attr(enc, "head")
     fs = {str(k): v for k, v in fp8_state.items()}
     use_warp_mma_scaled_epilogue_causal_conv3 = True
     use_warp_mma_scaled_epilogue_spatial_conv3 = True
@@ -658,99 +759,273 @@ def build_lightvae_encoder_fp8_staged_state(
     def ws(key: str, real: int, pad: int) -> torch.Tensor:
         return _weight_scale_any(fs, key, real, pad, device=device)
 
-    scale_input = act((
-        "encoder.conv1.input.activation_scale",
-        "encoder.input.activation_scale",
-        "input.activation_scale",
-    ), 3, 32)
+    scale_input = act(
+        (
+            "encoder.conv1.input.activation_scale",
+            "encoder.input.activation_scale",
+            "input.activation_scale",
+        ),
+        3,
+        32,
+    )
     scale_conv1 = act(("encoder.conv1.activation_scale",), 24, 32)
 
-    scale_s0_0_n1 = act((_ds_key(0, ".residual.1.activation_scale"), _ds_key(0, ".residual.0.activation_scale")), 24, 32)
+    scale_s0_0_n1 = act(
+        (
+            _ds_key(0, ".residual.1.activation_scale"),
+            _ds_key(0, ".residual.0.activation_scale"),
+        ),
+        24,
+        32,
+    )
     scale_s0_0_c1 = act((_ds_key(0, ".residual.2.activation_scale"),), 24, 32)
-    scale_s0_0_n2 = act((_ds_key(0, ".residual.4.activation_scale"), _ds_key(0, ".residual.3.activation_scale")), 24, 32)
+    scale_s0_0_n2 = act(
+        (
+            _ds_key(0, ".residual.4.activation_scale"),
+            _ds_key(0, ".residual.3.activation_scale"),
+        ),
+        24,
+        32,
+    )
     scale_s0_0 = act((_ds_key(0, ".activation_scale"),), 24, 32)
-    scale_s0_1_n1 = act((_ds_key(1, ".residual.1.activation_scale"), _ds_key(1, ".residual.0.activation_scale")), 24, 32)
+    scale_s0_1_n1 = act(
+        (
+            _ds_key(1, ".residual.1.activation_scale"),
+            _ds_key(1, ".residual.0.activation_scale"),
+        ),
+        24,
+        32,
+    )
     scale_s0_1_c1 = act((_ds_key(1, ".residual.2.activation_scale"),), 24, 32)
-    scale_s0_1_n2 = act((_ds_key(1, ".residual.4.activation_scale"), _ds_key(1, ".residual.3.activation_scale")), 24, 32)
+    scale_s0_1_n2 = act(
+        (
+            _ds_key(1, ".residual.4.activation_scale"),
+            _ds_key(1, ".residual.3.activation_scale"),
+        ),
+        24,
+        32,
+    )
     scale_s0_1 = act((_ds_key(1, ".activation_scale"),), 24, 32)
-    scale_ds0 = act((_ds_key(2, ".activation_scale"), _ds_key(2, ".resample.1.activation_scale")), 24, 32)
+    scale_ds0 = act(
+        (_ds_key(2, ".activation_scale"), _ds_key(2, ".resample.1.activation_scale")),
+        24,
+        32,
+    )
 
-    scale_s1_0_n1 = act((_ds_key(3, ".residual.1.activation_scale"), _ds_key(3, ".residual.0.activation_scale")), 24, 32)
+    scale_s1_0_n1 = act(
+        (
+            _ds_key(3, ".residual.1.activation_scale"),
+            _ds_key(3, ".residual.0.activation_scale"),
+        ),
+        24,
+        32,
+    )
     scale_s1_0_c1 = act((_ds_key(3, ".residual.2.activation_scale"),), 48, 64)
-    scale_s1_0_n2 = act((_ds_key(3, ".residual.4.activation_scale"), _ds_key(3, ".residual.3.activation_scale")), 48, 64)
+    scale_s1_0_n2 = act(
+        (
+            _ds_key(3, ".residual.4.activation_scale"),
+            _ds_key(3, ".residual.3.activation_scale"),
+        ),
+        48,
+        64,
+    )
     scale_s1_0_short = act((_ds_key(3, ".shortcut.activation_scale"),), 48, 64)
     scale_s1_0 = act((_ds_key(3, ".activation_scale"),), 48, 64)
-    scale_s1_1_n1 = act((_ds_key(4, ".residual.1.activation_scale"), _ds_key(4, ".residual.0.activation_scale")), 48, 64)
+    scale_s1_1_n1 = act(
+        (
+            _ds_key(4, ".residual.1.activation_scale"),
+            _ds_key(4, ".residual.0.activation_scale"),
+        ),
+        48,
+        64,
+    )
     scale_s1_1_c1 = act((_ds_key(4, ".residual.2.activation_scale"),), 48, 64)
-    scale_s1_1_n2 = act((_ds_key(4, ".residual.4.activation_scale"), _ds_key(4, ".residual.3.activation_scale")), 48, 64)
+    scale_s1_1_n2 = act(
+        (
+            _ds_key(4, ".residual.4.activation_scale"),
+            _ds_key(4, ".residual.3.activation_scale"),
+        ),
+        48,
+        64,
+    )
     scale_s1_1 = act((_ds_key(4, ".activation_scale"),), 48, 64)
     scale_ds1_spatial = act((_ds_key(5, ".resample.1.activation_scale"),), 48, 64)
-    scale_ds1 = act((_ds_key(5, ".activation_scale"), _ds_key(5, ".time_conv.activation_scale")), 48, 64)
+    scale_ds1 = act(
+        (_ds_key(5, ".activation_scale"), _ds_key(5, ".time_conv.activation_scale")),
+        48,
+        64,
+    )
 
-    scale_s2_0_n1 = act((_ds_key(6, ".residual.1.activation_scale"), _ds_key(6, ".residual.0.activation_scale")), 48, 64)
+    scale_s2_0_n1 = act(
+        (
+            _ds_key(6, ".residual.1.activation_scale"),
+            _ds_key(6, ".residual.0.activation_scale"),
+        ),
+        48,
+        64,
+    )
     scale_s2_0_c1 = act((_ds_key(6, ".residual.2.activation_scale"),), 96, 96)
-    scale_s2_0_n2 = act((_ds_key(6, ".residual.4.activation_scale"), _ds_key(6, ".residual.3.activation_scale")), 96, 96)
+    scale_s2_0_n2 = act(
+        (
+            _ds_key(6, ".residual.4.activation_scale"),
+            _ds_key(6, ".residual.3.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_s2_0_short = act((_ds_key(6, ".shortcut.activation_scale"),), 96, 96)
     scale_s2_0 = act((_ds_key(6, ".activation_scale"),), 96, 96)
-    scale_s2_1_n1 = act((_ds_key(7, ".residual.1.activation_scale"), _ds_key(7, ".residual.0.activation_scale")), 96, 96)
+    scale_s2_1_n1 = act(
+        (
+            _ds_key(7, ".residual.1.activation_scale"),
+            _ds_key(7, ".residual.0.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_s2_1_c1 = act((_ds_key(7, ".residual.2.activation_scale"),), 96, 96)
-    scale_s2_1_n2 = act((_ds_key(7, ".residual.4.activation_scale"), _ds_key(7, ".residual.3.activation_scale")), 96, 96)
+    scale_s2_1_n2 = act(
+        (
+            _ds_key(7, ".residual.4.activation_scale"),
+            _ds_key(7, ".residual.3.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_s2_1 = act((_ds_key(7, ".activation_scale"),), 96, 96)
     scale_ds2_spatial = act((_ds_key(8, ".resample.1.activation_scale"),), 96, 96)
-    scale_ds2 = act((_ds_key(8, ".activation_scale"), _ds_key(8, ".time_conv.activation_scale")), 96, 96)
+    scale_ds2 = act(
+        (_ds_key(8, ".activation_scale"), _ds_key(8, ".time_conv.activation_scale")),
+        96,
+        96,
+    )
 
-    scale_s3_0_n1 = act((_ds_key(9, ".residual.1.activation_scale"), _ds_key(9, ".residual.0.activation_scale")), 96, 96)
+    scale_s3_0_n1 = act(
+        (
+            _ds_key(9, ".residual.1.activation_scale"),
+            _ds_key(9, ".residual.0.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_s3_0_c1 = act((_ds_key(9, ".residual.2.activation_scale"),), 96, 96)
-    scale_s3_0_n2 = act((_ds_key(9, ".residual.4.activation_scale"), _ds_key(9, ".residual.3.activation_scale")), 96, 96)
+    scale_s3_0_n2 = act(
+        (
+            _ds_key(9, ".residual.4.activation_scale"),
+            _ds_key(9, ".residual.3.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_s3_0 = act((_ds_key(9, ".activation_scale"),), 96, 96)
-    scale_s3_1_n1 = act((_ds_key(10, ".residual.1.activation_scale"), _ds_key(10, ".residual.0.activation_scale")), 96, 96)
+    scale_s3_1_n1 = act(
+        (
+            _ds_key(10, ".residual.1.activation_scale"),
+            _ds_key(10, ".residual.0.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_s3_1_c1 = act((_ds_key(10, ".residual.2.activation_scale"),), 96, 96)
-    scale_s3_1_n2 = act((_ds_key(10, ".residual.4.activation_scale"), _ds_key(10, ".residual.3.activation_scale")), 96, 96)
+    scale_s3_1_n2 = act(
+        (
+            _ds_key(10, ".residual.4.activation_scale"),
+            _ds_key(10, ".residual.3.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_s3_1 = act((_ds_key(10, ".activation_scale"),), 96, 96)
 
-    scale_mid0_n1 = act((_mid_key(0, ".residual.1.activation_scale"), _mid_key(0, ".residual.0.activation_scale")), 96, 96)
+    scale_mid0_n1 = act(
+        (
+            _mid_key(0, ".residual.1.activation_scale"),
+            _mid_key(0, ".residual.0.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_mid0_c1 = act((_mid_key(0, ".residual.2.activation_scale"),), 96, 96)
-    scale_mid0_n2 = act((_mid_key(0, ".residual.4.activation_scale"), _mid_key(0, ".residual.3.activation_scale")), 96, 96)
+    scale_mid0_n2 = act(
+        (
+            _mid_key(0, ".residual.4.activation_scale"),
+            _mid_key(0, ".residual.3.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_mid0 = act((_mid_key(0, ".activation_scale"),), 96, 96)
-    scale_mid_attn_norm = act((
-        _mid_key(1, ".norm.activation_scale"),
-        _mid_key(1, ".to_qkv.input.activation_scale"),
-        _mid_key(0, ".activation_scale"),
-    ), 96, 96)
-    scale_mid_qkv = _activation_scale_scalar_any(fs, (
-        _mid_key(1, ".to_qkv.activation_scale"),
-        _mid_key(1, ".qkv.activation_scale"),
-        _mid_key(1, ".activation_scale"),
-        _mid_key(0, ".activation_scale"),
-    ), device=device)
-    scale_mid_sdpa = _activation_scale_scalar_any(fs, (
-        _mid_key(1, ".sdpa.activation_scale"),
-        _mid_key(1, ".attention.activation_scale"),
-        _mid_key(1, ".to_qkv.activation_scale"),
-        _mid_key(1, ".activation_scale"),
-        _mid_key(0, ".activation_scale"),
-    ), device=device)
-    scale_mid_attn = act((_mid_key(1, ".activation_scale"), _mid_key(0, ".activation_scale")), 96, 96)
-    scale_mid1_n1 = act((_mid_key(2, ".residual.1.activation_scale"), _mid_key(2, ".residual.0.activation_scale")), 96, 96)
+    scale_mid_attn_norm = act(
+        (
+            _mid_key(1, ".norm.activation_scale"),
+            _mid_key(1, ".to_qkv.input.activation_scale"),
+            _mid_key(0, ".activation_scale"),
+        ),
+        96,
+        96,
+    )
+    scale_mid_qkv = _activation_scale_scalar_any(
+        fs,
+        (
+            _mid_key(1, ".to_qkv.activation_scale"),
+            _mid_key(1, ".qkv.activation_scale"),
+            _mid_key(1, ".activation_scale"),
+            _mid_key(0, ".activation_scale"),
+        ),
+        device=device,
+    )
+    scale_mid_sdpa = _activation_scale_scalar_any(
+        fs,
+        (
+            _mid_key(1, ".sdpa.activation_scale"),
+            _mid_key(1, ".attention.activation_scale"),
+            _mid_key(1, ".to_qkv.activation_scale"),
+            _mid_key(1, ".activation_scale"),
+            _mid_key(0, ".activation_scale"),
+        ),
+        device=device,
+    )
+    scale_mid_attn = act(
+        (_mid_key(1, ".activation_scale"), _mid_key(0, ".activation_scale")), 96, 96
+    )
+    scale_mid1_n1 = act(
+        (
+            _mid_key(2, ".residual.1.activation_scale"),
+            _mid_key(2, ".residual.0.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_mid1_c1 = act((_mid_key(2, ".residual.2.activation_scale"),), 96, 96)
-    scale_mid1_n2 = act((_mid_key(2, ".residual.4.activation_scale"), _mid_key(2, ".residual.3.activation_scale")), 96, 96)
+    scale_mid1_n2 = act(
+        (
+            _mid_key(2, ".residual.4.activation_scale"),
+            _mid_key(2, ".residual.3.activation_scale"),
+        ),
+        96,
+        96,
+    )
     scale_mid1 = act((_mid_key(2, ".activation_scale"),), 96, 96)
-    scale_head_norm = act(("encoder.head.1.activation_scale", "encoder.head.0.activation_scale"), 96, 96)
+    scale_head_norm = act(
+        ("encoder.head.1.activation_scale", "encoder.head.0.activation_scale"), 96, 96
+    )
     scale_head_conv = act(("encoder.head.2.activation_scale",), 32, 32)
     scale_post = act(("conv1.activation_scale",), 32, 32)
 
-    conv1_w, conv1_b, conv1_source_scale, conv1_epilogue_scale, conv1_bias_scaled = _lightvae_fp8_causal_weight(
-        native_ext,
-        enc.conv1,
-        in_real=3,
-        in_pad=32,
-        out_real=24,
-        out_pad=32,
-        input_scale=scale_input,
-        output_scale=scale_conv1,
-        weight_scale=ws("encoder.conv1.weight_scale", 24, 32),
-        warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
-        device=device,
+    conv1_w, conv1_b, conv1_source_scale, conv1_epilogue_scale, conv1_bias_scaled = (
+        _lightvae_fp8_causal_weight(
+            native_ext,
+            enc_conv1,
+            in_real=3,
+            in_pad=32,
+            out_real=24,
+            out_pad=32,
+            input_scale=scale_input,
+            output_scale=scale_conv1,
+            weight_scale=ws("encoder.conv1.weight_scale", 24, 32),
+            warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
+            device=device,
+        )
     )
 
     def rb(
@@ -883,22 +1158,24 @@ def build_lightvae_encoder_fp8_staged_state(
         weight_scale=ws(_ds_key(8, ".time_conv.weight_scale"), 96, 96),
         device=device,
     )
-    head_w, head_b, head_source_scale, head_epilogue_scale, head_bias_scaled = _lightvae_fp8_causal_weight(
-        native_ext,
-        head[2],
-        in_real=96,
-        in_pad=96,
-        out_real=32,
-        out_pad=32,
-        input_scale=scale_head_norm,
-        output_scale=scale_head_conv,
-        weight_scale=ws("encoder.head.2.weight_scale", 32, 32),
-        warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
-        device=device,
+    head_w, head_b, head_source_scale, head_epilogue_scale, head_bias_scaled = (
+        _lightvae_fp8_causal_weight(
+            native_ext,
+            head[2],
+            in_real=96,
+            in_pad=96,
+            out_real=32,
+            out_pad=32,
+            input_scale=scale_head_norm,
+            output_scale=scale_head_conv,
+            weight_scale=ws("encoder.head.2.weight_scale", 32, 32),
+            warp_mma_scaled_epilogue=use_warp_mma_scaled_epilogue_causal_conv3,
+            device=device,
+        )
     )
     post_w, post_b = _lightvae_fp8_conv1_weight(
         native_ext,
-        model.conv1,
+        _module_attr(model, "conv1"),
         in_real=32,
         in_pad=32,
         out_real=32,
@@ -933,13 +1210,28 @@ def build_lightvae_encoder_fp8_staged_state(
         device=device,
     )
 
-    mean = model.mean.detach().to(device=device, dtype=torch.float16).reshape(-1).contiguous()
-    inv_std = model.inv_std.detach().to(device=device, dtype=torch.float16).reshape(-1).contiguous()
+    mean = (
+        _tensor_attr(model, "mean")
+        .detach()
+        .to(device=device, dtype=torch.float16)
+        .reshape(-1)
+        .contiguous()
+    )
+    inv_std = (
+        _tensor_attr(model, "inv_std")
+        .detach()
+        .to(device=device, dtype=torch.float16)
+        .reshape(-1)
+        .contiguous()
+    )
     if mean.numel() != 16 or inv_std.numel() != 16:
-        raise ValueError("native LightVAE fp8 encoder expects 16 latent mean/std channels")
+        raise ValueError(
+            "native LightVAE fp8 encoder expects 16 latent mean/std channels"
+        )
 
     staged = {
-        "warp_mma_scaled_epilogue": use_warp_mma_scaled_epilogue_causal_conv3 and use_warp_mma_scaled_epilogue_spatial_conv3,
+        "warp_mma_scaled_epilogue": use_warp_mma_scaled_epilogue_causal_conv3
+        and use_warp_mma_scaled_epilogue_spatial_conv3,
         "warp_mma_scaled_epilogue_causal_conv3": use_warp_mma_scaled_epilogue_causal_conv3,
         "warp_mma_scaled_epilogue_spatial_conv3": use_warp_mma_scaled_epilogue_spatial_conv3,
         "scale_input": scale_input,
@@ -950,20 +1242,161 @@ def build_lightvae_encoder_fp8_staged_state(
         "conv1_epilogue_scale": conv1_epilogue_scale,
         "conv1_bias_scaled": conv1_bias_scaled,
         "blocks": [
-            rb(0, downs[0], 24, 32, 24, 32, scale_conv1, scale_s0_0_n1, scale_s0_0_c1, scale_s0_0_n2, scale_s0_0),
-            rb(1, downs[1], 24, 32, 24, 32, scale_s0_0, scale_s0_1_n1, scale_s0_1_c1, scale_s0_1_n2, scale_s0_1),
-            rb(3, downs[3], 24, 32, 48, 64, scale_ds0, scale_s1_0_n1, scale_s1_0_c1, scale_s1_0_n2, scale_s1_0, scale_s1_0_short),
-            rb(4, downs[4], 48, 64, 48, 64, scale_s1_0, scale_s1_1_n1, scale_s1_1_c1, scale_s1_1_n2, scale_s1_1),
-            rb(6, downs[6], 48, 64, 96, 96, scale_ds1, scale_s2_0_n1, scale_s2_0_c1, scale_s2_0_n2, scale_s2_0, scale_s2_0_short),
-            rb(7, downs[7], 96, 96, 96, 96, scale_s2_0, scale_s2_1_n1, scale_s2_1_c1, scale_s2_1_n2, scale_s2_1),
-            rb(9, downs[9], 96, 96, 96, 96, scale_ds2, scale_s3_0_n1, scale_s3_0_c1, scale_s3_0_n2, scale_s3_0),
-            rb(10, downs[10], 96, 96, 96, 96, scale_s3_0, scale_s3_1_n1, scale_s3_1_c1, scale_s3_1_n2, scale_s3_1),
-            mid_rb(0, middle[0], scale_s3_1, scale_mid0_n1, scale_mid0_c1, scale_mid0_n2, scale_mid0),
-            mid_rb(2, middle[2], scale_mid_attn, scale_mid1_n1, scale_mid1_c1, scale_mid1_n2, scale_mid1),
+            rb(
+                0,
+                downs[0],
+                24,
+                32,
+                24,
+                32,
+                scale_conv1,
+                scale_s0_0_n1,
+                scale_s0_0_c1,
+                scale_s0_0_n2,
+                scale_s0_0,
+            ),
+            rb(
+                1,
+                downs[1],
+                24,
+                32,
+                24,
+                32,
+                scale_s0_0,
+                scale_s0_1_n1,
+                scale_s0_1_c1,
+                scale_s0_1_n2,
+                scale_s0_1,
+            ),
+            rb(
+                3,
+                downs[3],
+                24,
+                32,
+                48,
+                64,
+                scale_ds0,
+                scale_s1_0_n1,
+                scale_s1_0_c1,
+                scale_s1_0_n2,
+                scale_s1_0,
+                scale_s1_0_short,
+            ),
+            rb(
+                4,
+                downs[4],
+                48,
+                64,
+                48,
+                64,
+                scale_s1_0,
+                scale_s1_1_n1,
+                scale_s1_1_c1,
+                scale_s1_1_n2,
+                scale_s1_1,
+            ),
+            rb(
+                6,
+                downs[6],
+                48,
+                64,
+                96,
+                96,
+                scale_ds1,
+                scale_s2_0_n1,
+                scale_s2_0_c1,
+                scale_s2_0_n2,
+                scale_s2_0,
+                scale_s2_0_short,
+            ),
+            rb(
+                7,
+                downs[7],
+                96,
+                96,
+                96,
+                96,
+                scale_s2_0,
+                scale_s2_1_n1,
+                scale_s2_1_c1,
+                scale_s2_1_n2,
+                scale_s2_1,
+            ),
+            rb(
+                9,
+                downs[9],
+                96,
+                96,
+                96,
+                96,
+                scale_ds2,
+                scale_s3_0_n1,
+                scale_s3_0_c1,
+                scale_s3_0_n2,
+                scale_s3_0,
+            ),
+            rb(
+                10,
+                downs[10],
+                96,
+                96,
+                96,
+                96,
+                scale_s3_0,
+                scale_s3_1_n1,
+                scale_s3_1_c1,
+                scale_s3_1_n2,
+                scale_s3_1,
+            ),
+            mid_rb(
+                0,
+                middle[0],
+                scale_s3_1,
+                scale_mid0_n1,
+                scale_mid0_c1,
+                scale_mid0_n2,
+                scale_mid0,
+            ),
+            mid_rb(
+                2,
+                middle[2],
+                scale_mid_attn,
+                scale_mid1_n1,
+                scale_mid1_c1,
+                scale_mid1_n2,
+                scale_mid1,
+            ),
         ],
-        "ds0": {"w": ds0_w, "b": ds0_b, "scale": scale_ds0, "epilogue_scale": ds0_epilogue_scale, "bias_scaled": ds0_bias_scaled, "real": 24},
-        "ds1": {"spatial_w": ds1_w, "spatial_b": ds1_b, "spatial_scale": scale_ds1_spatial, "spatial_epilogue_scale": ds1_epilogue_scale, "spatial_bias_scaled": ds1_bias_scaled, "temporal_w": ds1_tw, "temporal_b": ds1_tb, "scale": scale_ds1, "real": 48},
-        "ds2": {"spatial_w": ds2_w, "spatial_b": ds2_b, "spatial_scale": scale_ds2_spatial, "spatial_epilogue_scale": ds2_epilogue_scale, "spatial_bias_scaled": ds2_bias_scaled, "temporal_w": ds2_tw, "temporal_b": ds2_tb, "scale": scale_ds2, "real": 96},
+        "ds0": {
+            "w": ds0_w,
+            "b": ds0_b,
+            "scale": scale_ds0,
+            "epilogue_scale": ds0_epilogue_scale,
+            "bias_scaled": ds0_bias_scaled,
+            "real": 24,
+        },
+        "ds1": {
+            "spatial_w": ds1_w,
+            "spatial_b": ds1_b,
+            "spatial_scale": scale_ds1_spatial,
+            "spatial_epilogue_scale": ds1_epilogue_scale,
+            "spatial_bias_scaled": ds1_bias_scaled,
+            "temporal_w": ds1_tw,
+            "temporal_b": ds1_tb,
+            "scale": scale_ds1,
+            "real": 48,
+        },
+        "ds2": {
+            "spatial_w": ds2_w,
+            "spatial_b": ds2_b,
+            "spatial_scale": scale_ds2_spatial,
+            "spatial_epilogue_scale": ds2_epilogue_scale,
+            "spatial_bias_scaled": ds2_bias_scaled,
+            "temporal_w": ds2_tw,
+            "temporal_b": ds2_tb,
+            "scale": scale_ds2,
+            "real": 96,
+        },
         "scale_mid0": scale_mid0,
         "scale_mid_attn": scale_mid_attn,
         "mid_attn": {
@@ -975,8 +1408,12 @@ def build_lightvae_encoder_fp8_staged_state(
             "qkv_b": mid_attn_qkv_b,
             "qkv_scale": scale_mid_qkv,
             "qkv_scale_float": _float_scalar(scale_mid_qkv, device=device),
-            "sdpa_inverse_scale_float": _inverse_float_scalar(scale_mid_sdpa, device=device),
-            "unit_float": torch.ones((1,), device=device, dtype=torch.float32).contiguous(),
+            "sdpa_inverse_scale_float": _inverse_float_scalar(
+                scale_mid_sdpa, device=device
+            ),
+            "unit_float": torch.ones(
+                (1,), device=device, dtype=torch.float32
+            ).contiguous(),
             "proj_w": mid_attn_proj_w,
             "proj_b": mid_attn_proj_b,
         },

--- a/integrations/omnidreams/omnidreams_singleview/src/omnidreams_singleview_ext.cpp
+++ b/integrations/omnidreams/omnidreams_singleview/src/omnidreams_singleview_ext.cpp
@@ -19,6 +19,7 @@
 
 #include "dit_streaming/streaming_dit_bindings.h"
 #include "native_primitives.h"
+#include "vae_streaming/vae_streaming_bindings.h"
 
 #ifndef OMNIDREAMS_SINGLEVIEW_WITH_CUDA
 #error "OmniDreams single-view native extension requires CUDA"
@@ -89,4 +90,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
   module.def("build_info", &build_info);
   omnidreams_singleview::bind_native_primitives(module);
   omnidreams_singleview::bind_optimized_dit(module);
+  omnidreams_singleview::bind_vae_streaming(module);
 }

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_attention.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_attention.cu
@@ -1,0 +1,518 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "lightvae_ops.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime_api.h>
+
+#include <cudnn_frontend.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <tuple>
+#include <unordered_map>
+
+namespace fe = cudnn_frontend;
+
+namespace omnidreams_singleview {
+namespace {
+
+constexpr int kFp8ChannelsPerSlice = 16;
+
+void check_u8_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(tensor.scalar_type() == at::kByte, name, " must be torch.uint8");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void check_tin16_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_u8_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.dim() == 5 && tensor.size(4) == kFp8ChannelsPerSlice,
+                name, " must be [T,C/16,H,W,16], got ", tensor.sizes());
+}
+
+void check_float_scalar_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(tensor.scalar_type() == at::kFloat, name, " must be torch.float32");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+    TORCH_CHECK(tensor.numel() == 1, name, " must contain exactly one scalar");
+}
+
+int launch_blocks(long long total) {
+    constexpr int threads = 256;
+    return static_cast<int>(std::min((total + threads - 1) / threads, 65535LL));
+}
+
+__global__ void qkv_tin16_to_bmhd_kernel(
+    const uint8_t* __restrict__ qkv,
+    uint8_t* __restrict__ q,
+    uint8_t* __restrict__ k,
+    uint8_t* __restrict__ v,
+    int frames,
+    int height,
+    int width) {
+    const long long seq = static_cast<long long>(height) * width;
+    const long long total = static_cast<long long>(frames) * seq * 96;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int d = static_cast<int>(rem % 96);
+        rem /= 96;
+        const int spatial = static_cast<int>(rem % seq);
+        const int t = static_cast<int>(rem / seq);
+        const int y = spatial / width;
+        const int x = spatial - y * width;
+        const int lane = d & 15;
+        const int slice = d >> 4;
+        const size_t q_base =
+            (((static_cast<size_t>(t) * 18 + slice) * height + y) * width + x) *
+                kFp8ChannelsPerSlice + lane;
+        const size_t k_base =
+            (((static_cast<size_t>(t) * 18 + slice + 6) * height + y) * width + x) *
+                kFp8ChannelsPerSlice + lane;
+        const size_t v_base =
+            (((static_cast<size_t>(t) * 18 + slice + 12) * height + y) * width + x) *
+                kFp8ChannelsPerSlice + lane;
+        q[idx] = qkv[q_base];
+        k[idx] = qkv[k_base];
+        v[idx] = qkv[v_base];
+    }
+}
+
+__global__ void bmhd_to_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    int frames,
+    int height,
+    int width) {
+    const long long seq = static_cast<long long>(height) * width;
+    const long long total = static_cast<long long>(frames) * seq * 96;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int d = static_cast<int>(rem % 96);
+        rem /= 96;
+        const int spatial = static_cast<int>(rem % seq);
+        const int t = static_cast<int>(rem / seq);
+        const int y = spatial / width;
+        const int x = spatial - y * width;
+        const int lane = d & 15;
+        const int slice = d >> 4;
+        const size_t out_idx =
+            (((static_cast<size_t>(t) * 6 + slice) * height + y) * width + x) *
+                kFp8ChannelsPerSlice + lane;
+        output[out_idx] = input[idx];
+    }
+}
+
+struct LightVaeFp8SdpaKey {
+    int batch;
+    int seq;
+    int head_dim;
+    float attn_scale;
+
+    bool operator==(const LightVaeFp8SdpaKey& other) const {
+        return batch == other.batch && seq == other.seq && head_dim == other.head_dim &&
+               attn_scale == other.attn_scale;
+    }
+};
+
+struct LightVaeFp8SdpaKeyHash {
+    std::size_t operator()(const LightVaeFp8SdpaKey& key) const {
+        std::size_t h = 0;
+        auto combine_hash = [&](std::size_t value) {
+            h ^= value + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        };
+        combine_hash(std::hash<int>{}(key.batch));
+        combine_hash(std::hash<int>{}(key.seq));
+        combine_hash(std::hash<int>{}(key.head_dim));
+        combine_hash(std::hash<float>{}(key.attn_scale));
+        return h;
+    }
+};
+
+struct LightVaeFp8SdpaResourceKey {
+    int device;
+    uintptr_t stream;
+
+    bool operator==(const LightVaeFp8SdpaResourceKey& other) const {
+        return device == other.device && stream == other.stream;
+    }
+};
+
+struct LightVaeFp8SdpaResourceKeyHash {
+    std::size_t operator()(const LightVaeFp8SdpaResourceKey& key) const {
+        std::size_t h = std::hash<int>{}(key.device);
+        h ^= std::hash<uintptr_t>{}(key.stream) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        return h;
+    }
+};
+
+struct LightVaeFp8SdpaStreamResources {
+    std::mutex mutex;
+    cudnnHandle_t cudnn_handle = nullptr;
+    void* workspace = nullptr;
+    size_t workspace_size = 0;
+    std::unordered_map<LightVaeFp8SdpaKey,
+                       std::shared_ptr<fe::graph::Graph>,
+                       LightVaeFp8SdpaKeyHash>
+        graph_cache;
+};
+
+struct LightVaeFp8SdpaResourceLease {
+    std::shared_ptr<LightVaeFp8SdpaStreamResources> resources;
+    std::unique_lock<std::mutex> lock;
+};
+
+std::mutex g_lightvae_fp8_sdpa_resources_mutex;
+std::unordered_map<LightVaeFp8SdpaResourceKey,
+                   std::shared_ptr<LightVaeFp8SdpaStreamResources>,
+                   LightVaeFp8SdpaResourceKeyHash>
+    g_lightvae_fp8_sdpa_resources;
+bool g_lightvae_fp8_sdpa_cleanup_in_progress = false;
+
+int current_lightvae_device_ordinal() {
+    int device = -1;
+    cudaError_t err = cudaGetDevice(&device);
+    TORCH_CHECK(err == cudaSuccess, "cudaGetDevice failed for OmniDreams LightVAE FP8 SDPA: ",
+                cudaGetErrorString(err));
+    TORCH_CHECK(device >= 0, "invalid current CUDA device ordinal ", device);
+    return device;
+}
+
+LightVaeFp8SdpaResourceLease lightvae_sdpa_resources(cudaStream_t stream) {
+    LightVaeFp8SdpaResourceKey key{
+        current_lightvae_device_ordinal(),
+        reinterpret_cast<uintptr_t>(stream),
+    };
+    std::unique_lock<std::mutex> map_lock(g_lightvae_fp8_sdpa_resources_mutex);
+    TORCH_CHECK(!g_lightvae_fp8_sdpa_cleanup_in_progress,
+                "OmniDreams LightVAE FP8 SDPA cleanup is in progress; no new SDPA work can start");
+    auto& resources = g_lightvae_fp8_sdpa_resources[key];
+    if (!resources) {
+        resources = std::make_shared<LightVaeFp8SdpaStreamResources>();
+    }
+    std::unique_lock<std::mutex> resource_lock(resources->mutex);
+    map_lock.unlock();
+    return LightVaeFp8SdpaResourceLease{resources, std::move(resource_lock)};
+}
+
+cudnnHandle_t lightvae_cudnn_handle(LightVaeFp8SdpaStreamResources& resources, cudaStream_t stream) {
+    if (!resources.cudnn_handle) {
+        cudnnStatus_t status = cudnnCreate(&resources.cudnn_handle);
+        TORCH_CHECK(status == CUDNN_STATUS_SUCCESS, "cudnnCreate failed for OmniDreams LightVAE FP8 SDPA");
+        status = cudnnSetStream(resources.cudnn_handle, stream);
+        TORCH_CHECK(status == CUDNN_STATUS_SUCCESS, "cudnnSetStream failed for OmniDreams LightVAE FP8 SDPA");
+    }
+    return resources.cudnn_handle;
+}
+
+cudaError_t ensure_lightvae_sdpa_workspace(LightVaeFp8SdpaStreamResources& resources, size_t bytes) {
+    if (bytes <= resources.workspace_size) {
+        return cudaSuccess;
+    }
+    if (resources.workspace) {
+        cudaFree(resources.workspace);
+        resources.workspace = nullptr;
+        resources.workspace_size = 0;
+    }
+    cudaError_t err = cudaMalloc(&resources.workspace, bytes);
+    if (err != cudaSuccess) {
+        return err;
+    }
+    resources.workspace_size = bytes;
+    return cudaSuccess;
+}
+
+cudaError_t run_cudnn_fp8_sdpa_bmhd(
+    const uint8_t* q,
+    const uint8_t* k,
+    const uint8_t* v,
+    uint8_t* o,
+    const float* descale_q,
+    const float* descale_k,
+    const float* descale_v,
+    const float* descale_s,
+    const float* scale_s,
+    const float* scale_o,
+    float* amax_s,
+    float* amax_o,
+    int batch,
+    int seq,
+    int head_dim,
+    float attn_scale,
+    cudaStream_t stream) {
+    if (!q || !k || !v || !o || !descale_q || !descale_k || !descale_v ||
+        !descale_s || !scale_s || !scale_o || !amax_s || !amax_o ||
+        batch <= 0 || seq <= 0 || head_dim <= 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    auto lease = lightvae_sdpa_resources(stream);
+    auto& resources = *lease.resources;
+    auto handle = lightvae_cudnn_handle(resources, stream);
+
+    LightVaeFp8SdpaKey cache_key{batch, seq, head_dim, attn_scale};
+    auto it = resources.graph_cache.find(cache_key);
+    std::shared_ptr<fe::graph::Graph> graph;
+    bool cache_miss = false;
+
+    if (it != resources.graph_cache.end()) {
+        graph = it->second;
+    } else {
+        cache_miss = true;
+        graph = std::make_shared<fe::graph::Graph>();
+        graph->set_io_data_type(fe::DataType_t::FP8_E4M3)
+             .set_intermediate_data_type(fe::DataType_t::FLOAT)
+             .set_compute_data_type(fe::DataType_t::FLOAT);
+
+        const int H = 1;
+        const int64_t hidden = int64_t(H) * head_dim;
+        const int64_t batch_stride = int64_t(seq) * hidden;
+        const int64_t head_stride = head_dim;
+        const int64_t seq_stride = hidden;
+        auto tQ = graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("Q").set_uid(1)
+                                    .set_dim({batch, H, seq, head_dim})
+                                    .set_stride({batch_stride, head_stride, seq_stride, 1})
+                                    .set_data_type(fe::DataType_t::FP8_E4M3));
+        auto tK = graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("K").set_uid(2)
+                                    .set_dim({batch, H, seq, head_dim})
+                                    .set_stride({batch_stride, head_stride, seq_stride, 1})
+                                    .set_data_type(fe::DataType_t::FP8_E4M3));
+        auto tV = graph->tensor(fe::graph::Tensor_attributes()
+                                    .set_name("V").set_uid(3)
+                                    .set_dim({batch, H, seq, head_dim})
+                                    .set_stride({batch_stride, head_stride, seq_stride, 1})
+                                    .set_data_type(fe::DataType_t::FP8_E4M3));
+
+        auto make_scalar = [&](const char* name, int64_t uid) {
+            return graph->tensor(fe::graph::Tensor_attributes()
+                                     .set_name(name).set_uid(uid)
+                                     .set_dim({1, 1, 1, 1})
+                                     .set_stride({1, 1, 1, 1})
+                                     .set_data_type(fe::DataType_t::FLOAT));
+        };
+        auto descale_q_t = make_scalar("Descale_Q", 5);
+        auto descale_k_t = make_scalar("Descale_K", 6);
+        auto descale_v_t = make_scalar("Descale_V", 7);
+        auto descale_s_t = make_scalar("Descale_S", 8);
+        auto scale_s_t = make_scalar("Scale_S", 9);
+        auto scale_o_t = make_scalar("Scale_O", 10);
+
+        auto sdpa_opts = fe::graph::SDPA_fp8_attributes()
+                             .set_name("omnidreams_lightvae_middle_sdpa_fp8")
+                             .set_generate_stats(false)
+                             .set_causal_mask(false)
+                             .set_attn_scale(attn_scale);
+
+        auto [tO, tStats, tAmaxS, tAmaxO] = graph->sdpa_fp8(
+            tQ, tK, tV,
+            descale_q_t, descale_k_t, descale_v_t, descale_s_t,
+            scale_s_t, scale_o_t,
+            sdpa_opts);
+        if (tStats != nullptr) {
+            return cudaErrorNotSupported;
+        }
+        tO->set_output(true)
+            .set_dim({batch, H, seq, head_dim})
+            .set_stride({batch_stride, head_stride, seq_stride, 1})
+            .set_data_type(fe::DataType_t::FP8_E4M3)
+            .set_uid(4);
+        tAmaxS->set_output(true)
+            .set_dim({1, 1, 1, 1})
+            .set_stride({1, 1, 1, 1})
+            .set_data_type(fe::DataType_t::FLOAT)
+            .set_uid(11);
+        tAmaxO->set_output(true)
+            .set_dim({1, 1, 1, 1})
+            .set_stride({1, 1, 1, 1})
+            .set_data_type(fe::DataType_t::FLOAT)
+            .set_uid(12);
+
+        if (!graph->build(handle,
+                          {fe::HeurMode_t::A, fe::HeurMode_t::B, fe::HeurMode_t::FALLBACK},
+                          fe::BuildPlanPolicy_t::ALL).is_good()) {
+            return cudaErrorNotSupported;
+        }
+    }
+
+    int64_t workspace_size = 0;
+    if (!graph->get_workspace_size(workspace_size).is_good()) {
+        return cudaErrorUnknown;
+    }
+    cudaError_t ws_err = ensure_lightvae_sdpa_workspace(resources, static_cast<size_t>(workspace_size));
+    if (ws_err != cudaSuccess) {
+        return ws_err;
+    }
+
+    std::unordered_map<fe::graph::Tensor_attributes::uid_t, void*> variant_pack = {
+        {1, const_cast<uint8_t*>(q)},
+        {2, const_cast<uint8_t*>(k)},
+        {3, const_cast<uint8_t*>(v)},
+        {4, o},
+        {5, const_cast<float*>(descale_q)},
+        {6, const_cast<float*>(descale_k)},
+        {7, const_cast<float*>(descale_v)},
+        {8, const_cast<float*>(descale_s)},
+        {9, const_cast<float*>(scale_s)},
+        {10, const_cast<float*>(scale_o)},
+        {11, amax_s},
+        {12, amax_o},
+    };
+
+    if (!graph->execute(handle, variant_pack, resources.workspace).is_good()) {
+        if (!cache_miss) {
+            resources.graph_cache.erase(cache_key);
+        }
+        return cudaErrorUnknown;
+    }
+    if (cache_miss) {
+        resources.graph_cache[cache_key] = graph;
+    }
+    return cudaSuccess;
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> lightvae_fp8_qkv_tin16_to_bmhd(
+    torch::Tensor qkv) {
+    check_tin16_cuda_contiguous(qkv, "qkv");
+    TORCH_CHECK(qkv.size(1) == 18, "qkv must have 288 channels in TIN16 layout, got ", qkv.sizes());
+    at::cuda::CUDAGuard guard(qkv.device());
+    auto qkv_c = qkv.contiguous();
+    const int frames = static_cast<int>(qkv_c.size(0));
+    const int height = static_cast<int>(qkv_c.size(2));
+    const int width = static_cast<int>(qkv_c.size(3));
+    const long long elems = static_cast<long long>(frames) * height * width * 96;
+    auto q = torch::empty({elems}, qkv_c.options());
+    auto k = torch::empty({elems}, qkv_c.options());
+    auto v = torch::empty({elems}, qkv_c.options());
+    if (frames <= 0 || height <= 0 || width <= 0 || elems == 0) {
+        return std::make_tuple(q, k, v);
+    }
+    qkv_tin16_to_bmhd_kernel<<<launch_blocks(elems), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        qkv_c.data_ptr<uint8_t>(),
+        q.data_ptr<uint8_t>(),
+        k.data_ptr<uint8_t>(),
+        v.data_ptr<uint8_t>(),
+        frames,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return std::make_tuple(q, k, v);
+}
+
+torch::Tensor lightvae_fp8_bmhd_to_tin16(
+    torch::Tensor input,
+    int frames,
+    int height,
+    int width) {
+    check_u8_cuda_contiguous(input, "input");
+    TORCH_CHECK(frames > 0 && height > 0 && width > 0, "frames/height/width must be positive");
+    const long long elems = static_cast<long long>(frames) * height * width * 96;
+    TORCH_CHECK(input.numel() == elems, "input has ", input.numel(), " elements, expected ", elems);
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto output = torch::empty({frames, 6, height, width, kFp8ChannelsPerSlice}, input.options());
+    bmhd_to_tin16_kernel<<<launch_blocks(elems), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.data_ptr<uint8_t>(),
+        output.data_ptr<uint8_t>(),
+        frames,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_sdpa_bmhd(
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor qkv_scale,
+    torch::Tensor sdpa_inverse_scale,
+    torch::Tensor unit_scale,
+    int batch,
+    int seq,
+    double attn_scale) {
+    check_u8_cuda_contiguous(q, "q");
+    check_u8_cuda_contiguous(k, "k");
+    check_u8_cuda_contiguous(v, "v");
+    TORCH_CHECK(q.sizes() == k.sizes() && q.sizes() == v.sizes(), "q/k/v shape mismatch");
+    TORCH_CHECK(k.device() == q.device() && v.device() == q.device(),
+                "q/k/v must be on the same CUDA device; q=", q.device(),
+                " k=", k.device(), " v=", v.device());
+    check_float_scalar_cuda_contiguous(qkv_scale, "qkv_scale");
+    check_float_scalar_cuda_contiguous(sdpa_inverse_scale, "sdpa_inverse_scale");
+    check_float_scalar_cuda_contiguous(unit_scale, "unit_scale");
+    TORCH_CHECK(qkv_scale.device() == q.device() && sdpa_inverse_scale.device() == q.device() &&
+                    unit_scale.device() == q.device(),
+                "all scale tensors must be on the q device");
+    const int head_dim = 96;
+    TORCH_CHECK(batch > 0 && seq > 0, "batch and seq must be positive");
+    TORCH_CHECK(q.numel() == static_cast<int64_t>(batch) * seq * head_dim,
+                "q/k/v numel must equal batch*seq*96; got ", q.numel(),
+                " for batch=", batch, " seq=", seq);
+    at::cuda::CUDAGuard guard(q.device());
+    auto q_c = q.contiguous();
+    auto k_c = k.contiguous();
+    auto v_c = v.contiguous();
+    auto output = torch::empty_like(q_c);
+    auto amax_s = torch::empty({1, 1, 1, 1}, q.options().dtype(at::kFloat));
+    auto amax_o = torch::empty({1, 1, 1, 1}, q.options().dtype(at::kFloat));
+
+    cudaError_t err = run_cudnn_fp8_sdpa_bmhd(
+        q_c.data_ptr<uint8_t>(),
+        k_c.data_ptr<uint8_t>(),
+        v_c.data_ptr<uint8_t>(),
+        output.data_ptr<uint8_t>(),
+        qkv_scale.data_ptr<float>(),
+        qkv_scale.data_ptr<float>(),
+        qkv_scale.data_ptr<float>(),
+        unit_scale.data_ptr<float>(),
+        unit_scale.data_ptr<float>(),
+        sdpa_inverse_scale.data_ptr<float>(),
+        amax_s.data_ptr<float>(),
+        amax_o.data_ptr<float>(),
+        batch,
+        seq,
+        head_dim,
+        static_cast<float>(attn_scale),
+        at::cuda::getCurrentCUDAStream());
+    TORCH_CHECK(err == cudaSuccess, "LightVAEEncoderFP8 cuDNN FP8 SDPA failed: ", cudaGetErrorString(err));
+    return output;
+}
+
+void lightvae_fp8_sdpa_cleanup() {
+    std::lock_guard<std::mutex> map_lock(g_lightvae_fp8_sdpa_resources_mutex);
+    g_lightvae_fp8_sdpa_cleanup_in_progress = true;
+    for (auto& item : g_lightvae_fp8_sdpa_resources) {
+        const int device = item.first.device;
+        auto& resources = *item.second;
+        std::unique_lock<std::mutex> resource_lock(resources.mutex);
+        at::cuda::CUDAGuard guard(c10::Device(c10::DeviceType::CUDA, device));
+        cudaStreamSynchronize(reinterpret_cast<cudaStream_t>(item.first.stream));
+        resources.graph_cache.clear();
+        if (resources.workspace) {
+            cudaFree(resources.workspace);
+            resources.workspace = nullptr;
+        }
+        resources.workspace_size = 0;
+        if (resources.cudnn_handle) {
+            cudnnDestroy(resources.cudnn_handle);
+            resources.cudnn_handle = nullptr;
+        }
+    }
+    g_lightvae_fp8_sdpa_resources.clear();
+    g_lightvae_fp8_sdpa_cleanup_in_progress = false;
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_direct_stages.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_direct_stages.cu
@@ -1,0 +1,731 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "lightvae_ops.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <cuda_fp16.h>
+
+#include <algorithm>
+
+#include <cutlass/numeric_conversion.h>
+
+namespace omnidreams_singleview {
+namespace {
+
+constexpr int kFp8ChannelsPerSlice = 16;
+
+int launch_blocks(long long total) {
+    constexpr int threads = 256;
+    return static_cast<int>(std::min((total + threads - 1) / threads, 65535LL));
+}
+
+void check_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void check_cuda_tensor(const torch::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+}
+
+void check_u8_cuda_tensor(const torch::Tensor& tensor, const char* name) {
+    check_cuda_tensor(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kByte, name, " must be torch.uint8");
+}
+
+void check_half_cuda_tensor(const torch::Tensor& tensor, const char* name) {
+    check_cuda_tensor(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kHalf, name, " must be torch.float16");
+}
+
+void check_scale_cuda_tensor(const torch::Tensor& tensor, const char* name) {
+    check_cuda_tensor(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kFloat || tensor.scalar_type() == at::kHalf,
+                name, " must be torch.float32 or torch.float16");
+    TORCH_CHECK(tensor.dim() == 0 || tensor.dim() == 1, name, " must be a scalar or 1D");
+}
+
+void check_u8_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kByte, name, " must be torch.uint8");
+}
+
+void check_half_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kHalf, name, " must be torch.float16");
+}
+
+torch::Tensor ensure_device_dtype_contiguous(
+    const torch::Tensor& tensor,
+    const c10::Device& device,
+    at::ScalarType dtype) {
+    if (tensor.device() == device && tensor.scalar_type() == dtype && tensor.is_contiguous()) {
+        return tensor;
+    }
+    return tensor.to(device, dtype, false, false).contiguous();
+}
+
+void check_tin16_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_u8_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.dim() == 5 && tensor.size(4) == kFp8ChannelsPerSlice,
+                name, " must be [T,C/16,H,W,16], got ", tensor.sizes());
+}
+
+const half* half_ptr_const(const torch::Tensor& tensor) {
+    return reinterpret_cast<const half*>(tensor.data_ptr<at::Half>());
+}
+
+template <typename ScaleT>
+__device__ __forceinline__ float scale_to_float(const ScaleT* scale, int idx) {
+    return static_cast<float>(scale[idx]);
+}
+
+template <>
+__device__ __forceinline__ float scale_to_float<half>(const half* scale, int idx) {
+    return __half2float(scale[idx]);
+}
+
+__device__ __forceinline__ uint8_t encode_e4m3(float value) {
+    cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+    cutlass::float_e4m3_t fp8 = to_fp8(value);
+    return *reinterpret_cast<uint8_t*>(&fp8);
+}
+
+__device__ __forceinline__ float decode_e4m3(uint8_t value) {
+    cutlass::float_e4m3_t fp8;
+    *reinterpret_cast<uint8_t*>(&fp8) = value;
+    cutlass::NumericConverter<float, cutlass::float_e4m3_t> to_float;
+    return to_float(fp8);
+}
+
+template <typename ScaleT>
+__device__ __forceinline__ uint8_t finalize_fp8_stage_value(
+    float accum,
+    const half* __restrict__ bias,
+    const ScaleT* __restrict__ output_scale,
+    int output_channel,
+    int output_scale_count,
+    bool relu) {
+    if (bias != nullptr) {
+        const int scale_idx = output_scale_count == 1 ? 0 : output_channel;
+        const float out_s = fmaxf(scale_to_float(output_scale, scale_idx), 1.0e-12f);
+        accum += __half2float(bias[output_channel]) / out_s;
+    }
+    if (relu) {
+        accum = fmaxf(accum, 0.0f);
+    }
+    return encode_e4m3(accum);
+}
+
+template <typename ScaleT>
+__global__ void conv1_tin16_direct_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ output_scale,
+    const half* __restrict__ bias,
+    long long total,
+    int frames,
+    int in_slices,
+    int height,
+    int width,
+    int out_channels,
+    int output_scale_count,
+    bool relu) {
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+    const int out_slices = out_channels / kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int out_slice = static_cast<int>(rem % out_slices);
+        rem /= out_slices;
+        const int frame = static_cast<int>(rem);
+        const int k = out_slice * kFp8ChannelsPerSlice + lane;
+
+        float accum = 0.0f;
+        for (int c = 0; c < in_channels; ++c) {
+            const int in_slice = c / kFp8ChannelsPerSlice;
+            const int in_lane = c - in_slice * kFp8ChannelsPerSlice;
+            const size_t in_idx =
+                (((static_cast<size_t>(frame) * in_slices + in_slice) * height + y) * width + x) *
+                    kFp8ChannelsPerSlice + in_lane;
+            const size_t w_idx = static_cast<size_t>(k) * in_channels + c;
+            accum += decode_e4m3(input[in_idx]) * decode_e4m3(weight[w_idx]);
+        }
+        output[idx] = finalize_fp8_stage_value(accum, bias, output_scale, k, output_scale_count, relu);
+    }
+}
+
+template <typename ScaleT>
+__global__ void spatial3_tin16_direct_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ output_scale,
+    const half* __restrict__ bias,
+    long long total,
+    int frames,
+    int in_slices,
+    int height,
+    int width,
+    int effective_height,
+    int effective_width,
+    int out_height,
+    int out_width,
+    int out_channels,
+    int stride,
+    int pad,
+    int output_scale_count,
+    bool relu) {
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+    const int out_slices = out_channels / kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int ox = static_cast<int>(rem % out_width);
+        rem /= out_width;
+        const int oy = static_cast<int>(rem % out_height);
+        rem /= out_height;
+        const int out_slice = static_cast<int>(rem % out_slices);
+        rem /= out_slices;
+        const int frame = static_cast<int>(rem);
+        const int k = out_slice * kFp8ChannelsPerSlice + lane;
+
+        float accum = 0.0f;
+        for (int r = 0; r < 3; ++r) {
+            const int iy = oy * stride + r - pad;
+            if (iy < 0 || iy >= effective_height || iy >= height) {
+                continue;
+            }
+            for (int s = 0; s < 3; ++s) {
+                const int ix = ox * stride + s - pad;
+                if (ix < 0 || ix >= effective_width || ix >= width) {
+                    continue;
+                }
+                for (int c = 0; c < in_channels; ++c) {
+                    const int in_slice = c / kFp8ChannelsPerSlice;
+                    const int in_lane = c - in_slice * kFp8ChannelsPerSlice;
+                    const size_t in_idx =
+                        (((static_cast<size_t>(frame) * in_slices + in_slice) * height + iy) * width + ix) *
+                            kFp8ChannelsPerSlice + in_lane;
+                    const size_t w_idx =
+                        (((static_cast<size_t>(k) * 3 + r) * 3 + s) * in_channels + c);
+                    accum += decode_e4m3(input[in_idx]) * decode_e4m3(weight[w_idx]);
+                }
+            }
+        }
+        output[idx] = finalize_fp8_stage_value(accum, bias, output_scale, k, output_scale_count, relu);
+    }
+}
+
+template <typename ScaleT>
+__global__ void causal3_tin16_direct_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    const uint8_t* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ output_scale,
+    const half* __restrict__ bias,
+    long long total,
+    int frames,
+    int cache_frames,
+    int in_slices,
+    int height,
+    int width,
+    int out_channels,
+    int output_scale_count,
+    bool relu) {
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+    const int packed_channels = in_channels * 3;
+    const int out_slices = out_channels / kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int ox = static_cast<int>(rem % width);
+        rem /= width;
+        const int oy = static_cast<int>(rem % height);
+        rem /= height;
+        const int out_slice = static_cast<int>(rem % out_slices);
+        rem /= out_slices;
+        const int frame = static_cast<int>(rem);
+        const int k = out_slice * kFp8ChannelsPerSlice + lane;
+
+        float accum = 0.0f;
+        for (int r = 0; r < 3; ++r) {
+            const int iy = oy + r - 1;
+            if (iy < 0 || iy >= height) {
+                continue;
+            }
+            for (int s = 0; s < 3; ++s) {
+                const int ix = ox + s - 1;
+                if (ix < 0 || ix >= width) {
+                    continue;
+                }
+                for (int dt = 0; dt < 3; ++dt) {
+                    const int src_ext_t = cache_frames + frame + dt - 2;
+                    const bool from_cache = src_ext_t >= 0 && src_ext_t < cache_frames && cache != nullptr;
+                    const int src_t = from_cache ? src_ext_t : (src_ext_t - cache_frames);
+                    const uint8_t* src_ptr = from_cache ? cache : input;
+                    const int src_frames = from_cache ? cache_frames : frames;
+                    if (src_t < 0 || src_t >= src_frames) {
+                        continue;
+                    }
+                    for (int c = 0; c < in_channels; ++c) {
+                        const int in_slice = c / kFp8ChannelsPerSlice;
+                        const int in_lane = c - in_slice * kFp8ChannelsPerSlice;
+                        const size_t in_idx =
+                            (((static_cast<size_t>(src_t) * in_slices + in_slice) * height + iy) * width + ix) *
+                                kFp8ChannelsPerSlice + in_lane;
+                        const int packed_c = dt * in_channels + c;
+                        const size_t w_idx =
+                            (((static_cast<size_t>(k) * 3 + r) * 3 + s) * packed_channels + packed_c);
+                        accum += decode_e4m3(src_ptr[in_idx]) * decode_e4m3(weight[w_idx]);
+                    }
+                }
+            }
+        }
+        output[idx] = finalize_fp8_stage_value(accum, bias, output_scale, k, output_scale_count, relu);
+    }
+}
+
+template <typename ScaleT>
+__global__ void temporal1_tin16_direct_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    const uint8_t* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ output_scale,
+    const half* __restrict__ bias,
+    long long total,
+    int frames,
+    int t_out,
+    int in_slices,
+    int height,
+    int width,
+    int out_channels,
+    int output_scale_count,
+    bool has_cache,
+    bool relu) {
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+    const int packed_channels = in_channels * 3;
+    const int out_slices = out_channels / kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int out_slice = static_cast<int>(rem % out_slices);
+        rem /= out_slices;
+        const int to = static_cast<int>(rem);
+        const int k = out_slice * kFp8ChannelsPerSlice + lane;
+
+        float accum = 0.0f;
+        for (int dt = 0; dt < 3; ++dt) {
+            const int src_ext_t = to * 2 + dt;
+            const bool from_cache = has_cache && src_ext_t == 0 && cache != nullptr;
+            const int src_t = from_cache ? 0 : (has_cache ? src_ext_t - 1 : src_ext_t);
+            if (!from_cache && (src_t < 0 || src_t >= frames)) {
+                continue;
+            }
+            const uint8_t* src_ptr = from_cache ? cache : input;
+            for (int c = 0; c < in_channels; ++c) {
+                const int in_slice = c / kFp8ChannelsPerSlice;
+                const int in_lane = c - in_slice * kFp8ChannelsPerSlice;
+                const size_t in_idx =
+                    (((static_cast<size_t>(src_t) * in_slices + in_slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + in_lane;
+                const int packed_c = dt * in_channels + c;
+                const size_t w_idx = static_cast<size_t>(k) * packed_channels + packed_c;
+                accum += decode_e4m3(src_ptr[in_idx]) * decode_e4m3(weight[w_idx]);
+            }
+        }
+        output[idx] = finalize_fp8_stage_value(accum, bias, output_scale, k, output_scale_count, relu);
+    }
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_conv1_direct(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    bool relu) {
+    const int frames = static_cast<int>(input.size(0));
+    const int in_slices = static_cast<int>(input.size(1));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    const int out_channels = static_cast<int>(weight.size(0));
+    auto output = torch::empty(
+        {frames, out_channels / kFp8ChannelsPerSlice, height, width, kFp8ChannelsPerSlice},
+        input.options());
+    const long long total = output.numel();
+    if (total == 0) {
+        return output;
+    }
+    conv1_tin16_direct_kernel<ScaleT><<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        weight.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const ScaleT*>(output_scale.data_ptr()),
+        bias,
+        total,
+        frames,
+        in_slices,
+        height,
+        width,
+        out_channels,
+        static_cast<int>(output_scale.numel()),
+        relu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_spatial3_direct(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom) {
+    const int frames = static_cast<int>(input.size(0));
+    const int in_slices = static_cast<int>(input.size(1));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    const int effective_height = height + (pad_right_bottom ? 1 : 0);
+    const int effective_width = width + (pad_right_bottom ? 1 : 0);
+    const int out_channels = static_cast<int>(weight.size(0));
+    const int out_height = (effective_height + 2 * pad - 3) / stride + 1;
+    const int out_width = (effective_width + 2 * pad - 3) / stride + 1;
+    TORCH_CHECK(out_height > 0 && out_width > 0, "invalid output shape");
+    auto output = torch::empty(
+        {frames, out_channels / kFp8ChannelsPerSlice, out_height, out_width, kFp8ChannelsPerSlice},
+        input.options());
+    const long long total = output.numel();
+    if (total == 0) {
+        return output;
+    }
+    spatial3_tin16_direct_kernel<ScaleT><<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        weight.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const ScaleT*>(output_scale.data_ptr()),
+        bias,
+        total,
+        frames,
+        in_slices,
+        height,
+        width,
+        effective_height,
+        effective_width,
+        out_height,
+        out_width,
+        out_channels,
+        stride,
+        pad,
+        static_cast<int>(output_scale.numel()),
+        relu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_causal3_direct(
+    torch::Tensor input,
+    torch::Tensor cache,
+    const uint8_t* cache_ptr,
+    int cache_frames,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    bool relu) {
+    const int frames = static_cast<int>(input.size(0));
+    const int in_slices = static_cast<int>(input.size(1));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    const int out_channels = static_cast<int>(weight.size(0));
+    auto output = torch::empty(
+        {frames, out_channels / kFp8ChannelsPerSlice, height, width, kFp8ChannelsPerSlice},
+        input.options());
+    const long long total = output.numel();
+    if (total == 0) {
+        return output;
+    }
+    causal3_tin16_direct_kernel<ScaleT><<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        cache_ptr,
+        weight.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const ScaleT*>(output_scale.data_ptr()),
+        bias,
+        total,
+        frames,
+        cache_frames,
+        in_slices,
+        height,
+        width,
+        out_channels,
+        static_cast<int>(output_scale.numel()),
+        relu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_temporal1_direct(
+    torch::Tensor input,
+    torch::Tensor cache,
+    const uint8_t* cache_ptr,
+    bool has_cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    bool relu) {
+    const int frames = static_cast<int>(input.size(0));
+    const int in_slices = static_cast<int>(input.size(1));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    const int out_channels = static_cast<int>(weight.size(0));
+    const int available = frames + (has_cache ? 1 : 0);
+    const int t_out = available < 3 ? 0 : ((available - 3) / 2 + 1);
+    TORCH_CHECK(t_out >= 0, "temporal direct stage produced invalid T_out=", t_out, " from T=", frames);
+    auto output = torch::empty(
+        {t_out, out_channels / kFp8ChannelsPerSlice, height, width, kFp8ChannelsPerSlice},
+        input.options());
+    const long long total = output.numel();
+    if (total == 0) {
+        return output;
+    }
+    temporal1_tin16_direct_kernel<ScaleT><<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        cache_ptr,
+        weight.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const ScaleT*>(output_scale.data_ptr()),
+        bias,
+        total,
+        frames,
+        t_out,
+        in_slices,
+        height,
+        width,
+        out_channels,
+        static_cast<int>(output_scale.numel()),
+        has_cache,
+        relu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor normalize_optional_cache(
+    c10::optional<torch::Tensor> cache,
+    const torch::Tensor& input,
+    int expected_cache_frames,
+    const char* name,
+    const uint8_t** cache_ptr,
+    int* cache_frames,
+    bool* has_cache) {
+    *cache_ptr = nullptr;
+    *cache_frames = 0;
+    *has_cache = false;
+    if (!(cache.has_value() && cache.value().defined())) {
+        return torch::Tensor();
+    }
+    auto cache_c = cache.value().contiguous();
+    check_tin16_cuda_contiguous(cache_c, name);
+    TORCH_CHECK(cache_c.device() == input.device(), name, " must be on the same device as input");
+    TORCH_CHECK(cache_c.size(1) == input.size(1) && cache_c.size(2) == input.size(2) &&
+                    cache_c.size(3) == input.size(3),
+                name, " shape must match input channel/spatial dimensions");
+    if (expected_cache_frames >= 0) {
+        TORCH_CHECK(cache_c.size(0) == expected_cache_frames,
+                    name, " must have ", expected_cache_frames, " frame(s)");
+    }
+    *cache_ptr = cache_c.template data_ptr<uint8_t>();
+    *cache_frames = static_cast<int>(cache_c.size(0));
+    *has_cache = true;
+    return cache_c;
+}
+
+}  // namespace
+
+torch::Tensor lightvae_fp8_conv1_tin16_direct_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    check_tin16_cuda_contiguous(input, "input");
+    check_u8_cuda_tensor(weight, "weight");
+    check_scale_cuda_tensor(output_scale, "output_scale");
+    TORCH_CHECK(weight.dim() == 4 && weight.size(1) == 1 && weight.size(2) == 1,
+                "weight must be [K,1,1,C], got ", weight.sizes());
+    TORCH_CHECK(weight.size(3) == input.size(1) * kFp8ChannelsPerSlice,
+                "weight C must match input channels");
+    TORCH_CHECK(weight.size(0) % kFp8ChannelsPerSlice == 0,
+                "weight K must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight.size(0),
+                "output_scale must be scalar or have one entry per output channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto weight_c = ensure_device_dtype_contiguous(weight, input.device(), weight.scalar_type());
+    auto out_s = ensure_device_dtype_contiguous(output_scale, input.device(), output_scale.scalar_type());
+    torch::Tensor bias_c;
+    const half* bias_ptr = nullptr;
+    if (bias.has_value() && bias.value().defined()) {
+        check_half_cuda_tensor(bias.value(), "bias");
+        bias_c = ensure_device_dtype_contiguous(bias.value(), input.device(), bias.value().scalar_type());
+        check_half_cuda_contiguous(bias_c, "bias");
+        TORCH_CHECK(bias_c.numel() == weight_c.size(0), "bias must have one entry per output channel");
+        bias_ptr = half_ptr_const(bias_c);
+    }
+    return out_s.scalar_type() == at::kHalf
+        ? dispatch_conv1_direct<half>(input_c, weight_c, out_s, bias_ptr, relu)
+        : dispatch_conv1_direct<float>(input_c, weight_c, out_s, bias_ptr, relu);
+}
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_direct_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom) {
+    check_tin16_cuda_contiguous(input, "input");
+    check_u8_cuda_tensor(weight, "weight");
+    check_scale_cuda_tensor(output_scale, "output_scale");
+    TORCH_CHECK(weight.dim() == 4 && weight.size(1) == 3 && weight.size(2) == 3,
+                "weight must be [K,3,3,C], got ", weight.sizes());
+    TORCH_CHECK(weight.size(3) == input.size(1) * kFp8ChannelsPerSlice,
+                "weight C must match input channels");
+    TORCH_CHECK(weight.size(0) % kFp8ChannelsPerSlice == 0,
+                "weight K must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight.size(0),
+                "output_scale must be scalar or have one entry per output channel");
+    TORCH_CHECK(stride > 0 && pad >= 0, "invalid stride/pad");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto weight_c = ensure_device_dtype_contiguous(weight, input.device(), weight.scalar_type());
+    auto out_s = ensure_device_dtype_contiguous(output_scale, input.device(), output_scale.scalar_type());
+    torch::Tensor bias_c;
+    const half* bias_ptr = nullptr;
+    if (bias.has_value() && bias.value().defined()) {
+        check_half_cuda_tensor(bias.value(), "bias");
+        bias_c = ensure_device_dtype_contiguous(bias.value(), input.device(), bias.value().scalar_type());
+        check_half_cuda_contiguous(bias_c, "bias");
+        TORCH_CHECK(bias_c.numel() == weight_c.size(0), "bias must have one entry per output channel");
+        bias_ptr = half_ptr_const(bias_c);
+    }
+    return out_s.scalar_type() == at::kHalf
+        ? dispatch_spatial3_direct<half>(input_c, weight_c, out_s, bias_ptr, stride, pad, relu, pad_right_bottom)
+        : dispatch_spatial3_direct<float>(input_c, weight_c, out_s, bias_ptr, stride, pad, relu, pad_right_bottom);
+}
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_direct_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    check_tin16_cuda_contiguous(input, "input");
+    check_u8_cuda_tensor(weight, "weight");
+    check_scale_cuda_tensor(output_scale, "output_scale");
+    TORCH_CHECK(weight.dim() == 4 && weight.size(1) == 3 && weight.size(2) == 3,
+                "weight must be [K,3,3,3*C], got ", weight.sizes());
+    TORCH_CHECK(weight.size(3) == input.size(1) * kFp8ChannelsPerSlice * 3,
+                "weight C must match packed causal input channels");
+    TORCH_CHECK(weight.size(0) % kFp8ChannelsPerSlice == 0,
+                "weight K must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight.size(0),
+                "output_scale must be scalar or have one entry per output channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const uint8_t* cache_ptr = nullptr;
+    int cache_frames = 0;
+    bool has_cache = false;
+    auto cache_c = normalize_optional_cache(cache, input_c, -1, "cache", &cache_ptr, &cache_frames, &has_cache);
+    TORCH_CHECK(cache_frames >= 0 && cache_frames <= 2, "causal cache must have 0, 1, or 2 frames");
+    auto weight_c = ensure_device_dtype_contiguous(weight, input.device(), weight.scalar_type());
+    auto out_s = ensure_device_dtype_contiguous(output_scale, input.device(), output_scale.scalar_type());
+    torch::Tensor bias_c;
+    const half* bias_ptr = nullptr;
+    if (bias.has_value() && bias.value().defined()) {
+        check_half_cuda_tensor(bias.value(), "bias");
+        bias_c = ensure_device_dtype_contiguous(bias.value(), input.device(), bias.value().scalar_type());
+        check_half_cuda_contiguous(bias_c, "bias");
+        TORCH_CHECK(bias_c.numel() == weight_c.size(0), "bias must have one entry per output channel");
+        bias_ptr = half_ptr_const(bias_c);
+    }
+    return out_s.scalar_type() == at::kHalf
+        ? dispatch_causal3_direct<half>(input_c, cache_c, cache_ptr, cache_frames, weight_c, out_s, bias_ptr, relu)
+        : dispatch_causal3_direct<float>(input_c, cache_c, cache_ptr, cache_frames, weight_c, out_s, bias_ptr, relu);
+}
+
+torch::Tensor lightvae_fp8_temporal_conv1_tin16_direct_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    check_tin16_cuda_contiguous(input, "input");
+    check_u8_cuda_tensor(weight, "weight");
+    check_scale_cuda_tensor(output_scale, "output_scale");
+    TORCH_CHECK(weight.dim() == 4 && weight.size(1) == 1 && weight.size(2) == 1,
+                "weight must be [K,1,1,3*C], got ", weight.sizes());
+    TORCH_CHECK(weight.size(3) == input.size(1) * kFp8ChannelsPerSlice * 3,
+                "weight C must match packed temporal input channels");
+    TORCH_CHECK(weight.size(0) % kFp8ChannelsPerSlice == 0,
+                "weight K must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight.size(0),
+                "output_scale must be scalar or have one entry per output channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const uint8_t* cache_ptr = nullptr;
+    int cache_frames = 0;
+    bool has_cache = false;
+    auto cache_c = normalize_optional_cache(cache, input_c, 1, "cache", &cache_ptr, &cache_frames, &has_cache);
+    auto weight_c = ensure_device_dtype_contiguous(weight, input.device(), weight.scalar_type());
+    auto out_s = ensure_device_dtype_contiguous(output_scale, input.device(), output_scale.scalar_type());
+    torch::Tensor bias_c;
+    const half* bias_ptr = nullptr;
+    if (bias.has_value() && bias.value().defined()) {
+        check_half_cuda_tensor(bias.value(), "bias");
+        bias_c = ensure_device_dtype_contiguous(bias.value(), input.device(), bias.value().scalar_type());
+        check_half_cuda_contiguous(bias_c, "bias");
+        TORCH_CHECK(bias_c.numel() == weight_c.size(0), "bias must have one entry per output channel");
+        bias_ptr = half_ptr_const(bias_c);
+    }
+    return out_s.scalar_type() == at::kHalf
+        ? dispatch_temporal1_direct<half>(input_c, cache_c, cache_ptr, has_cache, weight_c, out_s, bias_ptr, relu)
+        : dispatch_temporal1_direct<float>(input_c, cache_c, cache_ptr, has_cache, weight_c, out_s, bias_ptr, relu);
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_ops.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_ops.cu
@@ -1,0 +1,2132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "lightvae_ops.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <cuda_fp16.h>
+
+#include <algorithm>
+
+#include <cutlass/conv/conv2d_problem_size.h>
+#include <cutlass/conv/device/implicit_gemm_convolution.h>
+#include <cutlass/conv/kernel/default_conv2d_fprop.h>
+#include <cutlass/conv/kernel/default_conv2d_fprop_with_absmax.h>
+#include <cutlass/epilogue/thread/activation.h>
+#include <cutlass/epilogue/thread/linear_combination.h>
+#include <cutlass/epilogue/thread/linear_combination_generic_with_scaling.h>
+#include <cutlass/layout/tensor.h>
+#include <cutlass/numeric_conversion.h>
+
+namespace omnidreams_singleview {
+namespace {
+
+constexpr int kFp8ChannelsPerSlice = 16;
+
+int launch_blocks(long long total) {
+    constexpr int threads = 256;
+    return static_cast<int>(std::min((total + threads - 1) / threads, 65535LL));
+}
+
+void check_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void check_half_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kHalf, name, " must be torch.float16");
+}
+
+void check_u8_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kByte, name, " must be torch.uint8");
+}
+
+void check_tin16_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_u8_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.dim() == 5 && tensor.size(4) == kFp8ChannelsPerSlice,
+                name, " must be [N,C/16,H,W,16], got ", tensor.sizes());
+}
+
+void check_scale_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kFloat || tensor.scalar_type() == at::kHalf,
+                name, " must be torch.float32 or torch.float16");
+    TORCH_CHECK(tensor.dim() == 1, name, " must be 1D");
+}
+
+const half* half_ptr_const(const torch::Tensor& tensor) {
+    return reinterpret_cast<const half*>(tensor.data_ptr<at::Half>());
+}
+
+half* half_ptr(torch::Tensor& tensor) {
+    return reinterpret_cast<half*>(tensor.data_ptr<at::Half>());
+}
+
+template <typename ScaleT>
+__device__ __forceinline__ float scale_to_float(const ScaleT* scale, int idx) {
+    return static_cast<float>(scale[idx]);
+}
+
+template <>
+__device__ __forceinline__ float scale_to_float<half>(const half* scale, int idx) {
+    return __half2float(scale[idx]);
+}
+
+__device__ __forceinline__ uint8_t encode_e4m3(float value) {
+    cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+    cutlass::float_e4m3_t fp8 = to_fp8(value);
+    return *reinterpret_cast<uint8_t*>(&fp8);
+}
+
+__device__ __forceinline__ float decode_e4m3(uint8_t value) {
+    cutlass::float_e4m3_t fp8;
+    *reinterpret_cast<uint8_t*>(&fp8) = value;
+    cutlass::NumericConverter<float, cutlass::float_e4m3_t> to_float;
+    return to_float(fp8);
+}
+
+template <typename ScaleT>
+__global__ void quantize_bcthw_to_tin16_kernel(
+    const half* __restrict__ input,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ scale,
+    int channels,
+    int frames,
+    int height,
+    int width,
+    int padded_channels,
+    int padded_height,
+    int padded_width,
+    int scale_count) {
+    const int slices = padded_channels / kFp8ChannelsPerSlice;
+    const long long total =
+        static_cast<long long>(frames) * slices * padded_height * padded_width * kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % padded_width);
+        rem /= padded_width;
+        const int y = static_cast<int>(rem % padded_height);
+        rem /= padded_height;
+        const int slice = static_cast<int>(rem % slices);
+        const int frame = static_cast<int>(rem / slices);
+        const int c = slice * kFp8ChannelsPerSlice + lane;
+
+        float value = 0.0f;
+        if (c < channels && y < height && x < width) {
+            const size_t in_idx =
+                (((static_cast<size_t>(c) * frames + frame) * height + y) * width + x);
+            const int scale_idx = scale_count == 1 ? 0 : c;
+            const float s = fmaxf(scale_to_float(scale, scale_idx), 1.0e-12f);
+            value = __half2float(input[in_idx]) / s;
+        }
+        output[idx] = encode_e4m3(value);
+    }
+}
+
+template <typename ScaleT>
+__global__ void quantize_rgb_bcthw_to_tin16_kernel(
+    const half* __restrict__ input,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ scale,
+    int frames,
+    int height,
+    int width,
+    int padded_height,
+    int padded_width,
+    int scale_count) {
+    constexpr int padded_slices = 2;
+    const long long total = static_cast<long long>(frames) * padded_height * padded_width;
+    const uint4 zeros = make_uint4(0u, 0u, 0u, 0u);
+    const float s0 = fmaxf(scale_to_float(scale, 0), 1.0e-12f);
+    const float s1 = fmaxf(scale_to_float(scale, scale_count == 1 ? 0 : 1), 1.0e-12f);
+    const float s2 = fmaxf(scale_to_float(scale, scale_count == 1 ? 0 : 2), 1.0e-12f);
+    const size_t channel_stride = static_cast<size_t>(frames) * height * width;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int x = static_cast<int>(rem % padded_width);
+        rem /= padded_width;
+        const int y = static_cast<int>(rem % padded_height);
+        const int frame = static_cast<int>(rem / padded_height);
+
+        uint4 slice0 = zeros;
+        if (y < height && x < width) {
+            const size_t frame_offset = (static_cast<size_t>(frame) * height + y) * width + x;
+            const uint32_t q0 = static_cast<uint32_t>(encode_e4m3(__half2float(input[frame_offset]) / s0));
+            const uint32_t q1 = static_cast<uint32_t>(
+                encode_e4m3(__half2float(input[channel_stride + frame_offset]) / s1));
+            const uint32_t q2 = static_cast<uint32_t>(
+                encode_e4m3(__half2float(input[channel_stride * 2 + frame_offset]) / s2));
+            slice0.x = q0 | (q1 << 8) | (q2 << 16);
+        }
+
+        const size_t base0 =
+            (((static_cast<size_t>(frame) * padded_slices) * padded_height + y) * padded_width + x) *
+            kFp8ChannelsPerSlice;
+        const size_t base1 =
+            (((static_cast<size_t>(frame) * padded_slices + 1) * padded_height + y) * padded_width + x) *
+            kFp8ChannelsPerSlice;
+        reinterpret_cast<uint4*>(output + base0)[0] = slice0;
+        reinterpret_cast<uint4*>(output + base1)[0] = zeros;
+    }
+}
+
+template <typename ScaleT>
+__global__ void dequantize_tin16_to_bcthw_kernel(
+    const uint8_t* __restrict__ input,
+    half* __restrict__ output,
+    const ScaleT* __restrict__ scale,
+    int real_channels,
+    int frames,
+    int padded_channels,
+    int padded_height,
+    int padded_width,
+    int real_height,
+    int real_width,
+    int scale_count) {
+    const int slices = padded_channels / kFp8ChannelsPerSlice;
+    const long long total = static_cast<long long>(real_channels) * frames * real_height * real_width;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int x = static_cast<int>(rem % real_width);
+        rem /= real_width;
+        const int y = static_cast<int>(rem % real_height);
+        rem /= real_height;
+        const int frame = static_cast<int>(rem % frames);
+        const int c = static_cast<int>(rem / frames);
+        const int slice = c / kFp8ChannelsPerSlice;
+        const int lane = c - slice * kFp8ChannelsPerSlice;
+        const size_t in_idx =
+            (((static_cast<size_t>(frame) * slices + slice) * padded_height + y) * padded_width + x) *
+                kFp8ChannelsPerSlice + lane;
+        const int scale_idx = scale_count == 1 ? 0 : c;
+        output[idx] = __float2half_rn(decode_e4m3(input[in_idx]) * scale_to_float(scale, scale_idx));
+    }
+}
+
+template <int Channels, typename InScaleT, typename OutScaleT>
+__global__ void rmsnorm_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    const InScaleT* __restrict__ input_scale,
+    const half* __restrict__ gamma,
+    const OutScaleT* __restrict__ output_scale,
+    int frames,
+    int height,
+    int width,
+    int real_channels,
+    int input_scale_count,
+    int output_scale_count,
+    bool silu) {
+    constexpr int warps_per_block = (Channels <= 96) ? 4 : 2;
+    constexpr int slices = Channels / kFp8ChannelsPerSlice;
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    const int spatial_idx = blockIdx.x * warps_per_block + warp;
+    const int frame = blockIdx.y;
+    const int spatial_count = height * width;
+    if (spatial_idx >= spatial_count || frame >= frames) {
+        return;
+    }
+
+    const int y = spatial_idx / width;
+    const int x = spatial_idx - y * width;
+    float vals[(Channels + 31) / 32];
+    int count = 0;
+    float sum_sq = 0.0f;
+
+    for (int c = lane; c < Channels; c += 32) {
+        const int slice = c / kFp8ChannelsPerSlice;
+        const int sub = c - slice * kFp8ChannelsPerSlice;
+        const size_t idx =
+            (((static_cast<size_t>(frame) * slices + slice) * height + y) * width + x) *
+                kFp8ChannelsPerSlice + sub;
+        float v = 0.0f;
+        if (c < real_channels) {
+            const int scale_idx = input_scale_count == 1 ? 0 : c;
+            v = decode_e4m3(input[idx]) * scale_to_float(input_scale, scale_idx);
+            sum_sq += v * v;
+        }
+        vals[count++] = v;
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sum_sq += __shfl_down_sync(0xffffffffu, sum_sq, offset);
+    }
+    const float total_sum_sq = __shfl_sync(0xffffffffu, sum_sq, 0);
+    const float inv_rms = rsqrtf(total_sum_sq / static_cast<float>(real_channels) + 1.0e-8f);
+
+    int store_idx = 0;
+    for (int c = lane; c < Channels; c += 32) {
+        const int slice = c / kFp8ChannelsPerSlice;
+        const int sub = c - slice * kFp8ChannelsPerSlice;
+        const size_t idx =
+            (((static_cast<size_t>(frame) * slices + slice) * height + y) * width + x) *
+                kFp8ChannelsPerSlice + sub;
+        float result = 0.0f;
+        if (c < real_channels) {
+            result = vals[store_idx] * inv_rms * __half2float(gamma[c]);
+            if (silu) {
+                result = result / (1.0f + expf(-result));
+            }
+        }
+        const int scale_idx = output_scale_count == 1 ? 0 : c;
+        const float out_s = fmaxf(scale_to_float(output_scale, scale_idx), 1.0e-12f);
+        output[idx] = encode_e4m3(result / out_s);
+        ++store_idx;
+    }
+}
+
+template <typename AScaleT, typename BScaleT, typename OutScaleT>
+__global__ void add_tin16_pack_kernel(
+    const uint8_t* __restrict__ a,
+    const uint8_t* __restrict__ b,
+    uint8_t* __restrict__ output,
+    const AScaleT* __restrict__ a_scale,
+    const BScaleT* __restrict__ b_scale,
+    const OutScaleT* __restrict__ output_scale,
+    long long count,
+    int slices,
+    int height,
+    int width,
+    int real_channels,
+    int a_scale_count,
+    int b_scale_count,
+    int output_scale_count,
+    bool relu) {
+    const long long pack_count = count / kFp8ChannelsPerSlice;
+    for (long long pack_idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         pack_idx < pack_count;
+         pack_idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = pack_idx;
+        rem /= width;
+        rem /= height;
+        const int slice = static_cast<int>(rem % slices);
+        const int channel_base = slice * kFp8ChannelsPerSlice;
+        const size_t base = static_cast<size_t>(pack_idx) * kFp8ChannelsPerSlice;
+        const uint4 a_pack = reinterpret_cast<const uint4*>(a + base)[0];
+        const uint4 b_pack = reinterpret_cast<const uint4*>(b + base)[0];
+        const uint32_t* a_words = reinterpret_cast<const uint32_t*>(&a_pack);
+        const uint32_t* b_words = reinterpret_cast<const uint32_t*>(&b_pack);
+        uint4 out_pack = make_uint4(0u, 0u, 0u, 0u);
+        uint32_t* out_words = reinterpret_cast<uint32_t*>(&out_pack);
+        #pragma unroll
+        for (int group = 0; group < 4; ++group) {
+            uint32_t word = 0u;
+            const uint32_t aw = a_words[group];
+            const uint32_t bw = b_words[group];
+            #pragma unroll
+            for (int sub = 0; sub < 4; ++sub) {
+                const int lane = group * 4 + sub;
+                const int channel = channel_base + lane;
+                uint8_t out = encode_e4m3(0.0f);
+                if (real_channels < 0 || channel < real_channels) {
+                    const int a_idx = a_scale_count == 1 ? 0 : channel;
+                    const int b_idx = b_scale_count == 1 ? 0 : channel;
+                    const int out_idx = output_scale_count == 1 ? 0 : channel;
+                    float result = decode_e4m3(static_cast<uint8_t>((aw >> (sub * 8)) & 0xffu)) *
+                                       scale_to_float(a_scale, a_idx) +
+                                   decode_e4m3(static_cast<uint8_t>((bw >> (sub * 8)) & 0xffu)) *
+                                       scale_to_float(b_scale, b_idx);
+                    if (relu) {
+                        result = fmaxf(result, 0.0f);
+                    }
+                    const float out_s = fmaxf(scale_to_float(output_scale, out_idx), 1.0e-12f);
+                    out = encode_e4m3(result / out_s);
+                }
+                word |= static_cast<uint32_t>(out) << (sub * 8);
+            }
+            out_words[group] = word;
+        }
+        reinterpret_cast<uint4*>(output + base)[0] = out_pack;
+    }
+}
+
+template <typename AScaleT, typename BScaleT, typename OutScaleT>
+__global__ void add_relu_nhwc_tin16_to_tin16_kernel(
+    const uint8_t* __restrict__ a_nhwc,
+    const uint8_t* __restrict__ b_tin16,
+    uint8_t* __restrict__ output,
+    const AScaleT* __restrict__ a_scale,
+    const BScaleT* __restrict__ b_scale,
+    const OutScaleT* __restrict__ output_scale,
+    long long count,
+    int slices,
+    int height,
+    int width,
+    int real_channels,
+    int a_scale_count,
+    int b_scale_count,
+    int output_scale_count) {
+    const int channels = slices * kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < count;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int slice = static_cast<int>(rem % slices);
+        rem /= slices;
+        const int frame = static_cast<int>(rem);
+        const int c = slice * kFp8ChannelsPerSlice + lane;
+        float result = 0.0f;
+        if (real_channels < 0 || c < real_channels) {
+            const int a_idx = a_scale_count == 1 ? 0 : c;
+            const int b_idx = b_scale_count == 1 ? 0 : c;
+            const size_t a_offset =
+                (((static_cast<size_t>(frame) * height + y) * width + x) * channels + c);
+            result = decode_e4m3(a_nhwc[a_offset]) * scale_to_float(a_scale, a_idx) +
+                     decode_e4m3(b_tin16[idx]) * scale_to_float(b_scale, b_idx);
+            result = fmaxf(result, 0.0f);
+        }
+        const int out_idx = output_scale_count == 1 ? 0 : c;
+        const float out_s = fmaxf(scale_to_float(output_scale, out_idx), 1.0e-12f);
+        output[idx] = encode_e4m3(result / out_s);
+    }
+}
+
+__global__ void upsample2x_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    long long total,
+    int frames,
+    int slices,
+    int height,
+    int width) {
+    const int out_h = height * 2;
+    const int out_w = width * 2;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int ox = static_cast<int>(rem % out_w);
+        rem /= out_w;
+        const int oy = static_cast<int>(rem % out_h);
+        rem /= out_h;
+        const int slice = static_cast<int>(rem % slices);
+        rem /= slices;
+        const int frame = static_cast<int>(rem);
+        const int iy = oy >> 1;
+        const int ix = ox >> 1;
+        const size_t in_idx =
+            (((static_cast<size_t>(frame) * slices + slice) * height + iy) * width + ix) *
+                kFp8ChannelsPerSlice + lane;
+        output[idx] = input[in_idx];
+    }
+}
+
+template <typename ScaleT>
+__global__ void extract_mu_normalize_kernel(
+    const uint8_t* __restrict__ input,
+    half* __restrict__ output,
+    const ScaleT* __restrict__ input_scale,
+    const half* __restrict__ mean,
+    const half* __restrict__ inv_std,
+    int frames,
+    int padded_height,
+    int padded_width,
+    int real_height,
+    int real_width,
+    int scale_count) {
+    constexpr int channels = 16;
+    constexpr int slices = 32 / kFp8ChannelsPerSlice;
+    const long long total = static_cast<long long>(channels) * frames * real_height * real_width;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int x = static_cast<int>(rem % real_width);
+        rem /= real_width;
+        const int y = static_cast<int>(rem % real_height);
+        rem /= real_height;
+        const int frame = static_cast<int>(rem % frames);
+        const int c = static_cast<int>(rem / frames);
+        const int slice = c / kFp8ChannelsPerSlice;
+        const int lane = c - slice * kFp8ChannelsPerSlice;
+        const size_t in_idx =
+            (((static_cast<size_t>(frame) * slices + slice) * padded_height + y) * padded_width + x) *
+                kFp8ChannelsPerSlice + lane;
+        const int scale_idx = scale_count == 1 ? 0 : c;
+        const float mu = decode_e4m3(input[in_idx]) * scale_to_float(input_scale, scale_idx);
+        const float out = (mu - __half2float(mean[c])) * __half2float(inv_std[c]);
+        output[idx] = __float2half_rn(out);
+    }
+}
+
+template <typename InScaleT, typename OutScaleT>
+__global__ void prepare_conv2d_weight_krsc_kernel(
+    const half* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const InScaleT* __restrict__ input_scale,
+    const OutScaleT* __restrict__ output_scale,
+    long long count,
+    int channels,
+    int output_channels,
+    int r_size,
+    int s_size,
+    int input_scale_count,
+    int output_scale_count) {
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < count;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        const int c = static_cast<int>(idx % channels);
+        long long tmp = idx / channels;
+        tmp /= s_size;
+        tmp /= r_size;
+        const int k = static_cast<int>(tmp % output_channels);
+        const int in_idx = input_scale_count == 1 ? 0 : c;
+        const int out_idx = output_scale_count == 1 ? 0 : k;
+        const float in_s = scale_to_float(input_scale, in_idx);
+        const float out_s = fmaxf(scale_to_float(output_scale, out_idx), 1.0e-12f);
+        output[idx] = encode_e4m3(__half2float(weight[idx]) * in_s / out_s);
+    }
+}
+
+template <typename OutScaleT>
+__global__ void add_bias_act_fp8_nhwc_kernel(
+    uint8_t* __restrict__ output,
+    const half* __restrict__ bias,
+    const OutScaleT* __restrict__ output_scale,
+    long long count,
+    int channels,
+    int output_scale_count,
+    bool relu) {
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < count;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        const int c = static_cast<int>(idx % channels);
+        const int scale_idx = output_scale_count == 1 ? 0 : c;
+        const float out_s = fmaxf(scale_to_float(output_scale, scale_idx), 1.0e-12f);
+        float value = decode_e4m3(output[idx]) + __half2float(bias[c]) / out_s;
+        if (relu) {
+            value = fmaxf(value, 0.0f);
+        }
+        output[idx] = encode_e4m3(value);
+    }
+}
+
+__global__ void pack_causal3_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    uint8_t* __restrict__ output,
+    int frames,
+    int cache_frames,
+    int slices,
+    int height,
+    int width) {
+    const int out_slices = slices * 3;
+    const long long total =
+        static_cast<long long>(frames) * out_slices * height * width * kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int out_slice = static_cast<int>(rem % out_slices);
+        rem /= out_slices;
+        const int frame = static_cast<int>(rem);
+        const int dt = out_slice / slices;
+        const int slice = out_slice - dt * slices;
+        const int src_ext_t = cache_frames + frame + dt - 2;
+        uint8_t value = encode_e4m3(0.0f);
+        if (src_ext_t >= 0 && src_ext_t < cache_frames && cache != nullptr) {
+            const size_t src =
+                (((static_cast<size_t>(src_ext_t) * slices + slice) * height + y) * width + x) *
+                    kFp8ChannelsPerSlice + lane;
+            value = cache[src];
+        } else {
+            const int src_t = src_ext_t - cache_frames;
+            if (src_t >= 0 && src_t < frames) {
+                const size_t src =
+                    (((static_cast<size_t>(src_t) * slices + slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + lane;
+                value = input[src];
+            }
+        }
+        output[idx] = value;
+    }
+}
+
+__global__ void update_tail_cache_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    uint8_t* __restrict__ output,
+    int frames,
+    int old_cache_frames,
+    int new_cache_frames,
+    int slices,
+    int height,
+    int width) {
+    const long long total =
+        static_cast<long long>(new_cache_frames) * slices * height * width * kFp8ChannelsPerSlice;
+    const int tail_start = old_cache_frames + frames - new_cache_frames;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int slice = static_cast<int>(rem % slices);
+        rem /= slices;
+        const int ct = static_cast<int>(rem);
+        const int src_ext_t = tail_start + ct;
+        uint8_t value = encode_e4m3(0.0f);
+        if (src_ext_t >= 0 && src_ext_t < old_cache_frames && cache != nullptr) {
+            const size_t src =
+                (((static_cast<size_t>(src_ext_t) * slices + slice) * height + y) * width + x) *
+                    kFp8ChannelsPerSlice + lane;
+            value = cache[src];
+        } else {
+            const int src_t = src_ext_t - old_cache_frames;
+            if (src_t >= 0 && src_t < frames) {
+                const size_t src =
+                    (((static_cast<size_t>(src_t) * slices + slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + lane;
+                value = input[src];
+            }
+        }
+        output[idx] = value;
+    }
+}
+
+__global__ void spatial_pad_right_bottom_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    int frames,
+    int slices,
+    int height,
+    int width) {
+    const int out_h = height + 1;
+    const int out_w = width + 1;
+    const long long total =
+        static_cast<long long>(frames) * slices * out_h * out_w * kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % out_w);
+        rem /= out_w;
+        const int y = static_cast<int>(rem % out_h);
+        rem /= out_h;
+        const int slice = static_cast<int>(rem % slices);
+        rem /= slices;
+        const int frame = static_cast<int>(rem);
+        uint8_t value = encode_e4m3(0.0f);
+        if (y < height && x < width) {
+            const size_t src =
+                (((static_cast<size_t>(frame) * slices + slice) * height + y) * width + x) *
+                    kFp8ChannelsPerSlice + lane;
+            value = input[src];
+        }
+        output[idx] = value;
+    }
+}
+
+__global__ void pack_temporal3_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    uint8_t* __restrict__ output,
+    int frames,
+    int t_out,
+    int slices,
+    int height,
+    int width,
+    bool has_cache) {
+    const int out_slices = slices * 3;
+    const long long total =
+        static_cast<long long>(t_out) * out_slices * height * width * kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int out_slice = static_cast<int>(rem % out_slices);
+        rem /= out_slices;
+        const int to = static_cast<int>(rem);
+        const int dt = out_slice / slices;
+        const int slice = out_slice - dt * slices;
+        const int src_ext_t = to * 2 + dt;
+        uint8_t value = encode_e4m3(0.0f);
+        if (has_cache && src_ext_t == 0 && cache != nullptr) {
+            const size_t src =
+                ((static_cast<size_t>(slice) * height + y) * width + x) * kFp8ChannelsPerSlice + lane;
+            value = cache[src];
+        } else {
+            const int src_t = has_cache ? src_ext_t - 1 : src_ext_t;
+            if (src_t >= 0 && src_t < frames) {
+                const size_t src =
+                    (((static_cast<size_t>(src_t) * slices + slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + lane;
+                value = input[src];
+            }
+        }
+        output[idx] = value;
+    }
+}
+
+__global__ void tin16_to_nhwc_kernel(
+    const uint8_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    int frames,
+    int slices,
+    int height,
+    int width) {
+    const int channels = slices * kFp8ChannelsPerSlice;
+    const long long total = static_cast<long long>(frames) * height * width * channels;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int c = static_cast<int>(rem % channels);
+        rem /= channels;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int frame = static_cast<int>(rem);
+        const int slice = c / kFp8ChannelsPerSlice;
+        const int lane = c - slice * kFp8ChannelsPerSlice;
+        const size_t src =
+            (((static_cast<size_t>(frame) * slices + slice) * height + y) * width + x) *
+                kFp8ChannelsPerSlice + lane;
+        output[idx] = input[src];
+    }
+}
+
+__global__ void nhwc_to_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    int frames,
+    int slices,
+    int height,
+    int width) {
+    const int channels = slices * kFp8ChannelsPerSlice;
+    const long long total =
+        static_cast<long long>(frames) * slices * height * width * kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int slice = static_cast<int>(rem % slices);
+        rem /= slices;
+        const int frame = static_cast<int>(rem);
+        const int c = slice * kFp8ChannelsPerSlice + lane;
+        const size_t src = (((static_cast<size_t>(frame) * height + y) * width + x) * channels + c);
+        output[idx] = input[src];
+    }
+}
+
+template <typename SrcScaleT, typename OutScaleT>
+__global__ void nhwc_rescale_to_tin16_kernel(
+    const uint8_t* __restrict__ input,
+    uint8_t* __restrict__ output,
+    const SrcScaleT* __restrict__ source_scale,
+    const OutScaleT* __restrict__ output_scale,
+    int frames,
+    int slices,
+    int height,
+    int width,
+    int source_scale_count,
+    int output_scale_count) {
+    const int channels = slices * kFp8ChannelsPerSlice;
+    const long long total =
+        static_cast<long long>(frames) * slices * height * width * kFp8ChannelsPerSlice;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int lane = static_cast<int>(rem % kFp8ChannelsPerSlice);
+        rem /= kFp8ChannelsPerSlice;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int slice = static_cast<int>(rem % slices);
+        rem /= slices;
+        const int frame = static_cast<int>(rem);
+        const int c = slice * kFp8ChannelsPerSlice + lane;
+        const size_t src = (((static_cast<size_t>(frame) * height + y) * width + x) * channels + c);
+        const int src_scale_idx = source_scale_count == 1 ? 0 : c;
+        const int out_scale_idx = output_scale_count == 1 ? 0 : c;
+        const float src_s = scale_to_float(source_scale, src_scale_idx);
+        const float out_s = fmaxf(scale_to_float(output_scale, out_scale_idx), 1.0e-12f);
+        output[idx] = encode_e4m3(decode_e4m3(input[src]) * src_s / out_s);
+    }
+}
+
+__global__ void pack_causal3_tin16_to_nhwc_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    uint8_t* __restrict__ output,
+    int frames,
+    int cache_frames,
+    int slices,
+    int height,
+    int width) {
+    const int channels = slices * 3 * kFp8ChannelsPerSlice;
+    const long long total = static_cast<long long>(frames) * height * width * channels;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int c = static_cast<int>(rem % channels);
+        rem /= channels;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int frame = static_cast<int>(rem);
+        const int out_slice = c / kFp8ChannelsPerSlice;
+        const int lane = c - out_slice * kFp8ChannelsPerSlice;
+        const int dt = out_slice / slices;
+        const int slice = out_slice - dt * slices;
+        const int src_ext_t = cache_frames + frame + dt - 2;
+        uint8_t value = encode_e4m3(0.0f);
+        if (src_ext_t >= 0 && src_ext_t < cache_frames && cache != nullptr) {
+            const size_t src =
+                (((static_cast<size_t>(src_ext_t) * slices + slice) * height + y) * width + x) *
+                    kFp8ChannelsPerSlice + lane;
+            value = cache[src];
+        } else {
+            const int src_t = src_ext_t - cache_frames;
+            if (src_t >= 0 && src_t < frames) {
+                const size_t src =
+                    (((static_cast<size_t>(src_t) * slices + slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + lane;
+                value = input[src];
+            }
+        }
+        output[idx] = value;
+    }
+}
+
+__global__ void pack_temporal3_tin16_to_nhwc_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    uint8_t* __restrict__ output,
+    int frames,
+    int t_out,
+    int slices,
+    int height,
+    int width,
+    bool has_cache) {
+    const int channels = slices * 3 * kFp8ChannelsPerSlice;
+    const long long total = static_cast<long long>(t_out) * height * width * channels;
+    for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+         idx < total;
+         idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+        long long rem = idx;
+        const int c = static_cast<int>(rem % channels);
+        rem /= channels;
+        const int x = static_cast<int>(rem % width);
+        rem /= width;
+        const int y = static_cast<int>(rem % height);
+        rem /= height;
+        const int to = static_cast<int>(rem);
+        const int out_slice = c / kFp8ChannelsPerSlice;
+        const int lane = c - out_slice * kFp8ChannelsPerSlice;
+        const int dt = out_slice / slices;
+        const int slice = out_slice - dt * slices;
+        const int src_ext_t = to * 2 + dt;
+        uint8_t value = encode_e4m3(0.0f);
+        if (has_cache && src_ext_t == 0 && cache != nullptr) {
+            const size_t src =
+                ((static_cast<size_t>(slice) * height + y) * width + x) * kFp8ChannelsPerSlice + lane;
+            value = cache[src];
+        } else {
+            const int src_t = has_cache ? src_ext_t - 1 : src_ext_t;
+            if (src_t >= 0 && src_t < frames) {
+                const size_t src =
+                    (((static_cast<size_t>(src_t) * slices + slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + lane;
+                value = input[src];
+            }
+        }
+        output[idx] = value;
+    }
+}
+
+template <typename Kernel>
+cudaError_t run_fp8_conv2d(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output,
+    torch::Tensor zeros,
+    torch::Tensor ones,
+    torch::Tensor amax,
+    int stride,
+    int pad,
+    cudaStream_t stream) {
+    using Element = cutlass::float_e4m3_t;
+    using Conv2dOp = cutlass::conv::device::ImplicitGemmConvolution<Kernel>;
+
+    const int n = static_cast<int>(input.size(0));
+    const int h = static_cast<int>(input.size(1));
+    const int w = static_cast<int>(input.size(2));
+    const int c = static_cast<int>(input.size(3));
+    const int k = static_cast<int>(weight.size(0));
+    const int r = static_cast<int>(weight.size(1));
+    const int s = static_cast<int>(weight.size(2));
+    const int p = static_cast<int>(output.size(1));
+    const int q = static_cast<int>(output.size(2));
+
+    cutlass::conv::Conv2dProblemSize problem(
+        n, h, w, c, k, r, s, p, q,
+        pad, pad, stride, stride, 1, 1, cutlass::conv::Mode::kCrossCorrelation);
+    auto layout_a = cutlass::layout::TensorNHWC::packed({problem.N, problem.H, problem.W, problem.C});
+    auto layout_b = cutlass::layout::TensorNHWC::packed({problem.K, problem.R, problem.S, problem.C});
+    auto layout_c = cutlass::layout::TensorNHWC::packed({problem.N, problem.P, problem.Q, problem.K});
+    typename Kernel::TensorRefA ref_a(reinterpret_cast<Element*>(input.template data_ptr<uint8_t>()), layout_a);
+    typename Kernel::TensorRefB ref_b(reinterpret_cast<Element*>(weight.template data_ptr<uint8_t>()), layout_b);
+    typename Kernel::TensorRefC ref_c(reinterpret_cast<Element*>(zeros.template data_ptr<uint8_t>()), layout_c);
+    typename Kernel::TensorRefC ref_d(reinterpret_cast<Element*>(output.template data_ptr<uint8_t>()), layout_c);
+    typename Kernel::Epilogue::OutputOp::Params::ActivationParams activation_params(1.0f, 0.0f);
+    typename Kernel::Epilogue::OutputOp::Params epilogue(
+        activation_params,
+        ones.data_ptr<float>(),
+        ones.data_ptr<float>(),
+        ones.data_ptr<float>(),
+        ones.data_ptr<float>(),
+        ones.data_ptr<float>(),
+        amax.data_ptr<float>(),
+        amax.data_ptr<float>());
+
+    typename Conv2dOp::Arguments args(
+        problem,
+        ref_a,
+        ref_b,
+        ref_c,
+        ref_d,
+        ref_d,
+        epilogue,
+        cutlass::conv::SplitKMode::kSerial,
+        reinterpret_cast<Element*>(zeros.template data_ptr<uint8_t>()),
+        0);
+    Conv2dOp op;
+    cutlass::Status status = op.can_implement(args);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorNotSupported;
+    }
+    size_t workspace_size = Conv2dOp::get_workspace_size(args);
+    torch::Tensor workspace = torch::empty(
+        {static_cast<long long>(workspace_size)},
+        input.options().dtype(torch::kUInt8));
+    status = op.initialize(args, workspace.template data_ptr<uint8_t>(), stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorInitializationError;
+    }
+    status = op(stream);
+    return status == cutlass::Status::kSuccess ? cudaSuccess : cudaErrorUnknown;
+}
+
+template <template <typename T> class ActivationFunctor>
+cudaError_t cutlass_conv2d_fp8_impl(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output,
+    int stride,
+    int pad,
+    cudaStream_t stream) {
+    using Element = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using EpilogueOutputOp = cutlass::epilogue::thread::LinearCombinationGenericWithScalingAndAbsMax<
+        ActivationFunctor,
+        Element,
+        Element,
+        128 / cutlass::sizeof_bits<Element>::value,
+        ElementAccumulator,
+        ElementAccumulator>;
+    using Conv2dKernel = typename cutlass::conv::kernel::DefaultConv2dFpropWithAbsMax<
+        Element, cutlass::layout::TensorNHWC,
+        Element, cutlass::layout::TensorNHWC,
+        Element, cutlass::layout::TensorNHWC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm89,
+        cutlass::gemm::GemmShape<128, 256, 64>,
+        cutlass::gemm::GemmShape<64, 64, 64>,
+        cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOutputOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        3,
+        cutlass::arch::OpMultiplyAddFastAccum,
+        cutlass::conv::IteratorAlgorithm::kOptimized>::Kernel;
+
+    const auto u8_opts = input.options().dtype(torch::kUInt8);
+    torch::Tensor zeros = torch::zeros({std::max<int64_t>(output.numel(), weight.size(0))}, u8_opts);
+    torch::Tensor ones = torch::ones({1}, input.options().dtype(torch::kFloat32));
+    torch::Tensor amax = torch::zeros({1}, input.options().dtype(torch::kFloat32));
+    return run_fp8_conv2d<Conv2dKernel>(input, weight, output, zeros, ones, amax, stride, pad, stream);
+}
+
+cudaError_t cutlass_conv2d_fp8_plain_impl(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output,
+    int stride,
+    int pad,
+    cudaStream_t stream) {
+    using Element = cutlass::float_e4m3_t;
+    using ElementAccumulator = float;
+    using EpilogueOutputOp = cutlass::epilogue::thread::LinearCombination<
+        Element,
+        128 / cutlass::sizeof_bits<Element>::value,
+        ElementAccumulator,
+        ElementAccumulator>;
+    using Conv2dKernel = typename cutlass::conv::kernel::DefaultConv2dFprop<
+        Element, cutlass::layout::TensorNHWC,
+        Element, cutlass::layout::TensorNHWC,
+        Element, cutlass::layout::TensorNHWC,
+        ElementAccumulator,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm89,
+        cutlass::gemm::GemmShape<128, 256, 64>,
+        cutlass::gemm::GemmShape<64, 64, 64>,
+        cutlass::gemm::GemmShape<16, 8, 32>,
+        EpilogueOutputOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        3,
+        cutlass::arch::OpMultiplyAddFastAccum,
+        cutlass::conv::IteratorAlgorithm::kOptimized>::Kernel;
+    using Conv2dOp = cutlass::conv::device::ImplicitGemmConvolution<Conv2dKernel>;
+
+    const int n = static_cast<int>(input.size(0));
+    const int h = static_cast<int>(input.size(1));
+    const int w = static_cast<int>(input.size(2));
+    const int c = static_cast<int>(input.size(3));
+    const int k = static_cast<int>(weight.size(0));
+    const int r = static_cast<int>(weight.size(1));
+    const int s = static_cast<int>(weight.size(2));
+    const int p = static_cast<int>(output.size(1));
+    const int q = static_cast<int>(output.size(2));
+
+    cutlass::conv::Conv2dProblemSize problem(
+        n, h, w, c, k, r, s, p, q,
+        pad, pad, stride, stride, 1, 1, cutlass::conv::Mode::kCrossCorrelation);
+    auto layout_a = cutlass::layout::TensorNHWC::packed({problem.N, problem.H, problem.W, problem.C});
+    auto layout_b = cutlass::layout::TensorNHWC::packed({problem.K, problem.R, problem.S, problem.C});
+    auto layout_c = cutlass::layout::TensorNHWC::packed({problem.N, problem.P, problem.Q, problem.K});
+    typename Conv2dKernel::TensorRefA ref_a(reinterpret_cast<Element*>(input.template data_ptr<uint8_t>()), layout_a);
+    typename Conv2dKernel::TensorRefB ref_b(reinterpret_cast<Element*>(weight.template data_ptr<uint8_t>()), layout_b);
+    typename Conv2dKernel::TensorRefC ref_c(reinterpret_cast<Element*>(output.template data_ptr<uint8_t>()), layout_c);
+    typename Conv2dKernel::TensorRefC ref_d(reinterpret_cast<Element*>(output.template data_ptr<uint8_t>()), layout_c);
+    typename Conv2dKernel::Epilogue::OutputOp::Params epilogue(
+        ElementAccumulator(1.0f),
+        ElementAccumulator(0.0f));
+
+    typename Conv2dOp::Arguments args(
+        problem,
+        ref_a,
+        ref_b,
+        ref_c,
+        ref_d,
+        epilogue,
+        cutlass::conv::SplitKMode::kSerial);
+    Conv2dOp op;
+    cutlass::Status status = op.can_implement(args);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorNotSupported;
+    }
+    size_t workspace_size = Conv2dOp::get_workspace_size(args);
+    torch::Tensor workspace;
+    void* workspace_ptr = nullptr;
+    if (workspace_size > 0) {
+        workspace = torch::empty(
+            {static_cast<long long>(workspace_size)},
+            input.options().dtype(torch::kUInt8));
+        workspace_ptr = workspace.template data_ptr<uint8_t>();
+    }
+    status = op.initialize(args, workspace_ptr, stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorInitializationError;
+    }
+    status = op(stream);
+    return status == cutlass::Status::kSuccess ? cudaSuccess : cudaErrorUnknown;
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_quantize_bcthw_to_tin16(
+    torch::Tensor input,
+    torch::Tensor scale,
+    int padded_height,
+    int padded_width,
+    int padded_channels) {
+    const int channels = static_cast<int>(input.size(1));
+    const int frames = static_cast<int>(input.size(2));
+    const int height = static_cast<int>(input.size(3));
+    const int width = static_cast<int>(input.size(4));
+    auto output = torch::empty(
+        {frames, padded_channels / kFp8ChannelsPerSlice, padded_height, padded_width, kFp8ChannelsPerSlice},
+        input.options().dtype(torch::kUInt8));
+    if (channels == 3 && padded_channels == 32) {
+        const long long pixels = static_cast<long long>(frames) * padded_height * padded_width;
+        quantize_rgb_bcthw_to_tin16_kernel<ScaleT><<<
+            launch_blocks(pixels), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+            half_ptr_const(input),
+            output.template data_ptr<uint8_t>(),
+            reinterpret_cast<const ScaleT*>(scale.data_ptr()),
+            frames,
+            height,
+            width,
+            padded_height,
+            padded_width,
+            static_cast<int>(scale.numel()));
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        return output;
+    }
+    const long long total = output.numel();
+    quantize_bcthw_to_tin16_kernel<ScaleT><<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        half_ptr_const(input),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const ScaleT*>(scale.data_ptr()),
+        channels,
+        frames,
+        height,
+        width,
+        padded_channels,
+        padded_height,
+        padded_width,
+        static_cast<int>(scale.numel()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_dequantize_tin16_to_bcthw(
+    torch::Tensor input,
+    torch::Tensor scale,
+    int real_channels,
+    int real_height,
+    int real_width) {
+    const int frames = static_cast<int>(input.size(0));
+    const int padded_channels = static_cast<int>(input.size(1) * input.size(4));
+    const int padded_height = static_cast<int>(input.size(2));
+    const int padded_width = static_cast<int>(input.size(3));
+    auto output = torch::empty(
+        {1, real_channels, frames, real_height, real_width},
+        input.options().dtype(torch::kFloat16));
+    const long long total = output.numel();
+    dequantize_tin16_to_bcthw_kernel<ScaleT><<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        half_ptr(output),
+        reinterpret_cast<const ScaleT*>(scale.data_ptr()),
+        real_channels,
+        frames,
+        padded_channels,
+        padded_height,
+        padded_width,
+        real_height,
+        real_width,
+        static_cast<int>(scale.numel()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <int Channels, typename InScaleT, typename OutScaleT>
+torch::Tensor dispatch_rmsnorm_tin16(
+    torch::Tensor input,
+    torch::Tensor input_scale,
+    torch::Tensor gamma,
+    torch::Tensor output_scale,
+    int real_channels,
+    bool silu) {
+    auto output = torch::empty_like(input);
+    constexpr int warps_per_block = (Channels <= 96) ? 4 : 2;
+    const int frames = static_cast<int>(input.size(0));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    const int spatial_count = height * width;
+    rmsnorm_tin16_kernel<Channels, InScaleT, OutScaleT><<<
+        dim3((spatial_count + warps_per_block - 1) / warps_per_block, frames),
+        warps_per_block * 32,
+        0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const InScaleT*>(input_scale.data_ptr()),
+        half_ptr_const(gamma),
+        reinterpret_cast<const OutScaleT*>(output_scale.data_ptr()),
+        frames,
+        height,
+        width,
+        real_channels,
+        static_cast<int>(input_scale.numel()),
+        static_cast<int>(output_scale.numel()),
+        silu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <typename AScaleT, typename BScaleT, typename OutScaleT>
+torch::Tensor dispatch_add_tin16(
+    torch::Tensor a,
+    torch::Tensor b,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    torch::Tensor output_scale,
+    int real_channels,
+    bool relu) {
+    auto output = torch::empty_like(a);
+    const int slices = static_cast<int>(a.size(1));
+    const int height = static_cast<int>(a.size(2));
+    const int width = static_cast<int>(a.size(3));
+    const long long total = a.numel();
+    add_tin16_pack_kernel<AScaleT, BScaleT, OutScaleT><<<
+        launch_blocks((total + kFp8ChannelsPerSlice - 1) / kFp8ChannelsPerSlice),
+        256,
+        0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        a.template data_ptr<uint8_t>(),
+        b.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const AScaleT*>(a_scale.data_ptr()),
+        reinterpret_cast<const BScaleT*>(b_scale.data_ptr()),
+        reinterpret_cast<const OutScaleT*>(output_scale.data_ptr()),
+        total,
+        slices,
+        height,
+        width,
+        real_channels,
+        static_cast<int>(a_scale.numel()),
+        static_cast<int>(b_scale.numel()),
+        static_cast<int>(output_scale.numel()),
+        relu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_extract_mu_normalize_tin16(
+    torch::Tensor input,
+    torch::Tensor input_scale,
+    torch::Tensor mean,
+    torch::Tensor inv_std,
+    int real_height,
+    int real_width) {
+    const int frames = static_cast<int>(input.size(0));
+    const int padded_height = static_cast<int>(input.size(2));
+    const int padded_width = static_cast<int>(input.size(3));
+    auto output = torch::empty({1, 16, frames, real_height, real_width}, input.options().dtype(torch::kFloat16));
+    const long long total = output.numel();
+    extract_mu_normalize_kernel<ScaleT><<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        half_ptr(output),
+        reinterpret_cast<const ScaleT*>(input_scale.data_ptr()),
+        half_ptr_const(mean),
+        half_ptr_const(inv_std),
+        frames,
+        padded_height,
+        padded_width,
+        real_height,
+        real_width,
+        static_cast<int>(input_scale.numel()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+}  // namespace
+
+torch::Tensor lightvae_fp8_quantize_bcthw_to_tin16(
+    torch::Tensor input,
+    torch::Tensor scale,
+    int padded_height,
+    int padded_width,
+    int padded_channels) {
+    check_half_cuda_contiguous(input, "input");
+    check_scale_cuda_contiguous(scale, "scale");
+    TORCH_CHECK(input.dim() == 5 && input.size(0) == 1, "input must be [1,C,T,H,W], got ", input.sizes());
+    TORCH_CHECK(padded_channels % kFp8ChannelsPerSlice == 0,
+                "padded_channels must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(input.size(1) <= padded_channels, "padded_channels is smaller than input channels");
+    TORCH_CHECK(padded_height >= input.size(3) && padded_width >= input.size(4),
+                "padded spatial shape must cover input shape");
+    TORCH_CHECK(scale.numel() == 1 || scale.numel() == input.size(1),
+                "scale must be scalar or have one entry per real input channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto scale_c = scale.to(input.device(), scale.scalar_type(), false, true).contiguous();
+    if (scale_c.scalar_type() == at::kHalf) {
+        return dispatch_quantize_bcthw_to_tin16<half>(
+            input_c, scale_c, padded_height, padded_width, padded_channels);
+    }
+    return dispatch_quantize_bcthw_to_tin16<float>(
+        input_c, scale_c, padded_height, padded_width, padded_channels);
+}
+
+torch::Tensor lightvae_fp8_dequantize_tin16_to_bcthw(
+    torch::Tensor input,
+    torch::Tensor scale,
+    int real_channels,
+    int real_height,
+    int real_width) {
+    check_u8_cuda_contiguous(input, "input");
+    check_scale_cuda_contiguous(scale, "scale");
+    TORCH_CHECK(input.dim() == 5 && input.size(4) == kFp8ChannelsPerSlice,
+                "input must be [T,C/16,H,W,16], got ", input.sizes());
+    TORCH_CHECK(real_channels > 0 && real_channels <= input.size(1) * input.size(4),
+                "real_channels out of range");
+    TORCH_CHECK(real_height > 0 && real_height <= input.size(2) &&
+                    real_width > 0 && real_width <= input.size(3),
+                "real spatial shape must be within the padded tensor");
+    TORCH_CHECK(scale.numel() == 1 || scale.numel() == real_channels,
+                "scale must be scalar or have one entry per real output channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto scale_c = scale.to(input.device(), scale.scalar_type(), false, true).contiguous();
+    if (scale_c.scalar_type() == at::kHalf) {
+        return dispatch_dequantize_tin16_to_bcthw<half>(
+            input_c, scale_c, real_channels, real_height, real_width);
+    }
+    return dispatch_dequantize_tin16_to_bcthw<float>(
+        input_c, scale_c, real_channels, real_height, real_width);
+}
+
+torch::Tensor lightvae_fp8_rmsnorm_tin16(
+    torch::Tensor input,
+    torch::Tensor input_scale,
+    torch::Tensor gamma,
+    torch::Tensor output_scale,
+    int real_channels,
+    bool silu) {
+    check_u8_cuda_contiguous(input, "input");
+    check_scale_cuda_contiguous(input_scale, "input_scale");
+    check_half_cuda_contiguous(gamma, "gamma");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(input.dim() == 5 && input.size(4) == kFp8ChannelsPerSlice,
+                "input must be [T,C/16,H,W,16], got ", input.sizes());
+    const int channels = static_cast<int>(input.size(1) * input.size(4));
+    TORCH_CHECK(channels == 32 || channels == 48 || channels == 64 || channels == 96 || channels == 192 ||
+                    channels == 288,
+                "unsupported LightVAE FP8 RMSNorm padded channel count ", channels);
+    TORCH_CHECK(real_channels > 0 && real_channels <= channels, "real_channels out of range");
+    TORCH_CHECK(gamma.numel() >= real_channels, "gamma must have at least real_channels entries");
+    TORCH_CHECK(input_scale.numel() == 1 || input_scale.numel() == real_channels,
+                "input_scale must be scalar or per real channel");
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == real_channels,
+                "output_scale must be scalar or per real channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto gamma_c = gamma.contiguous();
+    auto in_s = input_scale.to(input.device(), input_scale.scalar_type(), false, true).contiguous();
+    auto out_s = output_scale.to(input.device(), output_scale.scalar_type(), false, true).contiguous();
+
+#define DISPATCH_RMS(CH, IN_T, OUT_T) \
+    dispatch_rmsnorm_tin16<CH, IN_T, OUT_T>(input_c, in_s, gamma_c, out_s, real_channels, silu)
+#define DISPATCH_RMS_IN(CH, IN_T) \
+    (out_s.scalar_type() == at::kHalf ? DISPATCH_RMS(CH, IN_T, half) : DISPATCH_RMS(CH, IN_T, float))
+#define DISPATCH_RMS_CH(CH) \
+    (in_s.scalar_type() == at::kHalf ? DISPATCH_RMS_IN(CH, half) : DISPATCH_RMS_IN(CH, float))
+    switch (channels) {
+        case 32: return DISPATCH_RMS_CH(32);
+        case 48: return DISPATCH_RMS_CH(48);
+        case 64: return DISPATCH_RMS_CH(64);
+        case 96: return DISPATCH_RMS_CH(96);
+        case 192: return DISPATCH_RMS_CH(192);
+        case 288: return DISPATCH_RMS_CH(288);
+        default: TORCH_CHECK(false, "unsupported channel count");
+    }
+#undef DISPATCH_RMS_CH
+#undef DISPATCH_RMS_IN
+#undef DISPATCH_RMS
+}
+
+torch::Tensor lightvae_fp8_add_tin16(
+    torch::Tensor a,
+    torch::Tensor b,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    torch::Tensor output_scale,
+    int real_channels) {
+    check_u8_cuda_contiguous(a, "a");
+    check_u8_cuda_contiguous(b, "b");
+    check_scale_cuda_contiguous(a_scale, "a_scale");
+    check_scale_cuda_contiguous(b_scale, "b_scale");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(a.sizes() == b.sizes(), "a and b shapes must match");
+    TORCH_CHECK(a.dim() == 5 && a.size(4) == kFp8ChannelsPerSlice,
+                "inputs must be [T,C/16,H,W,16], got ", a.sizes());
+    const int channels = static_cast<int>(a.size(1) * a.size(4));
+    if (real_channels < 0) {
+        real_channels = channels;
+    }
+    TORCH_CHECK(real_channels > 0 && real_channels <= channels, "real_channels out of range");
+    TORCH_CHECK(a_scale.numel() == 1 || a_scale.numel() == real_channels,
+                "a_scale must be scalar or per real channel");
+    TORCH_CHECK(b_scale.numel() == 1 || b_scale.numel() == real_channels,
+                "b_scale must be scalar or per real channel");
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == real_channels,
+                "output_scale must be scalar or per real channel");
+    at::cuda::CUDAGuard guard(a.device());
+    auto a_c = a.contiguous();
+    auto b_c = b.contiguous();
+    auto as = a_scale.to(a.device(), a_scale.scalar_type(), false, true).contiguous();
+    auto bs = b_scale.to(a.device(), b_scale.scalar_type(), false, true).contiguous();
+    auto os = output_scale.to(a.device(), output_scale.scalar_type(), false, true).contiguous();
+
+#define DISPATCH_ADD(A_T, B_T, O_T) \
+    dispatch_add_tin16<A_T, B_T, O_T>(a_c, b_c, as, bs, os, real_channels, false)
+#define DISPATCH_ADD_O(A_T, B_T) \
+    (os.scalar_type() == at::kHalf ? DISPATCH_ADD(A_T, B_T, half) : DISPATCH_ADD(A_T, B_T, float))
+#define DISPATCH_ADD_B(A_T) \
+    (bs.scalar_type() == at::kHalf ? DISPATCH_ADD_O(A_T, half) : DISPATCH_ADD_O(A_T, float))
+    return as.scalar_type() == at::kHalf ? DISPATCH_ADD_B(half) : DISPATCH_ADD_B(float);
+#undef DISPATCH_ADD_B
+#undef DISPATCH_ADD_O
+#undef DISPATCH_ADD
+}
+
+torch::Tensor lightvae_fp8_add_relu_tin16(
+    torch::Tensor a,
+    torch::Tensor b,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    torch::Tensor output_scale,
+    int real_channels) {
+    check_u8_cuda_contiguous(a, "a");
+    check_u8_cuda_contiguous(b, "b");
+    check_scale_cuda_contiguous(a_scale, "a_scale");
+    check_scale_cuda_contiguous(b_scale, "b_scale");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(a.sizes() == b.sizes(), "a and b shapes must match");
+    TORCH_CHECK(a.dim() == 5 && a.size(4) == kFp8ChannelsPerSlice,
+                "inputs must be [T,C/16,H,W,16], got ", a.sizes());
+    const int channels = static_cast<int>(a.size(1) * a.size(4));
+    if (real_channels < 0) {
+        real_channels = channels;
+    }
+    TORCH_CHECK(real_channels > 0 && real_channels <= channels, "real_channels out of range");
+    TORCH_CHECK(a_scale.numel() == 1 || a_scale.numel() == real_channels,
+                "a_scale must be scalar or per real channel");
+    TORCH_CHECK(b_scale.numel() == 1 || b_scale.numel() == real_channels,
+                "b_scale must be scalar or per real channel");
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == real_channels,
+                "output_scale must be scalar or per real channel");
+    at::cuda::CUDAGuard guard(a.device());
+    auto a_c = a.contiguous();
+    auto b_c = b.contiguous();
+    auto as = a_scale.to(a.device(), a_scale.scalar_type(), false, true).contiguous();
+    auto bs = b_scale.to(a.device(), b_scale.scalar_type(), false, true).contiguous();
+    auto os = output_scale.to(a.device(), output_scale.scalar_type(), false, true).contiguous();
+
+#define DISPATCH_ADD_RELU(A_T, B_T, O_T) \
+    dispatch_add_tin16<A_T, B_T, O_T>(a_c, b_c, as, bs, os, real_channels, true)
+#define DISPATCH_ADD_RELU_O(A_T, B_T) \
+    (os.scalar_type() == at::kHalf ? DISPATCH_ADD_RELU(A_T, B_T, half) : DISPATCH_ADD_RELU(A_T, B_T, float))
+#define DISPATCH_ADD_RELU_B(A_T) \
+    (bs.scalar_type() == at::kHalf ? DISPATCH_ADD_RELU_O(A_T, half) : DISPATCH_ADD_RELU_O(A_T, float))
+    return as.scalar_type() == at::kHalf ? DISPATCH_ADD_RELU_B(half) : DISPATCH_ADD_RELU_B(float);
+#undef DISPATCH_ADD_RELU_B
+#undef DISPATCH_ADD_RELU_O
+#undef DISPATCH_ADD_RELU
+}
+
+torch::Tensor lightvae_fp8_add_relu_nhwc_tin16_to_tin16(
+    torch::Tensor a_nhwc,
+    torch::Tensor b_tin16,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    torch::Tensor output_scale,
+    int real_channels) {
+    check_u8_cuda_contiguous(a_nhwc, "a_nhwc");
+    check_u8_cuda_contiguous(b_tin16, "b_tin16");
+    check_scale_cuda_contiguous(a_scale, "a_scale");
+    check_scale_cuda_contiguous(b_scale, "b_scale");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(a_nhwc.dim() == 4, "a_nhwc must be [T,H,W,C], got ", a_nhwc.sizes());
+    TORCH_CHECK(b_tin16.dim() == 5 && b_tin16.size(4) == kFp8ChannelsPerSlice,
+                "b_tin16 must be [T,C/16,H,W,16], got ", b_tin16.sizes());
+    const int channels = static_cast<int>(b_tin16.size(1) * b_tin16.size(4));
+    TORCH_CHECK(a_nhwc.size(0) == b_tin16.size(0) && a_nhwc.size(1) == b_tin16.size(2) &&
+                    a_nhwc.size(2) == b_tin16.size(3) && a_nhwc.size(3) == channels,
+                "a_nhwc shape must match b_tin16 as [T,H,W,C]");
+    if (real_channels < 0) {
+        real_channels = channels;
+    }
+    TORCH_CHECK(real_channels > 0 && real_channels <= channels, "real_channels out of range");
+    TORCH_CHECK(a_scale.numel() == 1 || a_scale.numel() == real_channels,
+                "a_scale must be scalar or per real channel");
+    TORCH_CHECK(b_scale.numel() == 1 || b_scale.numel() == real_channels,
+                "b_scale must be scalar or per real channel");
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == real_channels,
+                "output_scale must be scalar or per real channel");
+    at::cuda::CUDAGuard guard(b_tin16.device());
+    auto a_c = a_nhwc.contiguous();
+    auto b_c = b_tin16.contiguous();
+    auto as = a_scale.to(b_tin16.device(), a_scale.scalar_type(), false, true).contiguous();
+    auto bs = b_scale.to(b_tin16.device(), b_scale.scalar_type(), false, true).contiguous();
+    auto os = output_scale.to(b_tin16.device(), output_scale.scalar_type(), false, true).contiguous();
+    auto output = torch::empty_like(b_c);
+
+#define DISPATCH_ADD_NHWC(A_T, B_T, O_T) \
+    add_relu_nhwc_tin16_to_tin16_kernel<A_T, B_T, O_T><<< \
+        launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>( \
+        a_c.template data_ptr<uint8_t>(), b_c.template data_ptr<uint8_t>(), output.template data_ptr<uint8_t>(), \
+        reinterpret_cast<const A_T*>(as.data_ptr()), reinterpret_cast<const B_T*>(bs.data_ptr()), \
+        reinterpret_cast<const O_T*>(os.data_ptr()), output.numel(), static_cast<int>(b_c.size(1)), \
+        static_cast<int>(b_c.size(2)), static_cast<int>(b_c.size(3)), real_channels, \
+        static_cast<int>(as.numel()), static_cast<int>(bs.numel()), static_cast<int>(os.numel()))
+#define DISPATCH_ADD_NHWC_O(A_T, B_T) \
+    (os.scalar_type() == at::kHalf ? DISPATCH_ADD_NHWC(A_T, B_T, half) : DISPATCH_ADD_NHWC(A_T, B_T, float))
+#define DISPATCH_ADD_NHWC_B(A_T) \
+    (bs.scalar_type() == at::kHalf ? DISPATCH_ADD_NHWC_O(A_T, half) : DISPATCH_ADD_NHWC_O(A_T, float))
+    as.scalar_type() == at::kHalf ? DISPATCH_ADD_NHWC_B(half) : DISPATCH_ADD_NHWC_B(float);
+#undef DISPATCH_ADD_NHWC_B
+#undef DISPATCH_ADD_NHWC_O
+#undef DISPATCH_ADD_NHWC
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_upsample2x_tin16(torch::Tensor input) {
+    check_tin16_cuda_contiguous(input, "input");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    auto output = torch::empty(
+        {frames, slices, height * 2, width * 2, kFp8ChannelsPerSlice},
+        input_c.options());
+    const long long total = output.numel();
+    upsample2x_tin16_kernel<<<launch_blocks(total), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        total,
+        frames,
+        slices,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_extract_mu_normalize_tin16(
+    torch::Tensor input,
+    torch::Tensor input_scale,
+    torch::Tensor mean,
+    torch::Tensor inv_std,
+    int real_height,
+    int real_width) {
+    check_u8_cuda_contiguous(input, "input");
+    check_scale_cuda_contiguous(input_scale, "input_scale");
+    check_half_cuda_contiguous(mean, "mean");
+    check_half_cuda_contiguous(inv_std, "inv_std");
+    TORCH_CHECK(input.dim() == 5 && input.size(1) >= 2 && input.size(4) == kFp8ChannelsPerSlice,
+                "input must be [T,C/16,H,W,16] with at least 32 padded channels, got ", input.sizes());
+    TORCH_CHECK(mean.numel() >= 16 && inv_std.numel() >= 16, "mean and inv_std must have at least 16 entries");
+    TORCH_CHECK(input_scale.numel() == 1 || input_scale.numel() >= 16,
+                "input_scale must be scalar or have at least 16 entries");
+    TORCH_CHECK(real_height > 0 && real_height <= input.size(2) &&
+                    real_width > 0 && real_width <= input.size(3),
+                "real spatial shape must be within the padded tensor");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto in_s = input_scale.to(input.device(), input_scale.scalar_type(), false, true).contiguous();
+    auto mean_c = mean.contiguous();
+    auto inv_std_c = inv_std.contiguous();
+    if (in_s.scalar_type() == at::kHalf) {
+        return dispatch_extract_mu_normalize_tin16<half>(
+            input_c, in_s, mean_c, inv_std_c, real_height, real_width);
+    }
+    return dispatch_extract_mu_normalize_tin16<float>(
+        input_c, in_s, mean_c, inv_std_c, real_height, real_width);
+}
+
+torch::Tensor cutlass_conv3x3_nhwc_fp8(
+    torch::Tensor input,
+    torch::Tensor weight,
+    int stride,
+    int pad,
+    bool relu) {
+    check_u8_cuda_contiguous(input, "input");
+    check_u8_cuda_contiguous(weight, "weight");
+    TORCH_CHECK(input.dim() == 4, "input must be NHWC [N,H,W,C], got ", input.sizes());
+    TORCH_CHECK(weight.dim() == 4, "weight must be KRSC [K,R,S,C], got ", weight.sizes());
+    TORCH_CHECK(weight.size(1) == 3 && weight.size(2) == 3, "weight must be 3x3");
+    TORCH_CHECK(input.size(3) == weight.size(3), "weight C must match input C");
+    TORCH_CHECK(input.size(3) % 16 == 0 && weight.size(0) % 16 == 0,
+                "FP8 Conv2D requires C and K divisible by 16");
+    TORCH_CHECK(stride > 0 && pad >= 0, "invalid stride/pad");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto weight_c = weight.contiguous();
+    const int n = static_cast<int>(input_c.size(0));
+    const int h = static_cast<int>(input_c.size(1));
+    const int w = static_cast<int>(input_c.size(2));
+    const int k = static_cast<int>(weight_c.size(0));
+    const int h_out = (h + 2 * pad - 3) / stride + 1;
+    const int w_out = (w + 2 * pad - 3) / stride + 1;
+    TORCH_CHECK(h_out > 0 && w_out > 0, "invalid output shape");
+    auto output = torch::empty({n, h_out, w_out, k}, input_c.options());
+    cudaError_t err = relu
+        ? cutlass_conv2d_fp8_impl<cutlass::epilogue::thread::ReLu>(
+              input_c, weight_c, output, stride, pad, at::cuda::getCurrentCUDAStream())
+        : cutlass_conv2d_fp8_impl<cutlass::epilogue::thread::Identity>(
+              input_c, weight_c, output, stride, pad, at::cuda::getCurrentCUDAStream());
+    TORCH_CHECK(err == cudaSuccess, "CUTLASS FP8 Conv2D failed: ", cudaGetErrorString(err));
+    return output;
+}
+
+template <typename InScaleT, typename OutScaleT>
+torch::Tensor dispatch_prepare_conv2d_weight_krsc(
+    torch::Tensor weight_krsc,
+    torch::Tensor input_scale,
+    torch::Tensor output_scale) {
+    auto output = torch::empty(weight_krsc.sizes(), weight_krsc.options().dtype(torch::kUInt8));
+    prepare_conv2d_weight_krsc_kernel<InScaleT, OutScaleT><<<
+        launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        half_ptr_const(weight_krsc),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const InScaleT*>(input_scale.data_ptr()),
+        reinterpret_cast<const OutScaleT*>(output_scale.data_ptr()),
+        output.numel(),
+        static_cast<int>(weight_krsc.size(3)),
+        static_cast<int>(weight_krsc.size(0)),
+        static_cast<int>(weight_krsc.size(1)),
+        static_cast<int>(weight_krsc.size(2)),
+        static_cast<int>(input_scale.numel()),
+        static_cast<int>(output_scale.numel()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <typename OutScaleT>
+void dispatch_add_bias_act_fp8_nhwc(
+    torch::Tensor output,
+    torch::Tensor bias,
+    torch::Tensor output_scale,
+    bool relu) {
+    add_bias_act_fp8_nhwc_kernel<OutScaleT><<<
+        launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        output.template data_ptr<uint8_t>(),
+        half_ptr_const(bias),
+        reinterpret_cast<const OutScaleT*>(output_scale.data_ptr()),
+        output.numel(),
+        static_cast<int>(output.size(3)),
+        static_cast<int>(output_scale.numel()),
+        relu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename SrcScaleT, typename OutScaleT>
+torch::Tensor dispatch_nhwc_rescale_to_tin16(
+    torch::Tensor input,
+    torch::Tensor source_scale,
+    torch::Tensor output_scale) {
+    const int frames = static_cast<int>(input.size(0));
+    const int height = static_cast<int>(input.size(1));
+    const int width = static_cast<int>(input.size(2));
+    const int slices = static_cast<int>(input.size(3) / kFp8ChannelsPerSlice);
+    auto output = torch::empty({frames, slices, height, width, kFp8ChannelsPerSlice}, input.options());
+    nhwc_rescale_to_tin16_kernel<SrcScaleT, OutScaleT><<<
+        launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        reinterpret_cast<const SrcScaleT*>(source_scale.data_ptr()),
+        reinterpret_cast<const OutScaleT*>(output_scale.data_ptr()),
+        frames,
+        slices,
+        height,
+        width,
+        static_cast<int>(source_scale.numel()),
+        static_cast<int>(output_scale.numel()));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_prepare_conv2d_weight_krsc(
+    torch::Tensor weight_krsc,
+    torch::Tensor input_scale,
+    torch::Tensor output_scale) {
+    check_half_cuda_contiguous(weight_krsc, "weight_krsc");
+    check_scale_cuda_contiguous(input_scale, "input_scale");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(weight_krsc.dim() == 4, "weight_krsc must be [K,R,S,C], got ", weight_krsc.sizes());
+    TORCH_CHECK(weight_krsc.size(1) > 0 && weight_krsc.size(2) > 0,
+                "weight spatial shape must be non-empty");
+    TORCH_CHECK(weight_krsc.size(3) % 16 == 0 && weight_krsc.size(0) % 16 == 0,
+                "FP8 Conv2D requires C and K divisible by 16");
+    TORCH_CHECK(input_scale.numel() == 1 || input_scale.numel() == weight_krsc.size(3),
+                "input_scale must be scalar or have one entry per prepared input channel");
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight_krsc.size(0),
+                "output_scale must be scalar or have one entry per prepared output channel");
+    at::cuda::CUDAGuard guard(weight_krsc.device());
+    auto w = weight_krsc.contiguous();
+    auto in_s = input_scale.to(w.device(), input_scale.scalar_type(), false, true).contiguous();
+    auto out_s = output_scale.to(w.device(), output_scale.scalar_type(), false, true).contiguous();
+
+#define DISPATCH_PREP(IN_T, OUT_T) dispatch_prepare_conv2d_weight_krsc<IN_T, OUT_T>(w, in_s, out_s)
+#define DISPATCH_PREP_OUT(IN_T) \
+    (out_s.scalar_type() == at::kHalf ? DISPATCH_PREP(IN_T, half) : DISPATCH_PREP(IN_T, float))
+    return in_s.scalar_type() == at::kHalf ? DISPATCH_PREP_OUT(half) : DISPATCH_PREP_OUT(float);
+#undef DISPATCH_PREP_OUT
+#undef DISPATCH_PREP
+}
+
+torch::Tensor cutlass_conv2d_nhwc_fp8_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu) {
+    check_u8_cuda_contiguous(input, "input");
+    check_u8_cuda_contiguous(weight, "weight");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(input.dim() == 4, "input must be NHWC [N,H,W,C], got ", input.sizes());
+    TORCH_CHECK(weight.dim() == 4, "weight must be KRSC [K,R,S,C], got ", weight.sizes());
+    TORCH_CHECK(weight.size(1) > 0 && weight.size(2) > 0,
+                "weight spatial shape must be non-empty");
+    TORCH_CHECK(input.size(3) == weight.size(3), "weight C must match input C");
+    TORCH_CHECK(input.size(3) % 16 == 0 && weight.size(0) % 16 == 0,
+                "FP8 Conv2D requires C and K divisible by 16");
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight.size(0),
+                "output_scale must be scalar or have one entry per output channel");
+    TORCH_CHECK(stride > 0 && pad >= 0, "invalid stride/pad");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto weight_c = weight.contiguous();
+    auto out_s = output_scale.to(input.device(), output_scale.scalar_type(), false, true).contiguous();
+    const int n = static_cast<int>(input_c.size(0));
+    const int h = static_cast<int>(input_c.size(1));
+    const int w = static_cast<int>(input_c.size(2));
+    const int k = static_cast<int>(weight_c.size(0));
+    const int r = static_cast<int>(weight_c.size(1));
+    const int s = static_cast<int>(weight_c.size(2));
+    const int h_out = (h + 2 * pad - r) / stride + 1;
+    const int w_out = (w + 2 * pad - s) / stride + 1;
+    TORCH_CHECK(h_out > 0 && w_out > 0, "invalid output shape");
+    auto output = torch::empty({n, h_out, w_out, k}, input_c.options());
+    cudaError_t err = cutlass_conv2d_fp8_plain_impl(
+        input_c, weight_c, output, stride, pad, at::cuda::getCurrentCUDAStream());
+    TORCH_CHECK(err == cudaSuccess, "CUTLASS FP8 Conv2D failed: ", cudaGetErrorString(err));
+
+    if (bias.has_value() && bias.value().defined()) {
+        auto b = bias.value();
+        check_half_cuda_contiguous(b, "bias");
+        TORCH_CHECK(b.numel() == k, "bias must have one entry per output channel");
+        auto b_c = b.contiguous();
+        if (out_s.scalar_type() == at::kHalf) {
+            dispatch_add_bias_act_fp8_nhwc<half>(output, b_c, out_s, relu);
+        } else {
+            dispatch_add_bias_act_fp8_nhwc<float>(output, b_c, out_s, relu);
+        }
+    } else if (relu) {
+        auto zero_bias = torch::zeros({k}, input_c.options().dtype(torch::kFloat16));
+        if (out_s.scalar_type() == at::kHalf) {
+            dispatch_add_bias_act_fp8_nhwc<half>(output, zero_bias, out_s, true);
+        } else {
+            dispatch_add_bias_act_fp8_nhwc<float>(output, zero_bias, out_s, true);
+        }
+    }
+    return output;
+}
+
+torch::Tensor lightvae_fp8_tin16_to_nhwc(torch::Tensor input) {
+    check_tin16_cuda_contiguous(input, "input");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    auto output = torch::empty(
+        {frames, height, width, slices * kFp8ChannelsPerSlice},
+        input_c.options());
+    tin16_to_nhwc_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        frames,
+        slices,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_nhwc_to_tin16(torch::Tensor input) {
+    check_u8_cuda_contiguous(input, "input");
+    TORCH_CHECK(input.dim() == 4, "input must be NHWC [N,H,W,C], got ", input.sizes());
+    TORCH_CHECK(input.size(3) % kFp8ChannelsPerSlice == 0,
+                "input channel count must be divisible by ", kFp8ChannelsPerSlice);
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int height = static_cast<int>(input_c.size(1));
+    const int width = static_cast<int>(input_c.size(2));
+    const int slices = static_cast<int>(input_c.size(3) / kFp8ChannelsPerSlice);
+    auto output = torch::empty(
+        {frames, slices, height, width, kFp8ChannelsPerSlice},
+        input_c.options());
+    nhwc_to_tin16_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        frames,
+        slices,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_pack_causal3_tin16(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache) {
+    check_tin16_cuda_contiguous(input, "input");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    const uint8_t* cache_ptr = nullptr;
+    int cache_frames = 0;
+    torch::Tensor cache_c;
+    if (cache.has_value() && cache.value().defined()) {
+        cache_c = cache.value().contiguous();
+        check_tin16_cuda_contiguous(cache_c, "cache");
+        TORCH_CHECK(cache_c.device() == input_c.device(), "cache must be on the same device as input");
+        TORCH_CHECK(cache_c.size(1) == slices && cache_c.size(2) == height && cache_c.size(3) == width,
+                    "cache shape must match input channel/spatial dimensions");
+        cache_frames = static_cast<int>(cache_c.size(0));
+        TORCH_CHECK(cache_frames >= 0 && cache_frames <= 2, "causal cache must have 0, 1, or 2 frames");
+        cache_ptr = cache_c.template data_ptr<uint8_t>();
+    }
+    auto output = torch::empty(
+        {frames, slices * 3, height, width, kFp8ChannelsPerSlice},
+        input_c.options());
+    pack_causal3_tin16_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        cache_ptr,
+        output.template data_ptr<uint8_t>(),
+        frames,
+        cache_frames,
+        slices,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_nhwc_rescale_to_tin16(
+    torch::Tensor input,
+    torch::Tensor source_scale,
+    torch::Tensor output_scale) {
+    check_u8_cuda_contiguous(input, "input");
+    check_scale_cuda_contiguous(source_scale, "source_scale");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(input.dim() == 4, "input must be NHWC [N,H,W,C], got ", input.sizes());
+    TORCH_CHECK(input.size(3) % kFp8ChannelsPerSlice == 0,
+                "input channel count must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(source_scale.numel() == 1 || source_scale.numel() == input.size(3),
+                "source_scale must be scalar or have one entry per channel");
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == input.size(3),
+                "output_scale must be scalar or have one entry per channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto src_s = source_scale.to(input.device(), source_scale.scalar_type(), false, true).contiguous();
+    auto out_s = output_scale.to(input.device(), output_scale.scalar_type(), false, true).contiguous();
+
+#define DISPATCH_RESCALE(SRC_T, OUT_T) dispatch_nhwc_rescale_to_tin16<SRC_T, OUT_T>(input_c, src_s, out_s)
+#define DISPATCH_RESCALE_OUT(SRC_T) \
+    (out_s.scalar_type() == at::kHalf ? DISPATCH_RESCALE(SRC_T, half) : DISPATCH_RESCALE(SRC_T, float))
+    return src_s.scalar_type() == at::kHalf ? DISPATCH_RESCALE_OUT(half) : DISPATCH_RESCALE_OUT(float);
+#undef DISPATCH_RESCALE_OUT
+#undef DISPATCH_RESCALE
+}
+
+torch::Tensor lightvae_fp8_pack_causal3_tin16_to_nhwc(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache) {
+    check_tin16_cuda_contiguous(input, "input");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    const uint8_t* cache_ptr = nullptr;
+    int cache_frames = 0;
+    torch::Tensor cache_c;
+    if (cache.has_value() && cache.value().defined()) {
+        cache_c = cache.value().contiguous();
+        check_tin16_cuda_contiguous(cache_c, "cache");
+        TORCH_CHECK(cache_c.device() == input_c.device(), "cache must be on the same device as input");
+        TORCH_CHECK(cache_c.size(1) == slices && cache_c.size(2) == height && cache_c.size(3) == width,
+                    "cache shape must match input channel/spatial dimensions");
+        cache_frames = static_cast<int>(cache_c.size(0));
+        TORCH_CHECK(cache_frames >= 0 && cache_frames <= 2, "causal cache must have 0, 1, or 2 frames");
+        cache_ptr = cache_c.template data_ptr<uint8_t>();
+    }
+    auto output = torch::empty(
+        {frames, height, width, slices * 3 * kFp8ChannelsPerSlice},
+        input_c.options());
+    pack_causal3_tin16_to_nhwc_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        cache_ptr,
+        output.template data_ptr<uint8_t>(),
+        frames,
+        cache_frames,
+        slices,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_update_tail_cache_tin16(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    int cache_frames) {
+    check_tin16_cuda_contiguous(input, "input");
+    TORCH_CHECK(cache_frames > 0, "cache_frames must be positive");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    const uint8_t* cache_ptr = nullptr;
+    int old_cache_frames = 0;
+    torch::Tensor cache_c;
+    if (cache.has_value() && cache.value().defined()) {
+        cache_c = cache.value().contiguous();
+        check_tin16_cuda_contiguous(cache_c, "cache");
+        TORCH_CHECK(cache_c.device() == input_c.device(), "cache must be on the same device as input");
+        TORCH_CHECK(cache_c.size(1) == slices && cache_c.size(2) == height && cache_c.size(3) == width,
+                    "cache shape must match input channel/spatial dimensions");
+        old_cache_frames = static_cast<int>(cache_c.size(0));
+        cache_ptr = cache_c.template data_ptr<uint8_t>();
+    }
+    const int new_cache_frames = std::min(cache_frames, old_cache_frames + frames);
+    auto output = torch::empty(
+        {new_cache_frames, slices, height, width, kFp8ChannelsPerSlice},
+        input_c.options());
+    update_tail_cache_tin16_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        cache_ptr,
+        output.template data_ptr<uint8_t>(),
+        frames,
+        old_cache_frames,
+        new_cache_frames,
+        slices,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_spatial_pad_right_bottom_tin16(torch::Tensor input) {
+    check_tin16_cuda_contiguous(input, "input");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    auto output = torch::empty(
+        {frames, slices, height + 1, width + 1, kFp8ChannelsPerSlice},
+        input_c.options());
+    spatial_pad_right_bottom_tin16_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        output.template data_ptr<uint8_t>(),
+        frames,
+        slices,
+        height,
+        width);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_pack_temporal3_tin16(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache) {
+    check_tin16_cuda_contiguous(input, "input");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    const bool has_cache = cache.has_value() && cache.value().defined();
+    const uint8_t* cache_ptr = nullptr;
+    torch::Tensor cache_c;
+    if (has_cache) {
+        cache_c = cache.value().contiguous();
+        check_tin16_cuda_contiguous(cache_c, "cache");
+        TORCH_CHECK(cache_c.device() == input_c.device(), "cache must be on the same device as input");
+        TORCH_CHECK(cache_c.size(0) == 1 && cache_c.size(1) == slices &&
+                        cache_c.size(2) == height && cache_c.size(3) == width,
+                    "temporal cache must be [1,C/16,H,W,16] matching input");
+        cache_ptr = cache_c.template data_ptr<uint8_t>();
+    }
+    const int t_out = has_cache ? ((frames + 1 - 3) / 2 + 1) : ((frames - 3) / 2 + 1);
+    TORCH_CHECK(t_out > 0, "temporal pack produced invalid T_out=", t_out, " from T=", frames);
+    auto output = torch::empty(
+        {t_out, slices * 3, height, width, kFp8ChannelsPerSlice},
+        input_c.options());
+    pack_temporal3_tin16_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        cache_ptr,
+        output.template data_ptr<uint8_t>(),
+        frames,
+        t_out,
+        slices,
+        height,
+        width,
+        has_cache);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_pack_temporal3_tin16_to_nhwc(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache) {
+    check_tin16_cuda_contiguous(input, "input");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const int frames = static_cast<int>(input_c.size(0));
+    const int slices = static_cast<int>(input_c.size(1));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    const bool has_cache = cache.has_value() && cache.value().defined();
+    const uint8_t* cache_ptr = nullptr;
+    torch::Tensor cache_c;
+    if (has_cache) {
+        cache_c = cache.value().contiguous();
+        check_tin16_cuda_contiguous(cache_c, "cache");
+        TORCH_CHECK(cache_c.device() == input_c.device(), "cache must be on the same device as input");
+        TORCH_CHECK(cache_c.size(0) == 1 && cache_c.size(1) == slices &&
+                        cache_c.size(2) == height && cache_c.size(3) == width,
+                    "temporal cache must be [1,C/16,H,W,16] matching input");
+        cache_ptr = cache_c.template data_ptr<uint8_t>();
+    }
+    const int t_out = has_cache ? ((frames + 1 - 3) / 2 + 1) : ((frames - 3) / 2 + 1);
+    TORCH_CHECK(t_out > 0, "temporal pack produced invalid T_out=", t_out, " from T=", frames);
+    auto output = torch::empty(
+        {t_out, height, width, slices * 3 * kFp8ChannelsPerSlice},
+        input_c.options());
+    pack_temporal3_tin16_to_nhwc_kernel<<<launch_blocks(output.numel()), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        input_c.template data_ptr<uint8_t>(),
+        cache_ptr,
+        output.template data_ptr<uint8_t>(),
+        frames,
+        t_out,
+        slices,
+        height,
+        width,
+        has_cache);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    auto packed_nhwc = lightvae_fp8_pack_causal3_tin16_to_nhwc(input, cache);
+    auto y_nhwc = cutlass_conv2d_nhwc_fp8_prepared(
+        packed_nhwc,
+        weight,
+        output_scale,
+        bias,
+        1,
+        1,
+        relu);
+    return lightvae_fp8_nhwc_to_tin16(y_nhwc);
+}
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom) {
+    return lightvae_fp8_spatial_conv3_tin16_warp_mma_prepared(
+        input,
+        weight,
+        output_scale,
+        bias,
+        stride,
+        pad,
+        relu,
+        pad_right_bottom);
+}
+
+torch::Tensor lightvae_fp8_conv1_tin16_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    return lightvae_fp8_conv1_tin16_warp_mma_prepared(input, weight, output_scale, bias, relu);
+}
+
+torch::Tensor lightvae_fp8_temporal_conv1_tin16_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    auto input_nhwc = lightvae_fp8_pack_temporal3_tin16_to_nhwc(input, cache);
+    auto y_nhwc = cutlass_conv2d_nhwc_fp8_prepared(
+        input_nhwc,
+        weight,
+        output_scale,
+        bias,
+        1,
+        0,
+        relu);
+    return lightvae_fp8_nhwc_to_tin16(y_nhwc);
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_warp_mma_stages.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_fp8_warp_mma_stages.cu
@@ -1,0 +1,1239 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "lightvae_ops.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <cuda_fp16.h>
+
+#include <algorithm>
+#include <cutlass/numeric_conversion.h>
+#include <type_traits>
+
+namespace omnidreams_singleview {
+namespace {
+
+constexpr int kFp8ChannelsPerSlice = 16;
+
+void check_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void check_u8_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kByte, name, " must be torch.uint8");
+}
+
+void check_half_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kHalf, name, " must be torch.float16");
+}
+
+void check_scale_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.scalar_type() == at::kFloat || tensor.scalar_type() == at::kHalf,
+                name, " must be torch.float32 or torch.float16");
+    TORCH_CHECK(tensor.dim() == 1, name, " must be 1D");
+}
+
+void check_tin16_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    check_u8_cuda_contiguous(tensor, name);
+    TORCH_CHECK(tensor.dim() == 5 && tensor.size(4) == kFp8ChannelsPerSlice,
+                name, " must be [T,C/16,H,W,16], got ", tensor.sizes());
+}
+
+const half* half_ptr_const(const torch::Tensor& tensor) {
+    return reinterpret_cast<const half*>(tensor.data_ptr<at::Half>());
+}
+
+template <typename ScaleT>
+__device__ __forceinline__ float scale_to_float(const ScaleT* scale, int idx) {
+    return static_cast<float>(scale[idx]);
+}
+
+template <>
+__device__ __forceinline__ float scale_to_float<half>(const half* scale, int idx) {
+    return __half2float(scale[idx]);
+}
+
+__device__ __forceinline__ uint8_t encode_e4m3(float value) {
+    cutlass::NumericConverter<cutlass::float_e4m3_t, float> to_fp8;
+    cutlass::float_e4m3_t fp8 = to_fp8(value);
+    return *reinterpret_cast<uint8_t*>(&fp8);
+}
+
+__device__ __forceinline__ uint8_t encode_e4m3_half(half value) {
+    return encode_e4m3(__half2float(value));
+}
+
+constexpr int kWarpTileX = 16;
+constexpr int kWarpTileY = 8;
+constexpr int kWarpMmaWarps = 8;
+constexpr int kWarpMmaThreads = kWarpMmaWarps * 32;
+constexpr int kWarpRowsPerWarp = kWarpTileY / kWarpMmaWarps;
+constexpr int kWarpLocalPixels = kWarpTileX * kWarpRowsPerWarp;
+
+int default_out_tile_channels(int out_channels) {
+    if (out_channels <= 32) {
+        return 32;
+    }
+    if (out_channels <= 64) {
+        return 64;
+    }
+    if (out_channels <= 96) {
+        return 96;
+    }
+    return 16;
+}
+
+int default_conv1_out_tile_channels(int out_channels) {
+    if (out_channels <= 32) {
+        return 32;
+    }
+    if (out_channels <= 64) {
+        return 64;
+    }
+    return 96;
+}
+
+__device__ __forceinline__ int lane_id() {
+    int lane;
+    asm volatile("mov.u32 %0, %%laneid;" : "=r"(lane));
+    return lane;
+}
+
+__device__ __forceinline__ uint2 mma_f8e4m3_f16(uint4 a, uint2 b, uint2 c) {
+    uint2 d;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 890
+    asm volatile(
+        "mma.sync.aligned.m16n8k32.row.col.f16.e4m3.e4m3.f16 "
+        "{%0, %1}, {%2, %3, %4, %5}, {%6, %7}, {%8, %9};\n"
+        : "=r"(d.x), "=r"(d.y)
+        : "r"(a.x), "r"(a.y), "r"(a.z), "r"(a.w),
+          "r"(b.x), "r"(b.y),
+          "r"(c.x), "r"(c.y));
+#else
+    d.x = 0;
+    d.y = 0;
+#endif
+    return d;
+}
+
+__device__ __forceinline__ int a_fragment_row(int reg_idx, int lane) {
+    return (lane / 4) + (reg_idx % 2) * 8;
+}
+
+__device__ __forceinline__ int a_fragment_col_base(int reg_idx, int lane) {
+    return ((lane % 4) + (reg_idx / 2) * 4) * 4;
+}
+
+__device__ __forceinline__ int b_fragment_k_base(int reg_idx, int lane) {
+    return ((lane % 4) + (reg_idx % 2) * 4) * 4;
+}
+
+__device__ __forceinline__ int b_fragment_col(int reg_idx, int lane) {
+    return (lane / 4) + (reg_idx / 2) * 8;
+}
+
+__device__ __forceinline__ int c_fragment_row(int reg_idx, int lane) {
+    return (lane / 4) + (reg_idx % 2) * 8;
+}
+
+__device__ __forceinline__ int c_fragment_col_base(int reg_idx, int lane) {
+    return ((lane % 4) + (reg_idx / 2) * 4) * 2;
+}
+
+template <bool Causal>
+__device__ __forceinline__ uint32_t load_warp_mma_a_u32(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    int frame,
+    int frames,
+    int cache_frames,
+    int in_slices,
+    int height,
+    int width,
+    int effective_height,
+    int effective_width,
+    int tile_y,
+    int tile_x,
+    int local_pixel,
+    int c_base4,
+    int r,
+    int s,
+    int dt,
+    int stride,
+    int pad) {
+    const int local_y = local_pixel / kWarpTileX;
+    const int local_x = local_pixel - local_y * kWarpTileX;
+    const int oy = tile_y * kWarpTileY + local_y;
+    const int ox = tile_x * kWarpTileX + local_x;
+    const int iy = oy * stride + r - pad;
+    const int ix = ox * stride + s - pad;
+    if constexpr (Causal) {
+        const int src_ext_t = cache_frames + frame + dt - 2;
+        const bool from_cache = src_ext_t >= 0 && src_ext_t < cache_frames && cache != nullptr;
+        const int src_t = from_cache ? src_ext_t : (src_ext_t - cache_frames);
+        const uint8_t* src = from_cache ? cache : input;
+        const int src_frames = from_cache ? cache_frames : frames;
+        if (src == nullptr || src_t < 0 || src_t >= src_frames || iy < 0 || iy >= height || ix < 0 || ix >= width) {
+            return 0;
+        }
+        const int slice = c_base4 / kFp8ChannelsPerSlice;
+        const int lane = c_base4 - slice * kFp8ChannelsPerSlice;
+        const size_t idx =
+            (((static_cast<size_t>(src_t) * in_slices + slice) * height + iy) * width + ix) *
+                kFp8ChannelsPerSlice + lane;
+        return *reinterpret_cast<const uint32_t*>(src + idx);
+    } else {
+        if (iy < 0 || ix < 0 || iy >= effective_height || ix >= effective_width ||
+            iy >= height || ix >= width) {
+            return 0;
+        }
+        const int slice = c_base4 / kFp8ChannelsPerSlice;
+        const int lane = c_base4 - slice * kFp8ChannelsPerSlice;
+        const size_t idx =
+            (((static_cast<size_t>(frame) * in_slices + slice) * height + iy) * width + ix) *
+                kFp8ChannelsPerSlice + lane;
+        return *reinterpret_cast<const uint32_t*>(input + idx);
+    }
+}
+
+template <bool Causal>
+__device__ __forceinline__ uint32_t load_warp_mma_b_u32(
+    const uint8_t* __restrict__ weight,
+    int out_channel,
+    int c_base4,
+    int r,
+    int s,
+    int dt,
+    int in_channels,
+    int out_channels) {
+    if (out_channel >= out_channels || c_base4 >= in_channels) {
+        return 0;
+    }
+    if constexpr (Causal) {
+        const int packed_c = dt * in_channels + c_base4;
+        const size_t idx =
+            (((static_cast<size_t>(out_channel) * 3 + r) * 3 + s) * (in_channels * 3) + packed_c);
+        return *reinterpret_cast<const uint32_t*>(weight + idx);
+    } else {
+        const size_t idx =
+            (((static_cast<size_t>(out_channel) * 3 + r) * 3 + s) * in_channels + c_base4);
+        return *reinterpret_cast<const uint32_t*>(weight + idx);
+    }
+}
+
+__device__ __forceinline__ uint32_t load_conv1_warp_mma_a_u32(
+    const uint8_t* __restrict__ input,
+    int frame,
+    int in_slices,
+    int height,
+    int width,
+    int tile_y,
+    int tile_x,
+    int local_pixel,
+    int c_base4) {
+    const int local_y = local_pixel / kWarpTileX;
+    const int local_x = local_pixel - local_y * kWarpTileX;
+    const int y = tile_y * kWarpTileY + local_y;
+    const int x = tile_x * kWarpTileX + local_x;
+    if (y >= height || x >= width) {
+        return 0;
+    }
+    const int slice = c_base4 / kFp8ChannelsPerSlice;
+    const int lane = c_base4 - slice * kFp8ChannelsPerSlice;
+    const size_t idx =
+        (((static_cast<size_t>(frame) * in_slices + slice) * height + y) * width + x) *
+            kFp8ChannelsPerSlice + lane;
+    return *reinterpret_cast<const uint32_t*>(input + idx);
+}
+
+__device__ __forceinline__ uint32_t load_conv1_warp_mma_b_u32(
+    const uint8_t* __restrict__ weight,
+    int out_channel,
+    int c_base4,
+    int in_channels,
+    int out_channels) {
+    if (out_channel >= out_channels || c_base4 >= in_channels) {
+        return 0;
+    }
+    const size_t idx = static_cast<size_t>(out_channel) * in_channels + c_base4;
+    return *reinterpret_cast<const uint32_t*>(weight + idx);
+}
+
+template <bool Causal, int InChannels>
+__device__ __forceinline__ uint32_t load_conv3_static_warp_mma_a_u32(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    int frame,
+    int frames,
+    int cache_frames,
+    int height,
+    int width,
+    int effective_height,
+    int effective_width,
+    int out_height,
+    int out_width,
+    int tile_y,
+    int tile_x,
+    int local_pixel,
+    int c_base4,
+    int r,
+    int s,
+    int dt) {
+    constexpr int InSlices = InChannels / kFp8ChannelsPerSlice;
+    const int local_y = local_pixel / kWarpTileX;
+    const int local_x = local_pixel - local_y * kWarpTileX;
+    const int oy = tile_y * kWarpTileY + local_y;
+    const int ox = tile_x * kWarpTileX + local_x;
+    if (oy >= out_height || ox >= out_width) {
+        return 0;
+    }
+    int iy;
+    int ix;
+    if constexpr (Causal) {
+        iy = oy + r - 1;
+        ix = ox + s - 1;
+        const int src_ext_t = cache_frames + frame + dt - 2;
+        const bool from_cache = src_ext_t >= 0 && src_ext_t < cache_frames && cache != nullptr;
+        const int src_t = from_cache ? src_ext_t : (src_ext_t - cache_frames);
+        const uint8_t* src = from_cache ? cache : input;
+        const int src_frames = from_cache ? cache_frames : frames;
+        if (src == nullptr || src_t < 0 || src_t >= src_frames ||
+            iy < 0 || iy >= height || ix < 0 || ix >= width) {
+            return 0;
+        }
+        const int slice = c_base4 / kFp8ChannelsPerSlice;
+        const int lane = c_base4 - slice * kFp8ChannelsPerSlice;
+        const size_t idx =
+            (((static_cast<size_t>(src_t) * InSlices + slice) * height + iy) * width + ix) *
+                kFp8ChannelsPerSlice + lane;
+        return *reinterpret_cast<const uint32_t*>(src + idx);
+    } else {
+        iy = oy * 2 + r;
+        ix = ox * 2 + s;
+        if (iy >= effective_height || ix >= effective_width || iy >= height || ix >= width) {
+            return 0;
+        }
+        const int slice = c_base4 / kFp8ChannelsPerSlice;
+        const int lane = c_base4 - slice * kFp8ChannelsPerSlice;
+        const size_t idx =
+            (((static_cast<size_t>(frame) * InSlices + slice) * height + iy) * width + ix) *
+                kFp8ChannelsPerSlice + lane;
+        return *reinterpret_cast<const uint32_t*>(input + idx);
+    }
+}
+
+template <bool Causal, int InChannels, int OutChannels>
+__device__ __forceinline__ uint32_t load_conv3_static_warp_mma_b_u32(
+    const uint8_t* __restrict__ weight,
+    int out_channel,
+    int c_base4,
+    int r,
+    int s,
+    int dt) {
+    if (out_channel >= OutChannels || c_base4 >= InChannels) {
+        return 0;
+    }
+    if constexpr (Causal) {
+        const int packed_c = dt * InChannels + c_base4;
+        const size_t idx =
+            (((static_cast<size_t>(out_channel) * 3 + r) * 3 + s) * (InChannels * 3) + packed_c);
+        return *reinterpret_cast<const uint32_t*>(weight + idx);
+    } else {
+        const size_t idx =
+            (((static_cast<size_t>(out_channel) * 3 + r) * 3 + s) * InChannels + c_base4);
+        return *reinterpret_cast<const uint32_t*>(weight + idx);
+    }
+}
+
+template <typename ScaleT, int OutTileChannels>
+__global__ void __launch_bounds__(kWarpMmaThreads, 2) conv1_tin16_warp_mma_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ output_scale,
+    const half* __restrict__ bias,
+    int frames,
+    int in_slices,
+    int height,
+    int width,
+    int out_channels,
+    int output_scale_count,
+    bool relu) {
+    const int lane = lane_id();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int tile_x = static_cast<int>(blockIdx.x);
+    const int tile_y = static_cast<int>(blockIdx.y);
+    static_assert(OutTileChannels % kFp8ChannelsPerSlice == 0, "output tile must be a multiple of TIN16 channels");
+    constexpr int OutGroups = OutTileChannels / kFp8ChannelsPerSlice;
+    const int out_blocks = (out_channels + OutTileChannels - 1) / OutTileChannels;
+    const int frame = static_cast<int>(blockIdx.z) / out_blocks;
+    const int out_block = static_cast<int>(blockIdx.z) - frame * out_blocks;
+    const int out_base = out_block * OutTileChannels;
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+
+    uint32_t acc[OutGroups][4];
+    for (int group = 0; group < OutGroups; ++group) {
+        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+            acc[group][reg_idx] = 0;
+        }
+    }
+
+    for (int c_base = 0; c_base < in_channels; c_base += 32) {
+        uint4 a;
+        uint32_t* a_reg = reinterpret_cast<uint32_t*>(&a);
+        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+            const int local_row = a_fragment_row(reg_idx, lane);
+            const int local_pixel = warp * kWarpLocalPixels + local_row;
+            const int c0 = c_base + a_fragment_col_base(reg_idx, lane);
+            a_reg[reg_idx] = load_conv1_warp_mma_a_u32(
+                input, frame, in_slices, height, width, tile_y, tile_x, local_pixel, c0);
+        }
+
+        for (int group = 0; group < OutGroups; ++group) {
+            uint32_t b_regs[4];
+            const int group_out_base = out_base + group * kFp8ChannelsPerSlice;
+            for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+                const int c0 = c_base + b_fragment_k_base(reg_idx, lane);
+                const int out_channel = group_out_base + b_fragment_col(reg_idx, lane);
+                b_regs[reg_idx] = load_conv1_warp_mma_b_u32(
+                    weight, out_channel, c0, in_channels, out_channels);
+            }
+
+            uint2 b0{b_regs[0], b_regs[1]};
+            uint2 c0{acc[group][0], acc[group][1]};
+            uint2 d0 = mma_f8e4m3_f16(a, b0, c0);
+            acc[group][0] = d0.x;
+            acc[group][1] = d0.y;
+
+            uint2 b1{b_regs[2], b_regs[3]};
+            uint2 c1{acc[group][2], acc[group][3]};
+            uint2 d1 = mma_f8e4m3_f16(a, b1, c1);
+            acc[group][2] = d1.x;
+            acc[group][3] = d1.y;
+        }
+    }
+
+    const int out_slices = out_channels / kFp8ChannelsPerSlice;
+    for (int group = 0; group < OutGroups; ++group) {
+        const int group_out_base = out_base + group * kFp8ChannelsPerSlice;
+        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+            const int local_row = c_fragment_row(reg_idx, lane);
+            const int local_pixel = warp * kWarpLocalPixels + local_row;
+            const int local_y = local_pixel / kWarpTileX;
+            const int local_x = local_pixel - local_y * kWarpTileX;
+            const int y = tile_y * kWarpTileY + local_y;
+            const int x = tile_x * kWarpTileX + local_x;
+            if (frame >= frames || y >= height || x >= width) {
+                continue;
+            }
+            half2 hv = *reinterpret_cast<half2*>(&acc[group][reg_idx]);
+            const int c_pair = c_fragment_col_base(reg_idx, lane);
+            const int out_channel0 = group_out_base + c_pair;
+            const int out_channel1 = out_channel0 + 1;
+            if (out_channel0 < out_channels) {
+                const int out_slice = out_channel0 / kFp8ChannelsPerSlice;
+                const int out_lane = out_channel0 - out_slice * kFp8ChannelsPerSlice;
+                const size_t out_idx =
+                    (((static_cast<size_t>(frame) * out_slices + out_slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + out_lane;
+                float value = __half2float(hv.x);
+                if (bias != nullptr) {
+                    const float out_s = fmaxf(
+                        scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel0),
+                        1.0e-12f);
+                    value += __half2float(bias[out_channel0]) / out_s;
+                }
+                if (relu) {
+                    value = fmaxf(value, 0.0f);
+                }
+                output[out_idx] = encode_e4m3(value);
+            }
+            if (out_channel1 < out_channels) {
+                const int out_slice = out_channel1 / kFp8ChannelsPerSlice;
+                const int out_lane = out_channel1 - out_slice * kFp8ChannelsPerSlice;
+                const size_t out_idx =
+                    (((static_cast<size_t>(frame) * out_slices + out_slice) * height + y) * width + x) *
+                        kFp8ChannelsPerSlice + out_lane;
+                float value = __half2float(hv.y);
+                if (bias != nullptr) {
+                    const float out_s = fmaxf(
+                        scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel1),
+                        1.0e-12f);
+                    value += __half2float(bias[out_channel1]) / out_s;
+                }
+                if (relu) {
+                    value = fmaxf(value, 0.0f);
+                }
+                output[out_idx] = encode_e4m3(value);
+            }
+        }
+    }
+}
+
+template <bool Causal, typename ScaleT, int OutTileChannels, bool ScaledEpilogue>
+__global__ void __launch_bounds__(kWarpMmaThreads, 2) conv3_tin16_warp_mma_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    const uint8_t* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ output_scale,
+    const half* __restrict__ bias,
+    int frames,
+    int cache_frames,
+    int in_slices,
+    int height,
+    int width,
+    int effective_height,
+    int effective_width,
+    int out_height,
+    int out_width,
+    int out_channels,
+    int stride,
+    int pad,
+    int output_scale_count,
+    bool relu) {
+    const int lane = lane_id();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int tile_x = static_cast<int>(blockIdx.x);
+    const int tile_y = static_cast<int>(blockIdx.y);
+    static_assert(OutTileChannels % kFp8ChannelsPerSlice == 0, "output tile must be a multiple of TIN16 channels");
+    constexpr int OutGroups = OutTileChannels / kFp8ChannelsPerSlice;
+    const int out_blocks = (out_channels + OutTileChannels - 1) / OutTileChannels;
+    const int frame = static_cast<int>(blockIdx.z) / out_blocks;
+    const int out_block = static_cast<int>(blockIdx.z) - frame * out_blocks;
+    const int out_base = out_block * OutTileChannels;
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+
+    uint32_t acc[OutGroups][4];
+    for (int group = 0; group < OutGroups; ++group) {
+        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+            acc[group][reg_idx] = 0;
+        }
+    }
+
+    const int temporal_taps = Causal ? 3 : 1;
+    for (int dt = 0; dt < temporal_taps; ++dt) {
+        for (int r = 0; r < 3; ++r) {
+            for (int s = 0; s < 3; ++s) {
+                for (int c_base = 0; c_base < in_channels; c_base += 32) {
+                    uint4 a;
+                    uint32_t* a_reg = reinterpret_cast<uint32_t*>(&a);
+                    for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+                        const int local_row = a_fragment_row(reg_idx, lane);
+                        const int local_pixel = warp * kWarpLocalPixels + local_row;
+                        const int c0 = c_base + a_fragment_col_base(reg_idx, lane);
+                        a_reg[reg_idx] = load_warp_mma_a_u32<Causal>(
+                            input, cache, frame, frames, cache_frames, in_slices, height, width,
+                            effective_height, effective_width, tile_y, tile_x, local_pixel,
+                            c0, r, s, dt, stride, pad);
+                    }
+
+                    for (int group = 0; group < OutGroups; ++group) {
+                        uint32_t b_regs[4];
+                        const int group_out_base = out_base + group * kFp8ChannelsPerSlice;
+                        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+                            const int c0 = c_base + b_fragment_k_base(reg_idx, lane);
+                            const int out_channel = group_out_base + b_fragment_col(reg_idx, lane);
+                            b_regs[reg_idx] = load_warp_mma_b_u32<Causal>(
+                                weight, out_channel, c0, r, s, dt, in_channels, out_channels);
+                        }
+
+                        uint2 b0{b_regs[0], b_regs[1]};
+                        uint2 c0{acc[group][0], acc[group][1]};
+                        uint2 d0 = mma_f8e4m3_f16(a, b0, c0);
+                        acc[group][0] = d0.x;
+                        acc[group][1] = d0.y;
+
+                        uint2 b1{b_regs[2], b_regs[3]};
+                        uint2 c1{acc[group][2], acc[group][3]};
+                        uint2 d1 = mma_f8e4m3_f16(a, b1, c1);
+                        acc[group][2] = d1.x;
+                        acc[group][3] = d1.y;
+                    }
+                }
+            }
+        }
+    }
+
+    const int out_slices = out_channels / kFp8ChannelsPerSlice;
+    for (int group = 0; group < OutGroups; ++group) {
+        const int group_out_base = out_base + group * kFp8ChannelsPerSlice;
+        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+            const int local_row = c_fragment_row(reg_idx, lane);
+            const int local_pixel = warp * kWarpLocalPixels + local_row;
+            const int local_y = local_pixel / kWarpTileX;
+            const int local_x = local_pixel - local_y * kWarpTileX;
+            const int oy = tile_y * kWarpTileY + local_y;
+            const int ox = tile_x * kWarpTileX + local_x;
+            if (frame >= frames || oy >= out_height || ox >= out_width) {
+                continue;
+            }
+            half2 hv = *reinterpret_cast<half2*>(&acc[group][reg_idx]);
+            const int c_pair = c_fragment_col_base(reg_idx, lane);
+            const int out_channel0 = group_out_base + c_pair;
+            const int out_channel1 = out_channel0 + 1;
+            if (out_channel0 < out_channels) {
+                const int out_slice = out_channel0 / kFp8ChannelsPerSlice;
+                const int out_lane = out_channel0 - out_slice * kFp8ChannelsPerSlice;
+                const size_t out_idx =
+                    (((static_cast<size_t>(frame) * out_slices + out_slice) * out_height + oy) * out_width + ox) *
+                        kFp8ChannelsPerSlice + out_lane;
+                uint8_t encoded;
+                if constexpr (ScaledEpilogue) {
+                    float value = __half2float(hv.x) *
+                        scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel0);
+                    if (bias != nullptr) {
+                        value += __half2float(bias[out_channel0]);
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                } else {
+                    float value = __half2float(hv.x);
+                    if (bias != nullptr) {
+                        const float out_s = fmaxf(
+                            scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel0),
+                            1.0e-12f);
+                        value += __half2float(bias[out_channel0]) / out_s;
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                }
+                output[out_idx] = encoded;
+            }
+            if (out_channel1 < out_channels) {
+                const int out_slice = out_channel1 / kFp8ChannelsPerSlice;
+                const int out_lane = out_channel1 - out_slice * kFp8ChannelsPerSlice;
+                const size_t out_idx =
+                    (((static_cast<size_t>(frame) * out_slices + out_slice) * out_height + oy) * out_width + ox) *
+                        kFp8ChannelsPerSlice + out_lane;
+                uint8_t encoded;
+                if constexpr (ScaledEpilogue) {
+                    float value = __half2float(hv.y) *
+                        scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel1);
+                    if (bias != nullptr) {
+                        value += __half2float(bias[out_channel1]);
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                } else {
+                    float value = __half2float(hv.y);
+                    if (bias != nullptr) {
+                        const float out_s = fmaxf(
+                            scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel1),
+                            1.0e-12f);
+                        value += __half2float(bias[out_channel1]) / out_s;
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                }
+                output[out_idx] = encoded;
+            }
+        }
+    }
+}
+
+template <bool Causal, typename ScaleT, int InChannels, int OutChannels, bool ScaledEpilogue>
+__global__ void __launch_bounds__(kWarpMmaThreads, 2) conv3_tin16_static_warp_mma_kernel(
+    const uint8_t* __restrict__ input,
+    const uint8_t* __restrict__ cache,
+    const uint8_t* __restrict__ weight,
+    uint8_t* __restrict__ output,
+    const ScaleT* __restrict__ output_scale,
+    const half* __restrict__ bias,
+    int frames,
+    int cache_frames,
+    int height,
+    int width,
+    int effective_height,
+    int effective_width,
+    int out_height,
+    int out_width,
+    int output_scale_count,
+    bool relu) {
+    constexpr int OutGroups = OutChannels / kFp8ChannelsPerSlice;
+    constexpr int OutSlices = OutChannels / kFp8ChannelsPerSlice;
+    const int lane = lane_id();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int tile_x = static_cast<int>(blockIdx.x);
+    const int tile_y = static_cast<int>(blockIdx.y);
+    const int frame = static_cast<int>(blockIdx.z);
+
+    uint32_t acc[OutGroups][4];
+    for (int group = 0; group < OutGroups; ++group) {
+        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+            acc[group][reg_idx] = 0;
+        }
+    }
+
+    constexpr int TemporalTaps = Causal ? 3 : 1;
+    for (int dt = 0; dt < TemporalTaps; ++dt) {
+        for (int r = 0; r < 3; ++r) {
+            for (int s = 0; s < 3; ++s) {
+                for (int c_base = 0; c_base < InChannels; c_base += 32) {
+                    uint4 a;
+                    uint32_t* a_reg = reinterpret_cast<uint32_t*>(&a);
+                    for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+                        const int local_row = a_fragment_row(reg_idx, lane);
+                        const int local_pixel = warp * kWarpLocalPixels + local_row;
+                        const int c0 = c_base + a_fragment_col_base(reg_idx, lane);
+                        a_reg[reg_idx] = load_conv3_static_warp_mma_a_u32<Causal, InChannels>(
+                            input, cache, frame, frames, cache_frames, height, width,
+                            effective_height, effective_width, out_height, out_width,
+                            tile_y, tile_x, local_pixel, c0, r, s, dt);
+                    }
+
+                    for (int group = 0; group < OutGroups; ++group) {
+                        uint32_t b_regs[4];
+                        const int group_out_base = group * kFp8ChannelsPerSlice;
+                        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+                            const int c0 = c_base + b_fragment_k_base(reg_idx, lane);
+                            const int out_channel = group_out_base + b_fragment_col(reg_idx, lane);
+                            b_regs[reg_idx] = load_conv3_static_warp_mma_b_u32<Causal, InChannels, OutChannels>(
+                                weight, out_channel, c0, r, s, dt);
+                        }
+
+                        uint2 b0{b_regs[0], b_regs[1]};
+                        uint2 c0{acc[group][0], acc[group][1]};
+                        uint2 d0 = mma_f8e4m3_f16(a, b0, c0);
+                        acc[group][0] = d0.x;
+                        acc[group][1] = d0.y;
+
+                        uint2 b1{b_regs[2], b_regs[3]};
+                        uint2 c1{acc[group][2], acc[group][3]};
+                        uint2 d1 = mma_f8e4m3_f16(a, b1, c1);
+                        acc[group][2] = d1.x;
+                        acc[group][3] = d1.y;
+                    }
+                }
+            }
+        }
+    }
+
+    for (int group = 0; group < OutGroups; ++group) {
+        const int group_out_base = group * kFp8ChannelsPerSlice;
+        for (int reg_idx = 0; reg_idx < 4; ++reg_idx) {
+            const int local_row = c_fragment_row(reg_idx, lane);
+            const int local_pixel = warp * kWarpLocalPixels + local_row;
+            const int local_y = local_pixel / kWarpTileX;
+            const int local_x = local_pixel - local_y * kWarpTileX;
+            const int oy = tile_y * kWarpTileY + local_y;
+            const int ox = tile_x * kWarpTileX + local_x;
+            if (frame >= frames || oy >= out_height || ox >= out_width) {
+                continue;
+            }
+            half2 hv = *reinterpret_cast<half2*>(&acc[group][reg_idx]);
+            const int c_pair = c_fragment_col_base(reg_idx, lane);
+            const int out_channel0 = group_out_base + c_pair;
+            const int out_channel1 = out_channel0 + 1;
+            if constexpr (ScaledEpilogue && std::is_same<ScaleT, half>::value) {
+                if (!relu && out_channel1 < OutChannels) {
+                    half2 scale2;
+                    if (output_scale_count == 1) {
+                        scale2 = __halves2half2(output_scale[0], output_scale[0]);
+                    } else {
+                        scale2 = *reinterpret_cast<const half2*>(output_scale + out_channel0);
+                    }
+                    half2 value2 = __hmul2(hv, scale2);
+                    if (bias != nullptr) {
+                        const half2 bias2 = *reinterpret_cast<const half2*>(bias + out_channel0);
+                        value2 = __hadd2(value2, bias2);
+                    }
+
+                    const int out_slice = out_channel0 / kFp8ChannelsPerSlice;
+                    const int out_lane = out_channel0 - out_slice * kFp8ChannelsPerSlice;
+                    const size_t out_idx =
+                        (((static_cast<size_t>(frame) * OutSlices + out_slice) * out_height + oy) * out_width + ox) *
+                            kFp8ChannelsPerSlice + out_lane;
+                    output[out_idx] = encode_e4m3_half(value2.x);
+                    output[out_idx + 1] = encode_e4m3_half(value2.y);
+                    continue;
+                }
+            }
+            if (out_channel0 < OutChannels) {
+                const int out_slice = out_channel0 / kFp8ChannelsPerSlice;
+                const int out_lane = out_channel0 - out_slice * kFp8ChannelsPerSlice;
+                const size_t out_idx =
+                    (((static_cast<size_t>(frame) * OutSlices + out_slice) * out_height + oy) * out_width + ox) *
+                        kFp8ChannelsPerSlice + out_lane;
+                uint8_t encoded;
+                if constexpr (ScaledEpilogue) {
+                    float value = __half2float(hv.x) *
+                        scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel0);
+                    if (bias != nullptr) {
+                        value += __half2float(bias[out_channel0]);
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                } else {
+                    float value = __half2float(hv.x);
+                    if (bias != nullptr) {
+                        const float out_s = fmaxf(
+                            scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel0),
+                            1.0e-12f);
+                        value += __half2float(bias[out_channel0]) / out_s;
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                }
+                output[out_idx] = encoded;
+            }
+            if (out_channel1 < OutChannels) {
+                const int out_slice = out_channel1 / kFp8ChannelsPerSlice;
+                const int out_lane = out_channel1 - out_slice * kFp8ChannelsPerSlice;
+                const size_t out_idx =
+                    (((static_cast<size_t>(frame) * OutSlices + out_slice) * out_height + oy) * out_width + ox) *
+                        kFp8ChannelsPerSlice + out_lane;
+                uint8_t encoded;
+                if constexpr (ScaledEpilogue) {
+                    float value = __half2float(hv.y) *
+                        scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel1);
+                    if (bias != nullptr) {
+                        value += __half2float(bias[out_channel1]);
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                } else {
+                    float value = __half2float(hv.y);
+                    if (bias != nullptr) {
+                        const float out_s = fmaxf(
+                            scale_to_float(output_scale, output_scale_count == 1 ? 0 : out_channel1),
+                            1.0e-12f);
+                        value += __half2float(bias[out_channel1]) / out_s;
+                    }
+                    if (relu) {
+                        value = fmaxf(value, 0.0f);
+                    }
+                    encoded = encode_e4m3(value);
+                }
+                output[out_idx] = encoded;
+            }
+        }
+    }
+}
+
+template <typename ScaleT>
+torch::Tensor dispatch_conv1_warp_mma(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    bool relu) {
+    const int frames = static_cast<int>(input.size(0));
+    const int in_slices = static_cast<int>(input.size(1));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    const int out_channels = static_cast<int>(weight.size(0));
+    auto output = torch::empty(
+        {frames, out_channels / kFp8ChannelsPerSlice, height, width, kFp8ChannelsPerSlice},
+        input.options());
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+    TORCH_CHECK(in_channels % 32 == 0,
+                "warp-MMA/TIN16 FP8 1x1 stage requires padded input channels divisible by 32, got ",
+                in_channels);
+    const int out_tile_channels = default_conv1_out_tile_channels(out_channels);
+    const int out_blocks = (out_channels + out_tile_channels - 1) / out_tile_channels;
+    const dim3 grid(
+        static_cast<unsigned>((width + kWarpTileX - 1) / kWarpTileX),
+        static_cast<unsigned>((height + kWarpTileY - 1) / kWarpTileY),
+        static_cast<unsigned>(frames * out_blocks));
+#define OMNIDREAMS_VAE_LAUNCH_CONV1_TIN16(OUT_TILE_CHANNELS)                                             \
+    conv1_tin16_warp_mma_kernel<ScaleT, OUT_TILE_CHANNELS>                                        \
+        <<<grid, kWarpMmaThreads, 0, at::cuda::getCurrentCUDAStream()>>>(                          \
+            input.template data_ptr<uint8_t>(),                                                            \
+            weight.template data_ptr<uint8_t>(),                                                           \
+            output.template data_ptr<uint8_t>(),                                                           \
+            reinterpret_cast<const ScaleT*>(output_scale.data_ptr()),                              \
+            bias,                                                                                 \
+            frames,                                                                               \
+            in_slices,                                                                            \
+            height,                                                                               \
+            width,                                                                                \
+            out_channels,                                                                         \
+            static_cast<int>(output_scale.numel()),                                               \
+            relu)
+    switch (out_tile_channels) {
+    case 96:
+        OMNIDREAMS_VAE_LAUNCH_CONV1_TIN16(96);
+        break;
+    case 64:
+        OMNIDREAMS_VAE_LAUNCH_CONV1_TIN16(64);
+        break;
+    default:
+        OMNIDREAMS_VAE_LAUNCH_CONV1_TIN16(32);
+        break;
+    }
+#undef OMNIDREAMS_VAE_LAUNCH_CONV1_TIN16
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <bool Causal, typename ScaleT, int InChannels, int OutChannels, bool ScaledEpilogue>
+torch::Tensor dispatch_conv3_static_exact(
+    torch::Tensor input,
+    const uint8_t* cache_ptr,
+    int cache_frames,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    int effective_height,
+    int effective_width,
+    int out_height,
+    int out_width,
+    bool relu) {
+    const int frames = static_cast<int>(input.size(0));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    auto output = torch::empty(
+        {frames, OutChannels / kFp8ChannelsPerSlice, out_height, out_width, kFp8ChannelsPerSlice},
+        input.options());
+    const dim3 grid(
+        static_cast<unsigned>((out_width + kWarpTileX - 1) / kWarpTileX),
+        static_cast<unsigned>((out_height + kWarpTileY - 1) / kWarpTileY),
+        static_cast<unsigned>(frames));
+    conv3_tin16_static_warp_mma_kernel<Causal, ScaleT, InChannels, OutChannels, ScaledEpilogue>
+        <<<grid, kWarpMmaThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            input.template data_ptr<uint8_t>(),
+            cache_ptr,
+            weight.template data_ptr<uint8_t>(),
+            output.template data_ptr<uint8_t>(),
+            reinterpret_cast<const ScaleT*>(output_scale.data_ptr()),
+            bias,
+            frames,
+            cache_frames,
+            height,
+            width,
+            effective_height,
+            effective_width,
+            out_height,
+            out_width,
+            static_cast<int>(output_scale.numel()),
+            relu);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+template <bool Causal, typename ScaleT, bool ScaledEpilogue>
+torch::Tensor try_dispatch_conv3_static_exact(
+    torch::Tensor input,
+    const uint8_t* cache_ptr,
+    int cache_frames,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    int effective_height,
+    int effective_width,
+    int out_height,
+    int out_width,
+    bool relu,
+    bool* matched) {
+    *matched = true;
+    const int in_channels = static_cast<int>(input.size(1)) * kFp8ChannelsPerSlice;
+    const int out_channels = static_cast<int>(weight.size(0));
+#define OMNIDREAMS_VAE_TRY_CONV3_STATIC(IN_CHANNELS, OUT_CHANNELS)                                      \
+    if (in_channels == (IN_CHANNELS) && out_channels == (OUT_CHANNELS)) {                         \
+        return dispatch_conv3_static_exact<Causal, ScaleT, IN_CHANNELS, OUT_CHANNELS, ScaledEpilogue>( \
+            input, cache_ptr, cache_frames, weight, output_scale, bias, effective_height,          \
+            effective_width, out_height, out_width, relu);                                        \
+    }
+    OMNIDREAMS_VAE_TRY_CONV3_STATIC(32, 32);
+    OMNIDREAMS_VAE_TRY_CONV3_STATIC(32, 64);
+    OMNIDREAMS_VAE_TRY_CONV3_STATIC(64, 64);
+    OMNIDREAMS_VAE_TRY_CONV3_STATIC(64, 96);
+    OMNIDREAMS_VAE_TRY_CONV3_STATIC(96, 96);
+    OMNIDREAMS_VAE_TRY_CONV3_STATIC(96, 32);
+#undef OMNIDREAMS_VAE_TRY_CONV3_STATIC
+    *matched = false;
+    return torch::Tensor();
+}
+
+torch::Tensor checked_conv1_warp_mma(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    check_tin16_cuda_contiguous(input, "input");
+    check_u8_cuda_contiguous(weight, "weight");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(weight.dim() == 4 && weight.size(1) == 1 && weight.size(2) == 1,
+                "weight must be [K,1,1,C], got ", weight.sizes());
+    TORCH_CHECK(weight.size(3) == input.size(1) * kFp8ChannelsPerSlice,
+                "weight C must match input channels");
+    TORCH_CHECK(weight.size(0) % kFp8ChannelsPerSlice == 0,
+                "weight K must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight.size(0),
+                "output_scale must be scalar or have one entry per output channel");
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    auto weight_c = weight.contiguous();
+    auto out_s = output_scale.to(input.device(), output_scale.scalar_type(), false, true).contiguous();
+    torch::Tensor bias_c;
+    const half* bias_ptr = nullptr;
+    if (bias.has_value() && bias.value().defined()) {
+        bias_c = bias.value().contiguous();
+        check_half_cuda_contiguous(bias_c, "bias");
+        TORCH_CHECK(bias_c.numel() == weight_c.size(0), "bias must have one entry per output channel");
+        bias_ptr = half_ptr_const(bias_c);
+    }
+    return out_s.scalar_type() == at::kHalf
+        ? dispatch_conv1_warp_mma<half>(input_c, weight_c, out_s, bias_ptr, relu)
+        : dispatch_conv1_warp_mma<float>(input_c, weight_c, out_s, bias_ptr, relu);
+}
+
+template <bool Causal, typename ScaleT, bool ScaledEpilogue>
+torch::Tensor dispatch_conv3_warp_mma(
+    torch::Tensor input,
+    torch::Tensor cache,
+    const uint8_t* cache_ptr,
+    int cache_frames,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    const half* bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom) {
+    const int frames = static_cast<int>(input.size(0));
+    const int in_slices = static_cast<int>(input.size(1));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    const int effective_height = height + (!Causal && pad_right_bottom ? 1 : 0);
+    const int effective_width = width + (!Causal && pad_right_bottom ? 1 : 0);
+    const int out_channels = static_cast<int>(weight.size(0));
+    const int out_height = Causal ? height : ((effective_height + 2 * pad - 3) / stride + 1);
+    const int out_width = Causal ? width : ((effective_width + 2 * pad - 3) / stride + 1);
+    TORCH_CHECK(out_height > 0 && out_width > 0, "invalid output shape");
+
+    auto output = torch::empty(
+        {frames, out_channels / kFp8ChannelsPerSlice, out_height, out_width, kFp8ChannelsPerSlice},
+        input.options());
+    const int in_channels = in_slices * kFp8ChannelsPerSlice;
+    TORCH_CHECK(in_channels % 32 == 0,
+                "warp-MMA/TIN16 FP8 stage requires padded input channels divisible by 32, got ",
+                in_channels);
+    const int out_tile_channels = default_out_tile_channels(out_channels);
+    const int out_blocks = (out_channels + out_tile_channels - 1) / out_tile_channels;
+    const dim3 grid(
+        static_cast<unsigned>((out_width + kWarpTileX - 1) / kWarpTileX),
+        static_cast<unsigned>((out_height + kWarpTileY - 1) / kWarpTileY),
+        static_cast<unsigned>(frames * out_blocks));
+#define OMNIDREAMS_VAE_LAUNCH_CONV3_TIN16(OUT_TILE_CHANNELS)                                             \
+    conv3_tin16_warp_mma_kernel<Causal, ScaleT, OUT_TILE_CHANNELS, ScaledEpilogue>                 \
+        <<<grid, kWarpMmaThreads, 0, at::cuda::getCurrentCUDAStream()>>>(                           \
+            input.template data_ptr<uint8_t>(),                                                             \
+            cache_ptr,                                                                             \
+            weight.template data_ptr<uint8_t>(),                                                            \
+            output.template data_ptr<uint8_t>(),                                                            \
+            reinterpret_cast<const ScaleT*>(output_scale.data_ptr()),                               \
+            bias,                                                                                  \
+            frames,                                                                                \
+            cache_frames,                                                                          \
+            in_slices,                                                                             \
+            height,                                                                                \
+            width,                                                                                 \
+            effective_height,                                                                      \
+            effective_width,                                                                       \
+            out_height,                                                                            \
+            out_width,                                                                             \
+            out_channels,                                                                          \
+            stride,                                                                                \
+            pad,                                                                                   \
+            static_cast<int>(output_scale.numel()),                                                \
+            relu)
+    switch (out_tile_channels) {
+    case 96:
+        OMNIDREAMS_VAE_LAUNCH_CONV3_TIN16(96);
+        break;
+    case 64:
+        OMNIDREAMS_VAE_LAUNCH_CONV3_TIN16(64);
+        break;
+    case 32:
+        OMNIDREAMS_VAE_LAUNCH_CONV3_TIN16(32);
+        break;
+    default:
+        OMNIDREAMS_VAE_LAUNCH_CONV3_TIN16(16);
+        break;
+    }
+#undef OMNIDREAMS_VAE_LAUNCH_CONV3_TIN16
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor normalize_optional_cache(
+    c10::optional<torch::Tensor> cache,
+    const torch::Tensor& input,
+    const char* name,
+    const uint8_t** cache_ptr,
+    int* cache_frames) {
+    *cache_ptr = nullptr;
+    *cache_frames = 0;
+    if (!(cache.has_value() && cache.value().defined())) {
+        return torch::Tensor();
+    }
+    auto cache_c = cache.value().contiguous();
+    check_tin16_cuda_contiguous(cache_c, name);
+    TORCH_CHECK(cache_c.device() == input.device(), name, " must be on the same device as input");
+    TORCH_CHECK(cache_c.size(1) == input.size(1) && cache_c.size(2) == input.size(2) &&
+                    cache_c.size(3) == input.size(3),
+                name, " shape must match input channel/spatial dimensions");
+    TORCH_CHECK(cache_c.size(0) >= 0 && cache_c.size(0) <= 2, name, " must have 0, 1, or 2 frames");
+    *cache_ptr = cache_c.template data_ptr<uint8_t>();
+    *cache_frames = static_cast<int>(cache_c.size(0));
+    return cache_c;
+}
+
+template <bool Causal, bool ScaledEpilogue = false>
+torch::Tensor checked_conv3_warp_mma(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom) {
+    check_tin16_cuda_contiguous(input, "input");
+    check_u8_cuda_contiguous(weight, "weight");
+    check_scale_cuda_contiguous(output_scale, "output_scale");
+    TORCH_CHECK(weight.dim() == 4 && weight.size(1) == 3 && weight.size(2) == 3,
+                "weight must be [K,3,3,C], got ", weight.sizes());
+    const int packed_factor = Causal ? 3 : 1;
+    TORCH_CHECK(weight.size(3) == input.size(1) * kFp8ChannelsPerSlice * packed_factor,
+                "weight C must match input channels");
+    TORCH_CHECK(weight.size(0) % kFp8ChannelsPerSlice == 0,
+                "weight K must be divisible by ", kFp8ChannelsPerSlice);
+    TORCH_CHECK(output_scale.numel() == 1 || output_scale.numel() == weight.size(0),
+                "output_scale must be scalar or have one entry per output channel");
+    TORCH_CHECK(stride > 0 && pad >= 0, "invalid stride/pad");
+    if constexpr (Causal) {
+        TORCH_CHECK(stride == 1 && pad == 1 && !pad_right_bottom,
+                    "causal warp-MMA stage expects stride=1, pad=1, pad_right_bottom=false");
+    }
+    at::cuda::CUDAGuard guard(input.device());
+    auto input_c = input.contiguous();
+    const uint8_t* cache_ptr = nullptr;
+    int cache_frames = 0;
+    auto cache_c = normalize_optional_cache(cache, input_c, "cache", &cache_ptr, &cache_frames);
+    auto weight_c = weight.contiguous();
+    auto out_s = output_scale.to(input.device(), output_scale.scalar_type(), false, true).contiguous();
+    torch::Tensor bias_c;
+    const half* bias_ptr = nullptr;
+    if (bias.has_value() && bias.value().defined()) {
+        bias_c = bias.value().contiguous();
+        check_half_cuda_contiguous(bias_c, "bias");
+        TORCH_CHECK(bias_c.numel() == weight_c.size(0), "bias must have one entry per output channel");
+        bias_ptr = half_ptr_const(bias_c);
+    }
+    const int frames = static_cast<int>(input_c.size(0));
+    const int height = static_cast<int>(input_c.size(2));
+    const int width = static_cast<int>(input_c.size(3));
+    const int effective_height = height + (!Causal && pad_right_bottom ? 1 : 0);
+    const int effective_width = width + (!Causal && pad_right_bottom ? 1 : 0);
+    const int out_height = Causal ? height : ((effective_height + 2 * pad - 3) / stride + 1);
+    const int out_width = Causal ? width : ((effective_width + 2 * pad - 3) / stride + 1);
+    TORCH_CHECK(out_height > 0 && out_width > 0, "invalid output shape");
+    const bool can_use_static_exact = Causal || (stride == 2 && pad == 0 && pad_right_bottom);
+    if (can_use_static_exact && frames > 0) {
+        bool matched = false;
+        torch::Tensor static_out = out_s.scalar_type() == at::kHalf
+            ? try_dispatch_conv3_static_exact<Causal, half, ScaledEpilogue>(
+                  input_c, cache_ptr, cache_frames, weight_c, out_s, bias_ptr,
+                  effective_height, effective_width, out_height, out_width, relu, &matched)
+            : try_dispatch_conv3_static_exact<Causal, float, ScaledEpilogue>(
+                  input_c, cache_ptr, cache_frames, weight_c, out_s, bias_ptr,
+                  effective_height, effective_width, out_height, out_width, relu, &matched);
+        if (matched) {
+            return static_out;
+        }
+    }
+    return out_s.scalar_type() == at::kHalf
+        ? dispatch_conv3_warp_mma<Causal, half, ScaledEpilogue>(
+              input_c, cache_c, cache_ptr, cache_frames, weight_c, out_s, bias_ptr,
+              stride, pad, relu, pad_right_bottom)
+        : dispatch_conv3_warp_mma<Causal, float, ScaledEpilogue>(
+              input_c, cache_c, cache_ptr, cache_frames, weight_c, out_s, bias_ptr,
+              stride, pad, relu, pad_right_bottom);
+}
+
+}  // namespace
+
+torch::Tensor lightvae_fp8_conv1_tin16_warp_mma_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    return checked_conv1_warp_mma(input, weight, output_scale, bias, relu);
+}
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_warp_mma_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom) {
+    return checked_conv3_warp_mma<false>(
+        input, c10::nullopt, weight, output_scale, bias, stride, pad, relu, pad_right_bottom);
+}
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_warp_mma_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu) {
+    return checked_conv3_warp_mma<true>(
+        input, cache, weight, output_scale, bias, 1, 1, relu, false);
+}
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_warp_mma_scaled_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor epilogue_scale,
+    c10::optional<torch::Tensor> bias_scaled,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom) {
+    return checked_conv3_warp_mma<false, true>(
+        input, c10::nullopt, weight, epilogue_scale, bias_scaled, stride, pad, relu, pad_right_bottom);
+}
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_warp_mma_scaled_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor epilogue_scale,
+    c10::optional<torch::Tensor> bias_scaled,
+    bool relu) {
+    return checked_conv3_warp_mma<true, true>(
+        input, cache, weight, epilogue_scale, bias_scaled, 1, 1, relu, false);
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_ops.cu
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_ops.cu
@@ -1,0 +1,1273 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "lightvae_ops.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_fp16.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+
+#include <cutlass/conv/conv2d_problem_size.h>
+#include <cutlass/conv/conv3d_problem_size.h>
+#include <cutlass/conv/device/implicit_gemm_convolution.h>
+#include <cutlass/conv/kernel/default_conv2d_fprop.h>
+#include <cutlass/conv/kernel/default_conv3d_fprop.h>
+#include <cutlass/conv/kernel/default_conv3d_fprop_with_broadcast.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/epilogue/thread/activation.h>
+#include <cutlass/epilogue/thread/linear_combination.h>
+#include <cutlass/epilogue/thread/linear_combination_bias_elementwise.h>
+#include <cutlass/layout/tensor.h>
+
+namespace py = pybind11;
+
+namespace omnidreams_singleview {
+namespace {
+
+#define OMNIDREAMS_SINGLEVIEW_VAE_PACK_INPUT_LAYOUT_3D(problem) \
+    cutlass::layout::TensorNDHWC::packed({ \
+        (problem).N, (problem).D, (problem).H, (problem).W, (problem).C})
+
+#define OMNIDREAMS_SINGLEVIEW_VAE_PACK_WEIGHT_LAYOUT_3D(problem) \
+    cutlass::layout::TensorNDHWC::packed({ \
+        (problem).K, (problem).T, (problem).R, (problem).S, (problem).C})
+
+#define OMNIDREAMS_SINGLEVIEW_VAE_PACK_OUTPUT_LAYOUT_3D(problem) \
+    cutlass::layout::TensorNDHWC::packed({ \
+        (problem).N, (problem).Z, (problem).P, (problem).Q, (problem).K})
+
+#define OMNIDREAMS_SINGLEVIEW_VAE_PACK_INPUT_LAYOUT_2D(problem) \
+    cutlass::layout::TensorNHWC::packed({ \
+        (problem).N, (problem).H, (problem).W, (problem).C})
+
+#define OMNIDREAMS_SINGLEVIEW_VAE_PACK_WEIGHT_LAYOUT_2D(problem) \
+    cutlass::layout::TensorNHWC::packed({ \
+        (problem).K, (problem).R, (problem).S, (problem).C})
+
+#define OMNIDREAMS_SINGLEVIEW_VAE_PACK_OUTPUT_LAYOUT_2D(problem) \
+    cutlass::layout::TensorNHWC::packed({ \
+        (problem).N, (problem).P, (problem).Q, (problem).K})
+
+void check_half_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(tensor.scalar_type() == at::kHalf, name, " must be torch.float16");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void check_same_device_as_input(const torch::Tensor& tensor, const char* name, const torch::Tensor& input) {
+    TORCH_CHECK(tensor.device() == input.device(),
+                name, " must be on the same CUDA device as input; input=",
+                input.device(), " ", name, "=", tensor.device());
+}
+
+int ceil_multiple(int value, int multiple) {
+    return ((value + multiple - 1) / multiple) * multiple;
+}
+
+int conv_output_dim_or_zero(int extent, int pad, int kernel, int stride) {
+    if (extent <= 0 || kernel <= 0 || stride <= 0) {
+        return 0;
+    }
+    const int padded = extent + 2 * pad;
+    if (padded < kernel) {
+        return 0;
+    }
+    return (padded - kernel) / stride + 1;
+}
+
+const half* half_ptr_const(const torch::Tensor& tensor) {
+    return reinterpret_cast<const half*>(tensor.data_ptr<at::Half>());
+}
+
+half* half_ptr(torch::Tensor& tensor) {
+    return reinterpret_cast<half*>(tensor.data_ptr<at::Half>());
+}
+
+__global__ void bcthw_to_ndhwc_padded_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int bsz,
+    int cin,
+    int t,
+    int h,
+    int w,
+    int cpad,
+    int tpad_left,
+    int hpad,
+    int wpad,
+    int t_total,
+    int h_total,
+    int w_total) {
+    long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const long long total = static_cast<long long>(bsz) * cin * t * h * w;
+    if (idx >= total) {
+        return;
+    }
+    int x = static_cast<int>(idx % w);
+    idx /= w;
+    int y = static_cast<int>(idx % h);
+    idx /= h;
+    int ti = static_cast<int>(idx % t);
+    idx /= t;
+    int c = static_cast<int>(idx % cin);
+    idx /= cin;
+    int b = static_cast<int>(idx);
+
+    const int to = ti + tpad_left;
+    const int yo = y + hpad;
+    const int xo = x + wpad;
+    const long long out_idx =
+        (((static_cast<long long>(b) * t_total + to) * h_total + yo) * w_total + xo) * cpad + c;
+    const long long in_idx =
+        (((static_cast<long long>(b) * cin + c) * t + ti) * h + y) * w + x;
+    output[out_idx] = input[in_idx];
+}
+
+__global__ void kctrs_to_ktrsc_padded_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int kout,
+    int cin,
+    int kt,
+    int kh,
+    int kw,
+    int kpad,
+    int cpad) {
+    long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const long long total = static_cast<long long>(kout) * cin * kt * kh * kw;
+    if (idx >= total) {
+        return;
+    }
+    int s = static_cast<int>(idx % kw);
+    idx /= kw;
+    int r = static_cast<int>(idx % kh);
+    idx /= kh;
+    int tt = static_cast<int>(idx % kt);
+    idx /= kt;
+    int c = static_cast<int>(idx % cin);
+    idx /= cin;
+    int k = static_cast<int>(idx);
+
+    const long long in_idx =
+        (((static_cast<long long>(k) * cin + c) * kt + tt) * kh + r) * kw + s;
+    const long long out_idx =
+        ((((static_cast<long long>(k) * kt + tt) * kh + r) * kw + s) * cpad + c);
+    output[out_idx] = input[in_idx];
+}
+
+__global__ void add_bias_ndhwc_kernel(
+    half* __restrict__ data,
+    const half* __restrict__ bias,
+    long long total,
+    int channels,
+    int real_channels) {
+    long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const long long stride = static_cast<long long>(blockDim.x) * gridDim.x;
+    for (; idx < total; idx += stride) {
+        int c = static_cast<int>(idx % channels);
+        if (c < real_channels) {
+            data[idx] = __float2half(__half2float(data[idx]) + __half2float(bias[c]));
+        }
+    }
+}
+
+int launch_blocks_linear(long long total) {
+    constexpr int threads = 256;
+    return static_cast<int>(std::min((total + threads - 1) / threads, 65535LL));
+}
+
+__global__ void ndhwc_to_bcthw_crop_kernel(
+    const half* __restrict__ input,
+    half* __restrict__ output,
+    int bsz,
+    int kout,
+    int t,
+    int h,
+    int w,
+    int kpad) {
+    long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const long long total = static_cast<long long>(bsz) * kout * t * h * w;
+    if (idx >= total) {
+        return;
+    }
+    int x = static_cast<int>(idx % w);
+    idx /= w;
+    int y = static_cast<int>(idx % h);
+    idx /= h;
+    int ti = static_cast<int>(idx % t);
+    idx /= t;
+    int c = static_cast<int>(idx % kout);
+    idx /= kout;
+    int b = static_cast<int>(idx);
+
+    const long long in_idx =
+        (((static_cast<long long>(b) * t + ti) * h + y) * w + x) * kpad + c;
+    const long long out_idx =
+        (((static_cast<long long>(b) * kout + c) * t + ti) * h + y) * w + x;
+    output[out_idx] = input[in_idx];
+}
+
+cudaError_t cutlass_conv2d_nhwc(
+    const half* input,
+    const half* weight,
+    half* output,
+    int n,
+    int cin,
+    int cout,
+    int h,
+    int w,
+    int kh,
+    int kw,
+    int stride_h,
+    int stride_w,
+    cudaStream_t stream) {
+    const int h_out = conv_output_dim_or_zero(h, 0, kh, stride_h);
+    const int w_out = conv_output_dim_or_zero(w, 0, kw, stride_w);
+    if (!input || !weight || !output || n <= 0 || cin <= 0 || cout <= 0 ||
+        h <= 0 || w <= 0 || h_out <= 0 || w_out <= 0) {
+        return cudaSuccess;
+    }
+
+    using Element = cutlass::half_t;
+    using Accum = float;
+    using Conv2dKernel = typename cutlass::conv::kernel::DefaultConv2dFprop<
+        Element, cutlass::layout::TensorNHWC,
+        Element, cutlass::layout::TensorNHWC,
+        Element, cutlass::layout::TensorNHWC,
+        Accum,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        cutlass::epilogue::thread::LinearCombination<
+            Element, 128 / cutlass::sizeof_bits<Element>::value, Accum, Accum>,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        2,
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kOptimized,
+        cutlass::conv::StrideSupport::kStrided,
+        4,
+        4>::Kernel;
+    using Conv2dOp = cutlass::conv::device::ImplicitGemmConvolution<Conv2dKernel>;
+
+    cutlass::conv::Conv2dProblemSize problem(
+        n, h, w, cin, cout, kh, kw, h_out, w_out,
+        0, 0, stride_h, stride_w, 1, 1, cutlass::conv::Mode::kCrossCorrelation);
+    auto layout_a = OMNIDREAMS_SINGLEVIEW_VAE_PACK_INPUT_LAYOUT_2D(problem);
+    auto layout_b = OMNIDREAMS_SINGLEVIEW_VAE_PACK_WEIGHT_LAYOUT_2D(problem);
+    auto layout_c = OMNIDREAMS_SINGLEVIEW_VAE_PACK_OUTPUT_LAYOUT_2D(problem);
+    typename Conv2dKernel::TensorRefA ref_a(
+        const_cast<Element*>(reinterpret_cast<const Element*>(input)), layout_a);
+    typename Conv2dKernel::TensorRefB ref_b(
+        const_cast<Element*>(reinterpret_cast<const Element*>(weight)), layout_b);
+    typename Conv2dKernel::TensorRefC ref_c(reinterpret_cast<Element*>(output), layout_c);
+    typename Conv2dKernel::TensorRefC ref_d(reinterpret_cast<Element*>(output), layout_c);
+    typename Conv2dKernel::Epilogue::OutputOp::Params epilogue(Accum(1.0f), Accum(0.0f));
+    typename Conv2dOp::Arguments args(problem, ref_a, ref_b, ref_c, ref_d, epilogue, cutlass::conv::SplitKMode::kSerial);
+    Conv2dOp op;
+    cutlass::Status status = op.can_implement(args);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorNotSupported;
+    }
+    status = op.initialize(args, nullptr, stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorInitializationError;
+    }
+    status = op(stream);
+    return status == cutlass::Status::kSuccess ? cudaSuccess : cudaErrorUnknown;
+}
+
+cudaError_t cutlass_conv3d_ndhwc(
+    const half* input,
+    const half* weight,
+    half* output,
+    int n,
+    int cin,
+    int cout,
+    int t,
+    int h,
+    int w,
+    int kt,
+    int kh,
+    int kw,
+    int pad_d,
+    int pad_h,
+    int pad_w,
+    int stride_t,
+    int stride_h,
+    int stride_w,
+    cudaStream_t stream) {
+    const int t_out = conv_output_dim_or_zero(t, pad_d, kt, stride_t);
+    const int h_out = conv_output_dim_or_zero(h, pad_h, kh, stride_h);
+    const int w_out = conv_output_dim_or_zero(w, pad_w, kw, stride_w);
+    if (!input || !weight || !output || n <= 0 || cin <= 0 || cout <= 0 ||
+        t <= 0 || h <= 0 || w <= 0 || t_out <= 0 || h_out <= 0 || w_out <= 0) {
+        return cudaSuccess;
+    }
+    if (kt == 1 && stride_t == 1 && pad_d == 0 && pad_h == 0 && pad_w == 0) {
+        return cutlass_conv2d_nhwc(
+            input,
+            weight,
+            output,
+            n * t,
+            cin,
+            cout,
+            h,
+            w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            stream);
+    }
+
+    using Element = cutlass::half_t;
+    using Accum = float;
+    using Conv3dKernel = typename cutlass::conv::kernel::DefaultConv3dFprop<
+        Element, cutlass::layout::TensorNDHWC,
+        Element, cutlass::layout::TensorNDHWC,
+        Element, cutlass::layout::TensorNDHWC,
+        Accum,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<128, 128, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        cutlass::epilogue::thread::LinearCombination<
+            Element, 128 / cutlass::sizeof_bits<Element>::value, Accum, Accum>,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        4,
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kOptimized,
+        cutlass::conv::StrideSupport::kStrided>::Kernel;
+    using Conv3dOp = cutlass::conv::device::ImplicitGemmConvolution<Conv3dKernel>;
+
+    cutlass::conv::Conv3dProblemSize problem(
+        n, t, h, w, cin, cout, kt, kh, kw, t_out, h_out, w_out,
+        pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, 1, 1, 1, cutlass::conv::Mode::kCrossCorrelation);
+    auto layout_a = OMNIDREAMS_SINGLEVIEW_VAE_PACK_INPUT_LAYOUT_3D(problem);
+    auto layout_b = OMNIDREAMS_SINGLEVIEW_VAE_PACK_WEIGHT_LAYOUT_3D(problem);
+    auto layout_c = OMNIDREAMS_SINGLEVIEW_VAE_PACK_OUTPUT_LAYOUT_3D(problem);
+    typename Conv3dKernel::TensorRefA ref_a(
+        const_cast<Element*>(reinterpret_cast<const Element*>(input)), layout_a);
+    typename Conv3dKernel::TensorRefB ref_b(
+        const_cast<Element*>(reinterpret_cast<const Element*>(weight)), layout_b);
+    typename Conv3dKernel::TensorRefC ref_c(reinterpret_cast<Element*>(output), layout_c);
+    typename Conv3dKernel::TensorRefC ref_d(reinterpret_cast<Element*>(output), layout_c);
+    typename Conv3dKernel::Epilogue::OutputOp::Params epilogue(Accum(1.0f), Accum(0.0f));
+    typename Conv3dOp::Arguments args(problem, ref_a, ref_b, ref_c, ref_d, epilogue, cutlass::conv::SplitKMode::kSerial);
+    Conv3dOp op;
+    cutlass::Status status = op.can_implement(args);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorNotSupported;
+    }
+    status = op.initialize(args, nullptr, stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorInitializationError;
+    }
+    status = op(stream);
+    return status == cutlass::Status::kSuccess ? cudaSuccess : cudaErrorUnknown;
+}
+
+template <
+    int ThreadblockM,
+    int ThreadblockN,
+    int ThreadblockK,
+    int WarpM,
+    int WarpN,
+    int WarpK,
+    int Stages>
+cudaError_t cutlass_conv3d_ndhwc_bias(
+    const half* input,
+    const half* weight,
+    const half* bias,
+    half* output,
+    int n,
+    int cin,
+    int cout,
+    int t,
+    int h,
+    int w,
+    int kt,
+    int kh,
+    int kw,
+    int pad_d,
+    int pad_h,
+    int pad_w,
+    int stride_t,
+    int stride_h,
+    int stride_w,
+    cudaStream_t stream) {
+    const int t_out = conv_output_dim_or_zero(t, pad_d, kt, stride_t);
+    const int h_out = conv_output_dim_or_zero(h, pad_h, kh, stride_h);
+    const int w_out = conv_output_dim_or_zero(w, pad_w, kw, stride_w);
+    if (!input || !weight || !bias || !output || n <= 0 || cin <= 0 || cout <= 0 ||
+        t <= 0 || h <= 0 || w <= 0 || t_out <= 0 || h_out <= 0 || w_out <= 0) {
+        return cudaSuccess;
+    }
+
+    using Element = cutlass::half_t;
+    using Accum = float;
+    using Compute = float;
+    using EpilogueOutputOp = cutlass::epilogue::thread::LinearCombinationBiasElementwise<
+        Element,
+        Accum,
+        Compute,
+        Element,
+        Element,
+        128 / cutlass::sizeof_bits<Element>::value,
+        cutlass::epilogue::thread::Identity<Compute>,
+        cutlass::plus<Compute>,
+        false>;
+    using Conv3dKernel = typename cutlass::conv::kernel::DefaultConv3dFpropWithBroadcast<
+        Element, cutlass::layout::TensorNDHWC,
+        Element, cutlass::layout::TensorNDHWC,
+        Element, cutlass::layout::TensorNDHWC,
+        Accum,
+        cutlass::arch::OpClassTensorOp,
+        cutlass::arch::Sm80,
+        cutlass::gemm::GemmShape<ThreadblockM, ThreadblockN, ThreadblockK>,
+        cutlass::gemm::GemmShape<WarpM, WarpN, WarpK>,
+        cutlass::gemm::GemmShape<16, 8, 16>,
+        EpilogueOutputOp,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+        Stages,
+        cutlass::arch::OpMultiplyAdd,
+        cutlass::conv::IteratorAlgorithm::kOptimized,
+        cutlass::conv::StrideSupport::kStrided>::Kernel;
+    using Conv3dOp = cutlass::conv::device::ImplicitGemmConvolution<Conv3dKernel>;
+
+    cutlass::conv::Conv3dProblemSize problem(
+        n, t, h, w, cin, cout, kt, kh, kw, t_out, h_out, w_out,
+        pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, 1, 1, 1, cutlass::conv::Mode::kCrossCorrelation);
+    auto layout_a = OMNIDREAMS_SINGLEVIEW_VAE_PACK_INPUT_LAYOUT_3D(problem);
+    auto layout_b = OMNIDREAMS_SINGLEVIEW_VAE_PACK_WEIGHT_LAYOUT_3D(problem);
+    auto layout_c = OMNIDREAMS_SINGLEVIEW_VAE_PACK_OUTPUT_LAYOUT_3D(problem);
+    typename Conv3dKernel::TensorRefA ref_a(
+        const_cast<Element*>(reinterpret_cast<const Element*>(input)), layout_a);
+    typename Conv3dKernel::TensorRefB ref_b(
+        const_cast<Element*>(reinterpret_cast<const Element*>(weight)), layout_b);
+    typename Conv3dKernel::TensorRefC ref_c(reinterpret_cast<Element*>(output), layout_c);
+    typename Conv3dKernel::TensorRefC ref_d(reinterpret_cast<Element*>(output), layout_c);
+    typename EpilogueOutputOp::Params epilogue(Compute(1.0f), Compute(0.0f));
+    typename Conv3dOp::Arguments args(
+        problem,
+        ref_a,
+        ref_b,
+        ref_c,
+        ref_d,
+        epilogue,
+        cutlass::conv::SplitKMode::kSerial,
+        const_cast<Element*>(reinterpret_cast<const Element*>(bias)),
+        nullptr,
+        0,
+        cout);
+    Conv3dOp op;
+    cutlass::Status status = op.can_implement(args);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorNotSupported;
+    }
+    status = op.initialize(args, nullptr, stream);
+    if (status != cutlass::Status::kSuccess) {
+        return cudaErrorInitializationError;
+    }
+    status = op(stream);
+    return status == cutlass::Status::kSuccess ? cudaSuccess : cudaErrorUnknown;
+}
+
+cudaError_t cutlass_conv3d_ndhwc_bias(
+    const half* input,
+    const half* weight,
+    const half* bias,
+    half* output,
+    int n,
+    int cin,
+    int cout,
+    int t,
+    int h,
+    int w,
+    int kt,
+    int kh,
+    int kw,
+    int pad_d,
+    int pad_h,
+    int pad_w,
+    int stride_t,
+    int stride_h,
+    int stride_w,
+    cudaStream_t stream) {
+    if (bias == nullptr || kt == 1) {
+        return cudaErrorNotSupported;
+    }
+
+    const char* env_tile = std::getenv("OMNIDREAMS_SINGLEVIEW_VAE_CONV3D_TILE");
+    const std::string tile = env_tile == nullptr ? "auto" : std::string(env_tile);
+    auto run_current = [&]() {
+        return cutlass_conv3d_ndhwc_bias<128, 128, 32, 64, 64, 32, 4>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_128x64 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<128, 64, 32, 64, 32, 32, 4>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_128x32 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<128, 32, 32, 64, 32, 32, 4>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_current_s3 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<128, 128, 32, 64, 64, 32, 3>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_128x64_s3 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<128, 64, 32, 64, 32, 32, 3>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_128x32_s3 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<128, 32, 32, 64, 32, 32, 3>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_256x64_s3 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<256, 64, 32, 64, 32, 32, 3>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_256x32_s3 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<256, 32, 32, 64, 32, 32, 3>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_64x64_s3 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<64, 64, 32, 32, 32, 32, 3>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+    auto run_64x32_s3 = [&]() {
+        return cutlass_conv3d_ndhwc_bias<64, 32, 32, 32, 32, 32, 3>(
+            input, weight, bias, output,
+            n, cin, cout, t, h, w, kt, kh, kw,
+            pad_d, pad_h, pad_w, stride_t, stride_h, stride_w, stream);
+    };
+
+    if (tile == "128x128x32" || tile == "current") {
+        return run_current();
+    }
+    if (tile == "128x64x32") {
+        return run_128x64();
+    }
+    if (tile == "128x32x32") {
+        return run_128x32();
+    }
+    if (tile == "128x128x32_s3" || tile == "current_s3") {
+        return run_current_s3();
+    }
+    if (tile == "128x64x32_s3") {
+        return run_128x64_s3();
+    }
+    if (tile == "128x32x32_s3") {
+        return run_128x32_s3();
+    }
+    if (tile == "256x64x32_s3") {
+        return run_256x64_s3();
+    }
+    if (tile == "256x32x32_s3") {
+        return run_256x32_s3();
+    }
+    if (tile == "64x64x32_s3") {
+        return run_64x64_s3();
+    }
+    if (tile == "64x32x32_s3") {
+        return run_64x32_s3();
+    }
+    if (tile == "auto_s3") {
+        cudaError_t err = cout <= 32 ? run_128x32_s3() : (cout <= 64 ? run_128x64_s3() : run_current_s3());
+        if (err == cudaErrorNotSupported || err == cudaErrorInitializationError) {
+            return run_current();
+        }
+        return err;
+    }
+    if (tile == "auto" || tile == "auto_256_s3") {
+        cudaError_t err = cout <= 32 ? run_256x32_s3() : (cout <= 64 ? run_256x64_s3() : run_current_s3());
+        if (err == cudaErrorNotSupported || err == cudaErrorInitializationError) {
+            return run_current();
+        }
+        return err;
+    }
+    if (tile == "auto_64_s3") {
+        cudaError_t err = cout <= 32 ? run_64x32_s3() : (cout <= 64 ? run_64x64_s3() : run_current_s3());
+        if (err == cudaErrorNotSupported || err == cudaErrorInitializationError) {
+            return run_current();
+        }
+        return err;
+    }
+    if (tile != "auto_legacy") {
+        return cudaErrorNotSupported;
+    }
+
+    cudaError_t err = cout <= 32 ? run_128x32() : (cout <= 64 ? run_128x64() : run_current());
+    if (err == cudaErrorNotSupported || err == cudaErrorInitializationError) {
+        return run_current();
+    }
+    return err;
+}
+
+}  // namespace
+
+torch::Tensor lightvae_causal_conv3d_bcthw(
+    torch::Tensor input,
+    torch::Tensor weight,
+    c10::optional<torch::Tensor> bias,
+    int pad_t_left,
+    int pad_h,
+    int pad_w,
+    int stride_t,
+    int stride_h,
+    int stride_w) {
+    check_half_cuda_contiguous(input, "input");
+    check_half_cuda_contiguous(weight, "weight");
+    check_same_device_as_input(weight, "weight", input);
+    TORCH_CHECK(input.dim() == 5, "input must be [B, C, T, H, W]");
+    TORCH_CHECK(weight.dim() == 5, "weight must be [K, C, Kt, Kh, Kw]");
+    TORCH_CHECK(pad_t_left >= 0 && pad_h >= 0 && pad_w >= 0, "padding must be non-negative");
+    TORCH_CHECK(stride_t > 0 && stride_h > 0 && stride_w > 0, "stride must be positive");
+
+    const int bsz = static_cast<int>(input.size(0));
+    const int cin = static_cast<int>(input.size(1));
+    const int t = static_cast<int>(input.size(2));
+    const int h = static_cast<int>(input.size(3));
+    const int w = static_cast<int>(input.size(4));
+    const int kout = static_cast<int>(weight.size(0));
+    const int wcin = static_cast<int>(weight.size(1));
+    const int kt = static_cast<int>(weight.size(2));
+    const int kh = static_cast<int>(weight.size(3));
+    const int kw = static_cast<int>(weight.size(4));
+    TORCH_CHECK(wcin == cin, "weight input channels ", wcin, " do not match input channels ", cin);
+
+    torch::Tensor bias_tensor;
+    if (bias.has_value()) {
+        bias_tensor = bias.value();
+        check_half_cuda_contiguous(bias_tensor, "bias");
+        check_same_device_as_input(bias_tensor, "bias", input);
+        TORCH_CHECK(bias_tensor.dim() == 1 && bias_tensor.size(0) == kout,
+                    "bias must be [", kout, "]");
+    }
+
+    const int cpad = ceil_multiple(cin, 8);
+    const int kpad = ceil_multiple(kout, 8);
+    const int t_total = t + pad_t_left;
+    const int h_total = h + 2 * pad_h;
+    const int w_total = w + 2 * pad_w;
+    at::cuda::CUDAGuard guard(input.device());
+    auto opts = input.options();
+    const int t_out = conv_output_dim_or_zero(t_total, 0, kt, stride_t);
+    const int h_out = conv_output_dim_or_zero(h_total, 0, kh, stride_h);
+    const int w_out = conv_output_dim_or_zero(w_total, 0, kw, stride_w);
+    if (bsz <= 0 || cin <= 0 || kout <= 0 || t <= 0 || h <= 0 || w <= 0 ||
+        t_out <= 0 || h_out <= 0 || w_out <= 0) {
+        return torch::empty(
+            {bsz, kout, std::max(0, t_out), std::max(0, h_out), std::max(0, w_out)},
+            opts);
+    }
+    torch::Tensor input_ndhwc = torch::zeros({bsz, t_total, h_total, w_total, cpad}, opts);
+    torch::Tensor weight_ktrsc = torch::zeros({kpad, kt, kh, kw, cpad}, opts);
+    torch::Tensor output_ndhwc = torch::empty({bsz, t_out, h_out, w_out, kpad}, opts);
+    torch::Tensor output_bcthw = torch::empty({bsz, kout, t_out, h_out, w_out}, opts);
+    torch::Tensor bias_padded;
+    if (bias_tensor.defined()) {
+        if (kpad == kout) {
+            bias_padded = bias_tensor;
+        } else {
+            bias_padded = torch::zeros({kpad}, opts);
+            bias_padded.narrow(0, 0, kout).copy_(bias_tensor);
+        }
+    }
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    constexpr int threads = 256;
+
+    long long input_total = static_cast<long long>(bsz) * cin * t * h * w;
+    if (input_total > 0) {
+        bcthw_to_ndhwc_padded_kernel<<<static_cast<int>((input_total + threads - 1) / threads), threads, 0, stream>>>(
+        half_ptr_const(input),
+        half_ptr(input_ndhwc),
+        bsz,
+        cin,
+        t,
+        h,
+        w,
+        cpad,
+        pad_t_left,
+        pad_h,
+        pad_w,
+        t_total,
+        h_total,
+        w_total);
+    }
+
+    long long weight_total = static_cast<long long>(kout) * cin * kt * kh * kw;
+    if (weight_total > 0) {
+        kctrs_to_ktrsc_padded_kernel<<<static_cast<int>((weight_total + threads - 1) / threads), threads, 0, stream>>>(
+        half_ptr_const(weight),
+        half_ptr(weight_ktrsc),
+        kout,
+        cin,
+        kt,
+        kh,
+        kw,
+        kpad,
+        cpad);
+    }
+
+    bool fused_bias = false;
+    cudaError_t err = cudaErrorNotSupported;
+    if (bias_tensor.defined()) {
+        err = cutlass_conv3d_ndhwc_bias(
+            half_ptr_const(input_ndhwc),
+            half_ptr_const(weight_ktrsc),
+            half_ptr_const(bias_padded),
+            half_ptr(output_ndhwc),
+            bsz,
+            cpad,
+            kpad,
+            t_total,
+            h_total,
+            w_total,
+            kt,
+            kh,
+            kw,
+            0,
+            0,
+            0,
+            stride_t,
+            stride_h,
+            stride_w,
+            stream);
+        if (err == cudaSuccess) {
+            fused_bias = true;
+        } else {
+            TORCH_CHECK(err == cudaErrorNotSupported || err == cudaErrorInitializationError,
+                        "CUTLASS LightVAE Conv3D fused-bias failed: ", cudaGetErrorString(err));
+        }
+    }
+    if (!fused_bias) {
+        err = cutlass_conv3d_ndhwc(
+            half_ptr_const(input_ndhwc),
+            half_ptr_const(weight_ktrsc),
+            half_ptr(output_ndhwc),
+            bsz,
+            cpad,
+            kpad,
+            t_total,
+            h_total,
+            w_total,
+            kt,
+            kh,
+            kw,
+            0,
+            0,
+            0,
+            stride_t,
+            stride_h,
+            stride_w,
+            stream);
+        TORCH_CHECK(err == cudaSuccess, "CUTLASS LightVAE Conv3D failed: ", cudaGetErrorString(err));
+    }
+    if (bias_tensor.defined()) {
+        long long out_total = static_cast<long long>(bsz) * t_out * h_out * w_out * kpad;
+        if (!fused_bias && out_total > 0) {
+            add_bias_ndhwc_kernel<<<launch_blocks_linear(out_total), threads, 0, stream>>>(
+                half_ptr(output_ndhwc),
+                half_ptr_const(bias_tensor),
+                out_total,
+                kpad,
+                kout);
+        }
+    }
+
+    long long crop_total = static_cast<long long>(bsz) * kout * t_out * h_out * w_out;
+    if (crop_total > 0) {
+        ndhwc_to_bcthw_crop_kernel<<<static_cast<int>((crop_total + threads - 1) / threads), threads, 0, stream>>>(
+        half_ptr_const(output_ndhwc),
+        half_ptr(output_bcthw),
+        bsz,
+        kout,
+        t_out,
+        h_out,
+        w_out,
+        kpad);
+    }
+    return output_bcthw;
+}
+
+torch::Tensor cutlass_conv3d_nthwc(
+    torch::Tensor input,
+    torch::Tensor weight,
+    c10::optional<torch::Tensor> bias,
+    int pad_d,
+    int pad_h,
+    int pad_w,
+    int stride_d,
+    int stride_h,
+    int stride_w) {
+    check_half_cuda_contiguous(input, "input");
+    check_half_cuda_contiguous(weight, "weight");
+    check_same_device_as_input(weight, "weight", input);
+    TORCH_CHECK(input.dim() == 5, "input must be NDHWC [B,T,H,W,C]");
+    TORCH_CHECK(weight.dim() == 5, "weight must be [K,T,R,S,C]");
+    TORCH_CHECK(pad_d >= 0 && pad_h >= 0 && pad_w >= 0, "padding must be non-negative");
+    TORCH_CHECK(stride_d > 0 && stride_h > 0 && stride_w > 0, "stride must be positive");
+
+    const int bsz = static_cast<int>(input.size(0));
+    const int t = static_cast<int>(input.size(1));
+    const int h = static_cast<int>(input.size(2));
+    const int w = static_cast<int>(input.size(3));
+    const int cin = static_cast<int>(input.size(4));
+    const int cout = static_cast<int>(weight.size(0));
+    const int kt = static_cast<int>(weight.size(1));
+    const int kh = static_cast<int>(weight.size(2));
+    const int kw = static_cast<int>(weight.size(3));
+    TORCH_CHECK(weight.size(4) == cin, "weight Cin=", weight.size(4), " does not match input C=", cin);
+
+    torch::Tensor bias_tensor;
+    if (bias.has_value()) {
+        bias_tensor = bias.value();
+        check_half_cuda_contiguous(bias_tensor, "bias");
+        check_same_device_as_input(bias_tensor, "bias", input);
+        TORCH_CHECK(bias_tensor.dim() == 1 && bias_tensor.size(0) == cout,
+                    "bias must be [", cout, "]");
+    }
+
+    at::cuda::CUDAGuard guard(input.device());
+    const int t_out = conv_output_dim_or_zero(t, pad_d, kt, stride_d);
+    const int h_out = conv_output_dim_or_zero(h, pad_h, kh, stride_h);
+    const int w_out = conv_output_dim_or_zero(w, pad_w, kw, stride_w);
+    if (bsz <= 0 || cin <= 0 || cout <= 0 || t <= 0 || h <= 0 || w <= 0 ||
+        t_out <= 0 || h_out <= 0 || w_out <= 0) {
+        return torch::empty(
+            {bsz, std::max(0, t_out), std::max(0, h_out), std::max(0, w_out), cout},
+            input.options());
+    }
+    auto output = torch::empty({bsz, t_out, h_out, w_out, cout}, input.options());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    bool fused_bias = false;
+    cudaError_t err = cudaErrorNotSupported;
+    if (bias_tensor.defined()) {
+        err = cutlass_conv3d_ndhwc_bias(
+            half_ptr_const(input),
+            half_ptr_const(weight),
+            half_ptr_const(bias_tensor),
+            half_ptr(output),
+            bsz,
+            cin,
+            cout,
+            t,
+            h,
+            w,
+            kt,
+            kh,
+            kw,
+            pad_d,
+            pad_h,
+            pad_w,
+            stride_d,
+            stride_h,
+            stride_w,
+            stream);
+        if (err == cudaSuccess) {
+            fused_bias = true;
+        } else {
+            TORCH_CHECK(err == cudaErrorNotSupported || err == cudaErrorInitializationError,
+                        "CUTLASS Conv3D NDHWC fused-bias failed: ", cudaGetErrorString(err));
+        }
+    }
+    if (!fused_bias) {
+        err = cutlass_conv3d_ndhwc(
+            half_ptr_const(input),
+            half_ptr_const(weight),
+            half_ptr(output),
+            bsz,
+            cin,
+            cout,
+            t,
+            h,
+            w,
+            kt,
+            kh,
+            kw,
+            pad_d,
+            pad_h,
+            pad_w,
+            stride_d,
+            stride_h,
+            stride_w,
+            stream);
+        TORCH_CHECK(err == cudaSuccess, "CUTLASS Conv3D NDHWC failed: ", cudaGetErrorString(err));
+    }
+    if (bias_tensor.defined()) {
+        constexpr int threads = 256;
+        long long out_total = static_cast<long long>(bsz) * t_out * h_out * w_out * cout;
+        if (!fused_bias && out_total > 0) {
+            add_bias_ndhwc_kernel<<<launch_blocks_linear(out_total), threads, 0, stream>>>(
+                half_ptr(output),
+                half_ptr_const(bias_tensor),
+                out_total,
+                cout,
+                cout);
+        }
+    }
+    return output;
+}
+
+void bind_lightvae_ops(py::module_& m) {
+    m.def(
+        "lightvae_causal_conv3d_bcthw",
+        &lightvae_causal_conv3d_bcthw,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("bias") = py::none(),
+        py::arg("pad_t_left"),
+        py::arg("pad_h"),
+        py::arg("pad_w"),
+        py::arg("stride_t") = 1,
+        py::arg("stride_h") = 1,
+        py::arg("stride_w") = 1,
+        "TIN3-free CUTLASS Conv3D helper for LightVAE BCTHW tensors.");
+    m.def(
+        "cutlass_conv3d_nthwc",
+        &cutlass_conv3d_nthwc,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("bias") = py::none(),
+        py::arg("pad_d") = 0,
+        py::arg("pad_h") = 0,
+        py::arg("pad_w") = 0,
+        py::arg("stride_d") = 1,
+        py::arg("stride_h") = 1,
+        py::arg("stride_w") = 1,
+        "Prepared CUTLASS Conv3D helper for NDHWC tensors.");
+    m.def(
+        "lightvae_fp8_quantize_bcthw_to_tin16",
+        &lightvae_fp8_quantize_bcthw_to_tin16,
+        py::arg("input"),
+        py::arg("scale"),
+        py::arg("padded_height"),
+        py::arg("padded_width"),
+        py::arg("padded_channels"),
+        "Quantize [1,C,T,H,W] fp16 LightVAE activations to raw E4M3 TIN16 layout.");
+    m.def(
+        "lightvae_fp8_dequantize_tin16_to_bcthw",
+        &lightvae_fp8_dequantize_tin16_to_bcthw,
+        py::arg("input"),
+        py::arg("scale"),
+        py::arg("real_channels"),
+        py::arg("real_height"),
+        py::arg("real_width"),
+        "Dequantize raw E4M3 TIN16 LightVAE activations to [1,C,T,H,W] fp16.");
+    m.def(
+        "lightvae_fp8_rmsnorm_tin16",
+        &lightvae_fp8_rmsnorm_tin16,
+        py::arg("input"),
+        py::arg("input_scale"),
+        py::arg("gamma"),
+        py::arg("output_scale"),
+        py::arg("real_channels"),
+        py::arg("silu") = true,
+        "FP8 TIN16 RMSNorm with optional SiLU and FP8 output.");
+    m.def(
+        "lightvae_fp8_add_tin16",
+        &lightvae_fp8_add_tin16,
+        py::arg("a"),
+        py::arg("b"),
+        py::arg("a_scale"),
+        py::arg("b_scale"),
+        py::arg("output_scale"),
+        py::arg("real_channels") = -1,
+        "Scaled FP8 TIN16 residual add with FP8 output.");
+    m.def(
+        "lightvae_fp8_add_relu_tin16",
+        &lightvae_fp8_add_relu_tin16,
+        py::arg("a"),
+        py::arg("b"),
+        py::arg("a_scale"),
+        py::arg("b_scale"),
+        py::arg("output_scale"),
+        py::arg("real_channels") = -1,
+        "Scaled FP8 TIN16 residual add followed by ReLU with FP8 output.");
+    m.def(
+        "lightvae_fp8_upsample2x_tin16",
+        &lightvae_fp8_upsample2x_tin16,
+        py::arg("input"),
+        "Nearest-neighbor 2x spatial upsample for raw FP8 TIN16 tensors.");
+    m.def(
+        "lightvae_extract_mu_normalize_tin16",
+        &lightvae_fp8_extract_mu_normalize_tin16,
+        py::arg("input"),
+        py::arg("input_scale"),
+        py::arg("mean"),
+        py::arg("inv_std"),
+        py::arg("real_height"),
+        py::arg("real_width"),
+        "Dequantize TIN16 FP8 input, extract the first 16 channels, apply LightVAE latent normalization, and return fp16.");
+    m.def(
+        "cutlass_conv3x3_nhwc_fp8",
+        &cutlass_conv3x3_nhwc_fp8,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("stride") = 1,
+        py::arg("pad") = 1,
+        py::arg("relu") = false,
+        "TIN3-free CUTLASS FP8 Tensor Core 3x3 Conv2D primitive for NHWC raw E4M3 bytes.");
+    m.def(
+        "lightvae_fp8_prepare_conv2d_weight_krsc",
+        &lightvae_fp8_prepare_conv2d_weight_krsc,
+        py::arg("weight_krsc"),
+        py::arg("input_scale"),
+        py::arg("output_scale"),
+        "Prepare KRSC fp16 weights as raw E4M3 bytes scaled by input_scale/output_scale.");
+    m.def(
+        "cutlass_conv2d_nhwc_fp8_prepared",
+        &cutlass_conv2d_nhwc_fp8_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("stride") = 1,
+        py::arg("pad") = 1,
+        py::arg("relu") = false,
+        "TIN3-free CUTLASS FP8 Conv2D over prepared KRSC raw E4M3 weights with optional bias.");
+    m.def(
+        "lightvae_fp8_tin16_to_nhwc",
+        &lightvae_fp8_tin16_to_nhwc,
+        py::arg("input"),
+        "Convert raw FP8 TIN16 [T,C/16,H,W,16] bytes to raw FP8 NHWC bytes.");
+    m.def(
+        "lightvae_fp8_nhwc_to_tin16",
+        &lightvae_fp8_nhwc_to_tin16,
+        py::arg("input"),
+        "Convert raw FP8 NHWC bytes to raw FP8 TIN16 [T,C/16,H,W,16] bytes.");
+    m.def(
+        "lightvae_fp8_nhwc_rescale_to_tin16",
+        &lightvae_fp8_nhwc_rescale_to_tin16,
+        py::arg("input"),
+        py::arg("source_scale"),
+        py::arg("output_scale"),
+        "Convert raw FP8 NHWC bytes to TIN16 while rescaling from source_scale to output_scale.");
+    m.def(
+        "lightvae_fp8_pack_causal3_tin16",
+        &lightvae_fp8_pack_causal3_tin16,
+        py::arg("input"),
+        py::arg("cache") = py::none(),
+        "Pack current/cache TIN16 frames into a 3-frame causal TIN16 channel bundle.");
+    m.def(
+        "lightvae_fp8_pack_causal3_tin16_to_nhwc",
+        &lightvae_fp8_pack_causal3_tin16_to_nhwc,
+        py::arg("input"),
+        py::arg("cache") = py::none(),
+        "Pack current/cache TIN16 frames directly into raw FP8 NHWC bytes for CUTLASS FP8 Conv2D.");
+    m.def(
+        "lightvae_fp8_update_tail_cache_tin16",
+        &lightvae_fp8_update_tail_cache_tin16,
+        py::arg("input"),
+        py::arg("cache") = py::none(),
+        py::arg("cache_frames") = 2,
+        "Update a raw FP8 TIN16 tail cache without leaving TIN16 layout.");
+    m.def(
+        "lightvae_fp8_spatial_pad_right_bottom_tin16",
+        &lightvae_fp8_spatial_pad_right_bottom_tin16,
+        py::arg("input"),
+        "Append zero bottom/right padding to a raw FP8 TIN16 tensor.");
+    m.def(
+        "lightvae_fp8_pack_temporal3_tin16",
+        &lightvae_fp8_pack_temporal3_tin16,
+        py::arg("input"),
+        py::arg("cache") = py::none(),
+        "Pack temporal-downsample current/cache TIN16 frames into a 3-frame channel bundle.");
+    m.def(
+        "lightvae_fp8_pack_temporal3_tin16_to_nhwc",
+        &lightvae_fp8_pack_temporal3_tin16_to_nhwc,
+        py::arg("input"),
+        py::arg("cache") = py::none(),
+        "Pack temporal-downsample current/cache TIN16 frames directly into raw FP8 NHWC bytes.");
+    m.def(
+        "lightvae_fp8_causal_conv3_tin16_prepared",
+        &lightvae_fp8_causal_conv3_tin16_prepared,
+        py::arg("input"),
+        py::arg("cache"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run a true-FP8 LightVAE causal 3x3 stage from TIN16 input/cache to TIN16 output.");
+    m.def(
+        "lightvae_fp8_spatial_conv3_tin16_prepared",
+        &lightvae_fp8_spatial_conv3_tin16_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("stride") = 1,
+        py::arg("pad") = 1,
+        py::arg("relu") = false,
+        py::arg("pad_right_bottom") = false,
+        "Run a true-FP8 LightVAE spatial 3x3 stage from TIN16 input to TIN16 output.");
+    m.def(
+        "lightvae_fp8_conv1_tin16_prepared",
+        &lightvae_fp8_conv1_tin16_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run a true-FP8 LightVAE 1x1 stage from TIN16 input to TIN16 output.");
+    m.def(
+        "lightvae_fp8_temporal_conv1_tin16_prepared",
+        &lightvae_fp8_temporal_conv1_tin16_prepared,
+        py::arg("input"),
+        py::arg("cache"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run a true-FP8 LightVAE temporal-downsample 1x1 stage from packed TIN16 input/cache to TIN16 output.");
+    m.def(
+        "lightvae_fp8_qkv_tin16_to_bmhd",
+        &lightvae_fp8_qkv_tin16_to_bmhd,
+        py::arg("qkv"),
+        "Split raw FP8 TIN16 [T,288/16,H,W,16] QKV into cuDNN BMHD Q/K/V byte tensors.");
+    m.def(
+        "lightvae_fp8_bmhd_to_tin16",
+        &lightvae_fp8_bmhd_to_tin16,
+        py::arg("input"),
+        py::arg("frames"),
+        py::arg("height"),
+        py::arg("width"),
+        "Pack cuDNN BMHD raw FP8 attention output back into TIN16 [T,96/16,H,W,16].");
+    m.def(
+        "lightvae_fp8_sdpa_bmhd",
+        &lightvae_fp8_sdpa_bmhd,
+        py::arg("q"),
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("qkv_scale"),
+        py::arg("sdpa_inverse_scale"),
+        py::arg("unit_scale"),
+        py::arg("batch"),
+        py::arg("seq"),
+        py::arg("attn_scale"),
+        "Run cuDNN FP8 SDPA for LightVAE middle attention over raw FP8 BMHD bytes.");
+    m.def(
+        "lightvae_fp8_causal_conv3_tin16_direct_prepared",
+        &lightvae_fp8_causal_conv3_tin16_direct_prepared,
+        py::arg("input"),
+        py::arg("cache"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run the experimental direct-TIN16 FP8 causal 3x3 stage without pack/NHWC bridge launches.");
+    m.def(
+        "lightvae_fp8_spatial_conv3_tin16_direct_prepared",
+        &lightvae_fp8_spatial_conv3_tin16_direct_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("stride") = 1,
+        py::arg("pad") = 1,
+        py::arg("relu") = false,
+        py::arg("pad_right_bottom") = false,
+        "Run the experimental direct-TIN16 FP8 spatial 3x3 stage without pad/NHWC bridge launches.");
+    m.def(
+        "lightvae_fp8_conv1_tin16_direct_prepared",
+        &lightvae_fp8_conv1_tin16_direct_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run the experimental direct-TIN16 FP8 1x1 stage without NHWC bridge launches.");
+    m.def(
+        "lightvae_fp8_temporal_conv1_tin16_direct_prepared",
+        &lightvae_fp8_temporal_conv1_tin16_direct_prepared,
+        py::arg("input"),
+        py::arg("cache"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run the experimental direct-TIN16 FP8 temporal 1x1 stage without temporal-pack/NHWC bridge launches.");
+    m.def(
+        "lightvae_fp8_conv1_tin16_warp_mma_prepared",
+        &lightvae_fp8_conv1_tin16_warp_mma_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run the warp-MMA Tensor Core TIN16 FP8 1x1 stage.");
+    m.def(
+        "lightvae_fp8_spatial_conv3_tin16_warp_mma_prepared",
+        &lightvae_fp8_spatial_conv3_tin16_warp_mma_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("stride") = 1,
+        py::arg("pad") = 1,
+        py::arg("relu") = false,
+        py::arg("pad_right_bottom") = false,
+        "Run the experimental warp-MMA Tensor Core TIN16 FP8 spatial 3x3 stage.");
+    m.def(
+        "lightvae_fp8_causal_conv3_tin16_warp_mma_prepared",
+        &lightvae_fp8_causal_conv3_tin16_warp_mma_prepared,
+        py::arg("input"),
+        py::arg("cache"),
+        py::arg("weight"),
+        py::arg("output_scale"),
+        py::arg("bias") = py::none(),
+        py::arg("relu") = false,
+        "Run the experimental warp-MMA Tensor Core TIN16 FP8 causal 3x3 stage.");
+    m.def(
+        "lightvae_fp8_spatial_conv3_tin16_warp_mma_scaled_prepared",
+        &lightvae_fp8_spatial_conv3_tin16_warp_mma_scaled_prepared,
+        py::arg("input"),
+        py::arg("weight"),
+        py::arg("epilogue_scale"),
+        py::arg("bias_scaled") = py::none(),
+        py::arg("stride") = 1,
+        py::arg("pad") = 1,
+        py::arg("relu") = false,
+        py::arg("pad_right_bottom") = false,
+        "Run a warp-MMA FP8 spatial 3x3 stage with per-output epilogue scaling.");
+    m.def(
+        "lightvae_fp8_causal_conv3_tin16_warp_mma_scaled_prepared",
+        &lightvae_fp8_causal_conv3_tin16_warp_mma_scaled_prepared,
+        py::arg("input"),
+        py::arg("cache"),
+        py::arg("weight"),
+        py::arg("epilogue_scale"),
+        py::arg("bias_scaled") = py::none(),
+        py::arg("relu") = false,
+        "Run a warp-MMA FP8 causal 3x3 stage with per-output epilogue scaling.");
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_ops.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/lightvae_ops.h
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <torch/extension.h>
+#include <tuple>
+
+namespace omnidreams_singleview {
+
+torch::Tensor lightvae_causal_conv3d_bcthw(
+    torch::Tensor input,
+    torch::Tensor weight,
+    c10::optional<torch::Tensor> bias,
+    int pad_t_left,
+    int pad_h,
+    int pad_w,
+    int stride_t,
+    int stride_h,
+    int stride_w);
+
+torch::Tensor cutlass_conv3d_nthwc(
+    torch::Tensor input,
+    torch::Tensor weight,
+    c10::optional<torch::Tensor> bias,
+    int pad_d,
+    int pad_h,
+    int pad_w,
+    int stride_d,
+    int stride_h,
+    int stride_w);
+
+torch::Tensor lightvae_fp8_quantize_bcthw_to_tin16(
+    torch::Tensor input,
+    torch::Tensor scale,
+    int padded_height,
+    int padded_width,
+    int padded_channels);
+
+torch::Tensor lightvae_fp8_dequantize_tin16_to_bcthw(
+    torch::Tensor input,
+    torch::Tensor scale,
+    int real_channels,
+    int real_height,
+    int real_width);
+
+torch::Tensor lightvae_fp8_rmsnorm_tin16(
+    torch::Tensor input,
+    torch::Tensor input_scale,
+    torch::Tensor gamma,
+    torch::Tensor output_scale,
+    int real_channels,
+    bool silu);
+
+torch::Tensor lightvae_fp8_add_tin16(
+    torch::Tensor a,
+    torch::Tensor b,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    torch::Tensor output_scale,
+    int real_channels);
+
+torch::Tensor lightvae_fp8_add_relu_tin16(
+    torch::Tensor a,
+    torch::Tensor b,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    torch::Tensor output_scale,
+    int real_channels);
+
+torch::Tensor lightvae_fp8_add_relu_nhwc_tin16_to_tin16(
+    torch::Tensor a_nhwc,
+    torch::Tensor b_tin16,
+    torch::Tensor a_scale,
+    torch::Tensor b_scale,
+    torch::Tensor output_scale,
+    int real_channels);
+
+torch::Tensor lightvae_fp8_upsample2x_tin16(torch::Tensor input);
+
+torch::Tensor lightvae_fp8_extract_mu_normalize_tin16(
+    torch::Tensor input,
+    torch::Tensor input_scale,
+    torch::Tensor mean,
+    torch::Tensor inv_std,
+    int real_height,
+    int real_width);
+
+torch::Tensor cutlass_conv3x3_nhwc_fp8(
+    torch::Tensor input,
+    torch::Tensor weight,
+    int stride,
+    int pad,
+    bool relu);
+
+torch::Tensor lightvae_fp8_prepare_conv2d_weight_krsc(
+    torch::Tensor weight_krsc,
+    torch::Tensor input_scale,
+    torch::Tensor output_scale);
+
+torch::Tensor cutlass_conv2d_nhwc_fp8_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu);
+
+torch::Tensor lightvae_fp8_tin16_to_nhwc(torch::Tensor input);
+
+torch::Tensor lightvae_fp8_nhwc_to_tin16(torch::Tensor input);
+
+torch::Tensor lightvae_fp8_nhwc_rescale_to_tin16(
+    torch::Tensor input,
+    torch::Tensor source_scale,
+    torch::Tensor output_scale);
+
+torch::Tensor lightvae_fp8_pack_causal3_tin16(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache);
+
+torch::Tensor lightvae_fp8_pack_causal3_tin16_to_nhwc(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache);
+
+torch::Tensor lightvae_fp8_update_tail_cache_tin16(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    int cache_frames);
+
+torch::Tensor lightvae_fp8_spatial_pad_right_bottom_tin16(torch::Tensor input);
+
+torch::Tensor lightvae_fp8_pack_temporal3_tin16(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache);
+
+torch::Tensor lightvae_fp8_pack_temporal3_tin16_to_nhwc(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache);
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom);
+
+torch::Tensor lightvae_fp8_conv1_tin16_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+torch::Tensor lightvae_fp8_temporal_conv1_tin16_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> lightvae_fp8_qkv_tin16_to_bmhd(
+    torch::Tensor qkv);
+
+torch::Tensor lightvae_fp8_bmhd_to_tin16(
+    torch::Tensor input,
+    int frames,
+    int height,
+    int width);
+
+torch::Tensor lightvae_fp8_sdpa_bmhd(
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor qkv_scale,
+    torch::Tensor sdpa_inverse_scale,
+    torch::Tensor unit_scale,
+    int batch,
+    int seq,
+    double attn_scale);
+
+void lightvae_fp8_sdpa_cleanup();
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_direct_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_direct_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom);
+
+torch::Tensor lightvae_fp8_conv1_tin16_direct_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+torch::Tensor lightvae_fp8_temporal_conv1_tin16_direct_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+torch::Tensor lightvae_fp8_conv1_tin16_warp_mma_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_warp_mma_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom);
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_warp_mma_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor output_scale,
+    c10::optional<torch::Tensor> bias,
+    bool relu);
+
+torch::Tensor lightvae_fp8_spatial_conv3_tin16_warp_mma_scaled_prepared(
+    torch::Tensor input,
+    torch::Tensor weight,
+    torch::Tensor epilogue_scale,
+    c10::optional<torch::Tensor> bias_scaled,
+    int stride,
+    int pad,
+    bool relu,
+    bool pad_right_bottom);
+
+torch::Tensor lightvae_fp8_causal_conv3_tin16_warp_mma_scaled_prepared(
+    torch::Tensor input,
+    c10::optional<torch::Tensor> cache,
+    torch::Tensor weight,
+    torch::Tensor epilogue_scale,
+    c10::optional<torch::Tensor> bias_scaled,
+    bool relu);
+
+void bind_lightvae_ops(pybind11::module_& m);
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/vae_streaming_bindings.cpp
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/vae_streaming_bindings.cpp
@@ -1,0 +1,579 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vae_streaming/vae_streaming_bindings.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+
+#include "vae_streaming/lightvae_ops.h"
+
+namespace py = pybind11;
+
+namespace omnidreams_singleview {
+namespace {
+
+torch::Tensor dict_tensor(const py::dict& dict, const char* key) {
+  TORCH_CHECK(dict.contains(key), "prepared FP8 LightVAE state missing key ", key);
+  return dict[py::str(key)].cast<torch::Tensor>();
+}
+
+py::dict dict_dict(const py::dict& dict, const char* key) {
+  TORCH_CHECK(dict.contains(key), "prepared FP8 LightVAE state missing dict ", key);
+  return dict[py::str(key)].cast<py::dict>();
+}
+
+c10::optional<torch::Tensor> optional_dict_tensor(const py::dict& dict,
+                                                  const char* key) {
+  if (!dict.contains(key)) {
+    return c10::nullopt;
+  }
+  py::object obj = dict[py::str(key)].cast<py::object>();
+  if (obj.is_none()) {
+    return c10::nullopt;
+  }
+  return obj.cast<torch::Tensor>();
+}
+
+torch::Tensor scale_prefix(torch::Tensor scale, int64_t real_channels) {
+  if (scale.numel() == 1 || scale.numel() == real_channels) {
+    return scale.contiguous();
+  }
+  TORCH_CHECK(scale.numel() >= real_channels,
+              "scale has ", scale.numel(), " values, expected at least ",
+              real_channels);
+  return scale.narrow(0, 0, real_channels).contiguous();
+}
+
+class NativeWanVaeEncoderFp8 {
+ public:
+  explicit NativeWanVaeEncoderFp8(py::dict state) : state_(std::move(state)) {}
+
+  bool is_cuda() const {
+    return dict_tensor(state_, "scale_input").is_cuda();
+  }
+
+  void reset_cache() {
+    fp8_tensor_cache_.clear();
+    fp8_temporal_first_cache_.clear();
+  }
+
+  void release_resources() {
+    reset_cache();
+    lightvae_fp8_sdpa_cleanup();
+  }
+
+  torch::Tensor encode(torch::Tensor input, bool use_cache) {
+    return lightvae_encode_fp8_native(std::move(input), use_cache);
+  }
+
+ private:
+  c10::optional<torch::Tensor> cached_tensor(const std::string& key) const {
+    auto it = fp8_tensor_cache_.find(key);
+    if (it == fp8_tensor_cache_.end() || !it->second.defined()) {
+      return c10::nullopt;
+    }
+    return it->second;
+  }
+
+  void save_tail_cache_tin16_inplace(const std::string& key,
+                                     torch::Tensor input,
+                                     int cache_frames) {
+    TORCH_CHECK(input.is_cuda() && input.scalar_type() == at::kByte,
+                "LightVAE FP8 cache input must be CUDA uint8");
+    TORCH_CHECK(input.dim() == 5 && input.size(4) == 16,
+                "LightVAE FP8 cache input must be [T,C/16,H,W,16], got ",
+                input.sizes());
+    TORCH_CHECK(input.is_contiguous(), "LightVAE FP8 cache input must be contiguous");
+    TORCH_CHECK(cache_frames > 0, "cache_frames must be positive");
+    c10::cuda::CUDAGuard guard(input.device());
+
+    auto it = fp8_tensor_cache_.find(key);
+    torch::Tensor old;
+    int old_frames = 0;
+    if (it != fp8_tensor_cache_.end() && it->second.defined()) {
+      old = it->second;
+      TORCH_CHECK(old.is_cuda() && old.scalar_type() == at::kByte,
+                  "LightVAE FP8 existing cache must be CUDA uint8");
+      TORCH_CHECK(old.dim() == 5 && old.size(4) == 16,
+                  "LightVAE FP8 existing cache must be [T,C/16,H,W,16], got ",
+                  old.sizes());
+      TORCH_CHECK(old.device() == input.device(),
+                  "LightVAE FP8 cache device mismatch");
+      TORCH_CHECK(old.is_contiguous(),
+                  "LightVAE FP8 existing cache must be contiguous");
+      TORCH_CHECK(old.size(1) == input.size(1) && old.size(2) == input.size(2) &&
+                      old.size(3) == input.size(3),
+                  "LightVAE FP8 cache shape mismatch: cache=", old.sizes(),
+                  " input=", input.sizes());
+      old_frames = static_cast<int>(old.size(0));
+    }
+
+    const int frames = static_cast<int>(input.size(0));
+    const int new_frames = std::min(cache_frames, old_frames + frames);
+    TORCH_CHECK(new_frames > 0, "LightVAE FP8 cannot cache an empty tensor");
+    const bool can_reuse =
+        old.defined() && old_frames == new_frames && old.size(1) == input.size(1) &&
+        old.size(2) == input.size(2) && old.size(3) == input.size(3);
+    torch::Tensor dst = can_reuse
+        ? old
+        : torch::empty(
+              {new_frames, input.size(1), input.size(2), input.size(3),
+               input.size(4)},
+              input.options());
+
+    const size_t frame_bytes = static_cast<size_t>(input.size(1)) *
+                               static_cast<size_t>(input.size(2)) *
+                               static_cast<size_t>(input.size(3)) *
+                               static_cast<size_t>(input.size(4));
+    auto stream = at::cuda::getCurrentCUDAStream(input.device().index()).stream();
+    const int tail_start = old_frames + frames - new_frames;
+    auto* dst_ptr = dst.data_ptr<uint8_t>();
+    const auto* input_ptr = input.data_ptr<uint8_t>();
+    const auto* old_ptr = old.defined() ? old.data_ptr<uint8_t>() : nullptr;
+    for (int out_t = 0; out_t < new_frames; ++out_t) {
+      const int src_ext_t = tail_start + out_t;
+      const uint8_t* src_ptr = nullptr;
+      if (src_ext_t < old_frames) {
+        TORCH_CHECK(old_ptr != nullptr, "LightVAE FP8 cache source missing");
+        src_ptr = old_ptr + static_cast<size_t>(src_ext_t) * frame_bytes;
+      } else {
+        const int src_t = src_ext_t - old_frames;
+        TORCH_CHECK(src_t >= 0 && src_t < frames,
+                    "LightVAE FP8 cache source frame out of range");
+        src_ptr = input_ptr + static_cast<size_t>(src_t) * frame_bytes;
+      }
+      uint8_t* out_ptr = dst_ptr + static_cast<size_t>(out_t) * frame_bytes;
+      if (out_ptr != src_ptr) {
+        C10_CUDA_CHECK(cudaMemcpyAsync(
+            out_ptr, src_ptr, frame_bytes, cudaMemcpyDeviceToDevice, stream));
+      }
+    }
+    fp8_tensor_cache_[key] = dst;
+  }
+
+  torch::Tensor fp8_requantize_tin16(torch::Tensor input,
+                                     torch::Tensor input_scale,
+                                     torch::Tensor output_scale,
+                                     int real_channels) {
+    if (input_scale.data_ptr() == output_scale.data_ptr() &&
+        input_scale.numel() == output_scale.numel()) {
+      return input;
+    }
+    return lightvae_fp8_quantize_bcthw_to_tin16(
+        lightvae_fp8_dequantize_tin16_to_bcthw(
+            input,
+            scale_prefix(input_scale, real_channels),
+            real_channels,
+            static_cast<int>(input.size(2)),
+            static_cast<int>(input.size(3))),
+        scale_prefix(output_scale, real_channels),
+        static_cast<int>(input.size(2)),
+        static_cast<int>(input.size(3)),
+        static_cast<int>(input.size(1) * input.size(4)));
+  }
+
+  torch::Tensor run_causal_fp8(const std::string& key,
+                               torch::Tensor input,
+                               torch::Tensor weight,
+                               torch::Tensor output_scale,
+                               c10::optional<torch::Tensor> bias,
+                               bool cached,
+                               c10::optional<torch::Tensor> epilogue_scale,
+                               c10::optional<torch::Tensor> bias_scaled,
+                               bool relu) {
+    auto old = cached ? cached_tensor(key) : c10::nullopt;
+    torch::Tensor output = epilogue_scale.has_value()
+        ? lightvae_fp8_causal_conv3_tin16_warp_mma_scaled_prepared(
+              input, old, weight, epilogue_scale.value(), bias_scaled, relu)
+        : lightvae_fp8_causal_conv3_tin16_prepared(
+              input, old, weight, output_scale, bias, relu);
+    if (cached) {
+      save_tail_cache_tin16_inplace(key, input, 2);
+    }
+    return output;
+  }
+
+  torch::Tensor run_resblock_fp8(const py::dict& block,
+                                 torch::Tensor input,
+                                 bool cached) {
+    torch::Tensor skip;
+    torch::Tensor skip_scale;
+    py::object shortcut_obj = block[py::str("shortcut")].cast<py::object>();
+    if (shortcut_obj.is_none()) {
+      skip = input;
+      skip_scale = dict_tensor(block, "input_scale");
+    } else {
+      py::dict shortcut = shortcut_obj.cast<py::dict>();
+      skip = lightvae_fp8_conv1_tin16_prepared(
+          input,
+          dict_tensor(shortcut, "w"),
+          dict_tensor(shortcut, "scale"),
+          optional_dict_tensor(shortcut, "b"),
+          false);
+      skip_scale = dict_tensor(shortcut, "scale");
+    }
+
+    const int in_real = block[py::str("in_real")].cast<int>();
+    const int out_real = block[py::str("out_real")].cast<int>();
+    const std::string path = block[py::str("path")].cast<std::string>();
+    torch::Tensor output = lightvae_fp8_rmsnorm_tin16(
+        input,
+        dict_tensor(block, "input_scale_rms"),
+        dict_tensor(block, "norm1_gamma"),
+        dict_tensor(block, "norm1_scale_rms"),
+        in_real,
+        true);
+    output = run_causal_fp8(
+        path + ".residual.2",
+        output,
+        dict_tensor(block, "conv1_w"),
+        dict_tensor(block, "conv1_scale"),
+        optional_dict_tensor(block, "conv1_b"),
+        cached,
+        optional_dict_tensor(block, "conv1_epilogue_scale"),
+        optional_dict_tensor(block, "conv1_bias_scaled"),
+        false);
+    output = lightvae_fp8_rmsnorm_tin16(
+        output,
+        dict_tensor(block, "conv1_scale_rms"),
+        dict_tensor(block, "norm2_gamma"),
+        dict_tensor(block, "norm2_scale_rms"),
+        out_real,
+        true);
+    output = run_causal_fp8(
+        path + ".residual.6",
+        output,
+        dict_tensor(block, "conv2_w"),
+        dict_tensor(block, "output_scale"),
+        optional_dict_tensor(block, "conv2_b"),
+        cached,
+        optional_dict_tensor(block, "conv2_epilogue_scale"),
+        optional_dict_tensor(block, "conv2_bias_scaled"),
+        false);
+    return lightvae_fp8_add_tin16(
+        output,
+        skip,
+        scale_prefix(dict_tensor(block, "output_scale"), out_real),
+        scale_prefix(skip_scale, out_real),
+        scale_prefix(dict_tensor(block, "output_scale"), out_real),
+        out_real);
+  }
+
+  torch::Tensor run_downsample_fp8(const py::dict& stage,
+                                   torch::Tensor input,
+                                   bool cached,
+                                   const std::string& key) {
+    const bool has_spatial = stage.contains("spatial_w");
+    torch::Tensor spatial_w =
+        has_spatial ? dict_tensor(stage, "spatial_w") : dict_tensor(stage, "w");
+    torch::Tensor spatial_scale = has_spatial ? dict_tensor(stage, "spatial_scale")
+                                              : dict_tensor(stage, "scale");
+    c10::optional<torch::Tensor> spatial_b =
+        has_spatial ? optional_dict_tensor(stage, "spatial_b")
+                    : optional_dict_tensor(stage, "b");
+    c10::optional<torch::Tensor> spatial_epilogue =
+        optional_dict_tensor(stage, "spatial_epilogue_scale");
+    if (!spatial_epilogue.has_value()) {
+      spatial_epilogue = optional_dict_tensor(stage, "epilogue_scale");
+    }
+    c10::optional<torch::Tensor> spatial_bias_scaled =
+        optional_dict_tensor(stage, "spatial_bias_scaled");
+    if (!spatial_bias_scaled.has_value()) {
+      spatial_bias_scaled = optional_dict_tensor(stage, "bias_scaled");
+    }
+
+    torch::Tensor output = spatial_epilogue.has_value()
+        ? lightvae_fp8_spatial_conv3_tin16_warp_mma_scaled_prepared(
+              input,
+              spatial_w,
+              spatial_epilogue.value(),
+              spatial_bias_scaled,
+              2,
+              0,
+              false,
+              true)
+        : lightvae_fp8_spatial_conv3_tin16_prepared(
+              input, spatial_w, spatial_scale, spatial_b, 2, 0, false, true);
+    if (!stage.contains("temporal_w")) {
+      return output;
+    }
+
+    const std::string first_key = key + ".first";
+    const std::string data_key = key + ".cache";
+    const bool first_call =
+        fp8_temporal_first_cache_.find(first_key) ==
+            fp8_temporal_first_cache_.end() ||
+        fp8_temporal_first_cache_[first_key];
+    if (cached && first_call) {
+      fp8_tensor_cache_[data_key] =
+          output.narrow(0, output.size(0) - 1, 1).contiguous();
+      fp8_temporal_first_cache_[first_key] = false;
+      return fp8_requantize_tin16(
+          output,
+          dict_tensor(stage, "spatial_scale"),
+          dict_tensor(stage, "scale"),
+          stage[py::str("real")].cast<int>());
+    }
+
+    auto old = cached ? cached_tensor(data_key) : c10::nullopt;
+    torch::Tensor temporal_output = lightvae_fp8_temporal_conv1_tin16_prepared(
+        output,
+        old,
+        dict_tensor(stage, "temporal_w"),
+        dict_tensor(stage, "scale"),
+        optional_dict_tensor(stage, "temporal_b"),
+        false);
+    if (cached) {
+      fp8_tensor_cache_[data_key] =
+          output.narrow(0, output.size(0) - 1, 1).contiguous();
+    }
+    return temporal_output;
+  }
+
+  torch::Tensor run_attention_fp8(torch::Tensor input,
+                                  torch::Tensor input_scale,
+                                  const py::dict& attention,
+                                  torch::Tensor output_scale) {
+    torch::Tensor output = lightvae_fp8_rmsnorm_tin16(
+        input,
+        dict_tensor(attention, "input_scale_rms"),
+        dict_tensor(attention, "norm_gamma"),
+        dict_tensor(attention, "norm_scale_rms"),
+        96,
+        false);
+    torch::Tensor qkv = lightvae_fp8_conv1_tin16_prepared(
+        output,
+        dict_tensor(attention, "qkv_w"),
+        dict_tensor(attention, "qkv_scale"),
+        optional_dict_tensor(attention, "qkv_b"),
+        false);
+    auto qkv_tuple = lightvae_fp8_qkv_tin16_to_bmhd(qkv);
+    const int frames = static_cast<int>(input.size(0));
+    const int height = static_cast<int>(input.size(2));
+    const int width = static_cast<int>(input.size(3));
+    torch::Tensor sdpa = lightvae_fp8_sdpa_bmhd(
+        std::get<0>(qkv_tuple),
+        std::get<1>(qkv_tuple),
+        std::get<2>(qkv_tuple),
+        dict_tensor(attention, "qkv_scale_float"),
+        dict_tensor(attention, "sdpa_inverse_scale_float"),
+        dict_tensor(attention, "unit_float"),
+        frames,
+        height * width,
+        1.0 / std::sqrt(96.0));
+    torch::Tensor sdpa_tin16 =
+        lightvae_fp8_bmhd_to_tin16(sdpa, frames, height, width);
+    torch::Tensor proj = lightvae_fp8_conv1_tin16_prepared(
+        sdpa_tin16,
+        dict_tensor(attention, "proj_w"),
+        output_scale,
+        optional_dict_tensor(attention, "proj_b"),
+        false);
+    return lightvae_fp8_add_tin16(
+        proj,
+        input,
+        scale_prefix(output_scale, 96),
+        scale_prefix(input_scale, 96),
+        scale_prefix(output_scale, 96),
+        96);
+  }
+
+  torch::Tensor lightvae_encode_fp8_native(torch::Tensor input, bool cached) {
+    TORCH_CHECK(input.dim() == 5 && input.size(0) == 1 && input.size(1) == 3,
+                "LightVAE FP8 input must be [1,3,T,H,W], got ", input.sizes());
+    TORCH_CHECK(input.is_cuda() && input.scalar_type() == at::kHalf,
+                "LightVAE FP8 input boundary must be CUDA fp16");
+    const int h = static_cast<int>(input.size(3));
+    const int w = static_cast<int>(input.size(4));
+    TORCH_CHECK(h % 8 == 0 && w % 8 == 0,
+                "LightVAE FP8 input spatial dimensions must be divisible by 8, got ",
+                h, "x", w);
+    const int hp = ((h + 7) / 8) * 8;
+    const int wp = ((w + 7) / 8) * 8;
+
+    torch::Tensor output = lightvae_fp8_quantize_bcthw_to_tin16(
+        input.contiguous(),
+        scale_prefix(dict_tensor(state_, "scale_input"), 3),
+        hp,
+        wp,
+        32);
+    output = run_causal_fp8(
+        "encoder.conv1",
+        output,
+        dict_tensor(state_, "conv1_w"),
+        dict_tensor(state_, "scale_conv1"),
+        optional_dict_tensor(state_, "conv1_b"),
+        cached,
+        optional_dict_tensor(state_, "conv1_epilogue_scale"),
+        optional_dict_tensor(state_, "conv1_bias_scaled"),
+        false);
+
+    py::list blocks = state_[py::str("blocks")].cast<py::list>();
+    output = run_resblock_fp8(blocks[0].cast<py::dict>(), output, cached);
+    output = run_resblock_fp8(blocks[1].cast<py::dict>(), output, cached);
+    output =
+        run_downsample_fp8(dict_dict(state_, "ds0"), output, cached,
+                           "encoder.downsamples.2");
+
+    output = run_resblock_fp8(blocks[2].cast<py::dict>(), output, cached);
+    output = run_resblock_fp8(blocks[3].cast<py::dict>(), output, cached);
+    output =
+        run_downsample_fp8(dict_dict(state_, "ds1"), output, cached,
+                           "encoder.downsamples.5.time_conv");
+
+    output = run_resblock_fp8(blocks[4].cast<py::dict>(), output, cached);
+    output = run_resblock_fp8(blocks[5].cast<py::dict>(), output, cached);
+    output =
+        run_downsample_fp8(dict_dict(state_, "ds2"), output, cached,
+                           "encoder.downsamples.8.time_conv");
+
+    output = run_resblock_fp8(blocks[6].cast<py::dict>(), output, cached);
+    output = run_resblock_fp8(blocks[7].cast<py::dict>(), output, cached);
+    output = run_resblock_fp8(blocks[8].cast<py::dict>(), output, cached);
+    output = run_attention_fp8(
+        output,
+        dict_tensor(state_, "scale_mid0"),
+        dict_dict(state_, "mid_attn"),
+        dict_tensor(state_, "scale_mid_attn"));
+    output = run_resblock_fp8(blocks[9].cast<py::dict>(), output, cached);
+
+    output = lightvae_fp8_rmsnorm_tin16(
+        output,
+        dict_tensor(state_, "scale_mid1_rms"),
+        dict_tensor(state_, "head_norm_gamma"),
+        dict_tensor(state_, "scale_head_norm_rms"),
+        96,
+        true);
+    output = run_causal_fp8(
+        "encoder.head.2",
+        output,
+        dict_tensor(state_, "head_w"),
+        dict_tensor(state_, "scale_head_conv"),
+        optional_dict_tensor(state_, "head_b"),
+        cached,
+        optional_dict_tensor(state_, "head_epilogue_scale"),
+        optional_dict_tensor(state_, "head_bias_scaled"),
+        false);
+    output = lightvae_fp8_conv1_tin16_prepared(
+        output,
+        dict_tensor(state_, "post_w"),
+        dict_tensor(state_, "scale_post"),
+        optional_dict_tensor(state_, "post_b"),
+        false);
+    return lightvae_fp8_extract_mu_normalize_tin16(
+        output,
+        scale_prefix(dict_tensor(state_, "scale_post"), 32),
+        dict_tensor(state_, "mean"),
+        dict_tensor(state_, "inv_std"),
+        h / 8,
+        w / 8);
+  }
+
+  py::dict state_;
+  std::unordered_map<std::string, torch::Tensor> fp8_tensor_cache_;
+  std::unordered_map<std::string, bool> fp8_temporal_first_cache_;
+};
+
+py::dict vae_backend_status(const std::string& component,
+                            const std::string& backend) {
+  py::dict status;
+  status["component"] = component;
+  status["backend"] = backend;
+  status["available"] = false;
+  status["implementation"] = "warp_mma_tin16_fp8";
+  if (backend != "fp8") {
+    status["reason"] = "unsupported OmniDreams VAE native backend";
+    return status;
+  }
+  if (component == "vae_encoder") {
+    status["available"] = true;
+    status["implementation"] = "direct_tin16_fp8_lightvae_encoder";
+    status["reason"] = "LightVAE fp8 native encoder is available";
+    return status;
+  }
+  status["reason"] = "unknown OmniDreams VAE native component";
+  return status;
+}
+
+std::shared_ptr<NativeWanVaeEncoderFp8> create_wan_encoder_fp8(py::dict state) {
+  auto encoder = std::make_shared<NativeWanVaeEncoderFp8>(std::move(state));
+  TORCH_CHECK(encoder->is_cuda(), "LightVAE fp8 native encoder state must be CUDA");
+  return encoder;
+}
+
+torch::Tensor encode_wan_fp8(
+    const std::shared_ptr<NativeWanVaeEncoderFp8>& encoder,
+    torch::Tensor input,
+    bool use_cache) {
+  TORCH_CHECK(encoder, "LightVAE fp8 native encoder is null");
+  return encoder->encode(std::move(input), use_cache);
+}
+
+void reset_wan_encoder_fp8(
+    const std::shared_ptr<NativeWanVaeEncoderFp8>& encoder) {
+  TORCH_CHECK(encoder, "LightVAE fp8 native encoder is null");
+  encoder->reset_cache();
+}
+
+}  // namespace
+
+void bind_vae_streaming(py::module_& module) {
+  bind_lightvae_ops(module);
+
+  py::class_<NativeWanVaeEncoderFp8, std::shared_ptr<NativeWanVaeEncoderFp8>>(
+      module, "_OmnidreamsNativeWanVaeEncoderFp8")
+      .def("reset_cache", &NativeWanVaeEncoderFp8::reset_cache)
+      .def("release_resources", &NativeWanVaeEncoderFp8::release_resources)
+      .def("is_cuda", &NativeWanVaeEncoderFp8::is_cuda);
+
+  module.def(
+      "omnidreams_vae_backend_status",
+      &vae_backend_status,
+      py::arg("component"),
+      py::arg("backend"),
+      "Return availability for an OmniDreams VAE native backend.");
+  module.def(
+      "omnidreams_vae_create_wan_encoder_fp8",
+      &create_wan_encoder_fp8,
+      py::arg("state"),
+      "Create a cached fp8 native LightVAE encoder state.");
+  module.def(
+      "omnidreams_vae_reset_wan_encoder_fp8",
+      &reset_wan_encoder_fp8,
+      py::arg("encoder"),
+      "Reset cached fp8 native LightVAE encoder state.");
+  module.def(
+      "omnidreams_vae_encode_wan_fp8",
+      &encode_wan_fp8,
+      py::arg("encoder"),
+      py::arg("input"),
+      py::arg("use_cache") = true,
+      "Encode Wan LightVAE input through the fp8 native boundary with fp16 latents.");
+}
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/vae_streaming_bindings.h
+++ b/integrations/omnidreams/omnidreams_singleview/src/vae_streaming/vae_streaming_bindings.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <torch/extension.h>
+
+namespace omnidreams_singleview {
+
+void bind_vae_streaming(pybind11::module_& module);
+
+}  // namespace omnidreams_singleview

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -97,6 +97,7 @@ interactive-drive = "omnidreams.interactive_drive.demo:main"
 [project.entry-points."flashdreams.runner_configs"]
 "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae" = "omnidreams.config:RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE"
 "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf" = "omnidreams.config:RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF"
+"omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf" = "omnidreams.config:RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF"
 "omnidreams-sv-2steps-chunk2-loc6-vae-vae" = "omnidreams.config:RUNNER_SV_2STEPS_CHUNK2_LOC6_VAE_VAE"
 "omnidreams-sv-2steps-chunk3-loc6-vae-vae" = "omnidreams.config:RUNNER_SV_2STEPS_CHUNK3_LOC6_VAE_VAE"
 "omnidreams-sv-2steps-chunk4-loc8-pshuffle-lighttae" = "omnidreams.config:RUNNER_SV_2STEPS_CHUNK4_LOC8_PSHUFFLE_LIGHTTAE"

--- a/integrations/omnidreams/scripts/benchmark_native_vae.py
+++ b/integrations/omnidreams/scripts/benchmark_native_vae.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark PyTorch vs native FP8 OmniDreams LightVAE encoders.
+
+The native preset's FP8 LightVAE state must be provided through
+``OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH`` or ``--fp8-state-path``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import statistics
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+BASELINE_CONFIG = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
+NATIVE_CONFIG = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf"
+FP8_STATE_ENV = "OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH"
+
+
+@dataclass(frozen=True)
+class EncoderRow:
+    case: str
+    implementation: str
+    shape: str
+    dtype: str
+    mae: float | None
+    rmse: float | None
+    max_abs: float | None
+    rel_l2: float | None
+    p50_ms: float
+    p95_ms: float
+    speedup: float | None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-config", default=BASELINE_CONFIG)
+    parser.add_argument("--native-config", default=NATIVE_CONFIG)
+    parser.add_argument(
+        "--baseline-eager",
+        action="store_true",
+        help="Disable compile/cuda_graph on the baseline encoder for quick local checks.",
+    )
+    parser.add_argument("--fp8-state-path", default=os.environ.get(FP8_STATE_ENV))
+    parser.add_argument("--output-dir", type=Path, default=Path("artifacts/native_vae"))
+    parser.add_argument(
+        "--native-build-root",
+        type=Path,
+        default=None,
+        help="Optional build root used to preload the native extension before setup.",
+    )
+    parser.add_argument("--native-max-jobs", type=int, default=None)
+    parser.add_argument(
+        "--source-video",
+        type=Path,
+        default=None,
+        help="Optional video input; random input is used when omitted.",
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--height", type=int, default=704)
+    parser.add_argument("--width", type=int, default=1280)
+    parser.add_argument("--latent-t", type=int, default=2)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=30)
+    parser.add_argument("--seed", type=int, default=1234)
+    return parser.parse_args()
+
+
+def _import_configs(fp8_state_path: str | None) -> dict[str, Any]:
+    if fp8_state_path:
+        os.environ[FP8_STATE_ENV] = fp8_state_path
+    from omnidreams.config import OMNIDREAMS_CONFIGS
+
+    return OMNIDREAMS_CONFIGS
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def _gpu_name(device: torch.device) -> str:
+    if device.type != "cuda":
+        return str(device)
+    props = torch.cuda.get_device_properties(device)
+    return f"{props.name} sm_{props.major}{props.minor}"
+
+
+def _sync(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _time_ms(
+    fn: Callable[[], torch.Tensor],
+    *,
+    device: torch.device,
+    warmup: int,
+    iters: int,
+) -> tuple[list[float], torch.Tensor]:
+    output = fn()
+    _sync(device)
+    for _ in range(warmup):
+        output = fn()
+    _sync(device)
+
+    times: list[float] = []
+    for _ in range(iters):
+        if device.type == "cuda":
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            output = fn()
+            end.record()
+            end.synchronize()
+            times.append(float(start.elapsed_time(end)))
+        else:
+            import time
+
+            start_t = time.perf_counter()
+            output = fn()
+            times.append((time.perf_counter() - start_t) * 1000.0)
+    _sync(device)
+    return times, output
+
+
+def _p95(values: list[float]) -> float:
+    if len(values) < 2:
+        return values[0]
+    return statistics.quantiles(values, n=20, method="inclusive")[18]
+
+
+def _metrics(candidate: torch.Tensor, reference: torch.Tensor) -> dict[str, float]:
+    cand = candidate.detach().float()
+    ref = reference.detach().float()
+    diff = cand - ref
+    rmse = diff.square().mean().sqrt()
+    ref_norm = torch.linalg.vector_norm(ref).clamp_min(1.0e-12)
+    return {
+        "mae": float(diff.abs().mean().item()),
+        "rmse": float(rmse.item()),
+        "max_abs": float(diff.abs().max().item()),
+        "rel_l2": float((torch.linalg.vector_norm(diff) / ref_norm).item()),
+    }
+
+
+def _shape(tensor: torch.Tensor) -> str:
+    return "x".join(str(dim) for dim in tensor.shape)
+
+
+def _load_video_prefix_btchw(
+    path: Path,
+    *,
+    frames: int,
+    height: int,
+    width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    try:
+        import cv2  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError("OpenCV is required to load benchmark source video frames") from exc
+
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        raise FileNotFoundError(f"could not open video: {path}")
+    images: list[torch.Tensor] = []
+    while len(images) < frames:
+        ok, bgr = cap.read()
+        if not ok:
+            break
+        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+        if rgb.shape[:2] != (height, width):
+            rgb = cv2.resize(rgb, (width, height), interpolation=cv2.INTER_AREA)
+        images.append(torch.from_numpy(rgb).permute(2, 0, 1).contiguous())
+    cap.release()
+    if len(images) < frames:
+        raise RuntimeError(f"{path} has {len(images)} readable frames; need {frames}")
+    video = torch.stack(images, dim=0).unsqueeze(0).to(device=device, dtype=torch.float32)
+    return (video / 127.5 - 1.0).contiguous()
+
+
+def _make_row(
+    *,
+    case: str,
+    implementation: str,
+    output: torch.Tensor,
+    dtype: torch.dtype,
+    times: list[float],
+    metrics: dict[str, float] | None,
+    speedup: float | None,
+) -> EncoderRow:
+    return EncoderRow(
+        case=case,
+        implementation=implementation,
+        shape=_shape(output),
+        dtype=str(dtype).replace("torch.", ""),
+        mae=None if metrics is None else metrics["mae"],
+        rmse=None if metrics is None else metrics["rmse"],
+        max_abs=None if metrics is None else metrics["max_abs"],
+        rel_l2=None if metrics is None else metrics["rel_l2"],
+        p50_ms=statistics.median(times),
+        p95_ms=_p95(times),
+        speedup=speedup,
+    )
+
+
+def _bench_pair(
+    *,
+    case: str,
+    baseline_name: str,
+    native_name: str,
+    baseline_fn: Callable[[], torch.Tensor],
+    native_fn: Callable[[], torch.Tensor],
+    baseline_dtype: torch.dtype,
+    native_dtype: torch.dtype,
+    device: torch.device,
+    warmup: int,
+    iters: int,
+) -> list[EncoderRow]:
+    baseline_times, baseline_out = _time_ms(
+        baseline_fn, device=device, warmup=warmup, iters=iters
+    )
+    native_times, native_out = _time_ms(
+        native_fn, device=device, warmup=warmup, iters=iters
+    )
+    speedup = statistics.median(baseline_times) / statistics.median(native_times)
+    return [
+        _make_row(
+            case=case,
+            implementation=baseline_name,
+            output=baseline_out,
+            dtype=baseline_dtype,
+            times=baseline_times,
+            metrics=None,
+            speedup=None,
+        ),
+        _make_row(
+            case=case,
+            implementation=native_name,
+            output=native_out,
+            dtype=native_dtype,
+            times=native_times,
+            metrics=_metrics(native_out, baseline_out),
+            speedup=speedup,
+        ),
+    ]
+
+
+def _run(args: argparse.Namespace, configs: dict[str, Any]) -> list[EncoderRow]:
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA device requested but torch.cuda.is_available() is false")
+    torch.manual_seed(args.seed)
+
+    baseline_cfg = configs[args.baseline_config]
+    native_cfg = configs[args.native_config]
+    if args.baseline_eager:
+        from flashdreams.infra.config import derive_config
+
+        baseline_cfg = derive_config(
+            baseline_cfg,
+            image_encoder=dict(use_compile=False, use_cuda_graph=False),
+            encoder=dict(use_compile=False, use_cuda_graph=False),
+        )
+
+    baseline_encoder = baseline_cfg.encoder.setup().to(device)
+    native_encoder = native_cfg.encoder.setup().to(device)
+
+    first_pixel_t = 1 + (args.latent_t - 1) * 4
+    steady_pixel_t = args.latent_t * 4
+    source_t = first_pixel_t + steady_pixel_t
+    if args.source_video is None:
+        source = torch.randn(
+            (1, source_t, 3, args.height, args.width),
+            device=device,
+            dtype=torch.float32,
+        ).clamp_(-1, 1)
+    else:
+        source = _load_video_prefix_btchw(
+            args.source_video.expanduser().resolve(),
+            frames=source_t,
+            height=args.height,
+            width=args.width,
+            device=device,
+        )
+
+    first_source = source[:, :first_pixel_t]
+    steady_source = source[:, first_pixel_t : first_pixel_t + steady_pixel_t]
+
+    def baseline_encode_first() -> torch.Tensor:
+        cache = baseline_encoder.initialize_autoregressive_cache()
+        return baseline_encoder(first_source.to(baseline_encoder.config.dtype), cache=cache)
+
+    def native_encode_first() -> torch.Tensor:
+        cache = native_encoder.initialize_autoregressive_cache()
+        return native_encoder(first_source.to(native_encoder.config.dtype), cache=cache)
+
+    rows = _bench_pair(
+        case="lightvae_encoder_first_chunk",
+        baseline_name=args.baseline_config,
+        native_name=args.native_config,
+        baseline_fn=baseline_encode_first,
+        native_fn=native_encode_first,
+        baseline_dtype=baseline_encoder.config.dtype,
+        native_dtype=native_encoder.config.dtype,
+        device=device,
+        warmup=args.warmup,
+        iters=args.iters,
+    )
+
+    baseline_cache = baseline_encoder.initialize_autoregressive_cache()
+    native_cache = native_encoder.initialize_autoregressive_cache()
+    baseline_encoder(first_source.to(baseline_encoder.config.dtype), cache=baseline_cache)
+    native_encoder(first_source.to(native_encoder.config.dtype), cache=native_cache)
+
+    rows.extend(
+        _bench_pair(
+            case="lightvae_encoder_steady_chunk",
+            baseline_name=args.baseline_config,
+            native_name=args.native_config,
+            baseline_fn=lambda: baseline_encoder(
+                steady_source.to(baseline_encoder.config.dtype),
+                cache=baseline_cache,
+            ),
+            native_fn=lambda: native_encoder(
+                steady_source.to(native_encoder.config.dtype),
+                cache=native_cache,
+            ),
+            baseline_dtype=baseline_encoder.config.dtype,
+            native_dtype=native_encoder.config.dtype,
+            device=device,
+            warmup=args.warmup,
+            iters=args.iters,
+        )
+    )
+    return rows
+
+
+def _write_csv(path: Path, rows: list[EncoderRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(EncoderRow.__dataclass_fields__))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row.__dict__)
+
+
+def _fmt(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.4f}"
+
+
+def _write_markdown(path: Path, rows: list[EncoderRow], args: argparse.Namespace) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    device = torch.device(args.device)
+    lines = [
+        "# Native LightVAE FP8 Encoder Before/After Report",
+        "",
+        f"- commit: `{_git_commit()}`",
+        f"- device: `{_gpu_name(device)}`",
+        f"- seed: `{args.seed}`",
+        f"- warmup: `{args.warmup}`",
+        f"- iterations: `{args.iters}`",
+        f"- resolution: `{args.height}x{args.width}`",
+        f"- source_video: `{args.source_video or 'random'}`",
+        f"- baseline_config: `{args.baseline_config}`",
+        f"- native_config: `{args.native_config}`",
+        f"- baseline_eager: `{args.baseline_eager}`",
+        "",
+        "| case | implementation | shape | dtype | MAE | RMSE | max abs | rel L2 | p50 ms | p95 ms | speedup |",
+        "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    row.case,
+                    row.implementation,
+                    row.shape,
+                    row.dtype,
+                    _fmt(row.mae),
+                    _fmt(row.rmse),
+                    _fmt(row.max_abs),
+                    _fmt(row.rel_l2),
+                    _fmt(row.p50_ms),
+                    _fmt(row.p95_ms),
+                    _fmt(row.speedup),
+                ]
+            )
+            + " |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    args = _parse_args()
+    if not args.fp8_state_path:
+        raise SystemExit(
+            f"--fp8-state-path or {FP8_STATE_ENV} is required for the native FP8 encoder"
+        )
+    configs = _import_configs(args.fp8_state_path)
+    if args.native_build_root is not None:
+        from omnidreams.native import omnidreams_singleview
+
+        ext = omnidreams_singleview.load_extension(
+            build_root=args.native_build_root,
+            max_jobs=args.native_max_jobs,
+            verbose=False,
+        )
+        if ext is None:
+            raise RuntimeError(omnidreams_singleview.extension_load_error())
+
+    rows = _run(args, configs)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = args.output_dir / "native_lightvae_encoder_before_after.csv"
+    md_path = args.output_dir / "native_lightvae_encoder_before_after.md"
+    _write_csv(csv_path, rows)
+    _write_markdown(md_path, rows, args)
+    print(f"Wrote {md_path}")
+    print(f"Wrote {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/omnidreams/scripts/benchmark_native_vae.py
+++ b/integrations/omnidreams/scripts/benchmark_native_vae.py
@@ -21,7 +21,6 @@ from typing import Any
 
 import torch
 
-
 BASELINE_CONFIG = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
 NATIVE_CONFIG = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf"
 FP8_STATE_ENV = "OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH"
@@ -175,7 +174,9 @@ def _load_video_prefix_btchw(
     try:
         import cv2  # noqa: PLC0415
     except ImportError as exc:
-        raise ImportError("OpenCV is required to load benchmark source video frames") from exc
+        raise ImportError(
+            "OpenCV is required to load benchmark source video frames"
+        ) from exc
 
     cap = cv2.VideoCapture(str(path))
     if not cap.isOpened():
@@ -192,7 +193,9 @@ def _load_video_prefix_btchw(
     cap.release()
     if len(images) < frames:
         raise RuntimeError(f"{path} has {len(images)} readable frames; need {frames}")
-    video = torch.stack(images, dim=0).unsqueeze(0).to(device=device, dtype=torch.float32)
+    video = (
+        torch.stack(images, dim=0).unsqueeze(0).to(device=device, dtype=torch.float32)
+    )
     return (video / 127.5 - 1.0).contiguous()
 
 
@@ -266,7 +269,9 @@ def _bench_pair(
 def _run(args: argparse.Namespace, configs: dict[str, Any]) -> list[EncoderRow]:
     device = torch.device(args.device)
     if device.type == "cuda" and not torch.cuda.is_available():
-        raise RuntimeError("CUDA device requested but torch.cuda.is_available() is false")
+        raise RuntimeError(
+            "CUDA device requested but torch.cuda.is_available() is false"
+        )
     torch.manual_seed(args.seed)
 
     baseline_cfg = configs[args.baseline_config]
@@ -306,7 +311,9 @@ def _run(args: argparse.Namespace, configs: dict[str, Any]) -> list[EncoderRow]:
 
     def baseline_encode_first() -> torch.Tensor:
         cache = baseline_encoder.initialize_autoregressive_cache()
-        return baseline_encoder(first_source.to(baseline_encoder.config.dtype), cache=cache)
+        return baseline_encoder(
+            first_source.to(baseline_encoder.config.dtype), cache=cache
+        )
 
     def native_encode_first() -> torch.Tensor:
         cache = native_encoder.initialize_autoregressive_cache()
@@ -327,7 +334,9 @@ def _run(args: argparse.Namespace, configs: dict[str, Any]) -> list[EncoderRow]:
 
     baseline_cache = baseline_encoder.initialize_autoregressive_cache()
     native_cache = native_encoder.initialize_autoregressive_cache()
-    baseline_encoder(first_source.to(baseline_encoder.config.dtype), cache=baseline_cache)
+    baseline_encoder(
+        first_source.to(baseline_encoder.config.dtype), cache=baseline_cache
+    )
     native_encoder(first_source.to(native_encoder.config.dtype), cache=native_cache)
 
     rows.extend(
@@ -368,7 +377,9 @@ def _fmt(value: float | None) -> str:
     return f"{value:.4f}"
 
 
-def _write_markdown(path: Path, rows: list[EncoderRow], args: argparse.Namespace) -> None:
+def _write_markdown(
+    path: Path, rows: list[EncoderRow], args: argparse.Namespace
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     device = torch.device(args.device)
     lines = [

--- a/integrations/omnidreams/scripts/export_lightvae_fp8_state.py
+++ b/integrations/omnidreams/scripts/export_lightvae_fp8_state.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Export a calibrated LightVAE FP8 encoder state for OmniDreams native VAE."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from flashdreams.infra.config import derive_config
+from omnidreams.config import OMNIDREAMS_CONFIGS
+from omnidreams.runner import (
+    DEFAULT_EXAMPLE_DATA_UUID_1V,
+    DEFAULT_VIDEO_HEIGHT,
+    DEFAULT_VIDEO_WIDTH,
+    _ensure_hf_single_view_example_data_synced,
+)
+
+
+DEFAULT_CONFIG = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
+VAE_FP8_VERSION_KEY = "__omnidreams_vae_fp8_version__"
+MODEL_KIND_KEY = "__omnidreams_vae_fp8_model_kind__"
+STATE_SCALE_MAX_KEY = "__omnidreams_vae_fp8_scale_max__"
+MODEL_KIND_LIGHTVAE_ENCODER = 1
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True, help="Output .pt path.")
+    parser.add_argument(
+        "--config-name",
+        default=DEFAULT_CONFIG,
+        help="OmniDreams config whose encoder checkpoint should be calibrated.",
+    )
+    parser.add_argument("--calibration-video", type=Path, default=None)
+    parser.add_argument(
+        "--example-data",
+        action="store_true",
+        help="Fetch the bundled single-view HDMap sample and use it for calibration.",
+    )
+    parser.add_argument(
+        "--example-data-uuid",
+        default=DEFAULT_EXAMPLE_DATA_UUID_1V,
+        help="Single-view sample UUID used with --example-data.",
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--height", type=int, default=DEFAULT_VIDEO_HEIGHT)
+    parser.add_argument("--width", type=int, default=DEFAULT_VIDEO_WIDTH)
+    parser.add_argument("--frames", type=int, default=13)
+    parser.add_argument("--scale-max", type=float, default=24.0)
+    return parser.parse_args()
+
+
+def _require_float8() -> torch.dtype:
+    dtype = getattr(torch, "float8_e4m3fn", None)
+    if dtype is None:
+        raise RuntimeError("PyTorch float8_e4m3fn is required for FP8 state export")
+    return dtype
+
+
+def _scale_view_shape(tensor: torch.Tensor, channel_dim: int) -> tuple[int, ...]:
+    return tuple(tensor.shape[i] if i == channel_dim else 1 for i in range(tensor.dim()))
+
+
+def _quantize_fp8_per_channel(
+    tensor: torch.Tensor,
+    *,
+    channel_dim: int = 0,
+    scale_max: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not torch.is_floating_point(tensor):
+        raise TypeError(f"expected floating tensor, got {tensor.dtype}")
+    if tensor.dim() == 0:
+        raise ValueError("per-channel quantization requires a non-scalar tensor")
+    if scale_max <= 0:
+        raise ValueError(f"scale_max must be positive, got {scale_max}")
+
+    fp8_dtype = _require_float8()
+    if channel_dim < 0:
+        channel_dim += tensor.dim()
+    reduce_dims = tuple(i for i in range(tensor.dim()) if i != channel_dim)
+    tensor_fp32 = tensor.detach().float()
+    amax = tensor_fp32.abs().amax(dim=reduce_dims) if reduce_dims else tensor_fp32.abs()
+    scale = (amax / float(scale_max)).clamp(min=1.0e-6)
+    scaled = tensor_fp32 / scale.reshape(_scale_view_shape(tensor, channel_dim))
+    return scaled.to(fp8_dtype).contiguous().view(torch.uint8), scale.to(torch.float16)
+
+
+def _channel_amax(value: torch.Tensor, channel_dim: int) -> torch.Tensor:
+    reduce_dims = tuple(dim for dim in range(value.dim()) if dim != channel_dim)
+    return value.detach().float().abs().amax(dim=reduce_dims).cpu()
+
+
+def _collect_activation_amax(
+    model: torch.nn.Module,
+    video_bcthw: torch.Tensor,
+) -> dict[str, torch.Tensor]:
+    if video_bcthw.dim() != 5:
+        raise ValueError(f"expected calibration video [B,C,T,H,W], got {tuple(video_bcthw.shape)}")
+
+    amax: dict[str, torch.Tensor] = {}
+    handles: list[torch.utils.hooks.RemovableHandle] = []
+    cache_step_originals: list[tuple[torch.nn.Module, Any]] = []
+
+    def record(name: str, value: torch.Tensor) -> None:
+        if value.dim() not in (4, 5):
+            return
+        current = _channel_amax(value, 1)
+        previous = amax.get(name)
+        amax[name] = current if previous is None else torch.maximum(previous, current)
+
+    def hook(name: str):
+        def _hook(
+            _module: torch.nn.Module,
+            _inputs: tuple[torch.Tensor, ...],
+            output: object,
+        ) -> None:
+            if isinstance(output, torch.Tensor):
+                record(name, output)
+
+        return _hook
+
+    def pre_hook(name: str):
+        def _pre_hook(
+            _module: torch.nn.Module,
+            inputs: tuple[torch.Tensor, ...],
+        ) -> None:
+            if inputs and isinstance(inputs[0], torch.Tensor):
+                record(name, inputs[0])
+
+        return _pre_hook
+
+    record("encoder.conv1.input", video_bcthw)
+    record("encoder.input", video_bcthw)
+    record("input", video_bcthw)
+    for name, module in model.named_modules():
+        if not name:
+            continue
+        handles.append(module.register_forward_hook(hook(name)))
+        if name == "encoder.middle.1.proj":
+            handles.append(module.register_forward_pre_hook(pre_hook("encoder.middle.1.sdpa")))
+        cache_step = getattr(module, "cache_step", None)
+        if callable(cache_step):
+            cache_step_originals.append((module, cache_step))
+
+            def wrapped_cache_step(*args: Any, _name: str = name, _orig: Any = cache_step, **kwargs: Any) -> Any:
+                output = _orig(*args, **kwargs)
+                if isinstance(output, torch.Tensor):
+                    record(_name, output)
+                return output
+
+            setattr(module, "cache_step", wrapped_cache_step)
+
+    try:
+        cache = model.prepare_cache()
+        latent = model.encode(video_bcthw, cache=cache)
+    finally:
+        for handle in handles:
+            handle.remove()
+        for module, original in cache_step_originals:
+            setattr(module, "cache_step", original)
+
+    record("latent", latent)
+    return amax
+
+
+def _activation_scales(
+    amax: Mapping[str, torch.Tensor],
+    *,
+    scale_max: float,
+) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+    for name, value in amax.items():
+        out[f"{name}.activation_scale"] = (
+            value.float().abs() / float(scale_max)
+        ).clamp(min=1.0e-6).to(torch.float16).contiguous()
+    latent = out.get("latent.activation_scale")
+    if latent is not None:
+        out["latent.activation_scale"] = latent
+    return out
+
+
+def _build_fp8_state(
+    state_dict: Mapping[str, torch.Tensor],
+    activation_scales: Mapping[str, torch.Tensor],
+    *,
+    scale_max: float,
+) -> dict[str, torch.Tensor]:
+    state: dict[str, torch.Tensor] = {
+        VAE_FP8_VERSION_KEY: torch.tensor([1], dtype=torch.int32),
+        MODEL_KIND_KEY: torch.tensor([MODEL_KIND_LIGHTVAE_ENCODER], dtype=torch.int32),
+        STATE_SCALE_MAX_KEY: torch.tensor([float(scale_max)], dtype=torch.float32),
+    }
+
+    for name, tensor in state_dict.items():
+        if name.endswith(".weight") and torch.is_floating_point(tensor) and tensor.dim() >= 2:
+            q, scale = _quantize_fp8_per_channel(
+                tensor.detach(),
+                channel_dim=0,
+                scale_max=scale_max,
+            )
+            state[name] = q.cpu()
+            state[name.replace(".weight", ".weight_scale")] = scale.cpu()
+        elif torch.is_floating_point(tensor):
+            state[name] = tensor.detach().to(dtype=torch.float16, device="cpu").contiguous()
+        else:
+            state[name] = tensor.detach().cpu().contiguous()
+
+    for name, scale in activation_scales.items():
+        if scale.dim() != 1:
+            raise ValueError(f"{name} must be a 1D scale tensor, got {tuple(scale.shape)}")
+        state[name] = scale.detach().to(dtype=torch.float16, device="cpu").contiguous()
+    return state
+
+
+def _resolve_video(args: argparse.Namespace) -> Path:
+    if args.calibration_video is not None:
+        return args.calibration_video.expanduser().resolve()
+    if args.example_data:
+        hdmaps, _first_frames = _ensure_hf_single_view_example_data_synced(
+            args.example_data_uuid
+        )
+        return hdmaps[0]
+    raise SystemExit("--calibration-video or --example-data is required")
+
+
+def _load_video_prefix_bcthw(
+    path: Path,
+    *,
+    frames: int,
+    height: int,
+    width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    try:
+        import cv2  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - import-time gate
+        raise ImportError("OpenCV is required to load calibration video frames") from exc
+
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        raise FileNotFoundError(f"could not open video: {path}")
+    images: list[torch.Tensor] = []
+    while len(images) < frames:
+        ok, bgr = cap.read()
+        if not ok:
+            break
+        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+        if rgb.shape[:2] != (height, width):
+            rgb = cv2.resize(rgb, (width, height), interpolation=cv2.INTER_AREA)
+        images.append(torch.from_numpy(rgb).permute(2, 0, 1).contiguous())
+    cap.release()
+    if len(images) < frames:
+        raise RuntimeError(
+            f"{path} has {len(images)} readable frames; need {frames}"
+        )
+    video = torch.stack(images, dim=1).unsqueeze(0).to(device=device, dtype=torch.float16)
+    return (video / 127.5 - 1.0).contiguous()
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA device requested but torch.cuda.is_available() is false")
+
+    config = OMNIDREAMS_CONFIGS[args.config_name]
+    encoder_cfg = derive_config(
+        config.encoder,
+        dtype=torch.float16,
+        use_compile=False,
+        use_cuda_graph=False,
+    )
+    encoder = encoder_cfg.setup().to(device).eval()
+    model: Any = encoder.vae
+
+    video_path = _resolve_video(args)
+    video_bcthw = _load_video_prefix_bcthw(
+        video_path,
+        frames=args.frames,
+        height=args.height,
+        width=args.width,
+        device=device,
+    )
+    amax = _collect_activation_amax(model, video_bcthw)
+    state = _build_fp8_state(
+        model.state_dict(),
+        _activation_scales(amax, scale_max=args.scale_max),
+        scale_max=args.scale_max,
+    )
+
+    args.out.expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
+    torch.save(state, args.out)
+    print(f"Wrote {args.out}")
+    print(f"Calibration video: {video_path}")
+    print(f"Activation scales: {len([k for k in state if k.endswith('.activation_scale')])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/omnidreams/scripts/export_lightvae_fp8_state.py
+++ b/integrations/omnidreams/scripts/export_lightvae_fp8_state.py
@@ -11,8 +11,6 @@ from pathlib import Path
 from typing import Any
 
 import torch
-
-from flashdreams.infra.config import derive_config
 from omnidreams.config import OMNIDREAMS_CONFIGS
 from omnidreams.runner import (
     DEFAULT_EXAMPLE_DATA_UUID_1V,
@@ -21,6 +19,7 @@ from omnidreams.runner import (
     _ensure_hf_single_view_example_data_synced,
 )
 
+from flashdreams.infra.config import derive_config
 
 DEFAULT_CONFIG = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
 VAE_FP8_VERSION_KEY = "__omnidreams_vae_fp8_version__"
@@ -64,7 +63,9 @@ def _require_float8() -> torch.dtype:
 
 
 def _scale_view_shape(tensor: torch.Tensor, channel_dim: int) -> tuple[int, ...]:
-    return tuple(tensor.shape[i] if i == channel_dim else 1 for i in range(tensor.dim()))
+    return tuple(
+        tensor.shape[i] if i == channel_dim else 1 for i in range(tensor.dim())
+    )
 
 
 def _quantize_fp8_per_channel(
@@ -97,11 +98,13 @@ def _channel_amax(value: torch.Tensor, channel_dim: int) -> torch.Tensor:
 
 
 def _collect_activation_amax(
-    model: torch.nn.Module,
+    model: Any,
     video_bcthw: torch.Tensor,
 ) -> dict[str, torch.Tensor]:
     if video_bcthw.dim() != 5:
-        raise ValueError(f"expected calibration video [B,C,T,H,W], got {tuple(video_bcthw.shape)}")
+        raise ValueError(
+            f"expected calibration video [B,C,T,H,W], got {tuple(video_bcthw.shape)}"
+        )
 
     amax: dict[str, torch.Tensor] = {}
     handles: list[torch.utils.hooks.RemovableHandle] = []
@@ -143,12 +146,16 @@ def _collect_activation_amax(
             continue
         handles.append(module.register_forward_hook(hook(name)))
         if name == "encoder.middle.1.proj":
-            handles.append(module.register_forward_pre_hook(pre_hook("encoder.middle.1.sdpa")))
+            handles.append(
+                module.register_forward_pre_hook(pre_hook("encoder.middle.1.sdpa"))
+            )
         cache_step = getattr(module, "cache_step", None)
         if callable(cache_step):
             cache_step_originals.append((module, cache_step))
 
-            def wrapped_cache_step(*args: Any, _name: str = name, _orig: Any = cache_step, **kwargs: Any) -> Any:
+            def wrapped_cache_step(
+                *args: Any, _name: str = name, _orig: Any = cache_step, **kwargs: Any
+            ) -> Any:
                 output = _orig(*args, **kwargs)
                 if isinstance(output, torch.Tensor):
                     record(_name, output)
@@ -177,8 +184,11 @@ def _activation_scales(
     out: dict[str, torch.Tensor] = {}
     for name, value in amax.items():
         out[f"{name}.activation_scale"] = (
-            value.float().abs() / float(scale_max)
-        ).clamp(min=1.0e-6).to(torch.float16).contiguous()
+            (value.float().abs() / float(scale_max))
+            .clamp(min=1.0e-6)
+            .to(torch.float16)
+            .contiguous()
+        )
     latent = out.get("latent.activation_scale")
     if latent is not None:
         out["latent.activation_scale"] = latent
@@ -198,7 +208,11 @@ def _build_fp8_state(
     }
 
     for name, tensor in state_dict.items():
-        if name.endswith(".weight") and torch.is_floating_point(tensor) and tensor.dim() >= 2:
+        if (
+            name.endswith(".weight")
+            and torch.is_floating_point(tensor)
+            and tensor.dim() >= 2
+        ):
             q, scale = _quantize_fp8_per_channel(
                 tensor.detach(),
                 channel_dim=0,
@@ -207,13 +221,17 @@ def _build_fp8_state(
             state[name] = q.cpu()
             state[name.replace(".weight", ".weight_scale")] = scale.cpu()
         elif torch.is_floating_point(tensor):
-            state[name] = tensor.detach().to(dtype=torch.float16, device="cpu").contiguous()
+            state[name] = (
+                tensor.detach().to(dtype=torch.float16, device="cpu").contiguous()
+            )
         else:
             state[name] = tensor.detach().cpu().contiguous()
 
     for name, scale in activation_scales.items():
         if scale.dim() != 1:
-            raise ValueError(f"{name} must be a 1D scale tensor, got {tuple(scale.shape)}")
+            raise ValueError(
+                f"{name} must be a 1D scale tensor, got {tuple(scale.shape)}"
+            )
         state[name] = scale.detach().to(dtype=torch.float16, device="cpu").contiguous()
     return state
 
@@ -240,7 +258,9 @@ def _load_video_prefix_bcthw(
     try:
         import cv2  # noqa: PLC0415
     except ImportError as exc:  # pragma: no cover - import-time gate
-        raise ImportError("OpenCV is required to load calibration video frames") from exc
+        raise ImportError(
+            "OpenCV is required to load calibration video frames"
+        ) from exc
 
     cap = cv2.VideoCapture(str(path))
     if not cap.isOpened():
@@ -256,10 +276,10 @@ def _load_video_prefix_bcthw(
         images.append(torch.from_numpy(rgb).permute(2, 0, 1).contiguous())
     cap.release()
     if len(images) < frames:
-        raise RuntimeError(
-            f"{path} has {len(images)} readable frames; need {frames}"
-        )
-    video = torch.stack(images, dim=1).unsqueeze(0).to(device=device, dtype=torch.float16)
+        raise RuntimeError(f"{path} has {len(images)} readable frames; need {frames}")
+    video = (
+        torch.stack(images, dim=1).unsqueeze(0).to(device=device, dtype=torch.float16)
+    )
     return (video / 127.5 - 1.0).contiguous()
 
 
@@ -267,9 +287,13 @@ def main() -> None:
     args = _parse_args()
     device = torch.device(args.device)
     if device.type == "cuda" and not torch.cuda.is_available():
-        raise RuntimeError("CUDA device requested but torch.cuda.is_available() is false")
+        raise RuntimeError(
+            "CUDA device requested but torch.cuda.is_available() is false"
+        )
 
     config = OMNIDREAMS_CONFIGS[args.config_name]
+    if config.encoder is None:
+        raise TypeError(f"{args.config_name} does not define a VAE encoder")
     encoder_cfg = derive_config(
         config.encoder,
         dtype=torch.float16,
@@ -298,7 +322,9 @@ def main() -> None:
     torch.save(state, args.out)
     print(f"Wrote {args.out}")
     print(f"Calibration video: {video_path}")
-    print(f"Activation scales: {len([k for k in state if k.endswith('.activation_scale')])}")
+    print(
+        f"Activation scales: {len([k for k in state if k.endswith('.activation_scale')])}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/omnidreams/tests/test_omnidreams_native_vae.py
+++ b/integrations/omnidreams/tests/test_omnidreams_native_vae.py
@@ -20,8 +20,6 @@ from types import ModuleType
 
 import pytest
 import torch
-
-from flashdreams.recipes.wan.autoencoder.vae import WanVAECache
 from omnidreams.native.acceleration import (
     NativeAccelerationMode,
     NativeAccelerationUnavailable,
@@ -31,11 +29,13 @@ from omnidreams.vae_native import (
     NATIVE_LIGHTVAE_FP8_STATE_ENV,
     OmnidreamsWanVAEEncoder,
     OmnidreamsWanVAEEncoderConfig,
-    _NativeWanVAEEncoderExecutor,
     _native_vae_availability_check,
     _native_vae_fp8_state_path,
     _native_vae_preflight_reason,
+    _NativeWanVAEEncoderExecutor,
 )
+
+from flashdreams.recipes.wan.autoencoder.vae import WanVAECache
 
 
 def _fake_extension_module(**attrs: object) -> ModuleType:
@@ -179,8 +179,7 @@ def test_native_wan_vae_encoder_fp8_state_path_env_fallback(
     )
 
     assert (
-        _native_vae_preflight_reason(component="vae_encoder", config=config)
-        is not None
+        _native_vae_preflight_reason(component="vae_encoder", config=config) is not None
     )
 
     monkeypatch.setenv(NATIVE_LIGHTVAE_FP8_STATE_ENV, "state.pt")
@@ -283,7 +282,9 @@ def test_native_wan_vae_encoder_executor_builds_fp8_state() -> None:
     assert captured["model"] is model
     assert captured["fp8_state"] is fp8_state
     assert captured["extension"] is extension
-    assert captured["native_encoder"][0] == "fp8_encoder"
+    native_encoder = captured["native_encoder"]
+    assert isinstance(native_encoder, tuple)
+    assert native_encoder[0] == "fp8_encoder"
     assert captured["shape"] == (1, 3, 1, 8, 8)
     assert captured["use_cache"] is True
 
@@ -390,15 +391,23 @@ def test_omnidreams_native_vae_perf_config_is_opt_in() -> None:
     baseline = SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF
 
     assert native.name in OMNIDREAMS_CONFIGS
+    assert isinstance(baseline.encoder, OmnidreamsWanVAEEncoderConfig)
+    assert isinstance(native.encoder, OmnidreamsWanVAEEncoderConfig)
+    assert baseline.decoder is not None
+    assert native.decoder is not None
     assert baseline.encoder.native_vae_acceleration == "disabled"
     assert native.encoder.native_vae_acceleration == "required"
     assert native.encoder.native_vae_backend == "fp8"
     assert native.encoder.dtype is torch.float16
     assert type(native.decoder) is type(baseline.decoder)
     assert not hasattr(native.decoder, "native_vae_acceleration")
-    assert native.decoder.dtype == baseline.decoder.dtype
-    assert native.decoder.use_compile == baseline.decoder.use_compile
-    assert native.decoder.use_cuda_graph == baseline.decoder.use_cuda_graph
+    assert getattr(native.decoder, "dtype") == getattr(baseline.decoder, "dtype")
+    assert getattr(native.decoder, "use_compile") == getattr(
+        baseline.decoder, "use_compile"
+    )
+    assert getattr(native.decoder, "use_cuda_graph") == getattr(
+        baseline.decoder, "use_cuda_graph"
+    )
 
 
 @pytest.mark.ci_cpu

--- a/integrations/omnidreams/tests/test_omnidreams_native_vae.py
+++ b/integrations/omnidreams/tests/test_omnidreams_native_vae.py
@@ -1,0 +1,467 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+from flashdreams.recipes.wan.autoencoder.vae import WanVAECache
+from omnidreams.native.acceleration import (
+    NativeAccelerationMode,
+    NativeAccelerationUnavailable,
+    NativeBackendSelection,
+)
+from omnidreams.vae_native import (
+    NATIVE_LIGHTVAE_FP8_STATE_ENV,
+    OmnidreamsWanVAEEncoder,
+    OmnidreamsWanVAEEncoderConfig,
+    _NativeWanVAEEncoderExecutor,
+    _native_vae_availability_check,
+    _native_vae_fp8_state_path,
+    _native_vae_preflight_reason,
+)
+
+
+def _fake_extension_module(**attrs: object) -> ModuleType:
+    module = ModuleType("test_native_vae_extension")
+    for name, value in attrs.items():
+        setattr(module, name, value)
+    return module
+
+
+def _enabled_selection(
+    extension: ModuleType,
+    *,
+    mode: NativeAccelerationMode = "auto",
+    component: str = "vae_encoder",
+) -> NativeBackendSelection:
+    return NativeBackendSelection(
+        component=component,
+        mode=mode,
+        enabled=True,
+        reason="native VAE available in test",
+        extension=extension,
+    )
+
+
+@pytest.mark.ci_cpu
+def test_omnidreams_vae_configs_default_native_disabled() -> None:
+    encoder = OmnidreamsWanVAEEncoderConfig()
+
+    assert encoder._target is OmnidreamsWanVAEEncoder
+    assert encoder.native_vae_acceleration == "disabled"
+    assert encoder.native_vae_backend == "fp8"
+    assert encoder.native_vae_fp8_state_path is None
+
+
+@pytest.mark.ci_cpu
+def test_native_vae_availability_uses_status_mapping() -> None:
+    extension = _fake_extension_module(
+        omnidreams_vae_create_wan_encoder_fp8=object(),
+        omnidreams_vae_reset_wan_encoder_fp8=object(),
+        omnidreams_vae_encode_wan_fp8=object(),
+        omnidreams_vae_backend_status=lambda component, backend: {
+            "component": component,
+            "backend": backend,
+            "available": False,
+            "reason": "pending kernel port",
+        },
+    )
+
+    check = _native_vae_availability_check(
+        component="vae_encoder",
+        backend="fp8",
+        run_symbol="omnidreams_vae_encode_wan_fp8",
+        setup_symbols=(
+            "omnidreams_vae_create_wan_encoder_fp8",
+            "omnidreams_vae_reset_wan_encoder_fp8",
+        ),
+    )
+
+    assert check(extension) == (False, "pending kernel port")
+
+
+@pytest.mark.ci_cpu
+def test_native_vae_availability_reports_missing_symbols() -> None:
+    extension = _fake_extension_module(
+        omnidreams_vae_backend_status=lambda component, backend: {
+            "component": component,
+            "backend": backend,
+            "available": True,
+        },
+    )
+    check = _native_vae_availability_check(
+        component="vae_encoder",
+        backend="fp8",
+        run_symbol="omnidreams_vae_encode_wan_fp8",
+    )
+
+    ok, reason = check(extension)
+
+    assert ok is False
+    assert "omnidreams_vae_encode_wan_fp8" in reason
+
+
+@pytest.mark.ci_cpu
+def test_native_vae_fp8_availability_uses_status_mapping() -> None:
+    extension = _fake_extension_module(
+        omnidreams_vae_create_wan_encoder_fp8=object(),
+        omnidreams_vae_reset_wan_encoder_fp8=object(),
+        omnidreams_vae_encode_wan_fp8=object(),
+        omnidreams_vae_backend_status=lambda component, backend: {
+            "component": component,
+            "backend": backend,
+            "available": True,
+            "reason": "fp8 ready",
+        },
+    )
+
+    check = _native_vae_availability_check(
+        component="vae_encoder",
+        backend="fp8",
+        run_symbol="omnidreams_vae_encode_wan_fp8",
+        setup_symbols=(
+            "omnidreams_vae_create_wan_encoder_fp8",
+            "omnidreams_vae_reset_wan_encoder_fp8",
+        ),
+    )
+
+    assert check(extension) == (True, "fp8 ready")
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_fp8_requires_state_path() -> None:
+    assert (
+        _NativeWanVAEEncoderExecutor.from_config(
+            OmnidreamsWanVAEEncoderConfig(
+                native_vae_acceleration="auto",
+                native_vae_backend="fp8",
+            )
+        )
+        is None
+    )
+
+    with pytest.raises(
+        NativeAccelerationUnavailable,
+        match="requires native_vae_fp8_state_path",
+    ):
+        _NativeWanVAEEncoderExecutor.from_config(
+            OmnidreamsWanVAEEncoderConfig(
+                native_vae_acceleration="required",
+                native_vae_backend="fp8",
+            )
+        )
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_fp8_state_path_env_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = OmnidreamsWanVAEEncoderConfig(
+        native_vae_acceleration="auto",
+        native_vae_backend="fp8",
+    )
+
+    assert (
+        _native_vae_preflight_reason(component="vae_encoder", config=config)
+        is not None
+    )
+
+    monkeypatch.setenv(NATIVE_LIGHTVAE_FP8_STATE_ENV, "state.pt")
+
+    assert _native_vae_fp8_state_path(config) == "state.pt"
+    assert _native_vae_preflight_reason(component="vae_encoder", config=config) is None
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_executor_prepares_contiguous_fp8_boundary() -> None:
+    captured: dict[str, object] = {}
+
+    def encode_wan(
+        native_encoder: object,
+        tensor: torch.Tensor,
+        use_cache: bool,
+    ) -> torch.Tensor:
+        captured["native_encoder"] = native_encoder
+        captured["shape"] = tuple(tensor.shape)
+        captured["is_contiguous"] = tensor.is_contiguous()
+        captured["dtype"] = tensor.dtype
+        captured["use_cache"] = use_cache
+        return tensor
+
+    extension = _fake_extension_module(
+        omnidreams_vae_create_wan_encoder_fp8=lambda _state: "native_encoder",
+        omnidreams_vae_reset_wan_encoder_fp8=lambda _encoder: None,
+        omnidreams_vae_encode_wan_fp8=encode_wan,
+    )
+    executor = _NativeWanVAEEncoderExecutor(
+        selection=_enabled_selection(extension),
+        backend="fp8",
+    )
+    executor._fp8_state_path = "state.pt"
+    executor._helper = _fake_extension_module(
+        load_lightvae_fp8_state=lambda _path: {"input.activation_scale": torch.ones(1)},
+        build_lightvae_encoder_fp8_staged_state=lambda _model, _state, _ext: {
+            "scale_input": torch.empty(())
+        },
+    )
+    source = torch.empty((1, 3, 1, 8, 8), dtype=torch.float16).transpose(3, 4)
+
+    result = executor.try_encode(object(), source, WanVAECache())
+
+    assert result is not None
+    assert captured == {
+        "native_encoder": "native_encoder",
+        "shape": (1, 3, 1, 8, 8),
+        "is_contiguous": True,
+        "dtype": torch.float16,
+        "use_cache": True,
+    }
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_executor_builds_fp8_state() -> None:
+    captured: dict[str, object] = {}
+
+    def build_state(
+        model: object,
+        fp8_state: object,
+        extension: ModuleType,
+    ) -> dict[str, object]:
+        captured["model"] = model
+        captured["fp8_state"] = fp8_state
+        captured["extension"] = extension
+        return {"scale_input": torch.empty(())}
+
+    def encode_wan(
+        native_encoder: object,
+        tensor: torch.Tensor,
+        use_cache: bool,
+    ) -> torch.Tensor:
+        captured["native_encoder"] = native_encoder
+        captured["shape"] = tuple(tensor.shape)
+        captured["use_cache"] = use_cache
+        return tensor
+
+    extension = _fake_extension_module(
+        omnidreams_vae_create_wan_encoder_fp8=lambda state: ("fp8_encoder", state),
+        omnidreams_vae_reset_wan_encoder_fp8=lambda _encoder: None,
+        omnidreams_vae_encode_wan_fp8=encode_wan,
+    )
+    executor = _NativeWanVAEEncoderExecutor(
+        selection=_enabled_selection(extension),
+        backend="fp8",
+    )
+    executor._fp8_state_path = "state.pt"
+    fp8_state = {"input.activation_scale": torch.ones(1)}
+    model = object()
+    executor._helper = _fake_extension_module(
+        load_lightvae_fp8_state=lambda _path: fp8_state,
+        build_lightvae_encoder_fp8_staged_state=build_state,
+    )
+    source = torch.empty((1, 3, 1, 8, 8), dtype=torch.float16)
+
+    result = executor.try_encode(model, source, WanVAECache())
+
+    assert result is not None
+    assert captured["model"] is model
+    assert captured["fp8_state"] is fp8_state
+    assert captured["extension"] is extension
+    assert captured["native_encoder"][0] == "fp8_encoder"
+    assert captured["shape"] == (1, 3, 1, 8, 8)
+    assert captured["use_cache"] is True
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_fp8_rejects_batch_gt_one() -> None:
+    extension = _fake_extension_module(
+        omnidreams_vae_encode_wan_fp8=lambda *_args: pytest.fail(
+            "native dispatch should not run for unsupported fp8 batch size"
+        )
+    )
+    executor = _NativeWanVAEEncoderExecutor(
+        selection=_enabled_selection(extension, mode="required"),
+        backend="fp8",
+    )
+    source = torch.empty((2, 3, 1, 8, 8), dtype=torch.float16)
+
+    with pytest.raises(NativeAccelerationUnavailable, match="axis B"):
+        executor.try_encode(object(), source, WanVAECache())
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_executor_matches_streaming_chunking() -> None:
+    calls: list[tuple[int, ...]] = []
+
+    def encode_wan(
+        _native_encoder: object,
+        tensor: torch.Tensor,
+        _use_cache: bool,
+    ) -> torch.Tensor:
+        calls.append(tuple(tensor.shape))
+        return torch.empty(
+            (tensor.shape[0], 16, 1, tensor.shape[3] // 8, tensor.shape[4] // 8),
+            dtype=tensor.dtype,
+        )
+
+    extension = _fake_extension_module(
+        omnidreams_vae_create_wan_encoder_fp8=lambda _state: "native_encoder",
+        omnidreams_vae_reset_wan_encoder_fp8=lambda _encoder: None,
+        omnidreams_vae_encode_wan_fp8=encode_wan,
+    )
+    executor = _NativeWanVAEEncoderExecutor(
+        selection=_enabled_selection(extension),
+        backend="fp8",
+    )
+    executor._fp8_state_path = "state.pt"
+    executor._helper = _fake_extension_module(
+        load_lightvae_fp8_state=lambda _path: {"input.activation_scale": torch.ones(1)},
+        build_lightvae_encoder_fp8_staged_state=lambda _model, _state, _ext: {
+            "scale_input": torch.empty(())
+        },
+    )
+    source = torch.empty((1, 3, 5, 16, 16), dtype=torch.float16)
+
+    result = executor.try_encode(object(), source, WanVAECache())
+
+    assert result is not None
+    assert tuple(result.shape) == (1, 16, 2, 2, 2)
+    assert calls == [(1, 3, 1, 16, 16), (1, 3, 4, 16, 16)]
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_executor_auto_fallback_on_bad_dtype() -> None:
+    extension = _fake_extension_module(
+        omnidreams_vae_encode_wan_fp8=lambda *_args: pytest.fail(
+            "native dispatch should not run for bf16 input"
+        )
+    )
+    executor = _NativeWanVAEEncoderExecutor(
+        selection=_enabled_selection(extension),
+        backend="fp8",
+    )
+    source = torch.empty((1, 3, 1, 8, 8), dtype=torch.bfloat16)
+
+    assert executor.try_encode(object(), source, WanVAECache()) is None
+
+
+@pytest.mark.ci_cpu
+def test_native_wan_vae_encoder_executor_required_raises_on_bad_dtype() -> None:
+    extension = _fake_extension_module(
+        omnidreams_vae_encode_wan_fp8=lambda *_args: pytest.fail(
+            "native dispatch should not run for bf16 input"
+        )
+    )
+    executor = _NativeWanVAEEncoderExecutor(
+        selection=_enabled_selection(extension, mode="required"),
+        backend="fp8",
+    )
+    source = torch.empty((1, 3, 1, 8, 8), dtype=torch.bfloat16)
+
+    with pytest.raises(NativeAccelerationUnavailable, match="expected dtype"):
+        executor.try_encode(object(), source, WanVAECache())
+
+
+@pytest.mark.ci_cpu
+def test_omnidreams_native_vae_perf_config_is_opt_in() -> None:
+    from omnidreams.config import (
+        OMNIDREAMS_CONFIGS,
+        SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF,
+        SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF,
+    )
+
+    native = SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_NATIVE_PERF
+    baseline = SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE_PERF
+
+    assert native.name in OMNIDREAMS_CONFIGS
+    assert baseline.encoder.native_vae_acceleration == "disabled"
+    assert native.encoder.native_vae_acceleration == "required"
+    assert native.encoder.native_vae_backend == "fp8"
+    assert native.encoder.dtype is torch.float16
+    assert type(native.decoder) is type(baseline.decoder)
+    assert not hasattr(native.decoder, "native_vae_acceleration")
+    assert native.decoder.dtype == baseline.decoder.dtype
+    assert native.decoder.use_compile == baseline.decoder.use_compile
+    assert native.decoder.use_cuda_graph == baseline.decoder.use_cuda_graph
+
+
+@pytest.mark.ci_cpu
+def test_native_vae_path_does_not_keep_stale_extension_names() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    paths = [
+        repo_root / "integrations" / "omnidreams" / "omnidreams" / "vae_native.py",
+        repo_root
+        / "integrations"
+        / "omnidreams"
+        / "omnidreams_singleview"
+        / "src"
+        / "vae_streaming"
+        / "vae_streaming_bindings.cpp",
+        repo_root
+        / "integrations"
+        / "omnidreams"
+        / "omnidreams_singleview"
+        / "src"
+        / "vae_streaming"
+        / "vae_streaming_bindings.h",
+        repo_root
+        / "integrations"
+        / "omnidreams"
+        / "omnidreams_singleview"
+        / "python"
+        / "vae_weights.py",
+        *(
+            repo_root
+            / "integrations"
+            / "omnidreams"
+            / "omnidreams_singleview"
+            / "src"
+            / "vae_streaming"
+        ).glob("*.cu"),
+        *(
+            repo_root
+            / "integrations"
+            / "omnidreams"
+            / "omnidreams_singleview"
+            / "src"
+            / "vae_streaming"
+        ).glob("*.h"),
+    ]
+    stale_project_name = "true" + "sight"
+    stale_raw_abi = stale_project_name + "_fp8_latent_v1"
+    stale_legacy_extension = "tin" + "_ext"
+    stale_sister_project = "alpa" + "dreams"
+    stale_cute_stage_name = "lightvae_fp8_" + "cute" + "_stages"
+    banned = (
+        stale_legacy_extension,
+        stale_sister_project,
+        stale_project_name,
+        stale_project_name.upper(),
+        stale_raw_abi,
+        stale_cute_stage_name,
+        "cutlass_" + "cute",
+        "_cute_",
+        "cute_",
+        "Cu" + "Te",
+    )
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for token in banned:
+            assert token not in text, f"{token!r} should not appear in {path}"

--- a/integrations/omnidreams/tests/test_omnidreams_pipeline.py
+++ b/integrations/omnidreams/tests/test_omnidreams_pipeline.py
@@ -284,6 +284,37 @@ def test_bidirectional_transformer_requires_and_wires_negative_embeddings(
 
 
 @pytest.mark.ci_cpu
+def test_cosmos_transformer_patchify_casts_to_transformer_dtype() -> None:
+    class FakeNetwork:
+        def __init__(self) -> None:
+            self.patchify_input: torch.Tensor | None = None
+
+        def patchify_and_maybe_split_cp(
+            self, x: torch.Tensor, **_kwargs: Any
+        ) -> torch.Tensor:
+            self.patchify_input = x
+            return x
+
+    transformer = CosmosTransformer.__new__(CosmosTransformer)
+    torch.nn.Module.__init__(transformer)
+    fake_network = FakeNetwork()
+    transformer.config = cast(Any, SimpleNamespace(dtype=torch.bfloat16))
+    transformer.cp_groups = HierarchicalCPGroups(rank=0)
+    transformer.network = cast(Any, fake_network)
+    transformer.flatten_thw = False
+    transformer.register_parameter(
+        "_test_device_anchor", torch.nn.Parameter(torch.empty(0, device="cpu"))
+    )
+
+    input_tensor = torch.zeros(1, 1, 1, 1, 2, 2, dtype=torch.float16)
+    output = transformer.patchify_and_maybe_split_cp(input_tensor)
+
+    assert fake_network.patchify_input is not None
+    assert fake_network.patchify_input.dtype is torch.bfloat16
+    assert output.dtype is torch.bfloat16
+
+
+@pytest.mark.ci_cpu
 def test_cosmos_transformer_checkpoint_path_none_keeps_random_init(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
+++ b/integrations/omnidreams/tests/test_omnidreams_singleview_native.py
@@ -177,6 +177,7 @@ def test_load_extension_uses_build_root_for_torch_cache(
         str(native._DIT_STREAMING_KERNEL_DIR),
         str(native._DIT_STREAMING_PYEXT_DIR),
         str(native._DIT_STREAMING_COMMON_DIR),
+        str(native._VAE_STREAMING_DIR),
         str(cutlass_dir / "include"),
         str(cutlass_dir / "tools" / "util" / "include"),
         str(cutlass_dir / "examples" / "common"),
@@ -203,6 +204,12 @@ def test_load_extension_uses_build_root_for_torch_cache(
         "native_primitives.cpp",
         "native_primitives_cuda.cu",
         "streaming_dit_bindings.cpp",
+        "vae_streaming_bindings.cpp",
+        "lightvae_ops.cu",
+        "lightvae_fp8_ops.cu",
+        "lightvae_fp8_direct_stages.cu",
+        "lightvae_fp8_warp_mma_stages.cu",
+        "lightvae_fp8_attention.cu",
         "streaming_dit_bridge.cu",
         "sage3_blackwell_api_shim.cu",
         "sage3_fp4_quant_shim.cu",
@@ -231,6 +238,7 @@ def test_load_extension_uses_build_root_for_torch_cache(
         "src/native_common/tensor_ref.h",
         "src/native_common/tensor_ref_torch.h",
         "src/native_common/workspace_allocator.h",
+        "src/vae_streaming/vae_streaming_bindings.h",
     }.issubset(fingerprint_sources)
     assert "-DOMNIDREAMS_SINGLEVIEW_WITH_CUDA" in captured["extra_cflags"]
     assert (
@@ -831,6 +839,13 @@ def test_cuda_native_extension_builds(tmp_path: Path) -> None:
     assert hasattr(extension, "workspace_allocation_plan")
     assert hasattr(extension, "prepare_contiguous")
     assert hasattr(extension, "zero_workspace_")
+    assert hasattr(extension, "omnidreams_vae_backend_status")
+    assert hasattr(extension, "omnidreams_vae_create_wan_encoder_fp8")
+    assert hasattr(extension, "omnidreams_vae_reset_wan_encoder_fp8")
+    assert hasattr(extension, "omnidreams_vae_encode_wan_fp8")
+    assert hasattr(extension, "lightvae_fp8_prepare_conv2d_weight_krsc")
+    vae_fp8_status = extension.omnidreams_vae_backend_status("vae_encoder", "fp8")
+    assert vae_fp8_status["available"] is True
 
     if not torch.cuda.is_available():
         return

--- a/integrations/omnidreams/tests/test_service_composition.py
+++ b/integrations/omnidreams/tests/test_service_composition.py
@@ -99,7 +99,7 @@ def test_service_get_version_returns_package_version(
     engine = _DummyEngine()
     service = WorldModelService(engine=engine)  # ty:ignore[invalid-argument-type]
 
-    response = service.get_version(common_pb2.Empty(), None)  # ty:ignore[invalid-argument-type]
+    response = service.get_version(common_pb2.Empty(), None)
 
     assert response.version_id == "1.2.3rc4"
     assert response.git_hash == ""


### PR DESCRIPTION
- Adds an opt-in native LightVAE FP8 encoder path for the OmniDreams single-view perf preset.
- Keeps the decoder unchanged: the native preset still uses the existing PyTorch LightTAE decoder, not a native TAEHV decoder.
- Adds a new runner/config: omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf.
- Requires a calibrated FP8 state via OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH or native_vae_fp8_state_path.
- Wraps the existing Wan VAE encoder with native dispatch knobs while preserving the default disabled path.
- Adds Python-side LightVAE FP8 weight/state staging for the native kernels.
- Adds CUDA/C++ VAE bindings and LightVAE FP8 kernels under vae_streaming.
- Adds benchmark/export utilities for FP8 state generation and before/after encoder validation.
- Adds CPU tests for config safety, opt-in behavior, required-vs-auto fallback behavior, tensor prep, streaming chunking, and stale-name cleanup.