### PR TITLE
docs: hover-to-zoom, toctree fix, wording improvements, and docstring fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,44 +48,6 @@ Then keep this process running and open:
 
 Any changes under `docs/source/` rebuild automatically and refresh the page.
 
-## Layout
-
-```
-docs/
-└── source/
-    ├── conf.py             # Sphinx configuration (theme + extensions)
-    ├── index.rst           # overview landing page + top-level toctrees
-    ├── quickstart/
-    │   ├── index.rst
-    │   ├── installation.rst
-    │   └── first_world_model.rst
-    ├── developer_guides/
-    │   ├── offline_vs_online.rst
-    │   ├── index.rst
-    │   ├── new_integration.rst
-    │   ├── system_overview.rst
-    │   ├── usage_patterns.rst
-    │   ├── configs.rst
-    │   └── interactive_serving.rst
-    ├── api/
-    │   ├── index.rst
-    │   ├── cli.rst
-    │   ├── core.rst        # flashdreams.core (attention, distributed, …)
-    │   ├── infra.rst       # flashdreams.infra (pipeline, diffusion, …)
-    │   ├── integrations.rst     # flashdreams.recipes (wan, cosmos, …)
-    │   └── serving.rst     # serving architecture and launch patterns
-    └── models/
-        ├── index.rst
-        ├── omnidreams.rst
-        ├── self_forcing.rst
-        ├── causal_forcing.rst
-        ├── causal_wan22.rst
-        ├── lingbot_world.rst
-        ├── flashvsr.rst
-        ├── cosmos_predict2.rst
-        └── wan21.rst
-```
-
 Benchmark data now follows a JS + Markdown pipeline:
 
 - Per-model benchmark tables live in
@@ -132,12 +94,16 @@ to be present.
 
 ## Adding new content
 
-- **A new model integration** — append a section to `source/apis/integrations.rst`
-  using `.. automodule:: flashdreams.recipes.<name>`, and add a launcher
-  walk-through to `source/models/<name>.rst`. Wire the new file into
-  the models toctree in `source/models/index.rst`.
+- **A new model integration** — follow
+  `source/developer_guides/new_integration.rst`, add a model card at
+  `source/models/<name>.rst`, and wire it into the models toctree in
+  `source/index.rst` (and `source/models/index.rst` if you use that
+  index page for grouped links).
 - **A new infra component** — re-export the public symbols from the
   package `__init__.py`, then add an `.. autoclass::` block to the
-  relevant section of `source/apis/infra.rst`.
-- **A new API category** — drop a new `source/apis/<topic>.rst`, add it
-  to `index.rst`, and (optionally) introduce a new captioned toctree.
+  relevant section of `source/api/infra.rst`.
+- **A new API category** — add `source/api/<topic>.rst`, then include it
+  in the API toctree in `source/index.rst`.
+- **Plugin-first note** — most actively developed integrations live under
+  `integrations/<name>/`. Use `source/api/integrations.rst` to document
+  in-tree `flashdreams.recipes.*` API surface that remains public.

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -276,7 +276,6 @@ body.index .content h1 {
     overflow: hidden;
     border: 1px solid #c9c9c9;
     background: #101214;
-    min-height: 200px;
 }
 
 .model-video-placeholder {
@@ -291,7 +290,7 @@ body.index .content h1 {
 .model-video-player {
     display: block;
     width: 100%;
-    min-height: 200px;
+    height: auto;
     background: #000;
 }
 
@@ -326,4 +325,48 @@ body.index .content h1 {
     .model-video-grid {
         grid-template-columns: 1fr;
     }
+}
+
+/* -- Image hover-to-zoom (JS-driven overlay) ----------------------------- */
+
+img.zoomable,
+.zoomable img,
+.zoomable video {
+    cursor: zoom-in;
+}
+
+.img-zoom-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.55);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+.img-zoom-overlay.visible {
+    opacity: 1;
+}
+
+.img-zoom-clone {
+    max-width: 72vw;
+    max-height: 72vh;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    border-radius: 4px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1),
+                opacity 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+    transform: scale(0.92);
+    opacity: 0;
+}
+
+.img-zoom-overlay.visible .img-zoom-clone {
+    transform: scale(1);
+    opacity: 1;
 }

