### PR TITLE
docs: add Community section (Contributing, Discord) and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -439,8 +439,8 @@ upfront.
   [GitHub Issues](https://github.com/NVIDIA/flashdreams/issues). Please
   do not include confidential or customer information.
 - **Security vulnerabilities:** please do *not* file them as public
-  issues. Follow NVIDIA's coordinated disclosure process at
-  https://www.nvidia.com/en-us/security/.
+  issues. Follow the coordinated disclosure process in
+  [`SECURITY.md`](SECURITY.md).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ uv run pytest -m "not manual"
 
 See [`DEV.md`](DEV.md) for repository-specific workflow notes.
 
-## Community
+## Contributing
 
 For how to contribute, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 New integrations, bug reports, feature requests, performance tuning, and

--- a/README.md
+++ b/README.md
@@ -97,12 +97,21 @@ uv run pytest -m "not manual"
 
 See [`DEV.md`](DEV.md) for repository-specific workflow notes.
 
-## Contributing
+## Community
 
-Bug reports, feature requests, performance work, new integrations, and
-documentation fixes are all welcome. The full process — DCO sign-off, PR
-expectations, coding conventions, and local-build speedups — is in
-[`CONTRIBUTING.md`](CONTRIBUTING.md).
+For how to contribute, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+New integrations, bug reports, feature requests, performance tuning, and
+documentation edits are all welcome.
+
+Use [GitHub Issues](https://github.com/NVIDIA/flashdreams/issues) to report defects or request improvements.
+
+Join us on the [NVIDIA Omniverse Discord](https://discord.com/invite/nvidiaomniverse)
+to share your results and take part in technical discussion! Channel: [`#flashdreams`](https://discord.gg/yTdHDqFP)
+
+## Security
+
+To report a potential security vulnerability, follow the coordinated
+disclosure process in [`SECURITY.md`](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+## Security
+
+NVIDIA is dedicated to the security and trust of our software products and services, including all source code repositories managed through our organization.
+
+If you need to report a security issue, please use the appropriate contact points outlined below. **Please do not report security vulnerabilities through GitHub.** If a potential security issue is inadvertently reported via a public issue or pull request, NVIDIA maintainers may limit public discussion and redirect the reporter to the appropriate private disclosure channels.
+
+## Reporting Potential Security Vulnerability in an NVIDIA Product
+
+To report a potential security vulnerability in any NVIDIA product:
+- Web: [Security Vulnerability Submission Form](https://www.nvidia.com/object/submit-security-vulnerability.html)
+- E-Mail: psirt@nvidia.com
+    - We encourage you to use the following PGP key for secure email communication: [NVIDIA public PGP Key for communication](https://www.nvidia.com/en-us/security/pgp-key)
+    - Please include the following information:
+        - Product/Driver name and version/branch that contains the vulnerability
+     - Type of vulnerability (code execution, denial of service, buffer overflow, etc.)
+        - Instructions to reproduce the vulnerability
+        - Proof-of-concept or exploit code
+        - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
+
+While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
+
+## NVIDIA Product Security
+
+For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security

--- a/docs/source/community/contribute.rst
+++ b/docs/source/community/contribute.rst
@@ -1,0 +1,37 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+.. http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
+Contributing
+============
+
+FlashDreams is developed openly on the
+`GitHub repository <https://github.com/NVIDIA/flashdreams>`_. Bug reports,
+feature requests, performance work, new model integrations, and documentation
+fixes are all welcome.
+Before you start, read the
+`CONTRIBUTING.md <https://github.com/NVIDIA/flashdreams/blob/main/CONTRIBUTING.md>`_
+guide.
+
+
+Reporting issues
+----------------
+
+Use `GitHub Issues <https://github.com/NVIDIA/flashdreams/issues>`_ to report
+functional defects and to request improvements. Please do not include
+confidential or customer information.
+
+Do not file security vulnerabilities as public issues. Follow the coordinated
+disclosure process in
+`SECURITY.md <https://github.com/NVIDIA/flashdreams/blob/main/SECURITY.md>`_.

--- a/docs/source/community/discord.rst
+++ b/docs/source/community/discord.rst
@@ -1,0 +1,31 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+.. http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
+Discord
+=======
+
+Join us on the NVIDIA Omniverse Discord to share your results, attend office
+hours, and take part in technical discussion with the FlashDreams team and
+community.
+
+If you are new, start with the
+`server invite <https://discord.com/invite/nvidiaomniverse>`_ to on-board.
+
+Channels
+--------
+
+- `#world-model-chit-chat (LIVE) <https://discord.gg/APbw7EPk>`_
+- `#omni-dreams <https://discord.gg/bsjzh4uZ>`_
+- `#flashdreams <https://discord.gg/yTdHDqFP>`_

--- a/docs/source/community/discord.rst
+++ b/docs/source/community/discord.rst
@@ -26,6 +26,6 @@ If you are new, start with the
 Channels
 --------
 
-- `#world-model-chit-chat (LIVE) <https://discord.gg/APbw7EPk>`_
-- `#omni-dreams <https://discord.gg/bsjzh4uZ>`_
 - `#flashdreams <https://discord.gg/yTdHDqFP>`_
+- `#omni-dreams <https://discord.gg/bsjzh4uZ>`_
+- `#world-model-chit-chat <https://discord.gg/APbw7EPk>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -264,3 +264,11 @@ Start here
    Infra <api/infra>
    Pipelines and runners <api/integrations>
    Serving <api/serving>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Community
+   :hidden:
+
+   Contributing <community/contribute>
+   Discord <community/discord>


### PR DESCRIPTION
Append a Community section to the public docs with two sidebar pages:

- Contributing: links to the GitHub repository and CONTRIBUTING.md, and explains using GitHub Issues to report functional defects and request improvements.
- Discord: invites readers to join the NVIDIA Omniverse Discord to share results, attend office hours, and join technical discussion, with the server on-boarding invite and the #world-model-chit-chat, #omni-dreams, and #flashdreams channel invites.

Add SECURITY.md at the repo root using the NVIDIA OSS coordinated disclosure template, and point CONTRIBUTING.md's security section to it. Add Community and Security sections to README.md surfacing the Discord and GitHub Issues links.