### PR TITLE
refresh interactive recording assets

### DIFF
--- a/docs/source/models/causal_forcing.rst
+++ b/docs/source/models/causal_forcing.rst
@@ -117,7 +117,7 @@ Some generated samples from the above commands:
    <div class="model-video-grid">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/causal_forcing/causal-forcing-wan2.1-t2v-1.3b-framewise.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/causal_forcing/causal-forcing-wan2.1-t2v-1.3b-framewise.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -126,7 +126,7 @@ Some generated samples from the above commands:
      </div>
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/causal_forcing/causal-forcing-wan2.1-i2v-1.3b-framewise.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/causal_forcing/causal-forcing-wan2.1-i2v-1.3b-framewise.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">

--- a/docs/source/models/causal_wan22.rst
+++ b/docs/source/models/causal_wan22.rst
@@ -95,7 +95,7 @@ Some generated samples from the above commands:
    <div class="model-video-grid">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/causal_wan22/fastvideo-causal-wan2.2-t2v-14b_1.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/causal_wan22/fastvideo-causal-wan2.2-t2v-14b_1.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -104,7 +104,7 @@ Some generated samples from the above commands:
      </div>
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/causal_wan22/fastvideo-causal-wan2.2-t2v-14b_2.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/causal_wan22/fastvideo-causal-wan2.2-t2v-14b_2.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">

--- a/docs/source/models/cosmos_predict2.rst
+++ b/docs/source/models/cosmos_predict2.rst
@@ -116,7 +116,7 @@ Some generated samples from the above commands:
    <div class="model-video-grid">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/cosmos_predict2/cosmos2-t2v-2b-720p.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/cosmos_predict2/cosmos2-t2v-2b-720p.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -125,7 +125,7 @@ Some generated samples from the above commands:
      </div>
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/cosmos_predict2/cosmos2-i2v-2b-720p.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/cosmos_predict2/cosmos2-i2v-2b-720p.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">

--- a/docs/source/models/flashvsr.rst
+++ b/docs/source/models/flashvsr.rst
@@ -109,11 +109,11 @@ A generated sample from the above commands:
 
    <div class="model-video-card" style="width: 100%; margin: 10px auto 14px;">
      <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-       <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/flashvsr/flashvsr-v1.1-sparse-ratio-2.0.mp4" type="video/mp4">
+       <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/flashvsr/flashvsr-v1.1-sparse-ratio-2.0.mp4" type="video/mp4">
        Your browser does not support the video tag.
      </video>
      <video autoplay muted loop playsinline preload="metadata" style="position: absolute; left: 10px; bottom: 10px; width: 50%; border: 2px solid rgba(255, 255, 255, 0.9); border-radius: 8px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5); pointer-events: none;">
-       <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/flashvsr/example1.mp4" type="video/mp4">
+       <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/flashvsr/example1.mp4" type="video/mp4">
        Your browser does not support the video tag.
      </video>
      <div class="model-video-overlay">

--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -111,11 +111,11 @@ Some generated samples from the above commands:
    <div class="model-video-grid">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-fast-01.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-fast-01.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <video autoplay muted loop playsinline preload="metadata" style="position: absolute; right: 10px; bottom: 10px; width: 33.3333%; opacity: 0.7; border-radius: 8px; pointer-events: none;">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-traj-01.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-traj-01.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -124,11 +124,11 @@ Some generated samples from the above commands:
      </div>
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-fast-02.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-fast-02.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <video autoplay muted loop playsinline preload="metadata" style="position: absolute; right: 10px; bottom: 10px; width: 33.3333%; opacity: 0.7; border-radius: 8px; pointer-events: none;">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-traj-02.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-traj-02.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -163,7 +163,7 @@ When successfully connected, the browser-based UI looks like this:
 
   <div class="model-video-card" style="width: 100%; margin: 10px auto 14px;">
     <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-      <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-demo-0520-trim-720P.mp4" type="video/mp4">
+      <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-webrtc-recording-0529.mp4" type="video/mp4">
       Your browser does not support the video tag.
     </video>
   </div>

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -106,7 +106,7 @@ Some generated samples from the above commands:
      <div class="model-video-card">
        <!-- <div class="model-video-placeholder">Video placeholder</div> -->
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/omnidreams/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-239560dc-33d1-11ef-9720-00044bcbccac-pip.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/omnidreams/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-239560dc-33d1-11ef-9720-00044bcbccac-pip.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -116,7 +116,7 @@ Some generated samples from the above commands:
      <div class="model-video-card">
        <!-- <div class="model-video-placeholder">Video placeholder</div> -->
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/omnidreams/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-24b84744-4156-11ef-b27d-00044bf655de-pip.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/omnidreams/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-24b84744-4156-11ef-b27d-00044bf655de-pip.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -153,7 +153,7 @@ When successfully connected, the browser-based UI looks like this:
 
   <div class="model-video-card" style="width: 100%; margin: 10px auto 14px;">
     <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-      <source src="https://research.nvidia.com/labs/sil/projects/alpadreams/assets/omnidreams/omnidreams-demo-0524-720P.mp4" type="video/mp4">
