### PR TITLE
demo: wire native fp8 vae opt to manifest

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model_perf.yaml
+++ b/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model_perf.yaml
@@ -10,16 +10,17 @@
 #
 # Default is 1280x704. You can try smaller resolutions as long as both width
 # and height are multiples of 16; examples with roughly similar aspect ratio:
+#   - [1280, 704]
 #   - [1168, 640]
 #   - [1024, 560]
 #   - [896, 496]
 #   - [640, 352]
-resolution_wh: [1024, 560]
+resolution_wh: [1168, 640]
 fps: 30
 num_frames_per_block: 8
 # For interactive GUI bring-up, eager mode gives a much faster first chunk than
 # paying torch.compile on the first real inference call.
-compile_net: false
+compile_net: true
 light_vae: true
 encode_with_pixel_shuffle: false
 local_attn_size: 6
@@ -31,10 +32,29 @@ upsampling_scale: 4
 device: cuda:0
 seed_for_every_rollout:
 
-# Native optimized DiT is off by default so the demo still runs on machines
-# without the native extension. Set this to "required" when testing the
-# optimized path; it will fail loudly if the extension cannot build/load.
+# Native acceleration uses the OmniDreams single-view extension. Before the
+# first native DiT/VAE run on a fresh checkout, sync third-party sources:
+#   uv run --package flashdreams-omnidreams python integrations/omnidreams/omnidreams_singleview/tools/sync_thirdparty.py sync
+#
+# The required mode fails loudly if the extension cannot build/load.
 native_dit_acceleration: required
-native_dit_verbose_build: true
-native_dit_backend: bf16            # fp8_kvcache_cudnn | bf16
-native_dit_attention_backend: sage3 # auto | cudnn | sparge | sage3 | sage3_fp8
+# native_dit_verbose_build: true
+native_dit_backend: fp8_kvcache_cudnn            # fp8_kvcache_cudnn | bf16
+native_dit_attention_backend: cudnn # auto | cudnn | sparge | sage3 | sage3_fp8
+
+# Native LightVAE encoder. Set to "fp8" to use the native FP8 encoder path
+# from the native-perf recipe; set to "disabled" to use the PyTorch encoder.
+# The FP8 path requires either OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH or
+# native_vae_fp8_state_path. Generate a calibrated state from repo root with:
+#   uv run --no-sync --package flashdreams-omnidreams \
+#     python integrations/omnidreams/scripts/export_lightvae_fp8_state.py \
+#     --out artifacts/native_vae/lightvae_fp8_state.pt \
+#     --example-data \
+#     --height 640 \
+#     --width 1168
+#
+# Then either:
+#   export OMNIDREAMS_LIGHTVAE_FP8_STATE_PATH=artifacts/native_vae/lightvae_fp8_state.pt
+# or uncomment and set an absolute or manifest-relative path below.
+native_vae_encoder: disabled             # disabled | fp8
+# native_vae_fp8_state_path: /path/to/lightvae_fp8_state.pt

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -17,6 +17,11 @@ from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
 
 PipelineFactory = Callable[[WorldModelManifest, WorldModelProfileConfig], Any]
 _VIEW_NAMES = ["camera_front_wide_120fov"]
+_LIGHTVAE_RECIPE = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
+_LIGHTVAE_PERF_RECIPE = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
+_LIGHTVAE_NATIVE_PERF_RECIPE = (
+    "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf"
+)
 
 
 def _select_config_name(manifest: WorldModelManifest) -> str:
@@ -54,7 +59,7 @@ def _select_config_name(manifest: WorldModelManifest) -> str:
             raise ValueError(
                 "The light-VAE flashdreams recipe currently supports 8-frame chunks."
             )
-        return "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
+        return _LIGHTVAE_RECIPE
     if manifest.num_frames_per_block == 8:
         return "omnidreams-sv-2steps-chunk2-loc6-vae-vae"
     if manifest.num_frames_per_block == 12:
