### PR TITLE
Address VDR documentation and UX feedback

### DIFF
--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -181,6 +181,20 @@ first launch, much faster afterwards. When ready the server prints
 ``Connect via http://<server-ip>:8089/request_session`` (use
 ``localhost`` when running locally).
 
+.. note::
+
+   On a remote or cloud GPU instance (e.g. `Brev <https://www.brev.dev/>`_),
+   the server port is usually not reachable at the host IP directly.
+   Forward it to your local machine first, then open
+   ``http://localhost:8089/request_session``:
+
+   .. code-block:: bash
+
+      # Brev
+      brev port-forward <instance> -p 8089:8089
+      # or plain SSH
+      ssh -L 8089:localhost:8089 <user>@<host>
+
 When successfully connected, the browser-based UI looks like this:
 
 .. raw:: html

--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -104,6 +104,28 @@ To inspect all supported CLI arguments and their default values, run:
        lingbot-world-fast \
        --help
 
+What to expect
+--------------
+
+- **Example data**: ``--example-data True`` downloads ``image.jpg``,
+  ``intrinsics.npy``, ``poses.npy``, ``prompt.txt`` from the
+  `upstream examples folder <https://github.com/Robbyant/lingbot-world/tree/main/examples>`_
+  into ``assets/example_data/lingbot_world/<NN>/`` (``<NN>`` matches
+  ``--example-idx``). Cached after first run; no credentials needed.
+- **Model checkpoint**: ~70 GB pulled from
+  ``huggingface.co/robbyant/lingbot-world-fast`` on first run, cached
+  under ``$HF_HOME``. Export ``HF_TOKEN`` first.
+- **Disk**: keep ~200 GB free for the model + HF cache. Hosts under
+  ~100 GB have been seen to run out mid-load.
+- **First launch**: a few minutes (download + Triton autotuning +
+  CUDA-graph warmup). Subsequent launches reuse the caches.
+- **Outputs**: ``outputs/<runner-slug>.mp4`` (16 FPS, 464×832 by
+  default) and ``outputs/stats_<runner-slug>.json``. Override with
+  ``--output-dir`` / ``--pixel-height`` / ``--pixel-width`` / ``--fps``.
+
+See :doc:`/developer_guides/inference_pipeline_overview` for what one
+autoregressive chunk does end-to-end.
+
 Some generated samples from the above commands:
 
 .. raw:: html
@@ -152,10 +174,12 @@ Spin up the interactive LingBot-World server via WebRTC:
        --config_name lingbot-world-fast-taehv-window15-sink3 \
        --example-idx 0
 
-The server may take a few minutes to warm up. When it is ready, it prints
-``Connect via http://<server-ip>:8089/request_session``.
-Here, ``<server-ip>`` is the server IP address you are connecting to
-(can use ``localhost`` when running locally).
+``--example-idx`` selects which example to download
+(``0``, ``1``, ``2``, ``5``); assets auto-download on first launch.
+The HTTP port opens only after model load + warmup — a few minutes on
+first launch, much faster afterwards. When ready the server prints
+``Connect via http://<server-ip>:8089/request_session`` (use
+``localhost`` when running locally).
 
 When successfully connected, the browser-based UI looks like this:
 

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -128,17 +128,16 @@ Some generated samples from the above commands:
 Launch the interactive demo
 ---------------------------
 
-``interactive-drive`` runs the OmniDreams single-view pipeline in a
-single process and streams the camera view to your browser. The demo
-machine only needs a CUDA-capable GPU -- no graphics-capable GPU,
-display server, or Vulkan toolchain required.
+``interactive-drive`` runs the OmniDreams single-view pipeline and
+streams the camera view to your browser. It needs only a CUDA-capable
+GPU — no display server or Vulkan toolchain.
 
 Requires access to `NVIDIA/flashdreams <https://github.com/NVIDIA/flashdreams>`_
 and an ``HF_TOKEN`` with read access to
 `nvidia/omni-dreams-scenes <https://huggingface.co/datasets/nvidia/omni-dreams-scenes>`_
 (scene USDZs) and
 `nvidia/omni-dreams-models <https://huggingface.co/nvidia/omni-dreams-models>`_
-(world-model checkpoints).
+(checkpoints).
 
 First-time setup:
 
@@ -149,8 +148,8 @@ First-time setup:
    export HF_TOKEN=<your-hf-token>
    uv sync --package flashdreams-omnidreams --extra interactive-drive
 
-Optionally pre-download scenes and checkpoints so the first launch
-isn't blocked on network I/O:
+Optionally pre-download scenes and checkpoints to avoid blocking the
+first launch on network I/O:
 
 .. code-block:: bash
 
@@ -162,12 +161,9 @@ Run the demo and stream to your browser:
 
    uv run --package flashdreams-omnidreams interactive-drive --stream-mjpeg :8080
 
