### PR TITLE
Add the interactive-drive presenter CUDA interop

### DIFF
--- a/flashdreams/flashdreams/infra/cuda_graph.py
+++ b/flashdreams/flashdreams/infra/cuda_graph.py
@@ -92,9 +92,16 @@ class CUDAGraphWrapper:
             y = wrapper(chunk, timesteps=t, cache=cache)
     """
 
-    def __init__(self, fn: Callable[..., Any], warmup_iters: int = 2):
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        warmup_iters: int = 2,
+        *,
+        capture_error_mode: str = "thread_local",
+    ):
         self.fn = fn
         self.warmup_iters = warmup_iters
+        self.capture_error_mode = capture_error_mode
         self._graph: Optional[torch.cuda.CUDAGraph] = None
         # Input staging state.
         self._static_args: list[Any] = []  # one slot per positional arg
@@ -233,7 +240,12 @@ class CUDAGraphWrapper:
         # "replay without a preceding successful capture", hiding the real
         # capture error.
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
+        # The default PyTorch/CUDA capture mode is global: CUDA work in any
+        # other host thread can invalidate capture. Interactive-drive uses a
+        # UI-thread presenter that can enqueue CUDA interop work while the
+        # model worker captures/replays graph-backed stages, so keep capture
+        # restrictions local to the worker thread.
+        with torch.cuda.graph(graph, capture_error_mode=self.capture_error_mode):
             out = self.fn(*args, **kwargs)
         out_leaves, out_spec = tree_flatten(out)
         graph.replay()

--- a/flashdreams/tests/test_cuda_graph.py
+++ b/flashdreams/tests/test_cuda_graph.py
@@ -16,8 +16,9 @@ pytestmark = pytest.mark.ci_cpu
 def test_failed_capture_does_not_store_invalid_graph(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    state = {
+    state: dict[str, Any] = {
         "capture_attempts": 0,
+        "capture_error_mode": "",
         "in_capture": False,
         "replays": 0,
     }
@@ -27,11 +28,13 @@ def test_failed_capture_does_not_store_invalid_graph(
             state["replays"] += 1
 
     class FakeGraphContext:
-        def __init__(self, graph: FakeGraph) -> None:
+        def __init__(self, graph: FakeGraph, capture_error_mode: str) -> None:
             self.graph = graph
+            self.capture_error_mode = capture_error_mode
 
         def __enter__(self) -> None:
             del self.graph
+            state["capture_error_mode"] = self.capture_error_mode
             state["capture_attempts"] += 1
             state["in_capture"] = True
 
@@ -39,8 +42,12 @@ def test_failed_capture_does_not_store_invalid_graph(
             state["in_capture"] = False
             return False
 
-    def fake_graph(graph: FakeGraph) -> FakeGraphContext:
-        return FakeGraphContext(graph)
+    def fake_graph(
+        graph: FakeGraph,
+        *,
+        capture_error_mode: str = "global",
+    ) -> FakeGraphContext:
+        return FakeGraphContext(graph, capture_error_mode)
 
     def fn(x: torch.Tensor) -> torch.Tensor:
         if state["in_capture"] and state["capture_attempts"] == 1:
@@ -63,3 +70,4 @@ def test_failed_capture_does_not_store_invalid_graph(
     assert out.item() == 3
     assert isinstance(wrapper._graph, FakeGraph)
     assert state["replays"] == 1
+    assert state["capture_error_mode"] == "thread_local"

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -364,6 +364,25 @@ The browser control hint is static today, so it does not confirm every keydown
 visually. If the world-model backend is still producing a chunk, input can be
 accepted before the visual response arrives.
 
+### Generated-frame e2e profiling
+
+Set `INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT=1` to log generated-frame
+input-to-present timing while the demo runs:
+
+```bash
+INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT=1 \
+  OMNIDREAMS_TRUESIGHT=1 \
+  uv run --no-sync --package flashdreams-omnidreams interactive-drive --autoload-scene
+```
+
+The log line is `[profile] e2e ...`. `wall_present_fps` counts only frames
+consumed from the model pipeline queue, so loading-frame or hold-frame
+re-presents are excluded. `avg_adj_control_to_present_ms` subtracts the
+intentional per-frame spacing inside a generated chunk; the raw value is also
+printed for debugging. Set
+`INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT_INTERVAL_S` to adjust the report
+period; the default is `2`.
+
 ### Rollout drift and resets
 
 OmniDreams generates video autoregressively, so long rollouts can accumulate

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -347,6 +347,23 @@ Then open `http://localhost:8080/`.
 For a richer browser frontend with lower latency, prefer the separate
 `omnidreams.webrtc.server` entry point.
 
+Both Vulkan presenters can use SlangPy CUDA interop for generated RGB frames
+when the model output is still on CUDA. Because Torch usually owns the CUDA
+context before the presenter is constructed, this path follows upstream and is
+opt-in:
+
+```bash
+INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES=1 \
+  OMNIDREAMS_TRUESIGHT=1 \
+  uv run --no-sync --package flashdreams-omnidreams interactive-drive
+```
+
+Set `INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP=1` to force the host-upload
+fallback. In HUD mode, chrome is still rendered with PIL on the CPU, then
+uploaded as an alpha overlay; the generated camera frame stays lazy on CUDA and
+is resized/composited into the shared presentation buffer on the CUDA stream.
+Use `--no-hud` with the same environment variables for the bare presenter.
+
 Controls (apply in all three modes):
 
 - `W` throttle
@@ -382,6 +399,11 @@ intentional per-frame spacing inside a generated chunk; the raw value is also
 printed for debugging. Set
 `INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT_INTERVAL_S` to adjust the report
 period; the default is `2`.
+
+For HUD-specific render timing, set `INTERACTIVE_DRIVE_PROFILE_HUD=1`. The
+`[profile] hud ...` line breaks `present_frame` into stages such as PIL chrome
+rendering, full-window overlay extraction, CUDA enqueue, and Vulkan submission.
+Set `INTERACTIVE_DRIVE_PROFILE_HUD_INTERVAL_S` to adjust its report period.
 
 ### Rollout drift and resets
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/cuda_host_prefetch.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cuda_host_prefetch.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import numpy as np
+
+_STREAMS_LOCK = threading.Lock()
+_HOST_COPY_STREAMS: dict[int, Any] = {}
+
+
+class CudaHostPrefetch:
+    """Asynchronously stage one CUDA uint8 RGB frame into pinned host memory."""
+
+    def __init__(self, tensor: Any, *, source_event: Any | None = None) -> None:
+        self._tensor = tensor
+        self._source_event = source_event
+        self._host_tensor: Any | None = None
+        self._done_event: Any | None = None
+        self._started = False
+
+    def start(self) -> bool:
+        if self._started:
+            return self._host_tensor is not None
+        self._started = True
+
+        try:
+            import torch
+        except ImportError:
+            return False
+
+        tensor = self._tensor
+        if not torch.is_tensor(tensor) or not tensor.is_cuda:
+            return False
+
+        try:
+            host_tensor = torch.empty(
+                tuple(tensor.shape),
+                dtype=tensor.dtype,
+                device="cpu",
+                pin_memory=True,
+            )
+            copy_stream = _host_copy_stream(torch, tensor.device)
+            with torch.cuda.device(tensor.device):
+                if self._source_event is not None:
+                    copy_stream.wait_event(self._source_event)
+                with torch.cuda.stream(copy_stream):
+                    host_tensor.copy_(tensor, non_blocking=True)
+                    tensor.record_stream(copy_stream)
+                    done_event = torch.cuda.Event()
+                    done_event.record(copy_stream)
+        except Exception:
+            self._host_tensor = None
+            self._done_event = None
+            return False
+
+        self._host_tensor = host_tensor
+        self._done_event = done_event
+        return True
+
+    def to_numpy(self) -> np.ndarray:
+        host_tensor = self._host_tensor
+        if host_tensor is None:
+            raise RuntimeError("CUDA host prefetch was not started.")
+        done_event = self._done_event
+        if done_event is not None:
+            done_event.synchronize()
+        return np.ascontiguousarray(host_tensor.numpy(), dtype=np.uint8)
+
+
+def _host_copy_stream(torch: Any, device: Any) -> Any:
+    key = _device_index(device)
+    with _STREAMS_LOCK:
+        stream = _HOST_COPY_STREAMS.get(key)
+        if stream is None:
+            with torch.cuda.device(device):
+                stream = torch.cuda.Stream(device=device)
+            _HOST_COPY_STREAMS[key] = stream
+        return stream
+
+
+def _device_index(device: Any) -> int:
+    index = getattr(device, "index", None)
+    return 0 if index is None else int(index)

--- a/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
@@ -94,7 +94,9 @@ class SlangPyPresenter:
             rgb = _with_status_overlay(frame.model_rgb_host_uint8, frame.status_message)
             self._present_array(rgb)
             return
-        self._present_array(_with_status_overlay(frame.rgb_host_uint8, frame.status_message))
+        self._present_array(
+            _with_status_overlay(frame.rgb_host_uint8, frame.status_message)
+        )
 
     def _create_device(self):
         existing_device_handles = self._cuda_existing_device_handles()
@@ -105,12 +107,11 @@ class SlangPyPresenter:
             self._cuda_interop_unavailable_reason = (
                 "disabled after torch CUDA initialization"
             )
-        enable_cuda_interop = (
-            not _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP")
-            and (
-                not torch_cuda_initialized
-                or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
-            )
+        enable_cuda_interop = not _env_truthy(
+            "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"
+        ) and (
+            not torch_cuda_initialized
+            or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
         )
         device_kwargs = {
             "type": self._spy.DeviceType.vulkan,
@@ -152,7 +153,9 @@ class SlangPyPresenter:
         except Exception:
             return []
 
-        get_handles = getattr(self._spy, "get_cuda_current_context_native_handles", None)
+        get_handles = getattr(
+            self._spy, "get_cuda_current_context_native_handles", None
+        )
         if not callable(get_handles):
             return []
         try:
@@ -171,7 +174,9 @@ class SlangPyPresenter:
             return None
         if not self._device.supports_cuda_interop:
             reason = self._cuda_interop_unavailable_reason or "unsupported"
-            print(f"[presenter] cuda_interop={reason}; using host RGB upload", flush=True)
+            print(
+                f"[presenter] cuda_interop={reason}; using host RGB upload", flush=True
+            )
             return None
         try:
             interop = _CudaRGBInterop(
@@ -189,7 +194,9 @@ class SlangPyPresenter:
         print("[presenter] cuda_interop=enabled", flush=True)
         return interop
 
-    def _present_cuda_rgb(self, rgb_frame: object, *, status_message: str | None) -> bool:
+    def _present_cuda_rgb(
+        self, rgb_frame: object, *, status_message: str | None
+    ) -> bool:
         if self._cuda_rgb_interop is None:
             return False
 
@@ -538,14 +545,18 @@ class _CudaRGBInterop:
             if copy_done_event is None or not _cuda_event_ready(copy_done_event):
                 continue
             stream = int(self._copy_stream.cuda_stream)
-            cuda_stream = self._spy.NativeHandle(self._spy.NativeHandleType.CUstream, stream)
+            cuda_stream = self._spy.NativeHandle(
+                self._spy.NativeHandleType.CUstream, stream
+            )
             return shared_buffer, cuda_stream
         return None
 
     def close(self) -> None:
         self._copy_stream.close()
 
-    def mark_submitted(self, shared_buffer: "_SharedRGBABuffer", submit_id: int) -> None:
+    def mark_submitted(
+        self, shared_buffer: "_SharedRGBABuffer", submit_id: int
+    ) -> None:
         shared_buffer.copy_done_event = None
         shared_buffer.pending_submit_id = int(submit_id)
 
@@ -568,9 +579,7 @@ class _CudaRGBInterop:
         index = device.index
         return 0 if index is None else int(index)
 
-    def _resize_rgb_tensor(
-        self, rgb_tensor: Any, target_h: int, target_w: int
-    ) -> Any:
+    def _resize_rgb_tensor(self, rgb_tensor: Any, target_h: int, target_w: int) -> Any:
         if tuple(rgb_tensor.shape[:2]) == (target_h, target_w):
             return rgb_tensor if rgb_tensor.is_contiguous() else rgb_tensor.contiguous()
         nchw = rgb_tensor.permute(2, 0, 1).unsqueeze(0).to(self._torch.float32)
@@ -689,7 +698,9 @@ def _check_cuda_runtime_result(result: int, get_error_string: Any) -> None:
         return
     raw = get_error_string(int(result))
     message = (
-        raw.decode("utf-8", errors="replace") if raw is not None else f"CUDA error {result}"
+        raw.decode("utf-8", errors="replace")
+        if raw is not None
+        else f"CUDA error {result}"
     )
     raise RuntimeError(message)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import os
+import sys
 import time
+from typing import Any
 
 import numpy as np
 from omnidreams.interactive_drive.config import RasterConfig
@@ -23,19 +26,14 @@ class SlangPyPresenter:
         self._spy = spy
         self._raster = raster
         self._keyboard = keyboard
+        self._cuda_interop_unavailable_reason: str | None = None
         self._window = spy.Window(
             width=raster.width,
             height=raster.height,
             title="interactive_drive",
             resizable=False,
         )
-        self._device = spy.Device(
-            type=spy.DeviceType.vulkan,
-            enable_debug_layers=False,
-            # Workaround: avoid cuDNN MHA crash on NVIDIA Blackwell + R595.
-            enable_cuda_launch_from_gfx=False,
-            enable_ray_tracing=False,
-        )
+        self._device = self._create_device()
         print(f"[presenter] device={self._device.info.adapter_name}", flush=True)
         self._surface = self._device.create_surface(self._window)
         self._surface_format = self._choose_surface_format()
@@ -51,9 +49,14 @@ class SlangPyPresenter:
             format=self._display_format,
             width=raster.width,
             height=raster.height,
-            usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+            usage=(
+                spy.TextureUsage.shader_resource
+                | spy.TextureUsage.unordered_access
+                | spy.TextureUsage.copy_destination
+            ),
             label="display_texture",
         )
+        self._cuda_rgb_interop = self._create_cuda_rgb_interop()
         self._key_codes = self._build_key_codes()
         self._window.on_keyboard_event = self._on_keyboard_event
 
@@ -62,20 +65,189 @@ class SlangPyPresenter:
         return self._window.should_close()
 
     def close(self) -> None:
+        if self._cuda_rgb_interop is not None:
+            self._cuda_rgb_interop.close()
+            self._cuda_rgb_interop = None
         self._window.close()
 
     def process_events(self) -> None:
         self._window.process_events()
 
+    def prepare_frame(self, frame: PresentedFrame, view_mode: str) -> None:
+        if (
+            view_mode == "model_rgb"
+            and frame.model_rgb_host_uint8 is not None
+            and self._cuda_rgb_interop is None
+        ):
+            _prefetch_to_numpy(frame.model_rgb_host_uint8)
+            return
+        if view_mode != "model_rgb":
+            _prefetch_to_numpy(frame.rgb_host_uint8)
+
     def present_frame(self, frame: PresentedFrame, view_mode: str) -> None:
         if view_mode == "model_rgb" and frame.model_rgb_host_uint8 is not None:
-            self._present_array(
-                _with_status_overlay(frame.model_rgb_host_uint8, frame.status_message)
-            )
+            if self._present_cuda_rgb(
+                frame.model_rgb_host_uint8,
+                status_message=frame.status_message,
+            ):
+                return
+            rgb = _with_status_overlay(frame.model_rgb_host_uint8, frame.status_message)
+            self._present_array(rgb)
             return
-        self._present_array(
-            _with_status_overlay(frame.rgb_host_uint8, frame.status_message)
+        self._present_array(_with_status_overlay(frame.rgb_host_uint8, frame.status_message))
+
+    def _create_device(self):
+        existing_device_handles = self._cuda_existing_device_handles()
+        torch_cuda_initialized = _torch_cuda_initialized()
+        if torch_cuda_initialized and not _env_truthy(
+            "INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"
+        ):
+            self._cuda_interop_unavailable_reason = (
+                "disabled after torch CUDA initialization"
+            )
+        enable_cuda_interop = (
+            not _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP")
+            and (
+                not torch_cuda_initialized
+                or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
+            )
         )
+        device_kwargs = {
+            "type": self._spy.DeviceType.vulkan,
+            "enable_debug_layers": False,
+            "enable_cuda_interop": enable_cuda_interop,
+            "enable_cuda_launch_from_gfx": False,
+            "enable_ray_tracing": False,
+        }
+        if existing_device_handles:
+            device_kwargs["existing_device_handles"] = existing_device_handles
+        try:
+            return self._spy.Device(**device_kwargs)
+        except RuntimeError as exc:
+            print(
+                "[presenter] CUDA interop device creation failed; retrying Vulkan without "
+                f"interop ({exc})",
+                flush=True,
+            )
+            self._cuda_interop_unavailable_reason = "device creation failed"
+            return self._spy.Device(
+                type=self._spy.DeviceType.vulkan,
+                enable_debug_layers=False,
+                enable_cuda_launch_from_gfx=False,
+                enable_ray_tracing=False,
+            )
+
+    def _cuda_existing_device_handles(self) -> list[Any]:
+        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
+            return []
+        if not _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"):
+            return []
+        try:
+            import torch
+        except ImportError:
+            return []
+        try:
+            if not torch.cuda.is_initialized():
+                return []
+        except Exception:
+            return []
+
+        get_handles = getattr(self._spy, "get_cuda_current_context_native_handles", None)
+        if not callable(get_handles):
+            return []
+        try:
+            handles: Any = get_handles()
+            return list(handles)
+        except Exception:
+            return []
+
+    def _create_cuda_rgb_interop(self):
+        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
+            print(
+                "[presenter] cuda_interop=disabled by INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP; "
+                "using host RGB upload",
+                flush=True,
+            )
+            return None
+        if not self._device.supports_cuda_interop:
+            reason = self._cuda_interop_unavailable_reason or "unsupported"
+            print(f"[presenter] cuda_interop={reason}; using host RGB upload", flush=True)
+            return None
+        try:
+            interop = _CudaRGBInterop(
+                spy=self._spy,
+                device=self._device,
+                width=self._raster.width,
+                height=self._raster.height,
+            )
+        except Exception as exc:
+            print(
+                f"[presenter] cuda_interop=unavailable; using host RGB upload ({exc})",
+                flush=True,
+            )
+            return None
+        print("[presenter] cuda_interop=enabled", flush=True)
+        return interop
+
+    def _present_cuda_rgb(self, rgb_frame: object, *, status_message: str | None) -> bool:
+        if self._cuda_rgb_interop is None:
+            return False
+
+        cuda_rgb_frame = self._cuda_rgb_interop.as_cuda_rgb_frame(rgb_frame)
+        if cuda_rgb_frame is None:
+            return False
+
+        if not cuda_rgb_frame.ready:
+            self._submit_ready_cuda_rgb()
+            return True
+
+        # The loading/status overlay is rendered on the CPU today. Fall back
+        # only after the CUDA producer is done so this path does not become an
+        # accidental long UI-thread synchronization.
+        if status_message is not None:
+            return False
+
+        submitted = self._submit_ready_cuda_rgb()
+        self._cuda_rgb_interop.enqueue_rgb_to_shared_rgba(cuda_rgb_frame)
+        if not submitted:
+            submitted = self._submit_ready_cuda_rgb()
+        return True
+
+    def _submit_ready_cuda_rgb(self) -> bool:
+        if self._cuda_rgb_interop is None:
+            return False
+        interop_frame = self._cuda_rgb_interop.ready_rgba_buffer()
+        if interop_frame is None:
+            return False
+        rgba_buffer, cuda_stream = interop_frame
+        if not self._surface.config:
+            return False
+        surface_texture = self._surface.acquire_next_image()
+        if not surface_texture:
+            time.sleep(0.001)
+            return False
+
+        command_encoder = self._device.create_command_encoder()
+        command_encoder.copy_buffer_to_texture(
+            self._display_texture,
+            0,
+            0,
+            [0, 0, 0],
+            rgba_buffer.buffer,
+            0,
+            rgba_buffer.size_bytes,
+            rgba_buffer.row_pitch,
+            [self._raster.width, self._raster.height, 1],
+        )
+        command_encoder.blit(surface_texture, self._display_texture)
+        submit_id = self._device.submit_command_buffer(
+            command_encoder.finish(),
+            cuda_stream=cuda_stream,
+        )
+        self._cuda_rgb_interop.mark_submitted(rgba_buffer, submit_id)
+        del surface_texture
+        self._surface.present()
+        return True
 
     def _present_array(self, rgb_host_uint8: np.ndarray) -> None:
         if not self._surface.config:
@@ -154,17 +326,11 @@ class SlangPyPresenter:
             self._keyboard.set_key(key_map[event.key], is_press)
             return
 
-        # Two view modes: ``1`` = world-model RGB (the generated drive view,
-        # which is the point of the demo), ``2`` = HDMap with traffic (the
-        # rasterizer's conditioning input). No depth mode.
         if is_press and self._matches_key(event.key, "key1"):
             self._keyboard.set_view_mode("model_rgb")
         elif is_press and self._matches_key(event.key, "key2"):
             self._keyboard.set_view_mode("rgb")
         elif is_press and self._matches_key(event.key, "r"):
-            # ``r`` restarts the rollout: the simulation loop bumps its
-            # trajectory back to the scene's start pose and begins a new
-            # world-model session (new KV cache, new first chunk).
             self._keyboard.request_reset()
 
     def _build_key_codes(self) -> dict[str, object | None]:
@@ -195,7 +361,383 @@ class SlangPyPresenter:
         return key_code is not None and event_key == key_code
 
 
-def _with_status_overlay(rgb_host_uint8: np.ndarray, message: str | None) -> np.ndarray:
+class _CudaRGBInterop:
+    def __init__(self, *, spy: Any, device: Any, width: int, height: int) -> None:
+        import torch
+
+        self._spy = spy
+        self._device = device
+        self._torch = torch
+        self._width = int(width)
+        self._height = int(height)
+        self._row_pitch = self._width * 4
+        self._size_bytes = self._row_pitch * self._height
+        self._buffers = [
+            _SharedRGBABuffer(
+                buffer=device.create_buffer(
+                    size=self._size_bytes,
+                    usage=spy.BufferUsage.shared | spy.BufferUsage.copy_source,
+                    label=f"display_cuda_rgba_buffer_{index}",
+                ),
+                row_pitch=self._row_pitch,
+                size_bytes=self._size_bytes,
+                rgba_tensor=None,
+                copy_done_event=None,
+                pending_submit_id=None,
+            )
+            for index in range(3)
+        ]
+        for shared_buffer in self._buffers:
+            shared_buffer.rgba_tensor = shared_buffer.buffer.to_torch(
+                type=spy.DataType.uint8,
+                shape=[self._height, self._width, 4],
+            )
+        self._next_buffer_index = 0
+        first_tensor = self._buffers[0].rgba_tensor
+        if first_tensor is None:
+            raise RuntimeError("Shared RGBA buffer was not mapped into CUDA.")
+        self._cuda_device = first_tensor.device
+        self._copy_stream = _NonBlockingCudaStream(self._torch, self._cuda_device)
+        self._device_mismatch_logged = False
+
+    def as_cuda_rgb_frame(self, rgb_frame: object) -> "_CudaRGBFrame | None":
+        cuda_frame = self.as_cuda_rgb_source(rgb_frame)
+        if cuda_frame is None:
+            return None
+        if tuple(cuda_frame.tensor.shape) != (self._height, self._width, 3):
+            return None
+        return cuda_frame
+
+    def as_cuda_rgb_source(self, rgb_frame: object) -> "_CudaRGBFrame | None":
+        to_cuda_tensor = getattr(rgb_frame, "to_cuda_tensor", None)
+        try:
+            tensor = to_cuda_tensor() if callable(to_cuda_tensor) else rgb_frame
+        except RuntimeError:
+            return None
+        if not self._torch.is_tensor(tensor):
+            return None
+        if not tensor.is_cuda or tensor.dtype != self._torch.uint8:
+            return None
+        if self._cuda_device_index(tensor.device) != self._cuda_device_index(
+            self._cuda_device
+        ):
+            if not self._device_mismatch_logged:
+                print(
+                    "[presenter] cuda_interop skipped: model RGB tensor is on "
+                    f"{tensor.device}, presenter shared buffer is on {self._cuda_device}",
+                    flush=True,
+                )
+                self._device_mismatch_logged = True
+            return None
+        if tensor.ndim != 3 or tensor.shape[-1] < 3:
+            return None
+        to_cuda_event = getattr(rgb_frame, "to_cuda_event", None)
+        source_event = to_cuda_event() if callable(to_cuda_event) else None
+        return _CudaRGBFrame(
+            tensor=tensor[..., :3].detach(),
+            source_event=source_event,
+            ready=_cuda_event_ready(source_event),
+        )
+
+    def enqueue_rgb_to_shared_rgba(self, rgb_frame: "_CudaRGBFrame") -> bool:
+        shared_buffer = self._acquire_buffer()
+        if shared_buffer is None:
+            return False
+        rgba_tensor = shared_buffer.rgba_tensor
+        if rgba_tensor is None:
+            raise RuntimeError("Shared RGBA buffer was not mapped into CUDA.")
+        rgb_tensor = rgb_frame.tensor
+        if rgb_frame.source_event is not None:
+            self._copy_stream.stream.wait_event(rgb_frame.source_event)
+        with self._torch.cuda.stream(self._copy_stream.stream):
+            if not rgb_tensor.is_contiguous():
+                rgb_tensor = rgb_tensor.contiguous()
+            rgba_tensor[..., :3].copy_(rgb_tensor, non_blocking=True)
+            rgba_tensor[..., 3].fill_(255)
+            rgb_tensor.record_stream(self._copy_stream.stream)
+            rgba_tensor.record_stream(self._copy_stream.stream)
+            copy_done_event = self._torch.cuda.Event()
+            copy_done_event.record(self._copy_stream.stream)
+        shared_buffer.copy_done_event = copy_done_event
+        return True
+
+    def enqueue_camera_to_shared_rgba(
+        self,
+        rgb_frame: "_CudaRGBFrame",
+        *,
+        overlay_rgba: np.ndarray,
+        camera_area: tuple[int, int, int, int],
+        bg_rgb: tuple[int, int, int],
+    ) -> bool:
+        shared_buffer = self._acquire_buffer()
+        if shared_buffer is None:
+            return False
+        rgba_tensor = shared_buffer.rgba_tensor
+        if rgba_tensor is None:
+            raise RuntimeError("Shared RGBA buffer was not mapped into CUDA.")
+
+        overlay = np.ascontiguousarray(overlay_rgba, dtype=np.uint8)
+        if tuple(overlay.shape) != (self._height, self._width, 4):
+            raise ValueError(
+                "HUD overlay shape does not match shared display buffer: "
+                f"{tuple(overlay.shape)} vs {(self._height, self._width, 4)}"
+            )
+
+        rgb_tensor = rgb_frame.tensor
+        if rgb_frame.source_event is not None:
+            self._copy_stream.stream.wait_event(rgb_frame.source_event)
+
+        ax, ay, ar, ab = camera_area
+        area_w = max(1, int(ar) - int(ax))
+        area_h = max(1, int(ab) - int(ay))
+        src_h = int(rgb_tensor.shape[0])
+        src_w = int(rgb_tensor.shape[1])
+        if src_h <= 0 or src_w <= 0:
+            return False
+        scale = min(area_w / src_w, area_h / src_h)
+        target_w = max(1, int(src_w * scale))
+        target_h = max(1, int(src_h * scale))
+        target_x = int(ax) + (area_w - target_w) // 2
+        target_y = int(ay) + (area_h - target_h) // 2
+
+        with self._torch.cuda.stream(self._copy_stream.stream):
+            rgba_tensor[..., 0].fill_(int(bg_rgb[0]))
+            rgba_tensor[..., 1].fill_(int(bg_rgb[1]))
+            rgba_tensor[..., 2].fill_(int(bg_rgb[2]))
+            rgba_tensor[..., 3].fill_(255)
+
+            if not rgb_tensor.is_contiguous():
+                rgb_tensor = rgb_tensor.contiguous()
+            resized = self._resize_rgb_tensor(rgb_tensor, target_h, target_w)
+            rgba_tensor[
+                target_y : target_y + target_h,
+                target_x : target_x + target_w,
+                :3,
+            ].copy_(resized, non_blocking=True)
+
+            overlay_tensor = self._torch.from_numpy(overlay).to(
+                device=self._cuda_device,
+                non_blocking=True,
+            )
+            self._alpha_composite_rgba(rgba_tensor, overlay_tensor)
+
+            rgb_tensor.record_stream(self._copy_stream.stream)
+            resized.record_stream(self._copy_stream.stream)
+            overlay_tensor.record_stream(self._copy_stream.stream)
+            rgba_tensor.record_stream(self._copy_stream.stream)
+            copy_done_event = self._torch.cuda.Event()
+            copy_done_event.record(self._copy_stream.stream)
+        shared_buffer.copy_done_event = copy_done_event
+        return True
+
+    def ready_rgba_buffer(self) -> tuple["_SharedRGBABuffer", Any] | None:
+        for offset in range(len(self._buffers)):
+            index = (self._next_buffer_index + offset) % len(self._buffers)
+            shared_buffer = self._buffers[index]
+            copy_done_event = shared_buffer.copy_done_event
+            if copy_done_event is None or not _cuda_event_ready(copy_done_event):
+                continue
+            stream = int(self._copy_stream.cuda_stream)
+            cuda_stream = self._spy.NativeHandle(self._spy.NativeHandleType.CUstream, stream)
+            return shared_buffer, cuda_stream
+        return None
+
+    def close(self) -> None:
+        self._copy_stream.close()
+
+    def mark_submitted(self, shared_buffer: "_SharedRGBABuffer", submit_id: int) -> None:
+        shared_buffer.copy_done_event = None
+        shared_buffer.pending_submit_id = int(submit_id)
+
+    def _acquire_buffer(self) -> "_SharedRGBABuffer | None":
+        for offset in range(len(self._buffers)):
+            index = (self._next_buffer_index + offset) % len(self._buffers)
+            shared_buffer = self._buffers[index]
+            if shared_buffer.copy_done_event is not None:
+                continue
+            if shared_buffer.pending_submit_id is None:
+                self._next_buffer_index = (index + 1) % len(self._buffers)
+                return shared_buffer
+            if self._device.is_submit_finished(shared_buffer.pending_submit_id):
+                shared_buffer.pending_submit_id = None
+                self._next_buffer_index = (index + 1) % len(self._buffers)
+                return shared_buffer
+        return None
+
+    def _cuda_device_index(self, device: Any) -> int:
+        index = device.index
+        return 0 if index is None else int(index)
+
+    def _resize_rgb_tensor(
+        self, rgb_tensor: Any, target_h: int, target_w: int
+    ) -> Any:
+        if tuple(rgb_tensor.shape[:2]) == (target_h, target_w):
+            return rgb_tensor if rgb_tensor.is_contiguous() else rgb_tensor.contiguous()
+        nchw = rgb_tensor.permute(2, 0, 1).unsqueeze(0).to(self._torch.float32)
+        resized = self._torch.nn.functional.interpolate(
+            nchw,
+            size=(target_h, target_w),
+            mode="bilinear",
+            align_corners=False,
+        )
+        return (
+            resized[0]
+            .permute(1, 2, 0)
+            .round()
+            .clamp_(0, 255)
+            .to(self._torch.uint8)
+            .contiguous()
+        )
+
+    def _alpha_composite_rgba(self, base_rgba: Any, overlay_rgba: Any) -> None:
+        alpha = overlay_rgba[..., 3:4].to(self._torch.float32) * (1.0 / 255.0)
+        blended = (
+            overlay_rgba[..., :3].to(self._torch.float32) * alpha
+            + base_rgba[..., :3].to(self._torch.float32) * (1.0 - alpha)
+        ).round()
+        base_rgba[..., :3].copy_(blended.to(self._torch.uint8), non_blocking=True)
+        base_rgba[..., 3].fill_(255)
+
+
+class _CudaRGBFrame:
+    def __init__(self, *, tensor: Any, source_event: Any | None, ready: bool) -> None:
+        self.tensor = tensor
+        self.source_event = source_event
+        self.ready = ready
+
+
+class _NonBlockingCudaStream:
+    def __init__(self, torch_module: Any, device: Any) -> None:
+        import ctypes
+        import ctypes.util
+
+        self._runtime = None
+        self._stream_ptr = 0
+        self._stream = None
+
+        library_name = ctypes.util.find_library("cudart") or "libcudart.so"
+        runtime = ctypes.CDLL(library_name)
+        cuda_set_device = runtime.cudaSetDevice
+        cuda_set_device.argtypes = [ctypes.c_int]
+        cuda_set_device.restype = ctypes.c_int
+        cuda_stream_create = runtime.cudaStreamCreateWithFlags
+        cuda_stream_create.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_uint]
+        cuda_stream_create.restype = ctypes.c_int
+        cuda_get_error_string = runtime.cudaGetErrorString
+        cuda_get_error_string.argtypes = [ctypes.c_int]
+        cuda_get_error_string.restype = ctypes.c_char_p
+
+        device_index = 0 if device.index is None else int(device.index)
+        _check_cuda_runtime_result(cuda_set_device(device_index), cuda_get_error_string)
+        stream = ctypes.c_void_p()
+        cuda_stream_non_blocking = 1
+        _check_cuda_runtime_result(
+            cuda_stream_create(ctypes.byref(stream), cuda_stream_non_blocking),
+            cuda_get_error_string,
+        )
+
+        self._runtime = runtime
+        self._stream_ptr = int(stream.value or 0)
+        self._stream = torch_module.cuda.ExternalStream(self._stream_ptr, device=device)
+
+    @property
+    def stream(self) -> Any:
+        return self._stream
+
+    @property
+    def cuda_stream(self) -> int:
+        return self._stream_ptr
+
+    def close(self) -> None:
+        if self._runtime is None or self._stream_ptr == 0:
+            return
+        import ctypes
+
+        stream = self._stream
+        if stream is not None:
+            stream.synchronize()
+        cuda_stream_destroy = self._runtime.cudaStreamDestroy
+        cuda_stream_destroy.argtypes = [ctypes.c_void_p]
+        cuda_stream_destroy.restype = ctypes.c_int
+        cuda_stream_destroy(ctypes.c_void_p(self._stream_ptr))
+        self._runtime = None
+        self._stream_ptr = 0
+        self._stream = None
+
+
+class _SharedRGBABuffer:
+    def __init__(
+        self,
+        *,
+        buffer: Any,
+        row_pitch: int,
+        size_bytes: int,
+        rgba_tensor: Any | None,
+        copy_done_event: Any | None,
+        pending_submit_id: int | None,
+    ) -> None:
+        self.buffer = buffer
+        self.row_pitch = row_pitch
+        self.size_bytes = size_bytes
+        self.rgba_tensor = rgba_tensor
+        self.copy_done_event = copy_done_event
+        self.pending_submit_id = pending_submit_id
+
+
+def _check_cuda_runtime_result(result: int, get_error_string: Any) -> None:
+    if result == 0:
+        return
+    raw = get_error_string(int(result))
+    message = (
+        raw.decode("utf-8", errors="replace") if raw is not None else f"CUDA error {result}"
+    )
+    raise RuntimeError(message)
+
+
+def _cuda_event_ready(event: Any | None) -> bool:
+    if event is None:
+        return True
+    query = getattr(event, "query", None)
+    if not callable(query):
+        return True
+    try:
+        return bool(query())
+    except RuntimeError:
+        return False
+
+
+def _env_truthy(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _torch_cuda_initialized() -> bool:
+    torch_module = sys.modules.get("torch")
+    if torch_module is None:
+        return False
+    try:
+        return bool(torch_module.cuda.is_initialized())
+    except Exception:
+        return False
+
+
+def _prefetch_to_numpy(frame: object) -> None:
+    prefetch = getattr(frame, "prefetch_to_numpy", None)
+    if callable(prefetch):
+        prefetch()
+
+
+def _with_status_overlay(rgb_host_uint8: object, message: str | None) -> np.ndarray:
+    rgb_host_uint8 = _as_rgb_host_uint8(rgb_host_uint8)
     if message is None:
         return rgb_host_uint8
     return render_loading_overlay(rgb_host_uint8, message=message)
+
+
+def _as_rgb_host_uint8(frame: object) -> np.ndarray:
+    to_numpy = getattr(frame, "to_numpy", None)
+    if callable(to_numpy):
+        frame = to_numpy()
+    return np.ascontiguousarray(np.asarray(frame, dtype=np.uint8)[..., :3])

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import os
 import queue
 import time
 from dataclasses import dataclass, replace
@@ -20,6 +21,98 @@ from omnidreams.interactive_drive.video_model.chunk_pipeline import (
     ChunkRequest,
     QueuedFrame,
 )
+
+_PROFILE_INPUT_TO_PRESENT_ENV = "INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT"
+_PROFILE_INPUT_TO_PRESENT_INTERVAL_S_ENV = (
+    "INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT_INTERVAL_S"
+)
+
+_PROFILE_E2E_SUM_RAW_MS: float = 0.0
+_PROFILE_E2E_SUM_ADJ_MS: float = 0.0
+_PROFILE_E2E_COUNT: int = 0
+_PROFILE_E2E_WINDOW_START: float | None = None
+
+
+def _profile_input_to_present_enabled() -> bool:
+    raw = os.environ.get(_PROFILE_INPUT_TO_PRESENT_ENV, "")
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _profile_input_to_present_interval_s() -> float:
+    raw = os.environ.get(_PROFILE_INPUT_TO_PRESENT_INTERVAL_S_ENV, "2").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return 2.0
+    return max(0.25, value)
+
+
+def reset_input_to_present_profile_window() -> None:
+    """Clear accumulated e2e samples when the main loop starts."""
+    global _PROFILE_E2E_SUM_RAW_MS
+    global _PROFILE_E2E_SUM_ADJ_MS
+    global _PROFILE_E2E_COUNT
+    global _PROFILE_E2E_WINDOW_START
+
+    _PROFILE_E2E_SUM_RAW_MS = 0.0
+    _PROFILE_E2E_SUM_ADJ_MS = 0.0
+    _PROFILE_E2E_COUNT = 0
+    _PROFILE_E2E_WINDOW_START = None
+
+
+def _chunk_frame_interval_s(chunk_times: ChunkTimes) -> float:
+    frames = chunk_times.frames
+    if len(frames) >= 2:
+        return max(
+            0.0, frames[1].intended_present_time - frames[0].intended_present_time
+        )
+    return 0.0
+
+
+def _record_input_to_present_for_profile(
+    *,
+    present_time: float,
+    input_sample_time: float,
+    frame_index: int,
+    frame_interval_s: float,
+) -> None:
+    global _PROFILE_E2E_SUM_RAW_MS
+    global _PROFILE_E2E_SUM_ADJ_MS
+    global _PROFILE_E2E_COUNT
+    global _PROFILE_E2E_WINDOW_START
+
+    raw_ms = (present_time - input_sample_time) * 1000.0
+    scheduled_ms = frame_index * (frame_interval_s * 1000.0)
+    adj_ms = raw_ms - scheduled_ms
+    _PROFILE_E2E_SUM_RAW_MS += raw_ms
+    _PROFILE_E2E_SUM_ADJ_MS += adj_ms
+    _PROFILE_E2E_COUNT += 1
+    if _PROFILE_E2E_WINDOW_START is None:
+        _PROFILE_E2E_WINDOW_START = present_time
+
+    interval_s = _profile_input_to_present_interval_s()
+    if present_time - _PROFILE_E2E_WINDOW_START < interval_s:
+        return
+
+    count = _PROFILE_E2E_COUNT
+    if count <= 0:
+        return
+    window_s = present_time - _PROFILE_E2E_WINDOW_START
+    wall_present_fps = float(count) / window_s if window_s > 1e-9 else 0.0
+    avg_raw_ms = _PROFILE_E2E_SUM_RAW_MS / float(count)
+    avg_adj_ms = _PROFILE_E2E_SUM_ADJ_MS / float(count)
+    print(
+        "[profile] e2e "
+        f"wall_present_fps={wall_present_fps:.1f} "
+        f"avg_adj_control_to_present_ms={avg_adj_ms:.2f} "
+        f"avg_raw_control_to_present_ms={avg_raw_ms:.2f} "
+        f"samples={count}",
+        flush=True,
+    )
+    _PROFILE_E2E_SUM_RAW_MS = 0.0
+    _PROFILE_E2E_SUM_ADJ_MS = 0.0
+    _PROFILE_E2E_COUNT = 0
+    _PROFILE_E2E_WINDOW_START = present_time
 
 
 class PresenterBackend(Protocol):
@@ -180,6 +273,13 @@ def present_queued_frame(
     presenter.present_frame(display_frame, view_mode=view_mode)
     present_time = time.perf_counter()
     frame_times.present_time = present_time
+    if _profile_input_to_present_enabled():
+        _record_input_to_present_for_profile(
+            present_time=present_time,
+            input_sample_time=queued_frame.chunk_times.input_sample_time,
+            frame_index=queued_frame.frame_index,
+            frame_interval_s=_chunk_frame_interval_s(queued_frame.chunk_times),
+        )
     return present_time
 
 
@@ -355,6 +455,8 @@ def run_main_loop(
     state = MainLoopState()
     last_presented_frame: PresentedFrame = initial_presented_frame
     chunk_history = ChunkHistory.create(config.history_capacity)
+    if _profile_input_to_present_enabled():
+        reset_input_to_present_profile_window()
 
     while not presenter.should_close:
         presenter.process_events()

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -4,6 +4,7 @@
 import os
 import queue
 import time
+from collections import deque
 from dataclasses import dataclass, replace
 from typing import Protocol
 
@@ -421,6 +422,32 @@ def push_telemetry(
     update(simulation.current_state)
 
 
+def _prepare_queued_frame(
+    queued_frame: QueuedFrame,
+    presenter: PresenterBackend,
+    view_mode: str,
+) -> None:
+    prepare_frame = getattr(presenter, "prepare_frame", None)
+    if callable(prepare_frame):
+        prepare_frame(queued_frame.frame, view_mode=view_mode)
+
+
+def _drain_pipeline_frames(
+    *,
+    pipeline: ChunkPipeline,
+    ready_frames: "deque[QueuedFrame]",
+    presenter: PresenterBackend,
+    view_mode: str,
+) -> None:
+    while True:
+        try:
+            queued_frame = pipeline.frame_queue.get_nowait()
+        except queue.Empty:
+            return
+        _prepare_queued_frame(queued_frame, presenter, view_mode)
+        ready_frames.append(queued_frame)
+
+
 def run_main_loop(
     presenter: PresenterBackend,
     runtime_controls: RuntimeControls,
@@ -454,6 +481,7 @@ def run_main_loop(
     """
     state = MainLoopState()
     last_presented_frame: PresentedFrame = initial_presented_frame
