### PR TITLE
Add Omnidreams golden-clip quality regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
       # Limit parallel CUDA compilation jobs to avoid OOM (each nvcc job
       # uses ~9GB peak memory).
       MAX_JOBS: 8
+      OMNIDREAMS_QUALITY_REFERENCE_REPO: ${{ vars.OMNIDREAMS_QUALITY_REFERENCE_REPO || 'jarcherNV/omni-dreams-quality-references' }}
+      OMNIDREAMS_QUALITY_REFERENCE_PATH: ${{ vars.OMNIDREAMS_QUALITY_REFERENCE_PATH || 'data/quality_references/single_view/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae/239560dc-33d1-11ef-9720-00044bcbccac/reference_compare_region.mp4' }}
+      OMNIDREAMS_QUALITY_REFERENCE_CLIP: /tmp/omnidreams_quality_reference/reference_compare_region.mp4
+      OMNIDREAMS_QUALITY_ARTIFACT_DIR: /tmp/omnidreams_quality_artifacts
     steps:
       - name: Get PR info
         if: startsWith(github.ref_name, 'pull-request/')
@@ -153,10 +157,42 @@ jobs:
           echo "Verifying GPU access..."
           nvidia-smi
 
+      - name: Download Omnidreams quality reference
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")"
+          hf_args=()
+          if [ -n "${HF_TOKEN:-}" ]; then
+            hf_args+=(--token "${HF_TOKEN}")
+          fi
+          uv run --no-sync hf download \
+            "${OMNIDREAMS_QUALITY_REFERENCE_REPO}" \
+            "${OMNIDREAMS_QUALITY_REFERENCE_PATH}" \
+            --repo-type dataset \
+            --local-dir "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")" \
+            "${hf_args[@]}"
+          cp \
+            "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")/${OMNIDREAMS_QUALITY_REFERENCE_PATH}" \
+            "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}"
+          test -s "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}"
+
       - name: Run GPU unit tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          FLASHDREAMS_OMNIDREAMS_QUALITY_REFERENCE_CLIP: ${{ env.OMNIDREAMS_QUALITY_REFERENCE_CLIP }}
+          FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA: "1"
+          FLASHDREAMS_OMNIDREAMS_QUALITY_TOTAL_BLOCKS: "4"
+          FLASHDREAMS_OMNIDREAMS_QUALITY_ARTIFACT_DIR: ${{ env.OMNIDREAMS_QUALITY_ARTIFACT_DIR }}
         run: uv run --no-sync pytest -m ci_gpu -v
+
+      - name: Upload Omnidreams quality artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: omnidreams-quality-artifacts
+          path: ${{ env.OMNIDREAMS_QUALITY_ARTIFACT_DIR }}
+          if-no-files-found: ignore
 
       - name: Trim uv cache for upload
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       # Limit parallel CUDA compilation jobs to avoid OOM (each nvcc job
       # uses ~9GB peak memory).
       MAX_JOBS: 8
-      OMNIDREAMS_QUALITY_REFERENCE_REPO: ${{ vars.OMNIDREAMS_QUALITY_REFERENCE_REPO || 'jarcherNV/omni-dreams-quality-references' }}
+      OMNIDREAMS_QUALITY_REFERENCE_REPO: ${{ vars.OMNIDREAMS_QUALITY_REFERENCE_REPO || 'nvidia/omni-dreams-samples' }}
       OMNIDREAMS_QUALITY_REFERENCE_PATH: ${{ vars.OMNIDREAMS_QUALITY_REFERENCE_PATH || 'data/quality_references/single_view/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae/239560dc-33d1-11ef-9720-00044bcbccac/reference_compare_region.mp4' }}
       OMNIDREAMS_QUALITY_REFERENCE_CLIP: /tmp/omnidreams_quality_reference/reference_compare_region.mp4
       OMNIDREAMS_QUALITY_ARTIFACT_DIR: /tmp/omnidreams_quality_artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,16 +162,20 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           mkdir -p "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")"
-          hf_args=()
           if [ -n "${HF_TOKEN:-}" ]; then
-            hf_args+=(--token "${HF_TOKEN}")
+            uv run --no-sync hf download \
+              "${OMNIDREAMS_QUALITY_REFERENCE_REPO}" \
+              "${OMNIDREAMS_QUALITY_REFERENCE_PATH}" \
+              --repo-type dataset \
+              --local-dir "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")" \
+              --token "${HF_TOKEN}"
+          else
+            uv run --no-sync hf download \
+              "${OMNIDREAMS_QUALITY_REFERENCE_REPO}" \
+              "${OMNIDREAMS_QUALITY_REFERENCE_PATH}" \
+              --repo-type dataset \
+              --local-dir "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")"
           fi
-          uv run --no-sync hf download \
-            "${OMNIDREAMS_QUALITY_REFERENCE_REPO}" \
-            "${OMNIDREAMS_QUALITY_REFERENCE_PATH}" \
-            --repo-type dataset \
-            --local-dir "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")" \
-            "${hf_args[@]}"
           cp \
             "$(dirname "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}")/${OMNIDREAMS_QUALITY_REFERENCE_PATH}" \
             "${OMNIDREAMS_QUALITY_REFERENCE_CLIP}"