-Then open ``http://<server-ip>:8080/`` in any browser on the same
-network and pick a scene from the picker in the bottom-right.
-
-For deployments with a desktop NVIDIA GPU that has a graphics queue,
-omit ``--stream-mjpeg`` to open the demo in a local Vulkan window
-instead:
+Then open ``http://<server-ip>:8080/`` and pick a scene from the
+bottom-right picker. On a desktop GPU with a graphics queue, omit
+``--stream-mjpeg`` to open a local Vulkan window instead:
 
 .. code-block:: bash
 
@@ -176,14 +172,10 @@ instead:
 Alternative: WebRTC server
 --------------------------
 
-For deployments that need a richer browser frontend with WebRTC's
-lower video-delivery latency and a streaming gRPC service for
-multi-client setups, the standalone server at
-``omnidreams.webrtc.server`` ships a polished HTML5 client on top of
-the same OmniDreams pipeline. The MJPEG path above is the
-recommended starting point for most users; reach for WebRTC when you
-need bidirectional camera-control APIs or are already integrating
-the gRPC service into a larger product.
+The MJPEG path above is the recommended starting point. For lower
+video latency, a richer browser frontend, or bidirectional
+camera-control APIs, ``omnidreams.webrtc.server`` serves an HTML5
+client on the same OmniDreams pipeline.
 
 .. code-block:: bash
 
@@ -197,10 +189,9 @@ the gRPC service into a larger product.
 Sample scene UUIDs for the interactive server are available in the
 `nvidia/omni-dreams-scenes Hugging Face dataset <https://huggingface.co/datasets/nvidia/omni-dreams-scenes/tree/main/scenes>`_.
 
-The server may take a few minutes to warm up. When it is ready, it prints
-``Connect via http://<server-ip>:8089/request_session``.
-Here, ``<server-ip>`` is the server IP address you are connecting to
-(can use ``localhost`` when running locally).
+The server may take a few minutes to warm up, then prints
+``Connect via http://<server-ip>:8089/request_session`` (use
+``localhost`` when running locally).
 
 .. note::
 

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -144,7 +144,7 @@ First-time setup:
 
 .. code-block:: bash
 
-   git clone git@github.com:NVIDIA/flashdreams.git
+   git clone https://github.com/NVIDIA/flashdreams.git
    cd flashdreams
    export HF_TOKEN=<your-hf-token>
    uv sync --package flashdreams-omnidreams --extra interactive-drive

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -202,6 +202,20 @@ The server may take a few minutes to warm up. When it is ready, it prints
 Here, ``<server-ip>`` is the server IP address you are connecting to
 (can use ``localhost`` when running locally).
 
+.. note::
+
+   On a remote or cloud GPU instance (e.g. `Brev <https://www.brev.dev/>`_),
+   the server port is usually not reachable at the host IP directly.
+   Forward it to your local machine first, then open
+   ``http://localhost:8089/request_session``:
+
+   .. code-block:: bash
+
+      # Brev
+      brev port-forward <instance> -p 8089:8089
+      # or plain SSH
+      ssh -L 8089:localhost:8089 <user>@<host>
+
 When successfully connected, the browser-based UI looks like this:
 
 .. raw:: html

--- a/docs/source/models/self_forcing.rst
+++ b/docs/source/models/self_forcing.rst
@@ -99,6 +99,63 @@ To inspect all supported CLI arguments and their default values, run:
        self-forcing-wan2.1-t2v-1.3b \
        --help
 
+What to expect
+--------------
+
+**Default prompt.** Omitting ``--prompt`` uses a Tokyo street-scene
+default (the same prompt shown in the command above). To override, pass
+either an inline string or a path to a ``.txt`` file whose first
+non-empty line is read as the prompt.
+
+**Total blocks.** ``--total-blocks N`` runs ``N`` autoregressive chunks
+of the streaming pipeline; each chunk emits a fixed number of decoded
+video frames, so longer rollouts come from larger ``--total-blocks``.
+The commands on this page use ``--total-blocks 7`` to keep the demo
+fast; the runner config's own default is ``60`` for full-length
+rollouts. See :doc:`/developer_guides/inference_pipeline_overview` for
+what one chunk maps to in the encoder / diffusion / decoder loop.
+
+**Outputs.** The runner writes to ``outputs/`` (relative to the current
+working directory) by default:
+
+- ``outputs/<runner-slug>.mp4`` — the generated video at 16 FPS, 480×832
+  for the defaults above (override resolution with ``--pixel-height`` /
+  ``--pixel-width`` and frame rate with ``--fps``).
+- ``outputs/stats_<runner-slug>.json`` — per-autoregressive-step timing
+  stats, when the pipeline reports them.
+
+Pass ``--output-dir <path>`` to redirect the destination.
+
+**Runtime (measured on H100 80GB, ``--total-blocks 7``, defaults
+otherwise).** First runs are dominated by Triton autotuning and
+CUDA-graph warmup; subsequent runs in the same workspace reuse cached
+kernels and are much faster:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 36 32 32
+
+   * - Setup
+     - First run (cold)
+     - Subsequent runs
+   * - 1× H100 PCIe
+     - ~6.9 min
+     - ~42 s
+   * - 4× H100 HBM3 (``torchrun --nproc_per_node=4``)
+     - ~8.6 min
+     - ~73 s
+
+Most of the cold-run cost lands in the first two AR blocks; steady-state
+blocks (AR 2 onward) are sub-second.
+
+**When to use multi-GPU.** Per-block steady-state cost on 4 GPUs is
+roughly 2× faster than on 1 GPU (~251 ms vs ~500 ms), but the larger
+per-rank autotune + NCCL overhead makes 4 GPUs ~24% *slower* end-to-end
+for short rollouts like ``--total-blocks 7``. Multi-GPU only pays off
+once steady-state dominates warmup — stay on 1 GPU for short demos and
+move to ``torchrun --nproc_per_node=4`` for full-length rollouts
+(``--total-blocks 60+``).
+
 Some generated samples from the above commands:
 
 .. raw:: html

