### PR TITLE
demo: make HDMap raster cuda-interop

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -347,22 +347,22 @@ Then open `http://localhost:8080/`.
 For a richer browser frontend with lower latency, prefer the separate
 `omnidreams.webrtc.server` entry point.
 
-Both Vulkan presenters can use SlangPy CUDA interop for generated RGB frames
-when the model output is still on CUDA. Because Torch usually owns the CUDA
-context before the presenter is constructed, this path follows upstream and is
-opt-in:
+The interactive-drive CUDA fast path is enabled by default. HDMap raster frames
+stay CUDA-backed for world-model conditioning, and both Vulkan presenters use
+SlangPy CUDA interop for generated RGB frames when the model output is still on
+CUDA:
 
 ```bash
-INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES=1 \
-  OMNIDREAMS_TRUESIGHT=1 \
+OMNIDREAMS_TRUESIGHT=1 \
   uv run --no-sync --package flashdreams-omnidreams interactive-drive
 ```
 
-Set `INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP=1` to force the host-upload
-fallback. In HUD mode, chrome is still rendered with PIL on the CPU, then
-uploaded as an alpha overlay; the generated camera frame stays lazy on CUDA and
-is resized/composited into the shared presentation buffer on the CUDA stream.
-Use `--no-hud` with the same environment variables for the bare presenter.
+Set `INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP=1` to force the conservative host
+path for both HDMap raster conditioning and presenter CUDA interop. In HUD mode,
+chrome is still rendered with PIL on the CPU, then uploaded as an alpha overlay;
+the generated camera frame stays lazy on CUDA and is resized/composited into the
+shared presentation buffer on the CUDA stream. Use `--no-hud` with the same
+environment variable for the bare presenter.
 
 Controls (apply in all three modes):
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/cuda_env.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cuda_env.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import os
+
+DISABLE_CUDA_INTEROP_ENV = "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"
+
+
+def env_truthy(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}

--- a/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import os
-import sys
 import time
 from typing import Any
 
 import numpy as np
 from omnidreams.interactive_drive.config import RasterConfig
+from omnidreams.interactive_drive.cuda_env import (
+    DISABLE_CUDA_INTEROP_ENV,
+    env_truthy,
+)
 from omnidreams.interactive_drive.input.keyboard import KeyboardState
 from omnidreams.interactive_drive.loading_overlay import render_loading_overlay
 from omnidreams.interactive_drive.types import PresentedFrame
@@ -100,19 +102,11 @@ class SlangPyPresenter:
 
     def _create_device(self):
         existing_device_handles = self._cuda_existing_device_handles()
-        torch_cuda_initialized = _torch_cuda_initialized()
-        if torch_cuda_initialized and not _env_truthy(
-            "INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"
-        ):
+        enable_cuda_interop = not env_truthy(DISABLE_CUDA_INTEROP_ENV)
+        if not enable_cuda_interop:
             self._cuda_interop_unavailable_reason = (
-                "disabled after torch CUDA initialization"
+                f"disabled by {DISABLE_CUDA_INTEROP_ENV}"
             )
-        enable_cuda_interop = not _env_truthy(
-            "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"
-        ) and (
-            not torch_cuda_initialized
-            or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
-        )
         device_kwargs = {
             "type": self._spy.DeviceType.vulkan,
             "enable_debug_layers": False,
@@ -139,9 +133,7 @@ class SlangPyPresenter:
             )
 
     def _cuda_existing_device_handles(self) -> list[Any]:
-        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
-            return []
-        if not _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"):
+        if env_truthy(DISABLE_CUDA_INTEROP_ENV):
             return []
         try:
             import torch
@@ -165,9 +157,9 @@ class SlangPyPresenter:
             return []
 
     def _create_cuda_rgb_interop(self):
-        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
+        if env_truthy(DISABLE_CUDA_INTEROP_ENV):
             print(
-                "[presenter] cuda_interop=disabled by INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP; "
+                f"[presenter] cuda_interop=disabled by {DISABLE_CUDA_INTEROP_ENV}; "
                 "using host RGB upload",
                 flush=True,
             )
@@ -717,21 +709,7 @@ def _cuda_event_ready(event: Any | None) -> bool:
         return False
 
 
-def _env_truthy(name: str) -> bool:
-    value = os.environ.get(name)
-    if value is None:
-        return False
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _torch_cuda_initialized() -> bool:
-    torch_module = sys.modules.get("torch")
-    if torch_module is None:
-        return False
-    try:
-        return bool(torch_module.cuda.is_initialized())
-    except Exception:
-        return False
+_env_truthy = env_truthy
 
 
 def _prefetch_to_numpy(frame: object) -> None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