+    ready_frames: deque[QueuedFrame] = deque()
     chunk_history = ChunkHistory.create(config.history_capacity)
     if _profile_input_to_present_enabled():
         reset_input_to_present_profile_window()
@@ -490,6 +518,14 @@ def run_main_loop(
             # OOB check just consulted.
             push_telemetry(runtime_controls, simulation)
 
+        view_mode = runtime_controls.view_mode
+        _drain_pipeline_frames(
+            pipeline=pipeline,
+            ready_frames=ready_frames,
+            presenter=presenter,
+            view_mode=view_mode,
+        )
+
         now = time.perf_counter()
         if now < state.next_present_time:
             time.sleep(
@@ -497,9 +533,8 @@ def run_main_loop(
             )
             continue
 
-        view_mode = runtime_controls.view_mode
-        try:
-            queued_frame = pipeline.frame_queue.get_nowait()
+        if ready_frames:
+            queued_frame = ready_frames.popleft()
             if queued_frame.chunk_times.chunk_index != state.last_consumed_chunk_index:
                 state.last_consumed_chunk_index = queued_frame.chunk_times.chunk_index
                 state.chunks_outstanding = max(0, state.chunks_outstanding - 1)
@@ -511,7 +546,7 @@ def run_main_loop(
             )
             last_presented_frame = queued_frame.frame
             state.frame_count += 1
-        except queue.Empty:
+        else:
             # Re-present the last frame with whatever OOB overlay is current
             # for this tick; the merged frame is local to this call so the
             # cached ``last_presented_frame`` stays unmodified for the next

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -362,9 +362,7 @@ class SlangPyHudPresenter:
         )
         self._configure_surface(*self._configured_size)
         self._display_texture = self._build_display_texture(*self._configured_size)
-        self._cuda_hud_interop = self._create_cuda_hud_interop(
-            *self._configured_size
-        )
+        self._cuda_hud_interop = self._create_cuda_hud_interop(*self._configured_size)
         # ``_pending_resize`` is set by the on_resize callback (which
         # runs on the windowing thread) and consumed by ``present_frame``
         # on the main thread, where it's safe to recreate Vulkan
@@ -692,12 +690,11 @@ class SlangPyHudPresenter:
             self._cuda_interop_unavailable_reason = (
                 "disabled after torch CUDA initialization"
             )
-        enable_cuda_interop = (
-            not _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP")
-            and (
-                not torch_cuda_initialized
-                or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
-            )
+        enable_cuda_interop = not _env_truthy(
+            "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"
+        ) and (
+            not torch_cuda_initialized
+            or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
         )
         device_kwargs = {
             "type": self._spy.DeviceType.vulkan,
@@ -739,7 +736,9 @@ class SlangPyHudPresenter:
         except Exception:
             return []
 
-        get_handles = getattr(self._spy, "get_cuda_current_context_native_handles", None)
+        get_handles = getattr(
+            self._spy, "get_cuda_current_context_native_handles", None
+        )
         if not callable(get_handles):
             return []
         try:
@@ -748,7 +747,9 @@ class SlangPyHudPresenter:
         except Exception:
             return []
 
-    def _create_cuda_hud_interop(self, width: int, height: int) -> _CudaRGBInterop | None:
+    def _create_cuda_hud_interop(
+        self, width: int, height: int
+    ) -> _CudaRGBInterop | None:
         if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
             print(
                 "[presenter] hud_cuda_interop=disabled by "
@@ -1058,13 +1059,11 @@ class SlangPyHudPresenter:
         # an alpha allocation, a fresh RGBA allocation, and two
         # memory passes for what only needs to be one RGB slice
         # copy into a long-lived buffer.
-        if (
-            self._camera_rgba_staging is None
-            or self._camera_rgba_staging.shape[:2] != (src_h, src_w)
+        if self._camera_rgba_staging is None or self._camera_rgba_staging.shape[:2] != (
+            src_h,
+            src_w,
         ):
-            self._camera_rgba_staging = np.empty(
-                (src_h, src_w, 4), dtype=np.uint8
-            )
+            self._camera_rgba_staging = np.empty((src_h, src_w, 4), dtype=np.uint8)
             # One-time alpha fill -- the GPU camera path only ever
             # writes the RGB slice from here on, so alpha stays 255.
             self._camera_rgba_staging[..., 3] = 255

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -17,11 +17,10 @@ the chrome, and the presentation all live in one Python process here:
   this avoids pygame entirely.
 * Chrome (panel, scene/variant dropdowns, BEV minimap, speed digit,
   steering-wheel sprite, pedal sprites, status overlays) is rendered
-  on the CPU with PIL into an offscreen RGBA canvas, composited with
-  the camera frame, and uploaded to the swapchain texture per tick.
-  Sprite / font / panel caching matches the pygame HUD's strategy so
-  per-frame chrome work is dominated by a couple of paste calls and
-  one PCIe upload.
+  on the CPU with PIL into an offscreen RGBA canvas. With CUDA interop
+  enabled, generated camera frames stay on CUDA and the PIL canvas is
+  uploaded as an alpha overlay; otherwise the HUD falls back to the
+  original CPU camera composite + swapchain upload.
 * Mouse / keyboard input flows through ``Window.on_mouse_event`` /
   ``on_keyboard_event`` callbacks straight into
   :class:`~omnidreams.interactive_drive.input.keyboard.KeyboardState` (no HTTP,
@@ -46,6 +45,7 @@ from __future__ import annotations
 
 import contextlib
 import math as _math
+import os
 import time
 from collections import OrderedDict
 from typing import Any
@@ -53,6 +53,11 @@ from typing import Any
 import numpy as np
 from omnidreams.interactive_drive.config import RasterConfig
 from omnidreams.interactive_drive.input.keyboard import KeyboardState
+from omnidreams.interactive_drive.presenter import (
+    _CudaRGBInterop,
+    _env_truthy,
+    _torch_cuda_initialized,
+)
 from omnidreams.interactive_drive.types import DriverCommand, PresentedFrame
 from PIL import Image, ImageDraw, ImageFont
 
@@ -98,6 +103,22 @@ EVENT_POLL_INTERVAL_S = 0.005
 # ``_pending_drive_releases`` field documentation in
 # :class:`SlangPyHudPresenter`.
 DRIVE_KEY_RELEASE_DEBOUNCE_S = 0.08
+_HUD_PROFILE_ENV = "INTERACTIVE_DRIVE_PROFILE_HUD"
+_HUD_PROFILE_INTERVAL_S_ENV = "INTERACTIVE_DRIVE_PROFILE_HUD_INTERVAL_S"
+_HUD_PROFILE_FIELDS = (
+    "total_ms",
+    "camera_ms",
+    "bev_ms",
+    "render_ms",
+    "overlay_ms",
+    "pre_submit_ms",
+    "enqueue_ms",
+    "post_submit_ms",
+    "present_ms",
+)
+_HUD_PROFILE_SUMS: dict[str, float] = {}
+_HUD_PROFILE_COUNTS: dict[str, int] = {}
+_HUD_PROFILE_WINDOW_START: float | None = None
 
 
 def _allocate_canvas(width: int, height: int) -> tuple[np.ndarray, Image.Image]:
@@ -310,19 +331,15 @@ class SlangPyHudPresenter:
         # Window + device + surface setup mirrors SlangPyPresenter's
         # but with a resizable HUD-sized window and a display texture
         # we re-create on resize.
+        self._cuda_interop_unavailable_reason: str | None = None
+        self._cuda_hud_error_logged = False
         self._window = spy.Window(
             width=DEFAULT_WINDOW_W,
             height=DEFAULT_WINDOW_H,
             title="interactive-drive HUD",
             resizable=True,
         )
-        self._device = spy.Device(
-            type=spy.DeviceType.vulkan,
-            enable_debug_layers=False,
-            # Workaround: avoid cuDNN MHA crash on NVIDIA Blackwell + R595.
-            enable_cuda_launch_from_gfx=False,
-            enable_ray_tracing=False,
-        )
+        self._device = self._create_device()
         print(f"[presenter] device={self._device.info.adapter_name}", flush=True)
         self._surface = self._device.create_surface(self._window)
         self._surface_format = self._choose_surface_format()
@@ -345,6 +362,9 @@ class SlangPyHudPresenter:
         )
         self._configure_surface(*self._configured_size)
         self._display_texture = self._build_display_texture(*self._configured_size)
+        self._cuda_hud_interop = self._create_cuda_hud_interop(
+            *self._configured_size
+        )
         # ``_pending_resize`` is set by the on_resize callback (which
         # runs on the windowing thread) and consumed by ``present_frame``
         # on the main thread, where it's safe to recreate Vulkan
@@ -463,7 +483,15 @@ class SlangPyHudPresenter:
     def process_events(self) -> None:
         self._window.process_events()
 
+    def prepare_frame(self, frame: PresentedFrame, view_mode: str) -> None:
+        rgb = self._select_view_rgb(frame, view_mode)
+        if self._cuda_hud_interop is None or not _has_cuda_tensor(rgb):
+            _prefetch_to_numpy(rgb)
+        if frame.bev_host_uint8 is not None:
+            _prefetch_to_numpy(frame.bev_host_uint8)
+
     def present_frame(self, frame: PresentedFrame, view_mode: str) -> None:
+        total_start = time.perf_counter()
         # Apply any pending resize before touching the display texture
         # this frame. Done here (not inside on_resize) so Vulkan
         # resources are only ever rebuilt on the main thread.
@@ -473,11 +501,40 @@ class SlangPyHudPresenter:
             self._apply_resize(new_size[0], new_size[1])
 
         rgb = self._select_view_rgb(frame, view_mode)
+        try:
+            if self._present_cuda_hud_frame(frame, rgb):
+                return
+        except Exception as exc:
+            if not self._cuda_hud_error_logged:
+                print(
+                    "[presenter] hud_cuda_interop=failed; disabling and using "
+                    f"host HUD upload ({exc})",
+                    flush=True,
+                )
+                self._cuda_hud_error_logged = True
+            if self._cuda_hud_interop is not None:
+                with contextlib.suppress(Exception):
+                    self._cuda_hud_interop.close()
+                self._cuda_hud_interop = None
+        camera_start = time.perf_counter()
         self._update_camera_pil(rgb)
+        camera_end = time.perf_counter()
+        bev_start = camera_end
         if frame.bev_host_uint8 is not None:
             self._update_bev_pil(frame.bev_host_uint8)
+        bev_end = time.perf_counter()
         self._render_canvas(frame.status_message)
+        render_end = time.perf_counter()
         self._present_canvas(use_gpu_camera=frame.status_message is None)
+        present_end = time.perf_counter()
+        _record_hud_profile(
+            "host",
+            total_ms=(present_end - total_start) * 1000.0,
+            camera_ms=(camera_end - camera_start) * 1000.0,
+            bev_ms=(bev_end - bev_start) * 1000.0,
+            render_ms=(render_end - bev_end) * 1000.0,
+            present_ms=(present_end - render_end) * 1000.0,
+        )
 
     def present_loading(self, rgb_host_uint8: np.ndarray) -> None:
         # Used during world-model warmup. Goes through the same render
@@ -490,8 +547,79 @@ class SlangPyHudPresenter:
         self._render_canvas("Loading world model...")
         self._present_canvas(use_gpu_camera=False)
 
+    def _present_cuda_hud_frame(self, frame: PresentedFrame, rgb: object) -> bool:
+        total_start = time.perf_counter()
+        if self._cuda_hud_interop is None:
+            return False
+
+        cuda_frame = self._cuda_hud_interop.as_cuda_rgb_source(rgb)
+        if cuda_frame is None:
+            return False
+
+        if not cuda_frame.ready:
+            submit_start = time.perf_counter()
+            self._submit_ready_cuda_hud()
+            submit_end = time.perf_counter()
+            _record_hud_profile(
+                "cuda_pending",
+                total_ms=(submit_end - total_start) * 1000.0,
+                pre_submit_ms=(submit_end - submit_start) * 1000.0,
+            )
+            return True
+
+        bev_start = time.perf_counter()
+        if frame.bev_host_uint8 is not None:
+            self._update_bev_pil(frame.bev_host_uint8)
+        bev_end = time.perf_counter()
+        self._has_camera_frame = True
+        self._render_canvas(frame.status_message, camera_transparent=True)
+        render_end = time.perf_counter()
+        overlay = np.array(self._canvas, dtype=np.uint8)
+        overlay_end = time.perf_counter()
+        camera_area, _panel_rect = self._layout_regions()
+
+        pre_submit_start = time.perf_counter()
+        submitted = self._submit_ready_cuda_hud()
+        pre_submit_end = time.perf_counter()
+        queued = self._cuda_hud_interop.enqueue_camera_to_shared_rgba(
+            cuda_frame,
+            overlay_rgba=overlay,
+            camera_area=camera_area,
+            bg_rgb=BG_COLOR,
+        )
+        enqueue_end = time.perf_counter()
+        if not queued:
+            _record_hud_profile(
+                "cuda_busy",
+                total_ms=(enqueue_end - total_start) * 1000.0,
+                bev_ms=(bev_end - bev_start) * 1000.0,
+                render_ms=(render_end - bev_end) * 1000.0,
+                overlay_ms=(overlay_end - render_end) * 1000.0,
+                pre_submit_ms=(pre_submit_end - pre_submit_start) * 1000.0,
+                enqueue_ms=(enqueue_end - pre_submit_end) * 1000.0,
+            )
+            return True
+        post_submit_start = enqueue_end
+        if not submitted:
+            self._submit_ready_cuda_hud()
+        post_submit_end = time.perf_counter()
+        _record_hud_profile(
+            "cuda",
+            total_ms=(post_submit_end - total_start) * 1000.0,
+            bev_ms=(bev_end - bev_start) * 1000.0,
+            render_ms=(render_end - bev_end) * 1000.0,
+            overlay_ms=(overlay_end - render_end) * 1000.0,
+            pre_submit_ms=(pre_submit_end - pre_submit_start) * 1000.0,
+            enqueue_ms=(enqueue_end - pre_submit_end) * 1000.0,
+            post_submit_ms=(post_submit_end - post_submit_start) * 1000.0,
+        )
+        return True
+
     def close(self) -> None:
         self._should_close_flag = True
+        if self._cuda_hud_interop is not None:
+            self._cuda_hud_interop.close()
+            self._cuda_hud_interop = None
         if self._wheel is not None:
             try:
                 self._wheel.stop()
@@ -504,12 +632,13 @@ class SlangPyHudPresenter:
     # -- Frame helpers ---------------------------------------------
 
     @staticmethod
-    def _select_view_rgb(frame: PresentedFrame, view_mode: str) -> np.ndarray:
+    def _select_view_rgb(frame: PresentedFrame, view_mode: str) -> object:
         if view_mode == "model_rgb" and frame.model_rgb_host_uint8 is not None:
             return frame.model_rgb_host_uint8
         return frame.rgb_host_uint8
 
-    def _update_camera_pil(self, rgb: np.ndarray) -> None:
+    def _update_camera_pil(self, rgb: object) -> None:
+        rgb = _as_rgb_host_uint8(rgb)
         # ``Image.fromarray`` over a contiguous numpy buffer is zero-copy
         # at the C level (PIL keeps a buffer-protocol reference). The
         # resulting Image's ``.tobytes()`` would copy, but we only ever
@@ -535,7 +664,8 @@ class SlangPyHudPresenter:
         self._camera_resize_cache = None
         self._has_camera_frame = True
 
-    def _update_bev_pil(self, bev_rgb: np.ndarray) -> None:
+    def _update_bev_pil(self, bev_rgb: object) -> None:
+        bev_rgb = _as_rgb_host_uint8(bev_rgb)
         # Wrap the raw BEV without applying the GoogleMaps recolour
         # here -- the filter runs in :meth:`_get_bev_panel_image`
         # *after* the panel-sized resize, so the float32 pipeline
@@ -552,6 +682,102 @@ class SlangPyHudPresenter:
         self._bev_panel_cache = None
 
     # -- Vulkan / surface plumbing ---------------------------------
+
+    def _create_device(self) -> Any:
+        existing_device_handles = self._cuda_existing_device_handles()
+        torch_cuda_initialized = _torch_cuda_initialized()
+        if torch_cuda_initialized and not _env_truthy(
+            "INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"
+        ):
+            self._cuda_interop_unavailable_reason = (
+                "disabled after torch CUDA initialization"
+            )
+        enable_cuda_interop = (
+            not _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP")
+            and (
+                not torch_cuda_initialized
+                or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
+            )
+        )
+        device_kwargs = {
+            "type": self._spy.DeviceType.vulkan,
+            "enable_debug_layers": False,
+            "enable_cuda_interop": enable_cuda_interop,
+            "enable_cuda_launch_from_gfx": False,
+            "enable_ray_tracing": False,
+        }
+        if existing_device_handles:
+            device_kwargs["existing_device_handles"] = existing_device_handles
+        try:
+            return self._spy.Device(**device_kwargs)
+        except RuntimeError as exc:
+            print(
+                "[presenter] CUDA interop device creation failed; retrying Vulkan without "
+                f"interop ({exc})",
+                flush=True,
+            )
+            self._cuda_interop_unavailable_reason = "device creation failed"
+            return self._spy.Device(
+                type=self._spy.DeviceType.vulkan,
+                enable_debug_layers=False,
+                enable_cuda_launch_from_gfx=False,
+                enable_ray_tracing=False,
+            )
+
+    def _cuda_existing_device_handles(self) -> list[Any]:
+        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
+            return []
+        if not _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"):
+            return []
+        try:
+            import torch
+        except ImportError:
+            return []
+        try:
+            if not torch.cuda.is_initialized():
+                return []
+        except Exception:
+            return []
+
+        get_handles = getattr(self._spy, "get_cuda_current_context_native_handles", None)
+        if not callable(get_handles):
+            return []
+        try:
+            handles: Any = get_handles()
+            return list(handles)
+        except Exception:
+            return []
+
+    def _create_cuda_hud_interop(self, width: int, height: int) -> _CudaRGBInterop | None:
+        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
+            print(
+                "[presenter] hud_cuda_interop=disabled by "
+                "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP; using host HUD upload",
+                flush=True,
+            )
+            return None
+        if not self._device.supports_cuda_interop:
+            reason = self._cuda_interop_unavailable_reason or "unsupported"
+            print(
+                f"[presenter] hud_cuda_interop={reason}; using host HUD upload",
+                flush=True,
+            )
+            return None
+        try:
+            interop = _CudaRGBInterop(
+                spy=self._spy,
+                device=self._device,
+                width=width,
+                height=height,
+            )
+        except Exception as exc:
+            print(
+                f"[presenter] hud_cuda_interop=unavailable; using host HUD upload ({exc})",
+                flush=True,
+            )
+            return None
+        print("[presenter] hud_cuda_interop=enabled", flush=True)
+        return interop
 
     def _choose_surface_format(self) -> Any:
         """Pick a linear surface format (no implicit sRGB encode).
@@ -592,7 +818,11 @@ class SlangPyHudPresenter:
             format=self._display_format,
             width=width,
             height=height,
-            usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+            usage=(
+                spy.TextureUsage.shader_resource
+                | spy.TextureUsage.unordered_access
+                | spy.TextureUsage.copy_destination
+            ),
             label="hud_display_texture",
         )
 
@@ -608,6 +838,9 @@ class SlangPyHudPresenter:
         # Vulkan resource so it gets freed once any in-flight command
         # buffer using it completes.
         self._display_texture = self._build_display_texture(width, height)
+        if self._cuda_hud_interop is not None:
+            self._cuda_hud_interop.close()
+            self._cuda_hud_interop = self._create_cuda_hud_interop(width, height)
         # Drop the chrome panel cache (its size depends on screen size)
         # and reallocate the canvas. Other caches are size-independent.
         self._panel_chrome_cache_key = None
@@ -629,6 +862,52 @@ class SlangPyHudPresenter:
         # resources on the next tick. Doing it in the callback would
         # race with whatever frame is in flight.
         self._pending_resize = (int(width), int(height))
+
+    def _submit_ready_cuda_hud(self) -> bool:
+        if self._cuda_hud_interop is None:
+            return False
+        interop_frame = self._cuda_hud_interop.ready_rgba_buffer()
+        if interop_frame is None:
+            return False
+        rgba_buffer, cuda_stream = interop_frame
+        self._sync_window_size()
+        if not self._surface.config:
+            return False
+        try:
+            surface_texture = self._surface.acquire_next_image()
+        except RuntimeError as exc:
+            print(
+                f"[presenter] swapchain acquire failed ({exc}); reconfiguring",
+                flush=True,
+            )
+            self._reconfigure_surface()
+            return False
+        if not surface_texture:
+            time.sleep(0.001)
+            return False
+
+        width, height = self._configured_size
+        encoder = self._device.create_command_encoder()
+        encoder.copy_buffer_to_texture(
+            self._display_texture,
+            0,
+            0,
+            [0, 0, 0],
+            rgba_buffer.buffer,
+            0,
+            rgba_buffer.size_bytes,
+            rgba_buffer.row_pitch,
+            [width, height, 1],
+        )
+        encoder.blit(surface_texture, self._display_texture)
+        submit_id = self._device.submit_command_buffer(
+            encoder.finish(),
+            cuda_stream=cuda_stream,
+        )
+        self._cuda_hud_interop.mark_submitted(rgba_buffer, submit_id)
+        del surface_texture
+        self._surface.present()
+        return True
 
     def _present_canvas(self, use_gpu_camera: bool = False) -> None:
         # Sync to the window's CURRENT size before every present.
@@ -779,11 +1058,13 @@ class SlangPyHudPresenter:
         # an alpha allocation, a fresh RGBA allocation, and two
         # memory passes for what only needs to be one RGB slice
         # copy into a long-lived buffer.
-        if self._camera_rgba_staging is None or self._camera_rgba_staging.shape[:2] != (
-            src_h,
-            src_w,
+        if (
+            self._camera_rgba_staging is None
+            or self._camera_rgba_staging.shape[:2] != (src_h, src_w)
         ):
-            self._camera_rgba_staging = np.empty((src_h, src_w, 4), dtype=np.uint8)
+            self._camera_rgba_staging = np.empty(
+                (src_h, src_w, 4), dtype=np.uint8
+            )
             # One-time alpha fill -- the GPU camera path only ever
             # writes the RGB slice from here on, so alpha stays 255.
             self._camera_rgba_staging[..., 3] = 255
@@ -834,10 +1115,7 @@ class SlangPyHudPresenter:
     def _reconfigure_surface(self) -> None:
         """Rebuild the surface configuration at the current window size.
 
-        Used on the swapchain-lost path. We don't recreate the display
-        texture here because its size is independent of the swapchain
-        format (we ``blit`` the texture into the swapchain image, which
-        handles any resize implicitly via the blit destination size).
+        Used on the swapchain-lost path.
         """
         actual = self._window.size
         new_size = (
@@ -846,6 +1124,10 @@ class SlangPyHudPresenter:
         )
         self._configured_size = new_size
         self._configure_surface(*new_size)
+        self._display_texture = self._build_display_texture(*new_size)
+        if self._cuda_hud_interop is not None:
+            self._cuda_hud_interop.close()
+            self._cuda_hud_interop = self._create_cuda_hud_interop(*new_size)
         # Drop chrome panel cache because its size depends on screen size.
         self._panel_chrome_cache_key = None
         self._panel_chrome_cache = None
@@ -859,7 +1141,23 @@ class SlangPyHudPresenter:
 
     # -- Render ------------------------------------------------------
 
-    def _render_canvas(self, status_message: str | None) -> None:
+    def _layout_regions(
+        self,
+    ) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
+        screen_w, screen_h = self._canvas.size
+        panel_w = (
+            HUD_PANEL_WIDTH if screen_w > HUD_PANEL_WIDTH + MIN_WINDOW_W // 2 else 0
+        )
+        camera_area = (0, 0, max(1, screen_w - panel_w), screen_h)
+        panel_rect = (camera_area[2], 0, screen_w, screen_h)
+        return camera_area, panel_rect
+
+    def _render_canvas(
+        self,
+        status_message: str | None,
+        *,
+        camera_transparent: bool = False,
+    ) -> None:
         """Composite camera + chrome into ``self._canvas`` for this frame.
 
         Mirrors :meth:`PygameHudViewer._render_frame`'s structure:
@@ -885,11 +1183,8 @@ class SlangPyHudPresenter:
 
         canvas = self._canvas
         screen_w, screen_h = canvas.size
-        panel_w = (
-            HUD_PANEL_WIDTH if screen_w > HUD_PANEL_WIDTH + MIN_WINDOW_W // 2 else 0
-        )
-        camera_area = (0, 0, max(1, screen_w - panel_w), screen_h)
-        panel_rect = (camera_area[2], 0, screen_w, screen_h)
+        camera_area, panel_rect = self._layout_regions()
+        panel_w = panel_rect[2] - panel_rect[0]
 
         draw = ImageDraw.Draw(canvas)
         # No full-canvas clear here. The chrome panel paste in
@@ -901,9 +1196,16 @@ class SlangPyHudPresenter:
         # Only the placeholder branch needs to wipe the camera area --
         # see below. Skipping the full-canvas rectangle here saves a
         # 2 MP RGBA fill (~3-8 ms at 1080p) every render tick.
+        if camera_transparent:
+            # CUDA HUD mode composites the camera on the GPU, so keep
+            # only the camera area transparent before drawing any
+            # status/dropdown overlay that should sit above it.
+            draw.rectangle(camera_area, fill=(0, 0, 0, 0))
 
         camera_drawn = False
-        if self._latest_camera_pil is not None:
+        if camera_transparent:
+            camera_drawn = True
+        elif self._latest_camera_pil is not None:
             if status_message is None:
                 # GPU camera path will fill the centred fit rect after
                 # the canvas upload; we only need to paint the
@@ -2130,6 +2432,77 @@ def _lookup_key(key_enum: Any, *names: str) -> Any:
 def _rect_contains(rect: tuple[int, int, int, int], pos: tuple[int, int]) -> bool:
     x, y = pos
     return rect[0] <= x < rect[2] and rect[1] <= y < rect[3]
+
+
+def _hud_profile_interval_s() -> float:
+    raw = os.environ.get(_HUD_PROFILE_INTERVAL_S_ENV, "2").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return 2.0
+    return max(0.25, value)
+
+
+def _record_hud_profile(path: str, **stages_ms: float) -> None:
+    if not _env_truthy(_HUD_PROFILE_ENV):
+        return
+
+    global _HUD_PROFILE_WINDOW_START
+
+    now = time.perf_counter()
+    if _HUD_PROFILE_WINDOW_START is None:
+        _HUD_PROFILE_WINDOW_START = now
+
+    _HUD_PROFILE_COUNTS[path] = _HUD_PROFILE_COUNTS.get(path, 0) + 1
+    for field in _HUD_PROFILE_FIELDS:
+        key = f"{path}.{field}"
+        _HUD_PROFILE_SUMS[key] = _HUD_PROFILE_SUMS.get(key, 0.0) + float(
+            stages_ms.get(field, 0.0)
+        )
+
+    interval_s = _hud_profile_interval_s()
+    if now - _HUD_PROFILE_WINDOW_START < interval_s:
+        return
+
+    window_s = max(1e-9, now - _HUD_PROFILE_WINDOW_START)
+    for profiled_path in sorted(_HUD_PROFILE_COUNTS):
+        count = _HUD_PROFILE_COUNTS[profiled_path]
+        if count <= 0:
+            continue
+        fps = float(count) / window_s
+        parts = [
+            "[profile] hud",
+            f"path={profiled_path}",
+            f"fps={fps:.1f}",
+            f"samples={count}",
+        ]
+        for field in _HUD_PROFILE_FIELDS:
+            total = _HUD_PROFILE_SUMS.get(f"{profiled_path}.{field}", 0.0)
+            if total <= 0.0:
+                continue
+            parts.append(f"avg_{field}={total / float(count):.2f}")
+        print(" ".join(parts), flush=True)
+
+    _HUD_PROFILE_SUMS.clear()
+    _HUD_PROFILE_COUNTS.clear()
+    _HUD_PROFILE_WINDOW_START = now
+
+
+def _prefetch_to_numpy(frame: object) -> None:
+    prefetch = getattr(frame, "prefetch_to_numpy", None)
+    if callable(prefetch):
+        prefetch()
+
+
+def _has_cuda_tensor(frame: object) -> bool:
+    return callable(getattr(frame, "to_cuda_tensor", None))
+
+
+def _as_rgb_host_uint8(frame: object) -> np.ndarray:
+    to_numpy = getattr(frame, "to_numpy", None)
+    if callable(to_numpy):
+        frame = to_numpy()
+    return np.ascontiguousarray(np.asarray(frame, dtype=np.uint8)[..., :3])
 
 
 __all__ = [

--- a/integrations/omnidreams/omnidreams/interactive_drive/types.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/types.py
@@ -202,11 +202,11 @@ class TrajectoryChunk:
 @dataclass
 class PresentedFrame:
     timestamp_us: int
-    rgb_host_uint8: UInt8Array
+    rgb_host_uint8: Any
     depth_host_f32: FloatArray | None
     rgb_native: Any | None = None
     depth_native: Any | None = None
-    model_rgb_host_uint8: UInt8Array | None = None
+    model_rgb_host_uint8: Any | None = None
     # Top-down BEV map rendered from the same scene with a synthetic camera
     # 25m above the rig (configured by :class:`BevConfig`). Carried alongside
     # the main camera frame so the demo HUD can show a minimap panel without

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 import torch
 from omnidreams.interactive_drive.config import WorldModelProfileConfig
+from omnidreams.interactive_drive.cuda_host_prefetch import CudaHostPrefetch
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
 
 PipelineFactory = Callable[[WorldModelManifest, WorldModelProfileConfig], Any]
@@ -330,7 +331,7 @@ class FlashdreamsWorldModelSession:
         initial_rgb: object,
         condition_frames: list[object],
         prompt: str,
-    ) -> list[np.ndarray]:
+    ) -> list[object]:
         expected_frames = self.pipeline.get_num_frames(0)
         if len(condition_frames) != expected_frames:
             raise ValueError(
@@ -346,13 +347,15 @@ class FlashdreamsWorldModelSession:
                 cache=self._cache,
                 hdmap=self._condition_tensor(condition_frames),
             )
+            model_frames = self._video_tensor_to_frames(video)
+            _synchronize_cuda_frame_event(model_frames)
         self._pending_finalization_index = 0
         self._next_block_index = 1
         elapsed_ms = (time.perf_counter() - start) * 1000.0
         print(f"[flashdreams-session] start total_ms={elapsed_ms:.1f}", flush=True)
-        return self._video_tensor_to_host_frames(video)
+        return model_frames
 
-    def continue_generation(self, condition_frames: list[object]) -> list[np.ndarray]:
+    def continue_generation(self, condition_frames: list[object]) -> list[object]:
         if self._cache is None:
             raise RuntimeError("start() must be called before continue_generation()")
         expected_frames = self.pipeline.get_num_frames(self._next_block_index)
@@ -372,6 +375,8 @@ class FlashdreamsWorldModelSession:
                 cache=self._cache,
                 hdmap=self._condition_tensor(condition_frames),
             )
+            model_frames = self._video_tensor_to_frames(video)
+            _synchronize_cuda_frame_event(model_frames)
         block_index = self._next_block_index
         self._pending_finalization_index = block_index
         self._next_block_index += 1
@@ -381,7 +386,7 @@ class FlashdreamsWorldModelSession:
                 f"[flashdreams-session] continue block_index={block_index} total_ms={elapsed_ms:.1f}",
                 flush=True,
             )
-        return self._video_tensor_to_host_frames(video)
+        return model_frames
 
     def reset(self) -> None:
         self._cache = None
@@ -455,6 +460,10 @@ class FlashdreamsWorldModelSession:
         return _initial_rgb_tensor(initial_rgb, device=self.pipeline.device)
 
     def _condition_tensor(self, condition_frames: Sequence[object]) -> torch.Tensor:
+        cuda_video = _condition_cuda_video(condition_frames)
+        if cuda_video is not None:
+            tensor = cuda_video.permute(0, 3, 1, 2).unsqueeze(0).unsqueeze(0)
+            return self._to_model_range(tensor)
         video = np.stack([_rgb_hwc_uint8(frame) for frame in condition_frames], axis=0)
         tensor = torch.from_numpy(np.ascontiguousarray(video))
         tensor = tensor.permute(0, 3, 1, 2).unsqueeze(0).unsqueeze(0)
@@ -464,7 +473,7 @@ class FlashdreamsWorldModelSession:
         return _to_model_range(tensor, device=self.pipeline.device)
 
     @staticmethod
-    def _video_tensor_to_host_frames(video: torch.Tensor) -> list[np.ndarray]:
+    def _video_tensor_to_frames(video: torch.Tensor) -> list[object]:
         if video.ndim != 6:
             raise ValueError(
                 f"Expected [B,V,T,3,H,W] video tensor, got shape {tuple(video.shape)}"
@@ -473,11 +482,132 @@ class FlashdreamsWorldModelSession:
         if frames.dtype != torch.uint8:
             frames = frames.clamp(-1.0, 1.0)
             frames = ((frames + 1.0) * 127.5).round().to(torch.uint8)
-        frames = frames.permute(0, 2, 3, 1).detach().cpu().numpy()
-        return [np.ascontiguousarray(frame, dtype=np.uint8) for frame in frames]
+        frames = frames.permute(0, 2, 3, 1).contiguous()
+        source_event = None
+        if frames.is_cuda:
+            source_event = torch.cuda.Event()
+            source_event.record(torch.cuda.current_stream(frames.device))
+        return [
+            _LazyRGBFrame(frames, frame_index, source_event=source_event)
+            for frame_index in range(frames.shape[0])
+        ]
+
+
+class _LazyRGBFrame:
+    """Defer GPU-to-host copies until the presenter consumes each frame."""
+
+    def __init__(
+        self,
+        frames_hwc_uint8: torch.Tensor,
+        frame_index: int,
+        *,
+        source_event: object | None = None,
+    ) -> None:
+        self._frames_hwc_uint8: torch.Tensor | None = frames_hwc_uint8
+        self._frame_index = int(frame_index)
+        self._source_event = source_event
+        self._host: np.ndarray | None = None
+        self._prefetch: CudaHostPrefetch | None = None
+
+    def prefetch_to_numpy(self) -> None:
+        if (
+            self._host is not None
+            or self._prefetch is not None
+            or self._frames_hwc_uint8 is None
+        ):
+            return
+        frame = self._frames_hwc_uint8[self._frame_index].detach()
+        prefetch = CudaHostPrefetch(frame, source_event=self._source_event)
+        if prefetch.start():
+            self._prefetch = prefetch
+
+    def to_numpy(self) -> np.ndarray:
+        if self._host is None:
+            if self._prefetch is not None:
+                self._host = self._prefetch.to_numpy()
+                self._prefetch = None
+                self._frames_hwc_uint8 = None
+                return self._host
+            if self._frames_hwc_uint8 is None:
+                raise RuntimeError(
+                    "Lazy RGB frame lost its source tensor before materialization."
+                )
+            frame = self._frames_hwc_uint8[self._frame_index].detach().cpu().numpy()
+            self._host = np.ascontiguousarray(frame, dtype=np.uint8)
+            self._frames_hwc_uint8 = None
+        return self._host
+
+    def to_cuda_tensor(self) -> torch.Tensor:
+        if self._frames_hwc_uint8 is None:
+            raise RuntimeError("Lazy RGB frame was already materialized on the host.")
+        return self._frames_hwc_uint8[self._frame_index]
+
+    def to_cuda_event(self) -> object | None:
+        if self._frames_hwc_uint8 is None:
+            return None
+        return self._source_event
+
+    def __array__(
+        self,
+        dtype: object | None = None,
+        copy: bool | None = None,
+    ) -> np.ndarray:
+        array = self.to_numpy()
+        if dtype is not None:
+            array = array.astype(dtype, copy=False)
+        if copy:
+            return np.array(array, copy=True)
+        return array
 
 
 def _rgb_hwc_uint8(frame: object) -> np.ndarray:
     return np.ascontiguousarray(
         np.array(np.asarray(frame, dtype=np.uint8)[..., :3], copy=True)
     )
+
+
+def _condition_cuda_video(condition_frames: Sequence[object]) -> torch.Tensor | None:
+    tensors: list[torch.Tensor] = []
+    device: torch.device | None = None
+    for frame in condition_frames:
+        to_cuda_tensor = getattr(frame, "to_cuda_tensor", None)
+        if not callable(to_cuda_tensor):
+            return None
+        try:
+            tensor = to_cuda_tensor()
+        except RuntimeError:
+            return None
+        if (
+            not torch.is_tensor(tensor)
+            or not tensor.is_cuda
+            or tensor.dtype != torch.uint8
+            or tensor.ndim != 3
+            or tensor.shape[-1] < 3
+        ):
+            return None
+        if device is None:
+            device = tensor.device
+        elif tensor.device != device:
+            return None
+
+        to_cuda_event = getattr(frame, "to_cuda_event", None)
+        event = to_cuda_event() if callable(to_cuda_event) else None
+        if event is not None:
+            torch.cuda.current_stream(tensor.device).wait_event(event)
+        rgb = tensor[..., :3]
+        tensors.append(rgb if rgb.is_contiguous() else rgb.contiguous())
+
+    if not tensors:
+        return None
+    return torch.stack(tensors, dim=0)
+
+
+def _synchronize_cuda_frame_event(frames: Sequence[object]) -> None:
+    for frame in frames:
+        to_cuda_event = getattr(frame, "to_cuda_event", None)
+        event = to_cuda_event() if callable(to_cuda_event) else None
+        if event is None:
+            continue
+        synchronize = getattr(event, "synchronize", None)
+        if callable(synchronize):
+            synchronize()

--- a/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import pytest
+import omnidreams.interactive_drive.runtime.loop as loop_module
 from omnidreams.interactive_drive._pipeline_fakes import (
     FakeVideoModelBackend,
     make_trajectory,
@@ -178,6 +179,57 @@ def test_present_timestamp_recorded_after_present_call_returns() -> None:
     assert start <= present_time <= end
 
 
+def test_input_to_present_profile_records_queued_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, float | int]] = []
+    monkeypatch.setenv("INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT", "1")
+    monkeypatch.setattr(
+        loop_module,
+        "_record_input_to_present_for_profile",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    chunk_times = _chunk_times()
+    queued = QueuedFrame(frame=_make_frame(), chunk_times=chunk_times, frame_index=0)
+    presenter = _CountingPresenter(present_budget=1)
+
+    present_queued_frame(queued, presenter, view_mode="rgb")
+
+    assert len(calls) == 1
+    assert calls[0]["input_sample_time"] == chunk_times.input_sample_time
+    assert calls[0]["frame_index"] == 0
+
+
+def test_input_to_present_profile_prints_window_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT_INTERVAL_S", "0.25")
+    loop_module.reset_input_to_present_profile_window()
+
+    loop_module._record_input_to_present_for_profile(
+        present_time=1.0,
+        input_sample_time=0.9,
+        frame_index=0,
+        frame_interval_s=0.1,
+    )
+    loop_module._record_input_to_present_for_profile(
+        present_time=1.3,
+        input_sample_time=0.9,
+        frame_index=1,
+        frame_interval_s=0.1,
+    )
+
+    output = capsys.readouterr().out
+    assert "[profile] e2e" in output
+    assert "wall_present_fps=" in output
+    assert "avg_adj_control_to_present_ms=" in output
+    assert "avg_raw_control_to_present_ms=" in output
+    assert "samples=2" in output
+    loop_module.reset_input_to_present_profile_window()
+
+
 def test_run_main_loop_returns_false_when_presenter_starts_closed() -> None:
     presenter = _CountingPresenter(present_budget=0, start_closed=True)
     controls = _FakeRuntimeControls()
@@ -234,6 +286,33 @@ def test_loop_re_presents_initial_frame_while_pipeline_queue_is_empty() -> None:
     assert len(presenter.records) == 4
     for record in presenter.records:
         assert record.frame is initial
+
+
+def test_input_to_present_profile_ignores_represented_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, float | int]] = []
+    monkeypatch.setenv("INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT", "1")
+    monkeypatch.setattr(
+        loop_module,
+        "_record_input_to_present_for_profile",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    initial = _make_frame()
+    presenter = _CountingPresenter(present_budget=4)
+    controls = _FakeRuntimeControls()
+
+    result = _drive_loop(
+        presenter=presenter,
+        controls=controls,
+        backend=FakeVideoModelBackend(frames_per_render=0),
+        simulation=_FakeSimulation(),
+        initial=initial,
+        frame_interval_s=0.001,
+    )
+
+    assert result is False
+    assert calls == []
 
 
 def test_loop_presents_backend_frames_when_available() -> None:

--- a/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
@@ -5,8 +5,8 @@ import time
 from dataclasses import dataclass
 
 import numpy as np
-import pytest
 import omnidreams.interactive_drive.runtime.loop as loop_module
+import pytest
 from omnidreams.interactive_drive._pipeline_fakes import (
     FakeVideoModelBackend,
     make_trajectory,

--- a/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
@@ -95,6 +95,22 @@ class _CountingPresenter:
         return
 
 
+class _PreparingPresenter(_CountingPresenter):
+    def __init__(self, present_budget: int) -> None:
+        super().__init__(present_budget=present_budget)
+        self.prepared_frame_ids: set[int] = set()
+        self.unprepared_backend_frame_ids: set[int] = set()
+
+    def prepare_frame(self, frame: PresentedFrame, view_mode: str) -> None:
+        del view_mode
+        self.prepared_frame_ids.add(id(frame))
+
+    def present_frame(self, frame: PresentedFrame, view_mode: str) -> None:
+        if id(frame) not in self.prepared_frame_ids:
+            self.unprepared_backend_frame_ids.add(id(frame))
+        super().present_frame(frame, view_mode)
+
+
 class _FakeRuntimeControls:
     def __init__(self, *, reset_after_present: int | None = None) -> None:
         self._reset_after_present = reset_after_present
@@ -333,6 +349,24 @@ def test_loop_presents_backend_frames_when_available() -> None:
     assert result is False
     assert len(presenter.records) == 2
     assert any(record.frame is not initial for record in presenter.records)
+
+
+def test_loop_prepares_backend_frames_before_presenting_them() -> None:
+    presenter = _PreparingPresenter(present_budget=6)
+    controls = _FakeRuntimeControls()
+    initial = _make_frame()
+
+    _drive_loop(
+        presenter=presenter,
+        controls=controls,
+        backend=FakeVideoModelBackend(frames_per_render=1, rgb_value=9),
+        simulation=_FakeSimulation(),
+        initial=initial,
+        frame_interval_s=0.001,
+    )
+
+    assert presenter.prepared_frame_ids
+    assert presenter.unprepared_backend_frame_ids == {id(initial)}
 
 
 def test_loop_stamps_full_timing_chain_on_same_chunktimes_instance(

--- a/integrations/omnidreams/tests/interactive_drive/test_presenter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_presenter.py
@@ -157,7 +157,9 @@ def test_model_rgb_falls_back_to_host_when_cuda_path_declines() -> None:
     assert np.all(presented[0] == 127)
 
 
-def test_model_rgb_does_not_materialize_host_frame_when_cuda_source_is_pending() -> None:
+def test_model_rgb_does_not_materialize_host_frame_when_cuda_source_is_pending() -> (
+    None
+):
     presenter = _presenter_without_window()
     lazy = _LazyFrame()
 

--- a/integrations/omnidreams/tests/interactive_drive/test_presenter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_presenter.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from omnidreams.interactive_drive.presenter import (
+    SlangPyPresenter,
+    _CudaRGBFrame,
+    _CudaRGBInterop,
+)
+from omnidreams.interactive_drive.slangpy_hud_presenter import SlangPyHudPresenter
+from omnidreams.interactive_drive.types import PresentedFrame
+
+
+class _LazyFrame:
+    def __init__(self) -> None:
+        self.numpy_calls = 0
+        self.prefetch_calls = 0
+
+    def prefetch_to_numpy(self) -> None:
+        self.prefetch_calls += 1
+
+    def to_numpy(self) -> np.ndarray:
+        self.numpy_calls += 1
+        return np.full((4, 4, 3), 127, dtype=np.uint8)
+
+
+def _presenter_without_window() -> SlangPyPresenter:
+    return SlangPyPresenter.__new__(SlangPyPresenter)
+
+
+def _hud_presenter_without_window() -> SlangPyHudPresenter:
+    return SlangPyHudPresenter.__new__(SlangPyHudPresenter)
+
+
+def test_cuda_existing_device_handles_skips_by_default(monkeypatch) -> None:
+    presenter = _presenter_without_window()
+
+    class _Spy:
+        @staticmethod
+        def get_cuda_current_context_native_handles() -> list[object]:
+            raise AssertionError("native handle query should be opt-in")
+
+    fake_torch = SimpleNamespace(cuda=SimpleNamespace(is_initialized=lambda: True))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    presenter._spy = _Spy()
+
+    assert presenter._cuda_existing_device_handles() == []
+
+
+def test_create_device_disables_cuda_interop_when_torch_cuda_is_initialized(
+    monkeypatch,
+) -> None:
+    presenter = _presenter_without_window()
+    created_kwargs: list[dict[str, object]] = []
+
+    class _DeviceType:
+        vulkan = object()
+
+    class _Spy:
+        DeviceType = _DeviceType
+
+        @staticmethod
+        def Device(**kwargs):
+            created_kwargs.append(kwargs)
+            return SimpleNamespace(info=SimpleNamespace(adapter_name="fake"))
+
+    fake_torch = SimpleNamespace(cuda=SimpleNamespace(is_initialized=lambda: True))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    presenter._spy = _Spy()
+
+    presenter._create_device()
+
+    assert created_kwargs[0]["enable_cuda_interop"] is False
+    assert (
+        presenter._cuda_interop_unavailable_reason
+        == "disabled after torch CUDA initialization"
+    )
+
+
+def test_prepare_frame_prefetches_host_fallback_model_rgb() -> None:
+    presenter = _presenter_without_window()
+    lazy = _LazyFrame()
+    presenter._cuda_rgb_interop = None
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+    )
+
+    presenter.prepare_frame(frame, view_mode="model_rgb")
+
+    assert lazy.prefetch_calls == 1
+    assert lazy.numpy_calls == 0
+
+
+def test_model_rgb_uses_cuda_path_without_materializing_host_frame() -> None:
+    presenter = _presenter_without_window()
+    lazy = _LazyFrame()
+    cuda_calls: list[tuple[object, str | None]] = []
+
+    def present_cuda_rgb(rgb_frame: object, *, status_message: str | None) -> bool:
+        cuda_calls.append((rgb_frame, status_message))
+        return True
+
+    def present_array(rgb_host_uint8: np.ndarray) -> None:
+        del rgb_host_uint8
+        raise AssertionError("host presenter path should not run")
+
+    presenter._present_cuda_rgb = present_cuda_rgb
+    presenter._present_array = present_array
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+    )
+
+    presenter.present_frame(frame, view_mode="model_rgb")
+
+    assert cuda_calls == [(lazy, None)]
+    assert lazy.numpy_calls == 0
+
+
+def test_model_rgb_falls_back_to_host_when_cuda_path_declines() -> None:
+    presenter = _presenter_without_window()
+    lazy = _LazyFrame()
+    presented: list[np.ndarray] = []
+
+    presenter._present_cuda_rgb = lambda rgb_frame, *, status_message: False
+
+    def present_array(rgb_host_uint8: np.ndarray) -> None:
+        presented.append(rgb_host_uint8)
+
+    presenter._present_array = present_array
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+    )
+
+    presenter.present_frame(frame, view_mode="model_rgb")
+
+    assert lazy.numpy_calls == 1
+    assert len(presented) == 1
+    assert np.all(presented[0] == 127)
+
+
+def test_model_rgb_does_not_materialize_host_frame_when_cuda_source_is_pending() -> None:
+    presenter = _presenter_without_window()
+    lazy = _LazyFrame()
+
+    class _PendingInterop:
+        def as_cuda_rgb_frame(self, rgb_frame: object) -> _CudaRGBFrame | None:
+            assert rgb_frame is lazy
+            return _CudaRGBFrame(tensor=object(), source_event=object(), ready=False)
+
+        def ready_rgba_buffer(self) -> None:
+            return None
+
+    def present_array(rgb_host_uint8: np.ndarray) -> None:
+        del rgb_host_uint8
+        raise AssertionError("host presenter path should not run")
+
+    presenter._cuda_rgb_interop = _PendingInterop()
+    presenter._present_array = present_array
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+        status_message="pending",
+    )
+
+    presenter.present_frame(frame, view_mode="model_rgb")
+
+    assert lazy.numpy_calls == 0
+
+
+def test_model_rgb_does_not_fallback_to_host_when_interop_buffers_are_busy() -> None:
+    presenter = _presenter_without_window()
+    lazy = _LazyFrame()
+
+    class _BusyInterop:
+        enqueue_calls = 0
+
+        def as_cuda_rgb_frame(self, rgb_frame: object) -> _CudaRGBFrame | None:
+            assert rgb_frame is lazy
+            return _CudaRGBFrame(tensor=object(), source_event=None, ready=True)
+
+        def ready_rgba_buffer(self) -> None:
+            return None
+
+        def enqueue_rgb_to_shared_rgba(self, rgb_frame: _CudaRGBFrame) -> bool:
+            assert rgb_frame.ready
+            self.enqueue_calls += 1
+            return False
+
+    busy_interop = _BusyInterop()
+
+    def present_array(rgb_host_uint8: np.ndarray) -> None:
+        del rgb_host_uint8
+        raise AssertionError("host presenter path should not run")
+
+    presenter._cuda_rgb_interop = busy_interop
+    presenter._present_array = present_array
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+    )
+
+    presenter.present_frame(frame, view_mode="model_rgb")
+
+    assert lazy.numpy_calls == 0
+    assert busy_interop.enqueue_calls == 1
+
+
+def test_cuda_hud_alpha_composite_uses_supported_tensor_math() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for this regression test")
+
+    interop = _CudaRGBInterop.__new__(_CudaRGBInterop)
+    interop._torch = torch
+    base = torch.zeros((2, 2, 4), device="cuda", dtype=torch.uint8)
+    base[..., :3] = 10
+    base[..., 3] = 255
+    overlay = torch.zeros((2, 2, 4), device="cuda", dtype=torch.uint8)
+    overlay[..., 0] = 110
+    overlay[..., 3] = 128
+
+    interop._alpha_composite_rgba(base, overlay)
+    torch.cuda.synchronize()
+
+    assert base[..., 3].eq(255).all()
+    assert base[..., 0].eq(60).all()
+    assert base[..., 1].eq(5).all()
+    assert base[..., 2].eq(5).all()
+
+
+def test_hud_prepare_frame_keeps_cuda_model_rgb_lazy() -> None:
+    presenter = _hud_presenter_without_window()
+    model = _LazyFrame()
+    bev = _LazyFrame()
+    presenter._cuda_hud_interop = object()
+
+    model.to_cuda_tensor = lambda: object()  # type: ignore[attr-defined]
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=model,
+        bev_host_uint8=bev,
+    )
+
+    presenter.prepare_frame(frame, view_mode="model_rgb")
+
+    assert model.prefetch_calls == 0
+    assert model.numpy_calls == 0
+    assert bev.prefetch_calls == 1
+
+
+def test_hud_model_rgb_uses_cuda_path_without_materializing_host_frame() -> None:
+    presenter = _hud_presenter_without_window()
+    lazy = _LazyFrame()
+    cuda_calls: list[tuple[PresentedFrame, object]] = []
+
+    def present_cuda_hud_frame(frame: PresentedFrame, rgb: object) -> bool:
+        cuda_calls.append((frame, rgb))
+        return True
+
+    def update_camera_pil(rgb: object) -> None:
+        del rgb
+        raise AssertionError("host HUD camera path should not run")
+
+    presenter._pending_resize = None
+    presenter._present_cuda_hud_frame = present_cuda_hud_frame
+    presenter._update_camera_pil = update_camera_pil
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+    )
+
+    presenter.present_frame(frame, view_mode="model_rgb")
+
+    assert cuda_calls == [(frame, lazy)]
+    assert lazy.numpy_calls == 0
+
+
+def test_hud_model_rgb_falls_back_to_host_when_cuda_path_declines() -> None:
+    presenter = _hud_presenter_without_window()
+    lazy = _LazyFrame()
+    presented: list[object] = []
+
+    presenter._pending_resize = None
+    presenter._present_cuda_hud_frame = lambda frame, rgb: False
+    presenter._update_camera_pil = lambda rgb: presented.append(rgb)
+    presenter._render_canvas = lambda status_message: None
+    presenter._present_canvas = lambda *args, **kwargs: None
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+    )
+
+    presenter.present_frame(frame, view_mode="model_rgb")
+
+    assert presented == [lazy]
+
+
+def test_hud_model_rgb_falls_back_to_host_when_cuda_path_raises() -> None:
+    presenter = _hud_presenter_without_window()
+    lazy = _LazyFrame()
+    presented: list[object] = []
+    close_calls = 0
+
+    class _Interop:
+        def close(self) -> None:
+            nonlocal close_calls
+            close_calls += 1
+
+    def raise_cuda(frame: PresentedFrame, rgb: object) -> bool:
+        del frame, rgb
+        raise RuntimeError("cuda blend failed")
+
+    presenter._pending_resize = None
+    presenter._cuda_hud_interop = _Interop()
+    presenter._cuda_hud_error_logged = False
+    presenter._present_cuda_hud_frame = raise_cuda
+    presenter._update_camera_pil = lambda rgb: presented.append(rgb)
+    presenter._render_canvas = lambda status_message: None
+    presenter._present_canvas = lambda *args, **kwargs: None
+
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+        model_rgb_host_uint8=lazy,
+    )
+
+    presenter.present_frame(frame, view_mode="model_rgb")
+
+    assert presented == [lazy]
+    assert presenter._cuda_hud_interop is None
+    assert close_calls == 1

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 from dataclasses import replace
 
 import numpy as np
