### PR TITLE
interactive-drive: add browser-streaming mode with scene picker, HUD, and OOB respawn

### DIFF
--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -125,10 +125,65 @@ Some generated samples from the above commands:
      </div>
    </div>
 
-Launch the interactive server
------------------------------
+Launch the interactive demo
+---------------------------
 
-Spin up the interactive single-view OmniDreams server via WebRTC:
+``interactive-drive`` runs the OmniDreams single-view pipeline in a
+single process and streams the camera view to your browser. The demo
+machine only needs a CUDA-capable GPU -- no graphics-capable GPU,
+display server, or Vulkan toolchain required.
+
+Requires access to `NVIDIA/flashdreams <https://github.com/NVIDIA/flashdreams>`_
+and an ``HF_TOKEN`` with read access to
+`nvidia/omni-dreams-scenes <https://huggingface.co/datasets/nvidia/omni-dreams-scenes>`_
+(scene USDZs) and
+`nvidia/omni-dreams-models <https://huggingface.co/nvidia/omni-dreams-models>`_
+(world-model checkpoints).
+
+First-time setup:
+
+.. code-block:: bash
+
+   git clone git@github.com:NVIDIA/flashdreams.git
+   cd flashdreams
+   export HF_TOKEN=<your-hf-token>
+   uv sync --package flashdreams-omnidreams --extra interactive-drive
+
+Optionally pre-download scenes and checkpoints so the first launch
+isn't blocked on network I/O:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams omnidreams-prepare
+
+Run the demo and stream to your browser:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams interactive-drive --stream-mjpeg :8080
+
+Then open ``http://<server-ip>:8080/`` in any browser on the same
+network and pick a scene from the picker in the bottom-right.
+
+For deployments with a desktop NVIDIA GPU that has a graphics queue,
+omit ``--stream-mjpeg`` to open the demo in a local Vulkan window
+instead:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams interactive-drive
+
+Alternative: WebRTC server
+--------------------------
+
+For deployments that need a richer browser frontend with WebRTC's
+lower video-delivery latency and a streaming gRPC service for
+multi-client setups, the standalone server at
+``omnidreams.webrtc.server`` ships a polished HTML5 client on top of
+the same OmniDreams pipeline. The MJPEG path above is the
+recommended starting point for most users; reach for WebRTC when you
+need bidirectional camera-control APIs or are already integrating
+the gRPC service into a larger product.
 
 .. code-block:: bash
 
@@ -168,40 +223,6 @@ When successfully connected, the browser-based UI looks like this:
    - **Chrome / Edge:** ``chrome://flags/#enable-webrtc-hide-local-ips-with-mdns`` → **Disabled**, then restart the browser.
    - **Brave:** ``brave://settings/privacy/security`` → *WebRTC IP handling policy* → **Default public and private interfaces**.
    - **Firefox:** ``about:config`` → ``media.peerconnection.ice.obfuscate_host_addresses`` → **false**.
-
-Run the desktop demo
---------------------
-
-``interactive-drive`` runs the OmniDreams single-view pipeline in a
-local Vulkan window with keyboard or steering-wheel input. Requires
-access to `NVIDIA/flashdreams <https://github.com/NVIDIA/flashdreams>`_
-and an ``HF_TOKEN`` with read access to
-`nvidia/omni-dreams-scenes <https://huggingface.co/datasets/nvidia/omni-dreams-scenes>`_
-(scene USDZs) and
-`nvidia/omni-dreams-models <https://huggingface.co/nvidia/omni-dreams-models>`_
-(world-model checkpoints).
-
-First-time setup:
-
-.. code-block:: bash
-
-   git clone git@github.com:NVIDIA/flashdreams.git
-   cd flashdreams
-   export HF_TOKEN=<your-hf-token>
-   uv sync --package flashdreams-omnidreams --extra interactive-drive
-
-Optionally pre-download scenes and checkpoints so the first launch
-isn't blocked on network I/O:
-
-.. code-block:: bash
-
-   uv run --package flashdreams-omnidreams omnidreams-prepare
-
-Run the demo:
-
-.. code-block:: bash
-
-   uv run --package flashdreams-omnidreams interactive-drive
 
 Performance table
 -----------------

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -368,33 +368,44 @@ quality starts to drift.
 ### Out-of-bounds warning and auto-respawn
 
 The demo also auto-resets when you drive off the navigable area. The
-simulation thread tracks an OOB *proximity* metric -- the fraction of
-the ego's body-grid raycasts that miss the scene's ground mesh -- and
-the runtime loop reacts to it in two stages:
+implementation mirrors alpasim's ``is_ego_off_map`` algorithm: each
+chunk, the simulation computes how far the ego is from the ground
+mesh's axis-aligned bounding box (expanded by a 50 m margin) and the
+loop reacts to it in two stages:
 
-- **Approaching the edge** (proximity ≥ 0.7): the warning text
+- **Approaching the edge** (proximity ramps `0.0 → 1.0` across the
+  100 m warning zone inside the AABB+margin edge): the warning text
   *"Approaching map edge, turn back to avoid respawn"* is overlaid on
-  the current frame. Steering back onto the navigable area clears it
+  the current frame. Steering back into the navigable area clears it
   on the next chunk.
-- **Out of bounds** (proximity ≥ 0.95 for 3 consecutive chunks): the
-  overlay flips to *"Respawning..."* and the loop triggers the same
-  reset path that `R` uses, so the next iteration starts from the
-  scene's initial pose with a fresh world-model rollout.
+- **Out of bounds** (proximity = `2.0`, set when the ego has actually
+  crossed the AABB+margin boundary): the overlay flips to
+  *"Respawning..."* and the loop triggers the same reset path that `R`
+  uses, so the next iteration starts from the scene's initial pose.
 
-The respawn is debounced by 3 chunks (~800 ms) so a single corner ray
-briefly clipping a sidewalk during a sharp turn doesn't cause a
-teleport. The loop logs every state transition to stderr (e.g.
-`[loop] oob 'in-bounds' -> 'Approaching map edge…' proximity=0.750
-streak=0 action=warning`) so you can confirm the thresholds are firing
-at the right time and tune them if needed.
+Crucially, the respawn is a **binary** trigger — it fires only when
+the ego is actually past the AABB+margin edge, not when it's somewhere
+in the warning ramp. So driving on a sidewalk, brushing curbs, or
+crossing sparse-mesh patches inside the navigable area never trigger a
+teleport; only flying off the entire mapped area does. This matches
+alpasim's behaviour exactly, where ``oob_proximity >= 2.0`` is the
+respawn threshold.
+
+The loop logs every state transition to stderr so you can confirm the
+thresholds are firing at the right time:
+
+```
+[loop] oob 'in-bounds' -> 'Approaching map edge…' proximity=0.620 streak=0 action=warning
+[loop] oob 'Approaching map edge…' -> 'Respawning...' proximity=2.000 streak=1 action=firing respawn
+```
 
 Three CLI flags expose the thresholds:
 
 | Flag | Default | Effect |
 |---|---|---|
-| `--oob-warn-proximity` | `0.7` | Lower values warn earlier; raise if the warning fires while you still feel solidly on the road. |
-| `--oob-respawn-proximity` | `0.95` | Lower values respawn earlier; set to `1.01` to disable auto-respawn entirely while keeping the warning overlay. |
-| `--oob-respawn-debounce-chunks` | `3` | Higher values are stickier (more transient-tolerant); set to `1` to fire on the first qualifying chunk. |
+| `--oob-warn-proximity` | `0.6` | Lower values warn earlier; raise if the warning fires while you still feel solidly on the road. |
+| `--oob-respawn-proximity` | `2.0` | Default `2.0` matches alpasim's binary "off map" sentinel. Set to `2.5` (or any value > `2.0`) to disable auto-respawn entirely while keeping the warning overlay. |
+| `--oob-respawn-debounce-chunks` | `1` | Default `1` matches alpasim's immediate-on-step behaviour. Higher values add a per-chunk buffer; useful mainly if you've lowered the respawn threshold below 2.0. |
 
 Both messages render through the standard `status_message` overlay, so
 they look identical across the HUD, `--no-hud`, and `--stream-mjpeg`

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -217,18 +217,19 @@ this subpackage (via `__file__`), so you don't have to pass long
 `integrations/omnidreams/omnidreams/interactive_drive/...` paths unless
 you want to override them.
 
-There is one entry point — `interactive-drive` — and two modes selected by
+There is one entry point — `interactive-drive` — and three modes selected by
 flags:
 
 | Mode | When to use | How |
 |---|---|---|
 | **HUD (default)** | You have a graphical desktop session and want the full demo: scene/variant selector, steering wheel + pedals overlay, BEV minimap, keyboard *and* wheel input. | `interactive-drive ...` |
 | **Bare backend, local window** | You want the lightweight setup: a single Vulkan window showing the world-model output, no HUD chrome. | `interactive-drive --no-hud ...` |
+| **Bare backend, browser** | The demo machine has no graphics-capable GPU (e.g. compute-only GB300) or you want to view from a laptop browser while the model runs elsewhere. Implies `--no-hud`. | `interactive-drive --stream-mjpeg [HOST:]PORT ...` |
 
-For browser / remote streaming, use the separate
-`omnidreams.webrtc.server` entry point (see [`integrations/omnidreams/README.md`](../../README.md))
-— it ships a WebRTC viewer with a polished frontend and lower latency
-than an in-process HTTP stream would offer.
+For a richer remote-viewing experience with a polished frontend and lower
+latency than an in-process MJPEG stream, prefer the separate
+`omnidreams.webrtc.server` entry point (see
+[`integrations/omnidreams/README.md`](../../README.md)).
 
 The HUD itself uses pygame/SDL2 for rendering, which keeps the demo responsive
 in fullscreen at high display resolutions (press `F11` to toggle). It supervises
@@ -284,7 +285,61 @@ You should initially see the generated driving view. Press `2` to switch to the
 HD map view (conditioning input) and `1` to switch back to the photorealistic
 output.
 