@@ -91,15 +96,12 @@ def _build_pipeline_config(
     # global instances, so use ``derive_config`` to get a deep-copied
     # override-applied instance instead of mutating the global.
     transformer_overrides = _transformer_overrides(manifest)
-    base_config_name = (
-        "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
-        if config_name == "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
-        else config_name
-    )
+    base_config_name = _base_config_name(config_name, manifest)
     base = OMNIDREAMS_CONFIGS[base_config_name]
     config = derive_config(
         base,
         enable_sync_and_profile=bool(profile.enabled),
+        **_native_vae_overrides(manifest),
         diffusion_model=dict(
             seed=seed,
             transformer=transformer_overrides,
@@ -130,10 +132,41 @@ def _build_pipeline_config(
     print(
         "[flashdreams-session] resolved pipeline config\n"
         f"selected_recipe={config_name}\n"
+        f"base_recipe={base_config_name}\n"
         f"{config}",
         flush=True,
     )
     return config
+
+
+def _base_config_name(config_name: str, manifest: WorldModelManifest) -> str:
+    if manifest.native_vae_encoder != "disabled":
+        if config_name != _LIGHTVAE_RECIPE:
+            raise ValueError("native_vae_encoder=fp8 requires light_vae=true.")
+        return _LIGHTVAE_NATIVE_PERF_RECIPE
+    if config_name == _LIGHTVAE_RECIPE:
+        return _LIGHTVAE_PERF_RECIPE
+    return config_name
+
+
+def _native_vae_overrides(manifest: WorldModelManifest) -> dict[str, object]:
+    if manifest.native_vae_encoder == "disabled":
+        return {}
+    if manifest.native_vae_encoder != "fp8":
+        raise ValueError(
+            f"Unsupported native_vae_encoder={manifest.native_vae_encoder!r}"
+        )
+
+    common: dict[str, object] = {
+        "native_vae_acceleration": "required",
+        "native_vae_backend": "fp8",
+    }
+    if manifest.native_vae_fp8_state_path is not None:
+        common["native_vae_fp8_state_path"] = str(manifest.native_vae_fp8_state_path)
+    return {
+        "image_encoder": dict(common),
+        "encoder": dict(common),
+    }
 
 
 def _transformer_overrides(manifest: WorldModelManifest) -> dict[str, object]:

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
@@ -24,6 +24,7 @@ _DEFAULT_RESOLUTION_WH = (1280, 704)
 _RESOLUTION_ALIGNMENT_PX = 16
 _NATIVE_DIT_ACCELERATION_MODES = ("auto", "disabled", "required")
 _NATIVE_DIT_BACKENDS = ("fp8_kvcache_cudnn", "bf16")
+_NATIVE_VAE_ENCODERS = ("disabled", "fp8")
 
 
 def _is_hf_url(raw: str) -> bool:
@@ -134,6 +135,15 @@ def _parse_native_dit_backend(raw: object) -> str:
     return backend
 
 
+def _parse_native_vae_encoder(raw: object) -> str:
+    encoder = "disabled" if raw is None else str(raw)
+    if encoder not in _NATIVE_VAE_ENCODERS:
+        raise ValueError(
+            f"native_vae_encoder must be one of {_NATIVE_VAE_ENCODERS}, got {encoder!r}"
+        )
+    return encoder
+
+
 @dataclass(frozen=True)
 class WorldModelManifest:
     debug_condition_frame_dir: Path | None = None
@@ -160,6 +170,8 @@ class WorldModelManifest:
     native_dit_sparge_topk: float | None = None
     native_dit_sparge_hybrid_period: int | None = None
     native_dit_sparge_hybrid_phase: int | None = None
+    native_vae_encoder: str = "disabled"
+    native_vae_fp8_state_path: Path | None = None
 
 
 def load_world_model_manifest(path: str | Path) -> WorldModelManifest:
@@ -236,5 +248,10 @@ def load_world_model_manifest(path: str | Path) -> WorldModelManifest:
             int(data["native_dit_sparge_hybrid_phase"])
             if data.get("native_dit_sparge_hybrid_phase") is not None
             else None
+        ),
+        native_vae_encoder=_parse_native_vae_encoder(data.get("native_vae_encoder")),
+        native_vae_fp8_state_path=_resolve_manifest_path(
+            data.get("native_vae_fp8_state_path"),
+            manifest_dir=manifest_dir,
         ),
     )

--- a/integrations/omnidreams/tests/interactive_drive/test_manifest.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_manifest.py
@@ -28,6 +28,8 @@ class WorldModelManifestTest(unittest.TestCase):
             self.assertEqual(manifest.denoising_steps, [1000, 500])
             self.assertEqual(manifest.resolution_wh, (1280, 704))
             self.assertEqual(manifest.native_dit_acceleration, "disabled")
+            self.assertEqual(manifest.native_vae_encoder, "disabled")
+            self.assertIsNone(manifest.native_vae_fp8_state_path)
 
     def test_loads_native_dit_knobs(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -59,6 +61,28 @@ class WorldModelManifestTest(unittest.TestCase):
             self.assertEqual(manifest.native_dit_sparge_hybrid_period, 4)
             self.assertEqual(manifest.native_dit_sparge_hybrid_phase, 1)
 
+    def test_loads_native_vae_knobs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config_dir = root / "configs"
+            config_dir.mkdir()
+            path = config_dir / "manifest.yaml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    native_vae_encoder: fp8
+                    native_vae_fp8_state_path: ../native/lightvae-fp8-state.pt
+                    """
+                ).strip(),
+                encoding="utf-8",
+            )
+            manifest = load_world_model_manifest(path)
+            self.assertEqual(manifest.native_vae_encoder, "fp8")
+            self.assertEqual(
+                manifest.native_vae_fp8_state_path,
+                (root / "native/lightvae-fp8-state.pt").resolve(),
+            )
+
     def test_rejects_unaligned_resolution(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "manifest.yaml"
@@ -78,6 +102,13 @@ class WorldModelManifestTest(unittest.TestCase):
             path = Path(tmpdir) / "manifest.yaml"
             path.write_text("native_dit_acceleration: fast\n", encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "native_dit_acceleration"):
+                load_world_model_manifest(path)
+
+    def test_rejects_invalid_native_vae_encoder(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.yaml"
+            path.write_text("native_vae_encoder: fast\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "native_vae_encoder"):
                 load_world_model_manifest(path)
 
     def test_resolves_relative_paths_from_manifest_location(self) -> None:

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 
 import numpy as np
 import omnidreams.interactive_drive.world_model.flashdreams_adapter as adapter_module
+import pytest
 import torch
 from omnidreams.interactive_drive.config import WorldModelProfileConfig
 from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
@@ -110,6 +112,36 @@ def test_build_pipeline_config_uses_manifest_native_dit_overrides() -> None:
     assert transformer_config.native_dit_sparge_topk == 0.4
     assert transformer_config.native_dit_sparge_hybrid_period == 4
     assert transformer_config.native_dit_sparge_hybrid_phase == 1
+
+
+def test_build_pipeline_config_can_select_native_vae_encoder() -> None:
+    config = _build_pipeline_config(
+        replace(
+            _manifest(),
+            native_vae_encoder="fp8",
+            native_vae_fp8_state_path=Path("/tmp/lightvae-fp8-state.pt"),
+        ),
+        profile=WorldModelProfileConfig(),
+    )
+
+    assert (
+        config.name == "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf"
+    )
+    assert config.image_encoder.native_vae_acceleration == "required"
+    assert config.image_encoder.native_vae_backend == "fp8"
+    assert (
+        config.image_encoder.native_vae_fp8_state_path == "/tmp/lightvae-fp8-state.pt"
+    )
+    assert config.encoder.native_vae_acceleration == "required"
+    assert config.encoder.native_vae_backend == "fp8"
+
+
+def test_native_vae_encoder_requires_light_vae_recipe() -> None:
+    with pytest.raises(ValueError, match="native_vae_encoder=fp8 requires light_vae"):
+        _build_pipeline_config(
+            replace(_manifest(), light_vae=False, native_vae_encoder="fp8"),
+            profile=WorldModelProfileConfig(),
+        )
 
 
 def test_session_uses_flashdreams_pipeline_for_rollout() -> None:


### PR DESCRIPTION
This change adds an toggle to the demo manifest to enable or disable fp8 VAE native implementation.
By default, it's not enabled.