-import torch
 import omnidreams.interactive_drive.world_model.flashdreams_adapter as adapter_module
+import torch
 from omnidreams.interactive_drive.config import WorldModelProfileConfig
 from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
     FlashdreamsWorldModelSession,
-    _LazyRGBFrame,
     _build_pipeline_config,
+    _LazyRGBFrame,
     _select_config_name,
 )
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -7,9 +7,11 @@ from dataclasses import replace
 
 import numpy as np
 import torch
+import omnidreams.interactive_drive.world_model.flashdreams_adapter as adapter_module
 from omnidreams.interactive_drive.config import WorldModelProfileConfig
 from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
     FlashdreamsWorldModelSession,
+    _LazyRGBFrame,
     _build_pipeline_config,
     _select_config_name,
 )
@@ -138,6 +140,41 @@ def test_session_uses_flashdreams_pipeline_for_rollout() -> None:
 
     session.close()
     assert fake_pipeline.finalize_calls == [(0, "cache"), (1, "cache")]
+
+
+def test_session_synchronizes_generated_frame_events_before_return(monkeypatch) -> None:
+    fake_pipeline = _FakePipeline()
+    session = FlashdreamsWorldModelSession(
+        _manifest(),
+        pipeline_factory=lambda manifest, profile: fake_pipeline,
+    )
+    session.warmup()
+    sync_calls: list[list[object]] = []
+
+    def fake_sync(frames: list[object]) -> None:
+        sync_calls.append(frames)
+
+    monkeypatch.setattr(adapter_module, "_synchronize_cuda_frame_event", fake_sync)
+
+    initial_rgb = np.zeros((2, 3, 3), dtype=np.uint8)
+    first_condition_frames = [np.zeros((2, 3, 3), dtype=np.uint8) for _ in range(5)]
+    next_condition_frames = [np.zeros((2, 3, 3), dtype=np.uint8) for _ in range(8)]
+
+    first = session.start(initial_rgb, first_condition_frames, "demo prompt")
+    second = session.continue_generation(next_condition_frames)
+
+    assert sync_calls == [first, second]
+
+
+def test_lazy_rgb_frame_exposes_tensor_before_host_materialization() -> None:
+    frames = torch.arange(2 * 2 * 3 * 3, dtype=torch.uint8).reshape(2, 2, 3, 3)
+    lazy = _LazyRGBFrame(frames, frame_index=1)
+
+    tensor = lazy.to_cuda_tensor()
+
+    assert torch.equal(tensor, frames[1])
+    assert lazy.to_cuda_event() is None
+    assert np.array_equal(lazy.to_numpy(), frames[1].numpy())
 
 
 def test_session_offload_reuses_precomputed_embeddings_after_reset() -> None:


