### PR TITLE
fix(ludus-renderer): scope JIT cache by GPU arch to prevent shared-FS poisoning

### DIFF
--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
@@ -103,25 +103,86 @@ def _get_plugin():
         "../_cpp/bindings/torch_rasterize_cuda.cpp",
     ]
 
-    # Reset CUDA arch list to let PyTorch detect the installed GPU
-    os.environ["TORCH_CUDA_ARCH_LIST"] = ""
+    # Pin TORCH_CUDA_ARCH_LIST to the live device's compute capability and
+    # scope the JIT cache slot by that arch so a ``.so`` built for one SM
+    # can never be reused on another. ``torch.utils.cpp_extension.load``
+    # keys its cache off a hash of the SOURCE FILES but NOT the arch /
+    # compile flags, so on shared-filesystem hosts (NFS ``$HOME`` on
+    # Slurm/HPC clusters is the common case) a single user's
+    # ``~/.cache/torch_extensions/`` can hold a ``.so`` built on one node
+    # (e.g. a CPU-only login or a Hopper dev box) and then silently get
+    # reused on a node with a completely different GPU (Blackwell GB200 /
+    # GB300). The mismatched binary doesn't carry the right SASS, kernels
+    # fall back to PTX-JIT (or degraded paths) at every launch, and
+    # steady-state cudaludus throughput collapses by ~4x -- the exact
+    # symptom Junchen / Ruilong reported on the HSG GB200/GB300 cluster
+    # while the same code is fast on a locally-installed GB300 (where the
+    # cache was built fresh on the running GPU).
+    device_capability: tuple[int, int] | None = None
+    if torch.cuda.is_available():
+        try:
+            major, minor = torch.cuda.get_device_capability(0)
+            device_capability = (major, minor)
+            # nvcc-style arch tag, e.g. "sm_100" for Blackwell GB200/GB300.
+            arch_tag = f"sm_{major}{minor}"
+            # Pin the arch list so the build is deterministic and matches
+            # the cache slot below rather than depending on
+            # ``torch.cuda.get_arch_list()`` (which varies with the
+            # installed PyTorch wheel).
+            os.environ["TORCH_CUDA_ARCH_LIST"] = f"{major}.{minor}"
+        except Exception as exc:
+            logger.warning(
+                "Could not detect CUDA device capability ({}); falling back "
+                "to PyTorch auto-detect at build time. Cache slot will be "
+                "shared across archs, which is unsafe on shared filesystems.",
+                exc,
+            )
+            arch_tag = "auto"
+            os.environ["TORCH_CUDA_ARCH_LIST"] = ""
+    else:
+        arch_tag = "nocuda"
+        os.environ["TORCH_CUDA_ARCH_LIST"] = ""
 
-    # Check for stale lock files
-    plugin_name = "ludus_renderer_plugin"
+    plugin_name = f"ludus_renderer_plugin_{arch_tag}"
     build_directory = None
     try:
         build_directory = torch.utils.cpp_extension._get_build_directory(plugin_name, False)
         lock_fn = os.path.join(build_directory, "lock")
+        compiled_so = os.path.join(build_directory, f"{plugin_name}.so")
+        cache_state = "hit (no rebuild)" if os.path.exists(compiled_so) else "miss (will build)"
         logger.info(
-            "Loading Ludus renderer extension {}; build_directory={}.",
+            "Loading Ludus renderer extension {} (device_cap={}, arch={}, "
+            "TORCH_CUDA_ARCH_LIST={!r}); build_directory={}; cache={}.",
             plugin_name,
+            device_capability,
+            arch_tag,
+            os.environ.get("TORCH_CUDA_ARCH_LIST", ""),
             build_directory,
+            cache_state,
         )
         if os.path.exists(lock_fn):
             logger.warning(
                 "Ludus renderer extension lock file exists: {}. "
                 "If no compiler process is active, this may be a stale PyTorch JIT lock.",
                 lock_fn,
+            )
+        # Heads-up if the pre-arch-pinning cache slot still exists. We do
+        # NOT auto-delete it (conservative -- another tool may use it),
+        # but flag it so operators can clean up: any ``.so`` in there was
+        # built without the arch-pinned cache slot and may have been the
+        # source of arch-mismatch slowdowns prior to this patch.
+        legacy_dir = os.path.join(
+            os.path.dirname(build_directory),
+            "ludus_renderer_plugin",
+        )
+        if os.path.isdir(legacy_dir):
+            logger.warning(
+                "Found legacy Ludus extension cache at {}; this directory "
+                "was produced by a pre-arch-pinning build and may contain "
+                "a .so compiled for a different GPU. Safe to delete -- "
+                "the new arch-scoped cache slot ({}) is independent.",
+                legacy_dir,
+                build_directory,
             )
     except Exception as exc:
         logger.debug("Could not inspect Ludus renderer extension build directory: {}", exc)


### PR DESCRIPTION
## Summary

Renames the Ludus JIT cache slot from `ludus_renderer_plugin` to `ludus_renderer_plugin_sm_<cap>` (e.g. `_sm_100` on Blackwell GB200/GB300) and pins `TORCH_CUDA_ARCH_LIST` to the live device's compute capability instead of clearing it. Targets the ~4x cudaludus slowdown @Junchen / @Ruilong reported on the HSG GB200/GB300 Slurm cluster, while the same code runs fast on a locally-installed GB300.

## Root cause

`torch.utils.cpp_extension.load(...)` keys its build cache off a hash of the **source files** but NOT off the GPU arch / compile flags. On any shared-filesystem host (NFS `$HOME` on Slurm) a single user's `~/.cache/torch_extensions/` can hold a `.so` built on one node (CPU login, Hopper dev box, ...) and silently reuse it on a later job that lands on a different GPU generation. The mismatched binary lacks the right SASS, kernels fall back to PTX-JIT at every launch, and cudaludus throughput collapses by ~4x — exactly the omnidreams-webrtc demo's "20 fps on cluster, 30 fps locally" pattern. Local installs work because the cache is necessarily built fresh on the running GPU.

## Changes (`ludus_renderer/_ops/_plugin.py`)

1. **Pin `TORCH_CUDA_ARCH_LIST`** to the device's compute capability (e.g. `"10.0"` on GB200/GB300) instead of clearing it. Deterministic gencode; no dependency on `torch.cuda.get_arch_list()` (which varies per PyTorch wheel and can silently lack SM 10.0+ entries).
2. **Arch-tag the cache slot name** so a Hopper `.so` can't be reused on Blackwell, and vice versa. One-time ~30–60 s rebuild on first load after this lands.
3. **Richer startup log line** records `device_capability`, `arch_tag`, the value of `TORCH_CUDA_ARCH_LIST` actually used, and cache hit/miss.
4. **Warn (don't delete) the legacy cache slot** if it still exists, so operators can clean it up.

Fallback: no CUDA at import → `arch_tag="nocuda"`; capability detect fails → `arch_tag="auto"`. Both behave exactly as before the patch.

Out of scope: the same `TORCH_CUDA_ARCH_LIST=""` pattern in `ludus_renderer/nvjpeg.py` line 71 — separate extension, separate cache, follow-up.