### PR TITLE
interactive-drive: wire native DiT implementation

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -33,6 +33,7 @@ from omnidreams.scenes import local_scene_archive_path
 # the package -- they're staged into ``$FLASHDREAMS_CACHE_DIR/
 # omnidreams-scenes/`` (shared with the webrtc server).
 _PACKAGE_ROOT = Path(__file__).resolve().parent
+_CONFIGS_ROOT = _PACKAGE_ROOT / "configs"
 
 # UUID of the scene staged by ``omnidreams-prepare`` when no
 # ``--scene-uuid`` is specified and used as the demo's ``--scene``
@@ -45,6 +46,34 @@ DEFAULT_SCENE_UUID = "01d503d4-449b-46fc-8d78-9085e70d3554"
 # shared via huggingface_hub's content-addressed cache and a
 # pre-existing staged scene from one demo is visible to the other.
 DEFAULT_SCENE = local_scene_archive_path(DEFAULT_SCENE_UUID)
+
+
+def resolve_manifest_path(path: str | Path) -> Path:
+    """Resolve a CLI manifest value.
+
+    Relative paths first mean "from the caller's cwd". Bare filenames and
+    package-relative paths also fall back to the bundled interactive-drive
+    config directory, so ``--manifest example_world_model_perf.yaml`` works
+    from a workspace root.
+    """
+    raw_path = Path(path).expanduser()
+    if raw_path.is_absolute():
+        return raw_path
+
+    cwd_path = raw_path.resolve()
+    if cwd_path.exists():
+        return cwd_path
+
+    package_path = (_PACKAGE_ROOT / raw_path).resolve()
+    if package_path.exists():
+        return package_path
+
+    if len(raw_path.parts) == 1:
+        configs_path = (_CONFIGS_ROOT / raw_path).resolve()
+        if configs_path.exists():
+            return configs_path
+
+    return cwd_path
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -122,7 +151,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--manifest",
         type=Path,
         default=None,