@@ -39,6 +39,7 @@ from ludus_renderer.render_utils import SceneAdapter
 from ludus_renderer.torch import LudusCudaTimestampedContext
 from ludus_renderer.torch.ops import CAMERA_TYPE_BEV, CAMERA_TYPE_REGULAR
 from omnidreams.interactive_drive.config import BevConfig, RasterConfig
+from omnidreams.interactive_drive.cuda_env import DISABLE_CUDA_INTEROP_ENV, env_truthy
 from omnidreams.interactive_drive.cuda_host_prefetch import CudaHostPrefetch
 from omnidreams.interactive_drive.types import PresentedFrame, RasterChunk, SceneBundle
 from torch import Tensor
@@ -135,7 +136,9 @@ class _LazyRasterFrame:
 
     def to_cuda_tensor(self) -> Tensor:
         if self._frames_hwc_uint8 is None:
-            raise RuntimeError("Lazy raster frame was already materialized on the host.")
+            raise RuntimeError(
+                "Lazy raster frame was already materialized on the host."
+            )
         return self._frames_hwc_uint8[self._frame_index]
 
     def to_cuda_event(self) -> object | None:
@@ -181,6 +184,13 @@ class _LudusConditionRasterizerImpl:
         self._raster = raster
         self._bev = bev
         self._device = torch.device("cuda:0")
+        self._use_cuda_frames = not env_truthy(DISABLE_CUDA_INTEROP_ENV)
+        if not self._use_cuda_frames:
+            print(
+                f"[rasterizer] cuda_backend=disabled by {DISABLE_CUDA_INTEROP_ENV}; "
+                "using host raster frames",
+                flush=True,
+            )
 
         self.ctx = LudusCudaTimestampedContext(device=self._device)
         self.ctx.set_depth_scaling(True)
@@ -344,23 +354,41 @@ class _LudusConditionRasterizerImpl:
                 resolution=(self._bev.height, self._bev.width),
             )
 