-Controls (apply in both modes):
+### `--stream-mjpeg`: bare backend served over HTTP
+
+Use this when the demo machine has no graphics-capable GPU (e.g. a
+compute-only GB300 in a DGX Station), when you're connecting over the
+network, or when you want to demo from a laptop browser while the model
+runs elsewhere. Implies `--no-hud` because the user is then viewing
+through a browser, not a local Vulkan window — the slangpy HUD itself
+is a Vulkan presenter, so it can't run on the same hosts that need
+`--stream-mjpeg`.
+
+```bash
+uv run --package flashdreams-omnidreams interactive-drive \
+  --stream-mjpeg 8080
+```
+
+Open `http://<host-ip>:8080/` in a browser on the same network; keyboard
+events posted from the page are forwarded to the demo over the same socket.
+The flag accepts `8080`, `:8080`, or `0.0.0.0:8080` (all equivalent — bind
+on all interfaces); pass an explicit host (`127.0.0.1:8080`) to restrict
+the listener to a single interface.
+
+The browser viewer ships an HTML/CSS HUD overlay so the headless demo
+matches the desktop modes' affordances:
+
+- A **speed readout** in the lower-left, rendered in MPH, polls the
+  server's `/state` endpoint at 10 Hz. Reads `--` until the simulation
+  has produced its first chunk; numeric the moment chunks start
+  arriving.
+- **WASD chiclets** light up while the corresponding direction key is
+  held. The page tracks the `keydown`/`keyup` set locally so the
+  highlight is zero-latency (no server round-trip); arrow keys light
+  the same chiclets as their letter equivalents.
+- **Auto-crawl**: releasing throttle keeps the ego creeping toward
+  ~10 mph (4.47 m/s) instead of coasting to a stop, matching the
+  alpasim manual-driver behaviour and the slangpy HUD's keyboard
+  path. The `--stream-mjpeg` presenter routes browser keypresses
+  through the same `KeyboardDriveState` integrator the desktop HUD
+  uses, so it posts `DriverCommand(manual_control=True, ...)` which
+  unlocks the creep branch in `EgoVehicleKinematics.integrate_vehicle`.
+
+If you're running on a remote box (cloud GPU, lab machine, headless
+server), the demo port may not be reachable directly from your laptop.
+Forward the port over SSH (or your provisioner's CLI) and open the
+forwarded URL instead — for example:
+
+```bash
+ssh -L 8080:localhost:8080 <user>@<host>
+```
+
+Then open `http://localhost:8080/`.
+
+For a richer browser frontend with lower latency, prefer the separate
+`omnidreams.webrtc.server` entry point.
+
+Controls (apply in all three modes):
 
 - `W` throttle
 - `S` brake / reverse drag
@@ -309,6 +364,28 @@ especially after extended driving without a reset. This does not necessarily
 mean the demo is broken. Press `R` to restart from the scene's initial clean
 state. For long demos, reset every 30-50 generated chunks or whenever visual
 quality starts to drift.
+
+### Out-of-bounds warning and auto-respawn
+
+The demo also auto-resets when you drive off the navigable area. The
+simulation thread tracks an OOB *proximity* metric -- the fraction of
+the ego's body-grid raycasts that miss the scene's ground mesh -- and
+the runtime loop reacts to it in two stages:
+
+- **Approaching the edge** (proximity ≥ 0.5): the warning text
+  *"Approaching map edge, turn back to avoid respawn"* is overlaid on
+  the current frame. Steering back onto the navigable area clears it
+  on the next chunk.
+- **Out of bounds** (proximity ≥ 0.85): the overlay flips to
+  *"Respawning..."* and the loop triggers the same reset path that `R`
+  uses, so the next iteration starts from the scene's initial pose
+  with a fresh world-model rollout.
+
+Both messages render through the standard `status_message` overlay, so
+they look identical across the HUD, `--no-hud`, and `--stream-mjpeg`
+presenters. Scenes that ship no ground mesh (legacy fixtures with no
+`mesh_ground.ply`) report proximity `0.0` and never auto-respawn -- you
+get the same behaviour as the older builds.
 
 ### Without HD-map data (synthetic scene)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -372,14 +372,29 @@ simulation thread tracks an OOB *proximity* metric -- the fraction of
 the ego's body-grid raycasts that miss the scene's ground mesh -- and
 the runtime loop reacts to it in two stages:
 
-- **Approaching the edge** (proximity ≥ 0.5): the warning text
+- **Approaching the edge** (proximity ≥ 0.7): the warning text
   *"Approaching map edge, turn back to avoid respawn"* is overlaid on
   the current frame. Steering back onto the navigable area clears it
   on the next chunk.
-- **Out of bounds** (proximity ≥ 0.85): the overlay flips to
-  *"Respawning..."* and the loop triggers the same reset path that `R`
-  uses, so the next iteration starts from the scene's initial pose
-  with a fresh world-model rollout.
+- **Out of bounds** (proximity ≥ 0.95 for 3 consecutive chunks): the
+  overlay flips to *"Respawning..."* and the loop triggers the same
+  reset path that `R` uses, so the next iteration starts from the
+  scene's initial pose with a fresh world-model rollout.
+
+The respawn is debounced by 3 chunks (~800 ms) so a single corner ray
+briefly clipping a sidewalk during a sharp turn doesn't cause a
+teleport. The loop logs every state transition to stderr (e.g.
+`[loop] oob 'in-bounds' -> 'Approaching map edge…' proximity=0.750
+streak=0 action=warning`) so you can confirm the thresholds are firing
+at the right time and tune them if needed.
+
+Three CLI flags expose the thresholds:
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--oob-warn-proximity` | `0.7` | Lower values warn earlier; raise if the warning fires while you still feel solidly on the road. |
+| `--oob-respawn-proximity` | `0.95` | Lower values respawn earlier; set to `1.01` to disable auto-respawn entirely while keeping the warning overlay. |
+| `--oob-respawn-debounce-chunks` | `3` | Higher values are stickier (more transient-tolerant); set to `1` to fire on the first qualifying chunk. |
 
 Both messages render through the standard `status_message` overlay, so
 they look identical across the HUD, `--no-hud`, and `--stream-mjpeg`

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -309,6 +309,14 @@ the listener to a single interface.
 The browser viewer ships an HTML/CSS HUD overlay so the headless demo
 matches the desktop modes' affordances:
 
+- A **scene picker** in the upper-right lists the same scenes the
+  slangpy HUD discovers (anything under `--scene-dir`, defaulting to
+  `$FLASHDREAMS_CACHE_DIR/omnidreams-scenes/`). Pick a scene and a
+  variant, click *Load Scene*, and the demo tears down the current
+  rollout and rebuilds with the new scene without dropping the
+  browser session — the stream pauses briefly during the rebuild and
+  resumes the moment the new pipeline produces its first chunk. The
+  picker is hidden when no scenes were discovered.
 - A **speed readout** in the lower-left, rendered in MPH, polls the
   server's `/state` endpoint at 10 Hz. Reads `--` until the simulation
   has produced its first chunk; numeric the moment chunks start

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -368,10 +368,17 @@ quality starts to drift.
 ### Out-of-bounds warning and auto-respawn
 
 The demo also auto-resets when you drive off the navigable area. The
-implementation mirrors alpasim's ``is_ego_off_map`` algorithm: each
-chunk, the simulation computes how far the ego is from the ground
-mesh's axis-aligned bounding box (expanded by a 50 m margin) and the
-loop reacts to it in two stages:
+implementation mirrors alpasim's ``is_ego_off_map`` algorithm: at scene
+load time the demo computes an axis-aligned bounding box of **every**
+spatial layer in the scene (lane markers, drivable triangles,
+polygons, vehicle tracks, ground mesh) and prints it to stderr, e.g.
+
+```
+[ego_vehicle_kinematics] map bounds: x=[-127.4, 218.9] (346.3 m), y=[-89.6, 142.3] (231.9 m). Adds 50 m margin + 100 m warning zone for OOB.
+```
+
+Each chunk, the simulation computes how far the ego is from this AABB
+expanded by a 50 m margin and the loop reacts to it in two stages:
 
 - **Approaching the edge** (proximity ramps `0.0 → 1.0` across the
   100 m warning zone inside the AABB+margin edge): the warning text
@@ -381,15 +388,16 @@ loop reacts to it in two stages:
 - **Out of bounds** (proximity = `2.0`, set when the ego has actually
   crossed the AABB+margin boundary): the overlay flips to
   *"Respawning..."* and the loop triggers the same reset path that `R`
-  uses, so the next iteration starts from the scene's initial pose.
+  uses.
 
 Crucially, the respawn is a **binary** trigger — it fires only when
 the ego is actually past the AABB+margin edge, not when it's somewhere
-in the warning ramp. So driving on a sidewalk, brushing curbs, or
-crossing sparse-mesh patches inside the navigable area never trigger a
-teleport; only flying off the entire mapped area does. This matches
-alpasim's behaviour exactly, where ``oob_proximity >= 2.0`` is the
-respawn threshold.
+in the warning ramp. Driving on a sidewalk, brushing curbs, or
+crossing sparse-mesh patches *inside* the navigable area never trigger
+a teleport; only flying off the entire mapped area does. Because the
+AABB is the union of all geometry (not just the ground mesh, which is
+often a small strip representing only the road surface), it covers the
+full extent of where the scene "contains" content.
 
 The loop logs every state transition to stderr so you can confirm the
 thresholds are firing at the right time:
@@ -399,19 +407,21 @@ thresholds are firing at the right time:
 [loop] oob 'Approaching map edge…' -> 'Respawning...' proximity=2.000 streak=1 action=firing respawn
 ```
 
-Three CLI flags expose the thresholds:
+Five CLI flags expose the OOB knobs:
 
 | Flag | Default | Effect |
 |---|---|---|
-| `--oob-warn-proximity` | `0.6` | Lower values warn earlier; raise if the warning fires while you still feel solidly on the road. |
+| `--oob-margin-m` | `50` | Margin (m) added around the geometry AABB. Bigger = more room before the boundary. |
+| `--oob-warning-zone-m` | `100` | Depth (m) of the warning-ramp band inside the AABB+margin edge. Set to `0` to disable the ramp. |
+| `--oob-warn-proximity` | `0.6` | Lower values warn earlier. |
 | `--oob-respawn-proximity` | `2.0` | Default `2.0` matches alpasim's binary "off map" sentinel. Set to `2.5` (or any value > `2.0`) to disable auto-respawn entirely while keeping the warning overlay. |
-| `--oob-respawn-debounce-chunks` | `1` | Default `1` matches alpasim's immediate-on-step behaviour. Higher values add a per-chunk buffer; useful mainly if you've lowered the respawn threshold below 2.0. |
+| `--oob-respawn-debounce-chunks` | `1` | Default `1` matches alpasim. Higher values add a per-chunk buffer. |
 
 Both messages render through the standard `status_message` overlay, so
 they look identical across the HUD, `--no-hud`, and `--stream-mjpeg`
-presenters. Scenes that ship no ground mesh (legacy fixtures with no
-`mesh_ground.ply`) report proximity `0.0` and never auto-respawn -- you
-get the same behaviour as the older builds.
+presenters. Scenes that ship no spatial geometry report proximity
+`0.0` and never auto-respawn -- you get the same behaviour as the
+older builds.
 
 ### Without HD-map data (synthetic scene)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -143,9 +143,7 @@ class InteractiveDriveApp:
                 self._presenter.close()
 
 
-def _build_presenter(
-    config: AppConfig, keyboard: KeyboardState
-) -> PresenterBackend:
+def _build_presenter(config: AppConfig, keyboard: KeyboardState) -> PresenterBackend:
     """Default presenter factory.
 
     Returns an :class:`MJPEGStreamingPresenter` when

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -118,6 +118,11 @@ class InteractiveDriveApp:
                         initial_chunk_size=self._config.chunk.initial_chunk_frames,
                         chunk_size=self._config.chunk.chunk_frames,
                         frame_interval_s=self._config.chunk.frame_interval_s,
+                        oob_warn_proximity=self._config.oob_warn_proximity,
+                        oob_respawn_proximity=self._config.oob_respawn_proximity,
+                        oob_respawn_debounce_chunks=(
+                            self._config.oob_respawn_debounce_chunks
+                        ),
                     ),
                 )
                 if not reset_requested:

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -20,6 +20,7 @@ from omnidreams.interactive_drive.scene_loader import load_scene_bundle
 from omnidreams.interactive_drive.simulation.ego_vehicle_kinematics import (
     EgoVehicleKinematics,
     build_ground_snapper,
+    build_map_bounds,
     state_from_initial_pose,
 )
 from omnidreams.interactive_drive.streaming_presenter import (
@@ -90,6 +91,10 @@ class InteractiveDriveApp:
         )
         local_backend = LocalVideoModelAdapter(self._backend)
         pipeline = ChunkPipeline(local_backend, self._scene)
+        # Build the OOB map bounds once at scene load -- the AABB is a
+        # property of the scene's geometry and is invariant across the
+        # rollout-restart loop below.
+        map_bounds = build_map_bounds(self._scene)
         try:
             while not self._presenter.should_close:
                 simulation = EgoVehicleKinematics(
@@ -105,6 +110,9 @@ class InteractiveDriveApp:
                     vehicle_config=self._config.vehicle,
                     ground_snapper=build_ground_snapper(self._scene),
                     initial_timestamp_us=self._scene.initial_timestamp_us,
+                    map_bounds=map_bounds,
+                    oob_margin_m=self._config.oob_margin_m,
+                    oob_warning_zone_m=self._config.oob_warning_zone_m,
                 )
                 input_backend = KeyboardInputBackend(self._keyboard)
                 reset_requested = run_main_loop(

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -22,6 +22,10 @@ from omnidreams.interactive_drive.simulation.ego_vehicle_kinematics import (
     build_ground_snapper,
     state_from_initial_pose,
 )
+from omnidreams.interactive_drive.streaming_presenter import (
+    MJPEGStreamingPresenter,
+    parse_bind,
+)
 from omnidreams.interactive_drive.types import PresentedFrame
 from omnidreams.interactive_drive.video_model.chunk_pipeline import ChunkPipeline
 from omnidreams.interactive_drive.video_model.local import LocalVideoModelAdapter
@@ -44,11 +48,12 @@ class InteractiveDriveApp:
         presenter (e.g. :class:`SlangPyHudPresenter`) that needs
         constructor arguments outside :class:`AppConfig`'s vocabulary
         (scene-selector options, wheel device, control assets). When
-        ``None``, :func:`_build_presenter` returns the default
-        :class:`SlangPyPresenter` -- a local Vulkan window. Browser /
-        remote streaming use cases are served by
-        ``omnidreams.webrtc.server`` instead of an in-process HTTP
-        stream on the demo.
+        ``None``, :func:`_build_presenter` returns either the default
+        :class:`SlangPyPresenter` (a local Vulkan window) or, when
+        ``config.stream_mjpeg_bind`` is set, an
+        :class:`MJPEGStreamingPresenter` that serves frames over HTTP
+        with no GPU-graphics dependency. Browser viewers with a richer
+        frontend are served by ``omnidreams.webrtc.server`` instead.
         """
         self._config = config
         self._backend = backend
@@ -125,12 +130,28 @@ class InteractiveDriveApp:
                 self._presenter.close()
 
 
-def _build_presenter(config: AppConfig, keyboard: KeyboardState) -> SlangPyPresenter:
-    """Default presenter factory: a local Vulkan window via slangpy.
+def _build_presenter(
+    config: AppConfig, keyboard: KeyboardState
+) -> PresenterBackend:
+    """Default presenter factory.
 
-    Browser / remote streaming use cases are served by
-    ``omnidreams.webrtc.server`` (a separate entry point), not by an
-    in-process HTTP stream on the desktop demo. Hosts without a
-    graphics-capable GPU should run the webrtc server instead.
+    Returns an :class:`MJPEGStreamingPresenter` when
+    ``config.stream_mjpeg_bind`` is set (a HOST:PORT bind address) --
+    that path renders no window and has no graphics-GPU dependency, so
+    it works on compute-only SKUs (e.g. GB300) where SlangPy can't
+    create a Vulkan swapchain. Otherwise returns the default
+    :class:`SlangPyPresenter` -- a local Vulkan window.
+
+    For browser viewers with a richer frontend, ``omnidreams.webrtc.server``
+    (a separate entry point) is the preferred path; this MJPEG fallback
+    is the in-process, dependency-free alternative for headless boxes.
     """
+    if config.stream_mjpeg_bind is not None:
+        host, port = parse_bind(config.stream_mjpeg_bind)
+        return MJPEGStreamingPresenter(
+            raster=config.raster,
+            keyboard=keyboard,
+            bind_host=host,
+            bind_port=port,
+        )
     return SlangPyPresenter(raster=config.raster, keyboard=keyboard)

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -308,6 +308,31 @@ def build_parser() -> argparse.ArgumentParser:
             "if you've lowered the respawn threshold below 2.0."
         ),
     )
+    parser.add_argument(
+        "--oob-margin-m",
+        type=float,
+        default=None,
+        metavar="METERS",
+        help=(
+            "Margin (in metres) added around the scene's spatial-content "
+            "AABB before any in-bounds check. The respawn fires only "
+            "once the ego is past AABB+margin, so larger values give "
+            "more room to leave the explicitly mapped area. Default 50, "
+            "matching alpasim. Bump to 200+ on scenes whose geometry "
+            "layers don't cover the full driveable area."
+        ),
+    )
+    parser.add_argument(
+        "--oob-warning-zone-m",
+        type=float,
+        default=None,
+        metavar="METERS",
+        help=(
+            "Depth of the linear warning-ramp band inside the AABB+margin "
+            "edge. Default 100, matching alpasim. Set to 0 to disable the "
+            "ramp and only ever show the binary on/off respawn signal."
+        ),
+    )
     return parser
 
 
@@ -343,6 +368,10 @@ def _oob_kwargs(args: argparse.Namespace) -> dict[str, float | int]:
         overrides["oob_respawn_debounce_chunks"] = int(
             args.oob_respawn_debounce_chunks
         )
+    if args.oob_margin_m is not None:
+        overrides["oob_margin_m"] = float(args.oob_margin_m)
+    if args.oob_warning_zone_m is not None:
+        overrides["oob_warning_zone_m"] = float(args.oob_warning_zone_m)
     return overrides
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -271,12 +271,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="FLOAT",
         help=(
-            "Body-grid miss-fraction at which the loop overlays "
+            "Proximity at which the loop overlays "
             "'Approaching map edge, turn back to avoid respawn' on the "
-            "frame. Range [0.0, 1.0]; 0.0 = solidly in-bounds, 1.0 = no "
-            "rays hit the ground mesh. Defaults to 0.7. Lower values "
-            "warn earlier; raise this if the warning fires while you "
-            "still feel solidly on the road."
+            "frame. Mirrors alpasim's ``oob_proximity``: 0.0 is solidly "
+            "inside the navigable AABB+margin, 1.0 is at the AABB+margin "
+            "edge (the warning band ramps linearly across a 100 m zone "
+            "inside the edge), 2.0 is the off-map sentinel. Default 0.6, "
+            "matching alpasim's 'approaching' threshold."
         ),
     )
     parser.add_argument(
@@ -285,11 +286,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="FLOAT",
         help=(
-            "Body-grid miss-fraction above which the loop fires the "
-            "auto-respawn (after ``--oob-respawn-debounce-chunks`` "
-            "consecutive chunks at this level). Defaults to 0.95 "
-            "(essentially the entire body off the mesh). Set to 1.01 "
-            "to disable auto-respawn entirely while keeping the warning "
+            "Proximity above which the loop fires the auto-respawn (after "
+            "``--oob-respawn-debounce-chunks`` consecutive chunks at this "
+            "level). Default 2.0, matching alpasim: a hard binary trigger "
+            "that only fires when the ego has actually crossed the "
+            "AABB+margin boundary. Set to 2.5 (or any value > 2.0) to "
+            "disable auto-respawn entirely while keeping the warning "
             "overlay."
         ),
     )
@@ -299,10 +301,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="N",
         help=(
-            "Number of consecutive chunks the proximity must stay above "
-            "``--oob-respawn-proximity`` before the auto-respawn fires. "
-            "Defaults to 3 (~800 ms at 8-frame chunks). Set to 1 to "
-            "fire on the first qualifying chunk."
+            "Number of consecutive chunks the proximity must stay at or "
+            "above ``--oob-respawn-proximity`` before the auto-respawn "
+            "fires. Default 1, matching alpasim's immediate-on-step "
+            "behaviour. Raise this for an added buffer; useful mainly "
+            "if you've lowered the respawn threshold below 2.0."
         ),
     )
     return parser

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -365,9 +365,7 @@ def _oob_kwargs(args: argparse.Namespace) -> dict[str, float | int]:
     if args.oob_respawn_proximity is not None:
         overrides["oob_respawn_proximity"] = float(args.oob_respawn_proximity)
     if args.oob_respawn_debounce_chunks is not None:
-        overrides["oob_respawn_debounce_chunks"] = int(
-            args.oob_respawn_debounce_chunks
-        )
+        overrides["oob_respawn_debounce_chunks"] = int(args.oob_respawn_debounce_chunks)
     if args.oob_margin_m is not None:
         overrides["oob_margin_m"] = float(args.oob_margin_m)
     if args.oob_warning_zone_m is not None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -204,6 +204,23 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--stream-mjpeg",
+        default=None,
+        metavar="[HOST:]PORT",
+        help=(
+            "Instead of opening a Vulkan window, serve frames as an MJPEG "
+            "HTTP stream on this bind address. Accepts ``HOST:PORT`` (e.g. "
+            "``127.0.0.1:8080``), bare ``:PORT``, or a bare port number "
+            "(``8080``); the bare forms bind on all interfaces. The user "
+            "opens http://HOST:PORT/ in a browser to view the demo and "
+            "send keyboard input. Useful on compute-only hosts (e.g. "
+            "GB300-only DGX Station) where no Vulkan-capable GPU exists; "
+            "for a richer browser viewer prefer the separate "
+            "``omnidreams.webrtc.server`` entry point. Implies --no-hud "
+            "when launched via the demo wrapper."
+        ),
+    )
+    parser.add_argument(
         "--bev",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -351,6 +368,7 @@ def prepare_config_and_backend(
         ),
         world_model_offload_text_encoder=bool(args.offload_text_encoder),
         bev=bev_config,
+        stream_mjpeg_bind=args.stream_mjpeg,
     )
 
     backend: RenderBackend

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -265,6 +265,46 @@ def build_parser() -> argparse.ArgumentParser:
             " so the bottom of the image doesn't cross the horizon."
         ),
     )
+    parser.add_argument(
+        "--oob-warn-proximity",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help=(
+            "Body-grid miss-fraction at which the loop overlays "
+            "'Approaching map edge, turn back to avoid respawn' on the "
+            "frame. Range [0.0, 1.0]; 0.0 = solidly in-bounds, 1.0 = no "
+            "rays hit the ground mesh. Defaults to 0.7. Lower values "
+            "warn earlier; raise this if the warning fires while you "
+            "still feel solidly on the road."
+        ),
+    )
+    parser.add_argument(
+        "--oob-respawn-proximity",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help=(
+            "Body-grid miss-fraction above which the loop fires the "
+            "auto-respawn (after ``--oob-respawn-debounce-chunks`` "
+            "consecutive chunks at this level). Defaults to 0.95 "
+            "(essentially the entire body off the mesh). Set to 1.01 "
+            "to disable auto-respawn entirely while keeping the warning "
+            "overlay."
+        ),
+    )
+    parser.add_argument(
+        "--oob-respawn-debounce-chunks",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Number of consecutive chunks the proximity must stay above "
+            "``--oob-respawn-proximity`` before the auto-respawn fires. "
+            "Defaults to 3 (~800 ms at 8-frame chunks). Set to 1 to "
+            "fire on the first qualifying chunk."
+        ),
+    )
     return parser
 
 
@@ -281,6 +321,26 @@ def _parse_resolution(value: str) -> tuple[int, int]:
     if width <= 0 or height <= 0:
         raise SystemExit(f"--bev-resolution must be positive: {value!r}")
     return width, height
+
+
+def _oob_kwargs(args: argparse.Namespace) -> dict[str, float | int]:
+    """Forward only the OOB flags the user actually passed.
+
+    Each ``--oob-*`` flag defaults to ``None`` so the
+    :class:`AppConfig` field defaults stay authoritative; we only add
+    a kwarg to the ``AppConfig(**kwargs)`` call when the user passed
+    an explicit value.
+    """
+    overrides: dict[str, float | int] = {}
+    if args.oob_warn_proximity is not None:
+        overrides["oob_warn_proximity"] = float(args.oob_warn_proximity)
+    if args.oob_respawn_proximity is not None:
+        overrides["oob_respawn_proximity"] = float(args.oob_respawn_proximity)
+    if args.oob_respawn_debounce_chunks is not None:
+        overrides["oob_respawn_debounce_chunks"] = int(
+            args.oob_respawn_debounce_chunks
+        )
+    return overrides
 
 
 def main() -> None:
@@ -369,6 +429,7 @@ def prepare_config_and_backend(
         world_model_offload_text_encoder=bool(args.offload_text_encoder),
         bev=bev_config,
         stream_mjpeg_bind=args.stream_mjpeg,
+        **_oob_kwargs(args),
     )
 
     backend: RenderBackend

--- a/integrations/omnidreams/omnidreams/interactive_drive/config.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/config.py
@@ -138,6 +138,14 @@ class AppConfig:
     world_model_profile: WorldModelProfileConfig = WorldModelProfileConfig()
     world_model_offload_text_encoder: bool = False
     bev: BevConfig = BevConfig()
+    # Out-of-bounds detection thresholds plumbed through to
+    # :class:`~omnidreams.interactive_drive.runtime.loop.LoopConfig`.
+    # Exposed on AppConfig so the CLI's ``--oob-*`` flags can override
+    # them per-run; the defaults match the LoopConfig defaults so the
+    # behaviour is identical when the flags aren't passed.
+    oob_warn_proximity: float = 0.7
+    oob_respawn_proximity: float = 0.95
+    oob_respawn_debounce_chunks: int = 3
     # When non-None, the app swaps the Vulkan presenter out for
     # :class:`omnidreams.interactive_drive.streaming_presenter.MJPEGStreamingPresenter`
     # which serves frames to a browser over HTTP and reads keyboard

--- a/integrations/omnidreams/omnidreams/interactive_drive/config.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/config.py
@@ -138,6 +138,15 @@ class AppConfig:
     world_model_profile: WorldModelProfileConfig = WorldModelProfileConfig()
     world_model_offload_text_encoder: bool = False
     bev: BevConfig = BevConfig()
+    # When non-None, the app swaps the Vulkan presenter out for
+    # :class:`omnidreams.interactive_drive.streaming_presenter.MJPEGStreamingPresenter`
+    # which serves frames to a browser over HTTP and reads keyboard
+    # events back from it. Format: "HOST:PORT" (e.g. "0.0.0.0:8080"),
+    # or bare ":PORT" to bind on all interfaces. Required on
+    # compute-only boxes (e.g. GB300-only DGX Station) where no
+    # Vulkan-capable GPU exists; for richer browser viewers prefer
+    # ``omnidreams.webrtc.server`` instead.
+    stream_mjpeg_bind: str | None = None
     # Substring to match against the Vulkan adapter name for the presenter.
     # When None, SlangPy picks whichever Vulkan adapter it enumerates first.
     # When set (e.g. "RTX PRO"), we call ``spy.Device.enumerate_adapters``

--- a/integrations/omnidreams/omnidreams/interactive_drive/config.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/config.py
@@ -148,6 +148,17 @@ class AppConfig:
     oob_warn_proximity: float = 0.6
     oob_respawn_proximity: float = 2.0
     oob_respawn_debounce_chunks: int = 1
+    # OOB AABB geometry. ``oob_margin_m`` expands the scene's
+    # spatial-content AABB before any in-bounds check (alpasim uses
+    # 50 m around the GT trajectory; we use the same default around
+    # the union of all scene geometry). ``oob_warning_zone_m`` is the
+    # depth of the linear ramp inside that expanded AABB where the
+    # warning overlay shows. Set ``oob_margin_m`` higher to give the
+    # ego more room to leave the geometry-covered area without firing
+    # the respawn -- useful on scenes whose geometry layers don't
+    # cover the full driveable area.
+    oob_margin_m: float = 50.0
+    oob_warning_zone_m: float = 100.0
     # When non-None, the app swaps the Vulkan presenter out for
     # :class:`omnidreams.interactive_drive.streaming_presenter.MJPEGStreamingPresenter`
     # which serves frames to a browser over HTTP and reads keyboard

--- a/integrations/omnidreams/omnidreams/interactive_drive/config.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/config.py
@@ -142,10 +142,12 @@ class AppConfig:
     # :class:`~omnidreams.interactive_drive.runtime.loop.LoopConfig`.
     # Exposed on AppConfig so the CLI's ``--oob-*`` flags can override
     # them per-run; the defaults match the LoopConfig defaults so the
-    # behaviour is identical when the flags aren't passed.
-    oob_warn_proximity: float = 0.7
-    oob_respawn_proximity: float = 0.95
-    oob_respawn_debounce_chunks: int = 3
+    # behaviour is identical when the flags aren't passed. Mirrors
+    # alpasim's driver-side thresholds (warn > 0.6, respawn >= 2.0
+    # against the AABB-distance proximity).
+    oob_warn_proximity: float = 0.6
+    oob_respawn_proximity: float = 2.0
+    oob_respawn_debounce_chunks: int = 1
     # When non-None, the app swaps the Vulkan presenter out for
     # :class:`omnidreams.interactive_drive.streaming_presenter.MJPEGStreamingPresenter`
     # which serves frames to a browser over HTTP and reads keyboard

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -477,17 +477,19 @@ def build_parser() -> argparse.ArgumentParser:
     The parser is the union of three groups:
 
     * Backend args (``--scene``, ``--backend``, ``--manifest``,
-      ``--bev``, ...) inherited verbatim from
+      ``--bev``, ``--stream-mjpeg``, ...) inherited verbatim from
       :func:`omnidreams.interactive_drive.cli.build_parser`. These
       flags apply whether the user runs the supervised HUD wrapper or
-      the bare backend with ``--no-hud``.
+      the bare backend with ``--no-hud`` / ``--stream-mjpeg``.
     * Supervisor / HUD args (``--scene-dir``, ``--autoload-scene``,
       ``--cuda-visible-devices``, ``--wheel-*``, ``--no-wheel``) that
       only matter when a HUD viewer is running. They're harmlessly
-      ignored under ``--no-hud``.
+      ignored under ``--no-hud`` / ``--stream-mjpeg``.
     * The ``--no-hud`` toggle itself, which falls through to the bare
-      slangpy Vulkan window. Browser-stream use cases are served by
-      ``omnidreams.webrtc.server`` instead.
+      slangpy Vulkan window. ``--stream-mjpeg`` (in the inherited
+      backend group) implicitly does the same and serves the bare
+      backend's frames over HTTP. For a richer browser frontend use
+      ``omnidreams.webrtc.server``.
     """
     parser = _cli.build_parser()
     # Demo-friendly defaults: most users want the world model and the
@@ -505,7 +507,10 @@ def build_parser() -> argparse.ArgumentParser:
         " scene/variant selector, BEV minimap, and steering / pedal"
         " overlays, all rendered into a single Vulkan swapchain. Pass"
         " --no-hud to drop the chrome and just open the bare slangpy"
-        " Vulkan window. For browser / remote streaming use the separate"
+        " Vulkan window, or --stream-mjpeg HOST:PORT to skip the local"
+        " window entirely and serve frames to a browser as an MJPEG"
+        " HTTP stream (useful on compute-only hosts without a Vulkan"
+        " GPU). For a richer browser viewer use the separate"
         " ``omnidreams.webrtc.server`` entry point."
     )
     parser.add_argument(
@@ -625,9 +630,14 @@ def main() -> None:
     if not args.synthetic_scene:
         args.scene = _maybe_autostage_scene(args.scene)
     # ``--no-hud`` drops the slangpy HUD chrome and runs the backend
-    # against a bare Vulkan window. Browser / remote use cases live
-    # in the separate ``omnidreams.webrtc.server`` entry point.
-    if args.no_hud:
+    # against a bare Vulkan window. ``--stream-mjpeg`` similarly skips
+    # the HUD because the HUD itself is a Vulkan / SlangPy presenter
+    # and has the same graphics-GPU requirement we're trying to avoid;
+    # the bare CLI's ``_build_presenter`` then sees ``stream_mjpeg_bind``
+    # in :class:`AppConfig` and constructs the
+    # :class:`MJPEGStreamingPresenter` instead. For a richer browser
+    # frontend, ``omnidreams.webrtc.server`` remains the preferred path.
+    if args.no_hud or args.stream_mjpeg is not None:
         _cli.run(args)
         return
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -629,15 +629,16 @@ def main() -> None:
     args = build_parser().parse_args()
     if not args.synthetic_scene:
         args.scene = _maybe_autostage_scene(args.scene)
-    # ``--no-hud`` drops the slangpy HUD chrome and runs the backend
-    # against a bare Vulkan window. ``--stream-mjpeg`` similarly skips
-    # the HUD because the HUD itself is a Vulkan / SlangPy presenter
-    # and has the same graphics-GPU requirement we're trying to avoid;
-    # the bare CLI's ``_build_presenter`` then sees ``stream_mjpeg_bind``
-    # in :class:`AppConfig` and constructs the
-    # :class:`MJPEGStreamingPresenter` instead. For a richer browser
-    # frontend, ``omnidreams.webrtc.server`` remains the preferred path.
-    if args.no_hud or args.stream_mjpeg is not None:
+    # ``--stream-mjpeg`` runs through ``_run_streaming`` so the long-lived
+    # MJPEG presenter (HTTP server, browser session) survives across
+    # scene-change requests posted by the in-page picker. ``--no-hud``
+    # without MJPEG drops straight through to the bare CLI's Vulkan
+    # window, which has no scene picker UI of its own. The default path
+    # is the slangpy HUD with full chrome.
+    if args.stream_mjpeg is not None:
+        _run_streaming(args)
+        return
+    if args.no_hud:
         _cli.run(args)
         return
 
@@ -783,6 +784,110 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
             args.scene = new_scene_path
             args.variant = new_variant
             presenter.acknowledge_scene_change(new_scene_path, new_variant)
+    finally:
+        presenter.close()
+
+
+def _run_streaming(args: argparse.Namespace) -> None:
+    """Run the engine with the MJPEG streaming presenter and a scene-change loop.
+
+    Mirrors :func:`_run_slangpy_hud`'s outer-loop structure but with a
+    long-lived :class:`MJPEGStreamingPresenter` instead of a slangpy
+    window. The HTTP server (and any connected browser sessions) stay
+    alive across scene transitions; only the backend / pipeline /
+    simulation get rebuilt per scene. The browser shows the loading
+    overlay during the rebuild and resumes streaming the moment the
+    new pipeline produces its first chunk.
+
+    Scene options come from the same discovery layer the slangpy HUD
+    uses. They get serialised into a JSON-friendly shape and posted to
+    the presenter so the in-browser ``/scenes`` endpoint can populate
+    its dropdown without round-tripping through the SceneOption class.
+    """
+    from omnidreams.interactive_drive.input.keyboard import KeyboardState
+    from omnidreams.interactive_drive.streaming_presenter import (
+        MJPEGStreamingPresenter,
+        parse_bind,
+    )
+
+    _apply_cuda_visible_devices_inplace(args.cuda_visible_devices)
+    _resolve_demo_paths(args)
+    scene_options = _discover_scene_options(args.scene_dir, args.scene)
+    if not args.scene.exists() and scene_options:
+        args.scene = scene_options[0].path
+    if args.backend == "omnidreams":
+        if args.manifest is None:
+            raise SystemExit("--manifest is required for the omnidreams backend")
+        if not args.manifest.exists():
+            raise SystemExit(
+                f"--manifest path does not exist: {args.manifest}"
+                " (typo? expected a path or bundled config name like "
+                "example_world_model.yaml)"
+            )
+    if not scene_options and not args.scene.exists():
+        raise SystemExit(
+            f"--scene path does not exist and --scene-dir contains no scenes: {args.scene}"
+        )
+
+    # JSON-serialisable form of the discovered scenes for the browser
+    # ``/scenes`` endpoint. Thumbnails are dropped because the browser
+    # gets the live stream once a scene loads; a static thumbnail
+    # endpoint would just add more handlers without much UX win.
+    scenes_payload = tuple(
+        {
+            "label": opt.label,
+            "path": str(opt.path),
+            "variants": list(opt.variants),
+        }
+        for opt in scene_options
+    )
+
+    bind_host, bind_port = parse_bind(args.stream_mjpeg)
+    placeholder_keyboard = KeyboardState()
+    presenter = MJPEGStreamingPresenter(
+        raster=RasterConfig(),
+        keyboard=placeholder_keyboard,
+        bind_host=bind_host,
+        bind_port=bind_port,
+        scenes=scenes_payload,
+    )
+
+    def _factory(config: object, keyboard: KeyboardState) -> MJPEGStreamingPresenter:
+        # Each ``InteractiveDriveApp.__init__`` builds a fresh
+        # ``KeyboardState``; rebind so the long-lived presenter
+        # follows the new instance instead of writing into the
+        # placeholder keyboard from before the first scene loaded.
+        del config
+        presenter.bind_keyboard(keyboard)
+        return presenter
+
+    try:
+        while True:
+            config, backend = _cli.prepare_config_and_backend(args)
+            app = InteractiveDriveApp(
+                config=config,
+                backend=backend,
+                presenter_factory=_factory,
+                close_presenter_on_exit=False,
+            )
+            app.run()
+            requested = presenter.pending_scene_change
+            if requested is None:
+                # Either the process is shutting down (Ctrl-C) or the
+                # rollout finished without a scene-change request.
+                # ``MJPEGStreamingPresenter`` has no native quit
+                # affordance, so a "no pending change" exit is
+                # treated as the end of the session.
+                break
+            new_scene_path, new_variant = requested
+            args.scene = new_scene_path
+            args.variant = new_variant
+            presenter.acknowledge_scene_change(new_scene_path, new_variant)
+            print(
+                f"[demo] streaming scene change -> {new_scene_path.name} "
+                f"variant={new_variant!r}",
+                flush=True,
+            )
     finally:
         presenter.close()
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -830,10 +830,12 @@ def _run_streaming(args: argparse.Namespace) -> None:
         )
 
     # JSON-serialisable form of the discovered scenes for the browser
