### PR TITLE
interactive-drive: start ego at rest on initial scene load

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -378,11 +378,15 @@ class InteractiveDriveApp:
                 initial_state=state_from_initial_pose(
                     initial_rig_to_world=self._scene.initial_rig_to_world,
                     initial_yaw_rad=self._scene.initial_yaw_rad,
-                    initial_speed_mps=(
-                        0.0
-                        if self._keyboard.command().manual_control
-                        else self._scene.initial_speed_mps
-                    ),
+                    # The interactive demo is always hands-on-the-wheel, so
+                    # every rollout starts from a stop. Seeding the ego with
+                    # the clip's recorded speed (``scene.initial_speed_mps``)
+                    # only happened on the very first rollout -- before any
+                    # drive command flips ``manual_control`` true -- which made
+                    # the demo "launch" at highway speed until the first reset
+                    # rebuilt the sim at rest. Starting at 0 makes the initial
+                    # load behave identically to a reset.
+                    initial_speed_mps=0.0,
                 ),
                 vehicle_config=self._config.vehicle,
                 ground_snapper=self._ground_snapper,

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -378,14 +378,8 @@ class InteractiveDriveApp:
                 initial_state=state_from_initial_pose(
                     initial_rig_to_world=self._scene.initial_rig_to_world,
                     initial_yaw_rad=self._scene.initial_yaw_rad,
-                    # The interactive demo is always hands-on-the-wheel, so
-                    # every rollout starts from a stop. Seeding the ego with
-                    # the clip's recorded speed (``scene.initial_speed_mps``)
-                    # only happened on the very first rollout -- before any
-                    # drive command flips ``manual_control`` true -- which made
-                    # the demo "launch" at highway speed until the first reset
-                    # rebuilt the sim at rest. Starting at 0 makes the initial
-                    # load behave identically to a reset.
+                    # Always start at rest so the initial load matches a
+                    # reset, rather than launching at the clip's recorded speed.
                     initial_speed_mps=0.0,
                 ),
                 vehicle_config=self._config.vehicle,

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -12,7 +12,7 @@ import struct
 import threading
 import time
 import zipfile
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -106,6 +106,10 @@ class SceneOption:
     path: Path
     variants: tuple[str, ...]
     thumbnail: Image.Image | None = None
+    # Per-variant preview thumbnails keyed by variant slug, for the variant
+    # dropdown. Variants without a dedicated ``first_image_<variant>.png``
+    # map to the default image so every row still shows a preview.
+    variant_thumbnails: dict[str, Image.Image] = field(default_factory=dict)
 
 
 @dataclass
@@ -776,7 +780,7 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
     # ``--synthetic-scene`` (materialised to a temp USDZ) and any autostaged
     # default are honoured; a dropdown selection overrides it below.
     scene_path: Any = config.scene_path
-    variant = config.variant
+    variant = _resolve_scene_variant(scene_options, scene_path, config.variant)
     try:
         # Initial scene-selection wait: if the user didn't pass
         # ``--autoload-scene``, open the HUD and let them pick a scene from
