### PR TITLE
feat(hy_worldplay): pose-JSON default for --example-data

### DIFF
--- a/integrations/hy_worldplay/README.md
+++ b/integrations/hy_worldplay/README.md
@@ -81,13 +81,17 @@ uv run flashdreams-run hy-worldplay-wan-i2v-5b \
     --example-data \
     --ckpt-path /path/to/models/wan_distilled_model/model.pt \
     --num-chunk 1 \
-    --pose "w-3" \
     --output-dir outputs
 ```
 
-`--example-data` lazy-downloads upstream's `assets/img/test.png`
-into `data_local/hy_worldplay/` (gitignored) and uses it as the
-first frame. Pass `--image-path <path>` instead for a custom input.
+`--example-data` lazy-downloads upstream's sample first frame
+(`assets/img/test.png`) and camera trajectory
+(`assets/pose/test_forward_32_latents.json`) into
+`data_local/hy_worldplay/` (gitignored) and uses them as the input
+image + pose. Pass `--image-path <path>` and/or `--pose <script|json>`
+to override either; the pose source is prefix-sliced to the rollout's
+`num_chunk * 4` latent budget, so the 33-entry sample drives any
+`num-chunk` up to 8.
 
 `--ckpt-path` is optional. Without it the pipeline loads the base
 Wan 2.2 TI2V-5B safetensors and HY's conditioners stay zero-init

--- a/integrations/hy_worldplay/hy_worldplay/_pose.py
+++ b/integrations/hy_worldplay/hy_worldplay/_pose.py
@@ -192,8 +192,9 @@ def parse_pose_data(
             * A pose-script string like ``"w-3, right-0.5, d-4"``.
             * A pre-parsed mapping with the same shape as the JSON file.
         n_latents: Number of latent frames the rollout will produce
-            (``len_t`` times the AR-step count). The parsed pose script
-            must produce exactly this many entries.
+            (``len_t`` times the AR-step count). The pose source must
+            produce *at least* this many entries; any extra trailing
+            poses are ignored (the first ``n_latents`` are used).
         third_person: When ``True``, only emit translation classes for
             frames with small yaw / pitch (matches upstream's ``tps`` flag).
 
@@ -223,11 +224,17 @@ def parse_pose_data(
         )
 
     keys = list(pose_json.keys())
-    if len(keys) != n_latents:
+    if len(keys) < n_latents:
         raise ValueError(
-            f"pose corresponds to {len(keys)} latents, but n_latents={n_latents}. "
-            "Pass a pose script of matching length or adjust n_latents."
+            f"pose corresponds to {len(keys)} latents, but the rollout needs "
+            f"n_latents={n_latents}. Pass a longer pose script/file or reduce "
+            "num_chunk."
         )
+    # A pose source longer than the rollout is fine: take the first
+    # ``n_latents`` poses. This is vendor's prefix-slice behaviour and
+    # lets upstream's fixed-length sample (e.g. the 33-entry
+    # ``test_forward_32_latents.json``) drive a shorter ``num_chunk`` run.
+    keys = keys[:n_latents]
 
     c2w_list: list[np.ndarray] = []
     K_list: list[np.ndarray] = []

--- a/integrations/hy_worldplay/hy_worldplay/runner.py
+++ b/integrations/hy_worldplay/hy_worldplay/runner.py
@@ -50,6 +50,11 @@ identical -- including no trailing period -- so UMT5 tokenization
 matches the reference output (trailing ``.`` adds an extra token and
 shifts conditioning by ~5/255)."""
 
+DEFAULT_POSE = "w-15"
+"""Default camera trajectory: 15 forward steps (+ the identity input
+frame) = 16 latents, matching the default ``num_chunk=4`` rollout. With
+``--example-data`` this is swapped for upstream's sample pose JSON."""
+
 
 # Repo root = ``<this file>.parents[3]`` (``flashdreams/integrations/hy_worldplay/hy_worldplay/runner.py``).
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -64,6 +69,11 @@ EXAMPLE_DATA_DIR_LOCAL = _REPO_ROOT / "data_local/hy_worldplay"
 
 _EXAMPLE_IMAGE_FILENAME = "test.png"
 """Upstream's default ``--image_path`` fixture (704x1280)."""
+
+_EXAMPLE_POSE_FILENAME = "test_forward_32_latents.json"
+"""Upstream's sample camera trajectory (``assets/pose/``); 33 entries
+(32 forward-motion latents + the identity input frame). Long enough to
+drive any ``num_chunk <= 8`` rollout via the parser's prefix slice."""
 
 
 def preprocess_first_frame(
@@ -184,13 +194,14 @@ class HyWorldPlayWanI2VRunnerConfig(RunnerConfig):
     for the README demo; pass ``--image-path`` explicitly for
     production runs."""
 
-    pose: str = "w-15"
+    pose: str = DEFAULT_POSE
     """Camera trajectory as a pose-string (e.g. ``"w-15"``,
     ``"w-3, right-1, d-4"``) or the path to a JSON file produced by
     upstream's ``hyvideo/generate_custom_trajectory.py``. The parser
     prepends an identity pose for the input frame, so ``w-N`` produces
-    ``N + 1`` latents; pick ``N == num_chunk * 4 - 1`` to match the
-    rollout's latent budget."""
+    ``N + 1`` latents; the rollout consumes ``num_chunk * 4`` and a
+    longer source is prefix-sliced. With ``--example-data`` left at the
+    default, the runner swaps in upstream's sample pose JSON."""
 
     num_chunk: int = 4
     """Autoregressive chunks to roll out; each chunk emits 4 latents
@@ -340,8 +351,13 @@ class HyWorldPlayWanI2VRunner(
                     "CUDAGraphWrapper for diagnostic dumps."
                 )
 
-        if cfg.image_path is None and cfg.example_data:
-            cfg.image_path = self._fetch_example_image()
+        if cfg.example_data:
+            if cfg.image_path is None:
+                cfg.image_path = self._fetch_example_image()
+            # Swap the synthetic default pose for upstream's sample
+            # trajectory only when the user hasn't passed their own.
+            if cfg.pose == DEFAULT_POSE:
+                cfg.pose = str(self._fetch_example_pose())
         if cfg.image_path is None:
             raise ValueError(
                 "HY-WorldPlay WAN-5B is I2V only -- pass "
@@ -448,6 +464,24 @@ class HyWorldPlayWanI2VRunner(
             torch.distributed.barrier()
         return cache_dir / _EXAMPLE_IMAGE_FILENAME
 
+    def _fetch_example_pose(self) -> Path:
+        """Lazy-download upstream's sample ``assets/pose/`` trajectory on rank 0.
+
+        Symmetric to :meth:`_fetch_example_image`. The parser prefix-
+        slices this 33-entry file to the rollout's ``num_chunk * 4``
+        latent budget, so it drives any ``num_chunk <= 8`` demo run.
+        """
+        cache_dir = EXAMPLE_DATA_DIR_LOCAL
+        if self.is_rank_zero:
+            download_to_cache(
+                f"{EXAMPLE_DATA_BASE_URL}/pose/{_EXAMPLE_POSE_FILENAME}",
+                cache_dir=cache_dir,
+                filename=_EXAMPLE_POSE_FILENAME,
+            )
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+        return cache_dir / _EXAMPLE_POSE_FILENAME
+
     def _bind_action_labels(self) -> None:
         """Parse the pose string and bind per-rollout action labels on the encoder."""
         from hy_worldplay._action import HyWorldPlayWanCtrlEncoder
@@ -538,7 +572,6 @@ class HyWorldPlayWanI2VRunner(
         """
         import math
         import os
-        from typing import Any
         from unittest.mock import patch as _mock_patch
 
         from einops import rearrange

--- a/integrations/hy_worldplay/tests/test_action.py
+++ b/integrations/hy_worldplay/tests/test_action.py
@@ -92,12 +92,32 @@ def test_pose_data_returns_w2c_K_action() -> None:
     assert float(K[0, 1, 2]) == pytest.approx(0.5)
 
 
-def test_pose_data_length_mismatch_raises() -> None:
-    """Pose script with the wrong frame count must surface clearly."""
+def test_pose_data_too_short_raises() -> None:
+    """A pose source with fewer entries than the rollout needs must surface clearly."""
     from hy_worldplay._pose import parse_pose_action_labels
 
+    # "w-3" -> 3 motions + 1 identity = 4 entries; the rollout wants 10.
     with pytest.raises(ValueError, match="pose corresponds to"):
         parse_pose_action_labels("w-3", n_latents=10)
+
+
+def test_pose_data_longer_source_is_prefix_sliced() -> None:
+    """A pose source longer than ``n_latents`` is accepted; the first N poses are used.
+
+    Lets upstream's fixed-length sample (e.g. the 33-entry
+    ``test_forward_32_latents.json``) drive a shorter ``num_chunk`` run
+    without bespoke trimming -- mirrors vendor's prefix-slice behaviour.
+    """
+    from hy_worldplay._pose import parse_pose_action_labels, parse_pose_data
+
+    # "w-15" -> 15 motions + 1 identity = 16 entries; ask for only 4.
+    w2c, K, action = parse_pose_data("w-15", n_latents=4)
+    assert w2c.shape == (4, 4, 4)
+    assert K.shape == (4, 3, 3)
+    assert action.shape == (4,)
+    # The sliced prefix is identical to parsing a matching-length script.
+    exact = parse_pose_action_labels("w-3", n_latents=4)
+    assert action.tolist() == exact.tolist()
 
 
 def test_pose_data_rejects_unknown_action() -> None:


### PR DESCRIPTION
One follow-up item from #203 (HY-WorldPlay #155).

Makes the pose parser tolerant of longer pose sources and wires upstream's sample trajectory into `--example-data`.

- `_pose.py`: relax the strict `len(poses) == n_latents` check to `>=` and prefix-slice to the rollout's `num_chunk * 4` budget (vendor's behaviour). Under-supply still raises with the same message.
- `runner.py`: `--example-data` now also lazy-downloads `assets/pose/test_forward_32_latents.json` (33 entries) into `data_local/hy_worldplay/` and uses it as the default pose when `--pose` is unset. The 33-entry file drives any `num_chunk <= 8` run via the prefix slice.
- Tests: `test_pose_data_longer_source_is_prefix_sliced` + renamed the length-mismatch test to reflect that only under-supply raises. README updated.

CPU-verified (parser tests). No production default changes — additive/opt-in via `--example-data`.

Part of #203.