--- a/docs/source/models/self_forcing.rst
+++ b/docs/source/models/self_forcing.rst
@@ -102,34 +102,18 @@ To inspect all supported CLI arguments and their default values, run:
 What to expect
 --------------
 
-**Default prompt.** Omitting ``--prompt`` uses a Tokyo street-scene
-default (the same prompt shown in the command above). To override, pass
-either an inline string or a path to a ``.txt`` file whose first
-non-empty line is read as the prompt.
+- **Default prompt**: omitting ``--prompt`` uses a Tokyo street-scene
+  default. Override with an inline string or a path to a ``.txt`` file.
+- **Total blocks**: ``--total-blocks N`` runs ``N`` autoregressive
+  chunks. Commands here use ``7`` for a fast demo; the config default
+  is ``60`` for full rollouts. See
+  :doc:`/developer_guides/inference_pipeline_overview` for what one
+  chunk does end-to-end.
+- **Outputs**: ``outputs/<runner-slug>.mp4`` (16 FPS, 480×832 by
+  default) and ``outputs/stats_<runner-slug>.json``. Override with
+  ``--output-dir`` / ``--pixel-height`` / ``--pixel-width`` / ``--fps``.
 
-**Total blocks.** ``--total-blocks N`` runs ``N`` autoregressive chunks
-of the streaming pipeline; each chunk emits a fixed number of decoded
-video frames, so longer rollouts come from larger ``--total-blocks``.
-The commands on this page use ``--total-blocks 7`` to keep the demo
-fast; the runner config's own default is ``60`` for full-length
-rollouts. See :doc:`/developer_guides/inference_pipeline_overview` for
-what one chunk maps to in the encoder / diffusion / decoder loop.
-
-**Outputs.** The runner writes to ``outputs/`` (relative to the current
-working directory) by default:
-
-- ``outputs/<runner-slug>.mp4`` — the generated video at 16 FPS, 480×832
-  for the defaults above (override resolution with ``--pixel-height`` /
-  ``--pixel-width`` and frame rate with ``--fps``).
-- ``outputs/stats_<runner-slug>.json`` — per-autoregressive-step timing
-  stats, when the pipeline reports them.
-
-Pass ``--output-dir <path>`` to redirect the destination.
-
-**Runtime (measured on H100 80GB, ``--total-blocks 7``, defaults
-otherwise).** First runs are dominated by Triton autotuning and
-CUDA-graph warmup; subsequent runs in the same workspace reuse cached
-kernels and are much faster:
+Measured runtimes on H100 80GB with ``--total-blocks 7``:
 
 .. list-table::
    :header-rows: 1
@@ -145,16 +129,13 @@ kernels and are much faster:
      - ~8.6 min
      - ~73 s
 
-Most of the cold-run cost lands in the first two AR blocks; steady-state
-blocks (AR 2 onward) are sub-second.
+Cold runs are dominated by the first two AR blocks (Triton autotuning +
+CUDA-graph warmup); steady-state blocks are sub-second.
 
-**When to use multi-GPU.** Per-block steady-state cost on 4 GPUs is
-roughly 2× faster than on 1 GPU (~251 ms vs ~500 ms), but the larger
-per-rank autotune + NCCL overhead makes 4 GPUs ~24% *slower* end-to-end
-for short rollouts like ``--total-blocks 7``. Multi-GPU only pays off
-once steady-state dominates warmup — stay on 1 GPU for short demos and
-move to ``torchrun --nproc_per_node=4`` for full-length rollouts
-(``--total-blocks 60+``).
+Per-block steady-state on 4 GPUs is ~2× faster (~251 ms vs ~500 ms),
+but per-rank autotune + NCCL overhead makes 4 GPUs end-to-end slower
+than 1 GPU at ``--total-blocks 7``. Multi-GPU pays off once steady-state
+dominates warmup — use it for ``--total-blocks 60+``.
 
 Some generated samples from the above commands:
 

