### PR TITLE
fix webrtc hangs issue at warmup

### DIFF
--- a/integrations/lingbot/lingbot/webrtc/session.py
+++ b/integrations/lingbot/lingbot/webrtc/session.py
@@ -583,6 +583,7 @@ class LingbotWebRTCSessionManager:
         offer_sdp: str,
         offer_type: str,
         rtc_configuration: RTCConfiguration | None = None,
+        enable_liveness_watchdog: bool = True,
     ) -> dict[str, str]:
         if self._active_session is not None and not self._active_session.closed:
             raise SessionBusyError("A Lingbot session is already active.")
@@ -622,9 +623,10 @@ class LingbotWebRTCSessionManager:
             last_client_message_at=loop.time(),
         )
         self._active_session = managed_session
-        managed_session.liveness_task = asyncio.create_task(
-            self._client_liveness_watchdog(managed_session=managed_session)
-        )
+        if enable_liveness_watchdog:
+            managed_session.liveness_task = asyncio.create_task(
+                self._client_liveness_watchdog(managed_session=managed_session)
+            )
 
         @peer_connection.on("datachannel")
         def on_datachannel(channel: Any) -> None:
@@ -708,6 +710,7 @@ class LingbotWebRTCSessionManager:
                 offer_sdp=offer_sdp,
                 offer_type=offer_type,
                 rtc_configuration=RTCConfiguration(iceServers=[]),
+                enable_liveness_watchdog=False,
             )
 
     async def close_active_session(self) -> None:

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -963,6 +963,7 @@ class OmnidreamsWebRTCSessionManager:
         offer_sdp: str,
         offer_type: str,
         rtc_configuration: RTCConfiguration | None = None,
+        enable_liveness_watchdog: bool = True,
     ) -> dict[str, str]:
         if self._active_session is not None and not self._active_session.closed:
             raise SessionBusyError("An Omnidreams session is already active.")
@@ -989,9 +990,10 @@ class OmnidreamsWebRTCSessionManager:
             last_client_message_at=loop.time(),
         )
         self._active_session = managed_session
-        managed_session.liveness_task = asyncio.create_task(
-            self._client_liveness_watchdog(managed_session=managed_session)
-        )
+        if enable_liveness_watchdog:
+            managed_session.liveness_task = asyncio.create_task(
+                self._client_liveness_watchdog(managed_session=managed_session)
+            )
 
         @peer_connection.on("datachannel")
         def on_datachannel(channel: Any) -> None:
@@ -1088,6 +1090,7 @@ class OmnidreamsWebRTCSessionManager:
                 offer_sdp=offer_sdp,
                 offer_type=offer_type,
                 rtc_configuration=RTCConfiguration(iceServers=[]),
+                enable_liveness_watchdog=False,
             )
 
     async def close_active_session(self) -> None:


### PR DESCRIPTION
This MR fixes a WebRTC startup stall seen during runtime preload warmup in both Lingbot and Omnidreams.

