### PR TITLE
Add Google Analytics measurement tag to website

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -4,3 +4,16 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 {% extends "!layout.html" %}
+
+{# Google Analytics (GA4). Furo has no native analytics option, so the
+   gtag.js snippet is injected into <head> via the `extrahead` block. #}
+{% block extrahead %}
+{{ super() }}
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-Q44TKZ8777"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-Q44TKZ8777');
+</script>
+{% endblock %}


### PR DESCRIPTION
Adds a Google Analytics measurement tag to website.
The website currently uses the furo theme, so the best option is to embed the tag into every page on the site by adding it to the shared layout file, since the theme does not natively support analytics.