--- a/docs/source/quickstart/first_world_model.rst
+++ b/docs/source/quickstart/first_world_model.rst
@@ -39,6 +39,15 @@ Launch an offline inference run using the :doc:`Self-Forcing </models/self_forci
        flashdreams-run self-forcing-wan2.1-t2v-1.3b-taehv \
        --total-blocks 7
 
+The first run takes several minutes — most of that time is one-time
+Triton autotuning and CUDA-graph warmup, not the generation itself.
+Subsequent runs in the same workspace reuse the cached kernels and
+finish in well under a minute. The generated video lands at
+``outputs/self-forcing-wan2.1-t2v-1.3b-taehv.mp4`` (16 FPS, 480×832 by
+default). See :doc:`/models/self_forcing` for what ``--total-blocks``
+controls, measured cold-vs-warm runtimes on H100, and when multi-GPU
+pays off.
+
 Run LingBot-World interactive server
 ------------------------------------
 

--- a/docs/source/quickstart/first_world_model.rst
+++ b/docs/source/quickstart/first_world_model.rst
@@ -39,14 +39,11 @@ Launch an offline inference run using the :doc:`Self-Forcing </models/self_forci
        flashdreams-run self-forcing-wan2.1-t2v-1.3b-taehv \
        --total-blocks 7
 
-The first run takes several minutes — most of that time is one-time
-Triton autotuning and CUDA-graph warmup, not the generation itself.
-Subsequent runs in the same workspace reuse the cached kernels and
-finish in well under a minute. The generated video lands at
-``outputs/self-forcing-wan2.1-t2v-1.3b-taehv.mp4`` (16 FPS, 480×832 by
-default). See :doc:`/models/self_forcing` for what ``--total-blocks``
-controls, measured cold-vs-warm runtimes on H100, and when multi-GPU
-pays off.
+First runs take several minutes (Triton autotuning + CUDA-graph
+warmup); subsequent runs finish in well under a minute. Output lands
+at ``outputs/self-forcing-wan2.1-t2v-1.3b-taehv.mp4`` (16 FPS, 480×832
+by default). See :doc:`/models/self_forcing` for ``--total-blocks``,
+measured runtimes, and multi-GPU guidance.
 
 Run LingBot-World interactive server
 ------------------------------------

--- a/flashdreams/flashdreams/core/distributed/__init__.py
+++ b/flashdreams/flashdreams/core/distributed/__init__.py
@@ -27,6 +27,14 @@ import torch
 import torch.distributed as dist
 from loguru import logger
 
+# Side effect: install the stdlib-``logging`` filter that demotes benign
+# Inductor autotuner-fallback ERROR records to WARNING so first-run
+# warmup doesn't look like a hard failure. Pulled in here (rather than
+# from ``flashdreams.core.__init__``) because every FlashDreams entry
+# point that talks to torch.distributed already imports this module at
+# process start, and the filter is process-global and idempotent.
+from flashdreams.core import log_filters  # noqa: F401
+
 DEFAULT_LOG_LEVEL = "INFO"
 
 

