### PR TITLE
Lower PyTorch minimum from >=2.11 to >=2.9, drop unused torchvision dep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,18 +304,13 @@ uv run pytest                    # all tests including manual
 ## Dependency version bounds
 
 The `flashdreams/pyproject.toml` declares minimum version bounds for all
-runtime dependencies (e.g. `torch>=2.9`). These bounds reflect the oldest
-versions we believe are compatible based on API analysis -- for example,
-the `torch>=2.9` floor exists because
-`torch.distributed.tensor.experimental.context_parallel` requires the
-`buffers` / `buffer_seq_dims` / `no_restore_buffers` interface
-introduced in PyTorch 2.9.
+runtime dependencies. These bounds reflect the oldest versions we believe
+are compatible based on API analysis.
 
 **CI tests run against the pinned versions in `uv.lock`**, not against
 the declared minimums. This means:
 
-- We guarantee correctness at the locked versions (currently torch 2.12,
-  torchvision 0.27 on Linux).
+- We guarantee correctness at the locked versions.
 - We expect the package to work at the declared minimum bounds, but do
   not continuously validate this in CI.
 - If you encounter breakage with a version that satisfies the declared

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,12 @@ issue and we'll fix it.
 4. [Submitting a pull request](#submitting-a-pull-request)
 5. [Code review and merge](#code-review-and-merge)
 6. [Coding conventions](#coding-conventions)
-7. [Speeding up local builds](#speeding-up-local-builds)
-8. [Licensing of contributions](#licensing-of-contributions)
-9. [Filing issues and security reports](#filing-issues-and-security-reports)
-10. [Code of Conduct](#code-of-conduct)
+7. [Testing](#testing)
+8. [Dependency version bounds](#dependency-version-bounds)
+9. [Speeding up local builds](#speeding-up-local-builds)
+10. [Licensing of contributions](#licensing-of-contributions)
+11. [Filing issues and security reports](#filing-issues-and-security-reports)
+12. [Code of Conduct](#code-of-conduct)
 
 ## Ways to contribute
 
@@ -298,6 +300,28 @@ uv run pytest -m ci_gpu          # GPU tests only (needs CUDA)
 uv run pytest -m "not manual"    # everything that runs in CI
 uv run pytest                    # all tests including manual
 ```
+
+## Dependency version bounds
+
+The `flashdreams/pyproject.toml` declares minimum version bounds for all
+runtime dependencies (e.g. `torch>=2.9`). These bounds reflect the oldest
+versions we believe are compatible based on API analysis -- for example,
+the `torch>=2.9` floor exists because
+`torch.distributed.tensor.experimental.context_parallel` requires the
+`buffers` / `buffer_seq_dims` / `no_restore_buffers` interface
+introduced in PyTorch 2.9.
+
+**CI tests run against the pinned versions in `uv.lock`**, not against
+the declared minimums. This means:
+
+- We guarantee correctness at the locked versions (currently torch 2.12,
+  torchvision 0.27 on Linux).
+- We expect the package to work at the declared minimum bounds, but do
+  not continuously validate this in CI.
+- If you encounter breakage with a version that satisfies the declared
+  bounds but differs from the lock file, please
+  [open an issue](https://github.com/NVIDIA/flashdreams/issues). We will
+  either fix compatibility or bump the bound in `pyproject.toml`.
 
 ## Speeding up local builds
 

--- a/flashdreams/flashdreams/_version.py
+++ b/flashdreams/flashdreams/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0a3"
+__version__ = "0.1.0a4"

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -42,7 +42,9 @@ dependencies = [
     # tyro powers the ``flashdreams-run`` console script (subcommand
     # union over the integration registry, per-field CLI overrides), so it
     # has to ship as a runtime dependency, not a dev-only one.
-    "tyro>=0.8",
+    # 1.0 introduced ``sort_subcommands`` in
+    # ``tyro.extras.subcommand_type_from_defaults``, used by the CLI union.
+    "tyro>=1.0",
 
     # Minimum is 2.9: context_parallel(buffers=, buffer_seq_dims=,
     # no_restore_buffers=) and set_rotate_method in
@@ -76,7 +78,9 @@ Repository = "https://github.com/NVIDIA/flashdreams"
 dev = [
     "pytest>=8.0",
     "mediapy>=1.1",
-    "pytest-manual-marker",
+    # 2.0 rewrote the plugin for pytest 8+ (older versions use the removed
+    # ``Item.get_marker`` API).
+    "pytest-manual-marker>=2.0",
     "tomli>=2.0",
     # Transformer Engine is the parity / perf reference for the
     # in-house RoPE Triton kernel (see ``tests/test_rope_kernel.py``

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -44,8 +44,10 @@ dependencies = [
     # has to ship as a runtime dependency, not a dev-only one.
     "tyro>=0.8",
 
-    "torch>=2.11",
-    "torchvision>=0.26",
+    # Minimum is 2.9: context_parallel(buffers=, buffer_seq_dims=,
+    # no_restore_buffers=) and set_rotate_method in
+    # torch.distributed.tensor.experimental require PyTorch 2.9+.
+    "torch>=2.9",
     # ``torch.compile`` lowers conv/elementwise kernels through Inductor +
     # Triton. On Windows the upstream PyPI ``triton`` package is Linux-only,
     # so without ``triton-windows`` Inductor crashes deep inside its
@@ -127,9 +129,6 @@ explicit = true
 
 [tool.uv.sources]
 torch = [
-    { index = "pytorch-cu130", marker = "sys_platform == 'win32'" },
-]
-torchvision = [
     { index = "pytorch-cu130", marker = "sys_platform == 'win32'" },
 ]
 

--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -92,7 +92,7 @@ dev = [
 # main; the canonical extra is ``runners`` (same package set).
 examples = [
     "mediapy>=1.1",
-    "opencv-python-headless",
+    "opencv-python-headless>=4.5",
     "scipy>=1.11",
 ]
 # I/O dependencies the ``flashdreams-run`` CLI runners lazy-import
@@ -101,7 +101,7 @@ examples = [
 # pipeline (e.g. ``integrations/lingbot``) doesn't pull in ffmpeg / opencv.
 runners = [
     "mediapy>=1.1",
-    "opencv-python-headless",
+    "opencv-python-headless>=4.5",
     "scipy>=1.11",
 ]
 serving = [

--- a/integrations/causal_forcing/pyproject.toml
+++ b/integrations/causal_forcing/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10"
 dependencies = [
     "flashdreams",
     "mediapy>=1.1",
-    "opencv-python-headless",
+    "opencv-python-headless>=4.5",
 ]
 
 [tool.uv.sources]

--- a/integrations/causal_forcing/pyproject.toml
+++ b/integrations/causal_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-causal-forcing"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Causal-Forcing chunkwise / framewise streaming T2V + I2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/cosmos_predict2/pyproject.toml
+++ b/integrations/cosmos_predict2/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-cosmos-predict2"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Cosmos-Predict2 T2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/fastvideo_causal_wan22/pyproject.toml
+++ b/integrations/fastvideo_causal_wan22/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-fastvideo-causal-wan22"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "FastVideo CausalWan 2.2 14B MoE distilled streaming T2V inference, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/flashvsr/pyproject.toml
+++ b/integrations/flashvsr/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-flashvsr"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "FlashVSR streaming video super-resolution (LR projector + Wan 2.1 DiT + TC decoder), packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-lingbot"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Lingbot World streaming camera-control I2V integration + WebRTC server for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "aiohttp>=3.9",
     "aiortc>=1.9",
     "mediapy>=1.1",
-    "opencv-python-headless",
+    "opencv-python-headless>=4.5",
     "scipy>=1.11",
 ]
 

--- a/integrations/omnidreams/ludus-renderer/pyproject.toml
+++ b/integrations/omnidreams/ludus-renderer/pyproject.toml
@@ -25,23 +25,23 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "numpy",
+    "numpy>=1.24",
     "torch>=2.11",
-    "pandas",
-    "pyarrow",
-    "scipy",
-    "pillow",
-    "PyNvVideoCodec",
-    "setuptools",
+    "pandas>=2.0",
+    "pyarrow>=14.0",
+    "scipy>=1.11",
+    "pillow>=10.0",
+    "PyNvVideoCodec>=2.0",
+    "setuptools>=69",
     "ninja>=1.13.0",
-    "nvidia-nvcomp-cu12",
+    "nvidia-nvcomp-cu12>=4.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "imageio-ffmpeg",
-    "opencv-python",
+    "pytest>=8.0",
+    "imageio-ffmpeg>=0.5",
+    "opencv-python>=4.5",
 ]
 
 [build-system]

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -30,12 +30,12 @@ dependencies = [
     "flashdreams[serving]",
     "mediapy>=1.1",
     "ludus-renderer",
-    "imageio",
-    "grpcio-tools",
-    "grpcio",
+    "imageio>=2.20",
+    "grpcio-tools>=1.50",
+    "grpcio>=1.50",
     "nvidia-cudnn-frontend==1.22.1",
-    "opencv-python-headless",
-    "shapely",
+    "opencv-python-headless>=4.5",
+    "shapely>=2.0",
     # Runtime deps for the ``omnidreams.interactive_drive`` desktop demo
     # subpackage. Most are already transitive via ``flashdreams[serving]``
     # but listed here explicitly so the subpackage's dep surface is
@@ -69,7 +69,7 @@ interactive-drive = [
 ]
 dev = [
     "pytest>=8.0",
-    "pytest-manual-marker",
+    "pytest-manual-marker>=2.0",
     # ``omnidreams.interactive_drive`` test-only deps.
     "pyvirtualdisplay>=3.0",
     "flip-evaluator>=1.7",

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-omnidreams"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Omnidreams inference with flashdreams (webrtc / gRPC servers + the interactive-drive desktop demo)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/self_forcing/pyproject.toml
+++ b/integrations/self_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-self-forcing"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Self-Forcing distilled streaming T2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/wan21/pyproject.toml
+++ b/integrations/wan21/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-wan21"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Wan 2.1 T2V + I2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/wan21/pyproject.toml
+++ b/integrations/wan21/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10"
 dependencies = [
     "flashdreams",
     "mediapy>=1.1",
-    "opencv-python-headless",
+    "opencv-python-headless>=4.5",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,8 +171,7 @@ docs-ci = [
     "loguru>=0.7",
     "numpy>=1.24",
     "safetensors>=0.4",
-    "torch>=2.11",
-    "torchvision>=0.26",
+    "torch>=2.9",
     "tqdm>=4.60",
     "transformers>=5.0,<6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,18 +145,18 @@ markers = [
 test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
-    "pytest-manual-marker",
-    "imageio-ffmpeg",
+    "pytest-manual-marker>=2.0",
+    "imageio-ffmpeg>=0.5",
 ]
 lint = ["pre-commit>=4.3.0", "ty>=0.0.39", {include-group = "test"}]
 
 # Sphinx toolchain for building docs locally (`uv run --group docs sphinx-build ...`).
 docs = [
-    "furo",
-    "sphinx",
-    "sphinx-autobuild",
-    "sphinx-copybutton",
-    "sphinx-design",
+    "furo>=2024.0",
+    "sphinx>=7.0",
+    "sphinx-autobuild>=2024.0",
+    "sphinx-copybutton>=0.5",
+    "sphinx-design>=0.5",
 ]
 
 # CPU-only runtime deps needed by autodoc to import flashdreams on CI.

--- a/uv.lock
+++ b/uv.lock
@@ -52,8 +52,7 @@ docs-ci = [
     { name = "loguru", specifier = ">=0.7" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "safetensors", specifier = ">=0.4" },
-    { name = "torch", specifier = ">=2.11" },
-    { name = "torchvision", specifier = ">=0.26" },
+    { name = "torch", specifier = ">=2.9" },
     { name = "tqdm", specifier = ">=4.60" },
     { name = "transformers", specifier = ">=5.0,<6" },
 ]
@@ -1116,8 +1115,6 @@ dependencies = [
     { name = "safetensors" },
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "triton-windows", marker = "sys_platform == 'win32'" },
@@ -1174,10 +1171,8 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'examples'", specifier = ">=1.11" },
     { name = "scipy", marker = "extra == 'runners'", specifier = ">=1.11" },
     { name = "tomli", marker = "extra == 'dev'", specifier = ">=2.0" },
-    { name = "torch", marker = "sys_platform != 'win32'", specifier = ">=2.11" },
-    { name = "torch", marker = "sys_platform == 'win32'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu130" },
-    { name = "torchvision", marker = "sys_platform != 'win32'", specifier = ">=0.26" },
-    { name = "torchvision", marker = "sys_platform == 'win32'", specifier = ">=0.26", index = "https://download.pytorch.org/whl/cu130" },
+    { name = "torch", marker = "sys_platform != 'win32'", specifier = ">=2.9" },
+    { name = "torch", marker = "sys_platform == 'win32'", specifier = ">=2.9", index = "https://download.pytorch.org/whl/cu130" },
     { name = "tqdm", specifier = ">=4.60" },
     { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "sys_platform != 'win32' and extra == 'dev'", specifier = ">=2.12" },
     { name = "transformers", specifier = ">=5.0,<6" },
@@ -1346,7 +1341,7 @@ dependencies = [
     { name = "shapely" },
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
     { name = "tqdm" },
     { name = "transformers" },
@@ -5147,8 +5142,8 @@ wheels = [
 
 [[package]]
 name = "torchvision"
-version = "0.26.0+cu130"
-source = { registry = "https://download.pytorch.org/whl/cu130" }
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
@@ -5162,13 +5157,13 @@ dependencies = [
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp310-cp310-win_amd64.whl", hash = "sha256:a410cf52350ff4a5e0a71cedaf03bdec973c7a22421f36163d887a251acf51d7", upload-time = "2026-03-23T15:36:25Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:d019b9d02433515d59ad403d8a6f521da7844c030d6c8003eeec39e15e59f9fa", upload-time = "2026-04-09T23:21:52Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:a3578f7c8e8a2724306c68c56873a1675fa7ce45471e18235c720a2ed242fe44", upload-time = "2026-04-09T23:21:53Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:64de855465d6de60583e776889fad9412480f9f9e04fdd8d17ae96fa93864e9a", upload-time = "2026-04-09T23:21:54Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:a7e19c3ab5c6d8e3c9f8c6d427f6b8862dfb8227ea4a758ea7a709951daf2f0d", upload-time = "2026-04-09T23:21:55Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp314-cp314-win_amd64.whl", hash = "sha256:ab671ffe837aff470baad6af97133ea5a49f8ea2383832550e510a63caf711e4", upload-time = "2026-04-09T23:21:56Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp314-cp314t-win_amd64.whl", hash = "sha256:23b9666084c72d07fc715001880b648e6a410796d1925c10f054f1ee034f5cc7", upload-time = "2026-04-09T23:21:57Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ed/e53cd7c0da7ae002e5e929c1796ebbe7ec0c700c29f7a0a6696497fb3d8b/torchvision-0.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:f13f12b3791a266de2d599cb8162925261622a037d87fc03132848343cf68f75", size = 3669784, upload-time = "2026-03-23T18:12:49.949Z" },
+    { url = "https://files.pythonhosted.org/packages/10/58/ed8f7754299f3e91d6414b6dc09f62b3fa7c6e5d63dfe48d69ab81498a37/torchvision-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:de6424b12887ad884f39a0ee446994ae3cd3b6a00a9cafe1bead85a031132af0", size = 3983834, upload-time = "2026-03-23T18:13:00.224Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1b/f1bc86a918c5f6feab1eeff11982e2060f4704332e96185463d27855bdf5/torchvision-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:4280c35ec8cba1fcc8294fb87e136924708726864c379e4c54494797d86bc474", size = 4319880, upload-time = "2026-03-23T18:12:38.168Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a4/f1155e943ae5b32400d7000adc81c79bb0392b16ceb33bcf13e02e48cced/torchvision-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ebc043cc5a4f0bf22e7680806dbba37ffb19e70f6953bbb44ed1a90aeb5c9bea", size = 4248202, upload-time = "2026-03-23T18:12:41.423Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ba/1666f90bc0bdd77aaa11dcc42bb9f621a9c3668819c32430452e3d404730/torchvision-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:114bec0c0e98aa4ba446f63e2fe7a2cbca37b39ac933987ee4804f65de121800", size = 4348469, upload-time = "2026-03-23T18:12:24.44Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/6a/09f3844c10643f6c0de5d95abc863420cfaf194c88c7dffd0ac523e2015f/torchvision-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e9d0e022c19a78552fb055d0414d47fecb4a649309b9968573daea160ba6869c", size = 4454275, upload-time = "2026-03-23T18:12:27.487Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -39,11 +39,11 @@ overrides = [
 
 [manifest.dependency-groups]
 docs = [
-    { name = "furo" },
-    { name = "sphinx" },
-    { name = "sphinx-autobuild" },
-    { name = "sphinx-copybutton" },
-    { name = "sphinx-design" },
+    { name = "furo", specifier = ">=2024.0" },
+    { name = "sphinx", specifier = ">=7.0" },
+    { name = "sphinx-autobuild", specifier = ">=2024.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5" },
+    { name = "sphinx-design", specifier = ">=0.5" },
 ]
 docs-ci = [
     { name = "einops", specifier = ">=0.7" },
@@ -57,18 +57,18 @@ docs-ci = [
     { name = "transformers", specifier = ">=5.0,<6" },
 ]
 lint = [
-    { name = "imageio-ffmpeg" },
+    { name = "imageio-ffmpeg", specifier = ">=0.5" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "pytest-manual-marker" },
+    { name = "pytest-manual-marker", specifier = ">=2.0" },
     { name = "ty", specifier = ">=0.0.39" },
 ]
 test = [
-    { name = "imageio-ffmpeg" },
+    { name = "imageio-ffmpeg", specifier = ">=0.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "pytest-manual-marker" },
+    { name = "pytest-manual-marker", specifier = ">=2.0" },
 ]
 
 [[manifest.dependency-metadata]]
@@ -1163,8 +1163,8 @@ requires-dist = [
     { name = "mediapy", marker = "extra == 'runners'", specifier = ">=1.1" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "nvidia-ml-py", specifier = ">=12.0" },
-    { name = "opencv-python-headless", marker = "extra == 'examples'" },
-    { name = "opencv-python-headless", marker = "extra == 'runners'" },
+    { name = "opencv-python-headless", marker = "extra == 'examples'", specifier = ">=4.5" },
+    { name = "opencv-python-headless", marker = "extra == 'runners'", specifier = ">=4.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-manual-marker", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "safetensors", specifier = ">=0.4" },
@@ -1201,7 +1201,7 @@ dev = [
 requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
     { name = "mediapy", specifier = ">=1.1" },
-    { name = "opencv-python-headless" },
+    { name = "opencv-python-headless", specifier = ">=4.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
 provides-extras = ["dev"]
@@ -1310,7 +1310,7 @@ requires-dist = [
     { name = "aiortc", specifier = ">=1.9" },
     { name = "flashdreams", editable = "flashdreams" },
     { name = "mediapy", specifier = ">=1.1" },
-    { name = "opencv-python-headless" },
+    { name = "opencv-python-headless", specifier = ">=4.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "scipy", specifier = ">=1.11" },
@@ -1363,23 +1363,23 @@ requires-dist = [
     { name = "einops", specifier = ">=0.8" },
     { name = "flashdreams", extras = ["serving"], editable = "flashdreams" },
     { name = "flip-evaluator", marker = "extra == 'dev'", specifier = ">=1.7" },
-    { name = "grpcio" },
-    { name = "grpcio-tools" },
+    { name = "grpcio", specifier = ">=1.50" },
+    { name = "grpcio-tools", specifier = ">=1.50" },
     { name = "huggingface-hub", specifier = ">=0.24" },
-    { name = "imageio" },
+    { name = "imageio", specifier = ">=2.20" },
     { name = "ludus-renderer", editable = "integrations/omnidreams/ludus-renderer" },
     { name = "mediapy", specifier = ">=1.1" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "nvidia-cudnn-frontend", specifier = "==1.22.1" },
-    { name = "opencv-python-headless" },
+    { name = "opencv-python-headless", specifier = ">=4.5" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "pyarrow", specifier = ">=16.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-manual-marker", marker = "extra == 'dev'" },
+    { name = "pytest-manual-marker", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "pyvirtualdisplay", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "safetensors", specifier = ">=0.5" },
-    { name = "shapely" },
+    { name = "shapely", specifier = ">=2.0" },
     { name = "slangpy", marker = "extra == 'interactive-drive'", specifier = "==0.42.0" },
     { name = "torch", specifier = ">=2.11" },
     { name = "torchvision", specifier = ">=0.26" },
@@ -1429,7 +1429,7 @@ dev = [
 requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
     { name = "mediapy", specifier = ">=1.1" },
-    { name = "opencv-python-headless" },
+    { name = "opencv-python-headless", specifier = ">=4.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
 provides-extras = ["dev"]
@@ -2295,18 +2295,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "imageio-ffmpeg", marker = "extra == 'dev'" },
+    { name = "imageio-ffmpeg", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "ninja", specifier = ">=1.13.0" },
-    { name = "numpy" },
-    { name = "nvidia-nvcomp-cu12" },
-    { name = "opencv-python", marker = "extra == 'dev'" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "pyarrow" },
-    { name = "pynvvideocodec" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "scipy" },
-    { name = "setuptools" },
+    { name = "numpy", specifier = ">=1.24" },
+    { name = "nvidia-nvcomp-cu12", specifier = ">=4.0" },
+    { name = "opencv-python", marker = "extra == 'dev'", specifier = ">=4.5" },
+    { name = "pandas", specifier = ">=2.0" },
+    { name = "pillow", specifier = ">=10.0" },
+    { name = "pyarrow", specifier = ">=14.0" },
+    { name = "pynvvideocodec", specifier = ">=2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "scipy", specifier = ">=1.11" },
+    { name = "setuptools", specifier = ">=69" },
     { name = "torch", specifier = ">=2.11" },
 ]
 provides-extras = ["dev"]

--- a/uv.lock
+++ b/uv.lock
@@ -1166,7 +1166,7 @@ requires-dist = [
     { name = "opencv-python-headless", marker = "extra == 'examples'" },
     { name = "opencv-python-headless", marker = "extra == 'runners'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-manual-marker", marker = "extra == 'dev'" },
+    { name = "pytest-manual-marker", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "safetensors", specifier = ">=0.4" },
     { name = "scipy", marker = "extra == 'examples'", specifier = ">=1.11" },
     { name = "scipy", marker = "extra == 'runners'", specifier = ">=1.11" },
@@ -1177,7 +1177,7 @@ requires-dist = [
     { name = "transformer-engine", extras = ["core-cu13", "pytorch"], marker = "sys_platform != 'win32' and extra == 'dev'", specifier = ">=2.12" },
     { name = "transformers", specifier = ">=5.0,<6" },
     { name = "triton-windows", marker = "sys_platform == 'win32'", specifier = ">=3.5.0" },
-    { name = "tyro", specifier = ">=0.8" },
+    { name = "tyro", specifier = ">=1.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["dev", "examples", "runners", "serving"]


### PR DESCRIPTION
## Summary

Lower the declared PyTorch minimum from `>=2.11` to `>=2.9`, remove the unused `torchvision` core dependency, fix incorrect lower bounds on `tyro` and `pytest-manual-marker`, and pin all previously-unpinned workspace dependencies so that `uv sync --resolution lowest-direct` resolves cleanly across the entire workspace.

## Motivation

- **torchvision is never imported** by the flashdreams core package. Only integrations (flashvsr, omnidreams) use it and declare their own dependency. Removing it eliminates an implicit torch version floor (torchvision 0.26 requires torch 2.11).

- **The true API minimum is PyTorch 2.9**, driven by `torch.distributed.tensor.experimental.context_parallel`'s `buffers` / `buffer_seq_dims` / `no_restore_buffers` interface and `set_rotate_method`, both introduced in 2.9. All other APIs used only require PyTorch 2.2--2.4.

- **tyro>=0.8 was too low** -- the CLI uses `sort_subcommands` in `tyro.extras.subcommand_type_from_defaults`, which was introduced in tyro 1.0.0. Raised to `tyro>=1.0`.

- **pytest-manual-marker was unpinned** -- versions prior to 2.0 use the removed `Item.get_marker` pytest API, incompatible with pytest 8+. Pinned to `>=2.0`.

- **Many workspace deps had no lower bound**, causing `uv sync --resolution lowest-direct` to resolve ancient uninstallable packages (e.g. imageio 0.2.1 from 2014). Pinning them enables `uv sync --resolution lowest-direct` to work workspace-wide -- a prerequisite for adding a minimal-version CI matrix.

## Changes

**flashdreams/pyproject.toml:**
- `torch>=2.11` -> `torch>=2.9` (context_parallel API requires 2.9+)
- Remove `torchvision>=0.26` (unused by core package)
- Remove torchvision from `[tool.uv.sources]`
- `tyro>=0.8` -> `tyro>=1.0` (sort_subcommands introduced in 1.0)
- Pin `pytest-manual-marker>=2.0` (pytest 8 compat)
- Pin `opencv-python-headless>=4.5`

**pyproject.toml (root):**
- `torch>=2.11` -> `torch>=2.9` in docs-ci
- Remove `torchvision>=0.26` from docs-ci
- Pin `furo>=2024.0`, `sphinx>=7.0`, `sphinx-autobuild>=2024.0`, `sphinx-copybutton>=0.5`, `sphinx-design>=0.5`
- Pin `imageio-ffmpeg>=0.5`, `pytest-manual-marker>=2.0`

**integrations/omnidreams/pyproject.toml:**
- Pin `imageio>=2.20`, `grpcio-tools>=1.50`, `grpcio>=1.50`, `shapely>=2.0`, `opencv-python-headless>=4.5`, `pytest-manual-marker>=2.0`

**integrations/omnidreams/ludus-renderer/pyproject.toml:**
- Pin `numpy>=1.24`, `pandas>=2.0`, `pyarrow>=14.0`, `scipy>=1.11`, `pillow>=10.0`, `setuptools>=69`, `nvidia-nvcomp-cu12>=4.0`, `PyNvVideoCodec>=2.0`, `imageio-ffmpeg>=0.5`, `opencv-python>=4.5`, `pytest>=8.0`

**integrations/{lingbot,wan21,causal_forcing}/pyproject.toml:**
- Pin `opencv-python-headless>=4.5`

**Other:**
- `CONTRIBUTING.md`: add dependency version bounds policy section
- `flashdreams/_version.py`: bump to 0.1.0a4
- `uv.lock`: re-locked (specifier metadata only, no resolved version changes)

## Locked versions (unchanged)

The workspace lock file still resolves to the same pinned versions:
- Linux: `torch 2.12.0`, `torchvision 0.27.0`
- Windows: `torch 2.11.0+cu130`, `torchvision 0.26.0`

## Local validation

- CPU tests (torch 2.9.0, lowest-direct): 50 passed
- GPU tests (torch 2.9.0+cu128, RTX A6000): 21 passed, 56 skipped (TE not compiled)
- Both match the pinned (torch 2.12) baseline exactly
- `uv lock --check` passes
- `uv sync --resolution lowest-direct --package flashdreams --extra dev` resolves without warnings