### PR TITLE
interactive-drive: keep the world model loaded across scenes

### DIFF
--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -173,6 +173,18 @@ instead:
 
    uv run --package flashdreams-omnidreams interactive-drive
 
+.. note::
+
+   The local window needs a display server (X11) and the system OpenGL /
+   Vulkan client libraries. On Debian/Ubuntu:
+
+   .. code-block:: bash
+
+      sudo apt install -y libx11-6 libxcb1 libgl1 libglx-mesa0 libvulkan1
+
+   A ``Failed to initialize GLFW`` error means the display or one of these
+   libraries is missing.
+
 Steering wheel and game controller
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/_pipeline_fakes.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/_pipeline_fakes.py
@@ -77,12 +77,20 @@ class FakeVideoModelBackend:
     def __init__(self, frames_per_render: int, rgb_value: int = 0) -> None:
         self._frames_per_render = frames_per_render
         self._rgb_value = rgb_value
-        self.warmup_calls = 0
+        self.warmup_model_calls = 0
+        self.load_scene_calls = 0
         self.reset_calls = 0
 
-    def warmup(self, scene: SceneBundle) -> None:
+    @property
+    def can_prewarm(self) -> bool:
+        return True
+
+    def warmup_model(self) -> None:
+        self.warmup_model_calls += 1
+
+    def load_scene(self, scene: SceneBundle) -> None:
         del scene
-        self.warmup_calls += 1
+        self.load_scene_calls += 1
 
     def reset(self) -> None:
         self.reset_calls += 1

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import threading
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
 from omnidreams.interactive_drive.backends.base import RenderBackend
 from omnidreams.interactive_drive.config import AppConfig
 from omnidreams.interactive_drive.input.keyboard import (
@@ -20,6 +27,7 @@ from omnidreams.interactive_drive.simulation.ego_vehicle_kinematics import (
     build_map_bounds,
     state_from_initial_pose,
 )
+from omnidreams.interactive_drive.simulation.ground_snap import GroundSnapper
 from omnidreams.interactive_drive.simulation.map_bounds import MapBounds
 from omnidreams.interactive_drive.streaming_presenter import (
     MJPEGStreamingPresenter,
@@ -28,6 +36,11 @@ from omnidreams.interactive_drive.streaming_presenter import (
 from omnidreams.interactive_drive.types import PresentedFrame, SceneBundle
 from omnidreams.interactive_drive.video_model.chunk_pipeline import ChunkPipeline
 from omnidreams.interactive_drive.video_model.local import LocalVideoModelAdapter
+
+# Cadence for the event-pump loop that keeps the presenter alive while a
+# scene parses on a background thread. ~60 Hz keeps input latency low and
+# the loading indicator smooth without burning a core.
+_SCENE_LOAD_PUMP_INTERVAL_S = 1.0 / 60.0
 
 
 class InteractiveDriveApp:
@@ -93,6 +106,30 @@ class InteractiveDriveApp:
         self._pipeline = ChunkPipeline(self._adapter)
         self._scene: SceneBundle | None = None
         self._map_bounds: MapBounds | None = None
+        # Ground snapper for the current scene. Built once per scene (its
+        # spatial grid is invariant across rollouts) and reused, so a reset
+        # doesn't rebuild it -- that pure-Python grid build can take seconds
+        # on a dense mesh and would otherwise freeze the UI on every reset.
+        self._ground_snapper: GroundSnapper | None = None
+        # Lazily-built black frame at the render resolution, used as the
+        # backdrop for the loading overlay while a scene parses (before the
+        # scene's own initial frame is available).
+        self._loading_base_rgb: np.ndarray | None = None
+        # Optional parsed-scene cache, keyed by (path, variant, prompt).
+        # Disabled unless --preload-scenes opts in via preload_scenes(); when
+        # enabled, load_scene reuses parsed bundles so switching to a
+        # preloaded (or previously-visited) scene skips the USDZ parse.
+        self._cache_scenes = False
+        self._scene_cache: dict[
+            tuple[str, str, str | None],
+            tuple[SceneBundle, MapBounds | None, GroundSnapper | None],
+        ] = {}
+        self._scene_cache_lock = threading.Lock()
+        # Set while --preload-scenes is still parsing scenes in the
+        # background; the presenter locks scene selection until it clears so
+        # the user always gets the instant (cache-hit) switch.
+        self._preload_started = False
+        self._preload_done = threading.Event()
 
     @property
     def presenter(self) -> PresenterBackend:
@@ -113,26 +150,206 @@ class InteractiveDriveApp:
 
     def load_scene(
         self, scene_path: object, variant: str, prompt_override: str | None
-    ) -> None:
-        """Load a scene bundle and bind it on the pipeline worker.
+    ) -> bool:
+        """Load a scene bundle off the UI thread and bind it on the worker.
 
-        Cheap relative to warmup: reads the USDZ and enqueues a
-        ``request_scene`` that runs ``backend.load_scene`` (geometry
-        upload + rollout restart) on the worker, FIFO behind any pending
-        model warmup. The resident model is reused as-is.
+        ``load_scene_bundle`` parses the USDZ (camera rig, HD-map parquet,
+        ground mesh), which can take a second or more. Running it on a
+        background thread keeps the presenter responsive -- the window
+        manager won't flag the HUD as "not responding" -- and lets the
+        loading indicator stay on screen throughout. Once parsed, the scene
+        is bound on the pipeline worker (geometry upload + rollout restart,
+        FIFO behind any pending model warmup); the resident model is reused
+        as-is.
+
+        Returns ``False`` if the presenter closed before the scene finished
+        loading, in which case the caller must not call :meth:`run_scene`.
         """
-        self._scene = load_scene_bundle(
-            scene_path=scene_path,
-            camera_name=self._config.camera_name,
-            variant=variant,
-            prompt_override=prompt_override,
-            raster=self._config.raster,
+        # Fast path: a preloaded / previously-parsed bundle is reused with no
+        # parse (and no background pump). The worker still uploads geometry
+        # and renders the first chunk, so the loop's "Loading scene..."
+        # indicator still covers that part.
+        cached = self._cached_scene(scene_path, variant, prompt_override)
+        if cached is not None:
+            self._scene, self._map_bounds, self._ground_snapper = cached
+            self._pipeline.request_scene(self._scene)
+            return True
+
+        scene_ready = threading.Event()
+        loaded: list[object] = []
+        error: list[BaseException] = []
+
+        def _parse() -> None:
+            try:
+                scene = load_scene_bundle(
+                    scene_path=scene_path,
+                    camera_name=self._config.camera_name,
+                    variant=variant,
+                    prompt_override=prompt_override,
+                    raster=self._config.raster,
+                )
+                # The OOB AABB and the ground snapper's spatial grid are
+                # properties of the scene geometry and invariant across the
+                # rollout restarts inside run_scene -- build both here (on the
+                # background thread) so a reset never rebuilds the snapper.
+                loaded.append(scene)
+                loaded.append(build_map_bounds(scene))
+                loaded.append(build_ground_snapper(scene))
+            except BaseException as exc:  # re-raised on the UI thread below
+                error.append(exc)
+            finally:
+                scene_ready.set()
+
+        threading.Thread(
+            target=_parse, name="interactive_drive-scene-loader", daemon=True
+        ).start()
+        self._pump_presenter_until(scene_ready)
+        if not scene_ready.is_set():
+            return False  # presenter closed mid-load
+        if error:
+            raise error[0]
+        self._scene, self._map_bounds, self._ground_snapper = (  # type: ignore[assignment]
+            loaded[0],
+            loaded[1],
+            loaded[2],
         )
-        # Build the OOB map bounds at scene load -- the AABB is a property
-        # of the scene's geometry and is invariant across the rollout
-        # restarts inside run_scene.
-        self._map_bounds = build_map_bounds(self._scene)
+        self._store_scene(
+            scene_path,
+            variant,
+            prompt_override,
+            self._scene,
+            self._map_bounds,
+            self._ground_snapper,
+        )
         self._pipeline.request_scene(self._scene)
+        return True
+
+    def preload_scenes(
+        self, specs: Iterable[tuple[object, str, str | None]]
+    ) -> None:
+        """Parse scene bundles in the background so later switches are instant.
+
+        ``specs`` is an iterable of ``(scene_path, variant, prompt_override)``.
+        Opt-in (the demo's ``--preload-scenes``); parsing runs sequentially
+        on one daemon thread to bound peak CPU / memory, populating the cache
+        that :meth:`load_scene` consults. Already-cached entries are skipped,
+        and failures are logged and skipped so one bad scene doesn't abort the
+        rest. This only skips the USDZ parse on switch -- the per-scene
+        geometry upload and first-chunk generation still happen on the worker.
+        While it runs, :meth:`preload_in_progress` returns True so the
+        presenter can lock scene selection until every scene is ready.
+        """
+        self._cache_scenes = True
+        self._preload_started = True
+        self._preload_done.clear()
+        pending = list(specs)
+
+        def _worker() -> None:
+            try:
+                self._preload_worker(pending)
+            finally:
+                self._preload_done.set()
+
+        threading.Thread(
+            target=_worker, name="interactive_drive-scene-preloader", daemon=True
+        ).start()
+
+    def preload_in_progress(self) -> bool:
+        """True while --preload-scenes is still parsing scenes in the background."""
+        return self._preload_started and not self._preload_done.is_set()
+
+    def _preload_worker(
+        self, pending: list[tuple[object, str, str | None]]
+    ) -> None:
+        for scene_path, variant, prompt_override in pending:
+            key = self._scene_cache_key(scene_path, variant, prompt_override)
+            with self._scene_cache_lock:
+                if key in self._scene_cache:
+                    continue
+            try:
+                scene = load_scene_bundle(
+                    scene_path=scene_path,
+                    camera_name=self._config.camera_name,
+                    variant=variant,
+                    prompt_override=prompt_override,
+                    raster=self._config.raster,
+                )
+                bounds = build_map_bounds(scene)
+                snapper = build_ground_snapper(scene)
+            except BaseException as exc:  # noqa: BLE001 - log & skip one scene
+                print(
+                    f"[interactive-drive] scene preload failed for "
+                    f"{Path(str(scene_path)).name} variant={variant!r}: {exc}",
+                    flush=True,
+                )
+                continue
+            with self._scene_cache_lock:
+                self._scene_cache[key] = (scene, bounds, snapper)
+            print(
+                f"[interactive-drive] preloaded scene "
+                f"{Path(str(scene_path)).name} variant={variant!r}",
+                flush=True,
+            )
+
+    @staticmethod
+    def _scene_cache_key(
+        scene_path: object, variant: str, prompt_override: str | None
+    ) -> tuple[str, str, str | None]:
+        return (str(scene_path), variant, prompt_override)
+
+    def _cached_scene(
+        self, scene_path: object, variant: str, prompt_override: str | None
+    ) -> tuple[SceneBundle, MapBounds | None, GroundSnapper | None] | None:
+        if not self._cache_scenes:
+            return None
+        with self._scene_cache_lock:
+            return self._scene_cache.get(
+                self._scene_cache_key(scene_path, variant, prompt_override)
+            )
+
+    def _store_scene(
+        self,
+        scene_path: object,
+        variant: str,
+        prompt_override: str | None,
+        scene: SceneBundle,
+        map_bounds: MapBounds | None,
+        ground_snapper: GroundSnapper | None,
+    ) -> None:
+        if not self._cache_scenes:
+            return
+        with self._scene_cache_lock:
+            self._scene_cache[
+                self._scene_cache_key(scene_path, variant, prompt_override)
+            ] = (scene, map_bounds, ground_snapper)
+
+    def _pump_presenter_until(self, done: threading.Event) -> None:
+        """Pump events + a loading overlay until ``done`` is set or we close.
+
+        Keeps the window responsive and the loading indicator live while a
+        scene parses on the background thread, mirroring the loop's own
+        loading-phase rendering. The overlay text follows
+        :meth:`_loading_status_message` (model warmup takes priority).
+        """
+        frame = PresentedFrame(
+            timestamp_us=0,
+            rgb_host_uint8=self._loading_base_frame(),
+            depth_host_f32=None,
+        )
+        view_mode = self._keyboard.view_mode
+        while not done.is_set() and not self._presenter.should_close:
+            self._presenter.process_events()
+            self._presenter.present_frame(
+                replace(frame, status_message=self._loading_status_message()),
+                view_mode=view_mode,
+            )
+            time.sleep(_SCENE_LOAD_PUMP_INTERVAL_S)
+
+    def _loading_base_frame(self) -> np.ndarray:
+        if self._loading_base_rgb is None:
+            width, height = self._config.raster.resolution_wh
+            self._loading_base_rgb = np.zeros((height, width, 3), dtype=np.uint8)
+        return self._loading_base_rgb
 
     def run_scene(self) -> None:
         """Drive the current scene until the presenter closes or switches.
@@ -156,6 +373,10 @@ class InteractiveDriveApp:
             rgb_host_uint8=self._scene.initial_rgb,
             depth_host_f32=None,
         )
+        # First rollout is the scene load ("Loading scene..." / "Loading
+        # world model..."); subsequent rollouts come from a manual reset or
+        # OOB respawn, so switch the indicator to "Resetting..." for those.
+        loading_status = self._loading_status_message
         while not self._presenter.should_close:
             simulation = EgoVehicleKinematics(
                 initial_state=state_from_initial_pose(
@@ -168,7 +389,7 @@ class InteractiveDriveApp:
                     ),
                 ),
                 vehicle_config=self._config.vehicle,
-                ground_snapper=build_ground_snapper(self._scene),
+                ground_snapper=self._ground_snapper,
                 initial_timestamp_us=self._scene.initial_timestamp_us,
                 map_bounds=self._map_bounds,
                 oob_margin_m=self._config.oob_margin_m,
@@ -192,11 +413,31 @@ class InteractiveDriveApp:
                         self._config.oob_respawn_debounce_chunks
                     ),
                 ),
-                loading_status=self._loading_status_message,
+                loading_status=loading_status,
             )
             if not reset_requested:
                 break
             self._pipeline.reset()
