### PR TITLE
fix(test): increase present_budget in flaky latency loop test

### DIFF
--- a/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
@@ -334,7 +334,7 @@ def test_input_to_present_profile_ignores_represented_frames(
 
 def test_loop_presents_backend_frames_when_available() -> None:
     """Once the pipeline has rendered frames, the loop presents them."""
-    presenter = _CountingPresenter(present_budget=2)
+    presenter = _CountingPresenter(present_budget=4)
     controls = _FakeRuntimeControls()
     initial = _make_frame()
 
@@ -348,7 +348,7 @@ def test_loop_presents_backend_frames_when_available() -> None:
     )
 
     assert result is False
-    assert len(presenter.records) == 2
+    assert len(presenter.records) == 4
     assert any(record.frame is not initial for record in presenter.records)
 
 


### PR DESCRIPTION
## Problem

`test_loop_presents_backend_frames_when_available` in `test_latency_loop.py` is flaky on CI. It uses `present_budget=2` with `frame_interval_s=0.001`, giving the worker thread only ~2ms to warm up, process a render command, and deliver a frame. On slower CI runners this races and the backend frame never arrives within the budget.

## Fix

Increase `present_budget` from 2 to 4 (and update the corresponding assertion). This matches the pattern of the adjacent test (`test_loop_prepares_backend_frames_before_presenting_them`) which already uses `present_budget=6`.

No runtime code changes -- test-only fix.

## Introduced by

c3a7c812 (#240) -- `interactive-drive: keep the world model loaded across scenes`