-        help="Omnidreams pipeline manifest (YAML) overriding the bundled default",
+        help=(
+            "Omnidreams pipeline manifest (YAML). Accepts a path or a bundled "
+            "config filename such as example_world_model_perf.yaml."
+        ),
     )
     parser.add_argument(
         "--official-hdmap-dir",
@@ -299,6 +331,9 @@ def prepare_config_and_backend(
         fov_deg=float(args.bev_fov_deg),
         tilt_deg=float(args.bev_tilt_deg),
     )
+    manifest_path = (
+        resolve_manifest_path(args.manifest) if args.manifest is not None else None
+    )
 
     config = AppConfig(
         scene_path=scene_path,
@@ -306,7 +341,7 @@ def prepare_config_and_backend(
         camera_name=args.camera,
         variant=args.variant,
         prompt_override=args.prompt,
-        manifest_path=args.manifest,
+        manifest_path=manifest_path,
         raster=RasterConfig(
             compute_device=args.compute_device,
             sync_gpu_timing=args.sync_gpu_timing,

--- a/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model_perf.yaml
+++ b/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model_perf.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+# Perf-tuned world-model manifest for the interactive-drive single-view demo.
+#
+# Inference is handled by the packaged flashdreams Alpadreams pipeline.
+# Flashdreams owns checkpoint selection and cache layout for the selected
+# recipe; this manifest keeps the interactive demo's runtime shape and
+# performance knobs in one place.
+#
+# Default is 1280x704. You can try smaller resolutions as long as both width
+# and height are multiples of 16; examples with roughly similar aspect ratio:
+#   - [1168, 640]
+#   - [1024, 560]
+#   - [896, 496]
+#   - [640, 352]
+resolution_wh: [1024, 560]
+fps: 30
+num_frames_per_block: 8
+# For interactive GUI bring-up, eager mode gives a much faster first chunk than
+# paying torch.compile on the first real inference call.
+compile_net: false
+light_vae: true
+encode_with_pixel_shuffle: false
+local_attn_size: 6
+skip_finalize_kv_cache: true
+sink_size: 0
+denoising_steps: [1000, 100]
+upsampling_enabled: false
+upsampling_scale: 4
+device: cuda:0
+seed_for_every_rollout:
+
+# Native optimized DiT is off by default so the demo still runs on machines
+# without the native extension. Set this to "required" when testing the
+# optimized path; it will fail loudly if the extension cannot build/load.
+native_dit_acceleration: required
+native_dit_verbose_build: true
+native_dit_backend: bf16            # fp8_kvcache_cudnn | bf16
+native_dit_attention_backend: sage3 # auto | cudnn | sparge | sage3 | sage3_fp8

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -685,7 +685,8 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
         if not args.manifest.exists():
             raise SystemExit(
                 f"--manifest path does not exist: {args.manifest}"
-                " (typo? expected something like configs/example_world_model.yaml)"
+                " (typo? expected a path or bundled config name like "
+                "example_world_model.yaml)"
             )
     if not scene_options and not args.scene.exists():
         raise SystemExit(
@@ -799,10 +800,12 @@ def _apply_cuda_visible_devices_inplace(requested: str) -> None:
 
 
 def _resolve_demo_paths(args: argparse.Namespace) -> None:
-    for attr in ("scene", "manifest", "scene_dir", "wheel_profiles_dir"):
+    for attr in ("scene", "scene_dir", "wheel_profiles_dir"):
         value = getattr(args, attr)
         if value is not None:
             setattr(args, attr, _project_path(value))
+    if args.manifest is not None:
+        args.manifest = _cli.resolve_manifest_path(args.manifest)
     if args.control_assets_dir is not None:
         args.control_assets_dir = _project_path(args.control_assets_dir)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -86,44 +86,25 @@ def _build_pipeline_config(
     )
 
     # The lightvae chassis maps to the perf preset (use_compile + cuda_graph
-    # on every encoder/decoder); we always plumb the manifest's
-    # denoising_steps through. ``OMNIDREAMS_CONFIGS`` values are shared
+    # on every encoder/decoder). ``OMNIDREAMS_CONFIGS`` values are shared
     # global instances, so use ``derive_config`` to get a deep-copied
     # override-applied instance instead of mutating the global.
-    if config_name == "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae":
-        base = OMNIDREAMS_CONFIGS[
-            "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
-        ]
-        config = derive_config(
-            base,
-            enable_sync_and_profile=bool(profile.enabled),
-            diffusion_model=dict(
-                seed=seed,
-                transformer=dict(
-                    compile_network=manifest.compile_net,
-                    skip_finalize_kv_cache=manifest.skip_finalize_kv_cache,
-                ),
-                scheduler=dict(
-                    denoising_timesteps=list(manifest.denoising_steps),
-                    num_inference_steps=len(manifest.denoising_steps),
-                ),
-            ),
-        )
-        scheduler_uses_manifest_steps = True
-    else:
-        base = OMNIDREAMS_CONFIGS[config_name]
-        config = derive_config(
-            base,
-            enable_sync_and_profile=bool(profile.enabled),
-            diffusion_model=dict(
-                seed=seed,
-                transformer=dict(
-                    compile_network=manifest.compile_net,
-                    skip_finalize_kv_cache=manifest.skip_finalize_kv_cache,
-                ),
-            ),
-        )
-        scheduler_uses_manifest_steps = False
+    transformer_overrides = _transformer_overrides(manifest)
+    base_config_name = (
+        "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
+        if config_name == "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
+        else config_name
+    )
+    base = OMNIDREAMS_CONFIGS[base_config_name]
+    config = derive_config(
+        base,
+        enable_sync_and_profile=bool(profile.enabled),
+        diffusion_model=dict(
+            seed=seed,
+            transformer=transformer_overrides,
+        ),
+    )
+    scheduler_uses_manifest_steps = False
 
     if not scheduler_uses_manifest_steps and hasattr(
         config.diffusion_model, "scheduler"
@@ -145,16 +126,29 @@ def _build_pipeline_config(
             f"{config_name} uses flashdreams default denoising steps [1000, 450]; "
             f"got {manifest.denoising_steps}."
         )
-    transformer_config = getattr(config.diffusion_model, "transformer", None)
     print(
-        "[flashdreams-session] config "
-        f"recipe={config_name} "
-        f"manifest_skip_finalize_kv_cache={manifest.skip_finalize_kv_cache} "
-        "transformer_skip_finalize_kv_cache="
-        f"{getattr(transformer_config, 'skip_finalize_kv_cache', '<missing>')}",
+        "[flashdreams-session] resolved pipeline config\n"
+        f"selected_recipe={config_name}\n"
+        f"{config}",
         flush=True,
     )
     return config
+
+
+def _transformer_overrides(manifest: WorldModelManifest) -> dict[str, object]:
+    return {
+        "skip_finalize_kv_cache": manifest.skip_finalize_kv_cache,
+        "compile_network": manifest.compile_net,
+        "native_dit_acceleration": manifest.native_dit_acceleration,
+        "native_dit_build_root": manifest.native_dit_build_root,
+        "native_dit_max_jobs": manifest.native_dit_max_jobs,
+        "native_dit_verbose_build": manifest.native_dit_verbose_build,
+        "native_dit_backend": manifest.native_dit_backend,
+        "native_dit_attention_backend": manifest.native_dit_attention_backend,
+        "native_dit_sparge_topk": manifest.native_dit_sparge_topk,
+        "native_dit_sparge_hybrid_period": manifest.native_dit_sparge_hybrid_period,
+        "native_dit_sparge_hybrid_phase": manifest.native_dit_sparge_hybrid_phase,
+    }
 
 
 def _setup_pipeline_from_config(config: Any, manifest: WorldModelManifest) -> Any:

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
@@ -22,6 +22,8 @@ _HF_URL_PATTERN = re.compile(
 )
 _DEFAULT_RESOLUTION_WH = (1280, 704)
 _RESOLUTION_ALIGNMENT_PX = 16
+_NATIVE_DIT_ACCELERATION_MODES = ("auto", "disabled", "required")
+_NATIVE_DIT_BACKENDS = ("fp8_kvcache_cudnn", "bf16")
 
 
 def _is_hf_url(raw: str) -> bool:
@@ -113,6 +115,25 @@ def _parse_resolution_wh(raw: object) -> tuple[int, int]:
     return (width, height)
 
 
+def _parse_native_dit_acceleration(raw: object) -> str:
+    mode = "disabled" if raw is None else str(raw)
+    if mode not in _NATIVE_DIT_ACCELERATION_MODES:
+        raise ValueError(
+            "native_dit_acceleration must be one of "
+            f"{_NATIVE_DIT_ACCELERATION_MODES}, got {mode!r}"
+        )
+    return mode
+
+
+def _parse_native_dit_backend(raw: object) -> str:
+    backend = "fp8_kvcache_cudnn" if raw is None else str(raw)
+    if backend not in _NATIVE_DIT_BACKENDS:
+        raise ValueError(
+            f"native_dit_backend must be one of {_NATIVE_DIT_BACKENDS}, got {backend!r}"
+        )
+    return backend
+
+
 @dataclass(frozen=True)
 class WorldModelManifest:
     debug_condition_frame_dir: Path | None = None
@@ -130,6 +151,15 @@ class WorldModelManifest:
     upsampling_scale: int = 4
     device: str = "cuda:0"
     seed_for_every_rollout: int | None = None
+    native_dit_acceleration: str = "disabled"
+    native_dit_build_root: str | None = None
+    native_dit_max_jobs: int | str | None = None
+    native_dit_verbose_build: bool = False
+    native_dit_backend: str = "fp8_kvcache_cudnn"
+    native_dit_attention_backend: str = "auto"
+    native_dit_sparge_topk: float | None = None
+    native_dit_sparge_hybrid_period: int | None = None
+    native_dit_sparge_hybrid_phase: int | None = None
 
 
 def load_world_model_manifest(path: str | Path) -> WorldModelManifest:
@@ -176,6 +206,35 @@ def load_world_model_manifest(path: str | Path) -> WorldModelManifest:
         seed_for_every_rollout=(
             int(data["seed_for_every_rollout"])
             if data.get("seed_for_every_rollout") is not None
+            else None
+        ),
+        native_dit_acceleration=_parse_native_dit_acceleration(
+            data.get("native_dit_acceleration")
+        ),
+        native_dit_build_root=(
+            str(data["native_dit_build_root"])
+            if data.get("native_dit_build_root") is not None
+            else None
+        ),
+        native_dit_max_jobs=data.get("native_dit_max_jobs"),
+        native_dit_verbose_build=bool(data.get("native_dit_verbose_build", False)),
+        native_dit_backend=_parse_native_dit_backend(data.get("native_dit_backend")),
+        native_dit_attention_backend=str(
+            data.get("native_dit_attention_backend", "auto")
+        ),
+        native_dit_sparge_topk=(
+            float(data["native_dit_sparge_topk"])
+            if data.get("native_dit_sparge_topk") is not None
+            else None
+        ),
+        native_dit_sparge_hybrid_period=(
+            int(data["native_dit_sparge_hybrid_period"])
+            if data.get("native_dit_sparge_hybrid_period") is not None
+            else None
+        ),
+        native_dit_sparge_hybrid_phase=(
+            int(data["native_dit_sparge_hybrid_phase"])
+            if data.get("native_dit_sparge_hybrid_phase") is not None
             else None
         ),
     )

--- a/integrations/omnidreams/tests/interactive_drive/test_cli_manifest_resolution.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_cli_manifest_resolution.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from omnidreams.interactive_drive import cli
+
+
+class CliManifestResolutionTest(unittest.TestCase):
+    def test_resolves_bundled_manifest_by_filename(self) -> None:
+        manifest = cli.resolve_manifest_path("example_world_model_perf.yaml")
+
+        self.assertEqual(manifest.name, "example_world_model_perf.yaml")
+        self.assertEqual(manifest.parent, cli._CONFIGS_ROOT)
+        self.assertTrue(manifest.is_file())
+
+    def test_cwd_relative_manifest_wins(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = Path.cwd()
+            root = Path(tmpdir)
+            manifest = root / "example_world_model_perf.yaml"
+            manifest.write_text("resolution_wh: [1280, 704]\n", encoding="utf-8")
+            try:
+                os.chdir(root)
+                resolved = cli.resolve_manifest_path(manifest.name)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(resolved, manifest.resolve())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/omnidreams/tests/interactive_drive/test_manifest.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_manifest.py
@@ -27,6 +27,37 @@ class WorldModelManifestTest(unittest.TestCase):
             self.assertEqual(manifest.num_frames_per_block, 8)
             self.assertEqual(manifest.denoising_steps, [1000, 500])
             self.assertEqual(manifest.resolution_wh, (1280, 704))
+            self.assertEqual(manifest.native_dit_acceleration, "disabled")
+
+    def test_loads_native_dit_knobs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.yaml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    native_dit_acceleration: required
+                    native_dit_build_root: /tmp/omnidreams-native
+                    native_dit_max_jobs: 8
+                    native_dit_verbose_build: true
+                    native_dit_backend: bf16
+                    native_dit_attention_backend: sparge
+                    native_dit_sparge_topk: 0.4
+                    native_dit_sparge_hybrid_period: 4
+                    native_dit_sparge_hybrid_phase: 1
+                    """
+                ).strip(),
+                encoding="utf-8",
+            )
+            manifest = load_world_model_manifest(path)
+            self.assertEqual(manifest.native_dit_acceleration, "required")
+            self.assertEqual(manifest.native_dit_build_root, "/tmp/omnidreams-native")
+            self.assertEqual(manifest.native_dit_max_jobs, 8)
+            self.assertTrue(manifest.native_dit_verbose_build)
+            self.assertEqual(manifest.native_dit_backend, "bf16")
+            self.assertEqual(manifest.native_dit_attention_backend, "sparge")
+            self.assertEqual(manifest.native_dit_sparge_topk, 0.4)
+            self.assertEqual(manifest.native_dit_sparge_hybrid_period, 4)
+            self.assertEqual(manifest.native_dit_sparge_hybrid_phase, 1)
 
     def test_rejects_unaligned_resolution(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -40,6 +71,13 @@ class WorldModelManifestTest(unittest.TestCase):
                 encoding="utf-8",
             )
             with self.assertRaisesRegex(ValueError, "divisible by 16"):
+                load_world_model_manifest(path)
+
+    def test_rejects_invalid_native_dit_acceleration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.yaml"
+            path.write_text("native_dit_acceleration: fast\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "native_dit_acceleration"):
                 load_world_model_manifest(path)
 
     def test_resolves_relative_paths_from_manifest_location(self) -> None:

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -7,8 +7,10 @@ from dataclasses import replace
 
 import numpy as np
 import torch
+from omnidreams.interactive_drive.config import WorldModelProfileConfig
 from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
     FlashdreamsWorldModelSession,
+    _build_pipeline_config,
     _select_config_name,
 )
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
@@ -79,6 +81,33 @@ def test_select_config_name_uses_omnidreams_recipe_slugs() -> None:
         )
         == "omnidreams-sv-2steps-chunk4-loc8-pshuffle-lighttae"
     )
+
+
+def test_build_pipeline_config_uses_manifest_native_dit_overrides() -> None:
+    config = _build_pipeline_config(
+        replace(
+            _manifest(),
+            skip_finalize_kv_cache=True,
+            native_dit_acceleration="required",
+            native_dit_verbose_build=True,
+            native_dit_backend="bf16",
+            native_dit_attention_backend="sparge",
+            native_dit_sparge_topk=0.4,
+            native_dit_sparge_hybrid_period=4,
+            native_dit_sparge_hybrid_phase=1,
+        ),
+        profile=WorldModelProfileConfig(),
+    )
+    transformer_config = config.diffusion_model.transformer
+
+    assert transformer_config.skip_finalize_kv_cache is True
+    assert transformer_config.native_dit_acceleration == "required"
+    assert transformer_config.native_dit_verbose_build is True
+    assert transformer_config.native_dit_backend == "bf16"
+    assert transformer_config.native_dit_attention_backend == "sparge"
+    assert transformer_config.native_dit_sparge_topk == 0.4
+    assert transformer_config.native_dit_sparge_hybrid_period == 4
+    assert transformer_config.native_dit_sparge_hybrid_phase == 1
 
 
 def test_session_uses_flashdreams_pipeline_for_rollout() -> None:


### PR DESCRIPTION
## Summary

- Wire interactive-drive manifests into the native optimized DiT transformer knobs.
- Add `example_world_model_perf.yaml` for perf-oriented settings while keeping the default manifest conservative.
- Allow `--manifest example_world_model_perf.yaml` to resolve from bundled configs.
- Keep startup logging to the resolved pipeline config only.

## Sample command

```bash
uv run --no-sync --package flashdreams-omnidreams interactive-drive \
  --autoload-scene \
  --manifest example_world_model_perf.yaml
```