### PR TITLE
Add uv managed flag to FlashVSR pyprojects

### DIFF
--- a/integrations/flashvsr/pyproject.toml
+++ b/integrations/flashvsr/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "block-sparse-attn==0.0.2",
 ]
 
+[tool.uv]
+managed = true
+
 [tool.uv.sources]
 flashdreams = { workspace = true }
 # Upstream Block-Sparse-Attention is not on PyPI. Install from the public

--- a/integrations/flashvsr/tests/parity_check/pyproject.toml
+++ b/integrations/flashvsr/tests/parity_check/pyproject.toml
@@ -61,6 +61,9 @@ dependencies = [
     "pytest>=8.0",
 ]
 
+[tool.uv]
+managed = true
+
 [tool.uv.sources]
 # flashdreams is not on PyPI; install it from the local source tree
 # (../../../../flashdreams relative to this directory).


### PR DESCRIPTION
Set [tool.uv] managed = true in the FlashVSR package and parity-check
pyproject files so vulnerability scans identify them as uv-managed projects.