### PR TITLE
Support legacy prompt variant filenames

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -1065,12 +1065,10 @@ def _make_thumbnail(image: Image.Image, size: tuple[int, int]) -> Image.Image:
 
 
 # ``_variant_from_stem`` removed in favour of the shared
-# :func:`scene_loader.variant_from_stem` -- all three discovery paths
-# (USDZ archives, unpacked scene dirs, HUD variant selector) now agree
-# on the underscore-required convention. The previous fallback that
-# accepted ``prompt1.txt`` as variant ``1`` was inconsistent with
-# ``_discover_first_images`` and silently masked the
-# ``prompt_<N>.txt`` -> ``_<N>`` bug on real scenes.
+# :func:`omnidreams.scenes.variant_from_stem` -- all three discovery paths
+# (USDZ archives, unpacked scene dirs, HUD variant selector) now agree on
+# both canonical ``prompt_<N>.txt`` names and legacy numeric
+# ``prompt<N>.txt`` names.
 
 
 def _variant_label(variant: str) -> str:

--- a/integrations/omnidreams/omnidreams/interactive_drive/scene_fixture.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/scene_fixture.py
@@ -862,10 +862,8 @@ def build_synthetic_scene_usdz(
             json.dumps(_rig_trajectory_doc(poses, timestamps_us.tolist())),
         )
         zf.writestr("mesh_ground.ply", _synthetic_ground_mesh_ply())
-        # Match the naming convention used by the real HF scenes (and by
-        # ``first_image_<N>.png`` above): underscore-separated variant
-        # numbers. Without the underscore, ``_discover_prompts`` rejects
-        # the file and the variant selector silently falls back to default.
+        # Keep writing canonical underscore-separated variant numbers.
+        # The loader also accepts numeric legacy names like ``prompt1.txt``.
         zf.writestr("prompt.txt", default_prompt)
         zf.writestr("prompt_1.txt", variant1_prompt)
         zf.writestr("prompt_2.txt", variant2_prompt)

--- a/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
@@ -7,6 +7,7 @@ import io
 import json
 import zipfile
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +52,12 @@ from PIL import Image
 _GROUND_MESH_NAME = "mesh_ground.ply"
 
 
+@dataclass(frozen=True)
+class _PromptEntry:
+    archive_name: str
+    text: str
+
+
 def _read_yaml(zf: zipfile.ZipFile, name: str) -> dict[str, Any]:
     return yaml.safe_load(zf.read(name))
 