+            loading_status = self._resetting_status_message
+            # Paint the reset indicator at once, before the next rollout's
+            # setup, so a reset shows on screen the instant it's requested
+            # rather than after the rebuild completes.
+            self._present_loading_once(loading_status)
+
+    def _present_loading_once(self, loading_status: Callable[[], str]) -> None:
+        """Render a single loading-overlay frame immediately (used on reset)."""
+        if self._scene is None:
+            return
+        self._presenter.process_events()
+        frame = PresentedFrame(
+            timestamp_us=0,
+            rgb_host_uint8=self._scene.initial_rgb,
+            depth_host_f32=None,
+        )
+        self._presenter.present_frame(
+            replace(frame, status_message=loading_status()),
+            view_mode=self._keyboard.view_mode,
+        )
 
     def _loading_status_message(self) -> str:
         """Phase text shown over the loading frame until the first chunk.
@@ -209,6 +450,10 @@ class InteractiveDriveApp:
             return "Loading world model..."
         return "Loading scene..."
 
+    def _resetting_status_message(self) -> str:
+        """Phase text shown while a reset / respawn re-primes the rollout."""
+        return "Resetting..."
+
     def run(self) -> None:
         """Single-scene convenience: load the configured scene, run, tear down.
 
@@ -216,13 +461,13 @@ class InteractiveDriveApp:
         The scene-switching demo loops call ``load_scene`` / ``run_scene``
         / ``shutdown`` directly so the pipeline survives across scenes.
         """
-        self.load_scene(
-            self._config.scene_path,
-            self._config.variant,
-            self._config.prompt_override,
-        )
         try:
-            self.run_scene()
+            if self.load_scene(
+                self._config.scene_path,
+                self._config.variant,
+                self._config.prompt_override,
+            ):
+                self.run_scene()
         finally:
             self.shutdown()
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -1,15 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from collections.abc import Callable
-
 from omnidreams.interactive_drive.backends.base import RenderBackend
 from omnidreams.interactive_drive.config import AppConfig
 from omnidreams.interactive_drive.input.keyboard import (
     KeyboardInputBackend,
     KeyboardState,
 )
-from omnidreams.interactive_drive.loading_overlay import render_loading_overlay
 from omnidreams.interactive_drive.presenter import SlangPyPresenter
 from omnidreams.interactive_drive.runtime.loop import (
     LoopConfig,
@@ -23,124 +20,217 @@ from omnidreams.interactive_drive.simulation.ego_vehicle_kinematics import (
     build_map_bounds,
     state_from_initial_pose,
 )
+from omnidreams.interactive_drive.simulation.map_bounds import MapBounds
 from omnidreams.interactive_drive.streaming_presenter import (
     MJPEGStreamingPresenter,
     parse_bind,
 )
-from omnidreams.interactive_drive.types import PresentedFrame
+from omnidreams.interactive_drive.types import PresentedFrame, SceneBundle
 from omnidreams.interactive_drive.video_model.chunk_pipeline import ChunkPipeline
 from omnidreams.interactive_drive.video_model.local import LocalVideoModelAdapter
 
-PresenterFactory = Callable[[AppConfig, KeyboardState], PresenterBackend]
-
 
 class InteractiveDriveApp:
+    """Long-lived interactive-drive engine.
+
+    The backend, video-model adapter and :class:`ChunkPipeline` are built
+    once in :meth:`__init__`; the pipeline worker starts warming the
+    scene-independent model immediately, overlapping the model load with
+    any scene-selection wait. Each scene the user picks is bound via
+    :meth:`load_scene` and driven by :meth:`run_scene`. The warmed model
+    stays resident across scene changes, so switching scenes never re-pays
+    the warmup/compile cost (only the per-scene geometry upload).
+    """
+
     def __init__(
         self,
         config: AppConfig,
         backend: RenderBackend,
-        presenter_factory: PresenterFactory | None = None,
+        presenter: PresenterBackend | None = None,
         *,
         close_presenter_on_exit: bool = True,
     ) -> None:
-        """Construct the engine.
+        """Construct the engine and begin model warmup.
 
-        ``presenter_factory`` lets the demo wrapper inject a HUD-aware
-        presenter (e.g. :class:`SlangPyHudPresenter`) that needs
-        constructor arguments outside :class:`AppConfig`'s vocabulary
-        (scene-selector options, wheel device, control assets). When
-        ``None``, :func:`_build_presenter` returns either the default
-        :class:`SlangPyPresenter` (a local Vulkan window) or, when
-        ``config.stream_mjpeg_bind`` is set, an
-        :class:`MJPEGStreamingPresenter` that serves frames over HTTP
-        with no GPU-graphics dependency. Browser viewers with a richer
-        frontend are served by ``omnidreams.webrtc.server`` instead.
+        ``presenter`` lets the demo wrapper inject a HUD-aware presenter
+        (e.g. :class:`SlangPyHudPresenter`) that needs constructor
+        arguments outside :class:`AppConfig`'s vocabulary (scene-selector
+        options, wheel device, control assets); the app rebinds it to its
+        own long-lived keyboard. When ``None``, :func:`_build_presenter`
+        returns either the default :class:`SlangPyPresenter` (a local
+        Vulkan window) or, when ``config.stream_mjpeg_bind`` is set, an
+        :class:`MJPEGStreamingPresenter` that serves frames over HTTP with
+        no GPU-graphics dependency. Browser viewers with a richer frontend
+        are served by ``omnidreams.webrtc.server`` instead.
         """
         self._config = config
         self._backend = backend
-        self._scene = load_scene_bundle(
-            scene_path=config.scene_path,
-            camera_name=config.camera_name,
-            variant=config.variant,
-            prompt_override=config.prompt_override,
-            raster=config.raster,
-        )
         self._keyboard = KeyboardState()
         if config.backend == "omnidreams":
             self._keyboard.set_view_mode("model_rgb")
-        factory = presenter_factory or _build_presenter
-        self._presenter = factory(config, self._keyboard)
-        # When ``False`` the caller (the slangpy HUD's outer scene-change
-        # loop) owns the presenter's lifecycle: it constructs one
-        # presenter at startup, reuses it across many ``app.run()``
-        # calls, and only closes it when the user actually closes the
-        # window. Default ``True`` matches the bare ``--no-hud`` path
-        # where each ``app.run()`` owns one presenter end-to-end.
+        if presenter is None:
+            self._presenter = _build_presenter(config, self._keyboard)
+        else:
+            self._presenter = presenter
+            # Injected presenters (HUD / streaming) are constructed by the
+            # demo with a placeholder keyboard; rebind to ours so input
+            # lands on the engine's actual state object.
+            bind_keyboard = getattr(self._presenter, "bind_keyboard", None)
+            if callable(bind_keyboard):
+                bind_keyboard(self._keyboard)
+        # When ``False`` the caller (the demo's outer scene-change loop)
+        # owns the presenter's lifecycle: it constructs one presenter at
+        # startup, reuses it across many scenes, and only closes it when
+        # the user actually closes the window. Default ``True`` matches the
+        # bare ``--no-hud`` path where the app owns the presenter
+        # end-to-end.
         self._close_presenter_on_exit = bool(close_presenter_on_exit)
+        # Build the video-model pipeline once and start warming the
+        # scene-independent model now, on the pipeline worker thread.
+        # Scenes are bound later via load_scene; the model is never rebuilt
+        # on a scene change.
+        self._adapter = LocalVideoModelAdapter(backend)
+        self._pipeline = ChunkPipeline(self._adapter)
+        self._scene: SceneBundle | None = None
+        self._map_bounds: MapBounds | None = None
 
-    def run(self) -> None:
-        # Pre-rendered "Loading..." overlay. Used as the loop's initial
-        # ``last_presented_frame`` so the user sees something while the
-        # pipeline worker thread does ``backend.warmup`` (slow for the
-        # world-model backend) and again briefly between rollouts during
-        # ``pipeline.reset`` while the next chunk is being rendered.
+    @property
+    def presenter(self) -> PresenterBackend:
+        return self._presenter
+
+    @property
+    def keyboard(self) -> KeyboardState:
+        return self._keyboard
+
+    @property
+    def can_prewarm(self) -> bool:
+        """Whether model warmup runs without a scene (drives the HUD text)."""
+        return self._backend.can_prewarm
+
+    def model_ready(self) -> bool:
+        """``True`` once the scene-independent model warmup has completed."""
+        return self._pipeline.model_ready.is_set()
+
+    def load_scene(
+        self, scene_path: object, variant: str, prompt_override: str | None
+    ) -> None:
+        """Load a scene bundle and bind it on the pipeline worker.
+
+        Cheap relative to warmup: reads the USDZ and enqueues a
+        ``request_scene`` that runs ``backend.load_scene`` (geometry
+        upload + rollout restart) on the worker, FIFO behind any pending
+        model warmup. The resident model is reused as-is.
+        """
+        self._scene = load_scene_bundle(
+            scene_path=scene_path,
+            camera_name=self._config.camera_name,
+            variant=variant,
+            prompt_override=prompt_override,
+            raster=self._config.raster,
+        )
+        # Build the OOB map bounds at scene load -- the AABB is a property
+        # of the scene's geometry and is invariant across the rollout
+        # restarts inside run_scene.
+        self._map_bounds = build_map_bounds(self._scene)
+        self._pipeline.request_scene(self._scene)
+
+    def run_scene(self) -> None:
+        """Drive the current scene until the presenter closes or switches.
+
+        Must be called after :meth:`load_scene`. Returns when
+        ``run_main_loop`` reports the presenter wants to close -- which the
+        slangpy HUD also uses to signal a scene change -- so the caller
+        inspects ``presenter.pending_scene_change`` to tell the two apart.
+        A manual reset / OOB respawn keeps the loop going with a fresh
+        simulation and ``pipeline.reset`` (the warmed model is kept).
+        """
+        if self._scene is None or self._map_bounds is None:
+            raise RuntimeError("load_scene() must be called before run_scene()")
+        # Seed the loop's initial ``last_presented_frame`` with the scene's
+        # first frame. The loop overlays a live loading status over it (see
+        # ``_loading_status_message``) until the first generated chunk
+        # arrives, and again briefly between rollouts during
+        # ``pipeline.reset``.
         loading_frame = PresentedFrame(
             timestamp_us=0,
-            rgb_host_uint8=render_loading_overlay(self._scene.initial_rgb),
+            rgb_host_uint8=self._scene.initial_rgb,
             depth_host_f32=None,
         )
-        local_backend = LocalVideoModelAdapter(self._backend)
-        pipeline = ChunkPipeline(local_backend, self._scene)
-        # Build the OOB map bounds once at scene load -- the AABB is a
-        # property of the scene's geometry and is invariant across the
-        # rollout-restart loop below.
-        map_bounds = build_map_bounds(self._scene)
+        while not self._presenter.should_close:
+            simulation = EgoVehicleKinematics(
+                initial_state=state_from_initial_pose(
+                    initial_rig_to_world=self._scene.initial_rig_to_world,
+                    initial_yaw_rad=self._scene.initial_yaw_rad,
+                    initial_speed_mps=(
+                        0.0
+                        if self._keyboard.command().manual_control
+                        else self._scene.initial_speed_mps
+                    ),
+                ),
+                vehicle_config=self._config.vehicle,
+                ground_snapper=build_ground_snapper(self._scene),
+                initial_timestamp_us=self._scene.initial_timestamp_us,
+                map_bounds=self._map_bounds,
+                oob_margin_m=self._config.oob_margin_m,
+                oob_warning_zone_m=self._config.oob_warning_zone_m,
+            )
+            input_backend = KeyboardInputBackend(self._keyboard)
+            reset_requested = run_main_loop(
+                presenter=self._presenter,
+                runtime_controls=self._keyboard,
+                initial_presented_frame=loading_frame,
+                input_backend=input_backend,
+                simulation=simulation,
+                pipeline=self._pipeline,
+                config=LoopConfig(
+                    initial_chunk_size=self._config.chunk.initial_chunk_frames,
+                    chunk_size=self._config.chunk.chunk_frames,
+                    frame_interval_s=self._config.chunk.frame_interval_s,
+                    oob_warn_proximity=self._config.oob_warn_proximity,
+                    oob_respawn_proximity=self._config.oob_respawn_proximity,
+                    oob_respawn_debounce_chunks=(
+                        self._config.oob_respawn_debounce_chunks
+                    ),
+                ),
+                loading_status=self._loading_status_message,
+            )
+            if not reset_requested:
+                break
+            self._pipeline.reset()
+
+    def _loading_status_message(self) -> str:
+        """Phase text shown over the loading frame until the first chunk.
+
+        World-model warmup takes priority; once the model is resident a
+        scene (re)load only uploads geometry and renders the first chunk,
+        so the lighter "Loading scene..." message is shown instead.
+        """
+        if not self.model_ready():
+            return "Loading world model..."
+        return "Loading scene..."
+
+    def run(self) -> None:
+        """Single-scene convenience: load the configured scene, run, tear down.
+
+        Used by the bare ``--no-hud`` path, which never switches scenes.
+        The scene-switching demo loops call ``load_scene`` / ``run_scene``
+        / ``shutdown`` directly so the pipeline survives across scenes.
+        """
+        self.load_scene(
+            self._config.scene_path,
+            self._config.variant,
+            self._config.prompt_override,
+        )
         try:
-            while not self._presenter.should_close:
-                simulation = EgoVehicleKinematics(
-                    initial_state=state_from_initial_pose(
-                        initial_rig_to_world=self._scene.initial_rig_to_world,
-                        initial_yaw_rad=self._scene.initial_yaw_rad,
-                        initial_speed_mps=(
-                            0.0
-                            if self._keyboard.command().manual_control
-                            else self._scene.initial_speed_mps
-                        ),
-                    ),
-                    vehicle_config=self._config.vehicle,
-                    ground_snapper=build_ground_snapper(self._scene),
-                    initial_timestamp_us=self._scene.initial_timestamp_us,
-                    map_bounds=map_bounds,
-                    oob_margin_m=self._config.oob_margin_m,
-                    oob_warning_zone_m=self._config.oob_warning_zone_m,
-                )
-                input_backend = KeyboardInputBackend(self._keyboard)
-                reset_requested = run_main_loop(
-                    presenter=self._presenter,
-                    runtime_controls=self._keyboard,
-                    initial_presented_frame=loading_frame,
-                    input_backend=input_backend,
-                    simulation=simulation,
-                    pipeline=pipeline,
-                    config=LoopConfig(
-                        initial_chunk_size=self._config.chunk.initial_chunk_frames,
-                        chunk_size=self._config.chunk.chunk_frames,
-                        frame_interval_s=self._config.chunk.frame_interval_s,
-                        oob_warn_proximity=self._config.oob_warn_proximity,
-                        oob_respawn_proximity=self._config.oob_respawn_proximity,
-                        oob_respawn_debounce_chunks=(
-                            self._config.oob_respawn_debounce_chunks
-                        ),
-                    ),
-                )
-                if not reset_requested:
-                    break
-                pipeline.reset()
+            self.run_scene()
         finally:
-            pipeline.shutdown()
-            self._backend.close()
-            if self._close_presenter_on_exit:
-                self._presenter.close()
+            self.shutdown()
+
+    def shutdown(self) -> None:
+        self._pipeline.shutdown()
+        self._backend.close()
+        if self._close_presenter_on_exit:
+            self._presenter.close()
 
 
 def _build_presenter(config: AppConfig, keyboard: KeyboardState) -> PresenterBackend:

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -224,9 +224,7 @@ class InteractiveDriveApp:
         self._pipeline.request_scene(self._scene)
         return True
 
-    def preload_scenes(
-        self, specs: Iterable[tuple[object, str, str | None]]
-    ) -> None:
+    def preload_scenes(self, specs: Iterable[tuple[object, str, str | None]]) -> None:
         """Parse scene bundles in the background so later switches are instant.
 
         ``specs`` is an iterable of ``(scene_path, variant, prompt_override)``.
@@ -258,9 +256,7 @@ class InteractiveDriveApp:
         """True while --preload-scenes is still parsing scenes in the background."""
         return self._preload_started and not self._preload_done.is_set()
 
-    def _preload_worker(
-        self, pending: list[tuple[object, str, str | None]]
-    ) -> None:
+    def _preload_worker(self, pending: list[tuple[object, str, str | None]]) -> None:
         for scene_path, variant, prompt_override in pending:
             key = self._scene_cache_key(scene_path, variant, prompt_override)
             with self._scene_cache_lock:

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/base.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/base.py
@@ -26,9 +26,39 @@ class RenderBackend(ABC):
     def chunk_frames(self) -> int:
         return self._chunk.chunk_frames
 
+    @property
+    def can_prewarm(self) -> bool:
+        """Whether :meth:`warmup_model` does its heavy build without a scene.
+
+        ``True`` lets the demo start loading the model immediately at
+        launch, overlapping warmup with the scene-selection wait. ``False``
+        means the build is deferred until the first :meth:`load_scene`
+        (e.g. the world model under ``--offload-text-encoder``, which must
+        precompute per-scene embeddings and free the one-shot encoders
+        before allocating the diffusion pipeline to keep peak VRAM low).
+        """
+        return True
+
     @abstractmethod
-    def warmup(self, scene: SceneBundle) -> None:
+    def warmup_model(self) -> None:
+        """Load/compile the scene-independent model. Called once per process."""
         raise NotImplementedError
+
+    @abstractmethod
+    def load_scene(self, scene: SceneBundle) -> None:
+        """Bind one scene's geometry / conditioning. Called once per scene."""
+        raise NotImplementedError
+
+    def warmup(self, scene: SceneBundle) -> None:
+        """Load the model and a single scene in one call.
+
+        Convenience for callers that never switch scenes (the bare
+        ``--no-hud`` path and unit tests). The scene-switching pipeline
+        instead calls :meth:`warmup_model` once and :meth:`load_scene` per
+        scene so the model is not rebuilt on each scene change.
+        """
+        self.warmup_model()
+        self.load_scene(scene)
 
     @abstractmethod
     def render_first_chunk(self, trajectory: TrajectoryChunk) -> FrameChunk:

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/raster.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/raster.py
@@ -20,7 +20,12 @@ class RasterRenderBackend(RenderBackend):
         self._rasterizer = LudusConditionRasterizer(raster, bev=bev)
         self._scene: SceneBundle | None = None
 
-    def warmup(self, scene: SceneBundle) -> None:
+    def warmup_model(self) -> None:
+        # The raster backend has no model to load; all per-scene work
+        # happens in load_scene, so there is nothing to pre-warm.
+        return
+
+    def load_scene(self, scene: SceneBundle) -> None:
         self._scene = scene
         self._rasterizer.load_scene(scene)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
@@ -53,7 +53,11 @@ class WorldModelRenderBackend(RenderBackend):
         self._next_chunk_count = 0
         self._debug_first_chunk_condition_frames: tuple[np.ndarray, ...] | None = None
 
-    def warmup(self, scene: SceneBundle) -> None:
+    @property
+    def can_prewarm(self) -> bool:
+        return self._session.can_prewarm
+
+    def warmup_model(self) -> None:
         if self._manifest.resolution_wh != self._raster.resolution_wh:
             raise ValueError(
                 "World-model manifest resolution does not match the renderer resolution: "
@@ -72,22 +76,34 @@ class WorldModelRenderBackend(RenderBackend):
             raise ValueError(
                 "The flashdreams world-model path is locked to a 5-frame first chunk."
             )
+        start = time.perf_counter()
+        self._session.warmup_model()
+        print(
+            f"[world-model] model warmup session_ms={(time.perf_counter() - start) * 1000.0:.1f}",
+            flush=True,
+        )
 
+    def load_scene(self, scene: SceneBundle) -> None:
         self._scene = scene
+        self._next_chunk_count = 0
         self._debug_first_chunk_condition_frames = self._load_debug_condition_frames(
             self._manifest.debug_condition_frame_dir
         )
-        warmup_start = time.perf_counter()
-        rasterizer_start = warmup_start
+        load_start = time.perf_counter()
         self._rasterizer.load_scene(scene)
         rasterizer_end = time.perf_counter()
-        self._session.warmup(initial_rgb=scene.initial_rgb, prompt=scene.prompt)
-        session_end = time.perf_counter()
+        # Per-scene conditioning prep. On the default path this is a no-op
+        # (the prompt is re-embedded per rollout in the session); under
+        # --offload-text-encoder it (re)builds the per-scene embeddings.
+        self._session.prepare_for_scene(
+            initial_rgb=scene.initial_rgb, prompt=scene.prompt
+        )
+        prepare_end = time.perf_counter()
         print(
-            "[world-model] warmup "
-            f"rasterizer_ms={(rasterizer_end - rasterizer_start) * 1000.0:.1f} "
-            f"session_ms={(session_end - rasterizer_end) * 1000.0:.1f} "
-            f"total_ms={(session_end - warmup_start) * 1000.0:.1f}",
+            "[world-model] load_scene "
+            f"rasterizer_ms={(rasterizer_end - load_start) * 1000.0:.1f} "
+            f"prepare_ms={(prepare_end - rasterizer_end) * 1000.0:.1f} "
+            f"total_ms={(prepare_end - load_start) * 1000.0:.1f}",
             flush=True,
         )
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from omnidreams.hf_org import DEFAULT_HF_ORG, apply_cli_to_env
 from omnidreams.hf_org import ENV_VAR as _HF_ORG_ENV_VAR
-from omnidreams.interactive_drive.app import InteractiveDriveApp, PresenterFactory
+from omnidreams.interactive_drive.app import InteractiveDriveApp
 from omnidreams.interactive_drive.backends.base import RenderBackend
 from omnidreams.interactive_drive.backends.raster import RasterRenderBackend
 from omnidreams.interactive_drive.backends.world_model import WorldModelRenderBackend
@@ -391,13 +391,12 @@ def prepare_config_and_backend(
 ) -> tuple[AppConfig, RenderBackend]:
     """Build the :class:`AppConfig` and :class:`RenderBackend` for ``args``.
 
-    Split out of :func:`run` so the slangpy HUD path in
-    :mod:`omnidreams.interactive_drive.demo` can call this in a loop -- once per
-    scene change -- while keeping the same window / presenter alive
-    across runs. The HUD's outer loop tears down the old backend with
-    ``backend.close()``, calls this to build a fresh one for the
-    newly-selected scene, then constructs a new
-    :class:`InteractiveDriveApp` over the same presenter.
+    Split out of :func:`run` so the demo wrappers in
+    :mod:`omnidreams.interactive_drive.demo` can build the backend once, up
+    front, and hand it to a single long-lived
+    :class:`InteractiveDriveApp` that switches scenes in place via
+    ``app.load_scene`` -- keeping the warmed model resident instead of
+    rebuilding it on every scene click.
     """
     # Stamp the resolved HF org into the env var BEFORE we touch anything
     # that fetches (manifest loader, scene staging, world-model build).
@@ -495,18 +494,15 @@ def prepare_config_and_backend(
     return config, backend
 
 
-def run(
-    args: argparse.Namespace, *, presenter_factory: PresenterFactory | None = None
-) -> None:
+def run(args: argparse.Namespace) -> None:
     """Execute the interactive-drive backend with the given parsed args.
 
-    Convenience wrapper used by the ``--no-hud`` path that doesn't need
-    to switch scenes mid-run. The slangpy HUD path drives
-    :func:`prepare_config_and_backend` directly so it can rebuild the
-    backend per scene click without recreating the presenter.
+    Convenience wrapper used by the ``--no-hud`` path that doesn't need to
+    switch scenes mid-run. The slangpy HUD / streaming paths in
+    :mod:`omnidreams.interactive_drive.demo` build one long-lived
+    :class:`InteractiveDriveApp` and call ``load_scene`` / ``run_scene``
+    per scene so the warmed model survives across scene clicks.
     """
     config, backend = prepare_config_and_backend(args)
-    app = InteractiveDriveApp(
-        config=config, backend=backend, presenter_factory=presenter_factory
-    )
+    app = InteractiveDriveApp(config=config, backend=backend)
     app.run()

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -502,6 +502,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start loading --scene immediately. By default the HUD opens on Load Scene.",
     )
     parser.add_argument(
+        "--preload-scenes",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Parse every scene in --scene-dir in the background at startup so"
+            " switching scenes skips the USDZ parse (the per-scene geometry"
+            " upload and first-chunk generation still happen on switch)."
+            " Off by default; uses more memory the more scenes are staged."
+        ),
+    )
+    parser.add_argument(
         "--cuda-visible-devices",
         default="auto",
         help=(
@@ -753,6 +764,15 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
         wheel.start()
         presenter.set_wheel(wheel)
 
+    if args.preload_scenes:
+        app.preload_scenes(
+            (opt.path, opt.variants[0] if opt.variants else "default", args.prompt)
+            for opt in scene_options
+        )
+        # Lock scene selection until every scene is cached so the user only
+        # ever hits the instant (cache-hit) switch path.
+        presenter.set_scene_selection_locked(app.preload_in_progress)
+
     # First scene: prefer the resolved ``config.scene_path`` so
     # ``--synthetic-scene`` (materialised to a temp USDZ) and any autostaged
     # default are honoured; a dropdown selection overrides it below.
@@ -771,12 +791,17 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
 
         while True:
             presenter.set_engine_active(True)
-            app.load_scene(scene_path, variant, args.prompt)
-            app.run_scene()
+            # load_scene parses the USDZ on a background thread while keeping
+            # the window responsive; it returns False if the window closed
+            # (or a new scene was requested) before the parse finished, so
+            # we skip run_scene and let the pending-change check below decide
+            # whether to switch scenes or exit.
+            if app.load_scene(scene_path, variant, args.prompt):
+                app.run_scene()
             presenter.set_engine_active(False)
             requested = presenter.pending_scene_change
             if requested is None:
-                # User closed the window (X / ESC); we're done.
+                # Window closed (X / ESC) during load or run; we're done.
                 break
             scene_path, variant = requested
             presenter.acknowledge_scene_change(scene_path, variant)
@@ -881,6 +906,15 @@ def _run_streaming(args: argparse.Namespace) -> None:
     )
     presenter.set_model_status(can_prewarm=app.can_prewarm, ready_probe=app.model_ready)
 
+    if args.preload_scenes:
+        app.preload_scenes(
+            (opt.path, opt.variants[0] if opt.variants else "default", args.prompt)
+            for opt in scene_options
+        )
+        # Lock scene selection until every scene is cached so the user only
+        # ever hits the instant (cache-hit) switch path.
+        presenter.set_scene_selection_locked(app.preload_in_progress)
+
     try:
         # Don't auto-load: always wait for the browser to pick the first
         # scene. There's no Vulkan window to show progress in, so the
@@ -904,8 +938,12 @@ def _run_streaming(args: argparse.Namespace) -> None:
         )
 
         while True:
