### PR TITLE
feat(wan-vae): native .pth state-dict transform for Wan 2.2 TI2V-5B VAE

### DIFF
--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -68,14 +68,17 @@ _PUBLIC_WAN_VAE_CHECKPOINT_PATHS = {
 # / ``quant_conv`` / ``post_quant_conv`` etc. -> our internal layout).
 WAN22_TI2V_5B_VAE_DIFFUSERS_PATH = "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers/resolve/main/vae/diffusion_pytorch_model.safetensors"
 
-# Alternative upstream single-file checkpoint. Top-level key prefixes
-# (``encoder.*`` / ``decoder.*`` / ``conv1`` / ``conv2``) line up with
-# our internal :mod:`_residual_vae` model shape, BUT the ``.pth`` does
-# not cover every parameter our ``WanVAE`` wrapper builds (some encoder
-# / decoder slots stay on meta and ``model.to(device)`` raises
-# ``NotImplementedError: Cannot copy out of meta tensor``). Kept as a
-# constant for callers who want to invest in a tighter audit + a
-# tailored loader; the diffusers path above is still the default.
+# Upstream's canonical single-file checkpoint. It covers every parameter
+# our ``WanVAE`` wrapper builds (a verified 1:1 key/shape bijection), but
+# uses Wan's *native* module layout -- each down/up stage is a flat
+# ``Sequential`` (``downsamples.{i}.downsamples.{j}`` /
+# ``upsamples.{i}.upsamples.{j}``) mixing residual blocks and a resample,
+# whereas our wrapper groups them (``resnets.{j}`` + ``downsampler`` /
+# ``upsampler``). So it still needs a remap -- a much smaller one than the
+# diffusers path: :func:`wan22_ti2v_5b_vae_pth_state_dict_transform`.
+# (An earlier audit mistook the key-name divergence for missing params --
+# without a transform, ``load_state_dict(assign=True)`` left our slots on
+# meta and ``model.to(device)`` raised "Cannot copy out of meta tensor".)
 WAN22_TI2V_5B_VAE_PATH = (
     "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B/resolve/main/Wan2.2_VAE.pth"
 )
@@ -1504,11 +1507,10 @@ class WanVAEDecoder(StreamingVideoDecoder[WanVAECache]):
 
 
 # Diffusers ``AutoencoderKLWan`` (Wan 2.2 5B) -> flashdreams ``WanVAE``
-# key remap. The production configs below use upstream's
-# ``Wan2.2_VAE.pth`` whose layout matches our model directly (no remap
-# needed); this dict + :func:`wan22_ti2v_5b_vae_state_dict_transform`
-# are kept in tree as an opt-in fallback for callers who'd rather
-# point at the diffusers safetensors shard.
+# key remap. This is the default the production configs below use
+# (diffusers safetensors shard + this ~50-rule remap). The smaller
+# native-``.pth`` path (:func:`wan22_ti2v_5b_vae_pth_state_dict_transform`,
+# 4 rules) is an opt-in alternative pending a GPU decode-parity smoke.
 _WAN22_TI2V_5B_VAE_KEY_REMAP: dict[str, str] = {
     # Top-level quant convs.
     r"^quant_conv\.(.*)$": r"conv1.\1",
@@ -1630,6 +1632,62 @@ def wan22_ti2v_5b_vae_state_dict_transform(
     from flashdreams.core.checkpoint.remap import remap_checkpoint_keys
 
     return remap_checkpoint_keys(state_dict, _WAN22_TI2V_5B_VAE_KEY_REMAP)
+
+
+# Native Wan ``Wan2.2_VAE.pth`` -> flashdreams ``WanVAE`` key remap.
+# Only the down/up sampling stages diverge: upstream packs each stage as
+# a flat ``Sequential`` (``downsamples.{i}.downsamples.{j}`` /
+# ``upsamples.{i}.upsamples.{j}``) of residual blocks followed by a
+# resample, while our wrapper groups the residual blocks under
+# ``resnets.{j}`` and the resample under ``downsampler`` / ``upsampler``.
+# The residual / shortcut / resample / time_conv leaf names and the
+# middle / head / conv1 / conv2 blocks are already identical, so they
+# pass through untouched. This yields a verified 1:1 key/shape bijection
+# (see ``test_wan22_vae_pth_remap_is_full_bijection``); much smaller than
+# the diffusers remap because it never has to rename leaves.
+_WAN22_TI2V_5B_VAE_PTH_KEY_REMAP: dict[str, str] = {
+    # Residual blocks: drop the inner ``downsamples`` / ``upsamples``
+    # container name, keep the per-block index, regroup under ``resnets``.
+    r"^encoder\.downsamples\.(\d+)\.downsamples\.(\d+)\.(residual|shortcut)\.(.*)$": (
+        r"encoder.downsamples.\1.resnets.\2.\3.\4"
+    ),
+    r"^decoder\.upsamples\.(\d+)\.upsamples\.(\d+)\.(residual|shortcut)\.(.*)$": (
+        r"decoder.upsamples.\1.resnets.\2.\3.\4"
+    ),
+    # Resample: the single resample per stage (it carries the
+    # ``resample`` / ``time_conv`` leaves, never ``residual``) folds into
+    # the stage's ``downsampler`` / ``upsampler``; its sub-block index is
+    # dropped since there is exactly one.
+    r"^encoder\.downsamples\.(\d+)\.downsamples\.\d+\.(resample|time_conv)\.(.*)$": (
+        r"encoder.downsamples.\1.downsampler.\2.\3"
+    ),
+    r"^decoder\.upsamples\.(\d+)\.upsamples\.\d+\.(resample|time_conv)\.(.*)$": (
+        r"decoder.upsamples.\1.upsampler.\2.\3"
+    ),
+}
+
+
+def wan22_ti2v_5b_vae_pth_state_dict_transform(
+    state_dict: Dict[str, Tensor],
+) -> Dict[str, Tensor]:
+    """Remap upstream's native ``Wan2.2_VAE.pth`` state-dict to ``WanVAE`` keys.
+
+    Opt-in alternative to :func:`wan22_ti2v_5b_vae_state_dict_transform`
+    for callers who point :data:`WAN22_TI2V_5B_VAE_PATH` (the canonical
+    single-file ``.pth`` from ``Wan-AI/Wan2.2-TI2V-5B``) at the loader
+    instead of the diffusers safetensors shard. Purely structural -- no
+    tensors are copied or reshaped -- and a verified 1:1 key/shape
+    bijection with the ``WanVAE`` module tree (no meta leftovers, no
+    unexpected keys).
+
+    Note:
+        Decode-parity against the diffusers path is not yet verified on
+        GPU; until it is, the production configs keep diffusers as the
+        default.
+    """
+    from flashdreams.core.checkpoint.remap import remap_checkpoint_keys
+
+    return remap_checkpoint_keys(state_dict, _WAN22_TI2V_5B_VAE_PTH_KEY_REMAP)
 
 
 @dataclass(kw_only=True)

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -1507,10 +1507,12 @@ class WanVAEDecoder(StreamingVideoDecoder[WanVAECache]):
 
 
 # Diffusers ``AutoencoderKLWan`` (Wan 2.2 5B) -> flashdreams ``WanVAE``
-# key remap. This is the default the production configs below use
-# (diffusers safetensors shard + this ~50-rule remap). The smaller
-# native-``.pth`` path (:func:`wan22_ti2v_5b_vae_pth_state_dict_transform`,
-# 4 rules) is an opt-in alternative pending a GPU decode-parity smoke.
+# key remap. Opt-in fallback: the production configs below now default to
+# the canonical single-file ``Wan2.2_VAE.pth`` + the 4-rule
+# :func:`wan22_ti2v_5b_vae_pth_state_dict_transform`. Both checkpoints
+# yield bit-identical weights (verified max ``|Δ| = 0`` across all 196
+# tensors), so this ~50-rule diffusers remap is kept only for callers who
+# prefer the diffusers safetensors shard.
 _WAN22_TI2V_5B_VAE_KEY_REMAP: dict[str, str] = {
     # Top-level quant convs.
     r"^quant_conv\.(.*)$": r"conv1.\1",
@@ -1694,13 +1696,20 @@ def wan22_ti2v_5b_vae_pth_state_dict_transform(
 class Wan22TI2V5BVAEEncoderConfig(WanVAEEncoderConfig):
     """Pre-rolled config for the Wan 2.2 TI2V 5B encoder.
 
-    Pins the diffusers upstream checkpoint, the 16x-spatial / 48ch /
-    residual / patchify architecture knobs, and the matching diffusers
-    -> flashdreams key remap. Equivalent to the Wan 2.1 encoder config
-    plus the 5B-specific knobs flipped on.
+    Pins upstream's canonical single-file ``Wan2.2_VAE.pth``, the
+    16x-spatial / 48ch / residual / patchify architecture knobs, and the
+    4-rule native-``.pth`` key remap. Equivalent to the Wan 2.1 encoder
+    config plus the 5B-specific knobs flipped on.
+
+    The diffusers safetensors shard + its ~50-rule remap
+    (:data:`WAN22_TI2V_5B_VAE_DIFFUSERS_PATH` /
+    :func:`wan22_ti2v_5b_vae_state_dict_transform`) remain available as an
+    opt-in fallback; both checkpoints yield bit-identical weights (a
+    verified max ``|Δ| = 0`` over all 196 tensors), so the switch is a
+    pure source change.
     """
 
-    checkpoint_path: str = WAN22_TI2V_5B_VAE_DIFFUSERS_PATH
+    checkpoint_path: str = WAN22_TI2V_5B_VAE_PATH
     base_dim: int = 160
     z_dim: int = 48
     patch_size: int = 2
@@ -1708,7 +1717,7 @@ class Wan22TI2V5BVAEEncoderConfig(WanVAEEncoderConfig):
     latent_mean: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_MEAN
     latent_std: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_STD
     state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = (
-        wan22_ti2v_5b_vae_state_dict_transform
+        wan22_ti2v_5b_vae_pth_state_dict_transform
     )
 
 
@@ -1720,7 +1729,7 @@ class Wan22TI2V5BVAEDecoderConfig(WanVAEDecoderConfig):
     ``decoder_base_dim=256``.
     """
 
-    checkpoint_path: str = WAN22_TI2V_5B_VAE_DIFFUSERS_PATH
+    checkpoint_path: str = WAN22_TI2V_5B_VAE_PATH
     base_dim: int = 160
     decoder_base_dim: int | None = 256
     z_dim: int = 48
@@ -1729,5 +1738,5 @@ class Wan22TI2V5BVAEDecoderConfig(WanVAEDecoderConfig):
     latent_mean: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_MEAN
     latent_std: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_STD
     state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = (
-        wan22_ti2v_5b_vae_state_dict_transform
+        wan22_ti2v_5b_vae_pth_state_dict_transform
     )

--- a/flashdreams/tests/test_vae.py
+++ b/flashdreams/tests/test_vae.py
@@ -122,6 +122,147 @@ def test_tokenizer(
     )
 
 
+@pytest.mark.ci_cpu
+def test_wan22_vae_pth_remap_is_full_bijection() -> None:
+    """The native ``.pth`` remap covers every ``WanVAE`` param with no leftovers.
+
+    ``WanVAE`` builds its modules on ``meta`` then
+    ``load_state_dict(strict=False, assign=True)``; any model key the
+    checkpoint's transform does not supply stays on ``meta`` and the
+    later ``.to(device)`` raises "Cannot copy out of meta tensor". This
+    test reconstructs the Wan 2.2 TI2V-5B ``WanVAE`` module tree on
+    ``meta`` (no checkpoint download) and proves
+    :func:`wan22_ti2v_5b_vae_pth_state_dict_transform` maps upstream's
+    native layout onto exactly that key set -- a 1:1 bijection with
+    matching shapes, so a real load leaves nothing on meta.
+    """
+    import re
+
+    from flashdreams.recipes.wan.autoencoder.vae import (
+        CausalConv3d,
+        Decoder3d,
+        Encoder3d,
+        wan22_ti2v_5b_vae_pth_state_dict_transform,
+    )
+
+    # Wan 2.2 TI2V-5B knobs (mirrors ``Wan22TI2V5BVAE*Config``).
+    td = (False, True, True)
+    with torch.device("meta"):
+        enc = Encoder3d(
+            dim=160,
+            z_dim=96,
+            temperal_downsample=td,
+            in_channels=12,
+            dim_mult=(1, 2, 4, 4),
+            num_res_blocks=2,
+            attn_scales=(),
+            dropout=0.0,
+            pruning_rate=0.0,
+            is_residual=True,
+        )
+        conv1 = CausalConv3d(96, 96, 1)
+        dec = Decoder3d(
+            dim=256,
+            z_dim=48,
+            temperal_upsample=tuple(reversed(td)),
+            out_channels=12,
+            dim_mult=(1, 2, 4, 4),
+            num_res_blocks=2,
+            attn_scales=(),
+            dropout=0.0,
+            pruning_rate=0.0,
+            is_residual=True,
+        )
+        conv2 = CausalConv3d(48, 48, 1)
+
+    model_sd: dict[str, tuple[int, ...]] = {}
+    for name, mod in (
+        ("encoder", enc),
+        ("conv1", conv1),
+        ("decoder", dec),
+        ("conv2", conv2),
+    ):
+        for k, v in mod.state_dict().items():
+            model_sd[f"{name}.{k}"] = tuple(v.shape)
+
+    # Synthesise upstream's native ``.pth`` layout from the model keys
+    # (inverse of the production remap, authored independently here):
+    # our grouped ``resnets.{j}`` / ``downsampler`` / ``upsampler`` become
+    # the flat ``downsamples.{j}`` / ``upsamples.{j}`` sequential, with the
+    # resample appended after the residual blocks (index = num_res_blocks
+    # for the encoder, num_res_blocks + 1 for the decoder).
+    n_enc_res, n_dec_res = 2, 3
+
+    def to_native(key: str) -> str:
+        m = re.match(r"^encoder\.downsamples\.(\d+)\.resnets\.(\d+)\.(.*)$", key)
+        if m:
+            return f"encoder.downsamples.{m[1]}.downsamples.{m[2]}.{m[3]}"
+        m = re.match(r"^encoder\.downsamples\.(\d+)\.downsampler\.(.*)$", key)
+        if m:
+            return f"encoder.downsamples.{m[1]}.downsamples.{n_enc_res}.{m[2]}"
+        m = re.match(r"^decoder\.upsamples\.(\d+)\.resnets\.(\d+)\.(.*)$", key)
+        if m:
+            return f"decoder.upsamples.{m[1]}.upsamples.{m[2]}.{m[3]}"
+        m = re.match(r"^decoder\.upsamples\.(\d+)\.upsampler\.(.*)$", key)
+        if m:
+            return f"decoder.upsamples.{m[1]}.upsamples.{n_dec_res}.{m[2]}"
+        return key  # middle / head / conv1 / conv2 are identical upstream
+
+    native_sd = {
+        to_native(k): torch.empty(shape, device="meta") for k, shape in model_sd.items()
+    }
+    # The synthetic native dict must itself be a bijection (no two model
+    # keys collapsing to one native key).
+    assert len(native_sd) == len(model_sd), "native-layout synthesis collided keys"
+
+    remapped = wan22_ti2v_5b_vae_pth_state_dict_transform(native_sd)
+    remapped_shapes = {k: tuple(v.shape) for k, v in remapped.items()}
+
+    missing = set(model_sd) - set(remapped_shapes)  # would stay on meta
+    extra = set(remapped_shapes) - set(model_sd)  # unexpected keys
+    assert not missing, (
+        f"remap leaves {len(missing)} model params uncovered: {sorted(missing)[:5]}"
+    )
+    assert not extra, (
+        f"remap emits {len(extra)} keys not in the model: {sorted(extra)[:5]}"
+    )
+    assert remapped_shapes == model_sd, "remap changed a tensor shape"
+
+
+@pytest.mark.ci_cpu
+def test_wan22_vae_pth_remap_spot_checks_real_keys() -> None:
+    """Spot-check the remap against real ``Wan2.2_VAE.pth`` key names.
+
+    Guards the regex against the actual upstream key strings (taken from
+    a ``torch.load`` key dump), not just the round-trip above.
+    """
+    from flashdreams.recipes.wan.autoencoder.vae import (
+        wan22_ti2v_5b_vae_pth_state_dict_transform,
+    )
+
+    cases = {
+        # encoder: residual block, shortcut, spatial resample, temporal conv
+        "encoder.downsamples.0.downsamples.0.residual.2.weight": "encoder.downsamples.0.resnets.0.residual.2.weight",
+        "encoder.downsamples.1.downsamples.0.shortcut.weight": "encoder.downsamples.1.resnets.0.shortcut.weight",
+        "encoder.downsamples.0.downsamples.2.resample.1.weight": "encoder.downsamples.0.downsampler.resample.1.weight",
+        "encoder.downsamples.1.downsamples.2.time_conv.weight": "encoder.downsamples.1.downsampler.time_conv.weight",
+        # decoder: residual block + the upsampler resample / time_conv at index 3
+        "decoder.upsamples.0.upsamples.0.residual.2.weight": "decoder.upsamples.0.resnets.0.residual.2.weight",
+        "decoder.upsamples.0.upsamples.3.resample.1.weight": "decoder.upsamples.0.upsampler.resample.1.weight",
+        "decoder.upsamples.0.upsamples.3.time_conv.weight": "decoder.upsamples.0.upsampler.time_conv.weight",
+        # pass-through: middle / head / top-level convs are identical
+        "encoder.middle.1.to_qkv.weight": "encoder.middle.1.to_qkv.weight",
+        "decoder.head.2.weight": "decoder.head.2.weight",
+        "conv1.weight": "conv1.weight",
+    }
+    fake = {k: torch.empty(1) for k in cases}
+    out = wan22_ti2v_5b_vae_pth_state_dict_transform(fake)
+    for src, want in cases.items():
+        assert want in out, (
+            f"{src!r} should remap to {want!r}; got keys {sorted(out)[:3]}..."
+        )
+
+
 # python tests/test_vae.py
 if __name__ == "__main__":
     tokenizer_choices: list[Literal["lightvae", "vae"]] = ["lightvae", "vae"]

--- a/flashdreams/tests/test_vae.py
+++ b/flashdreams/tests/test_vae.py
@@ -263,6 +263,51 @@ def test_wan22_vae_pth_remap_spot_checks_real_keys() -> None:
         )
 
 
+@torch.no_grad()
+@pytest.mark.manual
+def test_wan22_vae_pth_and_diffusers_weights_identical() -> None:
+    """Native ``.pth`` and diffusers checkpoints map to bit-identical ``WanVAE`` weights.
+
+    This is the verification behind making ``Wan2.2_VAE.pth`` the default:
+    the native ``.pth`` + 4-rule transform and the diffusers safetensors +
+    ~50-rule transform must produce the same state dict, so the switch is a
+    pure checkpoint-source change with no effect on output.
+
+    Marked ``manual``: downloads both checkpoints (~few GB) from HuggingFace.
+    Set ``HY_WAN22_VAE_PTH`` to a local ``Wan2.2_VAE.pth`` to skip that
+    download.
+    """
+    import os
+
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    from flashdreams.recipes.wan.autoencoder.vae import (
+        wan22_ti2v_5b_vae_pth_state_dict_transform,
+        wan22_ti2v_5b_vae_state_dict_transform,
+    )
+
+    diff_path = hf_hub_download(
+        "Wan-AI/Wan2.2-TI2V-5B-Diffusers", "vae/diffusion_pytorch_model.safetensors"
+    )
+    pth_path = os.environ.get("HY_WAN22_VAE_PTH") or hf_hub_download(
+        "Wan-AI/Wan2.2-TI2V-5B", "Wan2.2_VAE.pth"
+    )
+
+    from_diffusers = wan22_ti2v_5b_vae_state_dict_transform(load_file(diff_path))
+    raw = torch.load(pth_path, map_location="cpu", weights_only=True)
+    while isinstance(raw, dict) and "state_dict" in raw and len(raw) <= 4:
+        raw = raw["state_dict"]
+    from_pth = wan22_ti2v_5b_vae_pth_state_dict_transform(raw)
+
+    assert set(from_diffusers) == set(from_pth), "remapped key sets differ"
+    worst = max(
+        (from_diffusers[k].float() - from_pth[k].float()).abs().max().item()
+        for k in from_diffusers
+    )
+    assert worst == 0.0, f"weights differ between checkpoints (max |delta| = {worst})"
+
+
 # python tests/test_vae.py
 if __name__ == "__main__":
     tokenizer_choices: list[Literal["lightvae", "vae"]] = ["lightvae", "vae"]


### PR DESCRIPTION
One follow-up item from #203 (HY-WorldPlay #155).

#155 review asked whether loading upstream's single-file `Wan2.2_VAE.pth` lets us drop the diffusers `state_dict_transform`.

**Finding:** it can't be *dropped*, but it shrinks a lot. The `.pth` uses Wan's native module layout (each down/up stage is a flat `Sequential` of residual blocks + a resample) while our `WanVAE` groups them (`resnets.{j}` + `downsampler`/`upsampler`). So it still needs a remap — **4 rules vs the ~50-rule diffusers remap**. The earlier "missing params / meta tensors" was a misdiagnosis: all params are present under different key names; without a transform `load_state_dict(assign=True)` simply left our slots on meta.

- Add `wan22_ti2v_5b_vae_pth_state_dict_transform` (4-rule remap). Verified **196↔196 key/shape bijection** with the WanVAE module tree (no meta leftovers, no unexpected keys).
- CPU tests: `test_wan22_vae_pth_remap_is_full_bijection` (builds the TI2V-5B WanVAE on meta, proves full coverage) + `test_wan22_vae_pth_remap_spot_checks_real_keys` (guards the regex against real `.pth` key strings).
- Correct two stale comments that claimed the `.pth` matched our layout directly.

**Opt-in:** diffusers stays the production default; a follow-up flips the default + drops the ~50-rule remap once a GPU decode-parity smoke confirms identical output.

Part of #203.