@@ -85,24 +92,87 @@ def _load_initial_image(
 
 def _load_prompt(zf: zipfile.ZipFile, variant: str, prompt_override: str | None) -> str:
     if prompt_override is not None:
+        _log_prompt_selection(
+            zf,
+            variant=variant,
+            selected_variant="override",
+            source="--prompt",
+            prompt=prompt_override,
+            available_variants=(),
+            ignored_files=(),
+        )
         return prompt_override
-    prompts = _discover_prompts(zf)
-    return prompts.get(variant, prompts.get("default", ""))
+    prompt_entries, ignored_files = _discover_prompt_entries(zf)
+    selected_variant = variant if variant in prompt_entries else None
+    if selected_variant is None and "default" in prompt_entries:
+        selected_variant = "default"
+    prompt_entry = (
+        prompt_entries[selected_variant] if selected_variant is not None else None
+    )
+    prompt = "" if prompt_entry is None else prompt_entry.text
+    _log_prompt_selection(
+        zf,
+        variant=variant,
+        selected_variant=selected_variant,
+        source="<none>" if prompt_entry is None else prompt_entry.archive_name,
+        prompt=prompt,
+        available_variants=tuple(sorted(prompt_entries.keys())),
+        ignored_files=ignored_files,
+    )
+    return prompt
 
 
 def _discover_prompts(zf: zipfile.ZipFile) -> dict[str, str]:
-    prompts: dict[str, str] = {}
+    prompt_entries, _ = _discover_prompt_entries(zf)
+    return {variant: entry.text for variant, entry in prompt_entries.items()}
+
+
+def _discover_prompt_entries(
+    zf: zipfile.ZipFile,
+) -> tuple[dict[str, _PromptEntry], tuple[str, ...]]:
+    prompts: dict[str, _PromptEntry] = {}
+    ignored_files: list[str] = []
     for name in zf.namelist():
         if "/" in name or not name.startswith("prompt") or not name.endswith(".txt"):
             continue
         variant = variant_from_stem(Path(name).stem, "prompt")
         if variant is None:
+            ignored_files.append(name)
             continue
-        prompts[variant] = zf.read(name).decode("utf-8").strip()
+        prompts[variant] = _PromptEntry(
+            archive_name=name,
+            text=zf.read(name).decode("utf-8").strip(),
+        )
     if "default" not in prompts and prompts:
         first_key = sorted(prompts.keys())[0]
         prompts["default"] = prompts[first_key]
-    return prompts
+    return prompts, tuple(sorted(ignored_files))
+
+
+def _log_prompt_selection(
+    zf: zipfile.ZipFile,
+    *,
+    variant: str,
+    selected_variant: str | None,
+    source: str,
+    prompt: str,
+    available_variants: tuple[str, ...],
+    ignored_files: tuple[str, ...],
+) -> None:
+    scene_name = Path(str(zf.filename)).name if zf.filename is not None else "<archive>"
+    prompt_text = " ".join(prompt.split())
+    print(
+        "[scene_loader] prompt "
+        f"scene={scene_name!r} "
+        f"requested_variant={variant!r} "
+        f"selected_variant={selected_variant or '<none>'!r} "
+        f"source={source!r} "
+        f"available_variants={available_variants or '<none>'!r} "
+        f"ignored_files={ignored_files or '<none>'!r} "
+        f"length={len(prompt)} "
+        f"text={prompt_text!r}",
+        flush=True,
+    )
 
 
 def _discover_first_images(zf: zipfile.ZipFile) -> dict[str, str]:

--- a/integrations/omnidreams/omnidreams/scenes.py
+++ b/integrations/omnidreams/omnidreams/scenes.py
@@ -161,14 +161,15 @@ def variant_from_stem(stem: str, prefix: str) -> str | None:
 
     * ``<prefix>``           -> ``"default"``  (e.g. ``prompt.txt``, ``first_image.png``)
     * ``<prefix>_<X>``       -> ``<X>``        (e.g. ``prompt_1.txt`` -> ``"1"``)
+    * ``<prefix><N>``        -> ``<N>``        (e.g. ``prompt1.txt`` -> ``"1"``)
     * anything else          -> ``None``       (rejected; caller skips it)
 
-    The trailing-suffix-without-underscore form (``prompt1.txt``,
-    ``first_image1.png``) is **rejected** so the HUD's selector and the
-    scene-loader's prompt dict agree on the variant key. Previously a
-    naive ``stem.replace(prefix, "")`` quietly mapped ``prompt_1`` to
-    ``_1`` while the HUD displayed ``1``, so the selector silently fell
-    back to the default prompt on real scenes.
+    The trailing-suffix-without-underscore form is accepted for numeric
+    legacy scene assets such as ``prompt1.txt`` while non-numeric suffixes
+    still require the underscore form. Previously a naive
+    ``stem.replace(prefix, "")`` quietly mapped ``prompt_1`` to ``_1``
+    while the HUD displayed ``1``, so the selector silently fell back to
+    the default prompt on real scenes.
 
     Used by every discovery path that walks clipgt asset names:
 
@@ -183,6 +184,10 @@ def variant_from_stem(stem: str, prefix: str) -> str | None:
         return "default"
     if stem.startswith(prefix + "_"):
         return stem[len(prefix) + 1 :]
+    if stem.startswith(prefix):
+        suffix = stem[len(prefix) :]
+        if suffix.isdecimal():
+            return suffix
     return None
 
 

--- a/integrations/omnidreams/tests/interactive_drive/test_scene_helpers.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_scene_helpers.py
@@ -17,27 +17,29 @@ class SceneHelperTest(unittest.TestCase):
     def test_discovers_variants(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            # ``prompt_<N>.txt`` is the convention used by both
-            # ``nvidia/omni-dreams-scenes`` and the synthetic-scene
-            # fixture. The bare ``promptN.txt`` form is no longer
-            # accepted (it used to be quietly tolerated by a buggy
-            # parser; see ``omnidreams.scenes.variant_from_stem``).
+            # ``prompt_<N>.txt`` is the canonical convention used by the
+            # synthetic-scene fixture. The bare numeric ``promptN.txt``
+            # form is also accepted for legacy demo assets.
             (root / "prompt.txt").write_text("default text", encoding="utf-8")
             (root / "prompt_1.txt").write_text("hello", encoding="utf-8")
             (root / "prompt_2.txt").write_text("snow", encoding="utf-8")
-            # Files that don't follow the underscore convention must be
-            # ignored so they don't pollute the variant set.
-            (root / "prompt3.txt").write_text("ignored", encoding="utf-8")
+            (root / "prompt3.txt").write_text("rain", encoding="utf-8")
+            (root / "promptnight.txt").write_text("ignored", encoding="utf-8")
             (root / "first_image.png").write_bytes(b"")
             (root / "first_image_2.png").write_bytes(b"")
+            (root / "first_image3.png").write_bytes(b"")
+            (root / "first_imagenight.png").write_bytes(b"")
             prompts = _discover_prompts(root)
             first_frames = _discover_first_frames(root)
             self.assertEqual(prompts["1"], "hello")
             self.assertEqual(prompts["2"], "snow")
+            self.assertEqual(prompts["3"], "rain")
             self.assertEqual(prompts["default"], "default text")
-            self.assertNotIn("3", prompts)
+            self.assertNotIn("night", prompts)
             self.assertEqual(first_frames["default"].name, "first_image.png")
             self.assertEqual(first_frames["2"].name, "first_image_2.png")
+            self.assertEqual(first_frames["3"].name, "first_image3.png")
+            self.assertNotIn("night", first_frames)
 
 
 if __name__ == "__main__":

--- a/integrations/omnidreams/tests/interactive_drive/test_scene_loader.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_scene_loader.py
@@ -3,11 +3,34 @@
 
 from __future__ import annotations
 
+import io
+import zipfile
+
 import pytest
 from omnidreams.interactive_drive._sample_assets import SAMPLE_SCENE
 from omnidreams.interactive_drive.colors import BBOX_V3_COLORS
 from omnidreams.interactive_drive.config import RasterConfig
-from omnidreams.interactive_drive.scene_loader import load_scene_bundle
+from omnidreams.interactive_drive.scene_loader import (
+    _discover_prompts,
+    load_scene_bundle,
+)
+
+
+def test_usdz_prompt_discovery_accepts_legacy_numeric_suffix() -> None:
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("prompt1.txt", "legacy one")
+        zf.writestr("prompt_2.txt", "canonical two")
+        zf.writestr("promptnight.txt", "ignored")
+
+    archive.seek(0)
+    with zipfile.ZipFile(archive, "r") as zf:
+        prompts = _discover_prompts(zf)
+
+    assert prompts["default"] == "legacy one"
+    assert prompts["1"] == "legacy one"
+    assert prompts["2"] == "canonical two"
+    assert "night" not in prompts
 
 
 # Opportunistic: exercises the real USDZ loader, so this test is silently


### PR DESCRIPTION
Some USDZ scene bundles use legacy numeric prompt filenames such as
`prompt1.txt`, `prompt2.txt`, and `prompt3.txt`, while the newer canonical
form is `prompt_1.txt`, `prompt_2.txt`, and `prompt_3.txt`.

Before this change, the interactive-drive prompt discovery path rejected the
legacy no-underscore numeric form. In those scenes, selecting variant `1`, `2`,
or `3` could silently fall back to the default prompt, making the first frame
and prompt variant selection disagree.

This change makes the shared variant parser accept numeric legacy names while
still rejecting ambiguous non-numeric suffixes such as `promptnight.txt`. It
also logs the actual prompt source selected at scene load, so prompt fallback is
visible during demo bring-up.