-            app.load_scene(scene_path, variant, args.prompt)
-            app.run_scene()
+            # load_scene parses the USDZ on a background thread while the
+            # browser keeps receiving frames; False means the session is
+            # ending (or a new scene was requested) before the parse
+            # finished, so skip run_scene and let the check below decide.
+            if app.load_scene(scene_path, variant, args.prompt):
+                app.run_scene()
             requested = presenter.pending_scene_change
             if requested is None:
                 # Either the process is shutting down (Ctrl-C) or the

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -548,7 +548,22 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _maybe_autostage_scene(scene: Path) -> Path:
+def _has_discoverable_scenes(scene_dir: Path, scene: Path) -> bool:
+    """Whether the scene picker would find any staged USDZ to offer.
+
+    Mirrors :func:`_discover_scene_options`'s directory sweep -- the
+    ``--scene-dir`` cache plus the requested scene's own folder -- so the
+    default-scene autostage can be skipped when a curated set of scenes is
+    already present.
+    """
+    for directory in (scene_dir, scene.parent):
+        resolved = _project_path(directory)
+        if resolved.is_dir() and any(resolved.glob("*.usdz")):
+            return True
+    return False
+
+
+def _maybe_autostage_scene(scene: Path, *, scene_dir: Path, allow_skip: bool) -> Path:
     """Auto-download a known scene UUID on first launch.
 
     Triggers only when ``scene`` lives under the shared scenes cache
@@ -558,6 +573,13 @@ def _maybe_autostage_scene(scene: Path) -> Path:
     and non-clipgt filenames are returned unchanged so the demo's
     normal "file not found" error fires for them.
 
+    With ``allow_skip`` (any scene-picker mode -- HUD or MJPEG), a missing
+    default scene is also returned unchanged whenever the picker already
+    has staged scenes to offer, so a demo curated to a specific scene set
+    never blocks on the default UUID (no Hugging Face download, no early
+    exit). The run loop then backfills ``args.scene`` from the first
+    discovered scene.
+
     The explicit ``omnidreams-prepare`` script remains the way to
     pre-stage arbitrary UUIDs and to pre-warm the Cosmos-Reason1 text
     encoder; this helper just covers the "I just ran ``interactive-drive``
@@ -565,6 +587,13 @@ def _maybe_autostage_scene(scene: Path) -> Path:
     single command.
     """
     if scene.exists():
+        return scene
+    if allow_skip and _has_discoverable_scenes(scene_dir, scene):
+        print(
+            f"[interactive-drive] default scene '{scene.name}' is not staged; "
+            f"using the scenes already present under {scene_dir} instead.",
+            flush=True,
+        )
         return scene
     cache_dir = scenes_cache_root().resolve()
     if scene.resolve().parent != cache_dir:
@@ -591,7 +620,14 @@ def _maybe_autostage_scene(scene: Path) -> Path:
 def main() -> None:
     args = build_parser().parse_args()
     if not args.synthetic_scene:
-        args.scene = _maybe_autostage_scene(args.scene)
+        # Only the bare ``--no-hud`` backend has no scene picker; the HUD
+        # and MJPEG paths both let the user pick from ``--scene-dir``, so a
+        # missing default scene there is fine as long as the directory
+        # already has other scenes staged (see _maybe_autostage_scene).
+        uses_scene_picker = args.stream_mjpeg is not None or not args.no_hud
+        args.scene = _maybe_autostage_scene(
+            args.scene, scene_dir=args.scene_dir, allow_skip=uses_scene_picker
+        )
     # ``--stream-mjpeg`` runs through ``_run_streaming`` so the long-lived
     # MJPEG presenter (HTTP server, browser session) survives across
     # scene-change requests posted by the in-page picker. ``--no-hud``
@@ -617,23 +653,21 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
     + Ludus + CUDA in one process consistently failed at the EGL or
     CUDA-GL interop layer).
 
-    The function loops over scene-change requests so the user can pick
-    a new scene from the HUD dropdown without the slangpy window
-    closing and reopening. One ``SlangPyHudPresenter`` is constructed
-    at startup and reused across many ``app.run()`` invocations -- one
-    per scene the user picks. Each iteration tears down only the
-    backend / pipeline / simulation, rebuilds them for the freshly
-    selected scene, and hands them to a new
-    :class:`InteractiveDriveApp` whose ``close_presenter_on_exit=False``
-    keeps the presenter (and therefore the window) alive across the
-    transition.
+    One ``SlangPyHudPresenter`` and one long-lived
+    :class:`InteractiveDriveApp` are constructed at startup. Building the
+    app starts the (scene-independent) model warmup on the pipeline worker
+    thread immediately, so the long weight-load + compile overlaps with
+    the user's scene-selection wait. The function then loops over
+    scene-change requests, calling ``app.load_scene`` + ``app.run_scene``
+    per scene: the warmed model stays resident, so each switch only
+    re-uploads the scene geometry instead of reloading the model, and the
+    slangpy window never closes and reopens (``close_presenter_on_exit=False``
+    keeps the presenter alive until the user actually closes the window).
 
-    The wheel is a long-lived resource too -- evdev fd, FFB context --
-    so it's constructed once and rebound to each successive
-    ``KeyboardState`` via the presenter's
-    :meth:`SlangPyHudPresenter.bind_keyboard`. We rebuild the wheel
-    bridge if the bind target differs because ``WheelBridge`` captures
-    the sink at init.
+    The wheel is a long-lived resource too -- evdev fd, FFB context -- and
+    binds once to the app's single ``KeyboardState`` via
+    :meth:`SlangPyHudPresenter.bind_keyboard`; no per-scene rebinding,
+    since the keyboard now lives for the whole session.
     """
     from omnidreams.interactive_drive.input.keyboard import KeyboardState
     from omnidreams.interactive_drive.slangpy_hud_presenter import (
@@ -686,68 +720,68 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
         control_assets=control_assets,
         wheel=None,
     )
-    # Attach the wheel up front, bound to the placeholder keyboard, so the
-    # HUD's steering / pedal chrome reacts to the physical device during the
-    # initial "Load Scene" wait -- not only once a scene is running. The
-    # evdev reader thread starts now; the per-run factory below just rebinds
-    # its drive sink to each run's KeyboardState.
+
+    # Build the backend + engine ONCE, up front. Constructing the app
+    # starts the (scene-independent) model warmup on the pipeline worker
+    # thread immediately, so the long weight-load + compile overlaps with
+    # the user's scene-selection wait below instead of starting only after
+    # the first pick. The app owns one long-lived KeyboardState and rebinds
+    # the presenter to it; scenes are switched in place via
+    # ``app.load_scene`` so the warmed model is never rebuilt.
+    config, backend = _cli.prepare_config_and_backend(args)
+    app = InteractiveDriveApp(
+        config=config,
+        backend=backend,
+        presenter=presenter,
+        close_presenter_on_exit=False,
+    )
+    presenter.set_model_status(can_prewarm=app.can_prewarm, ready_probe=app.model_ready)
+
+    # Attach the wheel up front, bound to the app's long-lived keyboard, so
+    # the HUD's steering / pedal chrome reacts to the physical device during
+    # the initial scene-selection wait -- not only once a scene is running.
+    # The evdev reader thread starts now and runs for the process lifetime;
+    # the single keyboard means it never needs rebinding across scenes.
     wheel: Any = None
     if wheel_selection is not None:
         profile, device_path = wheel_selection
         wheel = WheelBridge(
             device_path=device_path,
             profile=profile,
-            control=KeyboardStateDriveSink(placeholder_keyboard),
+            control=KeyboardStateDriveSink(app.keyboard),
         )
         wheel.start()
         presenter.set_wheel(wheel)
 
-    def _factory(config: Any, keyboard: Any) -> Any:
-        # Called once per ``InteractiveDriveApp.__init__``. Rebind the
-        # wheel's drive sink to this run's KeyboardState (the reader thread
-        # started above keeps running, state-machine-clean -- the only thing
-        # tied to the keyboard is the sink it posts ``set_drive`` into), then
-        # point the presenter at the new keyboard.
-        if wheel is not None:
-            wheel._control = KeyboardStateDriveSink(keyboard)  # noqa: SLF001 -- see comment
-        presenter.bind_keyboard(keyboard)
-        return presenter
-
+    # First scene: prefer the resolved ``config.scene_path`` so
+    # ``--synthetic-scene`` (materialised to a temp USDZ) and any autostaged
+    # default are honoured; a dropdown selection overrides it below.
+    scene_path: Any = config.scene_path
+    variant = config.variant
     try:
         # Initial scene-selection wait: if the user didn't pass
-        # ``--autoload-scene``, open the HUD and let them pick a
-        # scene from the dropdown. Skipping the autoload also lets
-        # the user pick a different scene than ``--scene`` advertises
-        # without re-running the binary.
+        # ``--autoload-scene``, open the HUD and let them pick a scene from
+        # the dropdown while the model warms in the background.
         if not args.autoload_scene:
             request = presenter.wait_for_scene_selection()
             if request is None:
                 return  # window closed before any scene was loaded
             scene_path, variant = request
-            args.scene = scene_path
-            args.variant = variant
             presenter.acknowledge_scene_change(scene_path, variant)
 
         while True:
             presenter.set_engine_active(True)
-            config, backend = _cli.prepare_config_and_backend(args)
-            app = InteractiveDriveApp(
-                config=config,
-                backend=backend,
-                presenter_factory=_factory,
-                close_presenter_on_exit=False,
-            )
-            app.run()
+            app.load_scene(scene_path, variant, args.prompt)
+            app.run_scene()
             presenter.set_engine_active(False)
             requested = presenter.pending_scene_change
             if requested is None:
                 # User closed the window (X / ESC); we're done.
                 break
-            new_scene_path, new_variant = requested
-            args.scene = new_scene_path
-            args.variant = new_variant
-            presenter.acknowledge_scene_change(new_scene_path, new_variant)
+            scene_path, variant = requested
+            presenter.acknowledge_scene_change(scene_path, variant)
     finally:
+        app.shutdown()
         presenter.close()
 
 
@@ -757,10 +791,10 @@ def _run_streaming(args: argparse.Namespace) -> None:
     Mirrors :func:`_run_slangpy_hud`'s outer-loop structure but with a
     long-lived :class:`MJPEGStreamingPresenter` instead of a slangpy
     window. The HTTP server (and any connected browser sessions) stay
-    alive across scene transitions; only the backend / pipeline /
-    simulation get rebuilt per scene. The browser shows the loading
-    overlay during the rebuild and resumes streaming the moment the
-    new pipeline produces its first chunk.
+    alive across scene transitions; the backend / pipeline are built once
+    and only the scene (geometry + simulation) is swapped per scene. The
+    browser shows the loading overlay during the swap and resumes
+    streaming the moment the new scene produces its first chunk.
 
     Scene options come from the same discovery layer the slangpy HUD
     uses. They get serialised into a JSON-friendly shape and posted to
@@ -833,25 +867,27 @@ def _run_streaming(args: argparse.Namespace) -> None:
         thumbnails=thumbnails,
     )
 
-    def _factory(config: object, keyboard: KeyboardState) -> MJPEGStreamingPresenter:
-        # Each ``InteractiveDriveApp.__init__`` builds a fresh
-        # ``KeyboardState``; rebind so the long-lived presenter
-        # follows the new instance instead of writing into the
-        # placeholder keyboard from before the first scene loaded.
-        del config
-        presenter.bind_keyboard(keyboard)
-        return presenter
+    # Build the backend + engine once so the model warms up (on the
+    # pipeline worker thread) while the browser is still choosing the first
+    # scene. The app rebinds the presenter to its long-lived keyboard and
+    # switches scenes in place via ``app.load_scene``, keeping the warmed
+    # model resident across scene changes.
+    config, backend = _cli.prepare_config_and_backend(args)
+    app = InteractiveDriveApp(
+        config=config,
+        backend=backend,
+        presenter=presenter,
+        close_presenter_on_exit=False,
+    )
+    presenter.set_model_status(can_prewarm=app.can_prewarm, ready_probe=app.model_ready)
 
     try:
-        # Don't auto-load: always wait for the browser to pick the
-        # first scene. This mirrors the slangpy HUD's ``--no-autoload-
-        # scene`` default (which is the *only* mode for the streaming
-        # path -- there's no Vulkan window to show progress in, so we
-        # would otherwise burn world-model warmup on whatever
-        # ``args.scene`` defaulted to before the user expressed any
-        # intent). The presenter publishes an idle "Select a scene to
-        # begin" overlay frame so connected browsers have something to
-        # render while the wait spins.
+        # Don't auto-load: always wait for the browser to pick the first
+        # scene. There's no Vulkan window to show progress in, so the
+        # presenter publishes an idle overlay frame ("Loading world
+        # model..." while warmup runs in the background, then "Select a
+        # scene to begin") so connected browsers have something to render
+        # while the wait spins.
         print(
             "[demo] streaming presenter waiting for first scene selection...",
             flush=True,
@@ -859,25 +895,17 @@ def _run_streaming(args: argparse.Namespace) -> None:
         request = presenter.wait_for_scene_selection()
         if request is None:
             return  # presenter closed before any selection (Ctrl-C)
-        first_scene_path, first_variant = request
-        args.scene = first_scene_path
-        args.variant = first_variant
-        presenter.acknowledge_scene_change(first_scene_path, first_variant)
+        scene_path, variant = request
+        presenter.acknowledge_scene_change(scene_path, variant)
         print(
-            f"[demo] streaming initial scene -> {first_scene_path.name} "
-            f"variant={first_variant!r}",
+            f"[demo] streaming initial scene -> {scene_path.name} "
+            f"variant={variant!r}",
             flush=True,
         )
 
         while True:
-            config, backend = _cli.prepare_config_and_backend(args)
-            app = InteractiveDriveApp(
-                config=config,
-                backend=backend,
-                presenter_factory=_factory,
-                close_presenter_on_exit=False,
-            )
-            app.run()
+            app.load_scene(scene_path, variant, args.prompt)
+            app.run_scene()
             requested = presenter.pending_scene_change
             if requested is None:
                 # Either the process is shutting down (Ctrl-C) or the
@@ -886,16 +914,15 @@ def _run_streaming(args: argparse.Namespace) -> None:
                 # affordance, so a "no pending change" exit is
                 # treated as the end of the session.
                 break
-            new_scene_path, new_variant = requested
-            args.scene = new_scene_path
-            args.variant = new_variant
-            presenter.acknowledge_scene_change(new_scene_path, new_variant)
+            scene_path, variant = requested
+            presenter.acknowledge_scene_change(scene_path, variant)
             print(
-                f"[demo] streaming scene change -> {new_scene_path.name} "
-                f"variant={new_variant!r}",
+                f"[demo] streaming scene change -> {scene_path.name} "
+                f"variant={variant!r}",
                 flush=True,
             )
     finally:
+        app.shutdown()
         presenter.close()
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -53,7 +53,6 @@ _query_axis_range = query_axis_range
 # of the live screen width. Pinned at 500 px because the panel content
 # (wheel asset, pedal pngs) is asset-driven and doesn't reflow.
 HUD_PANEL_WIDTH = 500
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SCENE_THUMB_SIZE = (140, 64)
 KEYBOARD_STEER_SCALE = 0.75
 KEYBOARD_STEER_RATE_PER_S = 0.6
@@ -932,8 +931,7 @@ def _run_streaming(args: argparse.Namespace) -> None:
         scene_path, variant = request
         presenter.acknowledge_scene_change(scene_path, variant)
         print(
-            f"[demo] streaming initial scene -> {scene_path.name} "
-            f"variant={variant!r}",
+            f"[demo] streaming initial scene -> {scene_path.name} variant={variant!r}",
             flush=True,
         )
 
@@ -1001,7 +999,11 @@ def _project_path(path: Path) -> Path:
     path = Path(path).expanduser()
     if path.is_absolute():
         return path
-    return (PROJECT_ROOT / path).resolve()
+    # Resolve relative paths against the current working directory -- the
+    # standard CLI convention, and what users expect when running from the
+    # repo root. (This previously resolved against the package directory,
+    # integrations/omnidreams, which was surprising for --scene/--scene-dir.)
+    return (Path.cwd() / path).resolve()
 
 
 def _discover_scene_options(

--- a/integrations/omnidreams/omnidreams/interactive_drive/loading_overlay.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/loading_overlay.py
@@ -3,16 +3,18 @@
 
 """Shared ``Loading...`` overlay used while the backend is warming up.
 