+        if self._use_cuda_frames:
+            frames = [
+                PresentedFrame(
+                    timestamp_us=int(timestamps_us[idx]),
+                    rgb_host_uint8=_LazyRasterFrame(
+                        rgb_frames.frames_hwc_uint8,
+                        idx,
+                        source_event=rgb_frames.ready_event,
+                    ),
+                    depth_host_f32=None,
+                    bev_host_uint8=(
+                        _LazyRasterFrame(
+                            bev_frames.frames_hwc_uint8,
+                            idx,
+                            source_event=bev_frames.ready_event,
+                        )
+                        if bev_frames is not None
+                        else None
+                    ),
+                )
+                for idx in range(len(timestamps_us))
+            ]
+            return RasterChunk(frames=tuple(frames))
+
+        rgb_host_frames = _rendered_frames_to_numpy(rgb_frames)
+        bev_host_frames = (
+            _rendered_frames_to_numpy(bev_frames) if bev_frames is not None else None
+        )
         frames = [
             PresentedFrame(
                 timestamp_us=int(timestamps_us[idx]),
-                rgb_host_uint8=_LazyRasterFrame(
-                    rgb_frames.frames_hwc_uint8,
-                    idx,
-                    source_event=rgb_frames.ready_event,
-                ),
+                rgb_host_uint8=rgb_host_frames[idx],
                 depth_host_f32=None,
                 bev_host_uint8=(
-                    _LazyRasterFrame(
-                        bev_frames.frames_hwc_uint8,
-                        idx,
-                        source_event=bev_frames.ready_event,
-                    )
-                    if bev_frames is not None
-                    else None
+                    bev_host_frames[idx] if bev_host_frames is not None else None
                 ),
             )
             for idx in range(len(timestamps_us))
@@ -493,6 +521,15 @@ class LudusConditionRasterizer:
     def __del__(self) -> None:
         with contextlib.suppress(Exception):
             self.cleanup()
+
+
+def _rendered_frames_to_numpy(rendered: _RenderedCameraFrames) -> list[np.ndarray]:
+    synchronize = getattr(rendered.ready_event, "synchronize", None)
+    if callable(synchronize):
+        synchronize()
+    frames = rendered.frames_hwc_uint8.detach().cpu().numpy()
+    frames = np.ascontiguousarray(frames, dtype=np.uint8)
+    return [frames[idx] for idx in range(frames.shape[0])]
 
 
 def _build_bev_camera(bev: BevConfig, device: torch.device) -> FThetaCamera:

--- a/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
@@ -39,6 +39,7 @@ from ludus_renderer.render_utils import SceneAdapter
 from ludus_renderer.torch import LudusCudaTimestampedContext
 from ludus_renderer.torch.ops import CAMERA_TYPE_BEV, CAMERA_TYPE_REGULAR
 from omnidreams.interactive_drive.config import BevConfig, RasterConfig
+from omnidreams.interactive_drive.cuda_host_prefetch import CudaHostPrefetch
 from omnidreams.interactive_drive.types import PresentedFrame, RasterChunk, SceneBundle
 from torch import Tensor
 
@@ -77,6 +78,82 @@ class _LoadedSceneData:
 
     clipgt_scene: ClipgtGpuScene
     scene_adapter: SceneAdapter
+
+
+@dataclass(frozen=True)
+class _RenderedCameraFrames:
+    frames_hwc_uint8: Tensor
+    ready_event: object | None
+
+
+class _LazyRasterFrame:
+    """Expose a rendered HDMap frame as CUDA first, NumPy only on fallback."""
+
+    def __init__(
+        self,
+        frames_hwc_uint8: Tensor,
+        frame_index: int,
+        *,
+        source_event: object | None = None,
+    ) -> None:
+        self._frames_hwc_uint8: Tensor | None = frames_hwc_uint8
+        self._frame_index = int(frame_index)
+        self._source_event = source_event
+        self._host: np.ndarray | None = None
+        self._prefetch: CudaHostPrefetch | None = None
+
+    def prefetch_to_numpy(self) -> None:
+        if (
+            self._host is not None
+            or self._prefetch is not None
+            or self._frames_hwc_uint8 is None
+        ):
+            return
+        frame = self._frames_hwc_uint8[self._frame_index].detach()
+        prefetch = CudaHostPrefetch(frame, source_event=self._source_event)
+        if prefetch.start():
+            self._prefetch = prefetch
+
+    def to_numpy(self) -> np.ndarray:
+        if self._host is None:
+            if self._prefetch is not None:
+                self._host = self._prefetch.to_numpy()
+                self._prefetch = None
+                self._frames_hwc_uint8 = None
+                return self._host
+            if self._frames_hwc_uint8 is None:
+                raise RuntimeError(
+                    "Lazy raster frame lost its source tensor before materialization."
+                )
+            synchronize = getattr(self._source_event, "synchronize", None)
+            if callable(synchronize):
+                synchronize()
+            frame = self._frames_hwc_uint8[self._frame_index].detach().cpu().numpy()
+            self._host = np.ascontiguousarray(frame, dtype=np.uint8)
+            self._frames_hwc_uint8 = None
+        return self._host
+
+    def to_cuda_tensor(self) -> Tensor:
+        if self._frames_hwc_uint8 is None:
+            raise RuntimeError("Lazy raster frame was already materialized on the host.")
+        return self._frames_hwc_uint8[self._frame_index]
+
+    def to_cuda_event(self) -> object | None:
+        if self._frames_hwc_uint8 is None:
+            return None
+        return self._source_event
+
+    def __array__(
+        self,
+        dtype: object | None = None,
+        copy: bool | None = None,
+    ) -> np.ndarray:
+        array = self.to_numpy()
+        if dtype is not None:
+            array = array.astype(dtype, copy=False)
+        if copy:
+            return np.array(array, copy=True)
+        return array
 
 
 class _LudusConditionRasterizerImpl:
@@ -240,7 +317,7 @@ class _LudusConditionRasterizerImpl:
             np.ascontiguousarray(timestamps_us, dtype=np.int64)
         ).to(device=self._device)
 