### PR DESCRIPTION
## Summary

- Add the interactive-drive presenter CUDA interop path to reduce HUD/upload CPU-GPU traffic.
- Keep CUDA graph perf pipelines compatible with presenter interop by using thread-local graph capture checks.
- Add e2e/HUD profiling logs for validating the presenter path.
```mermaid
flowchart TD
    Before["Before"] --> B1["Model output tensor on GPU"]
    B1 --> B2["Always materialize as NumPy"]
    B2 --> B3["GPU -> CPU copy"]
    B3 --> B4["CPU -> GPU upload into presenter texture"]
    B4 --> B5["HUD display"]

    After["After"] --> A1["Model output tensor on GPU"]
    A1 --> A2["_LazyRGBFrame preserves CUDA tensor"]
    A2 --> A3["Presenter asks for CUDA tensor/event"]
    A3 --> A4["CUDA interop imports/uses GPU buffer"]
    A4 --> A5["HUD display"]
```

## Sample commands

```bash
uv run --no-sync --package flashdreams-omnidreams interactive-drive \
  --autoload-scene \
  --manifest example_world_model_perf.yaml
```

```bash
xvfb-run -a env \
  INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES=1 \
  INTERACTIVE_DRIVE_PROFILE_HUD=1 \
  INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT=1 \
  uv run --no-sync --package flashdreams-omnidreams interactive-drive \
    --autoload-scene \
    --scene /home/gtong/gtc_scenes/clipgt-e2993759-36e1-4d97-868f-e2a737f1eb68.usdz \
    --manifest example_world_model_perf.yaml
```

## Testing

- `python -m compileall` on touched files
- `git diff --check`
- Full `xvfb-run` interactive-drive smoke with `example_world_model_perf.yaml`