--- a/docs/source/_static/js/image_zoom.js
+++ b/docs/source/_static/js/image_zoom.js
@@ -1,0 +1,116 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/**
+ * Hover-to-zoom for documentation images and videos (opt-in).
+ *
+ * Only elements inside a .zoomable container (or with the class directly)
+ * participate. On mouseenter the element's full-resolution version is shown
+ * in a fixed overlay. The overlay never captures pointer events -- the
+ * cursor stays on the source element, so mouseleave fires reliably.
+ */
+(function () {
+  "use strict";
+
+  var overlay = null;
+  var clone = null;
+  var activeEl = null;
+  var showTimer = null;
+  var SHOW_DELAY = 120; // ms before showing (avoids flash on quick pass-through)
+
+  function createOverlay() {
+    overlay = document.createElement("div");
+    overlay.className = "img-zoom-overlay";
+    document.body.appendChild(overlay);
+  }
+
+  function show(el) {
+    if (!overlay) createOverlay();
+    if (activeEl === el) return;
+    activeEl = el;
+
+    // Remove previous clone
+    if (clone && clone.parentNode) clone.parentNode.removeChild(clone);
+
+    if (el.tagName === "VIDEO") {
+      clone = document.createElement("video");
+      clone.src = el.currentSrc || el.src;
+      clone.poster = el.poster || "";
+      clone.autoplay = true;
+      clone.loop = true;
+      clone.muted = true;
+      clone.playsInline = true;
+      // Sync playback position
+      clone.currentTime = el.currentTime;
+    } else {
+      clone = document.createElement("img");
+      clone.src = el.currentSrc || el.src;
+      clone.alt = el.alt || "";
+    }
+    clone.className = "img-zoom-clone";
+    overlay.appendChild(clone);
+
+    // Force reflow then show
+    void overlay.offsetHeight;
+    overlay.classList.add("visible");
+  }
+
+  function hide() {
+    clearTimeout(showTimer);
+    showTimer = null;
+    if (!overlay) return;
+    overlay.classList.remove("visible");
+    activeEl = null;
+    // Clean up clone after fade-out
+    setTimeout(function () {
+      if (clone && clone.parentNode && !overlay.classList.contains("visible")) {
+        clone.parentNode.removeChild(clone);
+        clone = null;
+      }
+    }, 350);
+  }
+
+  function isZoomable(el) {
+    var node = el;
+    while (node && node !== document.body) {
+      if (node.classList && node.classList.contains("zoomable")) return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+
+  function isZoomTarget(el) {
+    return (el.tagName === "IMG" || el.tagName === "VIDEO") && isZoomable(el);
+  }
+
+  function init() {
+    var content = document.querySelector(".content") ||
+                  document.querySelector("[role='main']") ||
+                  document.body;
+
+    content.addEventListener("mouseenter", function (e) {
+      var target = e.target;
+      if (isZoomTarget(target)) {
+        clearTimeout(showTimer);
+        showTimer = setTimeout(function () {
+          show(target);
+        }, SHOW_DELAY);
+      }
+    }, true);
+
+    content.addEventListener("mouseleave", function (e) {
+      var target = e.target;
+      if (target === activeEl || (showTimer && isZoomTarget(target))) {
+        hide();
+      }
+    }, true);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/source/api/serving.rst
+++ b/docs/source/api/serving.rst
@@ -58,5 +58,5 @@ Multi GPU:
 See also
 --------
 
-- :doc:`/developer_guides/interactive_serving`
+.. - :doc:`/developer_guides/interactive_serving`
 - :doc:`/models/lingbot_world`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,6 +82,7 @@ html_context = {
 }
 
 html_css_files = ["custom.css"]
+html_js_files = ["js/image_zoom.js"]
 
 # -- Copybutton --------------------------------------------------------------
 

--- a/docs/source/developer_guides/config_system.rst
+++ b/docs/source/developer_guides/config_system.rst
@@ -17,14 +17,20 @@ Config system
 ===================================
 
 FlashDreams configuration is built around simple, strongly-typed Python ``dataclass`` objects.
-This configuration system is similar to the one employed in `nerfstudio <https://github.com/nerfstudio-project/nerfstudio>`_. It allows you to easily plug in different permutations of model components and nest configurations to define the complete inference pipeline.
+This configuration system is similar to the one employed in `nerfstudio <https://github.com/nerfstudio-project/nerfstudio>`_,
+allowing to easily compose different model components variants and nest configurations to define the complete
+inference pipeline.
 
 Base components
 ---------------
 
-All configurable components in FlashDreams—such as the encoder, transformer, scheduler, and decoder—have a corresponding configuration dataclass and can be found under ``flashdreams.infra``. As outlined in the :doc:`/developer_guides/inference_pipeline_overview`, the main entry point for defining an integration is the :class:`~flashdreams.infra.pipeline.StreamInferencePipelineConfig`.
+All configurable components in FlashDreams - such as the encoder, transformer, scheduler, and decoder -
+have a corresponding configuration dataclass in ``flashdreams.infra``.
+As outlined in the :doc:`/developer_guides/inference_pipeline_overview`, the main entry point for defining an integration
+is the :class:`~flashdreams.infra.pipeline.StreamInferencePipelineConfig`.
 
-These config objects are modular and nestable. A typical pipeline config defines the architecture by composing other config dataclasses:
+These config objects are modular and nestable.
+A typical pipeline config defines the architecture by composing other config dataclasses:
 
 .. code-block:: python
 
@@ -32,7 +38,7 @@ These config objects are modular and nestable. A typical pipeline config defines
    from flashdreams.infra.diffusion.scheduler.fm import FlowMatchSchedulerConfig
    from flashdreams.infra.pipeline import StreamInferencePipelineConfig
 
-   # Define your own configs for the encoder, transformer, and decoder.
+   # Define your own configs for the encoder, transformer, and decoder
    MyStreamingEncoderConfig = ...
    MyTransformerConfig = ...
    MyStreamingDecoderConfig = ...
@@ -51,9 +57,10 @@ These config objects are modular and nestable. A typical pipeline config defines
 Creating new configs
 --------------------
 
-If you are interested in creating a brand new model component, you will need to create a corresponding config with the associated parameters you want to expose.
+To create a brand new model component, a corresponding config with the associated parameters to be exposed has to be created.
 
-Let's say you want to create a new encoder called ``MyEncoder``. You can create a new ``Encoder`` class that extends the base class. Before the model definition, you define the actual ``MyEncoderConfig`` which points to the ``MyEncoder`` class using the ``_target`` field.
+To create a new encoder called ``MyEncoder``, a new ``Encoder`` class that extends the base class has to be defined.
+Before the model definition, the actual ``MyEncoderConfig``, which points to the ``MyEncoder`` class, has to be defined using the ``_target`` field.
 
 .. code-block:: python
 
@@ -83,13 +90,16 @@ Let's say you want to create a new encoder called ``MyEncoder``. You can create 
 
        def __init__(self, config: MyEncoderConfig) -> None:
            super().__init__(config)
+
            # Build your layers using self.config.embedding_dim, etc.
            ...
 
        def forward(self, input):
            ...
 
-Alternatively, you do not always have to write a complete configuration from scratch. You can use :func:`flashdreams.infra.config.derive_config` to create concise variants from existing configs. This allows you to inherit the base settings and only override the specific fields you want to change:
+Alternatively, it's not always required to define a complete configuration from scratch.
+One can use :func:`flashdreams.infra.config.derive_config` to create concise variants from existing configs,
+allowing to inherit the base settings and to only override specific fields:
 
 .. code-block:: python
 
@@ -97,7 +107,7 @@ Alternatively, you do not always have to write a complete configuration from scr
    from my_project.configs import MyBasePipelineConfig
 
    # Create a variant that inherits everything from MyBasePipelineConfig
-   # but overrides the encoder's embedding dimension.
+   # but overrides the encoder's embedding dimension
    my_variant_config = derive_config(
        MyBasePipelineConfig,
        encoder=dict(embedding_dim=1024),
@@ -106,11 +116,12 @@ Alternatively, you do not always have to write a complete configuration from scr
 Modifying from CLI
 ------------------
 
-Often times, you just want to play with the parameters of an existing model without having to specify a new one. You can easily do so via the CLI, which is powered by `tyro <https://github.com/brentyi/tyro>`_.
+To simply play with the parameters of an existing model without having to specify a new one, one can employ CLI arguments, which are powered by `tyro <https://github.com/brentyi/tyro>`_.
 
-Because our configurations are strongly typed dataclasses, ``tyro`` automatically generates a comprehensive command-line interface. You can use the ``flashdreams-run`` (The CLI carried in FlashDreams) command to dynamically override any nested dataclass field.
+Because the FlashDreams configurations are strongly typed dataclasses, ``tyro`` automatically generates a comprehensive command-line interface.
+The ``flashdreams-run`` cli command can be used to dynamically override any nested dataclass field.
 
-For example, to list out all existing configurable parameters for a model:
+For example, to list all existing configurable parameters for a model:
 
 .. code-block:: bash
 
@@ -119,7 +130,6 @@ For example, to list out all existing configurable parameters for a model:
 .. image:: /_static/diagrams/cli-screen-shot.png
    :alt: CLI helptext showing tyro dynamically parsing nested configuration arguments.
    :class: zoomable
-
 
 To run the model with a modified configuration:
 

--- a/docs/source/developer_guides/config_system.rst
+++ b/docs/source/developer_guides/config_system.rst
@@ -118,6 +118,7 @@ For example, to list out all existing configurable parameters for a model:
 
 .. image:: /_static/diagrams/cli-screen-shot.png
    :alt: CLI helptext showing tyro dynamically parsing nested configuration arguments.
+   :class: zoomable
 
 
 To run the model with a modified configuration:

--- a/docs/source/developer_guides/inference_pipeline_overview.rst
+++ b/docs/source/developer_guides/inference_pipeline_overview.rst
@@ -24,6 +24,7 @@ or modifying existing ones.
 
 .. image:: /_static/diagrams/flashdreams-inference-pipeline-overview.jpg
    :alt: FlashDreams autoregressive inference pipeline overview.
+   :class: zoomable
 
 The key entry point class for the inference pipeline is
 :class:`~flashdreams.infra.pipeline.StreamInferencePipeline`, which defines the

--- a/docs/source/developer_guides/inference_pipeline_overview.rst
+++ b/docs/source/developer_guides/inference_pipeline_overview.rst
@@ -17,7 +17,7 @@ Inference pipeline overview
 ===================================
 
 This page outlines the major computation flow in the FlashDreams inference pipeline.
-It should help you understand the core concepts and APIs for building your own model integration,
+It outlines the core concepts and APIs for building custom model integrations,
 or modifying existing ones.
 
 .. Figure creation trace: https://chatgpt.com/share/6a14ab0f-90bc-83e8-8145-c1a03b64f43a
@@ -26,11 +26,11 @@ or modifying existing ones.
    :alt: FlashDreams autoregressive inference pipeline overview.
    :class: zoomable
 
-The key entry point class for the inference pipeline is
-:class:`~flashdreams.infra.pipeline.StreamInferencePipeline`, which defines the
+The key entry point for the inference pipeline is the
+:class:`~flashdreams.infra.pipeline.StreamInferencePipeline` class, which defines the
 autoregressive generation loop shown in the figure. The persistent state is held in
 :class:`~flashdreams.infra.pipeline.StreamInferencePipelineCache` as a cache object,
-which is passed around and updated in each autoregressive step.
+which is shared within the pipeline and updated in each autoregressive step.
 
 .. code-block:: python
 
@@ -41,25 +41,25 @@ which is passed around and updated in each autoregressive step.
 
    pipeline: StreamInferencePipeline = ...
 
-   # One-shot encoding on global conditions, then initialize cache/state.
+   # One-shot encoding on global conditions, then initialize cache/state
    cache: StreamInferencePipelineCache = pipeline.initialize_cache(
        text=["a beautiful beach scene"],
        image=first_frame,
        ...,
    )
 
-   # Autoregressive generation loop.
+   # Autoregressive generation loop
    for autoregressive_index, control in enumerate(controls):
        current_output = pipeline.generate(autoregressive_index, cache, input=control)
        yield current_output
        pipeline.finalize(autoregressive_index, cache)
 
-The code snippet above shows the basic loop. At the top level, you first call :meth:`~flashdreams.infra.pipeline.StreamInferencePipeline.initialize_cache`
-once with global conditions, such as text prompts and the first frame. Then, for each autoregressive step, call
-:meth:`~flashdreams.infra.pipeline.StreamInferencePipeline.generate` to produce the current output chunk,
+The code snippet above shows the basic execution loop. The initial call :meth:`~flashdreams.infra.pipeline.StreamInferencePipeline.initialize_cache`
+consumes global conditions, such as text prompts and the first frame. Then, for each autoregressive step,
+:meth:`~flashdreams.infra.pipeline.StreamInferencePipeline.generate` is called to produce the current output chunk,
 followed by :meth:`~flashdreams.infra.pipeline.StreamInferencePipeline.finalize`. This split exists because
 :meth:`~flashdreams.infra.pipeline.StreamInferencePipeline.finalize` typically handles additional KV
-cache updates that are not in the hot path. This allows them to be offloaded to a background thread in many
+cache updates that are not in the hot path, which can be offloaded to a background thread in many
 cases to hide latency.
 
 Inside :meth:`~flashdreams.infra.pipeline.StreamInferencePipeline.generate`, the pipeline encodes the
@@ -72,7 +72,7 @@ the final output. The following snippet illustrates this internal flow:
    def generate(
        autoregressive_index: int, cache, input=None,
    ) -> torch.Tensor:
-       # 1. Convert per-step control into model conditioning.
+       # 1. Convert per-step control into model conditioning
        if input is not None:
            input = pipeline.encoder(
                input=input,
@@ -80,7 +80,7 @@ the final output. The following snippet illustrates this internal flow:
                cache=cache.encoder_cache,
            )
 
-       # 2. Run scheduler loop + DiT flow prediction.
+       # 2. Run scheduler loop + DiT flow prediction
        clean_latent, final_state = diffusion_model.generate(
            autoregressive_index=autoregressive_index,
            cache=cache.transformer_cache,
@@ -88,7 +88,7 @@ the final output. The following snippet illustrates this internal flow:
        )
        cache.final_state = final_state
 
-       # 3. Convert latent chunk to output chunk.
+       # 3. Convert latent chunk to output chunk
        if pipeline.decoder is None:
            return clean_latent
 
@@ -98,8 +98,8 @@ the final output. The following snippet illustrates this internal flow:
            cache=cache.decoder_cache,
        )
 
-In FlashDreams, these components are wired together using a configuration system. This allows you to build
-a customized pipeline by supplying different configurations for the encoder, diffusion model, and decoder.
+In FlashDreams, these components are composed using a configuration system. This allows building
+customized pipelines by supplying different configurations for the encoder, diffusion model, and decoder.
 A typical :class:`~flashdreams.infra.pipeline.StreamInferencePipelineConfig` is instantiated as follows:
 
 .. code-block:: python
@@ -108,7 +108,7 @@ A typical :class:`~flashdreams.infra.pipeline.StreamInferencePipelineConfig` is 
    from flashdreams.infra.diffusion.scheduler.fm import FlowMatchSchedulerConfig
    from flashdreams.infra.pipeline import StreamInferencePipelineConfig
 
-   # Define your own configs for the encoder, transformer, and decoder.
+   # Define your own configs for the encoder, transformer, and decoder
    CustomizedStreamingEncoderConfig = ...
    CustomizedTransformerConfig = ...
    CustomizedStreamingDecoderConfig = ...
@@ -132,7 +132,7 @@ More details on the config system can be found in :doc:`/developer_guides/config
 Examples
 --------
 
-Here is how existing models use this structure:
+Samples on how existing models use this structure:
 
 - `LingBot-World config <https://github.com/NVIDIA/flashdreams/blob/main/integrations/lingbot/lingbot/config.py>`_:
   A camera-controlled I2V model that uses the per-step camera encoder.
@@ -143,5 +143,5 @@ Here is how existing models use this structure:
 - `Wan2.1 config <https://github.com/NVIDIA/flashdreams/blob/main/integrations/wan21/wan21/config.py>`_:
   Treats a bidirectional video model as a single-rollout autoregressive model.
 
-For the detailed API documentation, check out :doc:`/api/infra`. If you are interested in implementing a new model,
+For the detailed API documentation, please reference :doc:`/api/infra`. To integrate a new model,
 please refer to :doc:`/developer_guides/new_integration`.

--- a/docs/source/developer_guides/interactive_serving.rst
+++ b/docs/source/developer_guides/interactive_serving.rst
@@ -21,19 +21,8 @@ Interactive serving
 FlashDreams serving keeps a world-model session alive while inputs and outputs
 stream through the application loop.
 
-.. raw:: html
-
-   <div class="ai-figure-placeholder">
-     <div class="ai-figure-title">Figure placeholder: persistent serving session</div>
-     <div class="ai-figure-body">
-       Replace this block with a diagram showing client input, serving session,
-       pipeline cache, model step, streaming decoder, and output returning to
-       the client.
-     </div>
-   </div>
-
-Serving model
--------------
+Serving models
+--------------
 
 .. raw:: html
 

--- a/docs/source/developer_guides/new_integration.rst
+++ b/docs/source/developer_guides/new_integration.rst
@@ -16,16 +16,16 @@
 Add a new method
 ===================================
 
-Before you start adding a new method, we highly recommend reading the :doc:`/developer_guides/inference_pipeline_overview` and :doc:`/developer_guides/config_system` pages first to get a big picture of the system architecture.
+Before starting to add a new method, we highly recommend reading the :doc:`/developer_guides/inference_pipeline_overview` and :doc:`/developer_guides/config_system` pages first to obtain an overview of the system's architecture.
 
-FlashDreams aims to offer researchers a codebase that they can utilize to extend and develop novel video and world models. Our vision is for users to establish a *standalone repository* that imports FlashDreams as a dependency and overrides pipeline components (such as encoders, transformers, or decoders) to cater to specific functionality requirements of the new approach. We encourage you to maintain your method externally rather than pushing changes directly into the `integrations/ <https://github.com/NVIDIA/flashdreams/tree/main/integrations>`_ directory of this repository.
+FlashDreams aims to offer researchers a codebase that they can utilize to extend and develop novel video and world models. Our vision is for users to establish a *standalone repository* that imports FlashDreams as a dependency and overrides pipeline components (such as encoders, transformers, or decoders) to cater to specific functionality requirements of the new approach. We encourage to maintain methods externally rather than pushing changes directly into the `integrations/ <https://github.com/NVIDIA/flashdreams/tree/main/integrations>`_ directory of this repository.
 
-However, if any of your new features require modifications to the core FlashDreams infra or introduce generally useful components (such as the :mod:`TAEHV decoder <flashdreams.recipes.taehv>`), we encourage you to submit a PR to enable others to benefit from them.
+However, if any new features requires modifications to the core FlashDreams infra or introduce generally useful components (such as the :mod:`TAEHV decoder <flashdreams.recipes.taehv>`), we encourage you to submit a PR to enable others to benefit from them.
 
 File structure
 --------------
 
-We recommend the following file structure for your new method:
+We recommend the following file structure for new methods:
 
 .. code-block:: text
 
@@ -41,7 +41,10 @@ We recommend the following file structure for your new method:
     │   └── ...
     └── pyproject.toml
 
-Add optional files only when you need to customize the behavior beyond what we carry in FlashDreams. Most integrations can use the base :class:`~flashdreams.infra.pipeline.StreamInferencePipeline` directly and only provide model components plus config literals. As explained in :doc:`/developer_guides/config_system`, a method typically defines a pipeline config and a runner config. The runner handles CLI-facing I/O and runtime loops.
+Add optional files are only if customization beyond what is available in FlashDreams is required.
+Most integrations can use the base :class:`~flashdreams.infra.pipeline.StreamInferencePipeline` directly and only provide model components plus config literals.
+As explained in :doc:`/developer_guides/config_system`, a method typically defines a pipeline config and a runner config.
+The runner handles CLI-facing I/O and runtime loops.
 
 .. code-block:: python
    :caption: customized_method/runner.py
@@ -61,16 +64,16 @@ Add optional files only when you need to customize the behavior beyond what we c
        def run(self) -> None:
            cfg = self.config
 
-           # 1. Initialize the autoregressive cache.
+           # 1. Initialize the autoregressive cache
            cache = self.pipeline.initialize_cache(text=[cfg.prompt])
 
-           # 2. Drive the autoregressive rollout.
+           # 2. Drive the autoregressive rollout
            for i in range(cfg.total_blocks):
                video_chunk = self.pipeline.generate(autoregressive_index=i, cache=cache)
                self.pipeline.finalize(autoregressive_index=i, cache=cache)
 
            if self.is_rank_zero:
-               # 3. Write outputs only on the main process.
+               # 3. Write outputs only on the main process
                ...
 
 .. code-block:: python
@@ -101,27 +104,29 @@ Add optional files only when you need to customize the behavior beyond what we c
    )
 
 
-You can use the existing integrations under the `integrations/ <https://github.com/NVIDIA/flashdreams/tree/main/integrations>`_ directory as a minimal guide. These folders are simple examples of what mini standalone repositories that depend on FlashDreams look like. Examples are often the best way to learn; take a look at the `LingBot-World <https://github.com/NVIDIA/flashdreams/tree/main/integrations/lingbot>`_ and `Self-Forcing <https://github.com/NVIDIA/flashdreams/tree/main/integrations/self_forcing>`_ integrations for good references on how to extend and use FlashDreams in your own projects.
+Existing integrations under the `integrations/ <https://github.com/NVIDIA/flashdreams/tree/main/integrations>`_ can be used as a minimal guide.
+These folders are simple examples of what mini standalone repositories that depend on FlashDreams look like.
+Examples are often the best way to learn; take a look at the `LingBot-World <https://github.com/NVIDIA/flashdreams/tree/main/integrations/lingbot>`_ and `Self-Forcing <https://github.com/NVIDIA/flashdreams/tree/main/integrations/self_forcing>`_ integrations for good references on how to extend and use FlashDreams in a custom project.
 
-Registering your method
------------------------
+Registering methods
+-------------------
 
-After registering your method you should be able to see it in the CLI helptext and run it, leveraging the existing CLI for complete command line control:
+After registering a method one should be able to see it in the CLI helptext and run it, leveraging the existing CLI for complete command line control:
 
 .. code-block:: bash
 
-   # List all available models, including your new one
+   # List all available models, including new ones
    flashdreams-run --help
 
-   # See configurable parameters for your new model
+   # See configurable parameters for new models
    flashdreams-run customized-method --help
 
-   # Run the model
+   # Run the new model
    flashdreams-run customized-method --prompt "A beautiful custom generation."
 
-In order to extend FlashDreams and register your own models, you can package your code as a Python package and register it with FlashDreams via an entrypoint in the ``pyproject.toml`` file. FlashDreams will automatically look for all registered runners and will register them to be used by the ``flashdreams-run`` CLI.
+In order to extend FlashDreams and register own models, one can package code as a Python package and register it with FlashDreams via an entrypoint in the ``pyproject.toml`` file. FlashDreams will automatically search for all registered runners and will register them to be used by the ``flashdreams-run`` CLI.
 
-Create a ``pyproject.toml`` file. This is where the entrypoint to your method is set and also where you can specify additional dependencies required by your codebase.
+A ``pyproject.toml`` file is where the entrypoint to custom methods is specified and additional dependencies are specified. For example:
 
 .. code-block:: toml
    :caption: pyproject.toml
@@ -131,7 +136,7 @@ Create a ``pyproject.toml`` file. This is where the entrypoint to your method is
    version = "0.1.0"
 
    dependencies = [
-       "flashdreams", # you may want to consider pinning the version, ie "flashdreams==0.1.0"
+       "flashdreams", # consider pinning the version, ie "flashdreams==0.1.0"
        "mediapy>=1.1",
    ]
 
@@ -147,15 +152,16 @@ Finally, run the following to register the method:
 
    pip install -e .
 
-When developing a new method, you don't always want to install your code as a package. Instead, you may use the ``FLASHDREAMS_RUNNER_CONFIGS`` environment variable to temporarily register your custom method.
+When developing a new methods they don't always need to be installed as a package. Instead, the ``FLASHDREAMS_RUNNER_CONFIGS`` environment variable can be usedto temporarily register custom custom method.
 
 .. code-block:: bash
 
    export FLASHDREAMS_RUNNER_CONFIGS="customized-method=customized_method.config:RUNNER_CONFIGS"
 
-The ``FLASHDREAMS_RUNNER_CONFIGS`` environment variable additionally accepts a function (a zero-arg callable) to temporarily register your custom runner if construction has side effects you want to defer until CLI time.
+The ``FLASHDREAMS_RUNNER_CONFIGS`` environment variable additionally accepts a function (a zero-arg callable) to temporarily register custom runners if construction has side effects to be deferred until CLI time.
 
 Adding to the FlashDreams documentation
 ---------------------------------------
 
-We invite researchers to contribute their own integrations to our official codebase and documentation. You can find more information on how to do this in the repository's `CONTRIBUTING.md <https://github.com/NVIDIA/flashdreams/blob/main/CONTRIBUTING.md>`_. See the existing model pages under the `docs/source/models/ <https://github.com/NVIDIA/flashdreams/tree/main/docs/source/models>`_ directory (e.g., :doc:`/models/self_forcing`) as templates for documenting your new method.
+We invite researchers to contribute their own integrations to our official codebase and documentation. More information on how to do this can be found in the repository's `CONTRIBUTING.md <https://github.com/NVIDIA/flashdreams/blob/main/CONTRIBUTING.md>`_.
+See the existing model pages under the `docs/source/models/ <https://github.com/NVIDIA/flashdreams/tree/main/docs/source/models>`_ (e.g., :doc:`/models/self_forcing`) as templates for documenting new methods.

--- a/docs/source/developer_guides/usage_patterns.rst
+++ b/docs/source/developer_guides/usage_patterns.rst
@@ -121,4 +121,4 @@ Next links
 
 - :doc:`/models/index` for model commands.
 - :doc:`/developer_guides/new_integration` for integration authoring.
-- :doc:`/developer_guides/interactive_serving` for serving concepts.
+.. - :doc:`/developer_guides/interactive_serving` for serving concepts.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -249,10 +249,10 @@ Start here
 
    Inference pipeline overview <developer_guides/inference_pipeline_overview>
    Config system <developer_guides/config_system>
-   Interactive serving <developer_guides/interactive_serving>
    Add a new method <developer_guides/new_integration>
 
 .. Temporarily commented out for internal development:
+..   Interactive serving <developer_guides/interactive_serving>
 ..   Developer workflow patterns <developer_guides/usage_patterns>
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,6 +62,7 @@ creative tools, virtual worlds, and game-like experiences.
 .. Figure creation trace: https://chatgpt.com/share/6a124478-4730-83e8-ba21-33628c8f1f3b
 .. image:: /_static/diagrams/compare-offline-online-video-model-v2.jpg
    :alt: Offline one-shot video inference compared with online autoregressive world-model serving.
+   :class: zoomable
 
 In a served world-model application, the key requirement is not only generating
 a high-quality video. The runtime must keep an interactive session responsive

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -249,10 +249,10 @@ Start here
 
    Inference pipeline overview <developer_guides/inference_pipeline_overview>
    Config system <developer_guides/config_system>
+   Interactive serving architecture <developer_guides/interactive_serving>
    Add a new method <developer_guides/new_integration>
 
 .. Temporarily commented out for internal development:
-..   Interactive serving architecture <developer_guides/interactive_serving>
 ..   Developer workflow patterns <developer_guides/usage_patterns>
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,7 +49,7 @@ GTC 2026 <https://research.nvidia.com/labs/sil/projects/omnidreams-blog/>`_.
    <p class="fd-subtitle">Interactive world models</p>
 
 A world model learns to generate and evolve an environment over time. In
-practice this often means video, but the same concept can include actions,
+practice, this often means video, but the same concept can include actions,
 state, audio, sensor input, and control signals.
 
 World-model serving is the runtime pattern for putting that model inside a live
@@ -64,8 +64,8 @@ creative tools, virtual worlds, and game-like experiences.
    :alt: Offline one-shot video inference compared with online autoregressive world-model serving.
    :class: zoomable
 
-In a served world-model application, the key requirement is not only generating
-a high-quality video. The runtime must keep an interactive session responsive
+In an online world-model application, the key requirement is not only generating
+high-quality videos. The runtime must keep an interactive session responsive
 while the model continues to advance the world.
 
 .. raw:: html
@@ -127,7 +127,7 @@ while the model continues to advance the world.
 
 FlashDreams is engineered with efficiency in mind. With a bottom-up system
 design tailored to autoregressive world-model inference patterns, it delivers best-in-class
-speed across many popular open-source models and GPU architectures.
+speed across many popular open-source models and GPU architectures:
 
 .. raw:: html
 
@@ -167,7 +167,7 @@ autoregressive pass.
 
    <p class="fd-subtitle">Production-oriented interactive serving backend</p>
 
-FlashDreams also includes a production-oriented serving backend for persistent,
+FlashDreams also includes a production-oriented serving backend for persistent and
 low-latency world-model sessions, with efficient inference execution, multi-GPU support, and
 streaming input/output. Explore the interactive demos powered by FlashDreams:
 
@@ -230,7 +230,7 @@ Start here
 
 .. toctree::
    :maxdepth: 1
-   :caption: Model cards
+   :caption: Models
    :hidden:
 
    Self-Forcing <models/self_forcing>
@@ -249,7 +249,7 @@ Start here
 
    Inference pipeline overview <developer_guides/inference_pipeline_overview>
    Config system <developer_guides/config_system>
-   Interactive serving architecture <developer_guides/interactive_serving>
+   Interactive serving <developer_guides/interactive_serving>
    Add a new method <developer_guides/new_integration>
 
 .. Temporarily commented out for internal development:

--- a/docs/source/models/causal_forcing.rst
+++ b/docs/source/models/causal_forcing.rst
@@ -114,7 +114,7 @@ Some generated samples from the above commands:
 
 .. raw:: html
 
-   <div class="model-video-grid">
+   <div class="model-video-grid zoomable">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
          <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/causal_forcing/causal-forcing-wan2.1-t2v-1.3b-framewise.mp4" type="video/mp4">

--- a/docs/source/models/causal_wan22.rst
+++ b/docs/source/models/causal_wan22.rst
@@ -92,7 +92,7 @@ Some generated samples from the above commands:
 
 .. raw:: html
 
-   <div class="model-video-grid">
+   <div class="model-video-grid zoomable">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
          <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/causal_wan22/fastvideo-causal-wan2.2-t2v-14b_1.mp4" type="video/mp4">

--- a/docs/source/models/cosmos_predict2.rst
+++ b/docs/source/models/cosmos_predict2.rst
@@ -113,7 +113,7 @@ Some generated samples from the above commands:
 
 .. raw:: html
 
-   <div class="model-video-grid">
+   <div class="model-video-grid zoomable">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
          <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/cosmos_predict2/cosmos2-t2v-2b-720p.mp4" type="video/mp4">

--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -108,7 +108,7 @@ Some generated samples from the above commands:
 
 .. raw:: html
 
-   <div class="model-video-grid">
+   <div class="model-video-grid zoomable">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
          <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/lingbot_world/lingbot-world-fast-01.mp4" type="video/mp4">

--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -63,7 +63,7 @@ To run LingBot-World, launch one of the registered runner slugs via
        --pixel-height 464 --pixel-width 832 \
        --total-blocks 21
 
-Sample data are downloaded from the
+Sample data is downloaded from the
 `LingBot-World repository <https://github.com/Robbyant/lingbot-world/tree/main/examples>`_.
 Valid ``--example-idx`` values are ``0, 1, 2, 5``. Note the single GPU command might run
 out of memory for large ``--total-blocks`` values.

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -102,7 +102,7 @@ Some generated samples from the above commands:
 
 .. raw:: html
 
-   <div class="model-video-grid">
+   <div class="model-video-grid zoomable">
      <div class="model-video-card">
        <!-- <div class="model-video-placeholder">Video placeholder</div> -->
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -24,7 +24,7 @@ OmniDreams
      <a class="model-link-button" href="https://github.com/NVIDIA/flashdreams/tree/main/integrations/omnidreams" target="_blank" rel="noopener noreferrer">Official code</a>
    </div>
 
-OmniDreams is an HDMap-conditioned world model for single-view and multi-view
+OmniDreams is a HDMap-conditioned world model for single-view and multi-view
 driving generation, with presets that balance visual fidelity and runtime
 throughput.
 
@@ -131,9 +131,9 @@ Launch the interactive demo
 ``interactive-drive`` runs the OmniDreams single-view pipeline in a
 single process and streams the camera view to your browser. The demo
 machine only needs a CUDA-capable GPU -- no graphics-capable GPU,
-display server, or Vulkan toolchain required.
+display server, or Vulkan support are required.
 
-Requires access to `NVIDIA/flashdreams <https://github.com/NVIDIA/flashdreams>`_
+The demo requires access to `NVIDIA/flashdreams <https://github.com/NVIDIA/flashdreams>`_
 and an ``HF_TOKEN`` with read access to
 `nvidia/omni-dreams-scenes <https://huggingface.co/datasets/nvidia/omni-dreams-scenes>`_
 (scene USDZs) and
@@ -149,7 +149,7 @@ First-time setup:
    export HF_TOKEN=<your-hf-token>
    uv sync --package flashdreams-omnidreams --extra interactive-drive
 
-Optionally pre-download scenes and checkpoints so the first launch
+Optionally, pre-download scenes and checkpoints so the first launch
 isn't blocked on network I/O:
 
 .. code-block:: bash
@@ -165,8 +165,8 @@ Run the demo and stream to your browser:
 Then open ``http://<server-ip>:8080/`` in any browser on the same
 network and pick a scene from the picker in the bottom-right.
 
-For deployments with a desktop NVIDIA GPU that has a graphics queue,
-omit ``--stream-mjpeg`` to open the demo in a local Vulkan window
+For execution using a consumer NVIDIA GPU that exposes a graphics stack,
+omit the ``--stream-mjpeg`` flag to open the demo in a local Vulkan window
 instead:
 
 .. code-block:: bash
@@ -175,40 +175,40 @@ instead:
 
 .. note::
 
-   The local window needs a display server (X11) and the system OpenGL /
+   The local window requires a display server and the system OpenGL /
    Vulkan client libraries. On Debian/Ubuntu:
 
    .. code-block:: bash
 
       sudo apt install -y libx11-6 libxcb1 libgl1 libglx-mesa0 libvulkan1
 
-   A ``Failed to initialize GLFW`` error means the display or one of these
-   libraries is missing.
+   A ``Failed to initialize GLFW`` error indicates the display or one of these
+   libraries are missing.
 
 Steering wheel and game controller
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With a local window you can drive using a steering wheel or game
-controller. Any device that Ubuntu detects as a standard game controller
-or joystick works. Run the configuration tool to calibrate it; the demo loads
-the saved profile automatically on its next launch:
+A steering wheel or game controller can be used to control the local window mode.
+Any device that Ubuntu detects as a standard game controller
+or joystick is viable. We provide a configuration tool to calibrate these:
 
 .. code-block:: bash
 
    uv run --package flashdreams-omnidreams interactive-drive-configuration
 
-Re-run it to edit a profile (steering sensitivity, deadzone, buttons),
-delete one, or set which is the default.
+The demo loads the saved profile automatically on subsequent launches.
+Re-run the configuration tool to specify the default profile, edit a profile
+(steering sensitivity, deadzone, buttons), or delete a profile.
 
 Alternative: WebRTC server
 --------------------------
 
-For deployments that need a richer browser frontend with WebRTC's
+For deployments that require a richer browser frontend with WebRTC's
 lower video-delivery latency and a streaming gRPC service for
 multi-client setups, the standalone server at
 ``omnidreams.webrtc.server`` ships a polished HTML5 client on top of
 the same OmniDreams pipeline. The MJPEG path above is the
-recommended starting point for most users; reach for WebRTC when you
+recommended starting point for most users; consider WebRTC if you
 need bidirectional camera-control APIs or are already integrating
 the gRPC service into a larger product.
 
@@ -224,12 +224,12 @@ the gRPC service into a larger product.
 Sample scene UUIDs for the interactive server are available in the
 `nvidia/omni-dreams-scenes Hugging Face dataset <https://huggingface.co/datasets/nvidia/omni-dreams-scenes/tree/main/scenes>`_.
 
-The server may take a few minutes to warm up. When it is ready, it prints
+The server may take a few minutes to warm up. Once ready, it prints
 ``Connect via http://<server-ip>:8089/request_session``.
 Here, ``<server-ip>`` is the server IP address you are connecting to
 (can use ``localhost`` when running locally).
 
-When successfully connected, the browser-based UI looks like this:
+Once successfully connected, the browser-based UI looks like this:
 
 .. raw:: html
 

--- a/docs/source/models/self_forcing.rst
+++ b/docs/source/models/self_forcing.rst
@@ -103,7 +103,7 @@ Some generated samples from the above commands:
 
 .. raw:: html
 
-   <div class="model-video-grid">
+   <div class="model-video-grid zoomable">
      <div class="model-video-card">
        <!-- <div class="model-video-placeholder">Video placeholder</div> -->
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">

--- a/docs/source/models/wan21.rst
+++ b/docs/source/models/wan21.rst
@@ -97,7 +97,7 @@ Some generated samples from the above commands:
 
 .. raw:: html
 
-   <div class="model-video-grid">
+   <div class="model-video-grid zoomable">
      <div class="model-video-card">
        <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
          <source src="https://research.nvidia.com/labs/sil/projects/flashdreams/assets/wan21/wan21-t2v-1.3b-480p.mp4" type="video/mp4">

--- a/docs/source/quickstart/first_world_model.rst
+++ b/docs/source/quickstart/first_world_model.rst
@@ -18,9 +18,9 @@ Launch your first model
 
 This page provides a minimal path for:
 
-1. offline / batch-like long-rollout model inference with
+1. Offline / batch-like long-rollout model inference with
    :doc:`Self-Forcing </models/self_forcing>`.
-2. online interactive world-model serving with
+2. Online interactive world-model serving with
    :doc:`LingBot-World </models/lingbot_world>`.
 
 Prerequisites

--- a/flashdreams/flashdreams/core/attention/cp.py
+++ b/flashdreams/flashdreams/core/attention/cp.py
@@ -68,6 +68,14 @@ class ContextParallelAttention(NativeAttention):
         method: Literal["ring", "ulysses"] = "ring",
         convert_to_fp32: bool = True,
     ) -> None:
+        """Configure context-parallel attention method and backend.
+
+        Args:
+            qkv_format: Layout of the QKV tensors; ``"bhsd"`` or ``"bshd"``.
+            backend: SDPA backend; ``"cudnn"`` or ``"flash"``.
+            method: Context-parallelism strategy; ``"ring"`` or ``"ulysses"``.
+            convert_to_fp32: Promote LSE accumulators to fp32 during ring merges.
+        """
         super().__init__()
         assert qkv_format in ["bhsd", "bshd"], f"Invalid qkv format: {qkv_format}"
         assert backend in ["cudnn", "flash"], f"Invalid backend: {backend}"

--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -25,7 +25,7 @@ from typing_extensions import Self
 @dataclass
 class BlockKVCache:
     """
-    KV cache for causal attention with a fixed-size local window and CUDA-graph support.
+    KV cache for causal attention with a fixed-size local window, CUDA-graph compatible.
 
     Keys and values can have arbitrary shape ``[..., total_size, ...]``; the sequence
     (rolling) dimension is given by ``seq_dim`` (dimension index, can be negative).
@@ -120,6 +120,7 @@ class BlockKVCache:
 
     @classmethod
     def from_tensor(cls, k: Tensor, v: Tensor, seq_dim: int) -> Self:
+        """Build a single-chunk cache pre-filled with the given key and value tensors."""
         cache = cls(
             k_shape=k.shape,
             v_shape=v.shape,

--- a/flashdreams/flashdreams/core/attention/native.py
+++ b/flashdreams/flashdreams/core/attention/native.py
@@ -78,7 +78,7 @@ class NativeAttention(torch.nn.Module):
         return self.device_mesh.size() if self.device_mesh is not None else 1
 
     def forward(self, query: Tensor, key: Tensor, value: Tensor) -> Tensor:
-        """Run ring attention (or single-rank SDPA when CP is disabled).
+        """Run context-parallel SDPA (or single-rank SDPA when CP is disabled).
 
         Args:
             query: Query tensor in configured ``qkv_format``.

--- a/flashdreams/flashdreams/core/distributed/__init__.py
+++ b/flashdreams/flashdreams/core/distributed/__init__.py
@@ -97,18 +97,6 @@ def configure_loguru_for_distributed(world_rank: int | None = None) -> None:
 configure_loguru_for_distributed()
 
 
-def is_distributed_initialized() -> bool:
-    """Return True when torch distributed is available and initialized."""
-    return dist.is_available() and dist.is_initialized()
-
-
-def get_global_rank() -> int:
-    """Return the torch distributed global rank, or 0 outside distributed runs."""
-    if is_distributed_initialized():
-        return dist.get_rank()
-    return 0
-
-
 class Device:
     """Lightweight wrapper around an NVML device handle for CPU-affinity queries."""
 

--- a/flashdreams/flashdreams/infra/diffusion/scheduler/base.py
+++ b/flashdreams/flashdreams/infra/diffusion/scheduler/base.py
@@ -98,9 +98,8 @@ class Scheduler(nn.Module, ABC):
     ) -> Tensor:
         """Apply the forward corruption ``x_t = (1 - sigma(t)) * x_0 + sigma(t) * eps``.
 
-        Timestep value semantics are scheduler-specific: FlowMatch snaps to
-        the nearest entry of its 1000-step training table; FlowUniPC
-        requires exact membership in its inference schedule.
+        Timestep value semantics are scheduler-specific: all schedulers snap
+        to the nearest entry of their inference schedule.
         """
 
 

--- a/flashdreams/flashdreams/infra/encoder/base.py
+++ b/flashdreams/flashdreams/infra/encoder/base.py
@@ -203,4 +203,5 @@ class NullEncoder(Encoder):
     """
 
     def forward(self, input: Any) -> Any:
+        """Return ``input`` unchanged."""
         return input

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -155,6 +155,7 @@ class TeahvVAEDecoder(StreamingVideoDecoder[TAEHVCache]):
             )
 
     def initialize_autoregressive_cache(self) -> TAEHVCache:
+        """Return an empty streaming decoder cache."""
         return self.taehv.prepare_cache()
 
     @torch.inference_mode()
@@ -196,16 +197,22 @@ class TeahvVAEDecoder(StreamingVideoDecoder[TAEHVCache]):
 
     @property
     def temporal_compression_ratio(self) -> int:
+        """Pixel frames / latent frames in steady state (AR >= 1)."""
         return self.TEMPORAL_COMPRESSION_RATIO
 
     @property
     def spatial_compression_ratio(self) -> int:
+        """Pixel side / latent side."""
         return self.SPATIAL_COMPRESSION_RATIO
 
     def get_output_temporal_size(
         self, autoregressive_index: int, input_temporal_size: int
     ) -> int:
-        """Causal: AR 0 first latent frame decodes to a single pixel frame."""
+        """Return pixel frame count from ``input_temporal_size`` latent frames.
+
+        AR 0 applies causal padding: the first latent frame yields one pixel
+        frame, remaining frames yield ``temporal_compression_ratio`` each.
+        AR >= 1 is a plain multiply."""
         r = self.temporal_compression_ratio
         if autoregressive_index == 0:
             return 1 + (input_temporal_size - 1) * r
@@ -214,6 +221,9 @@ class TeahvVAEDecoder(StreamingVideoDecoder[TAEHVCache]):
     def get_input_temporal_size(
         self, autoregressive_index: int, output_temporal_size: int
     ) -> int:
+        """Return latent frame count needed to produce ``output_temporal_size`` pixel frames.
+
+        Inverse of :meth:`get_output_temporal_size`."""
         r = self.temporal_compression_ratio
         if autoregressive_index == 0:
             assert (output_temporal_size - 1) % r == 0, (

--- a/flashdreams/flashdreams/recipes/wan/pipeline.py
+++ b/flashdreams/flashdreams/recipes/wan/pipeline.py
@@ -183,9 +183,9 @@ class WanInferencePipeline(
                 transformer's ``batch_shape``.
             image: First-frame pixels of shape ``[*batch_shape, 1, 3, H, W]``
                 in ``[-1, 1]``. Required for I2V (``self.encoder`` is set),
-                forbidden for T2V. ``H`` / ``W`` must equal
-                ``height * decoder.spatial_compression_ratio`` and likewise
-                for ``W``.
+                forbidden for T2V. ``H`` and ``W`` must equal
+                ``height * decoder.spatial_compression_ratio`` and
+                ``width * decoder.spatial_compression_ratio``, respectively.
             height: Pre-patchify latent height (post-VAE). Optional for
                 I2V — derived from ``image`` when omitted; required for T2V.
             width: Pre-patchify latent width (post-VAE). Same rules as


### PR DESCRIPTION
## Summary

Resolves #200 

Four documentation and code-quality improvements:

### 1. Hover-to-zoom for images and videos

Add an opt-in hover-to-zoom feature. Images and videos inside a `.zoomable` container show a full-resolution clone in a fixed viewport overlay on hover, with smooth fade-in/out transitions.

- `_static/js/image_zoom.js`: mouseenter/mouseleave overlay logic (pointer-events: none to avoid flicker)
- `_static/custom.css`: overlay styling, zoom-in cursor hint
- `conf.py`: register image_zoom.js globally
- Enabled on all model video grids (wan21, omnidreams, self_forcing, lingbot_world, causal_forcing, causal_wan22, cosmos_predict2) and key diagrams (pipeline overview, CLI screenshot, offline-vs-online comparison)
- Also fixes video aspect ratio by removing `min-height` on `.model-video-player`

### 2. Add interactive serving to developer guides toctree

The `interactive_serving.rst` page was only reachable from the serving API page. Now listed in the developer guides sidebar navigation.

### 3. Wording improvements in developer guides

Clarity and consistency pass across developer guide pages (config_system, inference_pipeline_overview, interactive_serving, new_integration, index, omnidreams, lingbot_world, quickstart).

### 4. Fix and complete public API docstrings

Correct inaccuracies and add missing docstrings across the public API surface:

**Inaccuracies fixed:**
- `NativeAttention.forward()`: said "ring attention" but uses `torch.context_parallel`; now "context-parallel SDPA"
- `BlockKVCache`: claimed "CUDA-graph support" but only provides compatibility
- `Scheduler.add_noise()`: incorrectly claimed UniPC requires exact schedule membership; all schedulers use argmin snapping

**Missing docstrings added:**
- `ContextParallelAttention.__init__`
- `BlockKVCache.from_tensor`
- `NullEncoder.forward`
- `TeahvVAEDecoder`: `temporal_compression_ratio`, `spatial_compression_ratio`, `initialize_autoregressive_cache`, `get_input_temporal_size`; rewrote `get_output_temporal_size`

**Other fixes:**
- Removed duplicate definitions of `is_distributed_initialized` and `get_global_rank` in `core/distributed/__init__.py`
- Fixed redundant wording in `WanInferencePipeline.initialize_cache`

## Testing

- `uv run pre-commit run -a` passes (ruff fix, ruff format, ty type check)
- All external links verified reachable (HTTP 200)
- All internal GitHub links verified against local checkout