--- a/flashdreams/flashdreams/core/log_filters.py
+++ b/flashdreams/flashdreams/core/log_filters.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-wide stdlib :mod:`logging` filters installed at import time.
+
+Currently houses one filter: :class:`_DowngradeInductorAutotuneFallback`.
+:func:`install_inductor_autotune_demote` is invoked at module load so any
+FlashDreams entry point that transitively imports :mod:`flashdreams.core`
+inherits the demotion without explicit setup.
+"""
+
+from __future__ import annotations
+
+import logging
+
+_AUTOTUNE_LOGGER_NAME = "torch._inductor.select_algorithm"
+
+# Inductor logs two structurally-equivalent autotuner fallbacks at ERROR
+# level (one via ``log.error`` for ``RuntimeError``, one via
+# ``log.exception`` for ``CUDACompileError``). Both are expected: the
+# autotuner tried a template, it raised, the template is skipped, and a
+# valid candidate is selected. Match by message prefix because Inductor
+# resolves the formatted message lazily and the exception body varies.
+_AUTOTUNE_FALLBACK_PREFIXES: tuple[str, ...] = (
+    "Runtime error during autotuning",
+    "CUDA compilation error during autotuning",
+)
+
+
+class _DowngradeInductorAutotuneFallback(logging.Filter):
+    """Demote benign Inductor autotuner-fallback ERROR records to WARNING.
+
+    ``torch._inductor.select_algorithm`` surfaces candidate-kernel
+    rejections at ERROR level even though they're an expected part of a
+    healthy autotune pass. Users hitting these mid-warmup reasonably
+    assume something is broken; downgrading the level keeps the trail
+    without the alarm.
+
+    Mutating ``record.levelno`` / ``record.levelname`` inside a filter
+    is supported by :mod:`logging`: the record is mutated before any
+    handler's own level check runs, so handlers that emit at WARNING
+    will still emit (just under a less alarming label).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno < logging.ERROR:
+            return True
+        message = record.getMessage()
+        if any(message.startswith(prefix) for prefix in _AUTOTUNE_FALLBACK_PREFIXES):
+            record.levelno = logging.WARNING
+            record.levelname = "WARNING"
+        return True
+
+
+def install_inductor_autotune_demote() -> None:
+    """Attach the autotune-fallback demoter to the Inductor logger.
+
+    Idempotent: if a filter of this class is already attached (e.g.
+    because :mod:`flashdreams.core.log_filters` was re-imported during a
+    long test session), we leave the existing instance in place rather
+    than stacking duplicates.
+    """
+    autotune_logger = logging.getLogger(_AUTOTUNE_LOGGER_NAME)
+    for existing in autotune_logger.filters:
+        if isinstance(existing, _DowngradeInductorAutotuneFallback):
+            return
+    autotune_logger.addFilter(_DowngradeInductorAutotuneFallback())
+
+
+install_inductor_autotune_demote()

--- a/flashdreams/tests/test_log_filters.py
+++ b/flashdreams/tests/test_log_filters.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from flashdreams.core import log_filters
+
+pytestmark = pytest.mark.ci_cpu
+
+
+@pytest.fixture
+def autotune_logger() -> logging.Logger:
+    """Return the Inductor autotune logger with the demoter freshly attached."""
+    return logging.getLogger("torch._inductor.select_algorithm")
+
+
+def _make_record(level: int, msg: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="torch._inductor.select_algorithm",
+        level=level,
+        pathname=__file__,
+        lineno=0,
+        msg=msg,
+        args=None,
+        exc_info=None,
+    )
+
+
+def test_demotes_runtime_error_during_autotuning_to_warning():
+    record = _make_record(
+        logging.ERROR,
+        "Runtime error during autotuning: \npermute(sparse_coo) failed. \nIgnoring this choice.",
+    )
+    log_filters._DowngradeInductorAutotuneFallback().filter(record)
+    assert record.levelno == logging.WARNING
+    assert record.levelname == "WARNING"
+
+
+def test_demotes_cuda_compilation_error_during_autotuning_to_warning():
+    record = _make_record(
+        logging.ERROR,
+        "CUDA compilation error during autotuning: \nptxas: foo. \nIgnoring this choice.",
+    )
+    log_filters._DowngradeInductorAutotuneFallback().filter(record)
+    assert record.levelno == logging.WARNING
+    assert record.levelname == "WARNING"
+
+
+def test_leaves_unrelated_error_records_untouched():
+    record = _make_record(logging.ERROR, "kernel launch failed: invalid configuration")
+    log_filters._DowngradeInductorAutotuneFallback().filter(record)
+    assert record.levelno == logging.ERROR
+    assert record.levelname == "ERROR"
+
+
+def test_leaves_warning_records_untouched():
+    record = _make_record(
+        logging.WARNING,
+        "Runtime error during autotuning: \nshape mismatch. \nIgnoring this choice.",
+    )
+    log_filters._DowngradeInductorAutotuneFallback().filter(record)
+    assert record.levelno == logging.WARNING
+    assert record.levelname == "WARNING"
+
+
+def test_installer_is_idempotent(autotune_logger: logging.Logger):
+    # The module already self-installed at import; calling again shouldn't
+    # stack a second filter instance.
+    before = sum(
+        isinstance(f, log_filters._DowngradeInductorAutotuneFallback)
+        for f in autotune_logger.filters
+    )
+    log_filters.install_inductor_autotune_demote()
+    log_filters.install_inductor_autotune_demote()
+    after = sum(
+        isinstance(f, log_filters._DowngradeInductorAutotuneFallback)
+        for f in autotune_logger.filters
+    )
+    assert before == after == 1
+
+
+def test_end_to_end_logger_emits_at_warning_level(
+    autotune_logger: logging.Logger, caplog: pytest.LogCaptureFixture
+):
+    # ``caplog`` captures records *after* logger filters run, so a record
+    # the filter mutates lands in caplog at the new level.
+    caplog.set_level(logging.WARNING, logger=autotune_logger.name)
+    autotune_logger.error(
+        "Runtime error during autotuning: \n%s. \nIgnoring this choice.",
+        "permute(sparse_coo)",
+    )
+    matching = [r for r in caplog.records if r.name == autotune_logger.name]
+    assert len(matching) == 1
+    assert matching[0].levelno == logging.WARNING
+    assert matching[0].levelname == "WARNING"
+    assert "permute(sparse_coo)" in matching[0].getMessage()

