### PR TITLE
interactive-drive: add input-device configuration tool

### DIFF
--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -173,6 +173,20 @@ instead:
 
    uv run --package flashdreams-omnidreams interactive-drive
 
+Steering wheel and game controller
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With a local window you can drive using a steering wheel or game
+controller. Run the configuration tool to calibrate your device; the demo
+loads the saved profile automatically on its next launch:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams interactive-drive-configuration
+
+Re-run it to edit a profile (steering sensitivity, deadzone, buttons),
+delete one, or set which is the default.
+
 Alternative: WebRTC server
 --------------------------
 

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -177,8 +177,9 @@ Steering wheel and game controller
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With a local window you can drive using a steering wheel or game
-controller. Run the configuration tool to calibrate your device; the demo
-loads the saved profile automatically on its next launch:
+controller. Any device that Ubuntu detects as a standard game controller
+or joystick works. Run the configuration tool to calibrate it; the demo loads
+the saved profile automatically on its next launch:
 
 .. code-block:: bash
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -271,6 +271,36 @@ to bind a known device path directly use `--wheel-device /dev/input/eventX`;
 to disable wheel input entirely use `--no-wheel`. No profiles ship with the
 repo — keyboard-only driving works fine without one.
 
+**Generate an input profile (wheel or game controller).** Instead of
+hand-writing that YAML, run the calibration wizard:
+
+```bash
+uv run --package flashdreams-omnidreams interactive-drive-configuration
+```
+
+It shows a live panel -- a steering-wheel and pedal visualization plus a
+per-axis activity strip -- so you can confirm the right device and watch each
+control move. It then listens while you move each control to capture the
+correct axes and directions (self-centering sticks and force-feedback wheels
+work because it peak-holds each axis' range rather than snapshotting after you
+let go), lets you bind reverse / reset buttons and test force feedback, then
+writes the profile to
+`$FLASHDREAMS_CACHE_DIR/interactive-drive/wheels/` (by default under
+`~/.cache/flashdreams/`). The next `interactive-drive` launch discovers it
+automatically through the same `--wheel-profile auto` detection. The wizard
+supports both steering wheels (with pedals) and game controllers (analog
+stick plus triggers); the generated file stays on your machine and is never
+committed. It needs a graphical session and read access to `/dev/input/*`
+(add your user to the `input` group if no devices are found).
+
+The opening screen also lists your saved profiles so you can edit their
+settings (display name, steering range and deadzone, inversion, force
+feedback, detection patterns), choose which one is the default, or delete
+them. Steering range and deadzone are most useful for game controllers,
+whose sticks are sensitive and tend to drift -- lower the range to make
+steering less twitchy and raise the deadzone to ignore a drifting stick at
+rest.
+
 ### `--no-hud`: bare backend, local Vulkan window
 
 This is the lighter-weight path that matches the older standalone

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import array
-import fcntl
 import io
 import math
 import os
@@ -14,26 +12,41 @@ import struct
 import threading
 import time
 import zipfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
 import numpy as np
-import yaml
 from omnidreams import scenes as _scenes
 from omnidreams.interactive_drive import cli as _cli
 from omnidreams.interactive_drive.app import InteractiveDriveApp
 from omnidreams.interactive_drive.config import BevConfig, RasterConfig
+from omnidreams.interactive_drive.input.wheel_profiles import (
+    EV_ABS,
+    EV_KEY,
+    EVDEV_EVENT_FORMAT,
+    EVDEV_EVENT_SIZE,
+    AutocenterFFB,
+    AxisRange,
+    EvdevDevice,
+    WheelProfile,
+    apply_steering_curve,
+    load_wheel_profiles,
+    name_match_strength,
+    query_axis_range,
+    read_evdev_name,
+    scan_evdev_devices,
+    user_wheel_profiles_dir,
+)
 from omnidreams.scenes import normalise_scene_uuid, scenes_cache_root
 from PIL import Image
 
-EVDEV_EVENT_FORMAT = "llHHi"
-EVDEV_EVENT_SIZE = struct.calcsize(EVDEV_EVENT_FORMAT)
-EV_ABS = 0x03
-EV_FF = 0x15
-FF_AUTOCENTER = 0x61
-FF_GAIN = 0x60
-EVIOCGABS = lambda axis: 0x80184540 + axis  # noqa: E731
+# The canonical implementations of these evdev helpers now live in
+# ``input/wheel_profiles.py`` so the configuration tool can share them.
+# Private aliases keep the existing call sites in this module unchanged.
+_scan_evdev_devices = scan_evdev_devices
+_read_evdev_name = read_evdev_name
+_query_axis_range = query_axis_range
 
 # Width of the right-side HUD panel that holds the steering wheel,
 # pedals, speed digit and BEV minimap. The camera area fills the rest
@@ -86,40 +99,6 @@ _GMAPS_TINTED_MUL = (
 _BEV_DEFAULTS = BevConfig()
 BEV_FOV_DEG = _BEV_DEFAULTS.fov_deg
 BEV_TILT_DEG = _BEV_DEFAULTS.tilt_deg
-
-
-@dataclass(frozen=True)
-class AxisRange:
-    minimum: int
-    maximum: int
-
-    @property
-    def center(self) -> float:
-        return (float(self.minimum) + float(self.maximum)) * 0.5
-
-    @property
-    def span(self) -> float:
-        return max(1.0, float(self.maximum - self.minimum))
-
-
-@dataclass(frozen=True)
-class EvdevDevice:
-    path: Path
-    name: str
-
-
-@dataclass(frozen=True)
-class WheelProfile:
-    name: str
-    display_name: str
-    detection_patterns: tuple[str, ...]
-    axis_map: dict[str, int]
-    inverted_pedals: bool = True
-    invert_steering: bool = False
-    ffb_enabled: bool = False
-    ffb_gain: float = 0.5
-    threshold: float = 0.12
-    is_default: bool = False
 
 
 @dataclass(frozen=True)
@@ -264,7 +243,13 @@ class WheelBridge:
         self._brake_axis = int(profile.axis_map["brake"])
         self._inverted_pedals = bool(profile.inverted_pedals)
         self._invert_steering = bool(profile.invert_steering)
+        self._steering_range = float(profile.steering_range)
+        self._steering_deadzone = float(profile.steering_deadzone)
         self._threshold = float(profile.threshold)
+        self._reverse_buttons = {int(b) for b in profile.reverse_buttons}
+        self._reset_buttons = {int(b) for b in profile.reset_buttons}
+        self._reverse = False
+        self._button_states: dict[int, int] = {}
         self._ffb = AutocenterFFB()
         self._axis_ranges: dict[int, AxisRange] = {}
         self._raw_axes: dict[int, int] = {}
@@ -299,7 +284,13 @@ class WheelBridge:
         self._thread.start()
         print(
             f"[demo] wheel profile={self._profile.name} device={self._device_path} "
-            f"axes={self._profile.axis_map} ranges={self._axis_ranges}",
+            f"axes={self._profile.axis_map} ranges={self._axis_ranges} "
+            f"invert_steering={self._invert_steering} "
+            f"steering_range={self._steering_range} "
+            f"steering_deadzone={self._steering_deadzone} "
+            f"inverted_pedals={self._inverted_pedals} "
+            f"reverse_buttons={sorted(self._reverse_buttons)} "
+            f"reset_buttons={sorted(self._reset_buttons)}",
             flush=True,
         )
 
@@ -343,6 +334,24 @@ class WheelBridge:
             )
             if event_type == EV_ABS:
                 self._raw_axes[int(code)] = int(value)
+            elif event_type == EV_KEY:
+                self._handle_button(int(code), int(value))
+
+    def _handle_button(self, code: int, value: int) -> None:
+        # Act on the rising edge (press) so a held button fires once.
+        # Reverse toggles a sticky flag fed into every drive command; reset
+        # is forwarded through the control sink, which owns the
+        # KeyboardState the runtime loop reads.
+        prev = self._button_states.get(code, 0)
+        self._button_states[code] = value
+        if value != 1 or prev == 1:
+            return
+        if code in self._reverse_buttons:
+            self._reverse = not self._reverse
+        elif code in self._reset_buttons:
+            request_reset = getattr(self._control, "request_reset", None)
+            if request_reset is not None:
+                request_reset()
 
     def _publish_controls(self) -> None:
         steering = self._normalize_steering(self._raw_axes[self._steering_axis])
@@ -359,7 +368,9 @@ class WheelBridge:
             self._state.brake = brake
             self._state.target_speed_mps = target_speed
 
-        self._control.set_drive(steer=steering, throttle=throttle, brake=brake)
+        self._control.set_drive(
+            steer=steering, throttle=throttle, brake=brake, reverse=self._reverse
+        )
         self._ffb.update(abs(target_speed), gain=self._profile.ffb_gain)
 
     def _normalize_steering(self, raw: int) -> float:
@@ -367,7 +378,9 @@ class WheelBridge:
         value = (float(raw) - axis_range.center) / (axis_range.span * 0.5)
         if self._invert_steering:
             value = -value
-        return max(-1.0, min(1.0, value))
+        return apply_steering_curve(
+            value, deadzone=self._steering_deadzone, scale=self._steering_range
+        )
 
     def _normalize_pedal(self, axis: int, raw: int) -> float:
         axis_range = self._axis_ranges[axis]
@@ -408,67 +421,6 @@ class WheelBridge:
             else:
                 speed = max(0.0, speed - 0.5 * dt)
         return max(0.0, min(36.0, speed))
-
-
-class AutocenterFFB:
-    def __init__(self) -> None:
-        self._fd: int | None = None
-        self._last_strength = -1
-        self._smoothed = 0.0
-
-    def init(self, device_path: Path, gain: float) -> None:
-        try:
-            self._fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
-            self._write_event(FF_AUTOCENTER, 0)
-            self._write_event(FF_GAIN, int(max(0.0, min(1.0, gain)) * 0xFFFF))
-            print(f"[demo] FFB autocenter enabled on {device_path}", flush=True)
-        except PermissionError:
-            print(
-                "[demo] FFB permission denied; add user to input group or adjust udev",
-                flush=True,
-            )
-            self._fd = None
-        except OSError as exc:
-            print(f"[demo] FFB unavailable on {device_path}: {exc}", flush=True)
-            self._fd = None
-
-    def update(self, speed_mps: float, *, gain: float) -> None:
-        if self._fd is None:
-            return
-        if speed_mps < 0.1:
-            target = 0.15
-        else:
-            norm = min(1.0, speed_mps / 14.0)
-            target = 0.35 + 0.65 * norm
-        self._smoothed += 0.12 * (target - self._smoothed)
-        strength = int(self._smoothed * max(0.0, min(1.0, gain)) * 0xFFFF)
-        strength = max(0, min(0xFFFF, strength))
-        if abs(strength - self._last_strength) > 500:
-            self._write_event(FF_AUTOCENTER, strength)
-            self._last_strength = strength
-
-    def cleanup(self) -> None:
-        if self._fd is None:
-            return
-        try:
-            self._write_event(FF_AUTOCENTER, 0)
-            os.close(self._fd)
-        except OSError:
-            pass
-        self._fd = None
-
-    def _write_event(self, code: int, value: int) -> None:
-        if self._fd is None:
-            return
-        now = time.time()
-        sec = int(now)
-        usec = int((now - sec) * 1_000_000)
-        try:
-            os.write(
-                self._fd, struct.pack(EVDEV_EVENT_FORMAT, sec, usec, EV_FF, code, value)
-            )
-        except OSError:
-            return
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -723,29 +675,29 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
         control_assets=control_assets,
         wheel=None,
     )
+    # Attach the wheel up front, bound to the placeholder keyboard, so the
+    # HUD's steering / pedal chrome reacts to the physical device during the
+    # initial "Load Scene" wait -- not only once a scene is running. The
+    # evdev reader thread starts now; the per-run factory below just rebinds
+    # its drive sink to each run's KeyboardState.
     wheel: Any = None
+    if wheel_selection is not None:
+        profile, device_path = wheel_selection
+        wheel = WheelBridge(
+            device_path=device_path,
+            profile=profile,
+            control=KeyboardStateDriveSink(placeholder_keyboard),
+        )
+        wheel.start()
+        presenter.set_wheel(wheel)
 
     def _factory(config: Any, keyboard: Any) -> Any:
-        # Called once per ``InteractiveDriveApp.__init__``. The first
-        # call lazily attaches the wheel (so the evdev reader thread
-        # only starts running once the user has actually picked a
-        # scene); subsequent calls rebind the wheel's drive sink to
-        # the new keyboard without restarting the reader.
-        nonlocal wheel
-        if wheel is None and wheel_selection is not None:
-            profile, device_path = wheel_selection
-            wheel = WheelBridge(
-                device_path=device_path,
-                profile=profile,
-                control=KeyboardStateDriveSink(keyboard),
-            )
-            wheel.start()
-            presenter.set_wheel(wheel)
-        elif wheel is not None:
-            # Rebind the wheel's drive sink to the new keyboard. We
-            # don't restart the wheel's evdev reader thread -- it's
-            # state-machine-clean and the only thing tied to keyboard
-            # is the sink it posts ``set_drive`` calls into.
+        # Called once per ``InteractiveDriveApp.__init__``. Rebind the
+        # wheel's drive sink to this run's KeyboardState (the reader thread
+        # started above keeps running, state-machine-clean -- the only thing
+        # tied to the keyboard is the sink it posts ``set_drive`` into), then
+        # point the presenter at the new keyboard.
+        if wheel is not None:
             wheel._control = KeyboardStateDriveSink(keyboard)  # noqa: SLF001 -- see comment
         presenter.bind_keyboard(keyboard)
         return presenter
@@ -1081,8 +1033,24 @@ def _variant_label(variant: str) -> str:
     return labels.get(variant, variant)
 
 
+def _merged_wheel_profiles(cli_profiles_dir: Path) -> tuple[WheelProfile, ...]:
+    """Profiles from the user config dir plus any ``--wheel-profiles-dir``.
+
+    User-generated profiles (written by ``interactive-drive-configuration``)
+    live in :func:`user_wheel_profiles_dir` and take precedence over a
+    profile of the same name found in the CLI-provided directory.
+    """
+    merged: dict[str, WheelProfile] = {}
+    for profile in (
+        *load_wheel_profiles(user_wheel_profiles_dir()),
+        *load_wheel_profiles(cli_profiles_dir),
+    ):
+        merged.setdefault(profile.name.lower(), profile)
+    return tuple(merged.values())
+
+
 def _select_wheel(args: argparse.Namespace) -> tuple[WheelProfile, Path] | None:
-    profiles = _load_wheel_profiles(args.wheel_profiles_dir)
+    profiles = _merged_wheel_profiles(args.wheel_profiles_dir)
     profile = _profile_by_name(profiles, args.wheel_profile)
     device_path: Path | None = args.wheel_device
 