-:class:`omnidreams.interactive_drive.app.InteractiveDriveApp` pre-renders this once at
-startup into a :class:`~omnidreams.interactive_drive.types.PresentedFrame` and seeds
-:func:`~omnidreams.interactive_drive.runtime.loop.run_main_loop` with it as the
-``initial_presented_frame``. The loop re-presents that frame on every
-display tick until the pipeline produces its first chunk (~60 s for the
-world-model backend due to HF download + torch.compile), so the user
-sees a high-contrast "Loading world model..." box instead of a frozen
-initial camera frame and reasonably assuming the demo has hung.
+Renders a high-contrast callout box with a status message over a base
+camera frame. Used as the status-overlay renderer for the loading phase:
+:func:`~omnidreams.interactive_drive.runtime.loop.run_main_loop` polls a
+``loading_status`` provider while no generated chunk has arrived yet and
+surfaces its message ("Loading world model..." until the model is
+resident, then "Loading scene..." while the picked scene uploads) over
+the seeded initial frame, so the user sees progress instead of a frozen
+frame and reasonably assuming the demo has hung. The MJPEG streaming
+presenter reuses this for its own status / idle overlays.
 
-PIL + ImageDraw.textbbox isn't cheap but it's called once per session.
+PIL + ImageDraw.textbbox isn't cheap, so it's only invoked on loading
+ticks (a few seconds), never in the steady-state present path.
 """
 
 from __future__ import annotations

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -440,11 +440,17 @@ def _drain_pipeline_frames(
     presenter: PresenterBackend,
     view_mode: str,
 ) -> None:
+    current_generation = pipeline.current_generation
     while True:
         try:
             queued_frame = pipeline.frame_queue.get_nowait()
         except queue.Empty:
             return
+        if queued_frame.generation != current_generation:
+            # Stale frame from a rollout / scene the user has moved past (a
+            # reset or scene switch bumped the pipeline generation); drop it
+            # so we don't flash old content over the new load.
+            continue
         _prepare_queued_frame(queued_frame, presenter, view_mode)
         ready_frames.append(queued_frame)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -5,6 +5,7 @@ import os
 import queue
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Protocol
 
@@ -456,6 +457,7 @@ def run_main_loop(
     simulation: SimulationBackend,
     pipeline: ChunkPipeline,
     config: LoopConfig,
+    loading_status: Callable[[], str | None] | None = None,
 ) -> bool:
     """Drive the request -> render -> present pipeline.
 
@@ -467,8 +469,15 @@ def run_main_loop(
     ``initial_presented_frame`` seeds ``last_presented_frame`` so the loop
     has a single uniform ``present_frame`` path: while the pipeline is
     warming up or hasn't produced a chunk yet, the loop keeps re-presenting
-    whatever it last presented, which is the loading-overlay frame the
-    caller pre-rendered.
+    whatever it last presented, which is the loading frame the caller
+    seeded.
+
+    ``loading_status`` is an optional per-tick text provider polled only
+    while no real frame has been produced yet (the loading phase). The
+    caller uses it to surface the current phase -- "Loading world model..."
+    while the model warms, "Loading scene..." once it's resident and the
+    picked scene is uploading -- as a status overlay over the loading
+    frame. The OOB warning still takes precedence when both apply.
 
     Returns ``True`` if the loop exited because the user requested a reset
     (caller should call ``pipeline.reset`` and re-run the loop with a fresh
@@ -547,12 +556,24 @@ def run_main_loop(
             last_presented_frame = queued_frame.frame
             state.frame_count += 1
         else:
-            # Re-present the last frame with whatever OOB overlay is current
-            # for this tick; the merged frame is local to this call so the
-            # cached ``last_presented_frame`` stays unmodified for the next
+            # Re-present the last frame with whatever overlay is current for
+            # this tick. The OOB warning wins; otherwise, while no real
+            # frame has been produced yet (``frame_count == 0``), surface
+            # the loading-phase status from ``loading_status`` -- "Loading
+            # world model..." until the model is resident, then "Loading
+            # scene..." while the picked scene uploads and its first chunk
+            # renders. The merged frame is local to this call so the cached
+            # ``last_presented_frame`` stays unmodified for the next
             # iteration.
+            overlay = state.oob_message
+            if (
+                overlay is None
+                and loading_status is not None
+                and state.frame_count == 0
+            ):
+                overlay = loading_status()
             presenter.present_frame(
-                _frame_with_overlay(last_presented_frame, state.oob_message),
+                _frame_with_overlay(last_presented_frame, overlay),
                 view_mode=view_mode,
             )
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -1544,7 +1544,9 @@ class SlangPyHudPresenter:
             fill=NVIDIA_GREEN + (255,),
         )
         if self._engine_active:
-            scene_label_full = f"Running {self._scene_label_fn(self._current_scene)}\u2026"
+            scene_label_full = (
+                f"Running {self._scene_label_fn(self._current_scene)}\u2026"
+            )
         elif self._scene_selection_locked():
             scene_label_full = "Preloading scenes\u2026"
         else:

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -469,6 +469,12 @@ class SlangPyHudPresenter:
         # wiring (or before it) behaves like the old "Load Scene" prompt.
         self._model_can_prewarm = False
         self._model_ready_probe: Callable[[], bool] = lambda: True
+        # Scene-selection lock, wired by the demo via
+        # :meth:`set_scene_selection_locked` when --preload-scenes is on.
+        # While the probe returns True the scene/variant dropdowns ignore
+        # clicks and the placeholder shows a "Preloading scenes..." hint, so
+        # the user can't pick a scene until every scene is cached.
+        self._scene_selection_locked_probe: Callable[[], bool] = lambda: False
 
         # Scene-change request set by the dropdown click handlers. The
         # outer demo loop checks this after each ``app.run_scene`` returns:
@@ -1247,6 +1253,8 @@ class SlangPyHudPresenter:
             if not self._engine_active:
                 if self._model_can_prewarm and not self._model_ready_probe():
                     placeholder = "Loading world model..."
+                elif self._scene_selection_locked():
+                    placeholder = "Preloading scenes..."
                 elif self._model_can_prewarm:
                     placeholder = "Ready - pick a scene"
                 else:
@@ -1347,8 +1355,13 @@ class SlangPyHudPresenter:
             "Loading Scene...",
             "Loading world model...",
             "Ready - pick a scene",
+            "Preloading scenes...",
         ):
-            hint = "Pick a scene from the panel on the right"
+            hint = (
+                "Preloading scenes, please wait..."
+                if self._scene_selection_locked()
+                else "Pick a scene from the panel on the right"
+            )
             hbox = _measure_text(self._font_small, hint)
             hw = hbox[2] - hbox[0]
             draw.text(
@@ -1501,6 +1514,9 @@ class SlangPyHudPresenter:
             self._variant_dropdown_open,
             has_multiple_variants,
             self._engine_active,
+            # Scene header reads "Preloading scenes..." while locked, so the
+            # lock state has to invalidate the cached chrome too.
+            self._scene_selection_locked(),
         )
         if key == self._panel_chrome_cache_key and self._panel_chrome_cache is not None:
             return self._panel_chrome_cache
@@ -1527,11 +1543,12 @@ class SlangPyHudPresenter:
             (margin + 8, header_y + 11, margin + 18, header_y + 21),
             fill=NVIDIA_GREEN + (255,),
         )