+      <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/omnidreams/omnidreams-webrtc-recording-0529.mp4" type="video/mp4">
       Your browser does not support the video tag.
     </video>
   </div>

--- a/docs/source/models/self_forcing.rst
+++ b/docs/source/models/self_forcing.rst
@@ -107,7 +107,7 @@ Some generated samples from the above commands:
      <div class="model-video-card">
        <!-- <div class="model-video-placeholder">Video placeholder</div> -->
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/self_forcing/self-forcing-wan2.1-t2v-1.3b-flash_1.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/self_forcing/self-forcing-wan2.1-t2v-1.3b-flash_1.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -117,7 +117,7 @@ Some generated samples from the above commands:
      <div class="model-video-card">
        <!-- <div class="model-video-placeholder">Video placeholder</div> -->
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/self_forcing/self-forcing-wan2.1-t2v-1.3b-flash_6.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/self_forcing/self-forcing-wan2.1-t2v-1.3b-flash_6.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">

--- a/docs/source/models/wan21.rst
+++ b/docs/source/models/wan21.rst
@@ -100,7 +100,7 @@ Some generated samples from the above commands:
    <div class="model-video-grid">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/wan21/wan21-t2v-1.3b-480p.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/wan21/wan21-t2v-1.3b-480p.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">
@@ -109,7 +109,7 @@ Some generated samples from the above commands:
      </div>
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
-         <source src="https://research-staging.nvidia.com/labs/sil/projects/flashdreams/assets/wan21/wan21-i2v-14b-480p.mp4" type="video/mp4">
+         <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/wan21/wan21-i2v-14b-480p.mp4" type="video/mp4">
          Your browser does not support the video tag.
        </video>
        <div class="model-video-overlay">

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -89,6 +89,12 @@ def parse_args() -> argparse.Namespace:
         help="Maximum seconds to wait for synthetic startup warmup chunks.",
     )
     parser.add_argument(
+        "--fps",
+        type=int,
+        default=16,
+        help="Output video framerate for WebRTC playback.",
+    )
+    parser.add_argument(
         "--example-idx",
         "--example_idx",
         type=int,
@@ -187,6 +193,8 @@ def initialize_distributed(
 def main() -> None:
     configure_logging()
     args = parse_args()
+    if args.fps <= 0:
+        raise ValueError("--fps must be > 0")
 
     runtime_device, world_rank, context_parallel_size = initialize_distributed(
         default_device=args.device
@@ -197,7 +205,10 @@ def main() -> None:
         device_override=str(runtime_device),
         context_parallel_size=context_parallel_size,
     )
-    session_manager = LingbotWebRTCSessionManager(runtime_config=runtime_config)
+    session_manager = LingbotWebRTCSessionManager(
+        runtime_config=runtime_config,
+        fps=args.fps,
+    )
     if world_rank == 0:
         external_ip = get_external_ip()
         app = create_app(

--- a/integrations/lingbot/lingbot/webrtc/web/assets/horizontal-dark.svg
+++ b/integrations/lingbot/lingbot/webrtc/web/assets/horizontal-dark.svg
@@ -1,0 +1,192 @@
+<svg width="2176" height="495" viewBox="0 0 2176 495" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_28_448)">
+<g clip-path="url(#clip1_28_448)">
+<mask id="mask0_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="495" height="495">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 495H495V6.10352e-05H0V495Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_28_448)">
+<mask id="mask1_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask1_28_448)">
+<mask id="mask2_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="61" y="366" width="95" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M64.9593 387.58L62.4372 384.403L61.1377 380.561L61.2138 376.505L62.6566 372.714L65.2961 369.634L68.8214 367.628L72.8174 366.932H155.997V390.57H72.8168L69.9796 390.225L67.3083 389.208L64.9593 387.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask2_28_448)">
+<mask id="mask3_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask3_28_448)">
+<rect x="58.7812" y="365.062" width="99" height="27.8438" fill="url(#pattern0_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask4_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask4_28_448)">
+<mask id="mask5_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="35" y="329" width="121" height="24">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M36.0768 345.069L35.3652 341.369L35.8542 337.633L37.4939 334.241L40.1179 331.537L43.4594 329.797L47.1789 329.196H155.997V352.834L47.1586 352.821L43.6139 352.276L40.3968 350.69L37.8046 348.212L36.0768 345.069Z" fill="white"/>
+</mask>
+<g mask="url(#mask5_28_448)">
+<mask id="mask6_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask6_28_448)">
+<rect x="34.0312" y="327.938" width="123.75" height="27.8438" fill="url(#pattern1_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask7_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask7_28_448)">
+<mask id="mask8_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="29" y="291" width="127" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M29.89 302.558L30.6381 299.083L32.386 295.987L34.9754 293.551L38.1721 291.995L41.6869 291.461H155.997V315.098H41.6943L37.987 314.502L34.6539 312.773L32.0314 310.085L30.3844 306.71L29.8789 302.989L29.89 302.558Z" fill="white"/>
+</mask>
+<g mask="url(#mask8_28_448)">
+<mask id="mask9_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask9_28_448)">
+<rect x="27.8435" y="290.812" width="129.938" height="24.75" fill="url(#pattern2_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask10_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask10_28_448)">
+<mask id="mask11_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="40" y="253" width="116" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M52.2254 277.362L48.2572 276.676L44.7497 274.698L42.1101 271.656L40.6449 267.905L40.5242 263.88L41.7619 260.048L43.6214 257.44L46.1126 255.428L49.0526 254.158L52.2255 253.725H155.997V277.362H52.2254Z" fill="white"/>
+</mask>
+<g mask="url(#mask11_28_448)">
+<mask id="mask12_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask12_28_448)">
+<rect x="40.2188" y="253.688" width="117.562" height="24.75" fill="url(#pattern3_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask13_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask13_28_448)">
+<mask id="mask14_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="76" y="215" width="80" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.6974 239.626L84.89 238.996L81.4886 237.173L78.8558 234.352L77.2722 230.833L76.9067 226.991L77.7983 223.236L79.8519 219.969L82.8486 217.537L85.6722 216.382L88.6974 215.989H155.997V239.626H88.6974Z" fill="white"/>
+</mask>
+<g mask="url(#mask14_28_448)">
+<mask id="mask15_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask15_28_448)">
+<rect x="74.25" y="213.469" width="83.5312" height="27.8438" fill="url(#pattern4_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask16_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask16_28_448)">
+<mask id="mask17_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="120" y="178" width="36" height="24">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M122.218 183.828L124.857 180.853L128.333 178.922L132.253 178.253H139.378H155.997V188.539V201.89H145.431H137.199H132.254L128.717 201.349L125.504 199.774L122.91 197.309L121.172 194.181L120.45 190.677L120.81 187.117L122.218 183.828Z" fill="white"/>
+</mask>
+<g mask="url(#mask17_28_448)">
+<mask id="mask18_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask18_28_448)">
+<rect x="117.562" y="176.344" width="40.2188" height="27.8438" fill="url(#pattern5_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask19_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask19_28_448)">
+<mask id="mask20_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="184" y="114" width="280" height="301">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M184.149 128.816L196.126 123.87L208.481 119.964L221.123 117.125L233.962 115.375L246.903 114.725L260.933 115.398L274.835 117.411L288.48 120.745L301.744 125.369L314.503 131.241L326.643 138.308L338.05 146.505L348.621 155.755L358.257 165.974L366.872 177.069L374.385 188.937L380.728 201.47L382.546 204.34L385.106 206.574L388.196 207.987L399.511 212.014L410.293 217.303L420.402 223.786L429.707 231.379L438.086 239.982L445.431 249.485L451.644 259.762L456.646 270.681L460.372 282.098L462.772 293.865L463.816 305.829L463.49 317.835L461.798 329.724L458.762 341.344L454.423 352.542L448.835 363.173L442.073 373.098L434.223 382.187L425.39 390.323L415.686 397.4L405.24 403.324L394.186 408.02L382.67 411.426L370.84 413.498L358.851 414.208H196.67L230.641 390.57H358.634L369.481 389.846L380.134 387.686L390.407 384.129L400.115 379.239L409.087 373.101L417.164 365.824L424.201 357.539L430.074 348.392L434.68 338.545L437.935 328.173L439.783 317.461L440.191 306.598L439.15 295.777L436.681 285.19L432.825 275.027L427.654 265.465L421.256 256.676L413.747 248.815L405.26 242.023L395.945 236.419L385.968 232.103L375.506 229.151L371.062 227.614L367.135 225.029L363.966 221.554L361.754 217.404L356.261 205.106L349.456 193.482L341.42 182.673L332.25 172.807L322.056 164.003L310.961 156.367L299.097 149.99L286.606 144.95L273.64 141.305L260.352 139.101L246.903 138.363L233.486 139.097L220.229 141.291L207.29 144.919L186.204 130.246L184.149 128.816Z" fill="white"/>
+</mask>
+<g mask="url(#mask20_28_448)">
+<mask id="mask21_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask21_28_448)">
+<rect x="182.531" y="114.469" width="281.531" height="300.094" fill="url(#pattern6_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask22_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask22_28_448)">
+<mask id="mask23_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="155" y="121" width="231" height="310">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M176.365 428.337L172.751 430.094L168.772 430.659L164.811 429.978L161.249 428.117L158.428 425.255L156.62 421.666L155.997 417.696V134.041L156.62 130.07L158.428 126.482L161.249 123.62L164.811 121.759L168.772 121.078L172.751 121.643L176.365 123.399L380.188 265.227L383.167 268.107L385.085 271.779L385.747 275.868L385.085 279.958L383.167 283.63L380.188 286.509L176.365 428.337ZM286.704 265.561L287.174 263.883L286.671 262.215L285.352 261.076L283.629 260.822L244.235 266.235L242.356 265.905L241.02 264.543L240.727 262.658L250.298 201.919L249.909 199.857L248.303 198.508L246.206 198.48L244.565 199.786L182.368 299.902L181.899 301.579L182.402 303.248L183.72 304.386L185.444 304.64L225.039 299.199L226.918 299.53L228.253 300.892L228.546 302.777L219.038 363.119L219.427 365.181L221.033 366.53L223.13 366.558L224.771 365.252L286.704 265.561Z" fill="white"/>
+</mask>
+<g mask="url(#mask23_28_448)">
+<mask id="mask24_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask24_28_448)">
+<rect x="154.688" y="120.656" width="232.031" height="312.469" fill="url(#pattern7_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask25_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask25_28_448)">
+<mask id="mask26_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask26_28_448)">
+<path d="M286.704 265.56L224.771 365.252L223.13 366.558L221.033 366.53L219.427 365.18L219.038 363.119L228.547 302.777L228.253 300.892L226.918 299.53L225.039 299.199L185.444 304.64L183.72 304.386L182.402 303.247L181.899 301.579L182.368 299.901L244.565 199.786L246.206 198.48L248.303 198.508L249.909 199.858L250.298 201.919L240.727 262.658L241.02 264.543L242.356 265.905L244.234 266.235L283.629 260.822L285.352 261.076L286.671 262.215L287.174 263.882L286.704 265.56Z" stroke="black" stroke-width="0.0993272" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</g>
+</g>
+</g>
+<path d="M514.18 391V303H481.4V277.7H514.18V268.9C514.18 258.487 517.187 250.127 523.2 243.82C529.213 237.367 538.6 234.14 551.36 234.14H599.32V259.44H559.28C550.48 259.44 546.08 263.913 546.08 272.86V277.7H593.16V303H546.08V391H514.18ZM613.709 391V233.7H645.609V391H613.709ZM699.924 391C688.044 391 678.95 387.993 672.644 381.98C666.337 375.967 663.184 367.387 663.184 356.24C663.184 345.24 666.337 336.733 672.644 330.72C678.95 324.707 688.044 321.7 699.924 321.7H784.404V316.42C784.404 307.473 780.004 303 771.204 303H677.924V277.7H779.564C792.91 277.7 802.37 280.78 807.944 286.94C813.517 292.953 816.304 301.46 816.304 312.46V391H699.924ZM705.644 365.7H784.404V347H705.644C702.857 347 700.657 347.88 699.044 349.64C697.577 351.253 696.844 353.453 696.844 356.24C696.844 359.027 697.577 361.3 699.044 363.06C700.657 364.82 702.857 365.7 705.644 365.7ZM836.844 392.1V366.8H944.644C950.804 366.8 953.884 363.353 953.884 356.46C953.884 349.713 950.804 346.34 944.644 346.34H874.904C861.851 346.34 851.951 343.407 845.204 337.54C838.458 331.527 835.084 322.947 835.084 311.8C835.084 300.507 838.458 291.853 845.204 285.84C852.098 279.68 861.998 276.6 874.904 276.6H975.224V301.9H876.444C870.138 301.9 866.984 304.98 866.984 311.14C866.984 314.22 867.864 316.64 869.624 318.4C871.384 320.16 873.658 321.04 876.444 321.04H950.364C961.804 321.04 970.531 324.047 976.544 330.06C982.704 335.927 985.784 344.507 985.784 355.8C985.784 367.24 982.704 376.187 976.544 382.64C970.384 388.947 961.658 392.1 950.364 392.1H836.844ZM1004.51 391V233.7H1036.41V277.7H1103.29C1116.2 277.7 1125.58 280.927 1131.45 287.38C1137.46 293.687 1140.47 302.047 1140.47 312.46V391H1108.57V316.2C1108.57 307.4 1104.17 303 1095.37 303H1036.41V391H1004.51Z" fill="white"/>
+<path d="M1302.97 391H1271.07V233.7H1302.97V391ZM1297.47 391H1221.57C1201.92 391 1186.59 386.16 1175.59 376.48C1164.59 366.8 1159.09 352.793 1159.09 334.46C1159.09 315.98 1164.59 301.9 1175.59 292.22C1186.59 282.54 1201.92 277.7 1221.57 277.7H1295.27V303H1221.57C1212.04 303 1204.71 305.64 1199.57 310.92C1194.59 316.053 1192.09 323.9 1192.09 334.46C1192.09 344.873 1194.59 352.72 1199.57 358C1204.71 363.133 1212.04 365.7 1221.57 365.7H1297.47V391ZM1327.21 391V277.7H1413.89C1426.65 277.7 1436.03 280.927 1442.05 287.38C1448.06 293.687 1451.07 302.047 1451.07 312.46V336H1418.73V316.42C1418.73 307.62 1414.33 303.22 1405.53 303.22H1359.55V391H1327.21ZM1530.95 392.1C1511.3 392.1 1495.97 387.26 1484.97 377.58C1473.97 367.753 1468.47 353.38 1468.47 334.46C1468.47 315.393 1473.97 301.02 1484.97 291.34C1495.97 281.513 1511.3 276.6 1530.95 276.6H1585.95C1598.86 276.6 1608.68 279.68 1615.43 285.84C1622.32 291.853 1625.77 300.507 1625.77 311.8C1625.77 334.827 1612.5 346.34 1585.95 346.34H1502.79C1505.87 359.98 1515.26 366.8 1530.95 366.8H1620.05V392.1H1530.95ZM1530.95 301.9C1515.84 301.9 1506.53 308.28 1503.01 321.04H1584.41C1587.34 321.04 1589.62 320.16 1591.23 318.4C1592.99 316.64 1593.87 314.22 1593.87 311.14C1593.87 304.98 1590.72 301.9 1584.41 301.9H1530.95ZM1675.74 391C1663.86 391 1654.77 387.993 1648.46 381.98C1642.16 375.967 1639 367.387 1639 356.24C1639 345.24 1642.16 336.733 1648.46 330.72C1654.77 324.707 1663.86 321.7 1675.74 321.7H1760.22V316.42C1760.22 307.473 1755.82 303 1747.02 303H1653.74V277.7H1755.38C1768.73 277.7 1778.19 280.78 1783.76 286.94C1789.34 292.953 1792.12 301.46 1792.12 312.46V391H1675.74ZM1681.46 365.7H1760.22V347H1681.46C1678.68 347 1676.48 347.88 1674.86 349.64C1673.4 351.253 1672.66 353.453 1672.66 356.24C1672.66 359.027 1673.4 361.3 1674.86 363.06C1676.48 364.82 1678.68 365.7 1681.46 365.7ZM1816.4 391V277.7H1963.14C1976.05 277.7 1985.51 280.927 1991.52 287.38C1997.54 293.687 2000.54 302.047 2000.54 312.46V391H1968.64V316.42C1968.64 307.473 1964.1 303 1955 303H1924.42V391H1892.52V303H1848.3V391H1816.4ZM2019.99 392.1V366.8H2127.79C2133.95 366.8 2137.03 363.353 2137.03 356.46C2137.03 349.713 2133.95 346.34 2127.79 346.34H2058.05C2045 346.34 2035.1 343.407 2028.35 337.54C2021.6 331.527 2018.23 322.947 2018.23 311.8C2018.23 300.507 2021.6 291.853 2028.35 285.84C2035.24 279.68 2045.14 276.6 2058.05 276.6H2158.37V301.9H2059.59C2053.28 301.9 2050.13 304.98 2050.13 311.14C2050.13 314.22 2051.01 316.64 2052.77 318.4C2054.53 320.16 2056.8 321.04 2059.59 321.04H2133.51C2144.95 321.04 2153.68 324.047 2159.69 330.06C2165.85 335.927 2168.93 344.507 2168.93 355.8C2168.93 367.24 2165.85 376.187 2159.69 382.64C2153.53 388.947 2144.8 392.1 2133.51 392.1H2019.99Z" fill="#76B900"/>
+<defs>
+<pattern id="pattern0_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_28_448" transform="scale(0.03125 0.111111)"/>
+</pattern>
+<pattern id="pattern1_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image1_28_448" transform="scale(0.025 0.111111)"/>
+</pattern>
+<pattern id="pattern2_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image2_28_448" transform="scale(0.0238095 0.125)"/>
+</pattern>
+<pattern id="pattern3_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image3_28_448" transform="scale(0.0263158 0.125)"/>
+</pattern>
+<pattern id="pattern4_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image4_28_448" transform="scale(0.037037 0.111111)"/>
+</pattern>
+<pattern id="pattern5_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image5_28_448" transform="scale(0.0769231 0.111111)"/>
+</pattern>
+<pattern id="pattern6_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image6_28_448" transform="scale(0.010989 0.0103093)"/>
+</pattern>
+<pattern id="pattern7_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image7_28_448" transform="scale(0.0133333 0.00990099)"/>
+</pattern>
+<clipPath id="clip0_28_448">
+<rect width="495" height="495" fill="white"/>
+</clipPath>
+<clipPath id="clip1_28_448">
+<rect width="495" height="495" fill="white"/>
+</clipPath>
+<image id="image0_28_448" width="32" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAJCAYAAABT2S4KAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAF0lEQVR4nGP4P8CAYdQBow4YdcCIdwAAqL97vQWQuOoAAAAASUVORK5CYII="/>
+<image id="image1_28_448" width="40" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAJCAYAAABADm7+AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIUlEQVR4nGP4P8gBw0A7gBAYdSClYNSBlIJRB1IKBr0DAVg9mqzZcxHuAAAAAElFTkSuQmCC"/>
+<image id="image2_28_448" width="42" height="8" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACoAAAAICAYAAACPp21mAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAH0lEQVR4nGP4P0QAw0A7gFgw6lBqg1GHUhuMOpTaAAD3aTsMbpJPbwAAAABJRU5ErkJggg=="/>
+<image id="image3_28_448" width="38" height="8" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAAICAYAAACVm43oAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAHklEQVR4nGP4P0gBw0A7ABcYdRipYNRhpIJRh5EKAFN4u33uxRMjAAAAAElFTkSuQmCC"/>
+<image id="image4_28_448" width="27" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAJCAYAAADDylfFAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVR4nGP4T0fAMGrZqGWjltEcAACIKMhiwoS4ngAAAABJRU5ErkJggg=="/>
+<image id="image5_28_448" width="13" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAJCAYAAADpeqZqAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAEklEQVR4nGP4TwZgGNU0JDQBAGlJ0jyyjOxDAAAAAElFTkSuQmCC"/>
+<image id="image6_28_448" width="91" height="97" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFsAAABhCAYAAAC5191SAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAA6UlEQVR4nO3QQREAMAjAMPybHi6yB42CXueFmd8BlzQbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYaaDTUbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYaaDTUbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYaaDTUbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYYW9FpqHJMJ0QEAAAAASUVORK5CYII="/>
+<image id="image7_28_448" width="75" height="101" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABlCAYAAAAF6B6sAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAA50lEQVR4nO3QQQ0AIAzAwPk3DRbWFyG5U9B0DmvzOuAnZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFF5ib7IDH4nxtAAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/integrations/lingbot/lingbot/webrtc/web/request_session.css
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.css
@@ -95,9 +95,7 @@ body.has-video .mockCanvas {
 .stageVignette {
   z-index: 2;
   pointer-events: none;
-  background:
-    linear-gradient(90deg, rgba(0, 0, 0, 0.48), rgba(0, 0, 0, 0.10) 32%, rgba(0, 0, 0, 0.16) 72%, rgba(0, 0, 0, 0.48)),
-    linear-gradient(180deg, rgba(0, 0, 0, 0.58), rgba(0, 0, 0, 0.08) 28%, rgba(0, 0, 0, 0.66));
+  background: none;
 }
 
 .srOnly {

--- a/integrations/lingbot/lingbot/webrtc/web/request_session.html
+++ b/integrations/lingbot/lingbot/webrtc/web/request_session.html
@@ -32,7 +32,7 @@ limitations under the License.
       <div class="stageVignette" aria-hidden="true"></div>
 
       <header class="brandOverlay" aria-label="FlashDreams World Model">
-        <img class="brandLogo" src="/static/assets/horizontal-light.svg" alt="FlashDreams">
+        <img class="brandLogo" src="/static/assets/horizontal-dark.svg" alt="FlashDreams">
       </header>
 
       <section class="statusCard overlayPanel" aria-live="polite">

--- a/integrations/lingbot/tests/test_distributed_server_main.py
+++ b/integrations/lingbot/tests/test_distributed_server_main.py
@@ -45,6 +45,7 @@ def _args(device: str = "cuda:0") -> Namespace:
         device=device,
         warmup_chunks=10,
         warmup_timeout_s=600.0,
+        fps=16,
     )
 
 
@@ -148,8 +149,11 @@ def test_main_rank0_sends_exit_signal(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda default_device: (torch.device("cuda:2"), 0, 1),
     )
 
-    def _make_manager(runtime_config):
+    manager_fps: list[int] = []
+
+    def _make_manager(runtime_config, fps):
         runtime_configs.append(runtime_config)
+        manager_fps.append(fps)
         return fake_manager
 
     monkeypatch.setattr(server, "LingbotWebRTCSessionManager", _make_manager)
@@ -171,6 +175,7 @@ def test_main_rank0_sends_exit_signal(monkeypatch: pytest.MonkeyPatch) -> None:
     assert fake_manager.wait_called is False
     assert runtime_configs[0].device == "cuda:2"
     assert runtime_configs[0].context_parallel_size == 1
+    assert manager_fps == [16]
     assert request_session_urls == ["http://203.0.113.10:8080/request_session"]
 
 
@@ -189,8 +194,11 @@ def test_main_worker_rank_waits_for_termination(
     monkeypatch.setattr(server.dist, "is_initialized", lambda: False)
     monkeypatch.setattr(server.torch.cuda, "is_available", lambda: False)
 
-    def _make_manager(runtime_config):
+    manager_fps: list[int] = []
+
+    def _make_manager(runtime_config, fps):
         runtime_configs.append(runtime_config)
+        manager_fps.append(fps)
         return fake_manager
 
     monkeypatch.setattr(server, "LingbotWebRTCSessionManager", _make_manager)
@@ -201,3 +209,4 @@ def test_main_worker_rank_waits_for_termination(
     assert fake_manager.exit_called is False
     assert runtime_configs[0].device == "cuda:1"
     assert runtime_configs[0].context_parallel_size == 2
+    assert manager_fps == [16]

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -134,25 +134,26 @@ def _resolve_webrtc_scene_assets(
         if clipgt_dir is None
         else _choose_existing_asset(
             clipgt_dir,
-            fallback_stems=("first_image",),
+            fallback_stems=("first_image_1",),
             allowed_suffixes=WEBRTC_SCENE_IMAGE_SUFFIXES,
             preferred_stems=("first_image",),
         )
     )
     if first_frame_path is None:
-        missing_assets.append(f"first_image.* under {clipgt_dirname}/")
+        missing_assets.append(f"first_image.* under {clipgt_dir}/")
 
     prompt_path = (
         None
         if clipgt_dir is None
         else _choose_existing_asset(
             clipgt_dir,
-            exact_name=prompt_filename,
+            fallback_stems=("prompt1",),
             allowed_suffixes={".txt"},
+            preferred_stems=("prompt",),
         )
     )
     if prompt_path is None:
-        missing_assets.append(f"{prompt_filename} under {clipgt_dirname}/")
+        missing_assets.append(f"{prompt_filename} under {clipgt_dir}/")
 
     if missing_assets:
         raise FileNotFoundError(
@@ -198,6 +199,48 @@ def _safe_extract_zip(source: Path, destination: Path) -> None:
             target.parent.mkdir(parents=True, exist_ok=True)
             with zf.open(member) as src, target.open("wb") as dst:
                 shutil.copyfileobj(src, dst)
+
+
+def _extract_local_webrtc_scene_if_needed(
+    scene_dir: Path,
+    *,
+    scene_uuid: str | None,
+    clipgt_dirname: str,
+) -> Path:
+    """Extract ``scene_uuid`` archive and normalize local WebRTC scene layout."""
+    if scene_uuid is None:
+        return scene_dir
+
+    scene_uuid = scene_uuid.strip()
+    assert scene_uuid, "scene_uuid must be non-empty when provided."
+    if not scene_dir.is_dir():
+        raise FileNotFoundError(f"scene_dir does not exist: {scene_dir}")
+
+    expected_names = (
+        f"clipgt-{scene_uuid}.usdz",
+        f"{scene_uuid}.usdz",
+    )
+    archive_path = _choose_existing_asset(scene_dir, exact_name=expected_names[0]) or (
+        _choose_existing_asset(scene_dir, exact_name=expected_names[1])
+    )
+    if archive_path is None:
+        # Fall back to prefixed local naming like ``clipgt-<uuid>-v2.usdz``.
+        archive_path = _choose_existing_asset(
+            scene_dir,
+            fallback_prefixes=(f"clipgt-{scene_uuid}", scene_uuid),
+            allowed_suffixes={".usdz"},
+            preferred_stems=(f"clipgt-{scene_uuid}", scene_uuid),
+        )
+    if archive_path is None:
+        raise FileNotFoundError(
+            "scene_uuid is set but no local USDZ archive was found in "
+            f"{scene_dir}. Expected one of: {', '.join(expected_names)}."
+        )
+
+    normalized_scene_dir = scene_dir / scene_uuid
+    normalized_clipgt_root = normalized_scene_dir / clipgt_dirname
+    _safe_extract_zip(archive_path, normalized_clipgt_root)
+    return normalized_scene_dir
 
 
 def _ensure_hf_webrtc_scene_synced(
@@ -501,10 +544,11 @@ class OmnidreamsInferenceRuntime:
                 clipgt_dirname=cfg.clipgt_dirname,
             )
         else:
-            assert cfg.scene_uuid is None, (
-                "scene_uuid must be None when scene_dir is set"
+            scene_dir = _extract_local_webrtc_scene_if_needed(
+                cfg.scene_dir,
+                scene_uuid=cfg.scene_uuid,
+                clipgt_dirname=cfg.clipgt_dirname,
             )
-            scene_dir = cfg.scene_dir
 
         cfg.scene_dir = scene_dir
         clipgt_dir, first_frame_path, prompt_path = _resolve_webrtc_scene_assets(

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -99,8 +99,10 @@ def _choose_existing_asset(
             continue
         if allowed_suffixes is not None and path.suffix.lower() not in allowed_suffixes:
             continue
-        if path.stem in fallback_stems or any(
-            path.stem.startswith(f"{prefix}-") for prefix in fallback_prefixes
+        if (
+            path.stem in preferred_stems
+            or path.stem in fallback_stems
+            or any(path.stem.startswith(f"{prefix}-") for prefix in fallback_prefixes)
         ):
             candidates.append(path)
 

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.css
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.css
@@ -96,9 +96,7 @@ body.has-video .stageBackdrop {
 .stageVignette {
   z-index: 3;
   pointer-events: none;
-  background:
-    linear-gradient(90deg, rgba(0, 0, 0, 0.48), rgba(0, 0, 0, 0.10) 32%, rgba(0, 0, 0, 0.16) 72%, rgba(0, 0, 0, 0.48)),
-    linear-gradient(180deg, rgba(0, 0, 0, 0.58), rgba(0, 0, 0, 0.08) 28%, rgba(0, 0, 0, 0.66));
+  background: none;
 }
 
 .srOnly {

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
       <div class="stageVignette" aria-hidden="true"></div>
 
       <header class="brandOverlay" aria-label="FlashDreams World Model">
-        <img class="brandLogo" src="/assets/logo/horizontal-light.svg" alt="FlashDreams">
+        <img class="brandLogo" src="/assets/logo/horizontal-dark.svg" alt="FlashDreams">
       </header>
 
       <section class="statusCard overlayPanel" aria-live="polite">

--- a/integrations/omnidreams/tests/test_webrtc_server_routes.py
+++ b/integrations/omnidreams/tests/test_webrtc_server_routes.py
@@ -80,7 +80,7 @@ async def test_request_session_uses_lingbot_aligned_viewer_shell() -> None:
         assert response.status == 200
         assert 'class="brandOverlay"' in body
         assert "FlashDreams" in body
-        assert "/assets/logo/horizontal-light.svg" in body
+        assert "/assets/logo/horizontal-dark.svg" in body
         assert 'class="statusCard overlayPanel"' in body
         assert 'class="controlCard overlayPanel"' in body
         assert 'class="logCard overlayPanel"' in body
@@ -116,7 +116,7 @@ async def test_shared_flashdreams_brand_asset_is_served() -> None:
     manager = FakeSessionManager()
     client = await _build_client(manager)
     try:
-        response = await client.get("/assets/logo/horizontal-light.svg")
+        response = await client.get("/assets/logo/horizontal-dark.svg")
         assert response.status == 200
         assert response.content_type == "image/svg+xml"
     finally:

--- a/uv.lock
+++ b/uv.lock
@@ -1184,7 +1184,7 @@ provides-extras = ["dev", "examples", "runners", "serving"]
 
 [[package]]
 name = "flashdreams-causal-forcing"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/causal_forcing" }
 dependencies = [
     { name = "flashdreams" },
@@ -1208,7 +1208,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-cosmos-predict2"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/cosmos_predict2" }
 dependencies = [
     { name = "flashdreams" },
@@ -1230,7 +1230,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-fastvideo-causal-wan22"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/fastvideo_causal_wan22" }
 dependencies = [
     { name = "flashdreams" },
@@ -1252,7 +1252,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-flashvsr"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/flashvsr" }
 dependencies = [
     { name = "block-sparse-attn" },
@@ -1286,7 +1286,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-lingbot"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/lingbot" }
 dependencies = [
     { name = "aiohttp" },
@@ -1319,7 +1319,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-omnidreams"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/omnidreams" }
 dependencies = [
     { name = "einops" },
@@ -1390,7 +1390,7 @@ provides-extras = ["interactive-drive", "dev"]
 
 [[package]]
 name = "flashdreams-self-forcing"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/self_forcing" }
 dependencies = [
     { name = "flashdreams" },
@@ -1412,7 +1412,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-wan21"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/wan21" }
 dependencies = [
     { name = "flashdreams" },


### PR DESCRIPTION
Resolves #199 Resolves #175 

- Improved WebRTC viewer visual clarity for both Lingbot and OmniDreams by removing the full-screen vignette darkening overlay, so streamed RGB content is shown without additional dimming.
- Added configurability for Lingbot WebRTC playback framerate by exposing --fps as a server CLI argument and wiring it into session manager initialization.
- Uploaded refreshed demo recordings to the FlashDreams website assets (OmniDreams and Lingbot) and ensured successful website deployment pipelines.
- Updated model-card documentation to point to the newly hosted production (research.nvidia.com) demo video URLs, keeping docs aligned with the latest demos.