--- a/flashdreams/tests/test_log_filters.py
+++ b/flashdreams/tests/test_log_filters.py
@@ -83,18 +83,34 @@ def test_installer_is_idempotent(autotune_logger: logging.Logger):
     assert before == after == 1
 
 
-def test_end_to_end_logger_emits_at_warning_level(
-    autotune_logger: logging.Logger, caplog: pytest.LogCaptureFixture
-):
-    # ``caplog`` captures records *after* logger filters run, so a record
-    # the filter mutates lands in caplog at the new level.
-    caplog.set_level(logging.WARNING, logger=autotune_logger.name)
-    autotune_logger.error(
-        "Runtime error during autotuning: \n%s. \nIgnoring this choice.",
-        "permute(sparse_coo)",
-    )
-    matching = [r for r in caplog.records if r.name == autotune_logger.name]
-    assert len(matching) == 1
-    assert matching[0].levelno == logging.WARNING
-    assert matching[0].levelname == "WARNING"
-    assert "permute(sparse_coo)" in matching[0].getMessage()
+def test_end_to_end_logger_emits_at_warning_level(autotune_logger: logging.Logger):
+    # Attach our own capturing handler directly to the autotune logger
+    # rather than relying on pytest's ``caplog`` (which needs record
+    # propagation to the root logger). Other imports in a shared test
+    # session — notably torch's logging setup — reconfigure stdlib
+    # logging and break that propagation, so capture at the source.
+    # The logger-level filter runs in ``Logger.handle`` before handlers
+    # are invoked, so a handler on this logger sees the mutated record.
+    captured: list[logging.LogRecord] = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _CaptureHandler(level=logging.DEBUG)
+    autotune_logger.addHandler(handler)
+    previous_level = autotune_logger.level
+    autotune_logger.setLevel(logging.DEBUG)
+    try:
+        autotune_logger.error(
+            "Runtime error during autotuning: \n%s. \nIgnoring this choice.",
+            "permute(sparse_coo)",
+        )
+    finally:
+        autotune_logger.removeHandler(handler)
+        autotune_logger.setLevel(previous_level)
+
+    assert len(captured) == 1
+    assert captured[0].levelno == logging.WARNING
+    assert captured[0].levelname == "WARNING"
+    assert "permute(sparse_coo)" in captured[0].getMessage()

--- a/integrations/lingbot/README.md
+++ b/integrations/lingbot/README.md
@@ -71,7 +71,8 @@ uv run flashdreams-run --help
 # Per-runner help: every overridable field is a CLI flag.
 uv run flashdreams-run lingbot-world-fast --help
 
-# Single-GPU demo with the bundled example assets (lazy-synced from S3).
+# Single-GPU demo with the bundled example assets (lazy-downloaded
+# from the upstream LingBot-World GitHub examples folder on first run).
 uv run flashdreams-run lingbot-world-fast --example-data True --total-blocks 21
 
 # Custom inputs (production layout).
@@ -167,13 +168,16 @@ Then open:
 
 ### Runtime requirements
 