@@ -1017,13 +1021,7 @@ def _discover_scene_options(
     if selected_scene.parent.is_dir():
         paths.update(path.resolve() for path in selected_scene.parent.glob("*.usdz"))
     options = tuple(
-        SceneOption(
-            label=_scene_label(path),
-            path=path,
-            variants=_discover_variants(path),
-            thumbnail=_load_scene_thumbnail(path),
-        )
-        for path in sorted(paths)
+        _scene_option(path, variants=_discover_variants(path)) for path in sorted(paths)
     )
     print(
         "[demo] discovered scenes: "
@@ -1031,6 +1029,21 @@ def _discover_scene_options(
         flush=True,
     )
     return options
+
+
+def _scene_option(path: Path, *, variants: tuple[str, ...]) -> SceneOption:
+    variant_thumbnails = _load_variant_thumbnails(path, variants)
+    # Reuse the per-variant "default" thumbnail for the scene row when present
+    # so the scene and variant dropdowns agree, falling back to the standalone
+    # loader for bundles whose images don't parse into variants.
+    thumbnail = variant_thumbnails.get("default") or _load_scene_thumbnail(path)
+    return SceneOption(
+        label=_scene_label(path),
+        path=path,
+        variants=variants,
+        thumbnail=thumbnail,
+        variant_thumbnails=variant_thumbnails,
+    )
 
 
 def _scene_label(path: Path) -> str:
@@ -1061,11 +1074,36 @@ def _discover_variants(scene_path: Path) -> tuple[str, ...]:
                     variants.add(variant)
     except (OSError, zipfile.BadZipFile):
         return ("default",)
-    if not variants:
-        variants.add("default")
-    if "default" not in variants:
-        variants.add(sorted(variants)[0])
-    return tuple(sorted(variants, key=lambda value: (value != "default", value)))
+    # A bare ``default`` (prompt.txt / first_image.png) duplicates the first
+    # numbered variant, so when numbered variants exist we expose just those --
+    # "1" is then the default selection. Scenes with no numbered variants show
+    # a single "default".
+    numbered = [value for value in variants if value != "default"]
+    if numbered:
+        numbered.sort(key=lambda v: (not v.isdigit(), int(v) if v.isdigit() else v))
+        return tuple(numbered)
+    return ("default",)
+
+
+def _resolve_scene_variant(
+    scene_options: tuple[SceneOption, ...], scene_path: Any, variant: str
+) -> str:
+    """Return a variant that actually exists for *scene_path*.
+
+    Numbered scenes no longer carry a bare ``default`` entry, so a configured
+    ``--variant default`` (or anything the scene lacks) falls back to the
+    scene's first variant rather than a selection the dropdown can't show.
+    """
+    try:
+        resolved = Path(str(scene_path)).resolve()
+    except OSError:
+        resolved = None
+    for option in scene_options:
+        if option.path == resolved or str(option.path) == str(scene_path):
+            if variant in option.variants:
+                return variant
+            return option.variants[0] if option.variants else variant
+    return variant
 
 
 def _load_scene_thumbnail(scene_path: Path) -> Image.Image | None:
@@ -1085,6 +1123,45 @@ def _load_scene_thumbnail(scene_path: Path) -> Image.Image | None:
                 return _make_thumbnail(image.convert("RGB"), SCENE_THUMB_SIZE)
     except (OSError, zipfile.BadZipFile):
         return None
+
+
+def _load_variant_thumbnails(
+    scene_path: Path, variants: tuple[str, ...]
+) -> dict[str, Image.Image]:
+    """Per-variant preview thumbnails for the HUD variant dropdown.
+
+    Mirrors :func:`scene_loader._discover_first_images`: a bundle may ship
+    ``first_image_<variant>.png`` per variant alongside ``first_image.png``
+    (the ``"default"`` variant). Each referenced image is decoded once;
+    variants without a dedicated image fall back to the default so every
+    dropdown row still shows a preview. Returns an empty mapping when the
+    archive has no parseable first images.
+    """
+    decoded: dict[str, Image.Image] = {}
+    try:
+        with zipfile.ZipFile(scene_path, "r") as zf:
+            names_by_variant: dict[str, str] = {}
+            for name in zf.namelist():
+                if (
+                    "/" in name
+                    or not name.startswith("first_image")
+                    or not name.endswith(".png")
+                ):
+                    continue
+                variant = _scenes.variant_from_stem(Path(name).stem, "first_image")
+                if variant is not None:
+                    names_by_variant[variant] = name
+            for variant, name in names_by_variant.items():
+                with Image.open(io.BytesIO(zf.read(name))) as image:
+                    decoded[variant] = _make_thumbnail(
+                        image.convert("RGB"), SCENE_THUMB_SIZE
+                    )
+    except (OSError, zipfile.BadZipFile):
+        return {}
+    if not decoded:
+        return {}
+    default = decoded.get("default") or next(iter(decoded.values()))
+    return {variant: decoded.get(variant, default) for variant in variants}
 
 
 def _make_thumbnail(image: Image.Image, size: tuple[int, int]) -> Image.Image:

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -397,6 +397,7 @@ class SlangPyHudPresenter:
         self._wheel_rotation_cache: _LRUCache = _LRUCache(maxsize=480)
         self._pedal_cache: _LRUCache = _LRUCache(maxsize=16)
         self._scene_thumb_cache: dict[Any, Image.Image | None] = {}
+        self._variant_thumb_cache: dict[tuple[Any, str], Image.Image | None] = {}
         self._bev_panel_cache_key: tuple[int, int, int] | None = None
         self._bev_panel_cache: Image.Image | None = None
 
@@ -1585,7 +1586,9 @@ class SlangPyHudPresenter:
             fill=TEXT_COLOR,
             font=self._font_small,
         )
-        if has_multiple_variants:
+        # Only advertise the dropdown affordance when a scene is loaded; the
+        # header isn't clickable otherwise (see _handle_click).
+        if has_multiple_variants and self._engine_active:
             v_arrow = "\u25b2" if self._variant_dropdown_open else "\u25bc"
             d.text(
                 (margin + header_w - 24, variant_y + 6),
@@ -2068,7 +2071,10 @@ class SlangPyHudPresenter:
         if scene_option is None or len(scene_option.variants) <= 1:
             return
         vx, vy, vr, vb = self._variant_header_rect
-        item_h = 34
+        # Taller rows when the scene ships per-variant previews, matching the
+        # scene dropdown; fall back to compact text-only rows otherwise.
+        has_thumbs = bool(scene_option.variant_thumbnails)
+        item_h = 80 if has_thumbs else 34
         items_top = vb + 2
         bg = (
             vx,
@@ -2087,12 +2093,23 @@ class SlangPyHudPresenter:
                 draw.rectangle(rect, fill=ACTIVE_BG + (255,))
             elif variant == self._hovered_variant:
                 draw.rectangle(rect, fill=HOVER_BG + (255,))
+            text_x = rect[0] + 12
+            text_y = top + item_h // 2 - 8
+            if has_thumbs:
+                thumb = self._get_variant_thumbnail(scene_option, variant)
+                if thumb is not None:
+                    tw, th = thumb.size
+                    tx = rect[0] + 6
+                    ty = top + max(0, (item_h - th) // 2)
+                    canvas.paste(thumb, (tx, ty))
+                    draw.rectangle(
+                        (tx, ty, tx + tw, ty + th), outline=(60, 60, 80, 255), width=1
+                    )
+                    text_x = tx + tw + 10
             label = _truncate_text_to_width(
-                self._font_tiny, variant, max(0, rect[2] - rect[0] - 24)
+                self._font_tiny, variant, max(0, rect[2] - text_x - 8)
             )
-            draw.text(
-                (rect[0] + 12, top + 7), label, fill=TEXT_COLOR, font=self._font_tiny
-            )
+            draw.text((text_x, text_y), label, fill=TEXT_COLOR, font=self._font_tiny)
 
     def _get_scene_thumbnail(self, scene: Any) -> Image.Image | None:
         if scene.path in self._scene_thumb_cache:
@@ -2104,6 +2121,16 @@ class SlangPyHudPresenter:
         if thumb.mode != "RGBA":
             thumb = thumb.convert("RGBA")
         self._scene_thumb_cache[scene.path] = thumb
+        return thumb
+
+    def _get_variant_thumbnail(self, scene: Any, variant: str) -> Image.Image | None:
+        key = (scene.path, variant)
+        if key in self._variant_thumb_cache:
+            return self._variant_thumb_cache[key]
+        thumb = scene.variant_thumbnails.get(variant)
+        if thumb is not None and thumb.mode != "RGBA":
+            thumb = thumb.convert("RGBA")
+        self._variant_thumb_cache[key] = thumb
         return thumb
 
     def _current_scene_option(self) -> Any:
@@ -2318,9 +2345,14 @@ class SlangPyHudPresenter:
             self._panel_chrome_cache_key = None
             return
 
+        # The variant dropdown is only meaningful once a scene is actually
+        # loaded/running. Before that (the initial selection wait and the gap
+        # between scene switches) the engine is inactive, so ignore clicks on
+        # the variant header.
         current_scene_option = self._current_scene_option()
         if (
-            self._variant_header_rect
+            self._engine_active
+            and self._variant_header_rect
             and _rect_contains(self._variant_header_rect, pos)
             and current_scene_option is not None
             and len(current_scene_option.variants) > 1
@@ -2411,6 +2443,10 @@ class SlangPyHudPresenter:
         state set via :meth:`set_model_status`.
         """
         self._engine_active = bool(active)
+        if not self._engine_active:
+            # No scene loaded -> the variant dropdown isn't selectable, so a
+            # previously-open one must not linger into the no-scene state.
+            self._variant_dropdown_open = False
         # Drop the chrome cache so the panel is redrawn promptly --
         # the cache key includes scene/variant/dropdown state but not
         # engine activity, and the camera placeholder lives outside

--- a/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import os
 import time
 from dataclasses import dataclass
 
@@ -29,6 +30,25 @@ from omnidreams.interactive_drive.video_model.chunk_pipeline import (
     ChunkPipeline,
     QueuedFrame,
 )
+
+
+def _on_ci() -> bool:
+    """True when running under CI (GitHub Actions et al. set ``CI=true``)."""
+    return os.environ.get("CI", "").lower() == "true"
+
+
+def _backend_frame_wait_budget() -> int:
+    """Present-tick ceiling for tests that wait on the render worker thread.
+
+    These tests assert that the background pipeline worker delivered a
+    rendered frame. Paired with ``_CountingPresenter(close_on_frame=...)`` the
+    loop closes the instant that frame arrives, so this value only bounds the
+    *stall* case (a worker that never delivers). Locally a small ceiling keeps
+    a genuine stall failing fast; CI runners are heavily loaded and can starve
+    the worker thread for many present ticks, so allow a generous ceiling
+    there to absorb scheduling jitter rather than flaking on a fixed budget.
+    """
+    return 500 if _on_ci() else 16
 
 
 def _chunk_times() -> ChunkTimes:
@@ -69,9 +89,21 @@ class _PresentRecord:
 class _CountingPresenter:
     """Records every presented frame; flips ``should_close`` after a budget."""
 
-    def __init__(self, present_budget: int, *, start_closed: bool = False) -> None:
+    def __init__(
+        self,
+        present_budget: int,
+        *,
+        start_closed: bool = False,
+        close_on_frame: PresentedFrame | None = None,
+    ) -> None:
         self._budget = present_budget
         self._closed = start_closed
+        # When set, close as soon as a frame that is *not* this one is
+        # presented -- i.e. the render worker delivered a backend frame. Lets
+        # timing tests wait on the worker instead of racing a fixed present
+        # budget, which flaked under CI load. ``present_budget`` then just
+        # bounds the stall case.
+        self._close_on_frame = close_on_frame
         self.records: list[_PresentRecord] = []
         self.process_events_calls = 0
 
@@ -84,7 +116,10 @@ class _CountingPresenter:
 
     def present_frame(self, frame: PresentedFrame, view_mode: str) -> None:
         self.records.append(_PresentRecord(frame=frame, view_mode=view_mode))
-        if len(self.records) >= self._budget:
+        backend_frame_arrived = (
+            self._close_on_frame is not None and frame is not self._close_on_frame
+        )
+        if backend_frame_arrived or len(self.records) >= self._budget:
             self._closed = True
 
     def close(self) -> None:
@@ -96,8 +131,10 @@ class _CountingPresenter:
 
 
 class _PreparingPresenter(_CountingPresenter):
-    def __init__(self, present_budget: int) -> None:
-        super().__init__(present_budget=present_budget)
+    def __init__(
+        self, present_budget: int, *, close_on_frame: PresentedFrame | None = None
+    ) -> None:
+        super().__init__(present_budget=present_budget, close_on_frame=close_on_frame)
         self.prepared_frame_ids: set[int] = set()
         self.unprepared_backend_frame_ids: set[int] = set()
 
@@ -334,9 +371,14 @@ def test_input_to_present_profile_ignores_represented_frames(
 
 def test_loop_presents_backend_frames_when_available() -> None:
     """Once the pipeline has rendered frames, the loop presents them."""
-    presenter = _CountingPresenter(present_budget=4)
-    controls = _FakeRuntimeControls()
     initial = _make_frame()
+    # Wait for the worker to deliver a backend frame rather than racing a
+    # fixed present budget (which flaked under CI load); the budget is just a
+    # stall ceiling, larger on CI.
+    presenter = _CountingPresenter(
+        present_budget=_backend_frame_wait_budget(), close_on_frame=initial
+    )
+    controls = _FakeRuntimeControls()
 
     result = _drive_loop(
         presenter=presenter,
@@ -348,14 +390,15 @@ def test_loop_presents_backend_frames_when_available() -> None:
     )
 
     assert result is False
-    assert len(presenter.records) == 4
     assert any(record.frame is not initial for record in presenter.records)
 
 
 def test_loop_prepares_backend_frames_before_presenting_them() -> None:
-    presenter = _PreparingPresenter(present_budget=6)
-    controls = _FakeRuntimeControls()
     initial = _make_frame()
+    presenter = _PreparingPresenter(
+        present_budget=_backend_frame_wait_budget(), close_on_frame=initial
+    )
+    controls = _FakeRuntimeControls()
 
     _drive_loop(
         presenter=presenter,
@@ -407,7 +450,9 @@ def test_loop_stamps_full_timing_chain_on_same_chunktimes_instance(
     monkeypatch.setattr(ChunkTimes, "create", capturing_create)
 
     initial = _make_frame()
-    presenter = _CountingPresenter(present_budget=3)
+    presenter = _CountingPresenter(
+        present_budget=_backend_frame_wait_budget(), close_on_frame=initial
+    )
     controls = _FakeRuntimeControls()
     _drive_loop(
         presenter=presenter,

--- a/integrations/omnidreams/tests/interactive_drive/test_variant_thumbnails.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_variant_thumbnails.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Per-variant thumbnail discovery feeding the HUD variant dropdown."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+from omnidreams.interactive_drive.demo import (
+    SCENE_THUMB_SIZE,
+    _discover_variants,
+    _load_variant_thumbnails,
+)
+from omnidreams.interactive_drive.scene_fixture import build_synthetic_scene_usdz
+from PIL import Image
+
+
+def test_load_variant_thumbnails_one_per_variant(tmp_path: Path) -> None:
+    # The synthetic bundle ships first_image.png + first_image_1/2.png, so
+    # each variant must get its own distinctly-rendered preview.
+    scene_path = build_synthetic_scene_usdz(tmp_path / "scene.usdz", length_frames=60)
+    # Numbered variants exist, so the bare "default" (a duplicate of "1") is
+    # dropped and "1" becomes the default selection.
+    variants = _discover_variants(scene_path)
+    assert variants == ("1", "2")
+
+    thumbs = _load_variant_thumbnails(scene_path, variants)
+    assert set(thumbs) == {"1", "2"}
+    for thumb in thumbs.values():
+        assert isinstance(thumb, Image.Image)
+        assert thumb.size == SCENE_THUMB_SIZE
+    # The per-variant first images are distinct (variant_1/2 are shifted),
+    # so the rendered thumbnails must not collapse to one shared image.
+    rendered = {variant: thumb.tobytes() for variant, thumb in thumbs.items()}
+    assert len(set(rendered.values())) == 2
+
+
+def test_discover_variants_default_only_when_unnumbered(tmp_path: Path) -> None:
+    # A scene with only the bare prompt / first_image (no numbered variants)
+    # exposes a single "default".
+    scene_path = tmp_path / "plain.usdz"
+    buf = io.BytesIO()
+    Image.new("RGB", (32, 32), color=(5, 5, 5)).save(buf, format="PNG")
+    with zipfile.ZipFile(scene_path, "w") as zf:
+        zf.writestr("first_image.png", buf.getvalue())
+        zf.writestr("prompt.txt", "a plain scene")
+    assert _discover_variants(scene_path) == ("default",)
+
+
+def test_load_variant_thumbnails_falls_back_to_default(tmp_path: Path) -> None:
+    # A bundle with only first_image.png (no per-variant images): every
+    # requested variant should reuse the single default thumbnail.
+    scene_path = tmp_path / "default_only.usdz"
+    buf = io.BytesIO()
+    Image.new("RGB", (64, 32), color=(10, 120, 200)).save(buf, format="PNG")
+    with zipfile.ZipFile(scene_path, "w") as zf:
+        zf.writestr("first_image.png", buf.getvalue())
+
+    thumbs = _load_variant_thumbnails(scene_path, ("default", "1"))
+    assert set(thumbs) == {"default", "1"}
+    assert thumbs["1"] is thumbs["default"]
+
+
+def test_load_variant_thumbnails_missing_images_returns_empty(tmp_path: Path) -> None:
+    # No first_image*.png at all -> empty mapping (HUD draws text-only rows).
+    scene_path = tmp_path / "empty.usdz"
+    with zipfile.ZipFile(scene_path, "w") as zf:
+        zf.writestr("metadata.yaml", "scene_id: x\n")
+    assert _load_variant_thumbnails(scene_path, ("default",)) == {}


### PR DESCRIPTION
The first rollout seeded the ego speed from the clip's recorded initial_speed_mps whenever manual_control was false. At launch no drive command is registered yet (the scene-selection click clears it), so the demo started already moving at the clip's recorded highway speed and only settled after the first reset rebuilt the sim at rest. The interactive demo is always manually driven, so seed every rollout at 0 m/s, making the initial load behave identically to a reset.