@@ -1136,42 +1104,12 @@ def _profile_for_device(
         return None
     fake_device = EvdevDevice(path=device_path, name=name)
     ordered = sorted(profiles, key=lambda p: p.is_default, reverse=True)
+    best: tuple[int, WheelProfile] | None = None
     for profile in ordered:
-        if _device_matches_profile(fake_device, profile):
-            return profile
-    return None
-
-
-def _load_wheel_profiles(profiles_dir: Path) -> tuple[WheelProfile, ...]:
-    profiles: list[WheelProfile] = []
-    if not profiles_dir.is_dir():
-        print(f"[demo] wheel profiles dir not found: {profiles_dir}", flush=True)
-        return tuple()
-    for path in sorted(profiles_dir.glob("*.yaml")):
-        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        axis_map = {
-            str(key): int(value) for key, value in data.get("axis_map", {}).items()
-        }
-        pedal = data.get("pedal", {}) or {}
-        profiles.append(
-            WheelProfile(
-                name=str(data.get("name", path.stem)),
-                display_name=str(data.get("display_name", data.get("name", path.stem))),
-                detection_patterns=tuple(
-                    str(pattern) for pattern in data.get("detection_patterns", ())
-                ),
-                axis_map=axis_map,
-                inverted_pedals=bool(
-                    pedal.get("inverted", data.get("inverted_pedals", True))
-                ),
-                invert_steering=bool(data.get("invert_steering", False)),
-                ffb_enabled=bool((data.get("ffb", {}) or {}).get("enabled", False)),
-                ffb_gain=float((data.get("ffb", {}) or {}).get("gain", 0.5)),
-                threshold=float(data.get("threshold", 0.12)),
-                is_default=bool(data.get("is_default", False)),
-            )
-        )
-    return tuple(profiles)
+        strength = _profile_device_match_strength(fake_device, profile)
+        if strength > 0 and (best is None or strength > best[0]):
+            best = (strength, profile)
+    return best[1] if best is not None else None
 
 
 def _profile_by_name(
@@ -1202,14 +1140,14 @@ def _detect_wheel(
     )
     devices = _scan_evdev_devices()
     for profile in ordered_profiles:
-        for device in devices:
-            if _device_matches_profile(device, profile):
-                print(
-                    f"[demo] auto-detected wheel profile={profile.name} "
-                    f"device={device.path} name={device.name!r}",
-                    flush=True,
-                )
-                return profile, device.path
+        device = _best_device_for_profile(profile, devices)
+        if device is not None:
+            print(
+                f"[demo] auto-detected wheel profile={profile.name} "
+                f"device={device.path} name={device.name!r}",
+                flush=True,
+            )
+            return profile, device.path
     if devices:
         print(
             "[demo] evdev devices seen but no wheel profile matched: "
@@ -1220,55 +1158,43 @@ def _detect_wheel(
 
 
 def _detect_device_for_profile(profile: WheelProfile) -> EvdevDevice | None:
-    for device in _scan_evdev_devices():
-        if _device_matches_profile(device, profile):
-            return device
-    return None
+    return _best_device_for_profile(profile, _scan_evdev_devices())
 
 
-def _scan_evdev_devices() -> tuple[EvdevDevice, ...]:
-    candidates: list[Path] = []
-    by_id = Path("/dev/input/by-id")
-    if by_id.is_dir():
-        candidates.extend(
-            sorted(path for path in by_id.glob("*event*") if path.exists())
-        )
-    candidates.extend(sorted(Path("/dev/input").glob("event*")))
+def _profile_device_match_strength(device: EvdevDevice, profile: WheelProfile) -> int:
+    """Match score for *device* vs *profile*: 0 none, 1 substring, 2 exact name.
 
-    devices: list[EvdevDevice] = []
-    seen: set[Path] = set()
-    for path in candidates:
-        try:
-            resolved = path.resolve()
-        except OSError:
-            resolved = path
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        name = _read_evdev_name(path)
-        if name is not None:
-            devices.append(EvdevDevice(path=path, name=name))
-    return tuple(devices)
-
-
-def _device_matches_profile(device: EvdevDevice, profile: WheelProfile) -> bool:
-    name = device.name.lower()
-    if not any(pattern.lower() in name for pattern in profile.detection_patterns):
-        return False
+    A non-zero score also requires every axis in the profile's ``axis_map``
+    to exist on the device. The exact-name tier is what stops a profile
+    captured from e.g. ``"Wireless Controller"`` from binding a sibling node
+    (``"Wireless Controller Motion Sensors"``) whose name merely contains the
+    pattern and may even expose overlapping axes.
+    """
+    if not profile.detection_patterns:
+        return 0
     required_axes = {int(axis) for axis in profile.axis_map.values()}
-    return all(
+    if not all(
         _query_axis_range(device.path, axis) is not None for axis in required_axes
-    )
+    ):
+        return 0
+    return name_match_strength(device.name, profile.detection_patterns)
 
 
-def _read_evdev_name(path: Path) -> str | None:
-    try:
-        with path.open("rb") as handle:
-            name_buf = array.array("B", [0] * 256)
-            fcntl.ioctl(handle.fileno(), 0x80004506 + (256 << 16), name_buf)
-            return name_buf.tobytes().split(b"\x00")[0].decode("utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
+def _best_device_for_profile(
+    profile: WheelProfile, devices: tuple[EvdevDevice, ...]
+) -> EvdevDevice | None:
+    """Return the device matching *profile* best, preferring an exact name.
+
+    Among all connected devices an exact-name match always beats a substring
+    match, so the real controller node wins over a same-named sensor/touchpad
+    sibling regardless of scan order.
+    """
+    best: tuple[int, EvdevDevice] | None = None
+    for device in devices:
+        strength = _profile_device_match_strength(device, profile)
+        if strength > 0 and (best is None or strength > best[0]):
+            best = (strength, device)
+    return best[1] if best is not None else None
 
 
 def _load_control_assets(control_assets_dir: Path | None) -> ControlAssets:
@@ -1352,28 +1278,12 @@ def _apply_wheel_overrides(
         if args.wheel_pedals_inverted is None
         else bool(args.wheel_pedals_inverted)
     )
-    return WheelProfile(
-        name=profile.name,
-        display_name=profile.display_name,
-        detection_patterns=profile.detection_patterns,
-        axis_map=axis_map,
-        inverted_pedals=inverted,
-        invert_steering=profile.invert_steering,
-        ffb_enabled=profile.ffb_enabled,
-        ffb_gain=profile.ffb_gain,
-        threshold=profile.threshold,
-        is_default=profile.is_default,
-    )
-
-
-def _query_axis_range(path: Path, axis: int) -> AxisRange | None:
-    try:
-        with path.open("rb") as handle:
-            payload = array.array("i", [0, 0, 0, 0, 0, 0])
-            fcntl.ioctl(handle.fileno(), EVIOCGABS(axis), payload, True)
-            return AxisRange(minimum=int(payload[1]), maximum=int(payload[2]))
-    except OSError:
-        return None
+    # Use ``replace`` so every other field is preserved. The previous manual
+    # reconstruction silently dropped any field it didn't relist -- which
+    # reset steering_range / steering_deadzone to their no-op defaults and
+    # unbound reverse/reset buttons at runtime, even though the saved
+    # profile had them.
+    return replace(profile, axis_map=axis_map, inverted_pedals=inverted)
 
 
 def _parse_axis(value: str) -> int:

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -116,6 +116,7 @@ class WheelState:
     brake: float = 0.0
     target_speed_mps: float = 0.0
     connected: bool = False
+    reverse: bool = False
 
 
 class KeyboardDriveState:
@@ -367,6 +368,7 @@ class WheelBridge:
             self._state.throttle = throttle
             self._state.brake = brake
             self._state.target_speed_mps = target_speed
+            self._state.reverse = self._reverse
 
         self._control.set_drive(
             steer=steering, throttle=throttle, brake=brake, reverse=self._reverse
@@ -400,6 +402,11 @@ class WheelBridge:
         self._last_update_s = now
         with self._state_lock:
             speed = self._state.target_speed_mps
+        # ``speed`` is signed: positive is forward, negative is reverse. The
+        # HUD shows its magnitude, so engaging reverse decelerates to 0 and
+        # then builds speed in the reverse direction (rather than the digit
+        # climbing forever while the throttle is held).
+        direction = -1.0 if self._reverse else 1.0
         if throttle > 0.01 and brake <= 0.05:
             accel = 2.0 * throttle * dt
             current = abs(speed)
@@ -409,9 +416,13 @@ class WheelBridge:
             else:
                 excess = (current - high_speed_knee) / max(1e-6, 36.0 - high_speed_knee)
                 taper = max(0.05, 0.5 * (1.0 - excess) ** 3)
-            speed += accel * taper
+            speed += direction * accel * taper
         elif brake > 0.01:
-            speed = max(0.0, speed - 12.0 * brake * dt)
+            # Brake bleeds speed toward a stop regardless of travel direction.
+            speed = _move_towards(speed, 0.0, 12.0 * brake * dt)
+        elif self._reverse:
+            # No auto-crawl in reverse; coast toward a stop.
+            speed = _move_towards(speed, 0.0, 0.5 * dt)
         else:
             creep_target = 4.47  # 10 mph, matching the AlpaSim manual-driver creep.
             if speed < creep_target + 0.1:
@@ -420,7 +431,7 @@ class WheelBridge:
                 speed += (creep_target - speed) * 0.18 * dt
             else:
                 speed = max(0.0, speed - 0.5 * dt)
-        return max(0.0, min(36.0, speed))
+        return max(-36.0, min(36.0, speed))
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/integrations/omnidreams/omnidreams/interactive_drive/input/wheel_profiles.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input/wheel_profiles.py
@@ -1,0 +1,443 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Shared input-device profile model, evdev helpers, and profile IO.
+
+A *profile* describes any analog driving input device -- a steering wheel
+with pedals or a game controller with an analog stick and triggers. The
+runtime (:class:`~omnidreams.interactive_drive.demo.WheelBridge`) only ever
+reads three absolute axes (steering / throttle / brake) and normalizes
+them, so the same profile shape covers both device classes; a controller is
+just a profile whose throttle/brake axes are triggers (``pedal.inverted:
+false``) and whose force feedback is disabled.
+
+Profiles are data-only YAML. Nothing here hardcodes a device's make or
+model: detection is by the device's own evdev-reported name, which the
+configuration tool captures live and writes only into the user's local
+profile -- never into shipped source or configs.
+
+This module is intentionally free of any GUI / slangpy imports so the
+configuration tool (:mod:`omnidreams.interactive_drive.input_config`) and
+the demo runtime can both depend on it cheaply.
+"""
+
+from __future__ import annotations
+
+import array
+import fcntl
+import os
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+# --- evdev wire format / ioctl constants -------------------------------
+# Linux input_event struct: two longs (timeval), two u16, one s32.
+EVDEV_EVENT_FORMAT = "llHHi"
+EVDEV_EVENT_SIZE = struct.calcsize(EVDEV_EVENT_FORMAT)
+EV_ABS = 0x03
+EV_KEY = 0x01
+EV_FF = 0x15
+FF_AUTOCENTER = 0x61
+FF_GAIN = 0x60
+# EVIOCGABS(axis): read an absolute axis' value/min/max range.
+EVIOCGABS = lambda axis: 0x80184540 + axis  # noqa: E731
+# EVIOCGNAME(len): read the device's human-readable name.
+EVIOCGNAME = lambda length: 0x80004506 + (length << 16)  # noqa: E731
+
+
+@dataclass(frozen=True)
+class AxisRange:
+    minimum: int
+    maximum: int
+
+    @property
+    def center(self) -> float:
+        return (float(self.minimum) + float(self.maximum)) * 0.5
+
+    @property
+    def span(self) -> float:
+        return max(1.0, float(self.maximum - self.minimum))
+
+
+@dataclass(frozen=True)
+class EvdevDevice:
+    path: Path
+    name: str
+
+
+@dataclass(frozen=True)
+class WheelProfile:
+    """A driving-input profile (steering wheel or game controller).
+
+    ``axis_map`` holds the evdev ABS codes for steering / throttle / brake.
+    ``inverted_pedals`` is shared by throttle and brake: ``True`` when the
+    control rests at its axis maximum and falls toward the minimum when
+    engaged (typical of wheel pedals), ``False`` when it rests at the
+    minimum and rises when engaged (typical of controller triggers).
+    """
+
+    name: str
+    display_name: str
+    detection_patterns: tuple[str, ...]
+    axis_map: dict[str, int]
+    inverted_pedals: bool = True
+    invert_steering: bool = False
+    ffb_enabled: bool = False
+    ffb_gain: float = 0.5
+    threshold: float = 0.12
+    is_default: bool = False
+    # evdev button codes (EV_KEY) bound to actions; empty when unbound.
+    reverse_buttons: tuple[int, ...] = ()
+    reset_buttons: tuple[int, ...] = ()
+    # Steering feel: output scale (``< 1`` = less sensitive) and a center
+    # deadzone fraction (hides analog-stick drift on game controllers).
+    steering_range: float = 1.0
+    steering_deadzone: float = 0.0
+
+
+def apply_steering_curve(
+    value: float, *, deadzone: float = 0.0, scale: float = 1.0
+) -> float:
+    """Shape a normalized steering value in ``[-1, 1]``.
+
+    ``deadzone`` (a fraction of the range) is removed around center and the
+    remainder rescaled so motion just past it starts from zero -- this hides
+    analog-stick drift. ``scale`` then limits the output magnitude (``< 1``
+    makes steering less sensitive). The result stays in ``[-1, 1]``.
+    """
+    if deadzone > 0.0:
+        magnitude = abs(value)
+        if magnitude <= deadzone:
+            return 0.0
+        sign = 1.0 if value > 0.0 else -1.0
+        value = sign * (magnitude - deadzone) / (1.0 - deadzone)
+    return max(-1.0, min(1.0, value * scale))
+
+
+def name_match_strength(device_name: str, patterns) -> int:
+    """Score a device name against a profile's detection patterns.
+
+    ``2`` when the name equals a pattern exactly, ``1`` when a pattern is a
+    substring of the name, ``0`` otherwise (case-insensitive). Exact beats
+    substring so a profile captured as ``"Wireless Controller"`` binds that
+    node rather than a sibling like ``"Wireless Controller Motion Sensors"``
+    whose name merely contains the pattern.
+    """
+    name = device_name.lower()
+    lowered = [str(pattern).lower() for pattern in patterns]
+    if any(name == pattern for pattern in lowered):
+        return 2
+    if any(pattern and pattern in name for pattern in lowered):
+        return 1
+    return 0
+
+
+# --- evdev device discovery / queries ----------------------------------
+
+
+def read_evdev_name(path: Path) -> str | None:
+    """Return the evdev device name at *path*, or ``None`` if unreadable."""
+    try:
+        with path.open("rb") as handle:
+            name_buf = array.array("B", [0] * 256)
+            fcntl.ioctl(handle.fileno(), EVIOCGNAME(256), name_buf)
+            return name_buf.tobytes().split(b"\x00")[0].decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def query_axis_range(path: Path, axis: int) -> AxisRange | None:
+    """Read an absolute axis' [min, max] via ``EVIOCGABS``.
+
+    Returns ``None`` when the device has no such axis (which is also how
+    callers test whether a candidate device exposes a required axis).
+    """
+    try:
+        with path.open("rb") as handle:
+            payload = array.array("i", [0, 0, 0, 0, 0, 0])
+            fcntl.ioctl(handle.fileno(), EVIOCGABS(axis), payload, True)
+            return AxisRange(minimum=int(payload[1]), maximum=int(payload[2]))
+    except OSError:
+        return None
+
+
+def scan_evdev_devices() -> tuple[EvdevDevice, ...]:
+    """Enumerate readable evdev devices.
+
+    Scans ``/dev/input/by-id`` first (stable, descriptive symlinks) then
+    ``/dev/input/event*``, de-duplicating by resolved path.
+    """
+    candidates: list[Path] = []
+    by_id = Path("/dev/input/by-id")
+    if by_id.is_dir():
+        candidates.extend(
+            sorted(path for path in by_id.glob("*event*") if path.exists())
+        )
+    candidates.extend(sorted(Path("/dev/input").glob("event*")))
+
+    devices: list[EvdevDevice] = []
+    seen: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        name = read_evdev_name(path)
+        if name is not None:
+            devices.append(EvdevDevice(path=path, name=name))
+    return tuple(devices)
+
+
+def read_axis_states(path: Path) -> dict[int, tuple[int, AxisRange]]:
+    """Return ``{abs_code: (current_value, range)}`` for every absolute axis.
+
+    Probes the common ABS code range (0x00-0x3F, which covers sticks,
+    triggers, pedals, and hats) via the same ``EVIOCGABS`` ioctl ``evtest``
+    uses. That ioctl reports the axis' *current* value alongside its
+    min/max, so the configuration tool can seed a live readout and
+    normalize movement immediately, without waiting for the device to emit
+    its first event.
+    """
+    states: dict[int, tuple[int, AxisRange]] = {}
+    try:
+        with path.open("rb") as handle:
+            for axis in range(0x40):
+                payload = array.array("i", [0, 0, 0, 0, 0, 0])
+                try:
+                    fcntl.ioctl(handle.fileno(), EVIOCGABS(axis), payload, True)
+                except OSError:
+                    continue
+                value, minimum, maximum = (
+                    int(payload[0]),
+                    int(payload[1]),
+                    int(payload[2]),
+                )
+                if maximum != minimum:
+                    states[axis] = (value, AxisRange(minimum=minimum, maximum=maximum))
+    except OSError:
+        return {}
+    return states
+
+
+def list_device_axes(path: Path) -> dict[int, AxisRange]:
+    """Return the min/max range of every absolute axis the device exposes."""
+    return {code: rng for code, (_value, rng) in read_axis_states(path).items()}
+
+
+# --- profile IO ---------------------------------------------------------
+
+
+def user_wheel_profiles_dir() -> Path:
+    """User-writable directory where generated profiles are stored.
+
+    Resolves to ``$FLASHDREAMS_CACHE_DIR/interactive-drive/wheels`` (the
+    same cache convention the scene staging uses). Read on every call so
+    tests that monkeypatch :data:`omnidreams.scenes.FLASHDREAMS_CACHE_DIR`
+    see the override.
+    """
+    from omnidreams.scenes import FLASHDREAMS_CACHE_DIR
+
+    return FLASHDREAMS_CACHE_DIR / "interactive-drive" / "wheels"
+
+
+def _profile_from_data(data: dict, fallback_name: str) -> WheelProfile:
+    axis_map = {
+        str(key): int(value) for key, value in (data.get("axis_map") or {}).items()
+    }
+    pedal = data.get("pedal", {}) or {}
+    ffb = data.get("ffb", {}) or {}
+    return WheelProfile(
+        name=str(data.get("name", fallback_name)),
+        display_name=str(data.get("display_name", data.get("name", fallback_name))),
+        detection_patterns=tuple(
+            str(pattern) for pattern in data.get("detection_patterns", ())
+        ),
+        axis_map=axis_map,
+        inverted_pedals=bool(pedal.get("inverted", data.get("inverted_pedals", True))),
+        invert_steering=bool(data.get("invert_steering", False)),
+        ffb_enabled=bool(ffb.get("enabled", False)),
+        ffb_gain=float(ffb.get("gain", 0.5)),
+        threshold=float(data.get("threshold", 0.12)),
+        is_default=bool(data.get("is_default", False)),
+        reverse_buttons=tuple(int(b) for b in data.get("reverse_buttons", ()) or ()),
+        reset_buttons=tuple(int(b) for b in data.get("reset_buttons", ()) or ()),
+        steering_range=float(data.get("steering_range", 1.0)),
+        steering_deadzone=float(data.get("steering_deadzone", 0.0)),
+    )
+
+
+def load_wheel_profile_files(
+    profiles_dir: Path,
+) -> tuple[tuple[Path, WheelProfile], ...]:
+    """Load ``(path, profile)`` for every ``*.yaml`` in *profiles_dir*.
+
+    The configuration tool needs the source path to edit or delete a
+    profile in place; the runtime only needs the profiles themselves
+    (:func:`load_wheel_profiles`).
+    """
+    if not profiles_dir.is_dir():
+        return tuple()
+    entries: list[tuple[Path, WheelProfile]] = []
+    for path in sorted(profiles_dir.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        entries.append((path, _profile_from_data(data, path.stem)))
+    return tuple(entries)
+
+
+def load_wheel_profiles(profiles_dir: Path) -> tuple[WheelProfile, ...]:
+    """Load every ``*.yaml`` profile in *profiles_dir* (empty if missing)."""
+    return tuple(profile for _path, profile in load_wheel_profile_files(profiles_dir))
+
+
+def wheel_profile_to_yaml_dict(profile: WheelProfile) -> dict:
+    """Serialize a profile to the dict shape :func:`load_wheel_profiles` reads.
+
+    Key order is preserved on dump for human-friendly files; round-tripping
+    the result back through :func:`load_wheel_profiles` reproduces an equal
+    :class:`WheelProfile`.
+    """
+    return {
+        "name": profile.name,
+        "display_name": profile.display_name,
+        "is_default": profile.is_default,
+        "detection_patterns": list(profile.detection_patterns),
+        "axis_map": {
+            "steering": int(profile.axis_map["steering"]),
+            "throttle": int(profile.axis_map["throttle"]),
+            "brake": int(profile.axis_map["brake"]),
+        },
+        "pedal": {"inverted": profile.inverted_pedals},
+        "invert_steering": profile.invert_steering,
+        "ffb": {"enabled": profile.ffb_enabled, "gain": profile.ffb_gain},
+        "threshold": profile.threshold,
+        "reverse_buttons": list(profile.reverse_buttons),
+        "reset_buttons": list(profile.reset_buttons),
+        "steering_range": profile.steering_range,
+        "steering_deadzone": profile.steering_deadzone,
+    }
+
+
+def profile_filename(name: str) -> str:
+    """Filesystem-safe ``<slug>.yaml`` filename for a profile *name*."""
+    slug = "".join(ch if ch.isalnum() else "-" for ch in name.strip().lower())
+    slug = "-".join(part for part in slug.split("-") if part)
+    return f"{slug or 'profile'}.yaml"
+
+
+def _write_profile_yaml(path: Path, profile: WheelProfile) -> None:
+    header = (
+        "# Generated by interactive-drive-configuration.\n"
+        "# Local input-device profile -- not tracked by the repository.\n\n"
+    )
+    body = yaml.safe_dump(
+        wheel_profile_to_yaml_dict(profile), sort_keys=False, default_flow_style=False
+    )
+    path.write_text(header + body, encoding="utf-8")
+
+
+def save_wheel_profile(profile: WheelProfile, profiles_dir: Path) -> Path:
+    """Write *profile* as a new YAML in *profiles_dir* and return the path."""
+    profiles_dir.mkdir(parents=True, exist_ok=True)
+    path = profiles_dir / profile_filename(profile.name)
+    _write_profile_yaml(path, profile)
+    return path
+
+
+def update_profile_file(path: Path, profile: WheelProfile) -> None:
+    """Rewrite an existing profile file in place (used by the editor)."""
+    _write_profile_yaml(path, profile)
+
+
+def delete_profile_file(path: Path) -> None:
+    """Delete a profile file, ignoring a missing file."""
+    path.unlink(missing_ok=True)
+
+
+# --- force feedback -----------------------------------------------------
+
+
+class AutocenterFFB:
+    """Speed-scaled autocenter force feedback via ``FF_AUTOCENTER``.
+
+    Used by the demo runtime for live driving and by the configuration
+    tool's FFB test. ``update`` is a no-op until :meth:`init` succeeds, so
+    devices without autocenter support (e.g. game controllers) silently do
+    nothing.
+    """
+
+    def __init__(self) -> None:
+        self._fd: int | None = None
+        self._last_strength = -1
+        self._smoothed = 0.0
+
+    def init(self, device_path: Path, gain: float) -> None:
+        try:
+            self._fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
+            self._write_event(FF_AUTOCENTER, 0)
+            self._write_event(FF_GAIN, int(max(0.0, min(1.0, gain)) * 0xFFFF))
+        except PermissionError:
+            print(
+                "[wheel] FFB permission denied; add user to input group or adjust udev",
+                flush=True,
+            )
+            self._fd = None
+        except OSError as exc:
+            print(f"[wheel] FFB unavailable on {device_path}: {exc}", flush=True)
+            self._fd = None
+
+    @property
+    def available(self) -> bool:
+        return self._fd is not None
+
+    def update(self, speed_mps: float, *, gain: float) -> None:
+        if self._fd is None:
+            return
+        if speed_mps < 0.1:
+            target = 0.15
+        else:
+            norm = min(1.0, speed_mps / 14.0)
+            target = 0.35 + 0.65 * norm
+        self._smoothed += 0.12 * (target - self._smoothed)
+        strength = int(self._smoothed * max(0.0, min(1.0, gain)) * 0xFFFF)
+        strength = max(0, min(0xFFFF, strength))
+        if abs(strength - self._last_strength) > 500:
+            self._write_event(FF_AUTOCENTER, strength)
+            self._last_strength = strength
+
+    def set_autocenter(self, fraction: float) -> None:
+        """Directly set the autocenter strength (used by the FFB test slider)."""
+        if self._fd is None:
+            return
+        strength = max(0, min(0xFFFF, int(max(0.0, min(1.0, fraction)) * 0xFFFF)))
+        self._write_event(FF_AUTOCENTER, strength)
+        self._last_strength = strength
+
+    def cleanup(self) -> None:
+        if self._fd is None:
+            return
+        try:
+            self._write_event(FF_AUTOCENTER, 0)
+            os.close(self._fd)
+        except OSError:
+            pass
+        self._fd = None
+
+    def _write_event(self, code: int, value: int) -> None:
+        if self._fd is None:
+            return
+        import time
+
+        now = time.time()
+        sec = int(now)
+        usec = int((now - sec) * 1_000_000)
+        try:
+            os.write(
+                self._fd, struct.pack(EVDEV_EVENT_FORMAT, sec, usec, EV_FF, code, value)
+            )
+        except OSError:
+            return

--- a/integrations/omnidreams/omnidreams/interactive_drive/input_config/__init__.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input_config/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Interactive configuration tool for driving input devices.
+
+Provides ``interactive-drive-configuration``: a small Tkinter wizard that
+auto-detects a connected steering wheel or game controller, calibrates its
+axes by capturing live input, and writes a local profile YAML the demo
+runtime discovers automatically. No device make/model is hardcoded; the
+only product-identifying string (the evdev device name used for detection)
+is captured at runtime and written solely into the user's local profile.
+"""

--- a/integrations/omnidreams/omnidreams/interactive_drive/input_config/__main__.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input_config/__main__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+# ``python -m omnidreams.interactive_drive.input_config`` mirrors the
+# ``interactive-drive-configuration`` console script.
+from omnidreams.interactive_drive.input_config.app import main
+
+if __name__ == "__main__":
+    main()

--- a/integrations/omnidreams/omnidreams/interactive_drive/input_config/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input_config/app.py
@@ -21,7 +21,6 @@ from dataclasses import replace
 from pathlib import Path
 
 import yaml
-
 from omnidreams.interactive_drive.input.wheel_profiles import (
     AutocenterFFB,
     EvdevDevice,
@@ -145,7 +144,9 @@ class ConfigApp:
 
         live = ttk.LabelFrame(self.root, text="Live inputs", padding=(8, 4))
         live.pack(side="bottom", fill="x", padx=12, pady=(0, 4))
-        ttk.Label(live, textvariable=self.activity_var, foreground="#2f8f2f").pack(anchor="w")
+        ttk.Label(live, textvariable=self.activity_var, foreground="#2f8f2f").pack(
+            anchor="w"
+        )
         # Fixed-size canvas: a steering-wheel + pedal visualization plus a
         # compact per-axis activity strip. Its dimensions are fixed, so the
         # widgets above never shift when it starts drawing on device select.
@@ -161,7 +162,9 @@ class ConfigApp:
             header, textvariable=self.title_var, font=("TkDefaultFont", 15, "bold")
         ).pack(anchor="w")
         self.step_var = tk.StringVar()
-        ttk.Label(header, textvariable=self.step_var, foreground="#888").pack(anchor="w")
+        ttk.Label(header, textvariable=self.step_var, foreground="#888").pack(
+            anchor="w"
+        )
 
         self.content = ttk.Frame(self.root, padding=(16, 4))
         self.content.pack(side="top", fill="both", expand=True)
@@ -245,34 +248,50 @@ class ConfigApp:
                 row = ttk.Frame(saved)
                 row.pack(fill="x", pady=2)
                 tag = "  [default]" if profile.is_default else ""
-                ttk.Label(row, text=f"{profile.display_name}{tag}", width=30, anchor="w").pack(side="left")
+                ttk.Label(
+                    row, text=f"{profile.display_name}{tag}", width=30, anchor="w"
+                ).pack(side="left")
                 ttk.Button(
-                    row, text="Edit", width=6,
+                    row,
+                    text="Edit",
+                    width=6,
                     command=lambda p=path, pr=profile: self._start_edit(p, pr),
                 ).pack(side="left", padx=2)
                 ttk.Button(
-                    row, text=("Unset default" if profile.is_default else "Make default"),
-                    width=13, command=lambda p=path, pr=profile: self._toggle_default(p, pr),
+                    row,
+                    text=("Unset default" if profile.is_default else "Make default"),
+                    width=13,
+                    command=lambda p=path, pr=profile: self._toggle_default(p, pr),
                 ).pack(side="left", padx=2)
                 ttk.Button(
-                    row, text="Delete", width=7,
+                    row,
+                    text="Delete",
+                    width=7,
                     command=lambda p=path, pr=profile: self._delete_profile(p, pr),
                 ).pack(side="left", padx=2)
 
         ttk.Label(
-            self.content, text="Create a new profile", font=("TkDefaultFont", 11, "bold")
+            self.content,
+            text="Create a new profile",
+            font=("TkDefaultFont", 11, "bold"),
         ).pack(anchor="w", pady=(6, 2))
         ttk.Label(
-            self.content, wraplength=680, justify="left",
+            self.content,
+            wraplength=680,
+            justify="left",
             text="Pick the device type, then click Next to detect and calibrate it.",
         ).pack(anchor="w", pady=(0, 6))
         ttk.Radiobutton(
-            self.content, text="Steering wheel + pedals", value="wheel",
+            self.content,
+            text="Steering wheel + pedals",
+            value="wheel",
             variable=self.device_type_var,
         ).pack(anchor="w")
         ttk.Radiobutton(
-            self.content, text="Game controller / gamepad (stick + triggers)",
-            value="controller", variable=self.device_type_var,
+            self.content,
+            text="Game controller / gamepad (stick + triggers)",
+            value="controller",
+            variable=self.device_type_var,
         ).pack(anchor="w")
 
     # -- existing-profile management + editor ---------------------------
@@ -351,7 +370,9 @@ class ConfigApp:
             except OSError:
                 self.session = None
         ttk.Label(
-            self.content, foreground="#2f8f2f", wraplength=680,
+            self.content,
+            foreground="#2f8f2f",
+            wraplength=680,
             text=(
                 f"Live preview from {device.name} -- operate the controls to see the feel."
                 if device is not None
@@ -362,11 +383,14 @@ class ConfigApp:
         form = ttk.Frame(self.content)
         form.pack(fill="x")
         ttk.Label(form, text="Display name").grid(row=0, column=0, sticky="w", pady=4)
-        ttk.Entry(form, textvariable=self._edit_display_name, width=44).grid(row=0, column=1, sticky="w")
+        ttk.Entry(form, textvariable=self._edit_display_name, width=44).grid(
+            row=0, column=1, sticky="w"
+        )
 
         axis_map = profile.axis_map
         ttk.Label(
-            self.content, foreground="#666",
+            self.content,
+            foreground="#666",
             text=(
                 "Axes (recalibrate by creating a new profile): "
                 f"steering 0x{axis_map.get('steering', 0):02x}, "
@@ -375,18 +399,31 @@ class ConfigApp:
             ),
         ).pack(anchor="w", pady=(4, 6))
 
-        ttk.Checkbutton(self.content, text="Invert steering", variable=self._edit_invert_steer).pack(anchor="w")
-        ttk.Checkbutton(self.content, text="Invert pedals", variable=self._edit_invert_pedals).pack(anchor="w")
+        ttk.Checkbutton(
+            self.content, text="Invert steering", variable=self._edit_invert_steer
+        ).pack(anchor="w")
+        ttk.Checkbutton(
+            self.content, text="Invert pedals", variable=self._edit_invert_pedals
+        ).pack(anchor="w")
         self._slider_row("Steering range (sensitivity)", self._edit_range, 0.1, 1.0)
         self._slider_row("Steering deadzone", self._edit_deadzone, 0.0, 0.3)
         ffb_row = ttk.Frame(self.content)
         ffb_row.pack(fill="x", pady=2)
-        ttk.Checkbutton(ffb_row, text="Force feedback", variable=self._edit_ffb).pack(side="left")
+        ttk.Checkbutton(ffb_row, text="Force feedback", variable=self._edit_ffb).pack(
+            side="left"
+        )
         ttk.Scale(
-            ffb_row, from_=0.0, to=1.0, orient="horizontal", length=200, variable=self._edit_ffb_gain
+            ffb_row,
+            from_=0.0,
+            to=1.0,
+            orient="horizontal",
+            length=200,
+            variable=self._edit_ffb_gain,
         ).pack(side="left", padx=8)
 
-        ttk.Label(self.content, text="Detection patterns (one per line):").pack(anchor="w", pady=(6, 0))
+        ttk.Label(self.content, text="Detection patterns (one per line):").pack(
+            anchor="w", pady=(6, 0)
+        )
         self._edit_patterns = tk.Text(self.content, height=3, width=60)
         self._edit_patterns.pack(anchor="w", pady=2)
         self._edit_patterns.insert("1.0", "\n".join(profile.detection_patterns))
@@ -395,7 +432,8 @@ class ConfigApp:
             self.content, text="Use as the default profile", variable=self._edit_default
         ).pack(anchor="w", pady=(6, 0))
         ttk.Button(
-            self.content, text="Delete this profile",
+            self.content,
+            text="Delete this profile",
             command=lambda: self._delete_profile(path, profile),
         ).pack(anchor="w", pady=(10, 0))
 
@@ -423,7 +461,9 @@ class ConfigApp:
         )
         update_profile_file(path, updated)
         if updated.is_default:
-            for other_path, other in load_wheel_profile_files(user_wheel_profiles_dir()):
+            for other_path, other in load_wheel_profile_files(
+                user_wheel_profiles_dir()
+            ):
                 if other_path != path and other.is_default:
                     update_profile_file(other_path, replace(other, is_default=False))
         messagebox.showinfo("Saved", f"Updated {path.name}.")
@@ -432,7 +472,9 @@ class ConfigApp:
     def _build_device(self) -> None:
         self.title_var.set("Select your device")
         ttk.Label(
-            self.content, wraplength=680, justify="left",
+            self.content,
+            wraplength=680,
+            justify="left",
             text=(
                 "Pick your device, then operate any control -- the Live inputs panel "
                 "below updates so you can confirm you chose the right one (some "
@@ -490,9 +532,13 @@ class ConfigApp:
 
     def _build_controls(self) -> None:
         self.title_var.set("Calibrate controls")
-        self.invert_pedals_var = tk.BooleanVar(value=self.state.get("inverted_pedals", True))
+        self.invert_pedals_var = tk.BooleanVar(
+            value=self.state.get("inverted_pedals", True)
+        )
         ttk.Label(
-            self.content, wraplength=680, justify="left",
+            self.content,
+            wraplength=680,
+            justify="left",
             text=(
                 "For each control: click Start listening, then move it a little -- "
                 "it auto-detects the axis (one at a time)."
@@ -505,23 +551,34 @@ class ConfigApp:
         self._steering_section(steer, "wheel" if is_wheel else "stick")
         thr = ttk.LabelFrame(self.content, text="Throttle", padding=(10, 6))
         thr.pack(fill="x", pady=3)
-        self._pedal_section(thr, "throttle", "throttle pedal" if is_wheel else "throttle trigger")
+        self._pedal_section(
+            thr, "throttle", "throttle pedal" if is_wheel else "throttle trigger"
+        )
         brk = ttk.LabelFrame(self.content, text="Brake", padding=(10, 6))
         brk.pack(fill="x", pady=3)
-        self._pedal_section(brk, "brake", "brake pedal" if is_wheel else "brake trigger")
+        self._pedal_section(
+            brk, "brake", "brake pedal" if is_wheel else "brake trigger"
+        )
         # Single shared pedal-invert flag (the schema stores one for both
         # pedals). Auto-set from calibration; here as a manual safety net.
         ttk.Checkbutton(
             self.content,
             text="Invert pedals (toggle if pressing throttle/brake reads backwards)",
-            variable=self.invert_pedals_var, command=self._apply_pedal_invert,
+            variable=self.invert_pedals_var,
+            command=self._apply_pedal_invert,
         ).pack(anchor="w", pady=(6, 0))
 
     def _steering_section(self, parent, control: str) -> None:
-        self.invert_steering_var = tk.BooleanVar(value=self.state.get("invert_steering", False))
-        self._steering_axis_choice = tk.StringVar(value=self.state.get("_steering_axis_label", ""))
+        self.invert_steering_var = tk.BooleanVar(
+            value=self.state.get("invert_steering", False)
+        )
+        self._steering_axis_choice = tk.StringVar(
+            value=self.state.get("_steering_axis_label", "")
+        )
         result = tk.StringVar(value=self.state.get("_steering_summary", ""))
-        ttk.Label(parent, text=f"Click Start, then turn the {control} a little to the LEFT.").pack(anchor="w")
+        ttk.Label(
+            parent, text=f"Click Start, then turn the {control} a little to the LEFT."
+        ).pack(anchor="w")
 
         def on_detect(axis: int, base: int, peak: int) -> None:
             rng = self.session.axis_ranges[axis]
@@ -542,17 +599,23 @@ class ConfigApp:
         row.pack(anchor="w", fill="x", pady=4)
         self._record_button(row, "steering", on_detect, result)
         self._axis_override(row, self._steering_axis_choice)
-        ttk.Label(parent, textvariable=result, foreground="#2f6fbf", wraplength=660).pack(anchor="w")
+        ttk.Label(
+            parent, textvariable=result, foreground="#2f6fbf", wraplength=660
+        ).pack(anchor="w")
         ttk.Checkbutton(
-            parent, text="Invert steering (toggle if left/right feels reversed)",
-            variable=self.invert_steering_var, command=self._apply_invert,
+            parent,
+            text="Invert steering (toggle if left/right feels reversed)",
+            variable=self.invert_steering_var,
+            command=self._apply_invert,
         ).pack(anchor="w")
 
     def _pedal_section(self, parent, key: str, control: str) -> None:
         axis_choice = tk.StringVar(value=self.state.get(f"_{key}_axis_label", ""))
         result = tk.StringVar(value=self.state.get(f"_{key}_summary", ""))
         setattr(self, f"_{key}_axis_choice", axis_choice)
-        ttk.Label(parent, text=f"Click Start, then press the {control} a little.").pack(anchor="w")
+        ttk.Label(parent, text=f"Click Start, then press the {control} a little.").pack(
+            anchor="w"
+        )
 
         def on_detect(axis: int, base: int, peak: int) -> None:
             inverted = bool(infer_pedal_inverted(base, peak))
@@ -574,7 +637,9 @@ class ConfigApp:
         row.pack(anchor="w", fill="x", pady=4)
         self._record_button(row, key, on_detect, result)
         self._axis_override(row, axis_choice)
-        ttk.Label(parent, textvariable=result, foreground="#2f6fbf", wraplength=660).pack(anchor="w")
+        ttk.Label(
+            parent, textvariable=result, foreground="#2f6fbf", wraplength=660
+        ).pack(anchor="w")
 
     def _record_button(self, parent, key: str, on_detect, result_var) -> None:
         """A Start/cancel listening toggle.
@@ -590,7 +655,9 @@ class ConfigApp:
 
         def toggle() -> None:
             if self.session is None:
-                messagebox.showwarning("No device", "Go back and select a device first.")
+                messagebox.showwarning(
+                    "No device", "Go back and select a device first."
+                )
                 return
             if self._recording_key == key:
                 self._recording_key = None
@@ -623,12 +690,16 @@ class ConfigApp:
         labels = [_axis_label(code) for code in codes] or ["(none)"]
         if not choice_var.get():
             choice_var.set(labels[0])
-        ttk.OptionMenu(parent, choice_var, choice_var.get(), *labels).pack(side="left", padx=6)
+        ttk.OptionMenu(parent, choice_var, choice_var.get(), *labels).pack(
+            side="left", padx=6
+        )
 
     def _build_buttons(self) -> None:
         self.title_var.set("Bind buttons (optional)")
         ttk.Label(
-            self.content, wraplength=680, justify="left",
+            self.content,
+            wraplength=680,
+            justify="left",
             text=(
                 "Optionally bind one button to toggle reverse and one to reset / "
                 "respawn. Click Bind, then press the button on your device. Leave "
@@ -643,13 +714,16 @@ class ConfigApp:
             row = ttk.Frame(frame)
             row.pack(anchor="w", fill="x")
             ttk.Button(
-                row, text=f"Bind {label.split()[0].lower()} button",
+                row,
+                text=f"Bind {label.split()[0].lower()} button",
                 command=lambda k=key: self._start_button_listen(k),
             ).pack(side="left")
-            ttk.Button(row, text="Clear", command=lambda k=key: self._clear_button(k)).pack(
-                side="left", padx=8
+            ttk.Button(
+                row, text="Clear", command=lambda k=key: self._clear_button(k)
+            ).pack(side="left", padx=8)
+            ttk.Label(frame, textvariable=result, foreground="#2f6fbf").pack(
+                anchor="w", pady=(4, 0)
             )
-            ttk.Label(frame, textvariable=result, foreground="#2f6fbf").pack(anchor="w", pady=(4, 0))
 
     def _button_summary(self, key: str) -> str:
         codes = self.state.get(f"{key}_buttons", ())
@@ -678,7 +752,9 @@ class ConfigApp:
         self.ffb_enabled_var = tk.BooleanVar(value=self.state.get("ffb_enabled", True))
         self.ffb_gain_var = tk.DoubleVar(value=self.state.get("ffb_gain", 0.6))
         ttk.Label(
-            self.content, wraplength=680, justify="left",
+            self.content,
+            wraplength=680,
+            justify="left",
             text=(
                 "Autocenter force feedback makes the wheel resist turning and return "
                 "to center, scaled by speed. Enable it and test the feel; leave it "
@@ -686,20 +762,27 @@ class ConfigApp:
             ),
         ).pack(anchor="w", pady=(0, 10))
         ttk.Checkbutton(
-            self.content, text="Enable autocenter force feedback",
+            self.content,
+            text="Enable autocenter force feedback",
             variable=self.ffb_enabled_var,
         ).pack(anchor="w")
         gain_row = ttk.Frame(self.content)
         gain_row.pack(anchor="w", pady=8, fill="x")
         ttk.Label(gain_row, text="Gain").pack(side="left")
         ttk.Scale(
-            gain_row, from_=0.0, to=1.0, orient="horizontal", length=300,
+            gain_row,
+            from_=0.0,
+            to=1.0,
+            orient="horizontal",
+            length=300,
             variable=self.ffb_gain_var,
         ).pack(side="left", padx=8)
         test_row = ttk.Frame(self.content)
         test_row.pack(anchor="w", pady=4)
         ttk.Button(test_row, text="Test", command=self._ffb_test).pack(side="left")
-        ttk.Button(test_row, text="Stop", command=self._ffb_stop).pack(side="left", padx=8)
+        ttk.Button(test_row, text="Stop", command=self._ffb_stop).pack(
+            side="left", padx=8
+        )
 
     def _ffb_test(self) -> None:
         if self.session is None:
@@ -727,7 +810,9 @@ class ConfigApp:
         device = self.state.get("device")
         default_name = device.name if device else "My device"
         controller = self.state.get("device_type") == "controller"
-        self.display_name_var = tk.StringVar(value=self.state.get("display_name", default_name))
+        self.display_name_var = tk.StringVar(
+            value=self.state.get("display_name", default_name)
+        )
         self.profile_name_var = tk.StringVar(
             value=self.state.get("name", profile_filename(default_name)[:-5])
         )
@@ -746,28 +831,40 @@ class ConfigApp:
         self.state["steering_deadzone"] = float(self.steering_deadzone_var.get())
         self.steering_range_var.trace_add(
             "write",
-            lambda *_: self.state.__setitem__("steering_range", float(self.steering_range_var.get())),
+            lambda *_: self.state.__setitem__(
+                "steering_range", float(self.steering_range_var.get())
+            ),
         )
         self.steering_deadzone_var.trace_add(
             "write",
-            lambda *_: self.state.__setitem__("steering_deadzone", float(self.steering_deadzone_var.get())),
+            lambda *_: self.state.__setitem__(
+                "steering_deadzone", float(self.steering_deadzone_var.get())
+            ),
         )
 
         form = ttk.Frame(self.content)
         form.pack(fill="x")
         ttk.Label(form, text="Display name").grid(row=0, column=0, sticky="w", pady=4)
-        ttk.Entry(form, textvariable=self.display_name_var, width=46).grid(row=0, column=1, sticky="w")
+        ttk.Entry(form, textvariable=self.display_name_var, width=46).grid(
+            row=0, column=1, sticky="w"
+        )
         ttk.Label(form, text="Profile name").grid(row=1, column=0, sticky="w", pady=4)
-        ttk.Entry(form, textvariable=self.profile_name_var, width=46).grid(row=1, column=1, sticky="w")
+        ttk.Entry(form, textvariable=self.profile_name_var, width=46).grid(
+            row=1, column=1, sticky="w"
+        )
 
         ttk.Label(
             self.content, text="Steering feel (turn the device to preview):"
         ).pack(anchor="w", pady=(8, 0))
-        self._slider_row("Steering range (sensitivity)", self.steering_range_var, 0.1, 1.0)
+        self._slider_row(
+            "Steering range (sensitivity)", self.steering_range_var, 0.1, 1.0
+        )
         self._slider_row("Steering deadzone", self.steering_deadzone_var, 0.0, 0.3)
 
         ttk.Label(
-            self.content, wraplength=680, justify="left",
+            self.content,
+            wraplength=680,
+            justify="left",
             text=(
                 "\nDetection patterns -- one per line. The device is auto-selected at "
                 "launch when its name contains any of these."
@@ -776,10 +873,13 @@ class ConfigApp:
         self.patterns_text = tk.Text(self.content, height=3, width=62)
         self.patterns_text.pack(anchor="w", pady=4)
         existing = self.state.get("detection_patterns")
-        self.patterns_text.insert("1.0", "\n".join(existing) if existing else (device.name if device else ""))
+        self.patterns_text.insert(
+            "1.0", "\n".join(existing) if existing else (device.name if device else "")
+        )
 
         ttk.Checkbutton(
-            self.content, text="Use as the default profile",
+            self.content,
+            text="Use as the default profile",
             variable=self.is_default_var,
         ).pack(anchor="w", pady=6)
 
@@ -788,7 +888,9 @@ class ConfigApp:
         profile = self._compose_profile()
         self.state["_profile"] = profile
         preview = yaml.safe_dump(
-            wheel_profile_to_yaml_dict(profile), sort_keys=False, default_flow_style=False
+            wheel_profile_to_yaml_dict(profile),
+            sort_keys=False,
+            default_flow_style=False,
         )
         ttk.Label(
             self.content,
@@ -812,13 +914,22 @@ class ConfigApp:
             return True, ""
         if step == "controls":
             for axis_key, human in (
-                ("steering", "steering"), ("throttle", "throttle"), ("brake", "brake")
+                ("steering", "steering"),
+                ("throttle", "throttle"),
+                ("brake", "brake"),
             ):
                 if f"{axis_key}_axis" not in self.state:
-                    return False, f"Calibrate {human} first (Start listening, move it, Stop)."
-            self.state["steering_axis"] = _axis_from_label(self._steering_axis_choice.get())
+                    return (
+                        False,
+                        f"Calibrate {human} first (Start listening, move it, Stop).",
+                    )
+            self.state["steering_axis"] = _axis_from_label(
+                self._steering_axis_choice.get()
+            )
             self.state["invert_steering"] = bool(self.invert_steering_var.get())
-            self.state["throttle_axis"] = _axis_from_label(self._throttle_axis_choice.get())
+            self.state["throttle_axis"] = _axis_from_label(
+                self._throttle_axis_choice.get()
+            )
             self.state["brake_axis"] = _axis_from_label(self._brake_axis_choice.get())
             self.state["inverted_pedals"] = bool(self.invert_pedals_var.get())
             return True, ""
@@ -1007,8 +1118,13 @@ class ConfigApp:
         if not editing and step == "buttons":
             held = sorted(c for c, v in self.session.buttons().items() if v == 1)
             canvas.create_text(
-                10, _CANVAS_H - 8, anchor="w", fill="#666", font=("TkFixedFont", 8),
-                text="Buttons held: " + (", ".join(str(c) for c in held) if held else "(none)"),
+                10,
+                _CANVAS_H - 8,
+                anchor="w",
+                fill="#666",
+                font=("TkFixedFont", 8),
+                text="Buttons held: "
+                + (", ".join(str(c) for c in held) if held else "(none)"),
             )
 
     def _sim_values(self, axes: dict, ranges: dict) -> tuple[float, float, float]:
@@ -1056,11 +1172,19 @@ class ConfigApp:
             y = cy - r * math.cos(a)
             is_top = spoke == 0
             canvas.create_line(
-                cx, cy, x, y, fill="#76b900" if is_top else "#bbb", width=5 if is_top else 3
+                cx,
+                cy,
+                x,
+                y,
+                fill="#76b900" if is_top else "#bbb",
+                width=5 if is_top else 3,
             )
         canvas.create_oval(cx - 8, cy - 8, cx + 8, cy + 8, fill="#555", outline="")
         canvas.create_text(
-            cx, cy + r + 14, fill="#666", text=f"{int(round(steer * _WHEEL_MAX_DEG)):+d}\u00b0"
+            cx,
+            cy + r + 14,
+            fill="#666",
+            text=f"{int(round(steer * _WHEEL_MAX_DEG)):+d}\u00b0",
         )
 
     def _draw_pedal(self, canvas, x: int, value: float, label: str, color: str) -> None:
@@ -1068,14 +1192,33 @@ class ConfigApp:
         value = max(0.0, min(1.0, value))
         canvas.create_rectangle(x, top, x + width, bottom, outline="#999")
         fill_h = value * (bottom - top)
-        canvas.create_rectangle(x, bottom - fill_h, x + width, bottom, fill=color, outline="")
-        canvas.create_text(x + width / 2, top - 8, fill="#666", font=("TkDefaultFont", 8), text=f"{int(value * 100)}%")
-        canvas.create_text(x + width / 2, bottom + 14, fill="#666", font=("TkDefaultFont", 8), text=label)
+        canvas.create_rectangle(
+            x, bottom - fill_h, x + width, bottom, fill=color, outline=""
+        )
+        canvas.create_text(
+            x + width / 2,
+            top - 8,
+            fill="#666",
+            font=("TkDefaultFont", 8),
+            text=f"{int(value * 100)}%",
+        )
+        canvas.create_text(
+            x + width / 2,
+            bottom + 14,
+            fill="#666",
+            font=("TkDefaultFont", 8),
+            text=label,
+        )
 
     def _draw_axis_strip(self, canvas, x0: int, axes: dict, ranges: dict) -> None:
         bar_x, bar_w, row_h = x0 + 52, 150, 16
         canvas.create_text(
-            x0, 6, anchor="w", fill="#888", font=("TkDefaultFont", 8, "bold"), text="Axes"
+            x0,
+            6,
+            anchor="w",
+            fill="#888",
+            font=("TkDefaultFont", 8, "bold"),
+            text="Axes",
         )
         for i, code in enumerate(sorted(ranges)):
             if i >= 8:
@@ -1084,10 +1227,26 @@ class ConfigApp:
             value = axes.get(code, rng.minimum)
             frac = max(0.0, min(1.0, (value - rng.minimum) / rng.span))
             y = 20 + i * row_h
-            canvas.create_text(x0, y, anchor="w", fill="#666", font=("TkFixedFont", 8), text=f"0x{code:02x}")
+            canvas.create_text(
+                x0,
+                y,
+                anchor="w",
+                fill="#666",
+                font=("TkFixedFont", 8),
+                text=f"0x{code:02x}",
+            )
             canvas.create_rectangle(bar_x, y - 5, bar_x + bar_w, y + 5, outline="#aaa")
-            canvas.create_rectangle(bar_x, y - 5, bar_x + frac * bar_w, y + 5, fill="#5a9bd5", outline="")
-            canvas.create_text(bar_x + bar_w + 6, y, anchor="w", fill="#666", font=("TkFixedFont", 8), text=str(value))
+            canvas.create_rectangle(
+                bar_x, y - 5, bar_x + frac * bar_w, y + 5, fill="#5a9bd5", outline=""
+            )
+            canvas.create_text(
+                bar_x + bar_w + 6,
+                y,
+                anchor="w",
+                fill="#666",
+                font=("TkFixedFont", 8),
+                text=str(value),
+            )
 
     def _on_close(self) -> None:
         self._ffb_stop()

--- a/integrations/omnidreams/omnidreams/interactive_drive/input_config/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input_config/app.py
@@ -1,0 +1,1121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tkinter wizard for ``interactive-drive-configuration``.
+
+Walks the user through selecting an input device (steering wheel or game
+controller), calibrating its steering / throttle / brake axes by listening
+to live input, optionally binding reverse / reset buttons and testing force
+feedback, then writing a local profile YAML the demo runtime auto-discovers.
+
+The GUI is intentionally thin: all calibration logic lives in
+:mod:`omnidreams.interactive_drive.input_config.capture` and all profile
+IO in :mod:`omnidreams.interactive_drive.input.wheel_profiles`.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import yaml
+
+from omnidreams.interactive_drive.input.wheel_profiles import (
+    AutocenterFFB,
+    EvdevDevice,
+    apply_steering_curve,
+    delete_profile_file,
+    list_device_axes,
+    load_wheel_profile_files,
+    name_match_strength,
+    profile_filename,
+    save_wheel_profile,
+    scan_evdev_devices,
+    update_profile_file,
+    user_wheel_profiles_dir,
+    wheel_profile_to_yaml_dict,
+)
+from omnidreams.interactive_drive.input_config.capture import (
+    CaptureSession,
+    build_profile,
+    infer_pedal_inverted,
+    infer_steering_invert,
+    peak_from_observed,
+    select_axis_by_span,
+)
+
+try:  # Tkinter is stdlib but needs the system Tk package installed.
+    import tkinter as tk
+    from tkinter import messagebox, ttk
+except ImportError:  # pragma: no cover - exercised only on Tk-less hosts
+    tk = None  # type: ignore[assignment]
+
+# Common absolute-axis code names, purely for nicer labels in the override
+# menu and live readout. Falls back to the raw code for anything unlisted.
+_ABS_NAMES = {
+    0x00: "ABS_X",
+    0x01: "ABS_Y",
+    0x02: "ABS_Z",
+    0x03: "ABS_RX",
+    0x04: "ABS_RY",
+    0x05: "ABS_RZ",
+    0x06: "ABS_THROTTLE",
+    0x07: "ABS_RUDDER",
+    0x08: "ABS_WHEEL",
+    0x09: "ABS_GAS",
+    0x0A: "ABS_BRAKE",
+    0x10: "ABS_HAT0X",
+    0x11: "ABS_HAT0Y",
+}
+
+# Steps whose live panel shows axis activity / status text.
+_AXIS_LIVE_STEPS = ("device", "controls")
+# Max wheel rotation drawn in the live panel, degrees each direction.
+_WHEEL_MAX_DEG = 120.0
+# Live-panel canvas size. Fixed so populating it never reflows the window
+# (which previously shifted the device list under the cursor mid-click).
+_CANVAS_W = 690
+_CANVAS_H = 150
+# Minimum movement (fraction of an axis' full range) before a calibration
+# step auto-binds that axis. The leeway keeps idle jitter or an accidental
+# nudge of a different control from being picked.
+_DETECT_FRACTION = 0.18
+
+
+def _axis_label(code: int) -> str:
+    return f"0x{code:02x} ({_ABS_NAMES.get(code, f'ABS_{code}')})"
+
+
+def _axis_from_label(label: str) -> int:
+    return int(label.split()[0], 16)
+
+
+class ConfigApp:
+    """Wizard controller built around a single ``tk.Tk`` root."""
+
+    def __init__(self, root) -> None:
+        self.root = root
+        self.root.title("interactive-drive input configuration")
+        self.root.geometry("780x740")
+        self.root.minsize(760, 700)
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        self.state: dict = {}
+        self.session: CaptureSession | None = None
+        self.devices: tuple[EvdevDevice, ...] = ()
+        self._ffb: AutocenterFFB | None = None
+        self._saved = False
+        self._step_index = 0
+        # When set to ``(path, profile)`` the editor screen is shown instead
+        # of the new-profile wizard.
+        self._editing: tuple | None = None
+        # Capture coordination: only one axis capture can listen at a time
+        # (they share the session's observed buffer). ``_recording_key`` is
+        # the section currently listening; ``_button_listening`` is the
+        # button binding currently waiting for a press.
+        self._recording_key: str | None = None
+        self._record_buttons: dict = {}
+        self._detect_callbacks: dict = {}
+        self._button_listening: str | None = None
+        self._button_result_vars: dict = {}
+
+        self.device_type_var = tk.StringVar(value="wheel")
+        self.activity_var = tk.StringVar(value="")
+
+        self._build_chrome()
+        self._render()
+        self._tick()
+
+    # -- window chrome ---------------------------------------------------
+
+    def _build_chrome(self) -> None:
+        # Pack the footer and live panel against the bottom FIRST so they
+        # always keep their space. The content area is packed last with
+        # ``expand`` so it gives up room when the window is small, instead
+        # of squeezing the Back/Next buttons off-screen.
+        footer = ttk.Frame(self.root, padding=(16, 10))
+        footer.pack(side="bottom", fill="x")
+        ttk.Button(footer, text="Cancel", command=self._on_close).pack(side="left")
+        self.primary_btn = ttk.Button(footer, text="Next", command=self._on_primary)
+        self.primary_btn.pack(side="right")
+        self.back_btn = ttk.Button(footer, text="Back", command=self._on_back)
+        self.back_btn.pack(side="right", padx=(0, 8))
+
+        live = ttk.LabelFrame(self.root, text="Live inputs", padding=(8, 4))
+        live.pack(side="bottom", fill="x", padx=12, pady=(0, 4))
+        ttk.Label(live, textvariable=self.activity_var, foreground="#2f8f2f").pack(anchor="w")
+        # Fixed-size canvas: a steering-wheel + pedal visualization plus a
+        # compact per-axis activity strip. Its dimensions are fixed, so the
+        # widgets above never shift when it starts drawing on device select.
+        self.live_canvas = tk.Canvas(
+            live, width=_CANVAS_W, height=_CANVAS_H, highlightthickness=0
+        )
+        self.live_canvas.pack(anchor="w")
+
+        header = ttk.Frame(self.root, padding=(16, 10))
+        header.pack(side="top", fill="x")
+        self.title_var = tk.StringVar()
+        ttk.Label(
+            header, textvariable=self.title_var, font=("TkDefaultFont", 15, "bold")
+        ).pack(anchor="w")
+        self.step_var = tk.StringVar()
+        ttk.Label(header, textvariable=self.step_var, foreground="#888").pack(anchor="w")
+
+        self.content = ttk.Frame(self.root, padding=(16, 4))
+        self.content.pack(side="top", fill="both", expand=True)
+
+    def _clear_content(self) -> None:
+        for child in self.content.winfo_children():
+            child.destroy()
+
+    # -- step navigation -------------------------------------------------
+
+    def _steps(self) -> list[str]:
+        steps = ["welcome", "device", "controls", "buttons"]
+        if self.state.get("device_type") == "wheel":
+            steps.append("ffb")
+        steps += ["details", "review"]
+        return steps
+
+    def _current_step(self) -> str:
+        steps = self._steps()
+        return steps[min(self._step_index, len(steps) - 1)]
+
+    def _render(self) -> None:
+        self._clear_content()
+        self._recording_key = None
+        self._record_buttons = {}
+        self._detect_callbacks = {}
+        self._button_listening = None
+        self._button_result_vars = {}
+        if self._editing is not None:
+            self.step_var.set("Editing an existing profile")
+            self.back_btn.state(["!disabled"])
+            self.primary_btn.config(text="Save changes")
+            self._build_edit()
+            return
+        step = self._current_step()
+        steps = self._steps()
+        self.step_var.set(f"Step {self._step_index + 1} of {len(steps)}")
+        self.back_btn.state(["!disabled"] if self._step_index > 0 else ["disabled"])
+        self.primary_btn.config(text="Save profile" if step == "review" else "Next")
+        getattr(self, f"_build_{step}")()
+
+    def _on_primary(self) -> None:
+        if self._saved:
+            self._on_close()
+            return
+        if self._editing is not None:
+            self._save_edit()
+            return
+        step = self._current_step()
+        ok, message = self._validate(step)
+        if not ok:
+            messagebox.showwarning("Not ready", message)
+            return
+        if step == "review":
+            self._save()
+            return
+        self._step_index += 1
+        self._render()
+
+    def _on_back(self) -> None:
+        if self._editing is not None:
+            self._stop_session()
+            self._editing = None
+            self._render()
+            return
+        if self._step_index > 0:
+            self._step_index -= 1
+            self._render()
+
+    # -- steps -----------------------------------------------------------
+
+    def _build_welcome(self) -> None:
+        self.title_var.set("Input device configuration")
+        entries = load_wheel_profile_files(user_wheel_profiles_dir())
+        saved = ttk.LabelFrame(self.content, text="Saved profiles", padding=(10, 6))
+        saved.pack(fill="x", pady=(0, 10))
+        if not entries:
+            ttk.Label(saved, text="No saved profiles yet.").pack(anchor="w")
+        else:
+            for path, profile in entries:
+                row = ttk.Frame(saved)
+                row.pack(fill="x", pady=2)
+                tag = "  [default]" if profile.is_default else ""
+                ttk.Label(row, text=f"{profile.display_name}{tag}", width=30, anchor="w").pack(side="left")
+                ttk.Button(
+                    row, text="Edit", width=6,
+                    command=lambda p=path, pr=profile: self._start_edit(p, pr),
+                ).pack(side="left", padx=2)
+                ttk.Button(
+                    row, text=("Unset default" if profile.is_default else "Make default"),
+                    width=13, command=lambda p=path, pr=profile: self._toggle_default(p, pr),
+                ).pack(side="left", padx=2)
+                ttk.Button(
+                    row, text="Delete", width=7,
+                    command=lambda p=path, pr=profile: self._delete_profile(p, pr),
+                ).pack(side="left", padx=2)
+
+        ttk.Label(
+            self.content, text="Create a new profile", font=("TkDefaultFont", 11, "bold")
+        ).pack(anchor="w", pady=(6, 2))
+        ttk.Label(
+            self.content, wraplength=680, justify="left",
+            text="Pick the device type, then click Next to detect and calibrate it.",
+        ).pack(anchor="w", pady=(0, 6))
+        ttk.Radiobutton(
+            self.content, text="Steering wheel + pedals", value="wheel",
+            variable=self.device_type_var,
+        ).pack(anchor="w")
+        ttk.Radiobutton(
+            self.content, text="Game controller / gamepad (stick + triggers)",
+            value="controller", variable=self.device_type_var,
+        ).pack(anchor="w")
+
+    # -- existing-profile management + editor ---------------------------
+
+    def _refresh_welcome(self) -> None:
+        self._stop_session()
+        self._editing = None
+        self._step_index = 0
+        self._render()
+
+    def _stop_session(self) -> None:
+        if self.session is not None:
+            self.session.stop()
+            self.session = None
+
+    def _start_edit(self, path, profile) -> None:
+        self._editing = (path, profile)
+        self._render()
+
+    def _delete_profile(self, path, profile) -> None:
+        if messagebox.askyesno("Delete profile", f"Delete '{profile.display_name}'?"):
+            delete_profile_file(path)
+            self._refresh_welcome()
+
+    def _toggle_default(self, path, profile) -> None:
+        make_default = not profile.is_default
+        for other_path, other in load_wheel_profile_files(user_wheel_profiles_dir()):
+            if other_path == path:
+                desired = make_default
+            elif make_default:
+                desired = False  # single default: clear the others
+            else:
+                desired = other.is_default
+            if desired != other.is_default:
+                update_profile_file(other_path, replace(other, is_default=desired))
+        self._refresh_welcome()
+
+    def _slider_row(self, label: str, var, low: float, high: float) -> None:
+        row = ttk.Frame(self.content)
+        row.pack(fill="x", pady=2)
+        ttk.Label(row, text=label, width=26, anchor="w").pack(side="left")
+        ttk.Scale(
+            row, from_=low, to=high, orient="horizontal", length=220, variable=var
+        ).pack(side="left", padx=8)
+        value_label = ttk.Label(row, width=5)
+        value_label.pack(side="left")
+
+        def _update(*_args) -> None:
+            value_label.config(text=f"{float(var.get()):.2f}")
+
+        var.trace_add("write", _update)
+        _update()
+
+    def _build_edit(self) -> None:
+        path, profile = self._editing
+        self.title_var.set(f"Edit: {profile.display_name}")
+        self._edit_display_name = tk.StringVar(value=profile.display_name)
+        self._edit_invert_steer = tk.BooleanVar(value=profile.invert_steering)
+        self._edit_invert_pedals = tk.BooleanVar(value=profile.inverted_pedals)
+        self._edit_ffb = tk.BooleanVar(value=profile.ffb_enabled)
+        self._edit_ffb_gain = tk.DoubleVar(value=profile.ffb_gain)
+        self._edit_range = tk.DoubleVar(value=profile.steering_range)
+        self._edit_deadzone = tk.DoubleVar(value=profile.steering_deadzone)
+        self._edit_default = tk.BooleanVar(value=profile.is_default)
+
+        # Open a live session for this profile's connected device so the
+        # steering preview below reflects the deadzone / sensitivity sliders
+        # as you drag them.
+        self._stop_session()
+        device = self._find_profile_device(profile)
+        if device is not None:
+            try:
+                session = CaptureSession(device.path)
+                session.start()
+                self.session = session
+            except OSError:
+                self.session = None
+        ttk.Label(
+            self.content, foreground="#2f8f2f", wraplength=680,
+            text=(
+                f"Live preview from {device.name} -- operate the controls to see the feel."
+                if device is not None
+                else "Connect this device to preview the steering feel live."
+            ),
+        ).pack(anchor="w", pady=(0, 6))
+
+        form = ttk.Frame(self.content)
+        form.pack(fill="x")
+        ttk.Label(form, text="Display name").grid(row=0, column=0, sticky="w", pady=4)
+        ttk.Entry(form, textvariable=self._edit_display_name, width=44).grid(row=0, column=1, sticky="w")
+
+        axis_map = profile.axis_map
+        ttk.Label(
+            self.content, foreground="#666",
+            text=(
+                "Axes (recalibrate by creating a new profile): "
+                f"steering 0x{axis_map.get('steering', 0):02x}, "
+                f"throttle 0x{axis_map.get('throttle', 0):02x}, "
+                f"brake 0x{axis_map.get('brake', 0):02x}"
+            ),
+        ).pack(anchor="w", pady=(4, 6))
+
+        ttk.Checkbutton(self.content, text="Invert steering", variable=self._edit_invert_steer).pack(anchor="w")
+        ttk.Checkbutton(self.content, text="Invert pedals", variable=self._edit_invert_pedals).pack(anchor="w")
+        self._slider_row("Steering range (sensitivity)", self._edit_range, 0.1, 1.0)
+        self._slider_row("Steering deadzone", self._edit_deadzone, 0.0, 0.3)
+        ffb_row = ttk.Frame(self.content)
+        ffb_row.pack(fill="x", pady=2)
+        ttk.Checkbutton(ffb_row, text="Force feedback", variable=self._edit_ffb).pack(side="left")
+        ttk.Scale(
+            ffb_row, from_=0.0, to=1.0, orient="horizontal", length=200, variable=self._edit_ffb_gain
+        ).pack(side="left", padx=8)
+
+        ttk.Label(self.content, text="Detection patterns (one per line):").pack(anchor="w", pady=(6, 0))
+        self._edit_patterns = tk.Text(self.content, height=3, width=60)
+        self._edit_patterns.pack(anchor="w", pady=2)
+        self._edit_patterns.insert("1.0", "\n".join(profile.detection_patterns))
+
+        ttk.Checkbutton(
+            self.content, text="Use as the default profile", variable=self._edit_default
+        ).pack(anchor="w", pady=(6, 0))
+        ttk.Button(
+            self.content, text="Delete this profile",
+            command=lambda: self._delete_profile(path, profile),
+        ).pack(anchor="w", pady=(10, 0))
+
+    def _save_edit(self) -> None:
+        path, profile = self._editing
+        patterns = tuple(
+            line.strip()
+            for line in self._edit_patterns.get("1.0", "end").splitlines()
+            if line.strip()
+        )
+        if not patterns:
+            messagebox.showwarning("Not ready", "Add at least one detection pattern.")
+            return
+        updated = replace(
+            profile,
+            display_name=self._edit_display_name.get().strip() or profile.display_name,
+            invert_steering=bool(self._edit_invert_steer.get()),
+            inverted_pedals=bool(self._edit_invert_pedals.get()),
+            ffb_enabled=bool(self._edit_ffb.get()),
+            ffb_gain=float(self._edit_ffb_gain.get()),
+            steering_range=float(self._edit_range.get()),
+            steering_deadzone=float(self._edit_deadzone.get()),
+            detection_patterns=patterns,
+            is_default=bool(self._edit_default.get()),
+        )
+        update_profile_file(path, updated)
+        if updated.is_default:
+            for other_path, other in load_wheel_profile_files(user_wheel_profiles_dir()):
+                if other_path != path and other.is_default:
+                    update_profile_file(other_path, replace(other, is_default=False))
+        messagebox.showinfo("Saved", f"Updated {path.name}.")
+        self._refresh_welcome()
+
+    def _build_device(self) -> None:
+        self.title_var.set("Select your device")
+        ttk.Label(
+            self.content, wraplength=680, justify="left",
+            text=(
+                "Pick your device, then operate any control -- the Live inputs panel "
+                "below updates so you can confirm you chose the right one (some "
+                "devices expose several nodes). Then click Next."
+            ),
+        ).pack(anchor="w", pady=(0, 8))
+
+        row = ttk.Frame(self.content)
+        row.pack(fill="both", expand=True)
+        self.device_list = tk.Listbox(row, height=7, exportselection=False)
+        self.device_list.pack(side="left", fill="both", expand=True)
+        scroll = ttk.Scrollbar(row, command=self.device_list.yview)
+        scroll.pack(side="right", fill="y")
+        self.device_list.config(yscrollcommand=scroll.set)
+        self.device_list.bind("<<ListboxSelect>>", self._on_device_selected)
+
+        ttk.Button(self.content, text="Rescan", command=self._refresh_devices).pack(
+            anchor="w", pady=8
+        )
+        self._refresh_devices()
+
+    def _refresh_devices(self) -> None:
+        self.devices = scan_evdev_devices()
+        self.device_list.delete(0, "end")
+        for device in self.devices:
+            self.device_list.insert("end", f"{device.name}  [{device.path}]")
+        if not self.devices:
+            self.device_list.insert("end", "(no readable input devices found)")
+
+    def _on_device_selected(self, _event=None) -> None:
+        selection = self.device_list.curselection()
+        if not selection or not self.devices:
+            return
+        device = self.devices[selection[0]]
+        if self.session is not None and self.session.device_path == device.path:
+            return
+        if self.session is not None:
+            self.session.stop()
+            self.session = None
+        session = CaptureSession(device.path)
+        try:
+            session.start()
+        except PermissionError:
+            messagebox.showerror(
+                "Permission denied",
+                f"Cannot read {device.path}.\n\nAdd your user to the 'input' group "
+                "(then log out/in) or add a udev rule, and try again.",
+            )
+            return
+        except OSError as exc:
+            messagebox.showerror("Cannot open device", f"{device.path}: {exc}")
+            return
+        self.session = session
+        self.state["device"] = device
+
+    def _build_controls(self) -> None:
+        self.title_var.set("Calibrate controls")
+        self.invert_pedals_var = tk.BooleanVar(value=self.state.get("inverted_pedals", True))
+        ttk.Label(
+            self.content, wraplength=680, justify="left",
+            text=(
+                "For each control: click Start listening, then move it a little -- "
+                "it auto-detects the axis (one at a time)."
+            ),
+        ).pack(anchor="w", pady=(0, 8))
+
+        is_wheel = self.state.get("device_type") == "wheel"
+        steer = ttk.LabelFrame(self.content, text="Steering", padding=(10, 6))
+        steer.pack(fill="x", pady=3)
+        self._steering_section(steer, "wheel" if is_wheel else "stick")
+        thr = ttk.LabelFrame(self.content, text="Throttle", padding=(10, 6))
+        thr.pack(fill="x", pady=3)
+        self._pedal_section(thr, "throttle", "throttle pedal" if is_wheel else "throttle trigger")
+        brk = ttk.LabelFrame(self.content, text="Brake", padding=(10, 6))
+        brk.pack(fill="x", pady=3)
+        self._pedal_section(brk, "brake", "brake pedal" if is_wheel else "brake trigger")
+        # Single shared pedal-invert flag (the schema stores one for both
+        # pedals). Auto-set from calibration; here as a manual safety net.
+        ttk.Checkbutton(
+            self.content,
+            text="Invert pedals (toggle if pressing throttle/brake reads backwards)",
+            variable=self.invert_pedals_var, command=self._apply_pedal_invert,
+        ).pack(anchor="w", pady=(6, 0))
+
+    def _steering_section(self, parent, control: str) -> None:
+        self.invert_steering_var = tk.BooleanVar(value=self.state.get("invert_steering", False))
+        self._steering_axis_choice = tk.StringVar(value=self.state.get("_steering_axis_label", ""))
+        result = tk.StringVar(value=self.state.get("_steering_summary", ""))
+        ttk.Label(parent, text=f"Click Start, then turn the {control} a little to the LEFT.").pack(anchor="w")
+
+        def on_detect(axis: int, base: int, peak: int) -> None:
+            rng = self.session.axis_ranges[axis]
+            # ``peak`` is the deflected value; if turning left lowered the raw
+            # value the steering sign must be flipped.
+            invert = bool(infer_steering_invert(peak, base))
+            self.state["steering_axis"] = axis
+            self.state["invert_steering"] = invert
+            self.state["_steering_axis_label"] = _axis_label(axis)
+            self.state["_steering_summary"] = (
+                f"Steering on {_axis_label(axis)} (range {rng.minimum}..{rng.maximum}), invert={invert}"
+            )
+            self.invert_steering_var.set(invert)
+            self._steering_axis_choice.set(_axis_label(axis))
+            result.set(self.state["_steering_summary"])
+
+        row = ttk.Frame(parent)
+        row.pack(anchor="w", fill="x", pady=4)
+        self._record_button(row, "steering", on_detect, result)
+        self._axis_override(row, self._steering_axis_choice)
+        ttk.Label(parent, textvariable=result, foreground="#2f6fbf", wraplength=660).pack(anchor="w")
+        ttk.Checkbutton(
+            parent, text="Invert steering (toggle if left/right feels reversed)",
+            variable=self.invert_steering_var, command=self._apply_invert,
+        ).pack(anchor="w")
+
+    def _pedal_section(self, parent, key: str, control: str) -> None:
+        axis_choice = tk.StringVar(value=self.state.get(f"_{key}_axis_label", ""))
+        result = tk.StringVar(value=self.state.get(f"_{key}_summary", ""))
+        setattr(self, f"_{key}_axis_choice", axis_choice)
+        ttk.Label(parent, text=f"Click Start, then press the {control} a little.").pack(anchor="w")
+
+        def on_detect(axis: int, base: int, peak: int) -> None:
+            inverted = bool(infer_pedal_inverted(base, peak))
+            self.state[f"{key}_axis"] = axis
+            self.state[f"{key}_inverted"] = inverted
+            # Throttle defines the shared pedal-invert flag; brake seeds it
+            # only when throttle hasn't been calibrated yet.
+            if key == "throttle" or "throttle_inverted" not in self.state:
+                self.state["inverted_pedals"] = inverted
+                self.invert_pedals_var.set(inverted)
+            self.state[f"_{key}_axis_label"] = _axis_label(axis)
+            self.state[f"_{key}_summary"] = (
+                f"{key.capitalize()} on {_axis_label(axis)} (inverted={inverted})"
+            )
+            axis_choice.set(_axis_label(axis))
+            result.set(self.state[f"_{key}_summary"])
+
+        row = ttk.Frame(parent)
+        row.pack(anchor="w", fill="x", pady=4)
+        self._record_button(row, key, on_detect, result)
+        self._axis_override(row, axis_choice)
+        ttk.Label(parent, textvariable=result, foreground="#2f6fbf", wraplength=660).pack(anchor="w")
+
+    def _record_button(self, parent, key: str, on_detect, result_var) -> None:
+        """A Start/cancel listening toggle.
+
+        Clicking starts listening; the axis auto-binds as soon as one moves
+        past the leeway threshold (handled in :meth:`_tick`), so there is no
+        Stop click. Clicking again before that cancels. Only one section
+        listens at a time, since they share the session's observed buffer.
+        """
+        btn = ttk.Button(parent, text="Start listening")
+        self._record_buttons[key] = btn
+        self._detect_callbacks[key] = on_detect
+
+        def toggle() -> None:
+            if self.session is None:
+                messagebox.showwarning("No device", "Go back and select a device first.")
+                return
+            if self._recording_key == key:
+                self._recording_key = None
+                btn.config(text="Start listening")
+                result_var.set("Cancelled.")
+            else:
+                if self._recording_key is not None:
+                    other = self._record_buttons.get(self._recording_key)
+                    if other is not None:
+                        other.config(text="Start listening")
+                self.session.reset_observed()
+                self._recording_key = key
+                btn.config(text="Listening... (click to cancel)")
+                result_var.set("Move the control a little to bind it.")
+
+        btn.config(command=toggle)
+        btn.pack(side="left")
+
+    def _apply_invert(self) -> None:
+        # Reflect the checkbox in state immediately so the live wheel flips.
+        self.state["invert_steering"] = bool(self.invert_steering_var.get())
+
+    def _apply_pedal_invert(self) -> None:
+        # Reflect the checkbox in state immediately so the live pedal bars flip.
+        self.state["inverted_pedals"] = bool(self.invert_pedals_var.get())
+
+    def _axis_override(self, parent, choice_var) -> None:
+        ttk.Label(parent, text="  Axis:").pack(side="left")
+        codes = sorted(self.session.axis_ranges) if self.session is not None else []
+        labels = [_axis_label(code) for code in codes] or ["(none)"]
+        if not choice_var.get():
+            choice_var.set(labels[0])
+        ttk.OptionMenu(parent, choice_var, choice_var.get(), *labels).pack(side="left", padx=6)
+
+    def _build_buttons(self) -> None:
+        self.title_var.set("Bind buttons (optional)")
+        ttk.Label(
+            self.content, wraplength=680, justify="left",
+            text=(
+                "Optionally bind one button to toggle reverse and one to reset / "
+                "respawn. Click Bind, then press the button on your device. Leave "
+                "unbound to skip -- you can always reset with the R key."
+            ),
+        ).pack(anchor="w", pady=(0, 8))
+        for key, label in (("reverse", "Reverse"), ("reset", "Reset / respawn")):
+            frame = ttk.LabelFrame(self.content, text=label, padding=(10, 6))
+            frame.pack(fill="x", pady=4)
+            result = tk.StringVar(value=self._button_summary(key))
+            self._button_result_vars[key] = result
+            row = ttk.Frame(frame)
+            row.pack(anchor="w", fill="x")
+            ttk.Button(
+                row, text=f"Bind {label.split()[0].lower()} button",
+                command=lambda k=key: self._start_button_listen(k),
+            ).pack(side="left")
+            ttk.Button(row, text="Clear", command=lambda k=key: self._clear_button(k)).pack(
+                side="left", padx=8
+            )
+            ttk.Label(frame, textvariable=result, foreground="#2f6fbf").pack(anchor="w", pady=(4, 0))
+
+    def _button_summary(self, key: str) -> str:
+        codes = self.state.get(f"{key}_buttons", ())
+        return f"Bound to button code {codes[0]}" if codes else "Not bound"
+
+    def _start_button_listen(self, key: str) -> None:
+        if self.session is None:
+            messagebox.showwarning("No device", "Go back and select a device first.")
+            return
+        self.session.reset_observed()
+        self._button_listening = key
+        var = self._button_result_vars.get(key)
+        if var is not None:
+            var.set("Press the button on your device now...")
+
+    def _clear_button(self, key: str) -> None:
+        self.state[f"{key}_buttons"] = ()
+        if self._button_listening == key:
+            self._button_listening = None
+        var = self._button_result_vars.get(key)
+        if var is not None:
+            var.set("Not bound")
+
+    def _build_ffb(self) -> None:
+        self.title_var.set("Force feedback (optional)")
+        self.ffb_enabled_var = tk.BooleanVar(value=self.state.get("ffb_enabled", True))
+        self.ffb_gain_var = tk.DoubleVar(value=self.state.get("ffb_gain", 0.6))
+        ttk.Label(
+            self.content, wraplength=680, justify="left",
+            text=(
+                "Autocenter force feedback makes the wheel resist turning and return "
+                "to center, scaled by speed. Enable it and test the feel; leave it "
+                "off if your device has no autocenter motor."
+            ),
+        ).pack(anchor="w", pady=(0, 10))
+        ttk.Checkbutton(
+            self.content, text="Enable autocenter force feedback",
+            variable=self.ffb_enabled_var,
+        ).pack(anchor="w")
+        gain_row = ttk.Frame(self.content)
+        gain_row.pack(anchor="w", pady=8, fill="x")
+        ttk.Label(gain_row, text="Gain").pack(side="left")
+        ttk.Scale(
+            gain_row, from_=0.0, to=1.0, orient="horizontal", length=300,
+            variable=self.ffb_gain_var,
+        ).pack(side="left", padx=8)
+        test_row = ttk.Frame(self.content)
+        test_row.pack(anchor="w", pady=4)
+        ttk.Button(test_row, text="Test", command=self._ffb_test).pack(side="left")
+        ttk.Button(test_row, text="Stop", command=self._ffb_stop).pack(side="left", padx=8)
+
+    def _ffb_test(self) -> None:
+        if self.session is None:
+            return
+        self._ffb_stop()
+        ffb = AutocenterFFB()
+        ffb.init(self.session.device_path, float(self.ffb_gain_var.get()))
+        if not ffb.available:
+            messagebox.showinfo(
+                "Force feedback unavailable",
+                "Could not open the device for force feedback (it may not support "
+                "autocenter, or write permission is missing).",
+            )
+            return
+        ffb.set_autocenter(float(self.ffb_gain_var.get()))
+        self._ffb = ffb
+
+    def _ffb_stop(self) -> None:
+        if self._ffb is not None:
+            self._ffb.cleanup()
+            self._ffb = None
+
+    def _build_details(self) -> None:
+        self.title_var.set("Settings & detection")
+        device = self.state.get("device")
+        default_name = device.name if device else "My device"
+        controller = self.state.get("device_type") == "controller"
+        self.display_name_var = tk.StringVar(value=self.state.get("display_name", default_name))
+        self.profile_name_var = tk.StringVar(
+            value=self.state.get("name", profile_filename(default_name)[:-5])
+        )
+        self.is_default_var = tk.BooleanVar(value=self.state.get("is_default", True))
+        # Controllers default to a reduced range + small deadzone (sticks are
+        # sensitive and tend to drift); wheels default to full range, none.
+        self.steering_range_var = tk.DoubleVar(
+            value=self.state.get("steering_range", 0.6 if controller else 1.0)
+        )
+        self.steering_deadzone_var = tk.DoubleVar(
+            value=self.state.get("steering_deadzone", 0.08 if controller else 0.0)
+        )
+        # Seed state so the live wheel preview reflects these immediately, and
+        # keep it updated as the sliders move.
+        self.state["steering_range"] = float(self.steering_range_var.get())
+        self.state["steering_deadzone"] = float(self.steering_deadzone_var.get())
+        self.steering_range_var.trace_add(
+            "write",
+            lambda *_: self.state.__setitem__("steering_range", float(self.steering_range_var.get())),
+        )
+        self.steering_deadzone_var.trace_add(
+            "write",
+            lambda *_: self.state.__setitem__("steering_deadzone", float(self.steering_deadzone_var.get())),
+        )
+
+        form = ttk.Frame(self.content)
+        form.pack(fill="x")
+        ttk.Label(form, text="Display name").grid(row=0, column=0, sticky="w", pady=4)
+        ttk.Entry(form, textvariable=self.display_name_var, width=46).grid(row=0, column=1, sticky="w")
+        ttk.Label(form, text="Profile name").grid(row=1, column=0, sticky="w", pady=4)
+        ttk.Entry(form, textvariable=self.profile_name_var, width=46).grid(row=1, column=1, sticky="w")
+
+        ttk.Label(
+            self.content, text="Steering feel (turn the device to preview):"
+        ).pack(anchor="w", pady=(8, 0))
+        self._slider_row("Steering range (sensitivity)", self.steering_range_var, 0.1, 1.0)
+        self._slider_row("Steering deadzone", self.steering_deadzone_var, 0.0, 0.3)
+
+        ttk.Label(
+            self.content, wraplength=680, justify="left",
+            text=(
+                "\nDetection patterns -- one per line. The device is auto-selected at "
+                "launch when its name contains any of these."
+            ),
+        ).pack(anchor="w")
+        self.patterns_text = tk.Text(self.content, height=3, width=62)
+        self.patterns_text.pack(anchor="w", pady=4)
+        existing = self.state.get("detection_patterns")
+        self.patterns_text.insert("1.0", "\n".join(existing) if existing else (device.name if device else ""))
+
+        ttk.Checkbutton(
+            self.content, text="Use as the default profile",
+            variable=self.is_default_var,
+        ).pack(anchor="w", pady=6)
+
+    def _build_review(self) -> None:
+        self.title_var.set("Review and save")
+        profile = self._compose_profile()
+        self.state["_profile"] = profile
+        preview = yaml.safe_dump(
+            wheel_profile_to_yaml_dict(profile), sort_keys=False, default_flow_style=False
+        )
+        ttk.Label(
+            self.content,
+            text=f"Will be written to:\n{user_wheel_profiles_dir() / profile_filename(profile.name)}",
+            justify="left",
+        ).pack(anchor="w", pady=(0, 8))
+        text = tk.Text(self.content, height=15, width=66)
+        text.pack(fill="both", expand=True)
+        text.insert("1.0", preview)
+        text.config(state="disabled")
+
+    # -- validation + compose -------------------------------------------
+
+    def _validate(self, step: str) -> tuple[bool, str]:
+        if step == "welcome":
+            self.state["device_type"] = self.device_type_var.get()
+            return True, ""
+        if step == "device":
+            if self.session is None:
+                return False, "Select a device from the list first."
+            return True, ""
+        if step == "controls":
+            for axis_key, human in (
+                ("steering", "steering"), ("throttle", "throttle"), ("brake", "brake")
+            ):
+                if f"{axis_key}_axis" not in self.state:
+                    return False, f"Calibrate {human} first (Start listening, move it, Stop)."
+            self.state["steering_axis"] = _axis_from_label(self._steering_axis_choice.get())
+            self.state["invert_steering"] = bool(self.invert_steering_var.get())
+            self.state["throttle_axis"] = _axis_from_label(self._throttle_axis_choice.get())
+            self.state["brake_axis"] = _axis_from_label(self._brake_axis_choice.get())
+            self.state["inverted_pedals"] = bool(self.invert_pedals_var.get())
+            return True, ""
+        if step == "buttons":
+            self.state.setdefault("reverse_buttons", ())
+            self.state.setdefault("reset_buttons", ())
+            return True, ""
+        if step == "ffb":
+            self._ffb_stop()
+            self.state["ffb_enabled"] = bool(self.ffb_enabled_var.get())
+            self.state["ffb_gain"] = float(self.ffb_gain_var.get())
+            return True, ""
+        if step == "details":
+            name = self.profile_name_var.get().strip()
+            if not name:
+                return False, "Profile name cannot be empty."
+            patterns = [
+                line.strip()
+                for line in self.patterns_text.get("1.0", "end").splitlines()
+                if line.strip()
+            ]
+            if not patterns:
+                return False, "Add at least one detection pattern."
+            self.state["name"] = name
+            self.state["display_name"] = self.display_name_var.get().strip() or name
+            self.state["detection_patterns"] = tuple(patterns)
+            self.state["is_default"] = bool(self.is_default_var.get())
+            self.state["steering_range"] = float(self.steering_range_var.get())
+            self.state["steering_deadzone"] = float(self.steering_deadzone_var.get())
+            return True, ""
+        return True, ""
+
+    def _compose_profile(self):
+        if self.state.get("device_type") == "controller":
+            ffb_enabled, ffb_gain = False, 0.0
+        else:
+            ffb_enabled = bool(self.state.get("ffb_enabled", False))
+            ffb_gain = float(self.state.get("ffb_gain", 0.0))
+        return build_profile(
+            name=self.state["name"],
+            display_name=self.state["display_name"],
+            detection_patterns=self.state["detection_patterns"],
+            steering_axis=self.state["steering_axis"],
+            throttle_axis=self.state["throttle_axis"],
+            brake_axis=self.state["brake_axis"],
+            invert_steering=self.state["invert_steering"],
+            inverted_pedals=bool(self.state.get("inverted_pedals", True)),
+            ffb_enabled=ffb_enabled,
+            ffb_gain=ffb_gain,
+            is_default=self.state["is_default"],
+            reverse_buttons=tuple(self.state.get("reverse_buttons", ())),
+            reset_buttons=tuple(self.state.get("reset_buttons", ())),
+            steering_range=float(self.state.get("steering_range", 1.0)),
+            steering_deadzone=float(self.state.get("steering_deadzone", 0.0)),
+        )
+
+    def _save(self) -> None:
+        profile = self.state.get("_profile") or self._compose_profile()
+        brake_inverted = self.state.get("brake_inverted")
+        if brake_inverted is not None and brake_inverted != profile.inverted_pedals:
+            if not messagebox.askyesno(
+                "Pedal direction mismatch",
+                "Throttle and brake appear to rest in opposite directions, but the "
+                "profile stores a single shared 'Invert pedals' setting. Check that "
+                "checkbox matches your throttle. Save anyway?",
+            ):
+                return
+        try:
+            path = save_wheel_profile(profile, user_wheel_profiles_dir())
+        except OSError as exc:
+            messagebox.showerror("Could not save", str(exc))
+            return
+        self._saved = True
+        self.primary_btn.config(text="Close")
+        self.back_btn.state(["disabled"])
+        messagebox.showinfo(
+            "Profile saved",
+            f"Saved to:\n{path}\n\nLaunch the demo with:\n"
+            "uv run --package flashdreams-omnidreams interactive-drive",
+        )
+
+    # -- live loop + teardown -------------------------------------------
+
+    def _tick(self) -> None:
+        if self.session is not None and self._button_listening is not None:
+            pressed = self.session.pressed_buttons()
+            if pressed:
+                code = min(pressed)
+                key = self._button_listening
+                self.state[f"{key}_buttons"] = (code,)
+                self._button_listening = None
+                var = self._button_result_vars.get(key)
+                if var is not None:
+                    var.set(f"Bound to button code {code}")
+        if self.session is not None and self._recording_key is not None:
+            axis = select_axis_by_span(
+                self.session.observed_ranges(),
+                self.session.axis_ranges,
+                min_fraction=_DETECT_FRACTION,
+            )
+            if axis is not None:
+                key = self._recording_key
+                self._recording_key = None
+                button = self._record_buttons.get(key)
+                if button is not None:
+                    button.config(text="Start listening")
+                observed = self.session.observed_ranges()
+                base = self.session.baseline().get(
+                    axis, int(self.session.axis_ranges[axis].center)
+                )
+                peak = peak_from_observed(observed[axis], base)
+                callback = self._detect_callbacks.get(key)
+                if callback is not None:
+                    callback(axis, base, peak)
+        self._draw_live()
+        self.root.after(60, self._tick)
+
+    # -- live wheel / pedal / axis visualization ------------------------
+
+    def _find_profile_device(self, profile):
+        """Best connected device matching *profile* (exact name preferred)."""
+        required = {int(axis) for axis in profile.axis_map.values()}
+        best = None  # (strength, device)
+        for device in scan_evdev_devices():
+            if not required.issubset(set(list_device_axes(device.path))):
+                continue
+            strength = name_match_strength(device.name, profile.detection_patterns)
+            if strength > 0 and (best is None or strength > best[0]):
+                best = (strength, device)
+        return best[1] if best is not None else None
+
+    def _live_config(self) -> dict:
+        """Axis map + steering feel source for the live preview.
+
+        In the editor it reads the edit widgets, so dragging the deadzone /
+        range sliders updates the preview immediately; otherwise it's the
+        new-profile wizard state.
+        """
+        if self._editing is not None and hasattr(self, "_edit_range"):
+            _path, profile = self._editing
+            return {
+                "steering_axis": profile.axis_map.get("steering"),
+                "throttle_axis": profile.axis_map.get("throttle"),
+                "brake_axis": profile.axis_map.get("brake"),
+                "invert_steering": bool(self._edit_invert_steer.get()),
+                "inverted_pedals": bool(self._edit_invert_pedals.get()),
+                "steering_range": float(self._edit_range.get()),
+                "steering_deadzone": float(self._edit_deadzone.get()),
+            }
+        return self.state
+
+    def _draw_live(self) -> None:
+        canvas = self.live_canvas
+        canvas.delete("all")
+        if self.session is None:
+            self.activity_var.set("")
+            return
+        editing = self._editing is not None
+        step = self._current_step()
+        if not editing and step in ("welcome", "review"):
+            self.activity_var.set("")
+            return
+        if editing:
+            self.activity_var.set("Move the stick / wheel to preview the steering feel")
+        elif step == "buttons":
+            self.activity_var.set(
+                "Press the button on your device..." if self._button_listening else ""
+            )
+        elif step in _AXIS_LIVE_STEPS:
+            if self._recording_key is not None:
+                self.activity_var.set("Listening -- move the control...")
+            elif self.session.is_active():
+                self.activity_var.set("Activity detected")
+            else:
+                self.activity_var.set("Operate a control to see it move")
+        else:
+            self.activity_var.set("")
+
+        axes = self.session.axes()
+        ranges = self.session.axis_ranges
+        steer, throttle, brake = self._sim_values(axes, ranges)
+        self._draw_wheel(canvas, 78, 70, 56, steer)
+        self._draw_pedal(canvas, 168, throttle, "Throttle", "#76b900")
+        self._draw_pedal(canvas, 226, brake, "Brake", "#d05a5a")
+        self._draw_axis_strip(canvas, 300, axes, ranges)
+        if not editing and step == "buttons":
+            held = sorted(c for c, v in self.session.buttons().items() if v == 1)
+            canvas.create_text(
+                10, _CANVAS_H - 8, anchor="w", fill="#666", font=("TkFixedFont", 8),
+                text="Buttons held: " + (", ".join(str(c) for c in held) if held else "(none)"),
+            )
+
+    def _sim_values(self, axes: dict, ranges: dict) -> tuple[float, float, float]:
+        """Normalized (steer, throttle, brake) from the active config source.
+
+        Unmapped controls read as neutral; the steering curve (deadzone +
+        sensitivity) is applied so the preview matches what the runtime does.
+        """
+        cfg = self._live_config()
+        steer = throttle = brake = 0.0
+        steer_axis = cfg.get("steering_axis")
+        if steer_axis is not None and steer_axis in ranges and steer_axis in axes:
+            rng = ranges[steer_axis]
+            value = (axes[steer_axis] - rng.center) / (rng.span / 2.0)
+            if cfg.get("invert_steering"):
+                value = -value
+            steer = apply_steering_curve(
+                value,
+                deadzone=float(cfg.get("steering_deadzone", 0.0) or 0.0),
+                scale=float(cfg.get("steering_range", 1.0) or 1.0),
+            )
+        for key in ("throttle", "brake"):
+            axis = cfg.get(f"{key}_axis")
+            if axis is None or axis not in ranges or axis not in axes:
+                continue
+            rng = ranges[axis]
+            if cfg.get("inverted_pedals", True):
+                value = (rng.maximum - axes[axis]) / rng.span
+            else:
+                value = (axes[axis] - rng.minimum) / rng.span
+            value = max(0.0, min(1.0, value))
+            if key == "throttle":
+                throttle = value
+            else:
+                brake = value
+        return steer, throttle, brake
+
+    def _draw_wheel(self, canvas, cx: int, cy: int, r: int, steer: float) -> None:
+        canvas.create_oval(cx - r, cy - r, cx + r, cy + r, outline="#999", width=5)
+        # Positive steer = left, which reads as a counter-clockwise turn.
+        angle = math.radians(-steer * _WHEEL_MAX_DEG)
+        for spoke in range(3):
+            a = angle + spoke * (2.0 * math.pi / 3.0)
+            x = cx + r * math.sin(a)
+            y = cy - r * math.cos(a)
+            is_top = spoke == 0
+            canvas.create_line(
+                cx, cy, x, y, fill="#76b900" if is_top else "#bbb", width=5 if is_top else 3
+            )
+        canvas.create_oval(cx - 8, cy - 8, cx + 8, cy + 8, fill="#555", outline="")
+        canvas.create_text(
+            cx, cy + r + 14, fill="#666", text=f"{int(round(steer * _WHEEL_MAX_DEG)):+d}\u00b0"
+        )
+
+    def _draw_pedal(self, canvas, x: int, value: float, label: str, color: str) -> None:
+        top, bottom, width = 16, 118, 34
+        value = max(0.0, min(1.0, value))
+        canvas.create_rectangle(x, top, x + width, bottom, outline="#999")
+        fill_h = value * (bottom - top)
+        canvas.create_rectangle(x, bottom - fill_h, x + width, bottom, fill=color, outline="")
+        canvas.create_text(x + width / 2, top - 8, fill="#666", font=("TkDefaultFont", 8), text=f"{int(value * 100)}%")
+        canvas.create_text(x + width / 2, bottom + 14, fill="#666", font=("TkDefaultFont", 8), text=label)
+
+    def _draw_axis_strip(self, canvas, x0: int, axes: dict, ranges: dict) -> None:
+        bar_x, bar_w, row_h = x0 + 52, 150, 16
+        canvas.create_text(
+            x0, 6, anchor="w", fill="#888", font=("TkDefaultFont", 8, "bold"), text="Axes"
+        )
+        for i, code in enumerate(sorted(ranges)):
+            if i >= 8:
+                break
+            rng = ranges[code]
+            value = axes.get(code, rng.minimum)
+            frac = max(0.0, min(1.0, (value - rng.minimum) / rng.span))
+            y = 20 + i * row_h
+            canvas.create_text(x0, y, anchor="w", fill="#666", font=("TkFixedFont", 8), text=f"0x{code:02x}")
+            canvas.create_rectangle(bar_x, y - 5, bar_x + bar_w, y + 5, outline="#aaa")
+            canvas.create_rectangle(bar_x, y - 5, bar_x + frac * bar_w, y + 5, fill="#5a9bd5", outline="")
+            canvas.create_text(bar_x + bar_w + 6, y, anchor="w", fill="#666", font=("TkFixedFont", 8), text=str(value))
+
+    def _on_close(self) -> None:
+        self._ffb_stop()
+        if self.session is not None:
+            self.session.stop()
+            self.session = None
+        self.root.destroy()
+
+
+def main() -> None:
+    if not sys.platform.startswith("linux") or not Path("/dev/input").exists():
+        print(
+            "interactive-drive-configuration requires Linux with evdev input "
+            "devices under /dev/input.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if tk is None:
+        print(
+            "Tkinter is not available. Install your platform's Tk package "
+            "(e.g. 'sudo apt-get install python3-tk') and retry.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    root = tk.Tk()
+    ConfigApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/omnidreams/omnidreams/interactive_drive/input_config/capture.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input_config/capture.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Device-agnostic evdev capture + calibration inference.
+
+This module has no GUI dependency so it can be unit-tested without
+hardware. It works identically for a steering wheel (pedals that rest at
+their axis maximum) and a game controller (analog stick + triggers that
+rest at zero) -- the difference is captured, not coded.
+
+Capture model: the UI starts a *listening* window (``reset_observed``),
+the user operates a control, and the session keeps a running min/max
+(peak-hold) per axis plus the first significant deflection. Reading the
+result on stop -- rather than snapshotting after the user lets go -- is
+what makes self-centering sticks and force-feedback wheels work: the
+extreme is retained even though the control springs back before the user
+can click.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import struct
+import threading
+import time
+from pathlib import Path
+
+from omnidreams.interactive_drive.input.wheel_profiles import (
+    EV_ABS,
+    EV_KEY,
+    EVDEV_EVENT_FORMAT,
+    EVDEV_EVENT_SIZE,
+    AxisRange,
+    WheelProfile,
+    read_axis_states,
+)
+
+# An axis must move at least this fraction of its full range to count as
+# "the control the user operated". Keeps idle jitter / unrelated axes from
+# being mistaken for the intended one.
+MIN_MOVE_FRACTION = 0.15
+# A deflection this far from the resting value (as a fraction of full
+# range) is recorded as the "first significant" move, used to tell which
+# physical direction the user pushed first (for steering invert).
+FIRST_DEFLECTION_FRACTION = 0.20
+
+
+def select_axis_by_span(
+    observed: dict[int, AxisRange],
+    axis_ranges: dict[int, AxisRange],
+    *,
+    min_fraction: float = MIN_MOVE_FRACTION,
+) -> int | None:
+    """Return the axis that moved the most during a listening window.
+
+    Movement is the observed span as a fraction of the axis' full device
+    range, so axes with different raw scales (an 8-bit trigger vs a 16-bit
+    wheel) compare fairly. ``None`` if nothing moved beyond *min_fraction*.
+    """
+    best_code: int | None = None
+    best_fraction = 0.0
+    for code, observed_range in observed.items():
+        full = axis_ranges.get(code)
+        span = full.span if full is not None else 65535.0
+        fraction = observed_range.span / span
+        if fraction > best_fraction:
+            best_fraction = fraction
+            best_code = code
+    return best_code if best_fraction >= min_fraction else None
+
+
+def peak_from_observed(observed_range: AxisRange, reference: float) -> int:
+    """Return the observed extreme farthest from *reference*.
+
+    For a pedal/trigger this is the fully-engaged value relative to its
+    resting baseline; for steering it is the held extreme relative to the
+    axis center.
+    """
+    low, high = observed_range.minimum, observed_range.maximum
+    return low if abs(low - reference) >= abs(high - reference) else high
+
+
+def detect_moved_axis(
+    before: dict[int, int],
+    after: dict[int, int],
+    axis_ranges: dict[int, AxisRange],
+    *,
+    min_fraction: float = MIN_MOVE_FRACTION,
+) -> int | None:
+    """Return the axis with the largest fractional change between two samples.
+
+    Snapshot-based helper retained for completeness/tests; the wizard uses
+    the peak-hold flow (:func:`select_axis_by_span`) instead.
+    """
+    best_code: int | None = None
+    best_fraction = 0.0
+    for code in set(before) | set(after):
+        if code not in before or code not in after:
+            continue
+        rng = axis_ranges.get(code)
+        span = rng.span if rng is not None else 65535.0
+        fraction = abs(after[code] - before[code]) / span
+        if fraction > best_fraction:
+            best_fraction = fraction
+            best_code = code
+    return best_code if best_fraction >= min_fraction else None
+
+
+def infer_steering_invert(left_raw: float, right_raw: float) -> bool:
+    """Whether steering must be inverted so full-left reads as positive steer.
+
+    Pass the full-left raw value and either the full-right raw value or the
+    axis center as the reference: if full-left is the lower value the sign
+    must be flipped (``command_from_snapshot`` treats positive steer as
+    left).
+    """
+    return left_raw < right_raw
+
+
+def infer_pedal_inverted(rest_raw: int, pressed_raw: int) -> bool:
+    """Whether a pedal/trigger rests high and falls when engaged.
+
+    ``True`` for wheel pedals (rest at axis max, pressed toward min);
+    ``False`` for controller triggers (rest at 0, pressed toward max).
+    """
+    return pressed_raw < rest_raw
+
+
+def build_profile(
+    *,
+    name: str,
+    display_name: str,
+    detection_patterns: tuple[str, ...],
+    steering_axis: int,
+    throttle_axis: int,
+    brake_axis: int,
+    invert_steering: bool,
+    inverted_pedals: bool,
+    ffb_enabled: bool,
+    ffb_gain: float,
+    is_default: bool,
+    reverse_buttons: tuple[int, ...] = (),
+    reset_buttons: tuple[int, ...] = (),
+    steering_range: float = 1.0,
+    steering_deadzone: float = 0.0,
+    threshold: float = 0.12,
+) -> WheelProfile:
+    """Assemble captured calibration values into a :class:`WheelProfile`."""
+    return WheelProfile(
+        name=name,
+        display_name=display_name,
+        detection_patterns=tuple(detection_patterns),
+        axis_map={
+            "steering": int(steering_axis),
+            "throttle": int(throttle_axis),
+            "brake": int(brake_axis),
+        },
+        inverted_pedals=bool(inverted_pedals),
+        invert_steering=bool(invert_steering),
+        ffb_enabled=bool(ffb_enabled),
+        ffb_gain=float(ffb_gain),
+        threshold=float(threshold),
+        is_default=bool(is_default),
+        reverse_buttons=tuple(int(b) for b in reverse_buttons),
+        reset_buttons=tuple(int(b) for b in reset_buttons),
+        steering_range=float(steering_range),
+        steering_deadzone=float(steering_deadzone),
+    )
+
+
+class CaptureSession:
+    """Background reader for a single evdev device.
+
+    On construction it seeds the current value and min/max range of every
+    absolute axis from ``EVIOCGABS`` so the UI can show all inputs live
+    immediately. During a listening window it keeps a running min/max
+    (peak-hold) and the first significant deflection per axis.
+    """
+
+    def __init__(self, device_path: Path) -> None:
+        self._device_path = Path(device_path)
+        self._lock = threading.Lock()
+        states = read_axis_states(self._device_path)
+        self._axis_ranges: dict[int, AxisRange] = {
+            code: rng for code, (_value, rng) in states.items()
+        }
+        self._raw_axes: dict[int, int] = {
+            code: value for code, (value, _rng) in states.items()
+        }
+        self._raw_buttons: dict[int, int] = {}
+        self._pressed_buttons: set[int] = set()
+        self._observed: dict[int, list[int]] = {}
+        self._baseline: dict[int, int] = dict(self._raw_axes)
+        self._first_big: dict[int, int] = {}
+        self._last_event_t = 0.0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._fd: int | None = None
+
+    @property
+    def device_path(self) -> Path:
+        return self._device_path
+
+    @property
+    def axis_ranges(self) -> dict[int, AxisRange]:
+        return dict(self._axis_ranges)
+
+    def start(self) -> None:
+        """Open the device and start the reader thread.
+
+        Raises ``OSError`` (e.g. ``PermissionError``) if the device cannot
+        be opened, so the caller can show actionable guidance.
+        """
+        self._fd = os.open(self._device_path, os.O_RDONLY | os.O_NONBLOCK)
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="input-config-capture", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = None
+
+    def _run(self) -> None:
+        fd = self._fd
+        if fd is None:
+            return
+        while not self._stop.is_set():
+            try:
+                readable, _, _ = select.select([fd], [], [], 0.02)
+            except OSError:
+                break
+            if readable:
+                self._read_events(fd)
+
+    def _read_events(self, fd: int) -> None:
+        try:
+            data = os.read(fd, EVDEV_EVENT_SIZE * 64)
+        except (BlockingIOError, OSError):
+            return
+        now = time.monotonic()
+        with self._lock:
+            for offset in range(0, len(data) - EVDEV_EVENT_SIZE + 1, EVDEV_EVENT_SIZE):
+                _, _, event_type, code, value = struct.unpack(
+                    EVDEV_EVENT_FORMAT, data[offset : offset + EVDEV_EVENT_SIZE]
+                )
+                code = int(code)
+                value = int(value)
+                if event_type == EV_ABS:
+                    self._raw_axes[code] = value
+                    bounds = self._observed.get(code)
+                    if bounds is None:
+                        self._observed[code] = [value, value]
+                    else:
+                        bounds[0] = min(bounds[0], value)
+                        bounds[1] = max(bounds[1], value)
+                    if code not in self._first_big:
+                        rng = self._axis_ranges.get(code)
+                        span = rng.span if rng is not None else 65535.0
+                        base = self._baseline.get(code, value)
+                        if abs(value - base) > FIRST_DEFLECTION_FRACTION * span:
+                            self._first_big[code] = value
+                    self._last_event_t = now
+                elif event_type == EV_KEY:
+                    self._raw_buttons[code] = value
+                    if value == 1:
+                        self._pressed_buttons.add(code)
+                    self._last_event_t = now
+
+    def axes(self) -> dict[int, int]:
+        with self._lock:
+            return dict(self._raw_axes)
+
+    def buttons(self) -> dict[int, int]:
+        with self._lock:
+            return dict(self._raw_buttons)
+
+    def reset_observed(self) -> None:
+        """Begin a fresh listening window from the current resting values."""
+        with self._lock:
+            self._observed = {}
+            self._first_big = {}
+            self._pressed_buttons = set()
+            self._baseline = dict(self._raw_axes)
+
+    def pressed_buttons(self) -> set[int]:
+        """Button codes (EV_KEY) pressed since the last :meth:`reset_observed`."""
+        with self._lock:
+            return set(self._pressed_buttons)
+
+    def observed_ranges(self) -> dict[int, AxisRange]:
+        with self._lock:
+            return {
+                code: AxisRange(minimum=bounds[0], maximum=bounds[1])
+                for code, bounds in self._observed.items()
+            }
+
+    def baseline(self) -> dict[int, int]:
+        """Resting values captured at the start of the listening window."""
+        with self._lock:
+            return dict(self._baseline)
+
+    def first_big(self) -> dict[int, int]:
+        """First significant deflection value per axis during the window."""
+        with self._lock:
+            return dict(self._first_big)
+
+    def is_active(self, window_s: float = 0.4) -> bool:
+        with self._lock:
+            if not self._last_event_t:
+                return False
+            return (time.monotonic() - self._last_event_t) < window_s

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -246,15 +246,20 @@ class KeyboardStateDriveSink:
     def __init__(self, keyboard: KeyboardState) -> None:
         self._keyboard = keyboard
 
-    def set_drive(self, *, steer: float, throttle: float, brake: float) -> None:
+    def set_drive(
+        self, *, steer: float, throttle: float, brake: float, reverse: bool = False
+    ) -> None:
         # ``manual_control`` + ``steer_is_direct`` mirror what the
         # MJPEG-era ``_apply_drive_control`` set so the engine state
         # is byte-identical regardless of which transport drove it.
+        # ``reverse`` is set by a wheel/controller's bound reverse button
+        # (the keyboard path leaves it at the default ``False``).
         self._keyboard.set_drive_command(
             DriverCommand(
                 throttle=max(0.0, min(1.0, throttle)),
                 brake=max(0.0, min(1.0, brake)),
                 steer=max(-1.0, min(1.0, steer)),
+                reverse=bool(reverse),
                 steer_is_direct=True,
                 manual_control=True,
             )
@@ -262,6 +267,11 @@ class KeyboardStateDriveSink:
 
     def release_all(self) -> None:
         self._keyboard.set_drive_command(None)
+
+    def request_reset(self) -> None:
+        # Lets a wheel/controller's bound reset button trigger the same
+        # rollout reset the ``R`` key does.
+        self._keyboard.request_reset()
 
     # The methods below are no-ops in-process because the slangpy HUD
     # writes pygame-style key events directly to ``KeyboardState`` from

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -1439,6 +1439,22 @@ class SlangPyHudPresenter:
         speed_y = variant_y + bar_h + 12
         self._draw_speed(canvas, draw, center_x, speed_y, int(self._speed_mph))
 
+        # Light the reverse indicator red when reverse is engaged; the cached
+        # chrome only draws the inactive grey "R" box at the same spot.
+        if getattr(wheel_state, "reverse", False):
+            rx0, ry0 = px + 14, speed_y + 70
+            draw.rounded_rectangle(
+                (rx0, ry0, px + 54, speed_y + 102), radius=5, fill=(200, 60, 60, 255)
+            )
+            rbox = _measure_text(self._font_tiny, "R")
+            rw, rh = rbox[2] - rbox[0], rbox[3] - rbox[1]
+            draw.text(
+                (rx0 + (40 - rw) // 2 - rbox[0], ry0 + (32 - rh) // 2 - rbox[1]),
+                "R",
+                fill=(255, 255, 255),
+                font=self._font_tiny,
+            )
+
         wheel_center = (center_x, speed_y + 185)
         self._draw_wheel(canvas, draw, wheel_center, 112, wheel_state.steering)
 
@@ -2069,7 +2085,10 @@ class SlangPyHudPresenter:
         return None
 
     def _update_speed(self, wheel_state: Any) -> None:
-        target_mph = wheel_state.target_speed_mps * 2.2369362920544
+        # Magnitude: the digit shows speed, and reverse is conveyed by the
+        # "R" indicator, so a reverse target reads as a positive number that
+        # dips to 0 at the direction change.
+        target_mph = abs(wheel_state.target_speed_mps) * 2.2369362920544
         delta = target_mph - self._speed_mph
         self._speed_mph += delta * 0.18
 

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -90,6 +90,11 @@ omnidreams-prepare = "omnidreams.prepare:main"
 # presenter import fails fast with a clear message.
 interactive-drive = "omnidreams.interactive_drive.demo:main"
 
+# Tkinter wizard that calibrates a connected steering wheel or game
+# controller and writes a local input profile the demo auto-discovers.
+# Stdlib-only (Tkinter); does not need the ``interactive-drive`` extra.
+interactive-drive-configuration = "omnidreams.interactive_drive.input_config.app:main"
+
 # Each entry registers one ``runner_name`` slug with ``flashdreams-run``.
 # The discovery layer (``flashdreams.plugins.registry.discover_runners``)
 # scans this group at CLI startup; the entry-point name itself is purely

--- a/integrations/omnidreams/tests/interactive_drive/test_input_config_capture.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_input_config_capture.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Calibration inference for the configuration tool.
+
+These are pure-function tests (no hardware): the same logic must classify a
+steering wheel (pedals resting at axis max) and a game controller (triggers
+resting at zero) correctly from captured raw samples.
+"""
+
+from __future__ import annotations
+
+from omnidreams.interactive_drive.input.wheel_profiles import AxisRange
+from omnidreams.interactive_drive.input_config.capture import (
+    build_profile,
+    detect_moved_axis,
+    infer_pedal_inverted,
+    infer_steering_invert,
+    peak_from_observed,
+    select_axis_by_span,
+)
+
+# A wheel-like steering axis (16-bit) plus two trigger/pedal-like axes (8-bit).
+RANGES = {
+    0x00: AxisRange(0, 65535),
+    0x02: AxisRange(0, 255),
+    0x05: AxisRange(0, 255),
+}
+
+
+def test_detect_moved_axis_picks_the_operated_control() -> None:
+    before = {0x00: 32768, 0x02: 0, 0x05: 0}
+    after = {0x00: 33000, 0x02: 255, 0x05: 5}
+    assert detect_moved_axis(before, after, RANGES) == 0x02
+
+
+def test_detect_moved_axis_ignores_idle_jitter() -> None:
+    before = {0x00: 32768, 0x02: 10}
+    after = {0x00: 32770, 0x02: 12}
+    assert detect_moved_axis(before, after, RANGES) is None
+
+
+def test_detect_moved_axis_normalizes_across_axis_scales() -> None:
+    # 0x00 moves 5000/65535 (~7.6%, below threshold); 0x02 moves 200/255 (~78%).
+    before = {0x00: 30000, 0x02: 0}
+    after = {0x00: 35000, 0x02: 200}
+    assert detect_moved_axis(before, after, RANGES) == 0x02
+
+
+def test_steering_invert_depends_on_which_extreme_is_lower() -> None:
+    # Full-left is the lower raw value -> sign must be flipped (invert).
+    assert infer_steering_invert(left_raw=100, right_raw=60000) is True
+    # Full-left is the higher raw value -> already correct (no invert).
+    assert infer_steering_invert(left_raw=60000, right_raw=100) is False
+
+
+def test_pedal_inverted_true_for_wheel_pedal() -> None:
+    # Wheel pedal rests at axis maximum and falls toward zero when pressed.
+    assert infer_pedal_inverted(rest_raw=65535, pressed_raw=0) is True
+
+
+def test_pedal_inverted_false_for_controller_trigger() -> None:
+    # Controller trigger rests at zero and rises when pressed.
+    assert infer_pedal_inverted(rest_raw=0, pressed_raw=255) is False
+
+
+def test_select_axis_by_span_picks_widest_relative_movement() -> None:
+    # 0x00 span 5000/65535 (~7.6%) vs 0x02 span 255/255 (100%).
+    observed = {0x00: AxisRange(30000, 35000), 0x02: AxisRange(0, 255)}
+    assert select_axis_by_span(observed, RANGES) == 0x02
+
+
+def test_select_axis_by_span_none_below_threshold() -> None:
+    observed = {0x00: AxisRange(32000, 33000)}  # 1000/65535 ~1.5%
+    assert select_axis_by_span(observed, RANGES) is None
+
+
+def test_peak_from_observed_returns_far_extreme() -> None:
+    # Controller trigger (rest 0): pressed peak is the high extreme.
+    assert peak_from_observed(AxisRange(0, 255), reference=0) == 255
+    # Wheel pedal (rest at max): pressed peak is the low extreme.
+    assert peak_from_observed(AxisRange(0, 65535), reference=65535) == 0
+    # Steering held left, center reference: the lower extreme is farther.
+    assert peak_from_observed(AxisRange(100, 60000), reference=32767.5) == 100
+
+
+def test_build_profile_assembles_axis_map_and_flags() -> None:
+    profile = build_profile(
+        name="my-gamepad",
+        display_name="Game controller",
+        detection_patterns=("Generic Gamepad",),
+        steering_axis=0x00,
+        throttle_axis=0x05,
+        brake_axis=0x02,
+        invert_steering=False,
+        inverted_pedals=False,
+        ffb_enabled=False,
+        ffb_gain=0.0,
+        is_default=False,
+        reverse_buttons=(304,),
+        reset_buttons=(305,),
+    )
+    assert profile.axis_map == {"steering": 0x00, "throttle": 0x05, "brake": 0x02}
+    assert profile.inverted_pedals is False
+    assert profile.ffb_enabled is False
+    assert profile.detection_patterns == ("Generic Gamepad",)
+    assert profile.reverse_buttons == (304,)
+    assert profile.reset_buttons == (305,)

--- a/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
@@ -128,11 +128,14 @@ def test_name_match_strength_prefers_exact() -> None:
     # sibling motion-sensor node whose name merely contains the pattern.
     assert name_match_strength("Wireless Controller", ["Wireless Controller"]) == 2
     assert (
-        name_match_strength("Wireless Controller Motion Sensors", ["Wireless Controller"])
+        name_match_strength(
+            "Wireless Controller Motion Sensors", ["Wireless Controller"]
+        )
         == 1
     )
     assert (
-        name_match_strength("Wireless Controller Touchpad", ["Wireless Controller"]) == 1
+        name_match_strength("Wireless Controller Touchpad", ["Wireless Controller"])
+        == 1
     )
     # Substring patterns still work for longer names; case-insensitive.
     assert name_match_strength("Generic Racing Wheel FFB", ["Racing Wheel"]) == 1

--- a/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Profile serialization, round-tripping, and the user profiles directory.
+
+The configuration tool's output must parse back to an identical profile via
+the same loader the demo runtime uses, so the round-trip guarantee is the
+key correctness contract here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from omnidreams.interactive_drive.input.wheel_profiles import (
+    WheelProfile,
+    apply_steering_curve,
+    delete_profile_file,
+    load_wheel_profile_files,
+    load_wheel_profiles,
+    name_match_strength,
+    profile_filename,
+    save_wheel_profile,
+    update_profile_file,
+    user_wheel_profiles_dir,
+    wheel_profile_to_yaml_dict,
+)
+
+
+def _wheel_profile() -> WheelProfile:
+    return WheelProfile(
+        name="my-wheel",
+        display_name="Racing wheel",
+        detection_patterns=("Generic Racing Wheel",),
+        axis_map={"steering": 0x00, "throttle": 0x02, "brake": 0x05},
+        inverted_pedals=True,
+        invert_steering=True,
+        ffb_enabled=True,
+        ffb_gain=0.6,
+        threshold=0.12,
+        is_default=True,
+        reverse_buttons=(294,),
+        reset_buttons=(300,),
+        steering_range=0.7,
+        steering_deadzone=0.1,
+    )
+
+
+def _controller_profile() -> WheelProfile:
+    return WheelProfile(
+        name="my-gamepad",
+        display_name="Game controller",
+        detection_patterns=("Generic Gamepad", "Wireless Controller"),
+        axis_map={"steering": 0x00, "throttle": 0x05, "brake": 0x02},
+        inverted_pedals=False,
+        invert_steering=False,
+        ffb_enabled=False,
+        ffb_gain=0.0,
+        threshold=0.12,
+        is_default=False,
+    )
+
+
+@pytest.mark.parametrize("profile", [_wheel_profile(), _controller_profile()])
+def test_round_trip_save_then_load(profile, tmp_path) -> None:
+    save_wheel_profile(profile, tmp_path)
+    loaded = load_wheel_profiles(tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0] == profile
+
+
+def test_yaml_dict_has_loader_schema_shape() -> None:
+    data = wheel_profile_to_yaml_dict(_wheel_profile())
+    assert set(data) == {
+        "name",
+        "display_name",
+        "is_default",
+        "detection_patterns",
+        "axis_map",
+        "pedal",
+        "invert_steering",
+        "ffb",
+        "threshold",
+        "reverse_buttons",
+        "reset_buttons",
+        "steering_range",
+        "steering_deadzone",
+    }
+    assert set(data["axis_map"]) == {"steering", "throttle", "brake"}
+    assert data["pedal"] == {"inverted": True}
+    assert data["ffb"] == {"enabled": True, "gain": 0.6}
+    assert data["reverse_buttons"] == [294]
+    assert data["reset_buttons"] == [300]
+    assert data["steering_range"] == 0.7
+    assert data["steering_deadzone"] == 0.1
+
+
+def test_load_missing_directory_is_empty(tmp_path) -> None:
+    assert load_wheel_profiles(tmp_path / "does-not-exist") == ()
+
+
+def test_profile_filename_is_slugged() -> None:
+    assert profile_filename("My Wheel!") == "my-wheel.yaml"
+    assert profile_filename("   ") == "profile.yaml"
+
+
+def test_user_dir_follows_cache_env(monkeypatch, tmp_path) -> None:
+    from omnidreams import scenes
+
+    monkeypatch.setattr(scenes, "FLASHDREAMS_CACHE_DIR", tmp_path)
+    assert user_wheel_profiles_dir() == tmp_path / "interactive-drive" / "wheels"
+
+
+def test_apply_steering_curve_scale_and_deadzone() -> None:
+    assert apply_steering_curve(1.0, scale=0.5) == 0.5
+    assert apply_steering_curve(-1.0, scale=0.5) == -0.5
+    # Inside the deadzone reads as zero; just past it rescales from zero.
+    assert apply_steering_curve(0.05, deadzone=0.1) == 0.0
+    assert apply_steering_curve(1.0, deadzone=0.1) == pytest.approx(1.0)
+    assert apply_steering_curve(0.55, deadzone=0.1) == pytest.approx(0.5)
+    # Output stays clamped to [-1, 1].
+    assert apply_steering_curve(1.0, scale=2.0) == 1.0
+
+
+def test_name_match_strength_prefers_exact() -> None:
+    # The reported bug: a "Wireless Controller" profile must not bind the
+    # sibling motion-sensor node whose name merely contains the pattern.
+    assert name_match_strength("Wireless Controller", ["Wireless Controller"]) == 2
+    assert (
+        name_match_strength("Wireless Controller Motion Sensors", ["Wireless Controller"])
+        == 1
+    )
+    assert (
+        name_match_strength("Wireless Controller Touchpad", ["Wireless Controller"]) == 1
+    )
+    # Substring patterns still work for brand-style names; case-insensitive.
+    assert name_match_strength("Fanatec FANATEC Wheel", ["Fanatec"]) == 1
+    assert name_match_strength("wireless controller", ["Wireless Controller"]) == 2
+    assert name_match_strength("Something Else", ["Wireless Controller"]) == 0
+
+
+def test_profile_file_management_round_trip(tmp_path) -> None:
+    profile = _wheel_profile()
+    path = save_wheel_profile(profile, tmp_path)
+    files = load_wheel_profile_files(tmp_path)
+    assert len(files) == 1
+    loaded_path, loaded = files[0]
+    assert loaded_path == path
+    assert loaded == profile
+    update_profile_file(path, replace(loaded, display_name="Renamed"))
+    assert load_wheel_profile_files(tmp_path)[0][1].display_name == "Renamed"
+    delete_profile_file(path)
+    assert load_wheel_profile_files(tmp_path) == ()

--- a/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
@@ -134,8 +134,8 @@ def test_name_match_strength_prefers_exact() -> None:
     assert (
         name_match_strength("Wireless Controller Touchpad", ["Wireless Controller"]) == 1
     )
-    # Substring patterns still work for brand-style names; case-insensitive.
-    assert name_match_strength("Fanatec FANATEC Wheel", ["Fanatec"]) == 1
+    # Substring patterns still work for longer names; case-insensitive.
+    assert name_match_strength("Generic Racing Wheel FFB", ["Racing Wheel"]) == 1
     assert name_match_strength("wireless controller", ["Wireless Controller"]) == 2
     assert name_match_strength("Something Else", ["Wireless Controller"]) == 0
 


### PR DESCRIPTION
## Summary

Adds `interactive-drive-configuration`, a small GUI tool for setting up a steering wheel or game controller for the `interactive-drive` demo, plus the runtime support to consume the profiles it writes. Device-specific profiles are generated locally and never checked in, so no product-named configs ship with the repo.

## What's included

**Configuration tool (`interactive-drive-configuration`)**
- Detects the connected device and calibrates steering / throttle / brake by listening to live input (auto-binds an axis once it moves past a leeway threshold).
- Binds optional reverse and reset buttons.
- Sets steering sensitivity (range) and a center deadzone — useful for controller sticks.
- Optional force-feedback test for wheels.
- Live steering-wheel + pedal visualization and a per-axis activity readout.
- Lists saved profiles to edit, delete, or set the default, with a live preview while editing.

**Runtime**
- `WheelBridge` applies steering range + deadzone and binds the reverse/reset buttons.
- Device detection prefers an exact evdev-name match over a substring, so a controller's sibling nodes (e.g. a motion-sensor node) no longer shadow the real device.
- The wheel/controller attaches before the scene-selection wait, so the HUD reacts to physical input on the load screen.
- Fixed `_apply_wheel_overrides` silently dropping newer profile fields.

**Shared module**
- Profile model, evdev helpers, and the steering curve moved to `interactive_drive.input.wheel_profiles`, used by both the tool and the runtime.

## Usage

```bash
uv run --package flashdreams-omnidreams interactive-drive-configuration
```

Calibrate the device; `interactive-drive` loads the profile automatically on its next launch.

## Testing

- Unit tests for profile round-tripping, the steering curve, axis-deflection inference, and exact-name device matching.
- `uv run --no-sync --package flashdreams-omnidreams pytest integrations/omnidreams/tests/interactive_drive`
- GUI flows verified manually on a Linux desktop with a wheel and a controller.

## Notes

- Linux + Tkinter (evdev): needs a graphical session and read access to `/dev/input/*`.
- No new dependencies.