--- a/flashdreams/flashdreams/quality/__init__.py
+++ b/flashdreams/flashdreams/quality/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for output-quality regression checks."""
+
+from flashdreams.quality.clip_compare import (
+    ClipComparisonResult,
+    ClipComparisonThresholds,
+    ClipFrameMetrics,
+    assert_clip_within_thresholds,
+    bottom_half,
+    compare_video_arrays,
+    format_clip_comparison,
+    parse_frame_indices,
+    read_video_rgb,
+    select_frame_indices,
+)
+
+__all__ = [
+    "ClipComparisonResult",
+    "ClipComparisonThresholds",
+    "ClipFrameMetrics",
+    "assert_clip_within_thresholds",
+    "bottom_half",
+    "compare_video_arrays",
+    "format_clip_comparison",
+    "parse_frame_indices",
+    "read_video_rgb",
+    "select_frame_indices",
+]

--- a/flashdreams/flashdreams/quality/clip_compare.py
+++ b/flashdreams/flashdreams/quality/clip_compare.py
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frame-sampled RGB clip comparison for golden-output regression tests."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import numpy.typing as npt
+
+RGBVideo = npt.NDArray[np.uint8]
+
+
+@dataclass(frozen=True)
+class ClipFrameMetrics:
+    """Per-sampled-frame image-difference metrics in RGB uint8 space."""
+
+    frame_index: int
+    mean_abs: float
+    rmse: float
+    psnr_db: float
+    mean_flip: float | None = None
+
+
+@dataclass(frozen=True)
+class ClipComparisonThresholds:
+    """Bounds used by :func:`assert_clip_within_thresholds`.
+
+    ``mean_abs`` and ``rmse`` are measured in 8-bit RGB intensity units
+    (0..255). ``mean_flip`` is optional and only computed when one of the
+    FLIP thresholds is non-``None``.
+    """
+
+    max_mean_abs: float = 4.0
+    max_rmse: float = 8.0
+    min_psnr_db: float = 30.0
+    max_frame_mean_abs: float = 8.0
+    max_frame_rmse: float = 14.0
+    max_mean_flip: float | None = 0.035
+    max_frame_flip: float | None = 0.060
+    require_same_frame_count: bool = True
+
+
+@dataclass(frozen=True)
+class ClipComparisonResult:
+    """Aggregate and per-frame metrics for one reference/candidate comparison."""
+
+    reference_frame_count: int
+    candidate_frame_count: int
+    frame_indices: tuple[int, ...]
+    mean_abs: float
+    rmse: float
+    psnr_db: float
+    frame_metrics: tuple[ClipFrameMetrics, ...]
+    mean_flip: float | None = None
+
+    @property
+    def max_frame_mean_abs(self) -> float:
+        return max((m.mean_abs for m in self.frame_metrics), default=0.0)
+
+    @property
+    def max_frame_rmse(self) -> float:
+        return max((m.rmse for m in self.frame_metrics), default=0.0)
+
+    @property
+    def max_frame_flip(self) -> float | None:
+        values = [m.mean_flip for m in self.frame_metrics if m.mean_flip is not None]
+        return max(values) if values else None
+
+
+def read_video_rgb(path: Path | str) -> RGBVideo:
+    """Read an RGB video file as ``uint8 [T, H, W, 3]``."""
+    try:
+        import mediapy as media  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - import-time gate
+        raise ImportError(
+            "Clip comparison needs mediapy to read videos. Install the dev or "
+            "runner extras before running quality regression tests."
+        ) from exc
+
+    video = media.read_video(str(path))
+    if video.ndim != 4 or video.shape[-1] < 3:
+        raise ValueError(f"Expected RGB/RGBA video [T,H,W,C], got shape {video.shape}")
+    return _as_uint8_rgb(video[..., :3])
+
+
+def parse_frame_indices(value: str | None) -> tuple[int, ...] | None:
+    """Parse a comma-separated frame-index list from an env var style string."""
+    if value is None or not value.strip():
+        return None
+    indices = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if not indices:
+        return None
+    if any(idx < 0 for idx in indices):
+        raise ValueError(f"Frame indices must be non-negative, got {indices}")
+    return indices
+
+
+def select_frame_indices(
+    reference_frame_count: int,
+    candidate_frame_count: int,
+    *,
+    frame_indices: Iterable[int] | None = None,
+    sample_count: int = 8,
+) -> tuple[int, ...]:
+    """Return explicit or evenly-spaced indices valid for both clips."""
+    if reference_frame_count <= 0:
+        raise ValueError("reference clip has no frames")
+    if candidate_frame_count <= 0:
+        raise ValueError("candidate clip has no frames")
+
+    max_common = min(reference_frame_count, candidate_frame_count)
+    if frame_indices is not None:
+        indices = tuple(dict.fromkeys(frame_indices))
+        if not indices:
+            raise ValueError("frame_indices was empty")
+        out_of_bounds = [idx for idx in indices if idx >= max_common]
+        if out_of_bounds:
+            raise ValueError(
+                f"Frame indices {out_of_bounds} exceed common frame count "
+                f"{max_common}; reference has {reference_frame_count}, "
+                f"candidate has {candidate_frame_count}."
+            )
+        return indices
+
+    sample_count = max(1, min(sample_count, max_common))
+    indices_np = np.linspace(0, max_common - 1, num=sample_count, dtype=np.int64)
+    return tuple(int(idx) for idx in dict.fromkeys(indices_np.tolist()))
+
+
+def bottom_half(video: RGBVideo) -> RGBVideo:
+    """Return the lower half of a ``[T,H,W,3]`` video.
+
+    Omnidreams runner MP4s stack the HDMap condition over the generated frames,
+    so this helper extracts the generated region.
+    """
+    _validate_video(video, name="video")
+    return video[:, video.shape[1] // 2 :, :, :]
+
+
+def compare_video_arrays(
+    reference: RGBVideo,
+    candidate: RGBVideo,
+    *,
+    frame_indices: Iterable[int] | None = None,
+    sample_count: int = 8,
+    compute_flip: bool = False,
+) -> ClipComparisonResult:
+    """Compare sampled frames from two RGB clips."""
+    reference = _as_uint8_rgb(reference)
+    candidate = _as_uint8_rgb(candidate)
+    _validate_compatible_spatial_shape(reference, candidate)
+
+    indices = select_frame_indices(
+        reference.shape[0],
+        candidate.shape[0],
+        frame_indices=frame_indices,
+        sample_count=sample_count,
+    )
+    ref = reference[list(indices)].astype(np.float32)
+    cand = candidate[list(indices)].astype(np.float32)
+    diff = cand - ref
+    mean_abs = float(np.mean(np.abs(diff)))
+    rmse = float(np.sqrt(np.mean(np.square(diff))))
+    psnr_db = _psnr_db(rmse)
+
+    frame_metrics = []
+    flip_scores = (
+        _compute_flip_scores(reference, candidate, indices) if compute_flip else None
+    )
+    for metric_pos, frame_idx in enumerate(indices):
+        frame_diff = diff[metric_pos]
+        frame_rmse = float(np.sqrt(np.mean(np.square(frame_diff))))
+        frame_metrics.append(
+            ClipFrameMetrics(
+                frame_index=frame_idx,
+                mean_abs=float(np.mean(np.abs(frame_diff))),
+                rmse=frame_rmse,
+                psnr_db=_psnr_db(frame_rmse),
+                mean_flip=flip_scores[metric_pos] if flip_scores is not None else None,
+            )
+        )
+
+    return ClipComparisonResult(
+        reference_frame_count=int(reference.shape[0]),
+        candidate_frame_count=int(candidate.shape[0]),
+        frame_indices=indices,
+        mean_abs=mean_abs,
+        rmse=rmse,
+        psnr_db=psnr_db,
+        frame_metrics=tuple(frame_metrics),
+        mean_flip=float(np.mean(flip_scores)) if flip_scores is not None else None,
+    )
+
+
+def assert_clip_within_thresholds(
+    reference: RGBVideo,
+    candidate: RGBVideo,
+    *,
+    thresholds: ClipComparisonThresholds = ClipComparisonThresholds(),
+    frame_indices: Iterable[int] | None = None,
+    sample_count: int = 8,
+) -> ClipComparisonResult:
+    """Compare two clips and raise ``AssertionError`` when any bound is crossed."""
+    compute_flip = (
+        thresholds.max_mean_flip is not None or thresholds.max_frame_flip is not None
+    )
+    result = compare_video_arrays(
+        reference,
+        candidate,
+        frame_indices=frame_indices,
+        sample_count=sample_count,
+        compute_flip=compute_flip,
+    )
+    failures = _threshold_failures(result, thresholds)
+    if failures:
+        details = "\n".join(f"- {failure}" for failure in failures)
+        raise AssertionError(
+            f"Clip quality regression detected:\n{details}\n"
+            f"{format_clip_comparison(result)}"
+        )
+    return result
+
+
+def format_clip_comparison(result: ClipComparisonResult) -> str:
+    """Return a compact human-readable metric summary."""
+    parts = [
+        "Compared "
+        f"{len(result.frame_indices)} sampled frame(s) "
+        f"{result.frame_indices} from reference "
+        f"{result.reference_frame_count} frame(s) and candidate "
+        f"{result.candidate_frame_count} frame(s):",
+        f"mean_abs={result.mean_abs:.4f}",
+        f"rmse={result.rmse:.4f}",
+        f"psnr={result.psnr_db:.2f} dB",
+        f"max_frame_mean_abs={result.max_frame_mean_abs:.4f}",
+        f"max_frame_rmse={result.max_frame_rmse:.4f}",
+    ]
+    if result.mean_flip is not None:
+        max_frame_flip = result.max_frame_flip
+        parts.append(f"mean_flip={result.mean_flip:.4f}")
+        parts.append(
+            "max_frame_flip="
+            f"{max_frame_flip:.4f}" if max_frame_flip is not None else "n/a"
+        )
+    worst = max(result.frame_metrics, key=lambda m: m.rmse, default=None)
+    if worst is not None:
+        parts.append(
+            f"worst_frame={worst.frame_index} "
+            f"(mean_abs={worst.mean_abs:.4f}, rmse={worst.rmse:.4f}, "
+            f"psnr={worst.psnr_db:.2f} dB)"
+        )
+    return " ".join(parts)
+
+
+def _threshold_failures(
+    result: ClipComparisonResult, thresholds: ClipComparisonThresholds
+) -> list[str]:
+    failures: list[str] = []
+    if (
+        thresholds.require_same_frame_count
+        and result.reference_frame_count != result.candidate_frame_count
+    ):
+        failures.append(
+            "frame count changed: "
+            f"reference={result.reference_frame_count}, "
+            f"candidate={result.candidate_frame_count}"
+        )
+    if result.mean_abs > thresholds.max_mean_abs:
+        failures.append(
+            f"mean_abs {result.mean_abs:.4f} > {thresholds.max_mean_abs:.4f}"
+        )
+    if result.rmse > thresholds.max_rmse:
+        failures.append(f"rmse {result.rmse:.4f} > {thresholds.max_rmse:.4f}")
+    if result.psnr_db < thresholds.min_psnr_db:
+        failures.append(
+            f"psnr {result.psnr_db:.2f} dB < {thresholds.min_psnr_db:.2f} dB"
+        )
+    if result.max_frame_mean_abs > thresholds.max_frame_mean_abs:
+        failures.append(
+            "max_frame_mean_abs "
+            f"{result.max_frame_mean_abs:.4f} > "
+            f"{thresholds.max_frame_mean_abs:.4f}"
+        )
+    if result.max_frame_rmse > thresholds.max_frame_rmse:
+        failures.append(
+            f"max_frame_rmse {result.max_frame_rmse:.4f} > "
+            f"{thresholds.max_frame_rmse:.4f}"
+        )
+    if (
+        thresholds.max_mean_flip is not None
+        and result.mean_flip is not None
+        and result.mean_flip > thresholds.max_mean_flip
+    ):
+        failures.append(
+            f"mean_flip {result.mean_flip:.4f} > "
+            f"{thresholds.max_mean_flip:.4f}"
+        )
+    max_frame_flip = result.max_frame_flip
+    if (
+        thresholds.max_frame_flip is not None
+        and max_frame_flip is not None
+        and max_frame_flip > thresholds.max_frame_flip
+    ):
+        failures.append(
+            f"max_frame_flip {max_frame_flip:.4f} > "
+            f"{thresholds.max_frame_flip:.4f}"
+        )
+    return failures
+
+
+def _compute_flip_scores(
+    reference: RGBVideo, candidate: RGBVideo, indices: tuple[int, ...]
+) -> tuple[float, ...]:
+    try:
+        import flip_evaluator  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - import-time gate
+        raise ImportError(
+            "FLIP clip comparison requires flip-evaluator. Install the "
+            "omnidreams dev extra or set max_mean_flip/max_frame_flip to None."
+        ) from exc
+
+    scores = []
+    for idx in indices:
+        _, mean_flip, _ = flip_evaluator.evaluate(
+            reference[idx].astype(np.float32) / 255.0,
+            candidate[idx].astype(np.float32) / 255.0,
+            "LDR",
+            inputsRGB=True,
+            computeMeanError=True,
+        )
+        scores.append(float(mean_flip))
+    return tuple(scores)
+
+
+def _validate_compatible_spatial_shape(
+    reference: RGBVideo, candidate: RGBVideo
+) -> None:
+    _validate_video(reference, name="reference")
+    _validate_video(candidate, name="candidate")
+    if reference.shape[1:] != candidate.shape[1:]:
+        raise ValueError(
+            f"Reference/candidate spatial shapes differ: "
+            f"{reference.shape[1:]} != {candidate.shape[1:]}"
+        )
+
+
+def _validate_video(video: np.ndarray, *, name: str) -> None:
+    if video.ndim != 4 or video.shape[-1] != 3:
+        raise ValueError(f"{name} must have shape [T,H,W,3], got {video.shape}")
+
+
+def _as_uint8_rgb(video: np.ndarray) -> RGBVideo:
+    _validate_video(video, name="video")
+    if video.dtype == np.uint8:
+        return video
+    if np.issubdtype(video.dtype, np.floating):
+        if np.nanmin(video) >= 0.0 and np.nanmax(video) <= 1.0:
+            video = video * 255.0
+        return np.clip(video, 0, 255).astype(np.uint8)
+    return np.clip(video, 0, 255).astype(np.uint8)
+
+
+def _psnr_db(rmse: float) -> float:
+    if rmse == 0.0:
+        return math.inf
+    return 20.0 * math.log10(255.0 / rmse)

--- a/flashdreams/flashdreams/quality/clip_compare.py
+++ b/flashdreams/flashdreams/quality/clip_compare.py
@@ -41,8 +41,8 @@ class ClipComparisonThresholds:
     min_psnr_db: float = 30.0
     max_frame_mean_abs: float = 8.0
     max_frame_rmse: float = 14.0
-    max_mean_flip: float | None = 0.035
-    max_frame_flip: float | None = 0.060
+    max_mean_flip: float | None = 0.050
+    max_frame_flip: float | None = 0.080
     require_same_frame_count: bool = True
 
 

--- a/flashdreams/flashdreams/quality/clip_compare.py
+++ b/flashdreams/flashdreams/quality/clip_compare.py
@@ -41,7 +41,7 @@ class ClipComparisonThresholds:
     min_psnr_db: float = 30.0
     max_frame_mean_abs: float = 8.0
     max_frame_rmse: float = 14.0
-    max_mean_flip: float | None = 0.050
+    max_mean_flip: float | None = 0.070
     max_frame_flip: float | None = 0.080
     require_same_frame_count: bool = True
 

--- a/flashdreams/flashdreams/quality/clip_compare.py
+++ b/flashdreams/flashdreams/quality/clip_compare.py
@@ -245,8 +245,9 @@ def format_clip_comparison(result: ClipComparisonResult) -> str:
         max_frame_flip = result.max_frame_flip
         parts.append(f"mean_flip={result.mean_flip:.4f}")
         parts.append(
-            "max_frame_flip="
-            f"{max_frame_flip:.4f}" if max_frame_flip is not None else "n/a"
+            f"max_frame_flip={max_frame_flip:.4f}"
+            if max_frame_flip is not None
+            else "n/a"
         )
     worst = max(result.frame_metrics, key=lambda m: m.rmse, default=None)
     if worst is not None:
@@ -298,8 +299,7 @@ def _threshold_failures(
         and result.mean_flip > thresholds.max_mean_flip
     ):
         failures.append(
-            f"mean_flip {result.mean_flip:.4f} > "
-            f"{thresholds.max_mean_flip:.4f}"
+            f"mean_flip {result.mean_flip:.4f} > {thresholds.max_mean_flip:.4f}"
         )
     max_frame_flip = result.max_frame_flip
     if (
@@ -308,8 +308,7 @@ def _threshold_failures(
         and max_frame_flip > thresholds.max_frame_flip
     ):
         failures.append(
-            f"max_frame_flip {max_frame_flip:.4f} > "
-            f"{thresholds.max_frame_flip:.4f}"
+            f"max_frame_flip {max_frame_flip:.4f} > {thresholds.max_frame_flip:.4f}"
         )
     return failures
 

--- a/flashdreams/tests/test_clip_compare.py
+++ b/flashdreams/tests/test_clip_compare.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from flashdreams.quality.clip_compare import (
+    ClipComparisonThresholds,
+    assert_clip_within_thresholds,
+    bottom_half,
+    parse_frame_indices,
+    select_frame_indices,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_clip_comparison_accepts_small_sampled_drift() -> None:
+    reference = np.zeros((5, 4, 4, 3), dtype=np.uint8)
+    candidate = reference.copy()
+    candidate[..., 0] = 2
+
+    result = assert_clip_within_thresholds(
+        reference,
+        candidate,
+        frame_indices=(0, 2, 4),
+        thresholds=ClipComparisonThresholds(
+            max_mean_abs=1.0,
+            max_rmse=2.0,
+            min_psnr_db=40.0,
+            max_frame_mean_abs=1.0,
+            max_frame_rmse=2.0,
+            max_mean_flip=None,
+            max_frame_flip=None,
+        ),
+    )
+
+    assert result.frame_indices == (0, 2, 4)
+    assert result.reference_frame_count == 5
+    assert result.candidate_frame_count == 5
+
+
+def test_clip_comparison_reports_large_drift() -> None:
+    reference = np.zeros((3, 4, 4, 3), dtype=np.uint8)
+    candidate = np.full_like(reference, 50)
+
+    with pytest.raises(AssertionError, match="mean_abs"):
+        assert_clip_within_thresholds(
+            reference,
+            candidate,
+            thresholds=ClipComparisonThresholds(
+                max_mean_abs=1.0,
+                max_rmse=2.0,
+                min_psnr_db=40.0,
+                max_frame_mean_abs=1.0,
+                max_frame_rmse=2.0,
+                max_mean_flip=None,
+                max_frame_flip=None,
+            ),
+        )
+
+
+def test_clip_comparison_reports_frame_count_regression() -> None:
+    reference = np.zeros((4, 4, 4, 3), dtype=np.uint8)
+    candidate = np.zeros((3, 4, 4, 3), dtype=np.uint8)
+
+    with pytest.raises(AssertionError, match="frame count changed"):
+        assert_clip_within_thresholds(
+            reference,
+            candidate,
+            thresholds=ClipComparisonThresholds(
+                max_mean_abs=1.0,
+                max_rmse=2.0,
+                min_psnr_db=40.0,
+                max_frame_mean_abs=1.0,
+                max_frame_rmse=2.0,
+                max_mean_flip=None,
+                max_frame_flip=None,
+            ),
+        )
+
+
+def test_frame_index_helpers() -> None:
+    assert parse_frame_indices("0, 3, 5") == (0, 3, 5)
+    assert parse_frame_indices("") is None
+    assert select_frame_indices(10, 10, sample_count=4) == (0, 3, 6, 9)
+    assert select_frame_indices(10, 7, frame_indices=(1, 1, 6)) == (1, 6)
+
+
+def test_bottom_half_extracts_generated_region() -> None:
+    video = np.zeros((2, 6, 4, 3), dtype=np.uint8)
+    video[:, 3:] = 255
+
+    generated = bottom_half(video)
+
+    assert generated.shape == (2, 3, 4, 3)
+    assert np.all(generated == 255)

--- a/integrations/omnidreams/tests/test_quality_regression.py
+++ b/integrations/omnidreams/tests/test_quality_regression.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Golden-clip quality regression test for Omnidreams rollouts.
+
+The test is intentionally fixture-gated: normal GPU CI skips it unless the
+reference clip and input assets are provided through environment variables.
+When wired in CI, it generates a short deterministic rollout and compares the
+generated half of the output MP4 against the reference clip.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from flashdreams.infra.config import derive_config
+from flashdreams.quality.clip_compare import (
+    ClipComparisonThresholds,
+    assert_clip_within_thresholds,
+    bottom_half,
+    format_clip_comparison,
+    parse_frame_indices,
+    read_video_rgb,
+)
+from omnidreams.config import OMNIDREAMS_RUNNERS
+
+pytestmark = pytest.mark.ci_gpu
+
+_ENV_PREFIX = "FLASHDREAMS_OMNIDREAMS_QUALITY_"
+_DEFAULT_RUNNER = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
+_DEFAULT_TOTAL_BLOCKS = 4  # ~1 second for chunk2 + 30fps output.
+
+
+def test_omnidreams_generated_clip_matches_reference(tmp_path: Path) -> None:
+    """Run a short Omnidreams rollout and compare sampled generated frames."""
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("Omnidreams quality regression requires CUDA.")
+
+    reference_clip = _env_existing_path("REFERENCE_CLIP", required=True)
+    assert reference_clip is not None
+    cfg = _quality_runner_config(tmp_path)
+
+    cfg.setup().run()
+
+    candidate_clip = tmp_path / f"{cfg.runner_name}.mp4"
+    assert candidate_clip.exists(), f"runner did not write {candidate_clip}"
+
+    reference = read_video_rgb(reference_clip)
+    candidate = read_video_rgb(candidate_clip)
+    if _env_bool("EXTRACT_GENERATED_REGION_FROM_REFERENCE", default=False):
+        reference = bottom_half(reference)
+    if _env_bool("EXTRACT_GENERATED_REGION_FROM_CANDIDATE", default=True):
+        candidate = bottom_half(candidate)
+    _write_artifacts(
+        reference_clip=reference_clip,
+        candidate_clip=candidate_clip,
+        reference_compare_region=reference,
+        candidate_compare_region=candidate,
+    )
+
+    thresholds = ClipComparisonThresholds(
+        max_mean_abs=_env_float("MAX_MEAN_ABS", 4.0),
+        max_rmse=_env_float("MAX_RMSE", 8.0),
+        min_psnr_db=_env_float("MIN_PSNR_DB", 30.0),
+        max_frame_mean_abs=_env_float("MAX_FRAME_MEAN_ABS", 8.0),
+        max_frame_rmse=_env_float("MAX_FRAME_RMSE", 14.0),
+        max_mean_flip=_env_optional_float("MAX_MEAN_FLIP", 0.035),
+        max_frame_flip=_env_optional_float("MAX_FRAME_FLIP", 0.060),
+        require_same_frame_count=_env_bool("REQUIRE_SAME_FRAME_COUNT", default=True),
+    )
+    result = assert_clip_within_thresholds(
+        reference,
+        candidate,
+        thresholds=thresholds,
+        frame_indices=parse_frame_indices(os.environ.get(_env("FRAME_INDICES"))),
+        sample_count=_env_int("SAMPLE_COUNT", 8),
+    )
+    print(format_clip_comparison(result))
+
+
+def _quality_runner_config(tmp_path: Path) -> Any:
+    runner_name = os.environ.get(_env("RUNNER"), _DEFAULT_RUNNER)
+    if runner_name not in OMNIDREAMS_RUNNERS:
+        pytest.fail(
+            f"{_env('RUNNER')}={runner_name!r} is not an Omnidreams runner. "
+            f"Known runners: {sorted(OMNIDREAMS_RUNNERS)}"
+        )
+
+    example_data = _env_bool("EXAMPLE_DATA", default=False)
+    hdmap_video_paths = _env_existing_paths(
+        "HDMAP_VIDEO_PATHS", required=not example_data
+    )
+    first_frame_paths = _env_existing_paths("FIRST_FRAME_PATHS", required=False)
+    embeddings_path = _env_existing_path("EMBEDDINGS_PATH", required=False)
+    if embeddings_path is None and not first_frame_paths and not example_data:
+        pytest.skip(
+            f"Set {_env('FIRST_FRAME_PATHS')} or {_env('EMBEDDINGS_PATH')} "
+            f"or {_env('EXAMPLE_DATA')}=1 to run the Omnidreams quality "
+            "regression."
+        )
+
+    changes: dict[str, Any] = {
+        "output_dir": tmp_path,
+        "total_blocks": _env_int("TOTAL_BLOCKS", _DEFAULT_TOTAL_BLOCKS),
+        "pixel_height": _env_int("PIXEL_HEIGHT", 704),
+        "pixel_width": _env_int("PIXEL_WIDTH", 1280),
+        "example_data": example_data,
+    }
+    if hdmap_video_paths:
+        changes["hdmap_video_paths"] = hdmap_video_paths
+    if first_frame_paths:
+        changes["first_frame_paths"] = first_frame_paths
+    if embeddings_path is not None:
+        changes["embeddings_path"] = embeddings_path
+        changes["pipeline"] = {"text_encoder": None, "image_encoder": None}
+    example_data_uuid = os.environ.get(_env("EXAMPLE_DATA_UUID"))
+    if example_data_uuid:
+        changes["example_data_uuid"] = example_data_uuid
+
+    prompt = os.environ.get(_env("PROMPT"))
+    if prompt:
+        changes["prompt"] = prompt
+
+    camera_names = _env_csv("CAMERA_NAMES")
+    if camera_names:
+        changes["camera_names"] = camera_names
+
+    return derive_config(OMNIDREAMS_RUNNERS[runner_name], **changes)
+
+
+def _env(name: str) -> str:
+    return f"{_ENV_PREFIX}{name}"
+
+
+def _env_existing_path(name: str, *, required: bool) -> Path | None:
+    value = os.environ.get(_env(name))
+    if not value:
+        if required:
+            pytest.skip(f"Set {_env(name)} to run the Omnidreams quality regression.")
+        return None
+    path = Path(value).expanduser()
+    if not path.exists():
+        pytest.skip(f"{_env(name)} does not exist: {path}")
+    return path
+
+
+def _env_existing_paths(name: str, *, required: bool) -> tuple[Path, ...]:
+    value = os.environ.get(_env(name))
+    if not value:
+        if required:
+            pytest.skip(f"Set {_env(name)} to run the Omnidreams quality regression.")
+        return ()
+    paths = tuple(
+        Path(part.strip()).expanduser() for part in value.split(",") if part.strip()
+    )
+    missing = [path for path in paths if not path.exists()]
+    if missing:
+        pytest.skip(f"{_env(name)} path(s) do not exist: {missing}")
+    return paths
+
+
+def _env_csv(name: str) -> tuple[str, ...]:
+    value = os.environ.get(_env(name))
+    if not value:
+        return ()
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.environ.get(_env(name), str(default)))
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(os.environ.get(_env(name), str(default)))
+
+
+def _env_optional_float(name: str, default: float | None) -> float | None:
+    value = os.environ.get(_env(name))
+    if value is None:
+        return default
+    if value.lower() in {"", "none", "off", "false"}:
+        return None
+    return float(value)
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    value = os.environ.get(_env(name))
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _write_artifacts(
+    *,
+    reference_clip: Path,
+    candidate_clip: Path,
+    reference_compare_region: Any,
+    candidate_compare_region: Any,
+) -> None:
+    artifact_dir_value = os.environ.get(_env("ARTIFACT_DIR"))
+    if not artifact_dir_value:
+        return
+
+    try:
+        import mediapy as media  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - read_video_rgb already imports it
+        raise ImportError(
+            "Writing quality-regression artifacts requires mediapy."
+        ) from exc
+
+    artifact_dir = Path(artifact_dir_value).expanduser()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(reference_clip, artifact_dir / "reference_original.mp4")
+    shutil.copy2(candidate_clip, artifact_dir / "candidate_original.mp4")
+    media.write_video(
+        str(artifact_dir / "reference_compare_region.mp4"),
+        reference_compare_region,
+        fps=_env_int("OUTPUT_FPS", 30),
+    )
+    media.write_video(
+        str(artifact_dir / "candidate_compare_region.mp4"),
+        candidate_compare_region,
+        fps=_env_int("OUTPUT_FPS", 30),
+    )

--- a/integrations/omnidreams/tests/test_quality_regression.py
+++ b/integrations/omnidreams/tests/test_quality_regression.py
@@ -71,7 +71,7 @@ def test_omnidreams_generated_clip_matches_reference(tmp_path: Path) -> None:
         min_psnr_db=_env_float("MIN_PSNR_DB", 30.0),
         max_frame_mean_abs=_env_float("MAX_FRAME_MEAN_ABS", 8.0),
         max_frame_rmse=_env_float("MAX_FRAME_RMSE", 14.0),
-        max_mean_flip=_env_optional_float("MAX_MEAN_FLIP", 0.050),
+        max_mean_flip=_env_optional_float("MAX_MEAN_FLIP", 0.070),
         max_frame_flip=_env_optional_float("MAX_FRAME_FLIP", 0.080),
         require_same_frame_count=_env_bool("REQUIRE_SAME_FRAME_COUNT", default=True),
     )

--- a/integrations/omnidreams/tests/test_quality_regression.py
+++ b/integrations/omnidreams/tests/test_quality_regression.py
@@ -71,8 +71,8 @@ def test_omnidreams_generated_clip_matches_reference(tmp_path: Path) -> None:
         min_psnr_db=_env_float("MIN_PSNR_DB", 30.0),
         max_frame_mean_abs=_env_float("MAX_FRAME_MEAN_ABS", 8.0),
         max_frame_rmse=_env_float("MAX_FRAME_RMSE", 14.0),
-        max_mean_flip=_env_optional_float("MAX_MEAN_FLIP", 0.035),
-        max_frame_flip=_env_optional_float("MAX_FRAME_FLIP", 0.060),
+        max_mean_flip=_env_optional_float("MAX_MEAN_FLIP", 0.050),
+        max_frame_flip=_env_optional_float("MAX_FRAME_FLIP", 0.080),
         require_same_frame_count=_env_bool("REQUIRE_SAME_FRAME_COUNT", default=True),
     )
     result = assert_clip_within_thresholds(

--- a/integrations/omnidreams/tests/test_quality_regression.py
+++ b/integrations/omnidreams/tests/test_quality_regression.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from omnidreams.config import OMNIDREAMS_RUNNERS
 
 from flashdreams.infra.config import derive_config
 from flashdreams.quality.clip_compare import (
@@ -27,7 +28,6 @@ from flashdreams.quality.clip_compare import (
     parse_frame_indices,
     read_video_rgb,
 )
-from omnidreams.config import OMNIDREAMS_RUNNERS
 
 pytestmark = pytest.mark.ci_gpu
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,8 +33,8 @@ is skipped.
 ## Omnidreams quality regression
 
 `integrations/omnidreams/tests/test_quality_regression.py` is the golden-clip
-gate for generated driving video. It is marked `ci_gpu`, but skips until CI
-provides the reference clip and deterministic input assets.
+gate for generated driving video. It is marked `ci_gpu` and skips in local
+runs until a reference clip and deterministic input assets are provided.
 
 For PR gating, prefer a short clip: `TOTAL_BLOCKS=4` on the default chunk2
 runner produces roughly one second at 30fps. A longer 5 second clip is better
@@ -77,6 +77,17 @@ encoders. Tune the metric gates with `MAX_MEAN_ABS`, `MAX_RMSE`,
 `MIN_PSNR_DB`, `MAX_MEAN_FLIP`, and `MAX_FRAME_FLIP`. Refresh the reference by
 running the same config, inspecting the generated MP4, and promoting it to the
 reference location.
+
+In GitHub Actions, the GPU job downloads `reference_compare_region.mp4` from a
+Hugging Face dataset before running `pytest -m ci_gpu`, then sets
+`FLASHDREAMS_OMNIDREAMS_QUALITY_REFERENCE_CLIP`,
+`FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA=1`, and
+`FLASHDREAMS_OMNIDREAMS_QUALITY_TOTAL_BLOCKS=4`. The default dataset is
+`jarcherNV/omni-dreams-quality-references`; set the repository variable
+`OMNIDREAMS_QUALITY_REFERENCE_REPO` when the references move to an official
+namespace. Set `OMNIDREAMS_QUALITY_REFERENCE_PATH` if the file path changes.
+The job uploads the generated comparison artifacts as a GitHub Actions artifact
+named `omnidreams-quality-artifacts`.
 
 ## Shared environment knobs
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -140,9 +140,10 @@ Hugging Face dataset before running `pytest -m ci_gpu`, then sets
 `FLASHDREAMS_OMNIDREAMS_QUALITY_REFERENCE_CLIP`,
 `FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA=1`, and
 `FLASHDREAMS_OMNIDREAMS_QUALITY_TOTAL_BLOCKS=4`. The default dataset is
-`jarcherNV/omni-dreams-quality-references`; set the repository variable
-`OMNIDREAMS_QUALITY_REFERENCE_REPO` when the references move to an official
-namespace. Set `OMNIDREAMS_QUALITY_REFERENCE_PATH` if the file path changes.
+`nvidia/omni-dreams-samples`. Set the repository variable
+`OMNIDREAMS_QUALITY_REFERENCE_REPO` if the references need to be read from a
+different dataset. Set `OMNIDREAMS_QUALITY_REFERENCE_PATH` if the file path
+changes.
 The job uploads the generated comparison artifacts as a GitHub Actions artifact
 named `omnidreams-quality-artifacts`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,54 @@ When no `TEST_TARGET` is given, each script performs global discovery of `**/tes
 Pytest is invoked with `-m "not manual"` so any test marked `@pytest.mark.manual`
 is skipped.
 
+## Omnidreams quality regression
+
+`integrations/omnidreams/tests/test_quality_regression.py` is the golden-clip
+gate for generated driving video. It is marked `ci_gpu`, but skips until CI
+provides the reference clip and deterministic input assets.
+
+For PR gating, prefer a short clip: `TOTAL_BLOCKS=4` on the default chunk2
+runner produces roughly one second at 30fps. A longer 5 second clip is better
+as a nightly/manual check because it costs more GPU time and is more exposed to
+small non-deterministic drift.
+
+Minimum single-view setup:
+
+```bash
+export FLASHDREAMS_OMNIDREAMS_QUALITY_REFERENCE_CLIP=/abs/path/reference.mp4
+export FLASHDREAMS_OMNIDREAMS_QUALITY_HDMAP_VIDEO_PATHS=/abs/path/hdmap.mp4
+export FLASHDREAMS_OMNIDREAMS_QUALITY_FIRST_FRAME_PATHS=/abs/path/first_frame.png
+uv run pytest integrations/omnidreams/tests/test_quality_regression.py -v
+```
+
+To use the runner's public single-view example data instead of supplying
+`HDMAP_VIDEO_PATHS` and `FIRST_FRAME_PATHS`, set:
+
+```bash
+export FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA=1
+```
+
+The default example UUID is `239560dc-33d1-11ef-9720-00044bcbccac`; override it
+with `FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA_UUID=<uuid>` if you want a
+different sample from `nvidia/omni-dreams-samples`.
+
+By default, the candidate MP4 is treated as the normal Omnidreams runner output:
+HDMap condition stacked above generated frames. The test extracts the generated
+lower half before comparison. The reference should normally be generated frames
+only; if you promote the full runner MP4 as the reference, also set
+`FLASHDREAMS_OMNIDREAMS_QUALITY_EXTRACT_GENERATED_REGION_FROM_REFERENCE=1`.
+Set `FLASHDREAMS_OMNIDREAMS_QUALITY_ARTIFACT_DIR=/abs/path/artifacts` to copy
+the original reference/candidate MP4s and the exact comparison-region MP4s to a
+stable directory for visual inspection.
+
+If prompt/image embeddings have been precomputed, set
+`FLASHDREAMS_OMNIDREAMS_QUALITY_EMBEDDINGS_PATH=/abs/path/embeddings.pt` instead
+of `FIRST_FRAME_PATHS`; the test then skips loading the one-shot text/image
+encoders. Tune the metric gates with `MAX_MEAN_ABS`, `MAX_RMSE`,
+`MIN_PSNR_DB`, `MAX_MEAN_FLIP`, and `MAX_FRAME_FLIP`. Refresh the reference by
+running the same config, inspecting the generated MP4, and promoting it to the
+reference location.
+
 ## Shared environment knobs
 
 `run_tests_docker.sh` reads these env vars

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,16 @@ runner produces roughly one second at 30fps. A longer 5 second clip is better
 as a nightly/manual check because it costs more GPU time and is more exposed to
 small non-deterministic drift.
 
-Minimum single-view setup:
+The test needs two things:
+
+- A reference clip containing generated frames only. In CI this is
+  `reference_compare_region.mp4`.
+- The same deterministic rollout inputs used to create the reference. For the
+  default single-view gate, use the public Omnidreams example data UUID
+  `239560dc-33d1-11ef-9720-00044bcbccac`; for custom data, provide matching
+  `HDMAP_VIDEO_PATHS` and `FIRST_FRAME_PATHS`.
+
+Minimum single-view setup with explicit local inputs:
 
 ```bash
 export FLASHDREAMS_OMNIDREAMS_QUALITY_REFERENCE_CLIP=/abs/path/reference.mp4
@@ -60,6 +69,54 @@ export FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA=1
 The default example UUID is `239560dc-33d1-11ef-9720-00044bcbccac`; override it
 with `FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA_UUID=<uuid>` if you want a
 different sample from `nvidia/omni-dreams-samples`.
+
+To generate a new short reference candidate from the default public example
+data, run on a CUDA machine with `ffmpeg` installed. Export `HF_TOKEN` first if
+your environment needs Hugging Face authentication for model or dataset access.
+
+```bash
+mkdir -p /tmp/omnidreams_quality_ref /tmp/omnidreams_quality_artifacts
+
+uv run --project integrations/omnidreams flashdreams-run \
+  omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae \
+  --example-data True \
+  --example_data_uuid "239560dc-33d1-11ef-9720-00044bcbccac" \
+  --total-blocks 4 \
+  --output-dir /tmp/omnidreams_quality_ref
+```
+
+That writes the normal Omnidreams runner MP4, with HDMap condition stacked above
+generated frames:
+
+```text
+/tmp/omnidreams_quality_ref/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae.mp4
+```
+
+Run the quality test once against that full MP4 to create the exact comparison
+artifact:
+
+```bash
+FLASHDREAMS_OMNIDREAMS_QUALITY_REFERENCE_CLIP=/tmp/omnidreams_quality_ref/omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae.mp4 \
+FLASHDREAMS_OMNIDREAMS_QUALITY_EXAMPLE_DATA=1 \
+FLASHDREAMS_OMNIDREAMS_QUALITY_EXTRACT_GENERATED_REGION_FROM_REFERENCE=1 \
+FLASHDREAMS_OMNIDREAMS_QUALITY_ARTIFACT_DIR=/tmp/omnidreams_quality_artifacts \
+FLASHDREAMS_OMNIDREAMS_QUALITY_TOTAL_BLOCKS=4 \
+uv run --project integrations/omnidreams pytest \
+  integrations/omnidreams/tests/test_quality_regression.py -v -s
+```
+
+After visually inspecting the artifacts, promote this file as the reference
+used by CI:
+
+```text
+/tmp/omnidreams_quality_artifacts/reference_compare_region.mp4
+```
+
+Keep `reference_original.mp4` only as an optional debug artifact. Do not promote
+`candidate_original.mp4` or `candidate_compare_region.mp4`; those are outputs
+from one test run. Store a small `metadata.json` next to the promoted reference
+recording the runner name, example UUID, `total_blocks`, producing commit, and
+thresholds.
 
 By default, the candidate MP4 is treated as the normal Omnidreams runner output:
 HDMap condition stacked above generated frames. The test extracts the generated


### PR DESCRIPTION
Introduce reusable clip-comparison utilities for sampled RGB video
regression checks, with MAE, RMSE, PSNR, and optional FLIP metrics.

Add a fixture-gated Omnidreams GPU test that generates a short
deterministic rollout, compares it against a reference clip, and can
write stable inspection artifacts for the reference/candidate clips and
their exact comparison regions.

Document how to run the quality gate with either explicit input assets
or the built-in Omnidreams example data.