-        rgb_numpy = self._render_one_camera(
+        rgb_frames = self._render_one_camera(
             rig_poses=rig_poses_torch,
             timestamps_batch=timestamps_batch,
             scene_id=self._scene_id,
@@ -250,14 +327,14 @@ class _LudusConditionRasterizerImpl:
             resolution=(self._raster.height, self._raster.width),
         )
 
-        bev_numpy: np.ndarray | None = None
+        bev_frames: _RenderedCameraFrames | None = None
         if (
             self._bev is not None
             and self._bev.enabled
             and self._bev_camera_id is not None
             and self._bev_sensor_to_rig is not None
         ):
-            bev_numpy = self._render_one_camera(
+            bev_frames = self._render_one_camera(
                 rig_poses=rig_poses_torch,
                 timestamps_batch=timestamps_batch,
                 scene_id=self._scene_id,
@@ -270,11 +347,19 @@ class _LudusConditionRasterizerImpl:
         frames = [
             PresentedFrame(
                 timestamp_us=int(timestamps_us[idx]),
-                rgb_host_uint8=np.ascontiguousarray(rgb_numpy[idx], dtype=np.uint8),
+                rgb_host_uint8=_LazyRasterFrame(
+                    rgb_frames.frames_hwc_uint8,
+                    idx,
+                    source_event=rgb_frames.ready_event,
+                ),
                 depth_host_f32=None,
                 bev_host_uint8=(
-                    np.ascontiguousarray(bev_numpy[idx], dtype=np.uint8)
-                    if bev_numpy is not None
+                    _LazyRasterFrame(
+                        bev_frames.frames_hwc_uint8,
+                        idx,
+                        source_event=bev_frames.ready_event,
+                    )
+                    if bev_frames is not None
                     else None
                 ),
             )
@@ -292,14 +377,15 @@ class _LudusConditionRasterizerImpl:
         sensor_to_rig: Tensor,
         camera_type: int,
         resolution: tuple[int, int],
-    ) -> np.ndarray:
+    ) -> _RenderedCameraFrames:
         """Single-camera rasterizer dispatch, shared by the main view and BEV.
 
         Both code paths build identical camera/timestamp batches and only
         differ in the camera id, sensor-to-rig, camera-type id, and
-        target resolution; the scene id is shared. Keeping them in one
-        helper keeps the GPU bookkeeping (vflip, dtype-cast, host copy)
-        consistent across paths.
+        target resolution; the scene id is shared. Keeping frames CUDA-backed
+        lets the world model consume HDMap conditioning without a GPU->CPU->GPU
+        round trip. Presenters can still materialize NumPy lazily for fallback
+        display paths.
         """
         n_frames = timestamps_batch.shape[0]
         camera_poses_world = torch.einsum(
@@ -329,12 +415,14 @@ class _LudusConditionRasterizerImpl:
         rgb = images[:, :, :, :3]
         if self.ctx.needs_vflip:
             rgb = rgb.flip(1)
-        rendered_host = rgb.detach().cpu()
-        if rendered_host.dtype != torch.uint8:
-            rendered_host = (rendered_host.clamp(0.0, 1.0) * 255.0 + 0.5).to(
-                torch.uint8
-            )
-        return rendered_host.numpy()
+        if rgb.dtype != torch.uint8:
+            rgb = (rgb.clamp(0.0, 1.0) * 255.0 + 0.5).to(torch.uint8)
+        rgb = rgb.detach().contiguous()
+        ready_event = None
+        if rgb.is_cuda:
+            ready_event = torch.cuda.Event()
+            ready_event.record(torch.cuda.current_stream(rgb.device))
+        return _RenderedCameraFrames(frames_hwc_uint8=rgb, ready_event=ready_event)
 
     def cleanup(self) -> None:
         """Cleanup resources."""

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -52,11 +52,11 @@ from typing import Any
 
 import numpy as np
 from omnidreams.interactive_drive.config import RasterConfig
+from omnidreams.interactive_drive.cuda_env import DISABLE_CUDA_INTEROP_ENV
 from omnidreams.interactive_drive.input.keyboard import KeyboardState
 from omnidreams.interactive_drive.presenter import (
     _CudaRGBInterop,
     _env_truthy,
-    _torch_cuda_initialized,
 )
 from omnidreams.interactive_drive.types import DriverCommand, PresentedFrame
 from PIL import Image, ImageDraw, ImageFont
@@ -683,19 +683,11 @@ class SlangPyHudPresenter:
 
     def _create_device(self) -> Any:
         existing_device_handles = self._cuda_existing_device_handles()
-        torch_cuda_initialized = _torch_cuda_initialized()
-        if torch_cuda_initialized and not _env_truthy(
-            "INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"
-        ):
+        enable_cuda_interop = not _env_truthy(DISABLE_CUDA_INTEROP_ENV)
+        if not enable_cuda_interop:
             self._cuda_interop_unavailable_reason = (
-                "disabled after torch CUDA initialization"
+                f"disabled by {DISABLE_CUDA_INTEROP_ENV}"
             )
-        enable_cuda_interop = not _env_truthy(
-            "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"
-        ) and (
-            not torch_cuda_initialized
-            or _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES")
-        )
         device_kwargs = {
             "type": self._spy.DeviceType.vulkan,
             "enable_debug_layers": False,
@@ -722,9 +714,7 @@ class SlangPyHudPresenter:
             )
 
     def _cuda_existing_device_handles(self) -> list[Any]:
-        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
-            return []
-        if not _env_truthy("INTERACTIVE_DRIVE_ENABLE_CUDA_CONTEXT_HANDLES"):
+        if _env_truthy(DISABLE_CUDA_INTEROP_ENV):
             return []
         try:
             import torch
@@ -750,10 +740,10 @@ class SlangPyHudPresenter:
     def _create_cuda_hud_interop(
         self, width: int, height: int
     ) -> _CudaRGBInterop | None:
-        if _env_truthy("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP"):
+        if _env_truthy(DISABLE_CUDA_INTEROP_ENV):
             print(
                 "[presenter] hud_cuda_interop=disabled by "
-                "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP; using host HUD upload",
+                f"{DISABLE_CUDA_INTEROP_ENV}; using host HUD upload",
                 flush=True,
             )
             return None

--- a/integrations/omnidreams/omnidreams/interactive_drive/types.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/types.py
@@ -213,7 +213,7 @@ class PresentedFrame:
     # needing a second rasterizer instance. ``None`` when BEV rendering is
     # disabled, or when the world-model backend's first chunk replays the
     # debug HDMap override (BEV is not in that override set).
-    bev_host_uint8: UInt8Array | None = None
+    bev_host_uint8: Any | None = None
     status_message: str | None = None
 
 

--- a/integrations/omnidreams/tests/interactive_drive/test_presenter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_presenter.py
@@ -39,22 +39,74 @@ def _hud_presenter_without_window() -> SlangPyHudPresenter:
     return SlangPyHudPresenter.__new__(SlangPyHudPresenter)
 
 
-def test_cuda_existing_device_handles_skips_by_default(monkeypatch) -> None:
+def test_cuda_existing_device_handles_uses_current_context_by_default(
+    monkeypatch,
+) -> None:
+    presenter = _presenter_without_window()
+    handles = [object()]
+
+    class _Spy:
+        @staticmethod
+        def get_cuda_current_context_native_handles() -> list[object]:
+            return handles
+
+    fake_torch = SimpleNamespace(cuda=SimpleNamespace(is_initialized=lambda: True))
+    monkeypatch.delenv("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP", raising=False)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    presenter._spy = _Spy()
+
+    assert presenter._cuda_existing_device_handles() == handles
+
+
+def test_cuda_existing_device_handles_can_be_disabled(monkeypatch) -> None:
     presenter = _presenter_without_window()
 
     class _Spy:
         @staticmethod
         def get_cuda_current_context_native_handles() -> list[object]:
-            raise AssertionError("native handle query should be opt-in")
+            raise AssertionError("native handle query should be disabled")
 
     fake_torch = SimpleNamespace(cuda=SimpleNamespace(is_initialized=lambda: True))
+    monkeypatch.setenv("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP", "1")
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
     presenter._spy = _Spy()
 
     assert presenter._cuda_existing_device_handles() == []
 
 
-def test_create_device_disables_cuda_interop_when_torch_cuda_is_initialized(
+def test_create_device_enables_cuda_interop_with_current_context_by_default(
+    monkeypatch,
+) -> None:
+    presenter = _presenter_without_window()
+    created_kwargs: list[dict[str, object]] = []
+
+    class _DeviceType:
+        vulkan = object()
+
+    class _Spy:
+        DeviceType = _DeviceType
+
+        @staticmethod
+        def get_cuda_current_context_native_handles() -> list[object]:
+            return ["cuda-context"]
+
+        @staticmethod
+        def Device(**kwargs):
+            created_kwargs.append(kwargs)
+            return SimpleNamespace(info=SimpleNamespace(adapter_name="fake"))
+
+    fake_torch = SimpleNamespace(cuda=SimpleNamespace(is_initialized=lambda: True))
+    monkeypatch.delenv("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP", raising=False)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    presenter._spy = _Spy()
+
+    presenter._create_device()
+
+    assert created_kwargs[0]["enable_cuda_interop"] is True
+    assert created_kwargs[0]["existing_device_handles"] == ["cuda-context"]
+
+
+def test_create_device_disables_cuda_interop_when_cuda_interop_is_disabled(
     monkeypatch,
 ) -> None:
     presenter = _presenter_without_window()
@@ -72,15 +124,16 @@ def test_create_device_disables_cuda_interop_when_torch_cuda_is_initialized(
             return SimpleNamespace(info=SimpleNamespace(adapter_name="fake"))
 
     fake_torch = SimpleNamespace(cuda=SimpleNamespace(is_initialized=lambda: True))
+    monkeypatch.setenv("INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP", "1")
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
     presenter._spy = _Spy()
 
     presenter._create_device()
 
     assert created_kwargs[0]["enable_cuda_interop"] is False
-    assert (
-        presenter._cuda_interop_unavailable_reason
-        == "disabled after torch CUDA initialization"
+    assert "existing_device_handles" not in created_kwargs[0]
+    assert "INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP" in (
+        presenter._cuda_interop_unavailable_reason or ""
     )
 
 

--- a/integrations/omnidreams/tests/interactive_drive/test_rasterizer.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_rasterizer.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+from omnidreams.interactive_drive.rasterizer import (
+    _LoadedSceneData,
+    _LudusConditionRasterizerImpl,
+    _RenderedCameraFrames,
+)
+
+
+class _Event:
+    def __init__(self) -> None:
+        self.sync_calls = 0
+
+    def synchronize(self) -> None:
+        self.sync_calls += 1
+
+
+def _impl_for_render_chunk(*, use_cuda_frames: bool) -> _LudusConditionRasterizerImpl:
+    impl = _LudusConditionRasterizerImpl.__new__(_LudusConditionRasterizerImpl)
+    impl._scene_data = _LoadedSceneData(clipgt_scene=object(), scene_adapter=object())
+    impl._scene_id = 7
+    impl._selected_camera_name = "front"
+    impl._all_camera_map = {"front": 0}
+    impl._sensor_to_rig = {"front": torch.eye(4)}
+    impl._bev = None
+    impl._bev_camera_id = None
+    impl._bev_sensor_to_rig = None
+    impl._temp_dir = None
+    impl._device = torch.device("cpu")
+    impl._raster = SimpleNamespace(height=2, width=3)
+    impl._use_cuda_frames = use_cuda_frames
+    impl._to_ludus_camera_pose = lambda poses: poses
+
+    def fake_render_one_camera(**kwargs):
+        n_frames = int(kwargs["timestamps_batch"].shape[0])
+        frames = torch.arange(n_frames * 2 * 3 * 3, dtype=torch.uint8).reshape(
+            n_frames, 2, 3, 3
+        )
+        return _RenderedCameraFrames(frames_hwc_uint8=frames, ready_event=_Event())
+
+    impl._render_one_camera = fake_render_one_camera
+    return impl
+
+
+def test_raster_chunk_uses_cuda_backed_frames_by_default() -> None:
+    impl = _impl_for_render_chunk(use_cuda_frames=True)
+
+    chunk = impl.render_chunk(
+        np.repeat(np.eye(4, dtype=np.float32)[None, :, :], 2, axis=0),
+        np.array([1, 2], dtype=np.int64),
+    )
+
+    assert callable(getattr(chunk.frames[0].rgb_host_uint8, "to_cuda_tensor", None))
+
+
+def test_raster_chunk_can_disable_cuda_backed_frames() -> None:
+    impl = _impl_for_render_chunk(use_cuda_frames=False)
+
+    chunk = impl.render_chunk(
+        np.repeat(np.eye(4, dtype=np.float32)[None, :, :], 2, axis=0),
+        np.array([1, 2], dtype=np.int64),
+    )
+
+    first = chunk.frames[0].rgb_host_uint8
+    assert isinstance(first, np.ndarray)
+    assert not callable(getattr(first, "to_cuda_tensor", None))
+    assert np.array_equal(first, np.arange(18, dtype=np.uint8).reshape(2, 3, 3))


### PR DESCRIPTION
## Summary

- Make the interactive-drive CUDA path the default.
- Use `INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP` as the single opt-out switch.
- Use that opt-out to disable both presenter CUDA interop and CUDA-backed HDMap raster frames.
- Update interactive-drive docs and add focused tests.

## Perf

Measured with:

```bash
xvfb-run -a ./run_demo.sh
INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP=1 xvfb-run -a ./run_demo.sh
```

At local `1168x640` perf config:

| Mode | Steady FPS | Steady next chunk |
| --- | ---: | ---: |
| default CUDA-backed path | ~20.7 avg | ~296 ms |
| disabled CUDA interop | ~18.0 avg | ~340 ms |

Default path is roughly 15% faster in this run.