### PR TITLE
Rename product to NVIDIA OmniDreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **FlashDreams** is a high-performance inference and serving library for
 interactive autoregressive video and world models. It began as the optimized
-runtime behind the [OmniDreams closed-loop demo for GTC 2026][omnidreams-blog]
+runtime behind the [NVIDIA OmniDreams closed-loop demo for GTC 2026][omnidreams-blog]
 and has grown into a general platform for real-time world-model applications
 across gaming, autonomous vehicles, robotics, simulated or virtual
 environments, and more.

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -68,7 +68,7 @@ were originally authored as part of the NVIDIA Cosmos-Drive-Dreams project
 (https://github.com/nv-tlabs/Cosmos-Drive-Dreams) and are redistributed and
 modified under the same Apache-2.0 license.
 
-OmniDreams single-view native builds use script-managed, pinned source
+NVIDIA OmniDreams single-view native builds use script-managed, pinned source
 downloads under integrations/omnidreams/omnidreams_singleview/3rdparty/.
 Those downloaded trees are ignored by Git and are not source-level
 redistributions in this repository.

--- a/docs/source/api/integrations.rst
+++ b/docs/source/api/integrations.rst
@@ -59,8 +59,8 @@ Reference integration folders
 - `flashvsr <https://github.com/NVIDIA/flashdreams/tree/main/integrations/flashvsr>`_
 - `cosmos_predict2 <https://github.com/NVIDIA/flashdreams/tree/main/integrations/cosmos_predict2>`_
 
-OmniDreams
-----------
+NVIDIA OmniDreams
+-----------------
 
 OmniDreams now ships as a plugin under ``integrations/omnidreams``; it
 registers its runners via the ``flashdreams.runner_configs`` entry-point

--- a/docs/source/developer_guides/inference_pipeline_overview.rst
+++ b/docs/source/developer_guides/inference_pipeline_overview.rst
@@ -137,7 +137,7 @@ Here is how existing models use this structure:
   A camera-controlled I2V model that uses the per-step camera encoder.
 - `Self-Forcing config <https://github.com/NVIDIA/flashdreams/blob/main/integrations/self_forcing/self_forcing/config.py>`_:
   A pure T2V model that sets ``encoder=None``, so each rollout starts from noise.
-- `OmniDreams config <https://github.com/NVIDIA/flashdreams/blob/main/integrations/omnidreams/omnidreams/config.py>`_:
+- `NVIDIA OmniDreams config <https://github.com/NVIDIA/flashdreams/blob/main/integrations/omnidreams/omnidreams/config.py>`_:
   An I2V video model with a VAE-based causal encoder for HDMap control.
 - `Wan2.1 config <https://github.com/NVIDIA/flashdreams/blob/main/integrations/wan21/wan21/config.py>`_:
   Treats a bidirectional video model as a single-rollout autoregressive model.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ FlashDreams is a *high-performance inference and serving library for
 interactive autoregressive video and world models*. It is a general platform
 for real-time world-model applications across gaming, autonomous vehicles,
 robotics, simulated or virtual environments, and more, and is the
-runtime backbone of the `OmniDreams closed-loop demo at
+runtime backbone of the `NVIDIA OmniDreams closed-loop demo at
 GTC 2026 <https://research.nvidia.com/labs/sil/projects/omnidreams-blog/>`_.
 
 .. raw:: html

--- a/docs/source/models/index.rst
+++ b/docs/source/models/index.rst
@@ -38,7 +38,7 @@ Examples:
 Implemented models
 ------------------
 
-- :doc:`OmniDreams </models/omnidreams>`
+- :doc:`NVIDIA OmniDreams </models/omnidreams>`
 - :doc:`Self-Forcing </models/self_forcing>`
 - :doc:`Causal-Forcing </models/causal_forcing>`
 - :doc:`Causal Wan2.2 </models/causal_wan22>`

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -13,7 +13,7 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
-OmniDreams
+NVIDIA OmniDreams
 ===================================
 
 .. raw:: html

--- a/integrations/omnidreams/README.md
+++ b/integrations/omnidreams/README.md
@@ -59,7 +59,7 @@ or to pre-warm the ~14 GB Cosmos-Reason1 text encoder.
 
 ## Native DiT defaults
 
-OmniDreams native DiT acceleration remains gated by the pipeline config's
+NVIDIA OmniDreams native DiT acceleration remains gated by the pipeline config's
 `native_dit_acceleration` policy (`disabled`, `auto`, or `required`). When that
 native path is enabled, the default compute profile is the FP8 KV-cache backend
 with cuDNN attention:

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -1,6 +1,6 @@
 # interactive-drive
 
-`interactive-drive` is an interactive demo for exploring OmniDreams live.
+`interactive-drive` is an interactive demo for exploring NVIDIA OmniDreams live.
 
 ![interactive-drive screenshot](screenshot.jpg)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -1,6 +1,6 @@
 # interactive-drive
 
-`interactive-drive` is an interactive demo for exploring Omniverse Dreams live.
+`interactive-drive` is an interactive demo for exploring OmniDreams live.
 
 ![interactive-drive screenshot](screenshot.jpg)
 


### PR DESCRIPTION
## Rename product to NVIDIA OmniDreams (public-facing text)

Contracts the public product name **"Omniverse Dreams" → "NVIDIA OmniDreams"** ahead of GA 1.1 (MVSB-33267).

**Naming rule (per NV-Trademark-HQ clearance, 2026-05-29):** "NVIDIA OmniDreams" is cleared (low-moderate risk); bare "OmniDreams" carries elevated risk. Use the full mark **"NVIDIA OmniDreams" on first use in each document**, short form "OmniDreams" thereafter. **No (TM)/(R) attribution** — NVIDIA is not registering the mark.

**Commits:**
1. `Omniverse Dreams` → `OmniDreams` (interactive-drive README).
2. First-use `NVIDIA OmniDreams` prefix (interactive-drive README).
3. Extend the first-use full mark to **every remaining user-facing material** so the rule is applied consistently, per legal's request.

**Materials now carrying the first-use full mark (commit 3):**
- `README.md` (project overview)
- `docs/source/index.rst` (docs landing page)
- `docs/source/models/omnidreams.rst` (model page H1 — the bare `:doc:` links in `interactive_serving.rst` and `usage_patterns.rst` render this title, so they inherit the full mark on their first use)
- `docs/source/models/index.rst` (model index link)
- `docs/source/api/integrations.rst` (section heading)
- `docs/source/developer_guides/inference_pipeline_overview.rst`
- `integrations/omnidreams/README.md`
- `THIRD-PARTY-NOTICES` (NVIDIA's own build note, not third-party text)

**Scope:** product display name in user-facing prose/docs only. Repo slugs/paths/identifiers (`flashdreams`, lowercase `omnidreams` modules/paths, `omnidreams.html`/`-blog` URLs, `OMNI_DREAMS_HF_ORG`) and third-party/license text unchanged. The ~30 `OmniDreams` references in code (the `omnidreams_singleview` native-extension family: comments, docstrings, error strings, CUTLASS patch annotations) are intentionally out of scope — internal technical references, not published materials.

**Related:** omni-dreams MR !128, model-card MR !3 (the latter is a content change to approved AI Transparency Card 2630 — needs MC++ re-review).