-- CUDA-capable GPU for Lingbot inference.
-- `HF_TOKEN` exported for HuggingFace model access.
-- Lingbot example assets available under `assets/example_data/lingbot_world`:
-  - `image.jpg`
-  - `intrinsics.npy`
-  - `poses.npy` (optional but recommended for world-scale normalization)
-  - `prompt.txt`
+- CUDA-capable GPU.
+- `HF_TOKEN` exported. The `robbyant/lingbot-world-fast` checkpoint
+  (~70 GB) is pulled from HuggingFace on first run and cached under
+  `$HF_HOME`.
+- ~200 GB free disk for the model + HF cache.
+- Example assets (`image.jpg`, `intrinsics.npy`, `poses.npy`,
+  `prompt.txt`) auto-download from the upstream
+  [`Robbyant/lingbot-world`](https://github.com/Robbyant/lingbot-world/tree/main/examples)
+  examples folder into `assets/example_data/lingbot_world/<NN>/` on
+  first launch (`<NN>` is the `--example-idx`: `00`, `01`, `02`, `05`).
 
 ### DataChannel message format
 

--- a/integrations/lingbot/lingbot/runner.py
+++ b/integrations/lingbot/lingbot/runner.py
@@ -75,7 +75,7 @@ EXAMPLE_DATA_AVAILABLE_IDXS = (0, 1, 2, 5)
 """Supported upstream example indices currently hosted under ``examples/``."""
 
 
-def _example_data_dirname(example_idx: int) -> str:
+def example_data_dirname(example_idx: int) -> str:
     """Format ``example_idx`` into the upstream folder naming convention."""
     assert example_idx in EXAMPLE_DATA_AVAILABLE_IDXS, (
         f"--example_idx must be one of {EXAMPLE_DATA_AVAILABLE_IDXS}."
@@ -83,9 +83,19 @@ def _example_data_dirname(example_idx: int) -> str:
     return f"{example_idx:02d}"
 
 
-def _ensure_example_data_downloaded(*, is_rank_zero: bool, example_idx: int) -> Path:
-    """Download bundled GitHub example files on rank 0; barrier other ranks."""
-    example_dirname = _example_data_dirname(example_idx)
+def ensure_example_data_downloaded(*, is_rank_zero: bool, example_idx: int) -> Path:
+    """Download bundled GitHub example files on rank 0; barrier other ranks.
+
+    The runner calls this from :meth:`LingbotWorldRunner._fill_example_data_defaults`;
+    the WebRTC server calls it from its ``main()`` so the same files
+    land on disk before the server's
+    ``LingbotWebRTCSessionManager._initialize_sync`` checks for them. The
+    download itself is small (image + intrinsics + poses + prompt for
+    the chosen example), uses the public LingBot-World GitHub raw URLs,
+    and is cached at :data:`EXAMPLE_DATA_DIR_LOCAL` so repeat calls are
+    no-ops.
+    """
+    example_dirname = example_data_dirname(example_idx)
     cache_dir = EXAMPLE_DATA_DIR_LOCAL / example_dirname
     if is_rank_zero:
         for filename in EXAMPLE_DATA_FILENAMES:
@@ -173,7 +183,7 @@ class LingbotWorldRunner(
     def _fill_example_data_defaults(self) -> None:
         """Lazy-download bundled assets and fill empty path defaults in-place."""
         cfg = self.config
-        example_dir = _ensure_example_data_downloaded(
+        example_dir = ensure_example_data_downloaded(
             is_rank_zero=self.is_rank_zero,
             example_idx=cfg.example_idx,
         )

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -34,14 +34,18 @@ from flashdreams.core.distributed import (
 )
 from flashdreams.serving.network import get_external_ip
 from flashdreams.serving.webrtc.server import WebRTCSessionManager, create_webrtc_app
+from lingbot.runner import (
+    EXAMPLE_DATA_AVAILABLE_IDXS,
+    EXAMPLE_DATA_DIR_LOCAL,
+    ensure_example_data_downloaded,
+    example_data_dirname,
+)
 from lingbot.webrtc.session import (
-    REPO_ROOT,
     LingbotRuntimeConfig,
     LingbotWebRTCSessionManager,
 )
 
 WEB_DIR = Path(__file__).resolve().parent / "web"
-EXAMPLE_DATA_AVAILABLE_IDXS = (0, 1, 2, 5)
 
 
 def configure_logging(*, world_rank: int | None = None) -> None:
@@ -126,10 +130,7 @@ def build_runtime_config(
     context_parallel_size: int = 1,
 ) -> LingbotRuntimeConfig:
     example_idx = getattr(args, "example_idx", 0)
-    assert example_idx in EXAMPLE_DATA_AVAILABLE_IDXS, (
-        f"--example_idx must be one of {EXAMPLE_DATA_AVAILABLE_IDXS}."
-    )
-    example_dir = REPO_ROOT / "assets/example_data/lingbot_world" / f"{example_idx:02d}"
+    example_dir = EXAMPLE_DATA_DIR_LOCAL / example_data_dirname(example_idx)
     return LingbotRuntimeConfig(
         config_name=args.config_name,
         compile_network=not args.no_compile,
@@ -198,6 +199,18 @@ def main() -> None:
 
     runtime_device, world_rank, context_parallel_size = initialize_distributed(
         default_device=args.device
+    )
+
+    # Pull the bundled example-data assets onto rank 0 (and barrier the
+    # rest) before constructing the session manager: the manager's
+    # initial-sync step checks the example_data_dir for the first frame
+    # / intrinsics / poses / prompt files and raises FileNotFoundError
+    # otherwise. Mirrors the offline runner's pre-flight behavior so the
+    # WebRTC entry point is launchable on a fresh checkout with no
+    # manual file staging.
+    ensure_example_data_downloaded(
+        is_rank_zero=(world_rank == 0),
+        example_idx=args.example_idx,
     )
 
     runtime_config = build_runtime_config(

--- a/integrations/lingbot/tests/test_distributed_server_main.py
+++ b/integrations/lingbot/tests/test_distributed_server_main.py
@@ -46,6 +46,7 @@ def _args(device: str = "cuda:0") -> Namespace:
         warmup_chunks=10,
         warmup_timeout_s=600.0,
         fps=16,
+        example_idx=0,
     )
 
 
@@ -148,6 +149,8 @@ def test_main_rank0_sends_exit_signal(monkeypatch: pytest.MonkeyPatch) -> None:
         "initialize_distributed",
         lambda default_device: (torch.device("cuda:2"), 0, 1),
     )
+    # Don't hit the network for the bundled example assets in a unit test.
+    monkeypatch.setattr(server, "ensure_example_data_downloaded", lambda **kwargs: None)
 
     manager_fps: list[int] = []
 
@@ -193,6 +196,8 @@ def test_main_worker_rank_waits_for_termination(
     )
     monkeypatch.setattr(server.dist, "is_initialized", lambda: False)
     monkeypatch.setattr(server.torch.cuda, "is_available", lambda: False)
+    # Don't hit the network for the bundled example assets in a unit test.
+    monkeypatch.setattr(server, "ensure_example_data_downloaded", lambda **kwargs: None)
 
     manager_fps: list[int] = []
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -13,8 +13,8 @@ matter most:
 This sample uses the flashdreams Alpadreams pipeline for world-model inference,
 uses Ludus to render the HD map view, and uses SlangPy for local windowing.
 
-Runs on Windows or Linux with a native host toolchain; the prebuilt Docker
-image option is Linux-only.
+Runs on Windows or Linux with a native host toolchain; the optional
+Docker path is Linux-only.
 
 The implementation is intentionally narrow:
 
@@ -70,28 +70,28 @@ on the host (see the [flashdreams root README](../../../../README.md) for the re
 hardware and CUDA setup). No additional work in this step — proceed to
 step 3 from the flashdreams workspace root.
 
-#### Option B — Docker (prebuilt `flashdreams` image)
+#### Option B — Docker (build a local image)
 
-If you'd rather skip installing CUDA, SDL, and the EGL toolchain on the host,
-the prebuilt `flashdreams` image gives you an end-to-end Linux environment.
-Additional prerequisites:
+If you'd rather skip installing CUDA, SDL, and the EGL toolchain on the
+host, the bundled `docker/Dockerfile` builds an end-to-end Linux
+environment locally. See [`docker/README.md`](../../../../docker/README.md)
+for the full build docs; the short version is below. Additional
+prerequisites:
 
 - Linux host (Wayland-based local windowing assumes Linux; Windows users
   should use the native path above)
 - Docker + `nvidia-container-toolkit`
-- GitHub PAT with `read:packages` for `ghcr.io/nvidia/flashdreams`
 
-1. **Pull the image.**
+1. **Build the image** from the `flashdreams` repo root:
 
    ```bash
-   echo "$GITHUB_PAT" | docker login ghcr.io -u <github-username> --password-stdin
-   docker pull ghcr.io/nvidia/flashdreams:base-v0.3-20260430-7985764
+   docker build -t flashdreams:local -f docker/Dockerfile .
    ```
 
-2. **Launch the container** from the `flashdreams` repo root. The repo
-   bind-mount lands at `/workspace/flashdreams` and the workdir leaves
-   you at the flashdreams workspace root (the same place you'd run uv
-   from on a native host):
+2. **Launch the container** from the same `flashdreams` repo root. The
+   repo bind-mount lands at `/workspace/flashdreams` and the workdir
+   leaves you at the flashdreams workspace root (the same place you'd
+   run uv from on a native host):
 
    ```bash
    docker run --rm -it \
@@ -108,7 +108,7 @@ Additional prerequisites:
      -e WAYLAND_DISPLAY=wayland-0 \
      -e XDG_RUNTIME_DIR=/run/user/0 \
      -e SDL_VIDEODRIVER=wayland \
-     ghcr.io/nvidia/flashdreams:base-v0.3-20260430-7985764 \
+     flashdreams:local \
      bash
    ```
 


### PR DESCRIPTION
## Summary

Addresses several items from the OmniDreams + FlashDreams VDR review — mostly docs, plus two small code fixes.

## Changes

- **Install docs:** drop the unpublished prebuilt-image path; lead with bare-metal `uv sync`, keep local `docker build` as an option. Fix the remaining SSH `git clone` URL to HTTPS so PAT users aren't blocked.
- **Self-Forcing docs:** add a "What to expect" section (default prompt, `--total-blocks`, output paths, H100 cold/warm runtimes, multi-GPU guidance).
- **Lingbot WebRTC server:** auto-download example assets on startup so a fresh checkout runs without manual staging; scrub stale S3 references; add disk/model-size notes.
- **WebRTC pages:** add a cloud port-forwarding note (Brev / `ssh -L`).
- **Autotuning logs:** demote benign Inductor autotuner-fallback `ERROR` logs to `WARNING` so first-run warmup doesn't look like a failure.
- **Docs cleanup:** tighten verbose prose in `omnidreams.rst`.