-        scene_label_full = (
-            f"Running {self._scene_label_fn(self._current_scene)}\u2026"
-            if self._engine_active
-            else "Select Scene"
-        )
+        if self._engine_active:
+            scene_label_full = f"Running {self._scene_label_fn(self._current_scene)}\u2026"
+        elif self._scene_selection_locked():
+            scene_label_full = "Preloading scenes\u2026"
+        else:
+            scene_label_full = "Select Scene"
         scene_label_max_w = header_w - 26 - 30  # 26 left for dot, 30 right for arrow
         scene_label = _truncate_text_to_width(
             self._font_small, scene_label_full, scene_label_max_w
@@ -2262,6 +2279,11 @@ class SlangPyHudPresenter:
                     break
 
     def _handle_click(self, pos: tuple[int, int]) -> None:
+        # While scenes are still preloading, the scene/variant dropdowns are
+        # locked (the only mouse-clickable HUD elements), so ignore clicks
+        # until every scene is cached and selection is instant.
+        if self._scene_selection_locked():
+            return
         # Variant dropdown sits on top of the scene dropdown items, so
         # check it first.
         if self._variant_dropdown_open:
@@ -2363,6 +2385,19 @@ class SlangPyHudPresenter:
         """
         self._model_can_prewarm = bool(can_prewarm)
         self._model_ready_probe = ready_probe
+
+    def set_scene_selection_locked(self, probe: Callable[[], bool]) -> None:
+        """Gate scene/variant selection while ``probe()`` returns True.
+
+        Used with --preload-scenes so the user can't pick a scene until
+        every scene has finished preloading (and would therefore hit the
+        instant cache path). While locked the dropdowns ignore clicks and
+        the camera placeholder shows a "Preloading scenes..." hint.
+        """
+        self._scene_selection_locked_probe = probe
+
+    def _scene_selection_locked(self) -> bool:
+        return self._scene_selection_locked_probe()
 
     def set_engine_active(self, active: bool) -> None:
         """Toggle the scene-running chrome and placeholder text.

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -30,15 +30,15 @@ the chrome, and the presentation all live in one Python process here:
 * Scene / variant changes from the dropdown signal the engine to
   exit by setting ``_pending_scene_change`` and flipping the close
   flag. The demo's outer loop in
-  :func:`omnidreams.interactive_drive.demo._run_slangpy_hud` then tears down the
-  current backend (``backend.close()``), builds a new one for the
-  newly-selected scene, and runs a fresh :class:`InteractiveDriveApp`
-  over this same presenter -- the slangpy window survives the
-  transition so the user sees a continuous HUD instead of a
-  close-and-reopen flash. The previous incarnation of this code used
-  ``os.execv`` for the same effect; the in-process path is faster
-  (~hundreds of ms vs ~1-2 s for a full process restart) and avoids
-  the visual interruption.
+  :func:`omnidreams.interactive_drive.demo._run_slangpy_hud` then calls
+  ``app.load_scene`` on the single long-lived
+  :class:`InteractiveDriveApp` and re-enters ``app.run_scene`` over this
+  same presenter. The warmed world model stays resident across the
+  switch (only the per-scene geometry is re-uploaded), so the slangpy
+  window survives the transition and the user sees a continuous HUD
+  instead of the close-and-reopen flash -- and minutes of model reload --
+  the older teardown/rebuild (and the ``os.execv`` path before it)
+  incurred.
 """
 
 from __future__ import annotations
@@ -48,6 +48,7 @@ import math as _math
 import os
 import time
 from collections import OrderedDict
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -453,20 +454,27 @@ class SlangPyHudPresenter:
         self._current_scene = args.scene
         self._selected_variant = args.variant
         self._has_camera_frame = False
-        # ``_engine_active`` is False during the initial "Load Scene"
+        # ``_engine_active`` is False during the initial scene-selection
         # wait (when the user hasn't picked a scene yet AND
-        # ``--autoload-scene`` was off) and during the brief reload gap
-        # between scene changes. Drives the camera-area placeholder
-        # text: "Load Scene" when False, "Loading World Model" /
-        # "Loading Scene..." when True. Toggled by the demo wrapper
-        # via :meth:`set_engine_active` around each ``app.run()``.
+        # ``--autoload-scene`` was off) and during the brief gap between
+        # scene changes. Drives the camera-area placeholder text together
+        # with the model-warmup state below. Toggled by the demo wrapper
+        # via :meth:`set_engine_active` around each scene's run.
         self._engine_active = False
+        # Model-warmup status, wired by the demo via :meth:`set_model_status`.
+        # ``_model_can_prewarm`` is True when the model loads at startup
+        # (so the selection wait shows "Loading world model..." instead of
+        # "Load Scene"); ``_model_ready_probe`` returns True once warmup
+        # has finished. Defaults are inert so a presenter used without the
+        # wiring (or before it) behaves like the old "Load Scene" prompt.
+        self._model_can_prewarm = False
+        self._model_ready_probe: Callable[[], bool] = lambda: True
 
         # Scene-change request set by the dropdown click handlers. The
-        # outer demo loop checks this after each ``app.run()`` returns:
-        # if non-None, it tears down the current backend, builds a new
-        # one for the requested scene, and runs the engine again over
-        # the SAME presenter so the slangpy window stays alive.
+        # outer demo loop checks this after each ``app.run_scene`` returns:
+        # if non-None, it calls ``app.load_scene`` for the requested scene
+        # and re-enters the engine over the SAME presenter so the slangpy
+        # window (and the warmed model) stay alive.
         self._pending_scene_change: tuple[Any, str] | None = None
 
         self._key_codes = self._build_key_codes()
@@ -1221,14 +1229,15 @@ class SlangPyHudPresenter:
                 self._draw_camera(canvas, self._latest_camera_pil, camera_area)
             camera_drawn = True
         if not camera_drawn:
-            # Three states:
-            #   - engine off (initial wait when ``--autoload-scene`` is
-            #     False, or the brief gap between scene switches):
-            #     "Load Scene" + dropdown hint.
-            #   - engine on but no frames yet (warmup): "Loading World Model".
-            #   - engine on, mid-rollout, transient empty queue: same as
-            #     warmup; the cached ``_latest_camera_pil`` covers the
-            #     normal case so this branch only fires before first frame.
+            # Placeholder states:
+            #   - engine off, model still warming (pre-warm overlapping the
+            #     selection wait): "Loading world model..." + dropdown hint.
+            #   - engine off, model warm (or pre-warm disabled): "Ready -
+            #     pick a scene" / "Load Scene" + dropdown hint.
+            #   - engine on, model not ready yet (user picked mid-warmup):
+            #     "Loading World Model".
+            #   - engine on, model warm, no frame yet (geometry upload +
+            #     first chunk): "Loading Scene...".
             # Wipe the camera area so the previous tick's placeholder
             # text / camera frame doesn't ghost behind the new
             # placeholder. Cheap relative to the full-screen clear we
@@ -1236,8 +1245,13 @@ class SlangPyHudPresenter:
             # *and* only on placeholder ticks rather than always.
             draw.rectangle(camera_area, fill=BG_COLOR + (255,))
             if not self._engine_active:
-                placeholder = "Load Scene"
-            elif self._has_camera_frame:
+                if self._model_can_prewarm and not self._model_ready_probe():
+                    placeholder = "Loading world model..."
+                elif self._model_can_prewarm:
+                    placeholder = "Ready - pick a scene"
+                else:
+                    placeholder = "Load Scene"
+            elif not self._model_ready_probe():
                 placeholder = "Loading World Model"
             else:
                 placeholder = "Loading Scene..."
@@ -1328,7 +1342,12 @@ class SlangPyHudPresenter:
             fill=TEXT_COLOR,
             font=self._font_large,
         )
-        if message in ("Load Scene", "Loading Scene..."):
+        if message in (
+            "Load Scene",
+            "Loading Scene...",
+            "Loading world model...",
+            "Ready - pick a scene",
+        ):
             hint = "Pick a scene from the panel on the right"
             hbox = _measure_text(self._font_small, hint)
             hw = hbox[2] - hbox[0]
@@ -2305,14 +2324,14 @@ class SlangPyHudPresenter:
         """Tell the engine to exit while keeping the window alive.
 
         Sets ``_pending_scene_change`` and flips the close flag so
-        :func:`run_main_loop` exits, ``app.run()`` tears the current
-        backend down, and the demo's outer scene-change loop in
+        :func:`run_main_loop` exits, ``app.run_scene`` returns, and the
+        demo's outer scene-change loop in
         :func:`omnidreams.interactive_drive.demo._run_slangpy_hud` picks the
-        request up. That loop builds a fresh backend for the new
-        scene and constructs a new :class:`InteractiveDriveApp` over
-        this same presenter, so the slangpy swapchain / window survives
-        the change without the close-and-reopen flash the previous
-        ``os.execv``-based path produced.
+        request up. That loop calls ``app.load_scene`` for the new scene
+        and re-enters ``app.run_scene`` over this same presenter, so the
+        slangpy swapchain / window (and the resident model) survive the
+        change without the close-and-reopen flash -- or model reload --
+        the older teardown/rebuild and ``os.execv`` paths produced.
         """
         self._args.scene = scene_path
         self._args.variant = variant
@@ -2329,13 +2348,30 @@ class SlangPyHudPresenter:
         """``(scene_path, variant)`` if a dropdown click is pending, else None."""
         return self._pending_scene_change
 
-    def set_engine_active(self, active: bool) -> None:
-        """Toggle the camera-area placeholder text.
+    def set_model_status(
+        self, *, can_prewarm: bool, ready_probe: Callable[[], bool]
+    ) -> None:
+        """Wire the camera-placeholder text to model-warmup progress.
 
-        ``active=False`` → "Load Scene" + dropdown hint (initial wait
-        and the brief gap between scene switches). ``active=True`` →
-        "Loading World Model" / "Loading Scene...". The demo's outer
-        loop calls this around each ``app.run()``.
+        ``can_prewarm`` is True when the model loads at startup (the
+        default world-model path), so the selection wait reads "Loading
+        world model..." then "Ready - pick a scene" once warmup finishes.
+        False (e.g. ``--offload-text-encoder``, which only builds after the
+        first scene is known) keeps the plain "Load Scene" prompt.
+        ``ready_probe`` returns True once warmup has completed; it is
+        polled each render tick, so the text updates live mid-wait.
+        """
+        self._model_can_prewarm = bool(can_prewarm)
+        self._model_ready_probe = ready_probe
+
+    def set_engine_active(self, active: bool) -> None:
+        """Toggle the scene-running chrome and placeholder text.
+
+        ``active=False`` is the initial selection wait and the brief gap
+        between scene switches; ``active=True`` is a scene running (or
+        loading). The demo's outer loop calls this around each scene's
+        run. The exact placeholder string also depends on the model-warmup
+        state set via :meth:`set_model_status`.
         """
         self._engine_active = bool(active)
         # Drop the chrome cache so the panel is redrawn promptly --
@@ -2377,13 +2413,13 @@ class SlangPyHudPresenter:
             self.set_engine_active(prior_engine_active)
 
     def acknowledge_scene_change(self, scene_path: Any, variant: str) -> None:
-        """Accept the scene change and prepare the presenter for the next ``app.run()``.
+        """Accept the scene change and prepare the presenter for the next scene.
 
-        Called by the demo's outer loop after it's torn down the old
-        backend and built a new one. Resets the close flag, clears
-        cached per-scene state (camera frames, BEV, dropdowns), and
-        updates ``_current_scene`` / ``_selected_variant`` so the
-        chrome reflects the new selection.
+        Called by the demo's outer loop just before it calls
+        ``app.load_scene`` for the newly-selected scene. Resets the close
+        flag, clears cached per-scene state (camera frames, BEV,
+        dropdowns), and updates ``_current_scene`` / ``_selected_variant``
+        so the chrome reflects the new selection.
         """
         self._pending_scene_change = None
         self._should_close_flag = False
@@ -2411,24 +2447,26 @@ class SlangPyHudPresenter:
     def set_wheel(self, wheel: Any | None) -> None:
         """Attach (or detach) a :class:`WheelBridge` after construction.
 
-        The demo wrapper attaches the wheel lazily on the first
-        ``app.run()`` so the evdev reader thread doesn't start during
-        the initial "Load Scene" wait. Without this hook the presenter
-        would still see ``self._wheel = None`` from its constructor
-        even after the wheel was created, and chrome rendering would
-        always fall through to the keyboard-drive smoother.
+        The demo wrapper builds the wheel just after the engine (so its
+        drive sink targets the app's keyboard) and attaches it here, before
+        the scene-selection wait, so the HUD's steering / pedal chrome
+        reacts to the physical device while the user is still picking a
+        scene. Without this hook the presenter would still see
+        ``self._wheel = None`` from its constructor even after the wheel
+        was created, and chrome rendering would always fall through to the
+        keyboard-drive smoother.
         """
         self._wheel = wheel
 
     def bind_keyboard(self, keyboard: KeyboardState) -> None:
-        """Rebind to a fresh ``KeyboardState`` for a new ``app.run()`` cycle.
+        """Rebind to the engine's ``KeyboardState``.
 
-        :class:`InteractiveDriveApp` constructs its own ``KeyboardState``
-        per run, so when the demo loop reuses this presenter across
-        scenes the previous run's keyboard becomes stale. Update our
-        reference + the ``KeyboardDriveState`` smoother that wraps it
-        so subsequent ``set_key`` / ``set_drive_command`` calls land
-        on the engine's actual state object.
+        :class:`InteractiveDriveApp` owns one long-lived ``KeyboardState``
+        and calls this once at construction to point the injected
+        presenter at it. Update our reference + the ``KeyboardDriveState``
+        smoother that wraps it so subsequent ``set_key`` /
+        ``set_drive_command`` calls land on the engine's actual state
+        object.
         """
         from omnidreams.interactive_drive.demo import KeyboardDriveState
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -585,6 +585,11 @@ class MJPEGStreamingPresenter:
         # reads "Select a scene to begin driving" if never wired.
         self._model_can_prewarm = False
         self._model_ready_probe: Callable[[], bool] = lambda: True
+        # Scene-selection lock (wired by the demo with --preload-scenes).
+        # While the probe returns True, /scene/select is rejected and the
+        # idle frame reads "Preloading scenes..." so the browser can't pick
+        # a scene until every scene is cached.
+        self._scene_selection_locked_probe: Callable[[], bool] = lambda: False
         # Keyboard drive integrator. Late-imported because ``demo``
         # imports the streaming presenter via the CLI's presenter
         # factory; a top-level import would be circular. The integrator
@@ -665,6 +670,16 @@ class MJPEGStreamingPresenter:
         self._model_can_prewarm = bool(can_prewarm)
         self._model_ready_probe = ready_probe
 
+    def set_scene_selection_locked(self, probe: Callable[[], bool]) -> None:
+        """Gate ``/scene/select`` while ``probe()`` returns True.
+
+        Mirrors :meth:`SlangPyHudPresenter.set_scene_selection_locked`: used
+        with --preload-scenes so the browser can't pick a scene until every
+        scene has preloaded. While locked the idle overlay reads "Preloading
+        scenes..." and select requests are rejected.
+        """
+        self._scene_selection_locked_probe = probe
+
     def wait_for_scene_selection(self) -> tuple[Path, str] | None:
         """Block until the browser POSTs a scene selection.
 
@@ -713,11 +728,12 @@ class MJPEGStreamingPresenter:
         up and push the frame out to the browser, which is what actually
         matters for late-arriving clients.
         """
-        message = (
-            "Loading world model..."
-            if self._model_can_prewarm and not self._model_ready_probe()
-            else "Select a scene to begin driving"
-        )
+        if self._model_can_prewarm and not self._model_ready_probe():
+            message = "Loading world model..."
+        elif self._scene_selection_locked_probe():
+            message = "Preloading scenes..."
+        else:
+            message = "Select a scene to begin driving"
         cached = self._idle_frame_cache_by_message.get(message)
         if cached is None:
             base = np.zeros(
@@ -907,6 +923,11 @@ class MJPEGStreamingPresenter:
         path latch into the next ``app.run`` iteration.
         """
         if not scene_path_str:
+            return False
+        if self._scene_selection_locked_probe():
+            # Scenes are still preloading; reject selection so the browser
+            # waits for the instant (cached) switch instead of triggering a
+            # mid-preload parse.
             return False
         # Match against the registered scenes by string-comparing the
         # path; ``Path("a") == "a"`` is False so we normalize first.

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -570,15 +570,21 @@ class MJPEGStreamingPresenter:
         # Scene-change request channel mirroring the slangpy HUD's
         # ``pending_scene_change`` flag. ``should_close`` returns True
         # when this is non-None so the runtime loop unwinds; the demo
-        # wrapper then tears down the backend, calls
-        # ``acknowledge_scene_change``, and re-enters with a fresh sim.
+        # wrapper then calls ``acknowledge_scene_change`` and re-enters
+        # the long-lived engine with the new scene (model stays resident).
         self._pending_scene_change: tuple[Path, str] | None = None
-        # Pre-cached idle "Select a scene" overlay. Lazy-initialised on
+        # Pre-cached idle overlay frames keyed by message. Lazily filled on
         # the first call to :meth:`_publish_idle_frame`. Cached so the
-        # heartbeat republish in ``wait_for_scene_selection`` doesn't
-        # redo the PIL text render every 2 s while the user is
-        # deciding what to load.
-        self._idle_frame_cache: np.ndarray | None = None
+        # heartbeat republish in ``wait_for_scene_selection`` doesn't redo
+        # the PIL text render every 2 s; keyed by message so the "Loading
+        # world model..." (warmup) and "Select a scene to begin driving"
+        # (ready) variants are each rendered at most once.
+        self._idle_frame_cache_by_message: dict[str, np.ndarray] = {}
+        # Model-warmup status, wired by the demo via :meth:`set_model_status`
+        # (mirrors the slangpy HUD). Defaults inert so the idle overlay
+        # reads "Select a scene to begin driving" if never wired.
+        self._model_can_prewarm = False
+        self._model_ready_probe: Callable[[], bool] = lambda: True
         # Keyboard drive integrator. Late-imported because ``demo``
         # imports the streaming presenter via the CLI's presenter
         # factory; a top-level import would be circular. The integrator
@@ -626,7 +632,7 @@ class MJPEGStreamingPresenter:
         # There's no window to close. The app loop runs until the
         # simulation thread finishes, the user Ctrl-C's the process,
         # or a /scene/select request flips the pending-change channel
-        # so the demo wrapper can rebuild the backend with a new scene.
+        # so the demo wrapper can switch the long-lived engine to a new scene.
         return self._stop_event.is_set() or self._pending_scene_change is not None
 
     @property
@@ -635,8 +641,8 @@ class MJPEGStreamingPresenter:
 
         Set by the ``/scene/select`` endpoint and cleared by
         :meth:`acknowledge_scene_change`. The demo wrapper polls this
-        between ``app.run()`` invocations to drive the scene-change
-        loop without tearing down the HTTP server / browser session.
+        between scenes to drive the scene-change loop without tearing
+        down the HTTP server / browser session.
         """
         return self._pending_scene_change
 
@@ -644,6 +650,20 @@ class MJPEGStreamingPresenter:
         """Clear the pending scene change after the demo wrapper has applied it."""
         del scene_path, variant  # accepted for symmetry with the slangpy HUD API
         self._pending_scene_change = None
+
+    def set_model_status(
+        self, *, can_prewarm: bool, ready_probe: Callable[[], bool]
+    ) -> None:
+        """Wire the idle overlay text to model-warmup progress.
+
+        Mirrors :meth:`SlangPyHudPresenter.set_model_status`. When
+        ``can_prewarm`` is True the idle "select a scene" frame published
+        during :meth:`wait_for_scene_selection` reads "Loading world
+        model..." until ``ready_probe`` returns True, then falls back to
+        the normal "Select a scene to begin driving" prompt.
+        """
+        self._model_can_prewarm = bool(can_prewarm)
+        self._model_ready_probe = ready_probe
 
     def wait_for_scene_selection(self) -> tuple[Path, str] | None:
         """Block until the browser POSTs a scene selection.
@@ -682,33 +702,38 @@ class MJPEGStreamingPresenter:
                 return self._pending_scene_change
 
     def _publish_idle_frame(self) -> None:
-        """Stream the cached black 'select a scene' placeholder frame.
+        """Stream the cached black placeholder frame.
 
-        The PIL render is memoised on :attr:`_idle_frame_cache` so the
-        heartbeat in :meth:`wait_for_scene_selection` doesn't pay the
-        text-overlay cost on every tick -- the placeholder is identical
-        every time so a single render is sufficient. Each publish call
-        still bumps :attr:`_frame_count` so connected MJPEG handlers
-        wake up and push the frame out to the browser, which is what
-        actually matters for late-arriving clients.
+        While the model is still pre-warming (see :meth:`set_model_status`)
+        the overlay reads "Loading world model..."; otherwise it reads
+        "Select a scene to begin driving". Each variant's PIL render is
+        memoised so the heartbeat in :meth:`wait_for_scene_selection`
+        doesn't pay the text-overlay cost on every tick. Each publish call
+        still bumps :attr:`_frame_count` so connected MJPEG handlers wake
+        up and push the frame out to the browser, which is what actually
+        matters for late-arriving clients.
         """
-        if self._idle_frame_cache is None:
+        message = (
+            "Loading world model..."
+            if self._model_can_prewarm and not self._model_ready_probe()
+            else "Select a scene to begin driving"
+        )
+        cached = self._idle_frame_cache_by_message.get(message)
+        if cached is None:
             base = np.zeros(
                 (self._raster.height, self._raster.width, 3), dtype=np.uint8
             )
-            self._idle_frame_cache = render_loading_overlay(
-                base, message="Select a scene to begin driving"
-            )
-        self._publish(self._idle_frame_cache)
+            cached = render_loading_overlay(base, message=message)
+            self._idle_frame_cache_by_message[message] = cached
+        self._publish(cached)
 
     def bind_keyboard(self, keyboard: KeyboardState) -> None:
-        """Re-target the presenter at a fresh ``KeyboardState``.
+        """Re-target the presenter at ``keyboard``.
 
-        ``InteractiveDriveApp`` constructs a new ``KeyboardState`` per
-        rollout; the demo wrapper reuses the same MJPEG presenter
-        across scene-change iterations, so the presenter has to follow
-        each new keyboard. The keyboard-drive integrator captures the
-        keyboard reference internally, so it gets rebuilt here.
+        :class:`InteractiveDriveApp` owns one long-lived ``KeyboardState``
+        and binds the injected presenter to it at construction. The
+        keyboard-drive integrator captures the keyboard reference
+        internally, so it gets rebuilt here.
         """
         self._keyboard = keyboard
         self._keyboard_drive = self._keyboard_drive_factory(
@@ -1013,8 +1038,8 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             """Mark ``?scene=PATH&variant=NAME`` as the next scene to load.
 
             Sets the presenter's ``pending_scene_change`` channel; the
-            demo wrapper picks it up between ``app.run()`` iterations
-            and rebuilds the backend with the new scene. Validates the
+            demo wrapper picks it up between scenes and switches the
+            long-lived engine to the new scene. Validates the
             requested scene against the presenter's ``_scenes`` list so a
             stale browser tab can't smuggle in an arbitrary path. The
             ``variant`` query parameter is optional: when omitted (or

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -56,6 +56,10 @@ class QueuedFrame:
     frame: PresentedFrame
     chunk_times: ChunkTimes
     frame_index: int
+    # Pipeline generation this frame was rendered under. A reset / scene
+    # switch bumps the generation; the loop drops frames whose generation
+    # no longer matches so stale rollout/scene frames aren't presented.
+    generation: int = 0
 
 
 # Worker commands are closures that take the backend and return ``True`` to
@@ -83,6 +87,15 @@ class ChunkPipeline:
         # Lets callers overlap the scene-selection wait with the model load
         # and show a "ready" affordance once the model is resident.
         self._model_ready = threading.Event()
+        # Monotonic generation bumped on every reset / scene switch. Renders
+        # submitted under an older generation are superseded: their frames
+        # are dropped instead of presented, so a reset or scene load doesn't
+        # first flash stale frames from the rollout it replaced. The worker
+        # can't interrupt an in-flight torch generate(), but its output is
+        # discarded -- the single-process analog of alpasim cancelling the
+        # runtime stream and clearing its frame queues on reload.
+        self._generation_lock = threading.Lock()
+        self._generation = 0
         self._thread = threading.Thread(
             target=self._worker,
             name="interactive_drive-chunk-pipeline",
@@ -94,6 +107,16 @@ class ChunkPipeline:
     def model_ready(self) -> threading.Event:
         """Event set when scene-independent model warmup has completed."""
         return self._model_ready
+
+    @property
+    def current_generation(self) -> int:
+        """Current generation token; frames tagged with an older value are stale."""
+        with self._generation_lock:
+            return self._generation
+
+    def _bump_generation(self) -> None:
+        with self._generation_lock:
+            self._generation += 1
 
     @property
     def frame_queue(self) -> "queue.Queue[QueuedFrame]":
@@ -110,6 +133,9 @@ class ChunkPipeline:
         never re-pays the warmup/compile cost.
         """
         self._raise_worker_error_if_any()
+        # Supersede any in-flight / queued render so its frames are dropped
+        # rather than briefly shown over the new scene's load.
+        self._bump_generation()
 
         def load_scene_command(backend: VideoModelBackend) -> bool:
             backend.load_scene(scene)
@@ -122,17 +148,26 @@ class ChunkPipeline:
 
         chunk_times = request.chunk_times
         trajectory = request.trajectory
+        submit_generation = self.current_generation
 
         def render_command(backend: VideoModelBackend) -> bool:
             chunk_times.chunk_render_start_time = time.perf_counter()
             frame_chunk = backend.render_chunk(trajectory)
             chunk_times.chunk_ready_time = time.perf_counter()
+            # Drop the output if a reset / scene switch superseded this chunk
+            # while it was queued or rendering -- its frames belong to a
+            # rollout the user has already moved on from.
+            if submit_generation != self.current_generation:
+                return True
             for frame_index, frame in enumerate(frame_chunk.frames):
                 frame_times = chunk_times.frames[frame_index]
                 frame_times.image_ready_time = time.perf_counter()
                 self._frame_queue.put(
                     QueuedFrame(
-                        frame=frame, chunk_times=chunk_times, frame_index=frame_index
+                        frame=frame,
+                        chunk_times=chunk_times,
+                        frame_index=frame_index,
+                        generation=submit_generation,
                     )
                 )
             return True
@@ -142,13 +177,16 @@ class ChunkPipeline:
     def reset(self) -> None:
         """Signal the worker to start a new rollout. Non-blocking.
 
-        The worker handles in-flight renders FIFO before processing the
-        reset, so a brief stretch of old-rollout frames may still be
-        presented before new-rollout frames arrive. That is accepted; the
-        alternative (blocking-and-draining) would freeze the display for
-        the duration of the in-flight chunk's render, which is worse UX.
+        Bumps the generation so any in-flight / queued render is superseded:
+        its frames are dropped rather than presented, so the reset doesn't
+        first replay a stretch of old-rollout frames (the single-process
+        analog of alpasim cancelling the runtime stream and clearing its
+        frame queues). The in-flight torch generate() can't be interrupted,
+        but its output is discarded; the worker still handles the reset
+        FIFO so the next rollout starts from a clean cache.
         """
         self._raise_worker_error_if_any()
+        self._bump_generation()
 
         def reset_command(backend: VideoModelBackend) -> bool:
             backend.reset()

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -20,13 +20,17 @@ from omnidreams.interactive_drive.types import (
 class VideoModelBackend(Protocol):
     """Video-model interface called from the pipeline worker thread.
 
-    Backends are *cold* after construction: ``warmup`` must be called before
-    any ``render_chunk``. :class:`ChunkPipeline` is the only thing that calls
-    ``warmup``, on its worker thread, before processing requests; callers
-    outside the pipeline never see a cold backend.
+    Backends are *cold* after construction. :class:`ChunkPipeline` calls
+    ``warmup_model`` once on its worker thread (model load/compile,
+    scene-independent), then ``load_scene`` for each scene before any
+    ``render_chunk`` against it. Callers outside the pipeline never see a
+    cold backend, and switching scenes re-runs only ``load_scene`` -- the
+    warmed model stays resident.
     """
 
-    def warmup(self, scene: SceneBundle) -> None: ...
+    def warmup_model(self) -> None: ...
+
+    def load_scene(self, scene: SceneBundle) -> None: ...
 
     def render_chunk(self, trajectory: TrajectoryChunk) -> FrameChunk: ...
 
@@ -61,9 +65,8 @@ _WorkerCommand = Callable[["VideoModelBackend"], bool]
 
 
 class ChunkPipeline:
-    def __init__(self, backend: VideoModelBackend, scene: SceneBundle) -> None:
+    def __init__(self, backend: VideoModelBackend) -> None:
         self._backend = backend
-        self._scene = scene
         # TODO: replace the loop's chunk-level ``chunks_outstanding`` gate with
         # frame-level in-flight tracking (frames requested - frames consumed,
         # alpasim style) and surface a hook here so callers gate at the
@@ -76,6 +79,10 @@ class ChunkPipeline:
         # caller's thread instead of silently leaking the worker.
         self._worker_error_lock = threading.Lock()
         self._worker_error: BaseException | None = None
+        # Set once ``warmup_model`` finishes on the worker thread (or fails).
+        # Lets callers overlap the scene-selection wait with the model load
+        # and show a "ready" affordance once the model is resident.
+        self._model_ready = threading.Event()
         self._thread = threading.Thread(
             target=self._worker,
             name="interactive_drive-chunk-pipeline",
@@ -84,9 +91,31 @@ class ChunkPipeline:
         self._thread.start()
 
     @property
+    def model_ready(self) -> threading.Event:
+        """Event set when scene-independent model warmup has completed."""
+        return self._model_ready
+
+    @property
     def frame_queue(self) -> "queue.Queue[QueuedFrame]":
         self._raise_worker_error_if_any()
         return self._frame_queue
+
+    def request_scene(self, scene: SceneBundle) -> None:
+        """Bind ``scene`` on the worker thread. Non-blocking.
+
+        Enqueued FIFO behind warmup and any in-flight renders, so a scene
+        picked before warmup finishes simply waits for the model load. The
+        worker runs ``backend.load_scene`` (geometry upload + rollout
+        restart); the warmed model stays resident, so switching scenes
+        never re-pays the warmup/compile cost.
+        """
+        self._raise_worker_error_if_any()
+
+        def load_scene_command(backend: VideoModelBackend) -> bool:
+            backend.load_scene(scene)
+            return True
+
+        self._command_queue.put(load_scene_command)
 
     def request_pose_chunk(self, request: ChunkRequest) -> None:
         self._raise_worker_error_if_any()
@@ -136,12 +165,13 @@ class ChunkPipeline:
         try:
             warmup_start = time.perf_counter()
             print("[chunk-pipeline] warmup start", flush=True)
-            self._backend.warmup(self._scene)
+            self._backend.warmup_model()
             warmup_elapsed_ms = (time.perf_counter() - warmup_start) * 1000.0
             print(
                 f"[chunk-pipeline] warmup done elapsed_ms={warmup_elapsed_ms:.1f}",
                 flush=True,
             )
+            self._model_ready.set()
             while True:
                 command = self._command_queue.get()
                 if not command(self._backend):
@@ -149,6 +179,9 @@ class ChunkPipeline:
         except BaseException as exc:
             with self._worker_error_lock:
                 self._worker_error = exc
+            # Unblock anyone waiting on warmup; the error resurfaces on the
+            # next public call via _raise_worker_error_if_any.
+            self._model_ready.set()
 
     def _raise_worker_error_if_any(self) -> None:
         with self._worker_error_lock:

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/local.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/local.py
@@ -10,16 +10,28 @@ class LocalVideoModelAdapter:
 
     Keeps the local path zero encode/decode and returns FrameChunk directly.
     Implements :class:`~omnidreams.interactive_drive.video_model.chunk_pipeline.VideoModelBackend`:
-    construction is cheap; ``warmup`` does the actual model/scene loading and
-    is called by :class:`ChunkPipeline` on its worker thread.
+    construction is cheap; ``warmup_model`` loads the model once and
+    ``load_scene`` binds each scene, both called by :class:`ChunkPipeline`
+    on its worker thread.
     """
 
     def __init__(self, backend: RenderBackend) -> None:
         self._backend = backend
         self._is_first_chunk = True
 
-    def warmup(self, scene: SceneBundle) -> None:
-        self._backend.warmup(scene)
+    @property
+    def can_prewarm(self) -> bool:
+        return self._backend.can_prewarm
+
+    def warmup_model(self) -> None:
+        self._backend.warmup_model()
+
+    def load_scene(self, scene: SceneBundle) -> None:
+        self._backend.load_scene(scene)
+        # A scene (re)load restarts the rollout: the next chunk must be a
+        # first chunk so the world-model session re-initialises its cache
+        # from the new scene's initial frame and prompt.
+        self._is_first_chunk = True
 
     def render_chunk(self, trajectory: TrajectoryChunk) -> FrameChunk:
         if self._is_first_chunk:

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -321,27 +321,75 @@ class FlashdreamsWorldModelSession:
             )
         return self._pipeline
 
-    def warmup(
+    @property
+    def can_prewarm(self) -> bool:
+        # The non-factory offload path defers its build to the first
+        # prepare_for_scene so the one-shot encoders are freed before the
+        # AR pipeline is allocated (peak-VRAM ordering); every other path
+        # builds the pipeline eagerly with no scene needed.
+        return self._pipeline_factory is not None or not self._offload_text_encoder
+
+    def warmup_model(self) -> None:
+        """Build the scene-independent diffusion pipeline (weights + compile).
+
+        Called once per process. The non-factory offload path returns here
+        and builds lazily in :meth:`prepare_for_scene` instead, so per-scene
+        embeddings are computed and the one-shot encoders freed before the
+        AR pipeline is allocated.
+        """
+        start = time.perf_counter()
+        if self._pipeline_factory is not None:
+            self._pipeline = self._pipeline_factory(self.manifest, self._profile_config)
+        elif self._offload_text_encoder:
+            return
+        else:
+            config = _build_pipeline_config(self.manifest, self._profile_config)
+            self._pipeline = _setup_pipeline_from_config(config, self.manifest)
+        self._validate_chunk_sizes()
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        print(
+            f"[flashdreams-session] model warmup runtime_ms={elapsed_ms:.1f}", flush=True
+        )
+
+    def prepare_for_scene(
         self, *, initial_rgb: object | None = None, prompt: str | None = None
     ) -> None:
-        start = time.perf_counter()
-        if self._pipeline_factory is None:
-            config = _build_pipeline_config(self.manifest, self._profile_config)
-            if self._offload_text_encoder:
-                if initial_rgb is None or prompt is None:
-                    raise RuntimeError(
-                        "offload_text_encoder warmup requires the scene initial_rgb and prompt."
-                    )
-                self._precomputed_embeddings = _precompute_embeddings_from_config(
-                    config,
-                    self.manifest,
-                    initial_rgb=initial_rgb,
-                    prompt=prompt,
-                )
-                config = replace(config, text_encoder=None, image_encoder=None)
-            self._pipeline = _setup_pipeline_from_config(config, self.manifest)
-        else:
-            self._pipeline = self._pipeline_factory(self.manifest, self._profile_config)
+        """Per-scene conditioning prep, run on every scene (re)load.
+
+        Default path: a no-op. The pipeline keeps its text/image encoders
+        and re-embeds the current prompt in ``initialize_cache`` on every
+        rollout, so switching scenes needs no model-side work here.
+
+        Offload path: the one-shot encoders are freed to save VRAM, so a
+        new scene's prompt/first-frame cannot reuse the previous scene's
+        cached embeddings. The factory (test) path recomputes them lazily
+        on the next ``start``; the real path rebuilds the pipeline per
+        scene (precompute embeddings -> free encoders -> build pipeline) to
+        keep peak VRAM low. This is the only path that does not keep the
+        model resident across scene changes.
+        """
+        if not self._offload_text_encoder:
+            return
+        self._precomputed_embeddings = None
+        if self._pipeline_factory is not None:
+            return
+        if initial_rgb is None or prompt is None:
+            raise RuntimeError(
+                "offload_text_encoder requires the scene initial_rgb and prompt."
+            )
+        self._release_pipeline()
+        config = _build_pipeline_config(self.manifest, self._profile_config)
+        self._precomputed_embeddings = _precompute_embeddings_from_config(
+            config,
+            self.manifest,
+            initial_rgb=initial_rgb,
+            prompt=prompt,
+        )
+        config = replace(config, text_encoder=None, image_encoder=None)
+        self._pipeline = _setup_pipeline_from_config(config, self.manifest)
+        self._validate_chunk_sizes()
+
+    def _validate_chunk_sizes(self) -> None:
         first_chunk_frames = self.pipeline.get_num_frames(0)
         # Flashdreams indexes the first post-initial chunk as AR step 1; this
         # is the steady-state frame count that interactive-drive loops over.
@@ -356,8 +404,16 @@ class FlashdreamsWorldModelSession:
                 "flashdreams steady-state chunk size does not match the manifest: "
                 f"{steady_chunk_frames} vs {self.manifest.num_frames_per_block}"
             )
-        elapsed_ms = (time.perf_counter() - start) * 1000.0
-        print(f"[flashdreams-session] warmup runtime_ms={elapsed_ms:.1f}", flush=True)
+
+    def _release_pipeline(self) -> None:
+        if self._pipeline is None:
+            return
+        self._pipeline = None
+        gc.collect()
+        device = torch.device(self.manifest.device)
+        if device.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.synchronize(device)
+            torch.cuda.empty_cache()
 
     def start(
         self,

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -348,7 +348,8 @@ class FlashdreamsWorldModelSession:
         self._validate_chunk_sizes()
         elapsed_ms = (time.perf_counter() - start) * 1000.0
         print(
-            f"[flashdreams-session] model warmup runtime_ms={elapsed_ms:.1f}", flush=True
+            f"[flashdreams-session] model warmup runtime_ms={elapsed_ms:.1f}",
+            flush=True,
         )
 
     def prepare_for_scene(

--- a/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
@@ -31,7 +31,8 @@ def _chunk_times(chunk_size: int) -> ChunkTimes:
 
 def test_chunk_pipeline_stamps_timing_and_orders_frames() -> None:
     backend = FakeVideoModelBackend(frames_per_render=3)
-    pipeline = ChunkPipeline(backend, minimal_scene())
+    pipeline = ChunkPipeline(backend)
+    pipeline.request_scene(minimal_scene())
     chunk_times = _chunk_times(chunk_size=3)
     pipeline.request_pose_chunk(
         ChunkRequest(trajectory=make_trajectory(3), chunk_times=chunk_times)
@@ -47,12 +48,14 @@ def test_chunk_pipeline_stamps_timing_and_orders_frames() -> None:
     assert chunk_times.chunk_render_start_time is not None
     assert chunk_times.chunk_ready_time is not None
     assert chunk_times.frames[0].image_ready_time is not None
-    assert backend.warmup_calls == 1
+    assert backend.warmup_model_calls == 1
+    assert backend.load_scene_calls == 1
 
 
 def test_chunk_pipeline_reset_invokes_backend_reset() -> None:
     backend = FakeVideoModelBackend(frames_per_render=1)
-    pipeline = ChunkPipeline(backend, minimal_scene())
+    pipeline = ChunkPipeline(backend)
+    pipeline.request_scene(minimal_scene())
     chunk_times = _chunk_times(chunk_size=1)
     pipeline.request_pose_chunk(
         ChunkRequest(trajectory=make_trajectory(1), chunk_times=chunk_times)
@@ -61,5 +64,23 @@ def test_chunk_pipeline_reset_invokes_backend_reset() -> None:
     pipeline.reset()
     pipeline.shutdown()
 
-    assert backend.warmup_calls == 1
+    assert backend.warmup_model_calls == 1
     assert backend.reset_calls == 1
+
+
+def test_chunk_pipeline_reuses_model_across_scene_changes() -> None:
+    backend = FakeVideoModelBackend(frames_per_render=1)
+    pipeline = ChunkPipeline(backend)
+    assert pipeline.model_ready.wait(timeout=1.0)
+    for _ in range(3):
+        pipeline.request_scene(minimal_scene())
+        chunk_times = _chunk_times(chunk_size=1)
+        pipeline.request_pose_chunk(
+            ChunkRequest(trajectory=make_trajectory(1), chunk_times=chunk_times)
+        )
+        pipeline.frame_queue.get(timeout=1.0)
+    pipeline.shutdown()
+
+    # The model is warmed exactly once even though the scene changed twice.
+    assert backend.warmup_model_calls == 1
+    assert backend.load_scene_calls == 3

--- a/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
@@ -1,18 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import threading
 import time
 
+import numpy as np
 from omnidreams.interactive_drive._pipeline_fakes import (
     FakeVideoModelBackend,
     make_trajectory,
     minimal_scene,
 )
 from omnidreams.interactive_drive.runtime.timing import ChunkPrediction, ChunkTimes
+from omnidreams.interactive_drive.types import FrameChunk, PresentedFrame
 from omnidreams.interactive_drive.video_model.chunk_pipeline import (
     ChunkPipeline,
     ChunkRequest,
 )
+
+
+class _GatedBackend:
+    """Backend whose render blocks on a gate so a reset can race it."""
+
+    def __init__(self) -> None:
+        self.warmup_model_calls = 0
+        self.reset_calls = 0
+        self.render_started = threading.Event()
+        self.release = threading.Event()
+
+    def warmup_model(self) -> None:
+        self.warmup_model_calls += 1
+
+    def load_scene(self, scene: object) -> None:
+        del scene
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+    def render_chunk(self, trajectory: object) -> FrameChunk:
+        self.render_started.set()
+        self.release.wait(timeout=5.0)
+        frame = PresentedFrame(
+            timestamp_us=0,
+            rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+            depth_host_f32=None,
+        )
+        return FrameChunk(
+            frames=(frame,),
+            boundary_state_after_chunk=trajectory.boundary_state_after_chunk,
+            source_name="gated",
+        )
 
 
 def _chunk_times(chunk_size: int) -> ChunkTimes:
@@ -84,3 +120,22 @@ def test_chunk_pipeline_reuses_model_across_scene_changes() -> None:
     # The model is warmed exactly once even though the scene changed twice.
     assert backend.warmup_model_calls == 1
     assert backend.load_scene_calls == 3
+
+
+def test_chunk_pipeline_drops_superseded_render_after_reset() -> None:
+    backend = _GatedBackend()
+    pipeline = ChunkPipeline(backend)
+    pipeline.request_scene(minimal_scene())
+    pipeline.request_pose_chunk(
+        ChunkRequest(trajectory=make_trajectory(1), chunk_times=_chunk_times(1))
+    )
+    # Wait until the (gated) render is in flight, then reset to supersede it.
+    assert backend.render_started.wait(timeout=1.0)
+    pipeline.reset()
+    backend.release.set()  # let the superseded render finish
+    pipeline.shutdown()
+
+    assert backend.reset_calls == 1
+    # The in-flight render belonged to the pre-reset generation, so its
+    # frame is dropped rather than queued.
+    assert pipeline.frame_queue.qsize() == 0

--- a/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
@@ -166,7 +166,8 @@ def _drive_loop(
     initial: PresentedFrame,
     frame_interval_s: float,
 ) -> bool:
-    pipeline = ChunkPipeline(backend, minimal_scene())
+    pipeline = ChunkPipeline(backend)
+    pipeline.request_scene(minimal_scene())
     try:
         return run_main_loop(
             presenter=presenter,

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -150,7 +150,7 @@ def test_session_uses_flashdreams_pipeline_for_rollout() -> None:
         _manifest(),
         pipeline_factory=lambda manifest, profile: fake_pipeline,
     )
-    session.warmup()
+    session.warmup_model()
 
     initial_rgb = np.zeros((2, 3, 3), dtype=np.uint8)
     first_condition_frames = [np.zeros((2, 3, 3), dtype=np.uint8) for _ in range(5)]
@@ -180,7 +180,7 @@ def test_session_synchronizes_generated_frame_events_before_return(monkeypatch) 
         _manifest(),
         pipeline_factory=lambda manifest, profile: fake_pipeline,
     )
-    session.warmup()
+    session.warmup_model()
     sync_calls: list[list[object]] = []
 
     def fake_sync(frames: list[object]) -> None:
@@ -216,7 +216,7 @@ def test_session_offload_reuses_precomputed_embeddings_after_reset() -> None:
         offload_text_encoder=True,
         pipeline_factory=lambda manifest, profile: fake_pipeline,
     )
-    session.warmup()
+    session.warmup_model()
 
     initial_rgb = np.zeros((2, 3, 3), dtype=np.uint8)
     first_condition_frames = [np.zeros((2, 3, 3), dtype=np.uint8) for _ in range(5)]


### PR DESCRIPTION
## Summary
The interactive-drive demo used to reload the entire world model (weights + `torch.compile`) every time you picked a scene, so each switch took minutes. This keeps the model resident and just swaps the scene, making switches fast — plus clearer loading UX and no UI freezes.

## Changes
- **Resident model:** build the backend + pipeline once and warm the model at startup (overlapping the scene-selection wait); scene switches reuse the warmed model instead of rebuilding it.
- **No UI freezes:** parse scenes (USDZ/HD-map) and build the ground snapper off the UI thread, fixing the window "not responding" hang on load/reset.
- **Loading indicators:** show "Loading world model…", "Loading scene…", and "Resetting…" so it's always clear what's happening.
- **Clean transitions:** drop stale frames on reset/scene-switch so a switch doesn't briefly replay the old video.
- **`--preload-scenes` (off by default):** pre-parse every scene in `--scene-dir` in the background so switching is instant; scene selection is locked until preloading finishes.
- **Default scene optional:** if the scene directory already has scenes, don't download or exit early when the default scene is missing.

Scoped entirely to `integrations/omnidreams` — no core flashdreams changes.

## Testing
- `pytest integrations/omnidreams/tests/interactive_drive/`
- Manual: launch the demo, switch scenes, hit reset, and try `--preload-scenes`.