-    # ``/scenes`` endpoint. Thumbnails are dropped because the browser
-    # gets the live stream once a scene loads; a static thumbnail
-    # endpoint would just add more handlers without much UX win.
-    scenes_payload = tuple(
+    # ``/scenes`` endpoint. Thumbnails are JPEG-encoded once at startup
+    # and stashed on the presenter so the per-card ``/thumbnail``
+    # request just blobs the bytes back -- no per-request encode cost
+    # under the HTTP handler thread, which would otherwise compete
+    # with the main camera's encode budget.
+    scenes_payload: tuple[dict[str, object], ...] = tuple(
         {
             "label": opt.label,
             "path": str(opt.path),
@@ -841,6 +843,21 @@ def _run_streaming(args: argparse.Namespace) -> None:
         }
         for opt in scene_options
     )
+    thumbnails: dict[str, bytes] = {}
+    for opt in scene_options:
+        if opt.thumbnail is None:
+            continue
+        buf = io.BytesIO()
+        # PIL's RGBA / palette-mode thumbnails need an explicit RGB
+        # conversion before JPEG encode. The discovery layer already
+        # returns RGB, but be defensive in case it changes upstream.
+        thumb_rgb = (
+            opt.thumbnail
+            if opt.thumbnail.mode == "RGB"
+            else opt.thumbnail.convert("RGB")
+        )
+        thumb_rgb.save(buf, format="JPEG", quality=85)
+        thumbnails[str(opt.path)] = buf.getvalue()
 
     bind_host, bind_port = parse_bind(args.stream_mjpeg)
     placeholder_keyboard = KeyboardState()
@@ -850,6 +867,7 @@ def _run_streaming(args: argparse.Namespace) -> None:
         bind_host=bind_host,
         bind_port=bind_port,
         scenes=scenes_payload,
+        thumbnails=thumbnails,
     )
 
     def _factory(config: object, keyboard: KeyboardState) -> MJPEGStreamingPresenter:
@@ -862,6 +880,32 @@ def _run_streaming(args: argparse.Namespace) -> None:
         return presenter
 
     try:
+        # Don't auto-load: always wait for the browser to pick the
+        # first scene. This mirrors the slangpy HUD's ``--no-autoload-
+        # scene`` default (which is the *only* mode for the streaming
+        # path -- there's no Vulkan window to show progress in, so we
+        # would otherwise burn world-model warmup on whatever
+        # ``args.scene`` defaulted to before the user expressed any
+        # intent). The presenter publishes an idle "Select a scene to
+        # begin" overlay frame so connected browsers have something to
+        # render while the wait spins.
+        print(
+            "[demo] streaming presenter waiting for first scene selection...",
+            flush=True,
+        )
+        request = presenter.wait_for_scene_selection()
+        if request is None:
+            return  # presenter closed before any selection (Ctrl-C)
+        first_scene_path, first_variant = request
+        args.scene = first_scene_path
+        args.variant = first_variant
+        presenter.acknowledge_scene_change(first_scene_path, first_variant)
+        print(
+            f"[demo] streaming initial scene -> {first_scene_path.name} "
+            f"variant={first_variant!r}",
+            flush=True,
+        )
+
         while True:
             config, backend = _cli.prepare_config_and_backend(args)
             app = InteractiveDriveApp(

--- a/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
@@ -5,7 +5,11 @@ import threading
 import time
 
 from omnidreams.interactive_drive.input.backend import InputBackend, SampledInput
-from omnidreams.interactive_drive.types import ControlSnapshot, DriverCommand
+from omnidreams.interactive_drive.types import (
+    ControlSnapshot,
+    DriverCommand,
+    VehicleState,
+)
 
 
 class KeyboardState:
@@ -16,6 +20,14 @@ class KeyboardState:
     the single loop reader. Pressed keys are still snapshotted via
     :meth:`snapshot` because iterating a shared set requires a defensive copy
     under the lock.
+
+    Also carries a one-slot output channel: :meth:`update_telemetry` /
+    :attr:`vehicle_state`. The runtime loop pushes the latest
+    :class:`VehicleState` here after every chunk so the MJPEG presenter's
+    ``/state`` endpoint and any other read-side observer can publish a live
+    speed / steer / position snapshot to the browser without holding a
+    reference to the simulation object (which is rebuilt per scene reset
+    while ``KeyboardState`` is shared across the whole app session).
     """
 
     def __init__(self) -> None:
@@ -24,6 +36,10 @@ class KeyboardState:
         self._view_mode = "rgb"
         self._drive_command: DriverCommand | None = None
         self._reset_pending = False
+        # Output telemetry slot. ``None`` means the simulation hasn't
+        # produced a chunk yet (warmup window) -- callers render an empty
+        # speed readout in that case.
+        self._vehicle_state: VehicleState | None = None
 
     def set_key(self, name: str, down: bool) -> None:
         with self._lock:
@@ -43,6 +59,23 @@ class KeyboardState:
     def set_drive_command(self, command: DriverCommand | None) -> None:
         with self._lock:
             self._drive_command = command
+
+    def update_telemetry(self, state: VehicleState) -> None:
+        """Publish the simulation's latest vehicle state for read-only consumers.
+
+        Called once per chunk by :func:`run_main_loop` after the simulation
+        advances. The MJPEG presenter's ``/state`` endpoint reads this on
+        the HTTP handler thread, so the assignment runs under the same
+        lock as the input mutators.
+        """
+        with self._lock:
+            self._vehicle_state = state
+
+    @property
+    def vehicle_state(self) -> VehicleState | None:
+        """Most-recent simulation snapshot, or ``None`` before the first chunk."""
+        with self._lock:
+            return self._vehicle_state
 
     def consume_reset_request(self) -> bool:
         with self._lock:

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -225,14 +225,20 @@ def update_oob_state(
         state.oob_message = OOB_RESPAWN_MESSAGE
         if state.oob_respawn_streak >= max(1, config.oob_respawn_debounce_chunks):
             _log_oob_transition(
-                previous_message, OOB_RESPAWN_MESSAGE, proximity,
-                streak=state.oob_respawn_streak, action="firing respawn",
+                previous_message,
+                OOB_RESPAWN_MESSAGE,
+                proximity,
+                streak=state.oob_respawn_streak,
+                action="firing respawn",
             )
             return True
         if previous_message != OOB_RESPAWN_MESSAGE:
             _log_oob_transition(
-                previous_message, OOB_RESPAWN_MESSAGE, proximity,
-                streak=state.oob_respawn_streak, action="respawn pending",
+                previous_message,
+                OOB_RESPAWN_MESSAGE,
+                proximity,
+                streak=state.oob_respawn_streak,
+                action="respawn pending",
             )
         return False
 
@@ -244,16 +250,22 @@ def update_oob_state(
         state.oob_message = OOB_WARN_MESSAGE
         if previous_message != OOB_WARN_MESSAGE:
             _log_oob_transition(
-                previous_message, OOB_WARN_MESSAGE, proximity,
-                streak=0, action="warning",
+                previous_message,
+                OOB_WARN_MESSAGE,
+                proximity,
+                streak=0,
+                action="warning",
             )
         return False
 
     state.oob_message = None
     if previous_message is not None:
         _log_oob_transition(
-            previous_message, None, proximity,
-            streak=0, action="cleared",
+            previous_message,
+            None,
+            proximity,
+            streak=0,
+            action="cleared",
         )
     return False
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -80,29 +80,33 @@ class LoopConfig:
     frame_interval_s: float
     poll_timeout_s: float = 0.001
     history_capacity: int = 16
-    # Out-of-bounds detection. Proximity is the GroundSnapper's
-    # ``1.0 - hit_ratio``: 0.0 is solidly in-bounds (every body-grid sample
-    # ray hit the ground mesh), 1.0 is fully off the mesh. With the
-    # default 4x4 = 16-sample body grid the readings quantize to
-    # multiples of 1/16: ``0.6875`` is the point at which
-    # :class:`GroundSnapper` itself bails out because fewer than
-    # ``min_intersections=6`` rays hit (so it can't fit a plane), which
-    # is the same signal we want for "ego is leaving the mesh". Respawn
-    # is held to ``>= 0.95`` so corner samples briefly clipping a
-    # sidewalk during a sharp turn don't trip a teleport. Both checks
-    # are skipped when the scene shipped no ground mesh
-    # (``simulation.last_proximity`` reads ``0.0`` in that case).
-    oob_warn_proximity: float = 0.7
-    oob_respawn_proximity: float = 0.95
+    # Out-of-bounds detection. ``simulation.last_proximity`` mirrors
+    # alpasim's ``oob_proximity`` semantics:
+    #   0.0  = solidly inside the mesh AABB (expanded by a 50 m margin),
+    #          more than 100 m from any edge.
+    #   (0,1] = within the 100 m warning zone, ramping linearly with
+    #          ``1.0 - dist_to_edge / 100``.
+    #   2.0  = "off map" sentinel; the ego has crossed AABB + margin.
+    #
+    # Defaults match the alpasim driver: warn at >= 0.6 (standard
+    # "approaching" threshold from
+    # ``alpasim_driver.models.manual_model``'s render path), respawn at
+    # >= 2.0 (the binary "you're past the boundary" trigger). The
+    # warning ramps over a wide band; the respawn is a hard step that
+    # only fires when ``dist_to_edge < 0`` -- so brushing curbs,
+    # driving on sidewalks, or other intra-AABB excursions never
+    # trigger a teleport. Both checks no-op when the scene shipped no
+    # ground mesh (``simulation.last_proximity`` reads ``0.0``).
+    oob_warn_proximity: float = 0.6
+    oob_respawn_proximity: float = 2.0
     # Number of consecutive chunks the boundary-state proximity must
-    # remain above ``oob_respawn_proximity`` before the loop fires the
-    # auto-respawn. With ~270 ms per 8-frame chunk this gives the user
-    # ~800 ms of "Respawning..." overlay -- long enough that a single
-    # transient mesh-edge spike (e.g. a corner ray missing for one
-    # chunk while the rest of the body is still on the road) doesn't
-    # cause a teleport, short enough that a true OOB drive feels
-    # responsive. Set to ``1`` to fire on the first qualifying chunk.
-    oob_respawn_debounce_chunks: int = 3
+    # remain at or above ``oob_respawn_proximity`` before the loop fires
+    # the auto-respawn. Default ``1`` matches alpasim's behaviour
+    # (immediate respawn on the off-map step). Raise this for an
+    # added "are you sure you want to teleport" buffer; the alpasim
+    # signal is binary so a small debounce mostly catches measurement
+    # noise that doesn't really exist for the AABB check.
+    oob_respawn_debounce_chunks: int = 1
 
 
 # Warning text shown when the ego enters the OOB warning band. Kept as a

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -56,6 +56,12 @@ class MainLoopState:
     # the navigable area; non-``None`` is the warning / respawn message
     # that the loop merges into the displayed frame's ``status_message``.
     oob_message: str | None
+    # Number of consecutive chunks whose boundary-state proximity has
+    # stayed at or above :attr:`LoopConfig.oob_respawn_proximity`. The
+    # auto-respawn only fires once the streak reaches
+    # :attr:`LoopConfig.oob_respawn_debounce_chunks`; resets to zero the
+    # moment a chunk reads below the respawn threshold.
+    oob_respawn_streak: int
 
     def __init__(self) -> None:
         self.next_present_time = time.perf_counter()
@@ -64,6 +70,7 @@ class MainLoopState:
         self.chunks_outstanding = 0
         self.last_consumed_chunk_index = None
         self.oob_message = None
+        self.oob_respawn_streak = 0
 
 
 @dataclass(frozen=True)
@@ -75,14 +82,27 @@ class LoopConfig:
     history_capacity: int = 16
     # Out-of-bounds detection. Proximity is the GroundSnapper's
     # ``1.0 - hit_ratio``: 0.0 is solidly in-bounds (every body-grid sample
-    # ray hit the ground mesh), 1.0 is fully off the mesh. Defaults are
-    # tuned for the alpasim-style 16-sample body grid -- the warn level
-    # fires once roughly half the rays leave the mesh, the respawn level
-    # fires when only a few stragglers are still hitting. Both checks
+    # ray hit the ground mesh), 1.0 is fully off the mesh. With the
+    # default 4x4 = 16-sample body grid the readings quantize to
+    # multiples of 1/16: ``0.6875`` is the point at which
+    # :class:`GroundSnapper` itself bails out because fewer than
+    # ``min_intersections=6`` rays hit (so it can't fit a plane), which
+    # is the same signal we want for "ego is leaving the mesh". Respawn
+    # is held to ``>= 0.95`` so corner samples briefly clipping a
+    # sidewalk during a sharp turn don't trip a teleport. Both checks
     # are skipped when the scene shipped no ground mesh
     # (``simulation.last_proximity`` reads ``0.0`` in that case).
-    oob_warn_proximity: float = 0.5
-    oob_respawn_proximity: float = 0.85
+    oob_warn_proximity: float = 0.7
+    oob_respawn_proximity: float = 0.95
+    # Number of consecutive chunks the boundary-state proximity must
+    # remain above ``oob_respawn_proximity`` before the loop fires the
+    # auto-respawn. With ~270 ms per 8-frame chunk this gives the user
+    # ~800 ms of "Respawning..." overlay -- long enough that a single
+    # transient mesh-edge spike (e.g. a corner ray missing for one
+    # chunk while the rest of the body is still on the road) doesn't
+    # cause a teleport, short enough that a true OOB drive feels
+    # responsive. Set to ``1`` to fire on the first qualifying chunk.
+    oob_respawn_debounce_chunks: int = 3
 
 
 # Warning text shown when the ego enters the OOB warning band. Kept as a
@@ -180,21 +200,92 @@ def update_oob_state(
 
     Reads ``simulation.last_proximity`` defensively so test fakes and
     other ``SimulationBackend`` implementations that don't track OOB
-    state default to ``0.0`` (always in-bounds). Returns ``True`` when
-    the proximity has crossed the respawn threshold and the loop should
-    abort with the existing reset signal -- the caller's ``app.run`` outer
-    loop then rebuilds the simulation from the scene's initial pose,
-    which auto-clears the OOB condition.
+    state default to ``0.0`` (always in-bounds). The respawn threshold
+    is debounced: the boundary-state proximity must stay above
+    :attr:`LoopConfig.oob_respawn_proximity` for
+    :attr:`LoopConfig.oob_respawn_debounce_chunks` consecutive chunks
+    before the loop returns ``True``. That smooths out single-chunk
+    spikes when a corner ray briefly misses the mesh during a sharp
+    turn -- the alpasim driver's auto-respawn was similarly sticky on
+    the runtime side. Returns ``True`` only on the chunk that actually
+    fires the respawn; the caller's ``app.run`` outer loop then
+    rebuilds the simulation from the scene's initial pose and the new
+    sim's first chunk re-enters with proximity ``0.0``, auto-clearing
+    the streak.
     """
     proximity = float(getattr(simulation, "last_proximity", 0.0))
+    previous_message = state.oob_message
+
     if proximity >= config.oob_respawn_proximity:
+        state.oob_respawn_streak += 1
         state.oob_message = OOB_RESPAWN_MESSAGE
-        return True
+        if state.oob_respawn_streak >= max(1, config.oob_respawn_debounce_chunks):
+            _log_oob_transition(
+                previous_message, OOB_RESPAWN_MESSAGE, proximity,
+                streak=state.oob_respawn_streak, action="firing respawn",
+            )
+            return True
+        if previous_message != OOB_RESPAWN_MESSAGE:
+            _log_oob_transition(
+                previous_message, OOB_RESPAWN_MESSAGE, proximity,
+                streak=state.oob_respawn_streak, action="respawn pending",
+            )
+        return False
+
+    # Below respawn threshold; reset the debounce streak so a brief dip
+    # back into the warning band can't accumulate toward a respawn.
+    state.oob_respawn_streak = 0
+
     if proximity >= config.oob_warn_proximity:
         state.oob_message = OOB_WARN_MESSAGE
+        if previous_message != OOB_WARN_MESSAGE:
+            _log_oob_transition(
+                previous_message, OOB_WARN_MESSAGE, proximity,
+                streak=0, action="warning",
+            )
         return False
+
     state.oob_message = None
+    if previous_message is not None:
+        _log_oob_transition(
+            previous_message, None, proximity,
+            streak=0, action="cleared",
+        )
     return False
+
+
+def _log_oob_transition(
+    previous: str | None,
+    current: str | None,
+    proximity: float,
+    *,
+    streak: int,
+    action: str,
+) -> None:
+    """Log OOB state transitions to stderr.
+
+    Fires once per state edge (in-bounds -> warn -> respawn-pending ->
+    fire, plus recovery), so the volume is bounded even on long
+    sessions: a typical drive sees only a handful of these lines.
+    Including the proximity reading and streak count makes it easy to
+    confirm whether the defaults are firing at the right time, and to
+    tune :attr:`LoopConfig.oob_warn_proximity` /
+    :attr:`LoopConfig.oob_respawn_proximity` /
+    :attr:`LoopConfig.oob_respawn_debounce_chunks` if not.
+    """
+    prev_label = "in-bounds" if previous is None else _truncate(previous, 32)
+    curr_label = "in-bounds" if current is None else _truncate(current, 32)
+    print(
+        f"[loop] oob {prev_label!r} -> {curr_label!r}"
+        f" proximity={proximity:.3f} streak={streak} action={action}",
+        flush=True,
+    )
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "\u2026"
 
 
 def push_telemetry(

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -3,7 +3,7 @@
 
 import queue
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Protocol
 
 from omnidreams.interactive_drive.input.backend import InputBackend
@@ -51,6 +51,11 @@ class MainLoopState:
     frame_count: int
     chunks_outstanding: int
     last_consumed_chunk_index: int | None
+    # Out-of-bounds overlay text, refreshed each tick from the simulation's
+    # ``last_proximity`` reading. ``None`` means the ego is solidly inside
+    # the navigable area; non-``None`` is the warning / respawn message
+    # that the loop merges into the displayed frame's ``status_message``.
+    oob_message: str | None
 
     def __init__(self) -> None:
         self.next_present_time = time.perf_counter()
@@ -58,6 +63,7 @@ class MainLoopState:
         self.frame_count = 0
         self.chunks_outstanding = 0
         self.last_consumed_chunk_index = None
+        self.oob_message = None
 
 
 @dataclass(frozen=True)
@@ -67,6 +73,24 @@ class LoopConfig:
     frame_interval_s: float
     poll_timeout_s: float = 0.001
     history_capacity: int = 16
+    # Out-of-bounds detection. Proximity is the GroundSnapper's
+    # ``1.0 - hit_ratio``: 0.0 is solidly in-bounds (every body-grid sample
+    # ray hit the ground mesh), 1.0 is fully off the mesh. Defaults are
+    # tuned for the alpasim-style 16-sample body grid -- the warn level
+    # fires once roughly half the rays leave the mesh, the respawn level
+    # fires when only a few stragglers are still hitting. Both checks
+    # are skipped when the scene shipped no ground mesh
+    # (``simulation.last_proximity`` reads ``0.0`` in that case).
+    oob_warn_proximity: float = 0.5
+    oob_respawn_proximity: float = 0.85
+
+
+# Warning text shown when the ego enters the OOB warning band. Kept as a
+# module-level constant so the slangpy HUD's status-overlay code can
+# special-case it for styling later if needed without re-deriving the
+# string.
+OOB_WARN_MESSAGE = "Approaching map edge, turn back to avoid respawn"
+OOB_RESPAWN_MESSAGE = "Respawning..."
 
 
 def should_request_chunk(state: MainLoopState) -> bool:
@@ -115,13 +139,79 @@ def present_queued_frame(
     queued_frame: QueuedFrame,
     presenter: PresenterBackend,
     view_mode: str,
+    oob_message: str | None = None,
 ) -> float:
+    """Hand a freshly-dequeued frame to the presenter.
+
+    ``oob_message`` is merged into the frame's ``status_message`` only for
+    the duration of this present call (via :func:`dataclasses.replace`),
+    so the original ``QueuedFrame`` keeps whatever message the backend
+    attached -- e.g. the world-model's "Optimizing world model..."
+    transition text on the first chunk's last frame stays intact across
+    re-presents that intersperse the warmup window with an OOB warning.
+    """
     frame_times = queued_frame.chunk_times.frames[queued_frame.frame_index]
     frame_times.sample_display_pose_time = time.perf_counter()
-    presenter.present_frame(queued_frame.frame, view_mode=view_mode)
+    display_frame = _frame_with_overlay(queued_frame.frame, oob_message)
+    presenter.present_frame(display_frame, view_mode=view_mode)
     present_time = time.perf_counter()
     frame_times.present_time = present_time
     return present_time
+
+
+def _frame_with_overlay(
+    frame: PresentedFrame, oob_message: str | None
+) -> PresentedFrame:
+    """Return ``frame`` with ``oob_message`` merged into ``status_message``.
+
+    The OOB message wins over an existing ``status_message`` because it's
+    a more time-sensitive affordance (the user is about to be teleported);
+    returns the frame unchanged when there's no OOB message to merge in.
+    """
+    if oob_message is None:
+        return frame
+    return replace(frame, status_message=oob_message)
+
+
+def update_oob_state(
+    state: MainLoopState, simulation: SimulationBackend, config: LoopConfig
+) -> bool:
+    """Refresh ``state.oob_message`` from the simulation's OOB proximity.
+
+    Reads ``simulation.last_proximity`` defensively so test fakes and
+    other ``SimulationBackend`` implementations that don't track OOB
+    state default to ``0.0`` (always in-bounds). Returns ``True`` when
+    the proximity has crossed the respawn threshold and the loop should
+    abort with the existing reset signal -- the caller's ``app.run`` outer
+    loop then rebuilds the simulation from the scene's initial pose,
+    which auto-clears the OOB condition.
+    """
+    proximity = float(getattr(simulation, "last_proximity", 0.0))
+    if proximity >= config.oob_respawn_proximity:
+        state.oob_message = OOB_RESPAWN_MESSAGE
+        return True
+    if proximity >= config.oob_warn_proximity:
+        state.oob_message = OOB_WARN_MESSAGE
+        return False
+    state.oob_message = None
+    return False
+
+
+def push_telemetry(
+    runtime_controls: RuntimeControls, simulation: SimulationBackend
+) -> None:
+    """Forward ``simulation.current_state`` to ``runtime_controls`` if it accepts it.
+
+    Defensively no-ops when ``runtime_controls`` is a minimal Protocol
+    implementation that doesn't expose ``update_telemetry`` (test fakes,
+    custom controllers); only the production :class:`KeyboardState`
+    subscribes to this channel today, so an unknown ``runtime_controls``
+    just doesn't get a per-chunk telemetry update.
+    """
+    update = getattr(runtime_controls, "update_telemetry", None)
+    if update is None:
+        return
+    update(simulation.current_state)
 
 
 def run_main_loop(
@@ -149,7 +239,11 @@ def run_main_loop(
     Returns ``True`` if the loop exited because the user requested a reset
     (caller should call ``pipeline.reset`` and re-run the loop with a fresh
     simulation), ``False`` if it exited because the presenter requested
-    close.
+    close. The OOB auto-respawn path also returns ``True``: the simulation's
+    boundary state crossed :attr:`LoopConfig.oob_respawn_proximity`, the
+    user-visible warning escalated to ``OOB_RESPAWN_MESSAGE``, and the
+    caller is expected to rebuild the simulation from the scene's
+    initial pose just as it does for a manual ``R`` press.
     """
     state = MainLoopState()
     last_presented_frame: PresentedFrame = initial_presented_frame
@@ -172,6 +266,20 @@ def run_main_loop(
                 config=config,
             )
             pipeline.request_pose_chunk(chunk_request)
+            # ``simulation.pose_chunk`` (called inside make_chunk_request) just
+            # advanced the authoritative state by ``chunk_size`` frames, so its
+            # ``last_proximity`` reading is now the OOB status of the boundary
+            # frame. Refresh the overlay text here -- and bail with the same
+            # ``return True`` the manual reset path uses when the ego is far
+            # enough off the map that auto-respawning is the right move.
+            if update_oob_state(state, simulation, config):
+                return True
+            # Republish telemetry on the same per-chunk cadence so
+            # downstream observers (e.g. the MJPEG presenter's ``/state``
+            # endpoint, which the browser polls for the speed readout)
+            # see a snapshot drawn from the same ``current_state`` the
+            # OOB check just consulted.
+            push_telemetry(runtime_controls, simulation)
 
         now = time.perf_counter()
         if now < state.next_present_time:
@@ -186,11 +294,23 @@ def run_main_loop(
             if queued_frame.chunk_times.chunk_index != state.last_consumed_chunk_index:
                 state.last_consumed_chunk_index = queued_frame.chunk_times.chunk_index
                 state.chunks_outstanding = max(0, state.chunks_outstanding - 1)
-            present_queued_frame(queued_frame, presenter, view_mode=view_mode)
+            present_queued_frame(
+                queued_frame,
+                presenter,
+                view_mode=view_mode,
+                oob_message=state.oob_message,
+            )
             last_presented_frame = queued_frame.frame
             state.frame_count += 1
         except queue.Empty:
-            presenter.present_frame(last_presented_frame, view_mode=view_mode)
+            # Re-present the last frame with whatever OOB overlay is current
+            # for this tick; the merged frame is local to this call so the
+            # cached ``last_presented_frame`` stays unmodified for the next
+            # iteration.
+            presenter.present_frame(
+                _frame_with_overlay(last_presented_frame, state.oob_message),
+                view_mode=view_mode,
+            )
 
         state.next_present_time += config.frame_interval_s
     return False

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
@@ -7,6 +7,7 @@ import numpy as np
 from omnidreams.interactive_drive.config import ChunkConfig, VehicleConfig
 from omnidreams.interactive_drive.math3d import rig_pose_from_state
 from omnidreams.interactive_drive.simulation.ground_snap import GroundSnapper
+from omnidreams.interactive_drive.simulation.map_bounds import MapBounds
 from omnidreams.interactive_drive.types import (
     DriverCommand,
     SceneBundle,
@@ -183,6 +184,35 @@ def build_ground_snapper(scene: SceneBundle) -> GroundSnapper | None:
     return GroundSnapper(scene.ground_mesh_vertices, scene.ground_mesh_faces)
 
 
+def build_map_bounds(scene: SceneBundle) -> MapBounds | None:
+    """Compute OOB bounds from every spatial layer in ``scene``.
+
+    Decoupled from :func:`build_ground_snapper` because the OOB check
+    cares about the union of all geometry (lane markers, vehicle
+    tracks, polygons, ground), not just the ground mesh -- many scenes
+    ship a ground mesh that's a small strip representing only the road
+    surface, which would respawn the user the moment they drove onto a
+    sidewalk. Logs the resulting AABB so it's easy to confirm the
+    bounds match the scene's playable area.
+    """
+    bounds = MapBounds.from_scene(scene)
+    if bounds is None:
+        print(
+            "[ego_vehicle_kinematics] scene has no spatial geometry; "
+            "OOB respawn will not fire.",
+            flush=True,
+        )
+        return None
+    print(
+        f"[ego_vehicle_kinematics] map bounds: "
+        f"x=[{bounds.x_min:.1f}, {bounds.x_max:.1f}] ({bounds.width_m:.1f} m), "
+        f"y=[{bounds.y_min:.1f}, {bounds.y_max:.1f}] ({bounds.height_m:.1f} m). "
+        "Adds 50 m margin + 100 m warning zone for OOB.",
+        flush=True,
+    )
+    return bounds
+
+
 class EgoVehicleKinematics:
     def __init__(
         self,
@@ -190,11 +220,17 @@ class EgoVehicleKinematics:
         vehicle_config: VehicleConfig,
         ground_snapper: GroundSnapper | None,
         initial_timestamp_us: int,
+        map_bounds: MapBounds | None = None,
+        oob_margin_m: float = 50.0,
+        oob_warning_zone_m: float = 100.0,
     ) -> None:
         self._state = initial_state
         self._vehicle_config = vehicle_config
         self._ground_snapper = ground_snapper
         self._next_timestamp_us = initial_timestamp_us
+        self._map_bounds = map_bounds
+        self._oob_margin_m = float(oob_margin_m)
+        self._oob_warning_zone_m = float(oob_warning_zone_m)
 
     @property
     def current_state(self) -> VehicleState:
@@ -206,28 +242,31 @@ class EgoVehicleKinematics:
 
         Mirrors alpasim's ``oob_proximity`` semantics:
 
-        - ``0.0`` -- ego is more than 100 m inside the mesh AABB
-          (expanded by a 50 m margin); solidly in-bounds.
-        - ``(0.0, 1.0]`` -- linear ramp across the 100 m warning zone
-          as the ego approaches the AABB+margin edge. The runtime loop
-          shows the "Approaching map edge..." overlay across this band.
+        - ``0.0`` -- ego is more than ``oob_warning_zone_m`` (default
+          100 m) inside the scene-content AABB expanded by
+          ``oob_margin_m`` (default 50 m); solidly in-bounds.
+        - ``(0.0, 1.0]`` -- linear ramp across the warning zone as the
+          ego approaches the AABB+margin edge.
         - ``2.0`` -- alpasim's "off map" sentinel; the ego has crossed
-          AABB+margin. Triggers the auto-respawn.
+          AABB+margin and the runtime loop will fire the auto-respawn.
 
-        The check is computed from the ego's current XY against the
-        ground mesh's spatial extent; it is **not** related to the
-        body-grid raycast (which only measures snap quality, and was
-        the wrong signal for OOB -- it false-positives on every curb,
-        sidewalk, or sparse-mesh patch the body brushes against).
+        The AABB is the union of every spatial layer in the scene
+        (lane markers, drivable triangles, polygons, vehicle tracks,
+        ground mesh) -- not just ``mesh_ground.ply``. This is critical
+        because many scenes ship a ground mesh that covers only the
+        road surface; OOB-checking against that alone would respawn
+        the user the moment they drove onto a sidewalk or shoulder.
 
-        Returns ``0.0`` for scenes that ship no ground mesh: there's no
-        way to be off a map that doesn't exist, so the OOB respawn path
-        is a no-op for those scenes.
+        Returns ``0.0`` when the scene has no spatial geometry to
+        compute an AABB from -- the OOB respawn path no-ops in that
+        case.
         """
-        if self._ground_snapper is None:
+        if self._map_bounds is None:
             return 0.0
-        return self._ground_snapper.oob_proximity_at(
-            (self._state.x_m, self._state.y_m)
+        return self._map_bounds.proximity(
+            (self._state.x_m, self._state.y_m),
+            margin_m=self._oob_margin_m,
+            warning_zone_m=self._oob_warning_zone_m,
         )
 
     def pose_chunk(

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
@@ -202,17 +202,33 @@ class EgoVehicleKinematics:
 
     @property
     def last_proximity(self) -> float:
-        """OOB proximity of the latest simulated frame, in [0.0, 1.0].
+        """Out-of-bounds proximity of the latest simulated frame.
 
-        Reads the underlying :class:`GroundSnapper`'s post-snap reading
-        (the boundary frame of the most-recent :meth:`pose_chunk`).
-        Returns ``0.0`` when the scene shipped no ground mesh -- there's
-        no way to be off a map that doesn't exist, so the OOB respawn
-        path is a no-op for those scenes.
+        Mirrors alpasim's ``oob_proximity`` semantics:
+
+        - ``0.0`` -- ego is more than 100 m inside the mesh AABB
+          (expanded by a 50 m margin); solidly in-bounds.
+        - ``(0.0, 1.0]`` -- linear ramp across the 100 m warning zone
+          as the ego approaches the AABB+margin edge. The runtime loop
+          shows the "Approaching map edge..." overlay across this band.
+        - ``2.0`` -- alpasim's "off map" sentinel; the ego has crossed
+          AABB+margin. Triggers the auto-respawn.
+
+        The check is computed from the ego's current XY against the
+        ground mesh's spatial extent; it is **not** related to the
+        body-grid raycast (which only measures snap quality, and was
+        the wrong signal for OOB -- it false-positives on every curb,
+        sidewalk, or sparse-mesh patch the body brushes against).
+
+        Returns ``0.0`` for scenes that ship no ground mesh: there's no
+        way to be off a map that doesn't exist, so the OOB respawn path
+        is a no-op for those scenes.
         """
         if self._ground_snapper is None:
             return 0.0
-        return self._ground_snapper.last_proximity
+        return self._ground_snapper.oob_proximity_at(
+            (self._state.x_m, self._state.y_m)
+        )
 
     def pose_chunk(
         self,

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
@@ -200,6 +200,20 @@ class EgoVehicleKinematics:
     def current_state(self) -> VehicleState:
         return self._state
 
+    @property
+    def last_proximity(self) -> float:
+        """OOB proximity of the latest simulated frame, in [0.0, 1.0].
+
+        Reads the underlying :class:`GroundSnapper`'s post-snap reading
+        (the boundary frame of the most-recent :meth:`pose_chunk`).
+        Returns ``0.0`` when the scene shipped no ground mesh -- there's
+        no way to be off a map that doesn't exist, so the OOB respawn
+        path is a no-op for those scenes.
+        """
+        if self._ground_snapper is None:
+            return 0.0
+        return self._ground_snapper.last_proximity
+
     def pose_chunk(
         self,
         command: DriverCommand,

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/ground_snap.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/ground_snap.py
@@ -108,69 +108,6 @@ class GroundSnapper:
             for cell, idxs in cell_buckets.items()
         }
 
-        # XY axis-aligned bounding box of the ground mesh, used by
-        # :meth:`oob_proximity_at` to compute the alpasim-style
-        # ``oob_proximity`` signal. Mirrors the role of the GT
-        # trajectory's spatial extent in
-        # :meth:`alpasim_runtime.events.state.is_ego_off_map`. Stored as
-        # plain floats so the value is cheap to read from the
-        # per-chunk OOB checker.
-        self._mesh_xy_bounds: tuple[float, float, float, float] = (
-            float(self._grid_origin[0]),
-            float(self._grid_origin[1]),
-            float(self._grid_origin[0] + self._grid_shape[0] * self._grid_resolution_m),
-            float(self._grid_origin[1] + self._grid_shape[1] * self._grid_resolution_m),
-        )
-
-    @property
-    def mesh_xy_bounds(self) -> tuple[float, float, float, float]:
-        """``(x_min, y_min, x_max, y_max)`` of the ground mesh's XY footprint."""
-        return self._mesh_xy_bounds
-
-    def oob_proximity_at(
-        self,
-        ego_xy: tuple[float, float],
-        *,
-        margin_m: float = 50.0,
-        warning_zone_m: float = 100.0,
-    ) -> float:
-        """Distance-from-AABB proximity, matching alpasim's ``is_ego_off_map``.
-
-        Returns:
-        - ``0.0`` when the ego is more than ``warning_zone_m`` inside the
-          mesh AABB expanded by ``margin_m`` -- solidly in-bounds.
-        - ``(0.0, 1.0]`` linearly ramping over the ``warning_zone_m`` band
-          as the ego approaches the edge.
-        - ``2.0`` (the alpasim sentinel value) when the ego has crossed
-          the AABB+margin boundary. The runtime loop respawns on this
-          step value, so transient warning-band excursions never trigger
-          a teleport.
-
-        The mesh AABB stands in for alpasim's GT-trajectory bounds: the
-        interactive demo lets the user drive freely instead of replaying
-        a recorded trajectory, so the navigable area is "wherever the
-        ground mesh covers" rather than "wherever the GT path went". The
-        50 m margin and 100 m warning zone match alpasim's defaults so
-        the UX feel is equivalent.
-        """
-        x_min, y_min, x_max, y_max = self._mesh_xy_bounds
-        bx_min = x_min - margin_m
-        by_min = y_min - margin_m
-        bx_max = x_max + margin_m
-        by_max = y_max + margin_m
-
-        dist_to_edge = min(
-            ego_xy[0] - bx_min,
-            bx_max - ego_xy[0],
-            ego_xy[1] - by_min,
-            by_max - ego_xy[1],
-        )
-        if dist_to_edge < 0.0:
-            return 2.0
-        if warning_zone_m > 0.0 and dist_to_edge < warning_zone_m:
-            return float(np.clip(1.0 - dist_to_edge / warning_zone_m, 0.0, 1.0))
-        return 0.0
-
     @property
     def anchor_offset_m(self) -> float | None:
         return self._anchor_offset_m

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/ground_snap.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/ground_snap.py
@@ -49,6 +49,15 @@ class GroundSnapper:
         self._num_sample_points = int(num_sample_points)
         self._min_intersections = int(min_intersections)
         self._anchor_offset_m: float | None = None
+        # Updated as a side effect of every ``snap()`` call. Reads as
+        # ``1.0 - hit_ratio`` of the body-grid raycast, so 0.0 means every
+        # sample ray hit the ground mesh (solidly in-bounds) and 1.0 means
+        # no rays hit (the ego is fully off the mesh). The runtime loop
+        # reads this between chunks to drive the OOB warning overlay and
+        # the auto-respawn trigger; matches the alpasim driver's
+        # ``oob_proximity`` semantics (warn near 0.5, respawn near 1.0)
+        # without needing a separate runtime channel.
+        self._last_proximity: float = 0.0
 
         vertices_d = np.asarray(vertices_xyz, dtype=np.float64)
         faces_i = np.asarray(faces_ijk, dtype=np.int32)
@@ -101,6 +110,18 @@ class GroundSnapper:
     @property
     def anchor_offset_m(self) -> float | None:
         return self._anchor_offset_m
+
+    @property
+    def last_proximity(self) -> float:
+        """Most-recent ``snap()``'s OOB proximity, in [0.0, 1.0].
+
+        ``0.0`` means every body-grid sample ray hit the ground mesh on the
+        last call (solidly inside the navigable area); ``1.0`` means no
+        rays hit (the ego is over a hole in the mesh or off the map).
+        Updated even on bail-out paths so the runtime can detect a
+        rapid OOB transition that the snap itself refuses to apply.
+        """
+        return self._last_proximity
 
     def _cell_x(self, x: float) -> int:
         i = int((x - self._grid_origin[0]) / self._grid_resolution_m)
@@ -168,11 +189,18 @@ class GroundSnapper:
         )
         mask = ~np.isnan(ground_zs)
         n_hits = int(mask.sum())
+        n_total = int(len(world_pts))
+        # Update proximity unconditionally so callers see the freshest
+        # OOB reading even when the snap itself bails out below. The
+        # runtime loop's auto-respawn path depends on this.
+        self._last_proximity = (
+            1.0 - float(n_hits) / float(n_total) if n_total > 0 else 0.0
+        )
         if n_hits < self._min_intersections:
             logger.debug(
                 "ground snap: %d/%d sample rays hit, below min=%d; passing through",
                 n_hits,
-                len(world_pts),
+                n_total,
                 self._min_intersections,
             )
             return state

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/ground_snap.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/ground_snap.py
@@ -49,15 +49,16 @@ class GroundSnapper:
         self._num_sample_points = int(num_sample_points)
         self._min_intersections = int(min_intersections)
         self._anchor_offset_m: float | None = None
-        # Updated as a side effect of every ``snap()`` call. Reads as
-        # ``1.0 - hit_ratio`` of the body-grid raycast, so 0.0 means every
-        # sample ray hit the ground mesh (solidly in-bounds) and 1.0 means
-        # no rays hit (the ego is fully off the mesh). The runtime loop
-        # reads this between chunks to drive the OOB warning overlay and
-        # the auto-respawn trigger; matches the alpasim driver's
-        # ``oob_proximity`` semantics (warn near 0.5, respawn near 1.0)
-        # without needing a separate runtime channel.
-        self._last_proximity: float = 0.0
+        # Updated as a side effect of every ``snap()`` call. ``snap_hit_ratio``
+        # is the fraction of body-grid sample rays that found ground in
+        # the most recent call; the runtime loop uses it as a *quality*
+        # signal for the snap itself (does it apply or bail out), NOT
+        # as the OOB metric. OOB is computed separately by
+        # :meth:`oob_proximity_at` from the ego's XY against the mesh
+        # AABB -- mirroring alpasim's ``is_ego_off_map`` algorithm,
+        # where the body-grid hit count would false-positive on every
+        # sidewalk or curb the ego brushes against.
+        self._last_snap_hit_ratio: float = 1.0
 
         vertices_d = np.asarray(vertices_xyz, dtype=np.float64)
         faces_i = np.asarray(faces_ijk, dtype=np.int32)
@@ -107,21 +108,83 @@ class GroundSnapper:
             for cell, idxs in cell_buckets.items()
         }
 
+        # XY axis-aligned bounding box of the ground mesh, used by
+        # :meth:`oob_proximity_at` to compute the alpasim-style
+        # ``oob_proximity`` signal. Mirrors the role of the GT
+        # trajectory's spatial extent in
+        # :meth:`alpasim_runtime.events.state.is_ego_off_map`. Stored as
+        # plain floats so the value is cheap to read from the
+        # per-chunk OOB checker.
+        self._mesh_xy_bounds: tuple[float, float, float, float] = (
+            float(self._grid_origin[0]),
+            float(self._grid_origin[1]),
+            float(self._grid_origin[0] + self._grid_shape[0] * self._grid_resolution_m),
+            float(self._grid_origin[1] + self._grid_shape[1] * self._grid_resolution_m),
+        )
+
+    @property
+    def mesh_xy_bounds(self) -> tuple[float, float, float, float]:
+        """``(x_min, y_min, x_max, y_max)`` of the ground mesh's XY footprint."""
+        return self._mesh_xy_bounds
+
+    def oob_proximity_at(
+        self,
+        ego_xy: tuple[float, float],
+        *,
+        margin_m: float = 50.0,
+        warning_zone_m: float = 100.0,
+    ) -> float:
+        """Distance-from-AABB proximity, matching alpasim's ``is_ego_off_map``.
+
+        Returns:
+        - ``0.0`` when the ego is more than ``warning_zone_m`` inside the
+          mesh AABB expanded by ``margin_m`` -- solidly in-bounds.
+        - ``(0.0, 1.0]`` linearly ramping over the ``warning_zone_m`` band
+          as the ego approaches the edge.
+        - ``2.0`` (the alpasim sentinel value) when the ego has crossed
+          the AABB+margin boundary. The runtime loop respawns on this
+          step value, so transient warning-band excursions never trigger
+          a teleport.
+
+        The mesh AABB stands in for alpasim's GT-trajectory bounds: the
+        interactive demo lets the user drive freely instead of replaying
+        a recorded trajectory, so the navigable area is "wherever the
+        ground mesh covers" rather than "wherever the GT path went". The
+        50 m margin and 100 m warning zone match alpasim's defaults so
+        the UX feel is equivalent.
+        """
+        x_min, y_min, x_max, y_max = self._mesh_xy_bounds
+        bx_min = x_min - margin_m
+        by_min = y_min - margin_m
+        bx_max = x_max + margin_m
+        by_max = y_max + margin_m
+
+        dist_to_edge = min(
+            ego_xy[0] - bx_min,
+            bx_max - ego_xy[0],
+            ego_xy[1] - by_min,
+            by_max - ego_xy[1],
+        )
+        if dist_to_edge < 0.0:
+            return 2.0
+        if warning_zone_m > 0.0 and dist_to_edge < warning_zone_m:
+            return float(np.clip(1.0 - dist_to_edge / warning_zone_m, 0.0, 1.0))
+        return 0.0
+
     @property
     def anchor_offset_m(self) -> float | None:
         return self._anchor_offset_m
 
     @property
-    def last_proximity(self) -> float:
-        """Most-recent ``snap()``'s OOB proximity, in [0.0, 1.0].
+    def last_snap_hit_ratio(self) -> float:
+        """Fraction of body-grid sample rays that hit ground in the latest ``snap()``.
 
-        ``0.0`` means every body-grid sample ray hit the ground mesh on the
-        last call (solidly inside the navigable area); ``1.0`` means no
-        rays hit (the ego is over a hole in the mesh or off the map).
-        Updated even on bail-out paths so the runtime can detect a
-        rapid OOB transition that the snap itself refuses to apply.
+        ``1.0`` means every ray landed on a ground triangle (clean snap);
+        ``0.0`` means none did. Useful for diagnosing snap quality on
+        sparse meshes; **not** the OOB signal -- see
+        :meth:`oob_proximity_at` for that.
         """
-        return self._last_proximity
+        return self._last_snap_hit_ratio
 
     def _cell_x(self, x: float) -> int:
         i = int((x - self._grid_origin[0]) / self._grid_resolution_m)
@@ -190,11 +253,11 @@ class GroundSnapper:
         mask = ~np.isnan(ground_zs)
         n_hits = int(mask.sum())
         n_total = int(len(world_pts))
-        # Update proximity unconditionally so callers see the freshest
-        # OOB reading even when the snap itself bails out below. The
-        # runtime loop's auto-respawn path depends on this.
-        self._last_proximity = (
-            1.0 - float(n_hits) / float(n_total) if n_total > 0 else 0.0
+        # Track snap quality (hit ratio) for diagnostics; OOB proximity
+        # is computed separately by ``oob_proximity_at`` from the ego XY
+        # against the mesh AABB.
+        self._last_snap_hit_ratio = (
+            float(n_hits) / float(n_total) if n_total > 0 else 1.0
         )
         if n_hits < self._min_intersections:
             logger.debug(

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/map_bounds.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/map_bounds.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Out-of-bounds detection bounds for interactive_drive.
+
+Stands in for alpasim's GT-trajectory bounds in the interactive case
+where the user drives freely instead of replaying a recorded path. The
+AABB is the union of *every* spatial layer in the
+:class:`SceneBundle` -- ground mesh, lane markers, drivable triangles,
+vehicle bbox tracks, polygons -- so it covers the full extent of the
+scene's content rather than only the road surface.
+
+The proximity calculation itself is a verbatim port of
+:meth:`alpasim_runtime.events.state.is_ego_off_map`: distance from the
+AABB+margin edge, ramped over a 100 m warning zone, with a hard ``2.0``
+sentinel when the ego has actually crossed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from omnidreams.interactive_drive.types import SceneBundle
+
+
+@dataclass(frozen=True)
+class MapBounds:
+    """XY axis-aligned bounding box of the scene's navigable area.
+
+    Built once at scene load time; the runtime loop reads :meth:`proximity`
+    once per chunk to drive the OOB warning overlay and auto-respawn.
+    Values are plain ``float`` so the per-chunk read path doesn't pay any
+    array indexing cost.
+    """
+
+    x_min: float
+    y_min: float
+    x_max: float
+    y_max: float
+
+    @property
+    def width_m(self) -> float:
+        return self.x_max - self.x_min
+
+    @property
+    def height_m(self) -> float:
+        return self.y_max - self.y_min
+
+    @classmethod
+    def from_scene(cls, scene: SceneBundle) -> "MapBounds | None":
+        """Compute the union AABB of every spatial layer in ``scene``.
+
+        Returns ``None`` when the scene has no usable spatial content
+        (empty fixtures, etc.) -- callers then default to "always
+        in-bounds" so the OOB respawn path is a no-op for that scene.
+        """
+        xs: list[np.ndarray] = []
+        ys: list[np.ndarray] = []
+
+        # Ground mesh vertices. Authoritative for the drivable surface
+        # but typically the smallest piece of geometry in the scene.
+        if scene.ground_mesh_vertices is not None:
+            verts = np.asarray(scene.ground_mesh_vertices, dtype=np.float32)
+            if verts.size:
+                xs.append(verts[:, 0])
+                ys.append(verts[:, 1])
+
+        # Line segments (lane lines, polylines). ``segments_world`` is
+        # shaped ``(N, 2, 3)`` (pair of endpoints) per the scene loader,
+        # so flatten the first two axes to harvest every endpoint.
+        for layer in scene.line_layers:
+            seg = np.asarray(layer.segments_world, dtype=np.float32)
+            if seg.size:
+                flat = seg.reshape(-1, seg.shape[-1])
+                xs.append(flat[:, 0])
+                ys.append(flat[:, 1])
+
+        # Triangles (drivable surface, intersection plates). ``(N, 3, 3)``;
+        # flatten to vertices.
+        for layer in scene.triangle_layers:
+            tri = np.asarray(layer.triangles_world, dtype=np.float32)
+            if tri.size:
+                flat = tri.reshape(-1, tri.shape[-1])
+                xs.append(flat[:, 0])
+                ys.append(flat[:, 1])
+
+        # Polygons -- each entry is its own ``(N, 3)`` ring.
+        for layer in scene.polygon_layers:
+            for ring in layer.polygons_world:
+                pts = np.asarray(ring, dtype=np.float32)
+                if pts.size:
+                    xs.append(pts[:, 0])
+                    ys.append(pts[:, 1])
+
+        # Vehicle track centers (other actors driving through the scene).
+        # The scene loader stores them as ``(N, 3)`` per track.
+        for track in scene.vehicle_bbox_tracks:
+            centers = np.asarray(track.centers_world, dtype=np.float32)
+            if centers.size:
+                xs.append(centers[:, 0])
+                ys.append(centers[:, 1])
+
+        if not xs or not ys:
+            return None
+
+        all_x = np.concatenate(xs)
+        all_y = np.concatenate(ys)
+        return cls(
+            x_min=float(all_x.min()),
+            y_min=float(all_y.min()),
+            x_max=float(all_x.max()),
+            y_max=float(all_y.max()),
+        )
+
+    def proximity(
+        self,
+        ego_xy: tuple[float, float],
+        *,
+        margin_m: float = 50.0,
+        warning_zone_m: float = 100.0,
+    ) -> float:
+        """Distance-from-AABB proximity, matching alpasim's ``is_ego_off_map``.
+
+        Returns:
+        - ``0.0`` when the ego is more than ``warning_zone_m`` inside
+          the AABB expanded by ``margin_m`` -- solidly in-bounds.
+        - ``(0.0, 1.0]`` linearly ramping over the ``warning_zone_m``
+          band as the ego approaches the edge.
+        - ``2.0`` (alpasim's sentinel) when the ego has actually
+          crossed the AABB+margin boundary.
+        """
+        bx_min = self.x_min - margin_m
+        by_min = self.y_min - margin_m
+        bx_max = self.x_max + margin_m
+        by_max = self.y_max + margin_m
+
+        dist_to_edge = min(
+            ego_xy[0] - bx_min,
+            bx_max - ego_xy[0],
+            ego_xy[1] - by_min,
+            by_max - ego_xy[1],
+        )
+        if dist_to_edge < 0.0:
+            return 2.0
+        if warning_zone_m > 0.0 and dist_to_edge < warning_zone_m:
+            return float(np.clip(1.0 - dist_to_edge / warning_zone_m, 0.0, 1.0))
+        return 0.0

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -957,7 +957,9 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             # pre-scene-picker tab open doesn't keep rendering the old
             # HTML after a server upgrade. The page is tiny (~10 KB) so
             # bypassing the cache on every reload costs nothing.
-            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+            self.send_header(
+                "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"
+            )
             self.send_header("Pragma", "no-cache")
             self.send_header("Expires", "0")
             self.end_headers()
@@ -992,7 +994,11 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             asset.
             """
             scenes_with_thumbs = [
-                {**entry, "has_thumbnail": str(entry.get("path", "")) in presenter._thumbnails}
+                {
+                    **entry,
+                    "has_thumbnail": str(entry.get("path", ""))
+                    in presenter._thumbnails,
+                }
                 for entry in presenter._scenes
             ]
             body = json.dumps({"scenes": scenes_with_thumbs}).encode("utf-8")

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -1,0 +1,733 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""MJPEG-over-HTTP presenter.
+
+An alternative to :class:`omnidreams.interactive_drive.presenter.SlangPyPresenter`
+for deployments where no graphics-capable GPU is available (e.g. a DGX
+Station with only a GB300 compute card). Frames produced by the backend
+are JPEG-encoded on the CPU and served to connected HTTP clients as a
+``multipart/x-mixed-replace`` stream. The user's browser posts keydown/
+keyup events back to the server so the demo stays interactive.
+
+For a full WebRTC viewer with a polished frontend and lower latency,
+use ``omnidreams.webrtc.server`` instead. This presenter is the
+single-process, dependency-free fallback for headless / compute-only
+hosts where the WebRTC server isn't a fit.
+
+Expected end-to-end latency on the same LAN:
+
+  * JPEG encode (PIL / libjpeg-turbo, 704x1280 @ quality 85): 10-15 ms
+  * TCP transmit: <5 ms on 1 Gbps LAN
+  * Browser decode + <img> swap: 15-30 ms
+
+so the *streaming* latency is roughly 50 ms. Keypress-to-visible-effect
+latency is dominated by the backend's per-chunk wall-clock time (~900 ms
+steady-state), which is the same problem we have with the local Vulkan
+presenter; streaming doesn't add more than ~50 ms on top of it.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import subprocess
+import sys
+import threading
+from collections.abc import Callable
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import numpy as np
+from omnidreams.interactive_drive.config import RasterConfig
+from omnidreams.interactive_drive.input.keyboard import KeyboardState
+from omnidreams.interactive_drive.loading_overlay import render_loading_overlay
+from omnidreams.interactive_drive.types import DriverCommand, PresentedFrame
+from PIL import Image
+
+# Boundary marker embedded in the multipart response. The exact string
+# doesn't matter as long as it never appears inside a JPEG payload (they
+# start with the JPEG SOI marker 0xFFD8 so ``--interactive_drive`` is always safe).
+_MULTIPART_BOUNDARY = "interactive_drive"
+
+# Browser ``event.key`` values to the keysym strings that
+# :meth:`KeyboardDriveState.set_key` (in ``demo.py``) recognises. The
+# slangpy HUD path uses the SDL/pygame-style ``"Up"``/``"Down"``/etc.
+# keysyms locally; the browser sends ``ArrowUp``/``ArrowDown`` instead,
+# so we re-map at the network boundary rather than extend
+# :func:`_keyboard_drive_key` with browser-specific aliases.
+_BROWSER_KEY_TO_DRIVE_KEYSYM: dict[str, str] = {
+    "w": "w",
+    "W": "w",
+    "a": "a",
+    "A": "a",
+    "s": "s",
+    "S": "s",
+    "d": "d",
+    "D": "d",
+    "ArrowUp": "Up",
+    "ArrowDown": "Down",
+    "ArrowLeft": "Left",
+    "ArrowRight": "Right",
+    " ": "space",
+    "Spacebar": "space",
+}
+
+_BROWSER_KEY_TO_VIEW_MODE: dict[str, str] = {
+    # 1 = world-model RGB (the generated drive view, the main demo output).
+    # 2 = HDMap with traffic (the rasterizer's conditioning input).
+    "1": "model_rgb",
+    "2": "rgb",
+}
+
+
+class _KeyboardDriveSink:
+    """In-process duck-typed ``ControlClient`` that writes to ``KeyboardState``.
+
+    The slangpy HUD ships its own ``KeyboardStateDriveSink`` in
+    :mod:`slangpy_hud_presenter`, but importing that module would pull
+    SlangPy / Vulkan into the streaming-presenter import graph -- the
+    very thing the streaming presenter exists to avoid (it's the
+    fallback for compute-only hosts where SlangPy can't initialise a
+    Vulkan device). We replicate the same minimal surface here so the
+    MJPEG keyboard path produces the byte-identical
+    ``DriverCommand(manual_control=True, steer_is_direct=True, ...)``
+    the HUD does, without dragging the graphics stack in.
+    """
+
+    def __init__(self, keyboard: KeyboardState) -> None:
+        self._keyboard = keyboard
+
+    def set_drive(self, *, steer: float, throttle: float, brake: float) -> None:
+        self._keyboard.set_drive_command(
+            DriverCommand(
+                throttle=max(0.0, min(1.0, throttle)),
+                brake=max(0.0, min(1.0, brake)),
+                steer=max(-1.0, min(1.0, steer)),
+                steer_is_direct=True,
+                manual_control=True,
+            )
+        )
+
+    def release_all(self) -> None:
+        self._keyboard.set_drive_command(None)
+
+    # The methods below exist so anything wired against the legacy
+    # supervisor-era ``ControlClient`` surface fails silently rather
+    # than raising ``AttributeError`` -- they're no-ops in-process
+    # because the streaming presenter writes directly via
+    # ``KeyboardState`` from its HTTP handler thread.
+    def set_key(self, key: str, down: bool) -> None:  # noqa: ARG002
+        return
+
+    def pulse(self, key: str) -> None:  # noqa: ARG002
+        return
+
+
+def _print_port_conflict_help(host: str, port: int, exc: OSError) -> None:
+    """Print a helpful message when the HTTP server can't bind to the port."""
+    print(
+        f"\n[presenter] MJPEG server failed to start: port {port} is already in use.\n"
+        f"            ({exc})\n",
+        file=sys.stderr,
+        flush=True,
+    )
+    # Try to show which process is using the port (Linux: ss, macOS/BSD: lsof).
+    shown = False
+    if shutil.which("ss"):
+        result = subprocess.run(
+            ["ss", "-tlnp", f"sport = :{port}"],
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout.strip():
+            print(
+                f"[presenter] The following process is blocking port {port}:\n",
+                file=sys.stderr,
+                flush=True,
+            )
+            print(result.stdout, file=sys.stderr, flush=True)
+            shown = True
+    if not shown and shutil.which("lsof"):
+        result = subprocess.run(
+            ["lsof", "-i", f":{port}"],
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout.strip():
+            print(
+                f"[presenter] The following process is blocking port {port}:\n",
+                file=sys.stderr,
+                flush=True,
+            )
+            print(result.stdout, file=sys.stderr, flush=True)
+            shown = True
+    if not shown:
+        print(
+            f"[presenter] Could not determine which process is using port {port}.\n",
+            file=sys.stderr,
+            flush=True,
+        )
+    print(
+        f"[presenter] To fix this, either:\n"
+        f"  1. Stop the process above, or\n"
+        f"  2. Choose a different port: --stream-mjpeg :{port + 1}\n",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+# Single HTML page served at ``/``. Shows the MJPEG stream and forwards
+# keydown/keyup to ``/control``. Kept inline (not a separate file) so the
+# presenter is a single-file drop-in with no template loading to configure.
+# Single HTML page served at ``/``. Shows the MJPEG stream, an HTML/CSS
+# HUD with a speed readout and WASD-indicator chiclets keyed off the
+# locally-tracked DOWN_KEYS set, and JS that forwards keydown/keyup to
+# ``/control``. The HUD is intentionally inline (no template loading)
+# because the presenter is meant to be a single-file drop-in for hosts
+# without local windowing. The browser reads the speed snapshot from
+# ``/state`` once every 100 ms; that's cheap (a ~80-byte JSON blob) and
+# keeps the readout responsive without flooding the server.
+_INDEX_HTML = """<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>interactive_drive (MJPEG)</title>
+<style>
+  html, body { margin: 0; padding: 0; background: #111; height: 100%; font-family: sans-serif; }
+  body { display: flex; align-items: center; justify-content: center; }
+  img#stream { max-width: 100%; max-height: 100%; object-fit: contain; image-rendering: pixelated; }
+  .hint { position: fixed; top: 8px; left: 8px; color: #aaa; font-size: 12px; }
+  .hud {
+    position: fixed; bottom: 24px; left: 24px;
+    display: flex; gap: 28px; align-items: flex-end;
+    pointer-events: none;
+    color: white;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.85), 0 0 4px rgba(0, 0, 0, 0.85);
+  }
+  .speed {
+    display: flex; align-items: baseline; gap: 6px;
+    line-height: 1;
+  }
+  .speed-value { font-size: 56px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .speed-unit { font-size: 18px; opacity: 0.75; letter-spacing: 0.04em; text-transform: uppercase; }
+  .speed.disconnected .speed-value { color: #888; }
+  .keys { display: flex; flex-direction: column; gap: 6px; align-items: center; }
+  .key-row { display: flex; gap: 6px; }
+  .key {
+    width: 38px; height: 38px;
+    border-radius: 7px;
+    background: rgba(0, 0, 0, 0.45);
+    border: 2px solid rgba(255, 255, 255, 0.35);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 16px; font-weight: 700;
+    transition: background-color 0.05s ease-out, border-color 0.05s ease-out, color 0.05s ease-out;
+  }
+  .key.down {
+    background: rgba(255, 255, 255, 0.92);
+    border-color: white;
+    color: #111;
+  }
+</style>
+</head>
+<body>
+<img id="stream" src="/stream">
+<div class="hint">WASD / Arrows = Drive &middot; Space = Brake &middot; 1 = World-Model RGB &middot; 2 = HDMap &middot; R = Reset Rollout</div>
+<div class="hud">
+  <div class="speed disconnected" id="speed">
+    <span class="speed-value" id="speed-value">--</span>
+    <span class="speed-unit">mph</span>
+  </div>
+  <div class="keys">
+    <div class="key-row"><div class="key" id="key-w">W</div></div>
+    <div class="key-row">
+      <div class="key" id="key-a">A</div>
+      <div class="key" id="key-s">S</div>
+      <div class="key" id="key-d">D</div>
+    </div>
+  </div>
+</div>
+<script>
+const DOWN_KEYS = new Set();
+const INDICATOR_FOR_KEY = {
+  "w":"w","W":"w","ArrowUp":"w",
+  "a":"a","A":"a","ArrowLeft":"a",
+  "s":"s","S":"s","ArrowDown":"s",
+  "d":"d","D":"d","ArrowRight":"d",
+};
+const PRESSED_INDICATORS = new Map();   // indicator-name -> count of held keys
+
+function paintIndicator(name) {
+  const el = document.getElementById("key-" + name);
+  if (!el) return;
+  const held = (PRESSED_INDICATORS.get(name) || 0) > 0;
+  el.classList.toggle("down", held);
+}
+function bumpIndicator(name, delta) {
+  const next = Math.max(0, (PRESSED_INDICATORS.get(name) || 0) + delta);
+  PRESSED_INDICATORS.set(name, next);
+  paintIndicator(name);
+}
+function send(key, down) {
+  if (down && DOWN_KEYS.has(key)) return;   // debounce: browsers send keydown repeatedly while held
+  if (!down) DOWN_KEYS.delete(key); else DOWN_KEYS.add(key);
+  // Update the local indicator UI immediately (no round-trip latency).
+  const indicator = INDICATOR_FOR_KEY[key];
+  if (indicator) bumpIndicator(indicator, down ? 1 : -1);
+  fetch('/control?key=' + encodeURIComponent(key) + '&down=' + (down ? 1 : 0))
+    .catch(() => {});                       // ignore network hiccups, next event will resync
+}
+document.addEventListener('keydown', e => send(e.key, true));
+document.addEventListener('keyup', e => send(e.key, false));
+// When the page loses focus we must release all keys so the car doesn't keep steering.
+window.addEventListener('blur', () => {
+  DOWN_KEYS.forEach(k => send(k, false));
+  PRESSED_INDICATORS.clear();
+  ["w","a","s","d"].forEach(paintIndicator);
+});
+// Speed readout polling. 100 ms keeps the digit lively without
+// generating meaningful HTTP load (~10 req/s of <100 B each).
+const speedEl = document.getElementById('speed');
+const speedValueEl = document.getElementById('speed-value');
+const MPS_TO_MPH = 2.236936;
+async function pollState() {
+  try {
+    const r = await fetch('/state', { cache: 'no-store' });
+    if (!r.ok) throw new Error('http ' + r.status);
+    const s = await r.json();
+    if (typeof s.speed_mps === 'number') {
+      speedValueEl.textContent = Math.round(s.speed_mps * MPS_TO_MPH).toString();
+      speedEl.classList.remove('disconnected');
+    } else {
+      speedValueEl.textContent = '--';
+      speedEl.classList.add('disconnected');
+    }
+  } catch {
+    speedValueEl.textContent = '--';
+    speedEl.classList.add('disconnected');
+  }
+}
+setInterval(pollState, 100);
+pollState();
+</script>
+</body>
+</html>
+"""
+
+
+class MJPEGStreamingPresenter:
+    """Drop-in replacement for :class:`SlangPyPresenter` that streams frames
+    over HTTP instead of opening a Vulkan swapchain window.
+
+    Exposes the same duck-typed interface consumed by
+    :class:`omnidreams.interactive_drive.app.InteractiveDriveApp`:
+    ``should_close`` / ``process_events`` / ``present_frame`` / ``close``.
+    The simulation thread doesn't know the presenter changed.
+    """
+
+    def __init__(
+        self,
+        raster: RasterConfig,
+        keyboard: KeyboardState,
+        bind_host: str,
+        bind_port: int,
+        *,
+        jpeg_quality: int = 85,
+    ) -> None:
+        self._raster = raster
+        self._keyboard = keyboard
+        self._jpeg_quality = int(jpeg_quality)
+        self._stop_event = threading.Event()
+        # Guarded by ``_frame_cond`` so a sending thread can ``wait()``
+        # for the next frame rather than spinning.
+        self._latest_jpeg: bytes | None = None
+        self._frame_count = 0
+        self._frame_cond = threading.Condition()
+        # BEV minimap stream lives on its own JPEG buffer so connected
+        # clients of /bev_stream can paginate at a different rate than
+        # /stream (e.g. if the HUD process throttles). We reuse the same
+        # condition variable as the main stream because frames are only
+        # published when ``present_frame`` runs anyway, so notifications
+        # to either waiter are always safe.
+        self._latest_bev_jpeg: bytes | None = None
+        self._bev_frame_count = 0
+        # Keyboard drive integrator. Late-imported because ``demo``
+        # imports the streaming presenter via the CLI's presenter
+        # factory; a top-level import would be circular. The integrator
+        # owns the same ``set_drive`` -> ``KeyboardState`` plumbing the
+        # slangpy HUD uses, which is what gives us the alpasim-style
+        # ~10 mph auto-crawl on key release: the integrator posts
+        # ``DriverCommand(manual_control=True, throttle=0, brake=0)``
+        # which routes through ``integrate_vehicle``'s manual branch
+        # where the creep-toward-4.47-m/s logic lives.
+        from omnidreams.interactive_drive.demo import KeyboardDriveState
+
+        self._keyboard_drive = KeyboardDriveState(_KeyboardDriveSink(keyboard))
+
+        try:
+            self._server = ThreadingHTTPServer(
+                (bind_host, bind_port), _make_handler(self)
+            )
+        except OSError as exc:
+            _print_port_conflict_help(bind_host, bind_port, exc)
+            raise
+        # ``daemon=True`` means the server thread won't block interpreter
+        # exit if the main thread raises; ``close()`` still shuts it down
+        # cleanly on the normal path.
+        self._server_thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="interactive_drive-mjpeg",
+            daemon=True,
+        )
+        self._server_thread.start()
+        # ThreadingHTTPServer.server_address is typed as
+        # ``_AfInetAddress | _AfInet6Address`` in stdlib stubs -- a 2-tuple
+        # for IPv4 and a 4-tuple for IPv6. Index into it instead of
+        # unpacking so pyright is happy on both variants.
+        actual_host = self._server.server_address[0]
+        actual_port = self._server.server_address[1]
+        print(
+            f"[presenter] MJPEG stream listening on http://{actual_host}:{actual_port}/ "
+            f"(open that URL in a browser on the same network)",
+            flush=True,
+        )
+
+    @property
+    def should_close(self) -> bool:
+        # There's no window to close. The app loop runs until the
+        # simulation thread finishes or the user Ctrl-C's the process.
+        return self._stop_event.is_set()
+
+    def process_events(self) -> None:
+        # Input arrives asynchronously via ``/control`` HTTP requests, but
+        # the keyboard-drive integrator owes a per-tick update so its
+        # auto-crawl smoothing (steer rate, throttle taper, creep target)
+        # advances at sim cadence regardless of how often the browser
+        # sends events. Mirrors the slangpy HUD's per-frame
+        # ``_keyboard_drive.update()`` call.
+        self._keyboard_drive.update()
+
+    def present_frame(self, frame: PresentedFrame, view_mode: str) -> None:
+        # Mirror SlangPyPresenter.present_frame's view-mode branching so
+        # the user's `1`/`2` toggles behave identically.
+        if view_mode == "model_rgb" and frame.model_rgb_host_uint8 is not None:
+            self._publish(
+                _with_status_overlay(frame.model_rgb_host_uint8, frame.status_message)
+            )
+        else:
+            self._publish(
+                _with_status_overlay(frame.rgb_host_uint8, frame.status_message)
+            )
+        if frame.bev_host_uint8 is not None:
+            self._publish_bev(frame.bev_host_uint8)
+
+    def close(self) -> None:
+        self._stop_event.set()
+        # Wake any /stream handlers blocked in ``_frame_cond.wait`` so
+        # they observe ``should_close`` and exit their per-connection loop.
+        with self._frame_cond:
+            self._frame_cond.notify_all()
+        self._server.shutdown()
+        self._server.server_close()
+        if self._server_thread.is_alive():
+            self._server_thread.join(timeout=1.0)
+
+    # -- Internals --------------------------------------------------
+
+    def _publish(self, rgb_host_uint8: np.ndarray) -> None:
+        buf = io.BytesIO()
+        Image.fromarray(rgb_host_uint8).save(
+            buf, format="JPEG", quality=self._jpeg_quality
+        )
+        jpeg = buf.getvalue()
+        with self._frame_cond:
+            self._latest_jpeg = jpeg
+            self._frame_count += 1
+            self._frame_cond.notify_all()
+
+    def _publish_bev(self, bev_rgb_host_uint8: np.ndarray) -> None:
+        """Encode the BEV minimap and stash it for ``/bev_stream`` waiters.
+
+        BEV frames are tiny (<= 384x384) so JPEG encode is sub-millisecond
+        and we boost quality to 95 vs 85 for the main stream. The HUD's
+        Google-Maps post-process is sensitive to JPEG ringing around the
+        high-contrast lane / vehicle edges (dim ringing pixels survive as
+        dirty grey halos), so paying ~12 KB / frame of bandwidth to keep
+        edges clean is a good trade.
+        """
+        buf = io.BytesIO()
+        Image.fromarray(bev_rgb_host_uint8).save(buf, format="JPEG", quality=95)
+        jpeg = buf.getvalue()
+        with self._frame_cond:
+            self._latest_bev_jpeg = jpeg
+            self._bev_frame_count += 1
+            self._frame_cond.notify_all()
+
+    def _wait_for_new_frame(self, last_seen_count: int) -> tuple[bytes, int] | None:
+        """Block until a frame newer than ``last_seen_count`` is ready or
+        the server is shutting down. Returns ``(jpeg_bytes, frame_count)``
+        on success, ``None`` when closing.
+        """
+        with self._frame_cond:
+            while self._latest_jpeg is None or self._frame_count <= last_seen_count:
+                if self._stop_event.is_set():
+                    return None
+                self._frame_cond.wait(timeout=1.0)
+            return self._latest_jpeg, self._frame_count
+
+    def _wait_for_new_bev_frame(self, last_seen_count: int) -> tuple[bytes, int] | None:
+        """Same as :meth:`_wait_for_new_frame` but for the BEV stream.
+
+        Returns ``None`` when the server is closing. Sharing the condition
+        variable means the waiter wakes immediately on every published
+        frame; the loop body then re-checks the BEV-specific counter.
+        """
+        with self._frame_cond:
+            while (
+                self._latest_bev_jpeg is None
+                or self._bev_frame_count <= last_seen_count
+            ):
+                if self._stop_event.is_set():
+                    return None
+                self._frame_cond.wait(timeout=1.0)
+            return self._latest_bev_jpeg, self._bev_frame_count
+
+    def _apply_control(self, key: str, down: bool) -> None:
+        # Direction keys (W/A/S/D + arrows + Space) flow through the
+        # ``KeyboardDriveState`` integrator so the MJPEG path posts the
+        # exact same ``DriverCommand(manual_control=True, ...)`` shape
+        # the slangpy HUD does -- which is what unlocks the integrator's
+        # ~10 mph creep-toward-target on key release.
+        drive_keysym = _BROWSER_KEY_TO_DRIVE_KEYSYM.get(key)
+        if drive_keysym is not None and self._keyboard_drive.set_key(
+            drive_keysym, down
+        ):
+            return
+        if down:
+            view_mode = _BROWSER_KEY_TO_VIEW_MODE.get(key)
+            if view_mode is not None:
+                self._keyboard.set_view_mode(view_mode)
+                return
+            # ``r`` / ``R`` restarts the rollout. Only fire on keydown so
+            # holding the key doesn't trigger a cascade of resets.
+            if key in ("r", "R"):
+                self._keyboard.request_reset()
+
+    def _apply_drive_control(
+        self,
+        *,
+        throttle: float,
+        brake: float,
+        steer: float,
+        reverse: bool = False,
+    ) -> None:
+        self._keyboard.set_drive_command(
+            DriverCommand(
+                throttle=max(0.0, min(1.0, throttle)),
+                brake=max(0.0, min(1.0, brake)),
+                steer=max(-1.0, min(1.0, steer)),
+                reverse=reverse,
+                steer_is_direct=True,
+                manual_control=True,
+            )
+        )
+
+    def _state_snapshot(self) -> dict[str, float | None]:
+        """Return a JSON-serialisable snapshot of the current sim telemetry.
+
+        Reads from :attr:`KeyboardState.vehicle_state`, which the runtime
+        loop refreshes once per chunk via
+        :func:`omnidreams.interactive_drive.runtime.loop.push_telemetry`.
+        Before the simulation has produced its first chunk (warmup
+        window), ``vehicle_state`` is ``None`` and we return ``None``s
+        so the browser shows ``--`` instead of a stale zero.
+        """
+        snapshot = self._keyboard.vehicle_state
+        if snapshot is None:
+            return {
+                "speed_mps": None,
+                "steer_rad": None,
+                "yaw_rad": None,
+            }
+        return {
+            "speed_mps": float(snapshot.speed_mps),
+            "steer_rad": float(snapshot.steer_rad),
+            "yaw_rad": float(snapshot.yaw_rad),
+        }
+
+
+# Type alias for ``_serve_mjpeg``'s blocking getter parameter. ``None``
+# means the server is shutting down; ``(jpeg, count)`` is a fresh frame.
+_WaitForFrame = Callable[[int], tuple[bytes, int] | None]
+
+
+def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHandler]:
+    """Build a BaseHTTPRequestHandler subclass closed over ``presenter``.
+
+    http.server instantiates handlers per-request with a fixed signature,
+    so this factory is the standard way to inject shared state.
+    """
+
+    class Handler(BaseHTTPRequestHandler):
+        # Keep log lines off stderr during normal operation; they'd
+        # interleave badly with the backend's per-chunk timing logs.
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            return
+
+        def do_GET(self) -> None:  # noqa: N802 (http.server mandated name)
+            parsed = urlparse(self.path)
+            if parsed.path in ("/", "/index.html"):
+                self._serve_index()
+            elif parsed.path == "/stream":
+                self._serve_stream()
+            elif parsed.path == "/bev_stream":
+                self._serve_bev_stream()
+            elif parsed.path == "/state":
+                self._serve_state()
+            elif parsed.path == "/control":
+                self._serve_control(parse_qs(parsed.query))
+            elif parsed.path == "/drive":
+                self._serve_drive(parse_qs(parsed.query))
+            else:
+                self.send_error(HTTPStatus.NOT_FOUND)
+
+        def _serve_index(self) -> None:
+            body = _INDEX_HTML.encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _serve_state(self) -> None:
+            """Return the latest simulation telemetry as JSON.
+
+            Polled by the browser ~10 Hz to drive the speed readout. The
+            payload is intentionally tiny so the polling cost is negligible
+            even on slow links; if a richer dashboard wants more state the
+            ``KeyboardState`` snapshot is the authoritative source and we
+            can extend this without touching the producer side.
+            """
+            body = json.dumps(presenter._state_snapshot()).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _serve_stream(self) -> None:
+            self._serve_mjpeg(presenter._wait_for_new_frame)
+
+        def _serve_bev_stream(self) -> None:
+            self._serve_mjpeg(presenter._wait_for_new_bev_frame)
+
+        def _serve_mjpeg(self, wait_fn: _WaitForFrame) -> None:
+            """Generic ``multipart/x-mixed-replace`` writer used by /stream and
+            /bev_stream. ``wait_fn(last_seen)`` is the per-stream blocking
+            getter that returns ``(jpeg, frame_count)`` or ``None`` on
+            shutdown.
+            """
+            self.send_response(HTTPStatus.OK)
+            self.send_header(
+                "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"
+            )
+            self.send_header("Pragma", "no-cache")
+            self.send_header(
+                "Content-Type",
+                f"multipart/x-mixed-replace; boundary={_MULTIPART_BOUNDARY}",
+            )
+            self.end_headers()
+            last_seen = 0
+            try:
+                while not presenter.should_close:
+                    result = wait_fn(last_seen)
+                    if result is None:
+                        break
+                    jpeg, last_seen = result
+                    part = (
+                        (
+                            f"--{_MULTIPART_BOUNDARY}\r\n"
+                            f"Content-Type: image/jpeg\r\n"
+                            f"Content-Length: {len(jpeg)}\r\n\r\n"
+                        ).encode("ascii")
+                        + jpeg
+                        + b"\r\n"
+                    )
+                    self.wfile.write(part)
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                # Client disconnected; that's normal, not an error.
+                return
+
+        def _serve_control(self, query: dict[str, list[str]]) -> None:
+            key = query.get("key", [""])[0]
+            down_raw = query.get("down", ["0"])[0]
+            try:
+                down = bool(int(down_raw))
+            except ValueError:
+                down = False
+            if key:
+                presenter._apply_control(key, down)
+            self.send_response(HTTPStatus.NO_CONTENT)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def _serve_drive(self, query: dict[str, list[str]]) -> None:
+            presenter._apply_drive_control(
+                throttle=_query_float(query, "throttle"),
+                brake=_query_float(query, "brake"),
+                steer=_query_float(query, "steer"),
+                reverse=bool(int(query.get("reverse", ["0"])[0])),
+            )
+            self.send_response(HTTPStatus.NO_CONTENT)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    return Handler
+
+
+def _query_float(query: dict[str, list[str]], name: str) -> float:
+    try:
+        return float(query.get(name, ["0"])[0])
+    except ValueError:
+        return 0.0
+
+
+def _with_status_overlay(rgb_host_uint8: np.ndarray, message: str | None) -> np.ndarray:
+    if message is None:
+        return rgb_host_uint8
+    return render_loading_overlay(rgb_host_uint8, message=message)
+
+
+def parse_bind(value: str) -> tuple[str, int]:
+    """Accept ``HOST:PORT``, bare ``:PORT``, or a bare port number.
+
+    All three forms bind on ``0.0.0.0`` (all interfaces) by default;
+    pass an explicit host (e.g. ``127.0.0.1:8080``) to restrict the
+    listener to a single interface, which is the right choice when
+    you're terminating the connection through an SSH tunnel and don't
+    want the port reachable directly from the network.
+    """
+    if ":" not in value:
+        # Bare port number form (``--stream-mjpeg 8080``). Friendly
+        # shortcut for the common all-interfaces case; equivalent to
+        # ``:8080``.
+        host = "0.0.0.0"
+        port_str = value
+    else:
+        host, port_str = value.rsplit(":", 1)
+        if not host:
+            host = "0.0.0.0"
+    try:
+        port = int(port_str)
+    except ValueError as exc:
+        raise ValueError(
+            f"--stream-mjpeg port must be an integer, got {port_str!r}"
+        ) from exc
+    if not 1 <= port <= 65535:
+        raise ValueError(f"--stream-mjpeg port out of range: {port}")
+    return host, port

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -38,6 +38,7 @@ import threading
 from collections.abc import Callable
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
@@ -230,11 +231,63 @@ _INDEX_HTML = """<!doctype html>
     border-color: white;
     color: #111;
   }
+  .scene-picker {
+    position: fixed; top: 16px; right: 16px;
+    background: rgba(0, 0, 0, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    padding: 10px 14px;
+    color: white;
+    font-size: 13px;
+    display: flex; flex-direction: column; gap: 8px;
+    min-width: 220px;
+    backdrop-filter: blur(6px);
+  }
+  .scene-picker.hidden { display: none; }
+  .scene-picker label { opacity: 0.75; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+  .scene-picker select {
+    background: #1a1a1a; color: white;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-radius: 5px;
+    padding: 6px 8px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .scene-picker select:focus { outline: 1px solid rgba(120, 200, 255, 0.7); }
+  .scene-picker button {
+    background: rgba(120, 200, 255, 0.85);
+    color: #001020;
+    border: none;
+    border-radius: 5px;
+    padding: 8px 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background-color 0.1s, transform 0.05s;
+  }
+  .scene-picker button:hover { background: rgba(140, 215, 255, 1.0); }
+  .scene-picker button:active { transform: translateY(1px); }
+  .scene-picker button:disabled {
+    background: rgba(255, 255, 255, 0.18);
+    color: rgba(255, 255, 255, 0.45);
+    cursor: not-allowed;
+  }
+  .scene-picker .row { display: flex; flex-direction: column; gap: 3px; }
 </style>
 </head>
 <body>
 <img id="stream" src="/stream">
 <div class="hint">WASD / Arrows = Drive &middot; Space = Brake &middot; 1 = World-Model RGB &middot; 2 = HDMap &middot; R = Reset Rollout</div>
+<div class="scene-picker hidden" id="scene-picker">
+  <div class="row">
+    <label for="scene-select">Scene</label>
+    <select id="scene-select"></select>
+  </div>
+  <div class="row">
+    <label for="variant-select">Variant</label>
+    <select id="variant-select"></select>
+  </div>
+  <button id="load-scene-btn">Load Scene</button>
+</div>
 <div class="hud">
   <div class="speed disconnected" id="speed">
     <span class="speed-value" id="speed-value">--</span>
@@ -279,8 +332,16 @@ function send(key, down) {
   fetch('/control?key=' + encodeURIComponent(key) + '&down=' + (down ? 1 : 0))
     .catch(() => {});                       // ignore network hiccups, next event will resync
 }
-document.addEventListener('keydown', e => send(e.key, true));
-document.addEventListener('keyup', e => send(e.key, false));
+// Skip key handling when focus is on an input/select inside the scene
+// picker so the user can navigate the dropdowns with arrow keys.
+function shouldIgnoreKey(e) {
+  const t = e.target;
+  if (!t) return false;
+  const tag = t.tagName;
+  return tag === 'SELECT' || tag === 'INPUT' || tag === 'BUTTON' || tag === 'TEXTAREA';
+}
+document.addEventListener('keydown', e => { if (!shouldIgnoreKey(e)) send(e.key, true); });
+document.addEventListener('keyup', e => { if (!shouldIgnoreKey(e)) send(e.key, false); });
 // When the page loses focus we must release all keys so the car doesn't keep steering.
 window.addEventListener('blur', () => {
   DOWN_KEYS.forEach(k => send(k, false));
@@ -311,6 +372,71 @@ async function pollState() {
 }
 setInterval(pollState, 100);
 pollState();
+
+// Scene picker. Hidden by default; revealed once /scenes returns
+// at least one entry so demos that don't pass scene_options stay
+// visually clean. The dropdown variants follow whichever scene is
+// currently selected.
+const scenePicker = document.getElementById('scene-picker');
+const sceneSelect = document.getElementById('scene-select');
+const variantSelect = document.getElementById('variant-select');
+const loadSceneBtn = document.getElementById('load-scene-btn');
+let SCENES = [];
+function rebuildVariants(sceneIndex) {
+  variantSelect.innerHTML = '';
+  const scene = SCENES[sceneIndex];
+  const variants = scene && Array.isArray(scene.variants) ? scene.variants : [];
+  for (const v of (variants.length ? variants : ['default'])) {
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.textContent = v.charAt(0).toUpperCase() + v.slice(1);
+    variantSelect.appendChild(opt);
+  }
+}
+async function fetchScenes() {
+  try {
+    const r = await fetch('/scenes', { cache: 'no-store' });
+    if (!r.ok) return;
+    const data = await r.json();
+    SCENES = Array.isArray(data.scenes) ? data.scenes : [];
+    if (!SCENES.length) {
+      scenePicker.classList.add('hidden');
+      return;
+    }
+    sceneSelect.innerHTML = '';
+    SCENES.forEach((s, i) => {
+      const opt = document.createElement('option');
+      opt.value = String(i);
+      opt.textContent = s.label || ('Scene ' + (i + 1));
+      sceneSelect.appendChild(opt);
+    });
+    rebuildVariants(0);
+    scenePicker.classList.remove('hidden');
+  } catch {}
+}
+sceneSelect.addEventListener('change', () => {
+  rebuildVariants(parseInt(sceneSelect.value, 10) || 0);
+});
+loadSceneBtn.addEventListener('click', async () => {
+  const idx = parseInt(sceneSelect.value, 10) || 0;
+  const scene = SCENES[idx];
+  if (!scene) return;
+  loadSceneBtn.disabled = true;
+  loadSceneBtn.textContent = 'Loading…';
+  try {
+    await fetch('/scene/select?scene=' + encodeURIComponent(scene.path) +
+                '&variant=' + encodeURIComponent(variantSelect.value),
+                { method: 'GET', cache: 'no-store' });
+  } catch {}
+  // Re-enable shortly so the user can pick a different scene if the
+  // request was rejected; the actual scene transition is driven by
+  // the server-side loop and the stream will pause briefly.
+  setTimeout(() => {
+    loadSceneBtn.disabled = false;
+    loadSceneBtn.textContent = 'Load Scene';
+  }, 1200);
+});
+fetchScenes();
 </script>
 </body>
 </html>
@@ -335,6 +461,7 @@ class MJPEGStreamingPresenter:
         bind_port: int,
         *,
         jpeg_quality: int = 85,
+        scenes: tuple[dict[str, object], ...] = (),
     ) -> None:
         self._raster = raster
         self._keyboard = keyboard
@@ -353,6 +480,17 @@ class MJPEGStreamingPresenter:
         # to either waiter are always safe.
         self._latest_bev_jpeg: bytes | None = None
         self._bev_frame_count = 0
+        # Scene options surfaced to the browser dropdown via /scenes.
+        # Each entry is a dict with ``label``, ``path``, ``variants``;
+        # the demo wrapper builds these from its scene-discovery layer
+        # and passes them in. Empty tuple = no dropdown.
+        self._scenes: tuple[dict[str, object], ...] = tuple(scenes)
+        # Scene-change request channel mirroring the slangpy HUD's
+        # ``pending_scene_change`` flag. ``should_close`` returns True
+        # when this is non-None so the runtime loop unwinds; the demo
+        # wrapper then tears down the backend, calls
+        # ``acknowledge_scene_change``, and re-enters with a fresh sim.
+        self._pending_scene_change: tuple[Path, str] | None = None
         # Keyboard drive integrator. Late-imported because ``demo``
         # imports the streaming presenter via the CLI's presenter
         # factory; a top-level import would be circular. The integrator
@@ -364,6 +502,7 @@ class MJPEGStreamingPresenter:
         # where the creep-toward-4.47-m/s logic lives.
         from omnidreams.interactive_drive.demo import KeyboardDriveState
 
+        self._keyboard_drive_factory = KeyboardDriveState
         self._keyboard_drive = KeyboardDriveState(_KeyboardDriveSink(keyboard))
 
         try:
@@ -397,8 +536,40 @@ class MJPEGStreamingPresenter:
     @property
     def should_close(self) -> bool:
         # There's no window to close. The app loop runs until the
-        # simulation thread finishes or the user Ctrl-C's the process.
-        return self._stop_event.is_set()
+        # simulation thread finishes, the user Ctrl-C's the process,
+        # or a /scene/select request flips the pending-change channel
+        # so the demo wrapper can rebuild the backend with a new scene.
+        return self._stop_event.is_set() or self._pending_scene_change is not None
+
+    @property
+    def pending_scene_change(self) -> tuple[Path, str] | None:
+        """Scene the browser asked to load next, or ``None`` if no change is pending.
+
+        Set by the ``/scene/select`` endpoint and cleared by
+        :meth:`acknowledge_scene_change`. The demo wrapper polls this
+        between ``app.run()`` invocations to drive the scene-change
+        loop without tearing down the HTTP server / browser session.
+        """
+        return self._pending_scene_change
+
+    def acknowledge_scene_change(self, scene_path: Path, variant: str) -> None:
+        """Clear the pending scene change after the demo wrapper has applied it."""
+        del scene_path, variant  # accepted for symmetry with the slangpy HUD API
+        self._pending_scene_change = None
+
+    def bind_keyboard(self, keyboard: KeyboardState) -> None:
+        """Re-target the presenter at a fresh ``KeyboardState``.
+
+        ``InteractiveDriveApp`` constructs a new ``KeyboardState`` per
+        rollout; the demo wrapper reuses the same MJPEG presenter
+        across scene-change iterations, so the presenter has to follow
+        each new keyboard. The keyboard-drive integrator captures the
+        keyboard reference internally, so it gets rebuilt here.
+        """
+        self._keyboard = keyboard
+        self._keyboard_drive = self._keyboard_drive_factory(
+            _KeyboardDriveSink(keyboard)
+        )
 
     def process_events(self) -> None:
         # Input arrives asynchronously via ``/control`` HTTP requests, but
@@ -557,6 +728,40 @@ class MJPEGStreamingPresenter:
             "yaw_rad": float(snapshot.yaw_rad),
         }
 
+    def _request_scene_change(self, scene_path_str: str, variant: str) -> bool:
+        """Validate and stash a ``/scene/select`` request.
+
+        The validation gate is paranoid on purpose: the only paths that
+        can be loaded are ones the demo wrapper explicitly registered
+        in :attr:`_scenes`. A stale browser tab that POSTs an arbitrary
+        ``scene=`` path gets a 400 instead of having its filesystem
+        path latch into the next ``app.run`` iteration.
+        """
+        if not scene_path_str:
+            return False
+        # Match against the registered scenes by string-comparing the
+        # path; ``Path("a") == "a"`` is False so we normalize first.
+        for entry in self._scenes:
+            entry_path = str(entry.get("path", ""))
+            if entry_path == scene_path_str:
+                entry_variants = entry.get("variants", ()) or ("default",)
+                if not isinstance(entry_variants, (list, tuple)):
+                    entry_variants = ("default",)
+                resolved_variant = (
+                    variant if variant in entry_variants else entry_variants[0]
+                )
+                # Wake any handlers waiting on the frame condition so
+                # they observe ``should_close`` flipping and exit their
+                # per-connection loop promptly. Not strictly required
+                # for correctness (the existing 1 s timeout would
+                # eventually retry) but it makes the scene transition
+                # feel snappier.
+                self._pending_scene_change = (Path(entry_path), str(resolved_variant))
+                with self._frame_cond:
+                    self._frame_cond.notify_all()
+                return True
+        return False
+
 
 # Type alias for ``_serve_mjpeg``'s blocking getter parameter. ``None``
 # means the server is shutting down; ``(jpeg, count)`` is a fresh frame.
@@ -586,6 +791,10 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
                 self._serve_bev_stream()
             elif parsed.path == "/state":
                 self._serve_state()
+            elif parsed.path == "/scenes":
+                self._serve_scenes()
+            elif parsed.path == "/scene/select":
+                self._serve_scene_select(parse_qs(parsed.query))
             elif parsed.path == "/control":
                 self._serve_control(parse_qs(parsed.query))
             elif parsed.path == "/drive":
@@ -618,6 +827,43 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             self.send_header("Cache-Control", "no-store")
             self.end_headers()
             self.wfile.write(body)
+
+        def _serve_scenes(self) -> None:
+            """Return the discovered scene options as JSON for the browser dropdown.
+
+            Each entry is ``{label, path, variants}``; the browser renders
+            them into ``<select>`` elements in the upper-right scene
+            picker. Empty list when the demo wasn't given any scene
+            options (e.g. bare ``--no-hud --stream-mjpeg`` without going
+            through the demo wrapper's discovery layer); the browser
+            then hides the picker entirely.
+            """
+            body = json.dumps({"scenes": list(presenter._scenes)}).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _serve_scene_select(self, query: dict[str, list[str]]) -> None:
+            """Mark ``?scene=PATH&variant=NAME`` as the next scene to load.
+
+            Sets the presenter's ``pending_scene_change`` channel; the
+            demo wrapper picks it up between ``app.run()`` iterations
+            and rebuilds the backend with the new scene. Validates the
+            requested scene against the presenter's ``_scenes`` list so a
+            stale browser tab can't smuggle in an arbitrary path.
+            """
+            scene = query.get("scene", [""])[0]
+            variant = query.get("variant", ["default"])[0]
+            ok = presenter._request_scene_change(scene, variant)
+            if not ok:
+                self.send_error(HTTPStatus.BAD_REQUEST)
+                return
+            self.send_response(HTTPStatus.NO_CONTENT)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
 
         def _serve_stream(self) -> None:
             self._serve_mjpeg(presenter._wait_for_new_frame)

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -35,6 +35,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from collections.abc import Callable
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -232,61 +233,114 @@ _INDEX_HTML = """<!doctype html>
     color: #111;
   }
   .scene-picker {
-    position: fixed; top: 16px; right: 16px;
+    position: fixed; bottom: 16px; right: 16px;
     background: rgba(0, 0, 0, 0.7);
     border: 1px solid rgba(255, 255, 255, 0.18);
     border-radius: 10px;
-    padding: 10px 14px;
     color: white;
-    font-size: 13px;
-    display: flex; flex-direction: column; gap: 8px;
-    min-width: 220px;
+    font-size: 12px;
+    display: flex; flex-direction: column;
+    max-height: 60vh;
     backdrop-filter: blur(6px);
+    overflow: hidden;
+    /* Animate the collapse so the toggle feels physical rather than a
+       hard show/hide. ``max-height`` is the lever rather than ``display``
+       because ``display: none`` short-circuits transitions. */
+    transition: max-height 0.18s ease-out;
   }
   .scene-picker.hidden { display: none; }
-  .scene-picker label { opacity: 0.75; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
-  .scene-picker select {
-    background: #1a1a1a; color: white;
-    border: 1px solid rgba(255, 255, 255, 0.22);
-    border-radius: 5px;
+  .scene-picker.collapsed { max-height: 38px; }
+  .scene-picker-toggle {
+    background: none; border: none; color: white;
+    padding: 9px 12px;
+    display: flex; align-items: center; gap: 8px;
+    cursor: pointer;
+    font-size: 11px; font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    width: 100%;
+    text-align: left;
+    flex-shrink: 0;
+    pointer-events: auto;
+    user-select: none;
+  }
+  .scene-picker-toggle:hover { background: rgba(255, 255, 255, 0.06); }
+  .scene-picker-count {
+    opacity: 0.55;
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 11px;
+  }
+  .scene-picker-chevron {
+    margin-left: auto;
+    font-size: 10px;
+    transition: transform 0.18s ease-out;
+  }
+  .scene-picker.collapsed .scene-picker-chevron {
+    transform: rotate(-90deg);
+  }
+  .scene-picker-list {
+    display: flex; flex-direction: column; gap: 6px;
+    padding: 0 10px 10px 10px;
+    overflow-y: auto;
+  }
+  /* Hide the list's scroll viewport entirely while the panel is
+     collapsed so no scrollbar artifacts leak through the parent's
+     ``overflow: hidden`` clipping. */
+  .scene-picker.collapsed .scene-picker-list { overflow: hidden; }
+  /* Replace Chromium's default scrollbar (which carries the up/down
+     arrow buttons that were poking out the bottom-right of the
+     collapsed panel) with a slim button-less rail. Firefox's
+     standards-track ``scrollbar-width`` covers the same ground. */
+  .scene-picker-list { scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.22) transparent; }
+  .scene-picker-list::-webkit-scrollbar { width: 6px; }
+  .scene-picker-list::-webkit-scrollbar-track { background: transparent; }
+  .scene-picker-list::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.22);
+    border-radius: 3px;
+  }
+  .scene-picker-list::-webkit-scrollbar-button { display: none; }
+  .scene-picker-list::-webkit-scrollbar-corner { background: transparent; }
+  .scene-card {
+    width: 160px;
+    border-radius: 6px;
+    overflow: hidden;
+    cursor: pointer;
+    border: 2px solid transparent;
+    transition: border-color 0.1s, transform 0.05s;
+    background: rgba(255, 255, 255, 0.05);
+    pointer-events: auto;
+    user-select: none;
+  }
+  .scene-card:hover { border-color: rgba(120, 200, 255, 0.7); }
+  .scene-card.loading {
+    border-color: rgba(120, 200, 255, 1.0);
+    pointer-events: none;
+    opacity: 0.7;
+  }
+  .scene-card img {
+    width: 100%; height: 72px;
+    object-fit: cover;
+    display: block;
+    background: #222;
+  }
+  .scene-card .scene-label {
     padding: 6px 8px;
-    font-size: 13px;
-    cursor: pointer;
+    font-size: 11px; line-height: 1.3;
   }
-  .scene-picker select:focus { outline: 1px solid rgba(120, 200, 255, 0.7); }
-  .scene-picker button {
-    background: rgba(120, 200, 255, 0.85);
-    color: #001020;
-    border: none;
-    border-radius: 5px;
-    padding: 8px 12px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: background-color 0.1s, transform 0.05s;
-  }
-  .scene-picker button:hover { background: rgba(140, 215, 255, 1.0); }
-  .scene-picker button:active { transform: translateY(1px); }
-  .scene-picker button:disabled {
-    background: rgba(255, 255, 255, 0.18);
-    color: rgba(255, 255, 255, 0.45);
-    cursor: not-allowed;
-  }
-  .scene-picker .row { display: flex; flex-direction: column; gap: 3px; }
 </style>
 </head>
 <body>
 <img id="stream" src="/stream">
-<div class="hint">WASD / Arrows = Drive &middot; Space = Brake &middot; 1 = World-Model RGB &middot; 2 = HDMap &middot; R = Reset Rollout</div>
+<div class="hint">WASD / Arrows = Drive &middot; 1 = World-Model RGB &middot; 2 = HDMap &middot; R = Reset Rollout</div>
 <div class="scene-picker hidden" id="scene-picker">
-  <div class="row">
-    <label for="scene-select">Scene</label>
-    <select id="scene-select"></select>
-  </div>
-  <div class="row">
-    <label for="variant-select">Variant</label>
-    <select id="variant-select"></select>
-  </div>
-  <button id="load-scene-btn">Load Scene</button>
+  <button class="scene-picker-toggle" id="scene-picker-toggle" type="button">
+    <span>Scenes</span>
+    <span class="scene-picker-count" id="scene-picker-count"></span>
+    <span class="scene-picker-chevron">&#9662;</span>
+  </button>
+  <div class="scene-picker-list" id="scene-picker-list"></div>
 </div>
 <div class="hud">
   <div class="speed disconnected" id="speed">
@@ -332,13 +386,14 @@ function send(key, down) {
   fetch('/control?key=' + encodeURIComponent(key) + '&down=' + (down ? 1 : 0))
     .catch(() => {});                       // ignore network hiccups, next event will resync
 }
-// Skip key handling when focus is on an input/select inside the scene
-// picker so the user can navigate the dropdowns with arrow keys.
+// Skip key handling when focus is on a form input (e.g. a future
+// settings panel). The scene picker is now click-driven so the
+// keyboard never lands on a button there.
 function shouldIgnoreKey(e) {
   const t = e.target;
   if (!t) return false;
   const tag = t.tagName;
-  return tag === 'SELECT' || tag === 'INPUT' || tag === 'BUTTON' || tag === 'TEXTAREA';
+  return tag === 'INPUT' || tag === 'TEXTAREA';
 }
 document.addEventListener('keydown', e => { if (!shouldIgnoreKey(e)) send(e.key, true); });
 document.addEventListener('keyup', e => { if (!shouldIgnoreKey(e)) send(e.key, false); });
@@ -373,69 +428,86 @@ async function pollState() {
 setInterval(pollState, 100);
 pollState();
 
-// Scene picker. Hidden by default; revealed once /scenes returns
-// at least one entry so demos that don't pass scene_options stay
-// visually clean. The dropdown variants follow whichever scene is
-// currently selected.
+// Scene picker. Hidden until /scenes returns at least one entry,
+// then renders as a panel in the bottom-right. Auto-expanded on first
+// load because nothing happens until the user picks a scene -- the
+// server is blocked on ``wait_for_scene_selection`` and the MJPEG
+// stream shows the "Select a scene to begin driving" overlay frame.
+// After the first pick it auto-collapses (and click-outside collapses
+// thereafter), so the panel stays out of the way during driving.
 const scenePicker = document.getElementById('scene-picker');
-const sceneSelect = document.getElementById('scene-select');
-const variantSelect = document.getElementById('variant-select');
-const loadSceneBtn = document.getElementById('load-scene-btn');
+const scenePickerList = document.getElementById('scene-picker-list');
+const scenePickerToggle = document.getElementById('scene-picker-toggle');
+const scenePickerCount = document.getElementById('scene-picker-count');
 let SCENES = [];
-function rebuildVariants(sceneIndex) {
-  variantSelect.innerHTML = '';
-  const scene = SCENES[sceneIndex];
-  const variants = scene && Array.isArray(scene.variants) ? scene.variants : [];
-  for (const v of (variants.length ? variants : ['default'])) {
-    const opt = document.createElement('option');
-    opt.value = v;
-    opt.textContent = v.charAt(0).toUpperCase() + v.slice(1);
-    variantSelect.appendChild(opt);
-  }
+let firstSceneLoaded = false;
+function setScenePickerCollapsed(collapsed) {
+  scenePicker.classList.toggle('collapsed', collapsed);
 }
+scenePickerToggle.addEventListener('click', () => {
+  setScenePickerCollapsed(!scenePicker.classList.contains('collapsed'));
+});
+// Click outside the panel collapses it -- but only after the user has
+// actually picked their first scene. Pre-selection clicks (e.g. the
+// user clicking on the camera area to dismiss something) don't tuck
+// the picker away, since the panel is the only way to start driving.
+document.addEventListener('mousedown', e => {
+  if (!firstSceneLoaded) return;
+  if (scenePicker.classList.contains('hidden')) return;
+  if (scenePicker.contains(e.target)) return;
+  setScenePickerCollapsed(true);
+});
 async function fetchScenes() {
   try {
     const r = await fetch('/scenes', { cache: 'no-store' });
     if (!r.ok) return;
     const data = await r.json();
     SCENES = Array.isArray(data.scenes) ? data.scenes : [];
+    scenePickerCount.textContent = SCENES.length ? `(${SCENES.length})` : '';
     if (!SCENES.length) {
       scenePicker.classList.add('hidden');
       return;
     }
-    sceneSelect.innerHTML = '';
+    scenePickerList.innerHTML = '';
     SCENES.forEach((s, i) => {
-      const opt = document.createElement('option');
-      opt.value = String(i);
-      opt.textContent = s.label || ('Scene ' + (i + 1));
-      sceneSelect.appendChild(opt);
+      const card = document.createElement('div');
+      card.className = 'scene-card';
+      card.dataset.idx = String(i);
+      if (s.has_thumbnail) {
+        const img = document.createElement('img');
+        img.src = '/thumbnail?scene=' + encodeURIComponent(s.path);
+        img.alt = '';
+        img.onerror = () => { img.style.display = 'none'; };
+        card.appendChild(img);
+      }
+      const label = document.createElement('div');
+      label.className = 'scene-label';
+      label.textContent = s.label || ('Scene ' + (i + 1));
+      card.appendChild(label);
+      card.addEventListener('click', () => loadScene(i, card));
+      scenePickerList.appendChild(card);
     });
-    rebuildVariants(0);
     scenePicker.classList.remove('hidden');
   } catch {}
 }
-sceneSelect.addEventListener('change', () => {
-  rebuildVariants(parseInt(sceneSelect.value, 10) || 0);
-});
-loadSceneBtn.addEventListener('click', async () => {
-  const idx = parseInt(sceneSelect.value, 10) || 0;
+async function loadScene(idx, card) {
   const scene = SCENES[idx];
   if (!scene) return;
-  loadSceneBtn.disabled = true;
-  loadSceneBtn.textContent = 'Loading…';
+  card.classList.add('loading');
   try {
-    await fetch('/scene/select?scene=' + encodeURIComponent(scene.path) +
-                '&variant=' + encodeURIComponent(variantSelect.value),
+    // Variant is omitted; the server falls back to the scene's first
+    // registered variant (typically ``default``). The streaming UI
+    // intentionally doesn't expose the variant selector.
+    await fetch('/scene/select?scene=' + encodeURIComponent(scene.path),
                 { method: 'GET', cache: 'no-store' });
   } catch {}
-  // Re-enable shortly so the user can pick a different scene if the
-  // request was rejected; the actual scene transition is driven by
-  // the server-side loop and the stream will pause briefly.
-  setTimeout(() => {
-    loadSceneBtn.disabled = false;
-    loadSceneBtn.textContent = 'Load Scene';
-  }, 1200);
-});
+  // Tuck the panel away so the user gets the camera view back; the
+  // scene transition itself is driven by the server-side loop. From
+  // this point on, click-outside dismissal is enabled too.
+  firstSceneLoaded = true;
+  setScenePickerCollapsed(true);
+  setTimeout(() => { card.classList.remove('loading'); }, 1500);
+}
 fetchScenes();
 </script>
 </body>
@@ -462,6 +534,7 @@ class MJPEGStreamingPresenter:
         *,
         jpeg_quality: int = 85,
         scenes: tuple[dict[str, object], ...] = (),
+        thumbnails: dict[str, bytes] | None = None,
     ) -> None:
         self._raster = raster
         self._keyboard = keyboard
@@ -485,12 +558,27 @@ class MJPEGStreamingPresenter:
         # the demo wrapper builds these from its scene-discovery layer
         # and passes them in. Empty tuple = no dropdown.
         self._scenes: tuple[dict[str, object], ...] = tuple(scenes)
+        # Pre-encoded JPEG thumbnails keyed by scene path. The demo
+        # wrapper takes :class:`SceneOption.thumbnail` (a PIL ``Image``)
+        # and JPEG-encodes once at startup -- per-tile encoding under
+        # the HTTP handler thread would compete with the main camera's
+        # encode budget for no good reason. Keys must match the
+        # ``path`` strings posted in :attr:`_scenes` so the
+        # ``/thumbnail`` endpoint can resolve them by an exact string
+        # compare instead of building a separate id->path map.
+        self._thumbnails: dict[str, bytes] = dict(thumbnails or {})
         # Scene-change request channel mirroring the slangpy HUD's
         # ``pending_scene_change`` flag. ``should_close`` returns True
         # when this is non-None so the runtime loop unwinds; the demo
         # wrapper then tears down the backend, calls
         # ``acknowledge_scene_change``, and re-enters with a fresh sim.
         self._pending_scene_change: tuple[Path, str] | None = None
+        # Pre-cached idle "Select a scene" overlay. Lazy-initialised on
+        # the first call to :meth:`_publish_idle_frame`. Cached so the
+        # heartbeat republish in ``wait_for_scene_selection`` doesn't
+        # redo the PIL text render every 2 s while the user is
+        # deciding what to load.
+        self._idle_frame_cache: np.ndarray | None = None
         # Keyboard drive integrator. Late-imported because ``demo``
         # imports the streaming presenter via the CLI's presenter
         # factory; a top-level import would be circular. The integrator
@@ -556,6 +644,62 @@ class MJPEGStreamingPresenter:
         """Clear the pending scene change after the demo wrapper has applied it."""
         del scene_path, variant  # accepted for symmetry with the slangpy HUD API
         self._pending_scene_change = None
+
+    def wait_for_scene_selection(self) -> tuple[Path, str] | None:
+        """Block until the browser POSTs a scene selection.
+
+        Used by the demo wrapper at startup so we don't burn world-model
+        warmup on whatever ``args.scene`` defaulted to before the user
+        has actually picked something. Publishes an idle "Select a
+        scene to begin" overlay frame so connected browsers have
+        something to display while the wait spins; then polls
+        :attr:`_pending_scene_change` until either the browser triggers
+        ``/scene/select`` or :meth:`close` flips the stop event.
+
+        Re-publishes the idle frame on a slow heartbeat (every 2 s) so
+        a browser that connects after ``wait_for_scene_selection``
+        first fired -- e.g. the user navigates to the demo URL after
+        the server has already started waiting -- gets the placeholder
+        promptly via the standard MJPEG ``frame_count`` increment path
+        instead of having to wait for an unrelated frame.
+
+        Returns ``(scene_path, variant)`` once the user picks, or
+        ``None`` when the presenter is closed first (Ctrl-C in the
+        terminal where the demo is running). Mirrors
+        :meth:`SlangPyHudPresenter.wait_for_scene_selection`'s contract
+        so the demo wrapper's flow is identical across HUD / MJPEG.
+        """
+        idle_heartbeat_s = 2.0
+        last_publish = 0.0
+        while True:
+            now = time.monotonic()
+            if now - last_publish >= idle_heartbeat_s:
+                self._publish_idle_frame()
+                last_publish = now
+            if self._stop_event.wait(timeout=0.1):
+                return None
+            if self._pending_scene_change is not None:
+                return self._pending_scene_change
+
+    def _publish_idle_frame(self) -> None:
+        """Stream the cached black 'select a scene' placeholder frame.
+
+        The PIL render is memoised on :attr:`_idle_frame_cache` so the
+        heartbeat in :meth:`wait_for_scene_selection` doesn't pay the
+        text-overlay cost on every tick -- the placeholder is identical
+        every time so a single render is sufficient. Each publish call
+        still bumps :attr:`_frame_count` so connected MJPEG handlers
+        wake up and push the frame out to the browser, which is what
+        actually matters for late-arriving clients.
+        """
+        if self._idle_frame_cache is None:
+            base = np.zeros(
+                (self._raster.height, self._raster.width, 3), dtype=np.uint8
+            )
+            self._idle_frame_cache = render_loading_overlay(
+                base, message="Select a scene to begin driving"
+            )
+        self._publish(self._idle_frame_cache)
 
     def bind_keyboard(self, keyboard: KeyboardState) -> None:
         """Re-target the presenter at a fresh ``KeyboardState``.
@@ -795,6 +939,8 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
                 self._serve_scenes()
             elif parsed.path == "/scene/select":
                 self._serve_scene_select(parse_qs(parsed.query))
+            elif parsed.path == "/thumbnail":
+                self._serve_thumbnail(parse_qs(parsed.query))
             elif parsed.path == "/control":
                 self._serve_control(parse_qs(parsed.query))
             elif parsed.path == "/drive":
@@ -807,7 +953,13 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
-            self.send_header("Cache-Control", "no-store")
+            # Aggressive no-cache so a browser that still has a
+            # pre-scene-picker tab open doesn't keep rendering the old
+            # HTML after a server upgrade. The page is tiny (~10 KB) so
+            # bypassing the cache on every reload costs nothing.
+            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+            self.send_header("Pragma", "no-cache")
+            self.send_header("Expires", "0")
             self.end_headers()
             self.wfile.write(body)
 
@@ -831,14 +983,19 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
         def _serve_scenes(self) -> None:
             """Return the discovered scene options as JSON for the browser dropdown.
 
-            Each entry is ``{label, path, variants}``; the browser renders
-            them into ``<select>`` elements in the upper-right scene
-            picker. Empty list when the demo wasn't given any scene
-            options (e.g. bare ``--no-hud --stream-mjpeg`` without going
-            through the demo wrapper's discovery layer); the browser
-            then hides the picker entirely.
+            Each entry is ``{label, path, variants, has_thumbnail}``;
+            the browser renders them as clickable cards in the
+            bottom-right scene picker. ``has_thumbnail`` lets the
+            client decide whether to issue a ``/thumbnail`` request --
+            cleaner than relying on ``<img onerror>`` and avoids the
+            broken-image flash for scenes that ship no first-image
+            asset.
             """
-            body = json.dumps({"scenes": list(presenter._scenes)}).encode("utf-8")
+            scenes_with_thumbs = [
+                {**entry, "has_thumbnail": str(entry.get("path", "")) in presenter._thumbnails}
+                for entry in presenter._scenes
+            ]
+            body = json.dumps({"scenes": scenes_with_thumbs}).encode("utf-8")
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
@@ -853,7 +1010,11 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             demo wrapper picks it up between ``app.run()`` iterations
             and rebuilds the backend with the new scene. Validates the
             requested scene against the presenter's ``_scenes`` list so a
-            stale browser tab can't smuggle in an arbitrary path.
+            stale browser tab can't smuggle in an arbitrary path. The
+            ``variant`` query parameter is optional: when omitted (or
+            unrecognised) the scene's first registered variant is used,
+            which is what the streaming UI relies on now that it has
+            no variant selector.
             """
             scene = query.get("scene", [""])[0]
             variant = query.get("variant", ["default"])[0]
@@ -864,6 +1025,30 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             self.send_response(HTTPStatus.NO_CONTENT)
             self.send_header("Content-Length", "0")
             self.end_headers()
+
+        def _serve_thumbnail(self, query: dict[str, list[str]]) -> None:
+            """Return the JPEG-encoded thumbnail for ``?scene=PATH``.
+
+            The thumbnails were JPEG-encoded once at startup in the
+            demo wrapper (no per-request encode cost). Sends a 404
+            when the scene has no thumbnail or wasn't registered, so
+            the browser's ``onerror`` hook can hide the ``<img>``
+            element cleanly.
+            """
+            scene = query.get("scene", [""])[0]
+            data = presenter._thumbnails.get(scene)
+            if not data:
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "image/jpeg")
+            self.send_header("Content-Length", str(len(data)))
+            # Long cache: the thumbnail never changes for a given
+            # session, and the path string already keys the cache
+            # bucket per-scene.
+            self.send_header("Cache-Control", "public, max-age=3600")
+            self.end_headers()
+            self.wfile.write(data)
 
         def _serve_stream(self) -> None:
             self._serve_mjpeg(presenter._wait_for_new_frame)

--- a/uv.lock
+++ b/uv.lock
@@ -1184,7 +1184,7 @@ provides-extras = ["dev", "examples", "runners", "serving"]
 
 [[package]]
 name = "flashdreams-causal-forcing"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/causal_forcing" }
 dependencies = [
     { name = "flashdreams" },
@@ -1208,7 +1208,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-cosmos-predict2"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/cosmos_predict2" }
 dependencies = [
     { name = "flashdreams" },
@@ -1230,7 +1230,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-fastvideo-causal-wan22"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/fastvideo_causal_wan22" }
 dependencies = [
     { name = "flashdreams" },
@@ -1252,7 +1252,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-flashvsr"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/flashvsr" }
 dependencies = [
     { name = "block-sparse-attn" },
@@ -1286,7 +1286,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-lingbot"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/lingbot" }
 dependencies = [
     { name = "aiohttp" },
@@ -1319,7 +1319,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-omnidreams"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/omnidreams" }
 dependencies = [
     { name = "einops" },
@@ -1390,7 +1390,7 @@ provides-extras = ["interactive-drive", "dev"]
 
 [[package]]
 name = "flashdreams-self-forcing"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/self_forcing" }
 dependencies = [
     { name = "flashdreams" },
@@ -1412,7 +1412,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "flashdreams-wan21"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "integrations/wan21" }
 dependencies = [
     { name = "flashdreams" },


### PR DESCRIPTION
## Summary
Restores `--stream-mjpeg` for `omnidreams.interactive_drive` (dropped during the move into flashdreams) and grows it into a full HTML demo: scene picker with thumbnails, live speed/key HUD, auto-crawl, and alpasim-matched out-of-bounds auto-respawn. Docs now point users at this single-process, no-graphics-GPU-required path before WebRTC.
## What changed
### Browser presenter (`--stream-mjpeg`)
- New `MJPEGStreamingPresenter` (port of the version that lived in `omni-dreams` pre-monorepo) JPEG-encodes camera frames on the CPU and serves `multipart/x-mixed-replace`. Accepts `--stream-mjpeg [HOST:]PORT` (bare ports OK).
- `demo.py`'s `_run_streaming` mirrors `_run_slangpy_hud`'s long-lived-presenter / scene-change-loop topology so the HTTP server and connected browser tabs survive scene rebuilds. Hosts without a graphics queue (compute-only DGX, etc.) can now run the demo end-to-end against a remote browser.
### In-page HUD
- Speed readout (MPH) polled from a new `/state` endpoint at 10 Hz; runtime loop publishes `simulation.current_state` once per chunk through `KeyboardState.update_telemetry`.
- WASD chiclets light up locally on `keydown`/`keyup` (zero round-trip); arrow keys highlight the same chiclets.
- Auto-crawl: keypresses route through the slangpy HUD's `KeyboardDriveState` integrator (via a local `_KeyboardDriveSink` so the streaming module doesn't drag in SlangPy), so releasing throttle creeps to ~10 mph.
### Scene selector
- Endpoints: `/scenes` (JSON, includes `has_thumbnail`), `/scene/select?scene=PATH`, `/thumbnail?scene=PATH`. Validation gates the requested path against the registered list; unknown variants fall back to the scene's first registered variant.
- Bottom-right HTML panel, default-collapsed to a `Scenes (N) ▾` pill that expands on click into a thumbnail-card list. Click-outside auto-collapse, suppressed until the user has picked their first scene.
- New `wait_for_scene_selection()` mirrors the slangpy HUD's API and blocks before the first `app.run()` so warmup never burns on `args.scene`'s default. Publishes a `Select a scene to begin driving` overlay frame on a 2 s heartbeat so late-arriving tabs still see the prompt.
### Out-of-bounds detection (alpasim parity)
- New `MapBounds` (`simulation/map_bounds.py`) computes the union XY AABB across every spatial layer in the `SceneBundle` — lane markers, drivable triangles, polygons, vehicle tracks, ground mesh — *not* just `mesh_ground.ply`, which was a strip-of-road on most scenes.
- Proximity is a verbatim port of `alpasim_runtime.events.state.is_ego_off_map`: distance from the AABB+margin edge ramped over a 100 m warning zone, hard `2.0` sentinel once the ego crosses. Loop overlays *Approaching map edge…* / *Respawning…* and triggers the same reset path `R` uses; every state transition is logged to stderr.
- Five tunable flags: `--oob-margin-m`, `--oob-warning-zone-m`, `--oob-warn-proximity`, `--oob-respawn-proximity`, `--oob-respawn-debounce-chunks`. `GroundSnapper` is back to a snap-quality-only role.
### Documentation
- `flashdreams/docs/source/models/omnidreams.rst` rewritten so `interactive-drive --stream-mjpeg` is the recommended interactive path; WebRTC kept as an alternative section.
- Integration README documents all three presenter modes, OOB knobs, scene-selector flow, and HUD overlays. Removed the lingering "Space = Brake" hint (S already brakes).
## Test plan
- [ ] `interactive-drive --stream-mjpeg :8080` → page loads with expanded scene picker, "Select a scene to begin driving" overlay in the camera area, speed reads `--`.
- [ ] Click a scene tile → picker collapses, scene loads, speed reads numeric MPH after first chunk lands.
- [ ] Hold `W` / arrow keys → chiclets light; release → ego coasts to ~10 mph (auto-crawl). `R` resets the rollout.
- [ ] Switch scenes from the now-collapsed pill → backend rebuilds while the browser session stays connected; stream resumes once the new pipeline produces frames.
- [ ] Drive past the navigable area → stderr `[loop] oob …` transitions, *Approaching map edge…* in the warning band, *Respawning…* + reset fires once across AABB+margin.
- [ ] Verify slangpy HUD (`interactive-drive`) and `--no-hud` still work — they share the same simulation / OOB / telemetry plumbing.
- [ ] `pytest integrations/omnidreams/tests/interactive_drive` stays green (loop reads `last_proximity` / `update_telemetry` via `getattr`, so existing fakes don't need touching).