### PR TITLE
omnidreams: consume new per-weather scene format

### DIFF
--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -204,6 +204,36 @@ The demo loads the saved profile automatically on subsequent launches.
 Re-run the configuration tool to specify the default profile, edit a profile
 (steering sensitivity, deadzone, buttons), or delete a profile.
 
+Native acceleration (perf manifest)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The bundled ``example_world_model_perf.yaml`` manifest runs the DiT and
+LightVAE through the OmniDreams single-view CUDA extension
+(``native_dit_acceleration: required``), which is faster than the default
+PyTorch path. The extension builds against pinned checkouts of CUTLASS,
+SageAttention, SpargeAttn, and cudnn-frontend that are not vendored in the
+repo. ``omnidreams-prepare --perf`` clones them at their pinned commits into
+``integrations/omnidreams/omnidreams_singleview/3rdparty/``:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams omnidreams-prepare --perf
+
+This step only syncs sources; the extension itself compiles on the first
+launch that uses the manifest (one-time, a few minutes). It requires a
+Blackwell-class GPU (SM 12.0) or newer, a source checkout (the
+``omnidreams_singleview`` sources ship only in the git tree, not the wheel),
+``git``, and a CUDA toolchain (``nvcc``) matching your PyTorch build. Then
+point the demo at the perf manifest:
+
+.. code-block:: bash
+
+   uv run --package flashdreams-omnidreams interactive-drive \
+       --manifest example_world_model_perf.yaml
+
+``native_dit_acceleration: required`` makes the manifest fail loudly if the
+extension can't build or load, rather than silently falling back to PyTorch.
+
 Alternative: WebRTC server
 --------------------------
 

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -173,6 +173,10 @@ instead:
 
    uv run --package flashdreams-omnidreams interactive-drive
 
+The local window's HUD adds a weather-variant selector (clear, rain, snow)
+next to the scene picker, so the same scene can be switched between
+conditions.
+
 .. note::
 
    The local window requires a display server and the system OpenGL /
@@ -219,10 +223,13 @@ the gRPC service into a larger product.
        -m omnidreams.webrtc.server \
        --host 0.0.0.0 --port 8089 \
        --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf \
-       --scene-uuid "065dcac9-ee67-4434-a835-c6b816c88e48"
+       --scene-uuid "0d404ff7-2b66-498c-b047-1ed8cded60d4"
 
 Sample scene UUIDs for the interactive server are available in the
 `nvidia/omni-dreams-scenes Hugging Face dataset <https://huggingface.co/datasets/nvidia/omni-dreams-scenes/tree/main/scenes>`_.
+Each scene ships clear, rain, and snow weather variants as sibling
+archives; add ``--scene-variant rain`` (or ``snow``) to serve a specific
+one (the default is the clear-weather scene).
 
 The server may take a few minutes to warm up. Once ready, it prints
 ``Connect via http://<server-ip>:8089/request_session``.

--- a/integrations/omnidreams/README.md
+++ b/integrations/omnidreams/README.md
@@ -77,15 +77,19 @@ Sparge/SageAttention-3 hybrid schedule when the extension and GPU support it.
 From the workspace root, run:
 
 ```bash
-uv run --package flashdreams-omnidreams torchrun --nproc_per_node 1 -m omnidreams.webrtc.server --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf --scene-uuid 065dcac9-ee67-4434-a835-c6b816c88e48 --port 8089
+uv run --package flashdreams-omnidreams torchrun --nproc_per_node 1 -m omnidreams.webrtc.server --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf --scene-uuid 0d404ff7-2b66-498c-b047-1ed8cded60d4 --port 8089
 ```
 
 When `--scene_dir` is omitted, the server downloads the selected scene from the
-configured Hugging Face org, extracts its `clipgt-<uuid>.usdz` archive, and
-stages it under `FLASHDREAMS_CACHE_DIR` (or `~/.cache/flashdreams`). If
-`--scene-uuid` is omitted too, the server uses the default WebRTC scene. The
-runtime expects `clipgt/first_image.*` and `clipgt/prompt.txt` under the scene
-directory. Pass `--scene_dir <path>` to use a pre-staged local scene instead.
+configured Hugging Face org, extracts its `clipgt-<uuid>[-<variant>].usdz`
+archive, and stages it under `FLASHDREAMS_CACHE_DIR` (or `~/.cache/flashdreams`).
+If `--scene-uuid` is omitted too, the server uses the default WebRTC scene.
+Weather variants ship as sibling archives; pass `--scene-variant rain` (or
+`snow`) to serve one (default is the clear-weather scene). The runtime seeds
+from the scene's first ground-truth camera frame
+(`clipgt/frames/<camera>/<ts>.jpeg`, falling back to `clipgt/first_image.*`) and
+the weather-matched `clipgt/prompt<N>.txt` (falling back to `clipgt/prompt.txt`).
+Pass `--scene_dir <path>` to use a pre-staged local scene instead.
 
 ## Run gRPC server
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -144,7 +144,7 @@ flashdreams convention. The `interactive-drive` extra pulls in `slangpy`
 ```bash
 uv sync --package flashdreams-omnidreams --extra interactive-drive
 uv run --package flashdreams-omnidreams omnidreams-prepare \
-  --scene-uuid clipgt-01d503d4-449b-46fc-8d78-9085e70d3554
+  --scene-uuid clipgt-0d404ff7-2b66-498c-b047-1ed8cded60d4
 ```
 
 `uv sync --extra interactive-drive` installs the full demo runtime (slangpy + Ludus
@@ -167,9 +167,12 @@ owns video checkpoint selection and cache layout for the selected recipe.
 Common `omnidreams-prepare` flags:
 
 - `--scene-uuid <clipgt-...>` — stage only one specific scene instead of
-  all of them. Useful on bandwidth-constrained links (and a good first
-  choice inside the container). Browse available UUIDs on the
+  all of them (every published weather variant of it). Useful on
+  bandwidth-constrained links (and a good first choice inside the
+  container). Browse available UUIDs on the
   [scenes dataset page](https://huggingface.co/datasets/nvidia/omni-dreams-scenes/tree/main/scenes).
+- `--scene-variant <default|rain|snow>` — with `--scene-uuid`, stage only
+  that weather variant instead of all of them.
 - `--skip-hf-prewarm` — skip pre-warming Hugging Face model repos;
   flashdreams will pull assets lazily on first use.
 - `--skip-text-encoder` — skip the ~14 GB text-encoder prewarm when you're
@@ -180,14 +183,16 @@ Common `omnidreams-prepare` flags:
 If `omnidreams-prepare` fails with `401`, `403`, or a gated-repo
 error, verify `HF_TOKEN` and confirm access to `nvidia/omni-dreams-scenes`.
 
-Once done, you should see this binary asset under the shared scenes cache:
+Once done, you should see the scene's variant archive(s) under the shared
+scenes cache, one per weather:
 
-- `~/.cache/flashdreams/omnidreams-scenes/clipgt-<scene-uuid>.usdz`
+- `~/.cache/flashdreams/omnidreams-scenes/clipgt-<scene-uuid>.usdz` (and
+  `-rain` / `-snow` siblings when published)
 
 That directory (`$FLASHDREAMS_CACHE_DIR/omnidreams-scenes/`) is shared
-with the WebRTC server: the desktop demo keeps the archive there and
+with the WebRTC server: the desktop demo keeps the archives there and
 the WebRTC session pipeline extracts each scene's `clipgt/` payload
-under `<uuid>/` next to it. Both demos go through the same
+under `<uuid>[-<variant>]/` next to them. Both demos go through the same
 `huggingface_hub` content-addressed cache for the actual download, so
 the HF round-trip happens at most once per scene UUID regardless of
 which demo you launch first. Hugging Face model snapshots live in the
@@ -244,7 +249,7 @@ uv run --package flashdreams-omnidreams interactive-drive
 ```
 
 The default `--scene` resolves to
-`$FLASHDREAMS_CACHE_DIR/omnidreams-scenes/clipgt-01d503d4-449b-46fc-8d78-9085e70d3554.usdz`
+`$FLASHDREAMS_CACHE_DIR/omnidreams-scenes/clipgt-0d404ff7-2b66-498c-b047-1ed8cded60d4.usdz`
 (staged on first launch via the HF auto-stage flow described above);
 `--manifest` resolves to the bundled `configs/example_world_model.yaml`.
 Pass a different `--scene` or `--manifest` to override.

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -20,7 +20,10 @@ from omnidreams.interactive_drive.runtime.loop import (
     PresenterBackend,
     run_main_loop,
 )
-from omnidreams.interactive_drive.scene_loader import load_scene_bundle
+from omnidreams.interactive_drive.scene_loader import (
+    load_scene_bundle,
+    reseed_scene_bundle,
+)
 from omnidreams.interactive_drive.simulation.ego_vehicle_kinematics import (
     EgoVehicleKinematics,
     build_ground_snapper,
@@ -124,6 +127,12 @@ class InteractiveDriveApp:
             tuple[str, str, str | None],
             tuple[SceneBundle, MapBounds | None, GroundSnapper | None],
         ] = {}
+        # Parsed geometry per base scene path. Weather variants share all
+        # geometry and differ only in seed frame + prompt, so we parse once and
+        # re-seed per variant rather than re-parsing the USDZ each switch.
+        self._geometry_cache: dict[
+            str, tuple[SceneBundle, MapBounds | None, GroundSnapper | None]
+        ] = {}
         self._scene_cache_lock = threading.Lock()
         # Set while --preload-scenes is still parsing scenes in the
         # background; the presenter locks scene selection until it clears so
@@ -181,20 +190,12 @@ class InteractiveDriveApp:
 
         def _parse() -> None:
             try:
-                scene = load_scene_bundle(
-                    scene_path=scene_path,
-                    camera_name=self._config.camera_name,
-                    variant=variant,
-                    prompt_override=prompt_override,
-                    raster=self._config.raster,
+                # Map bounds + ground snapper are geometry-derived; built here
+                # on the background thread and cached so resets and variant
+                # switches don't rebuild them.
+                loaded.extend(
+                    self._resolve_scene_assets(scene_path, variant, prompt_override)
                 )
-                # The OOB AABB and the ground snapper's spatial grid are
-                # properties of the scene geometry and invariant across the
-                # rollout restarts inside run_scene -- build both here (on the
-                # background thread) so a reset never rebuilds the snapper.
-                loaded.append(scene)
-                loaded.append(build_map_bounds(scene))
-                loaded.append(build_ground_snapper(scene))
             except BaseException as exc:  # re-raised on the UI thread below
                 error.append(exc)
             finally:
@@ -263,15 +264,11 @@ class InteractiveDriveApp:
                 if key in self._scene_cache:
                     continue
             try:
-                scene = load_scene_bundle(
-                    scene_path=scene_path,
-                    camera_name=self._config.camera_name,
-                    variant=variant,
-                    prompt_override=prompt_override,
-                    raster=self._config.raster,
+                # Reuses cached geometry, so only the first variant of each
+                # scene pays the full parse; the rest are cheap re-seeds.
+                scene, bounds, snapper = self._resolve_scene_assets(
+                    scene_path, variant, prompt_override
                 )
-                bounds = build_map_bounds(scene)
-                snapper = build_ground_snapper(scene)
             except BaseException as exc:  # noqa: BLE001 - log & skip one scene
                 print(
                     f"[interactive-drive] scene preload failed for "
@@ -286,6 +283,39 @@ class InteractiveDriveApp:
                 f"{Path(str(scene_path)).name} variant={variant!r}",
                 flush=True,
             )
+
+    def _resolve_scene_assets(
+        self, scene_path: object, variant: str, prompt_override: str | None
+    ) -> tuple[SceneBundle, MapBounds | None, GroundSnapper | None]:
+        """Resolve ``(scene, map_bounds, ground_snapper)``, caching geometry per scene.
+
+        First variant of a scene: full parse + build bounds/snapper, then cache.
+        Later variants: re-seed the cached bundle (frame + prompt only).
+        """
+        geometry = self._cached_geometry(scene_path)
+        if geometry is not None:
+            base_scene, map_bounds, ground_snapper = geometry
+            scene = reseed_scene_bundle(
+                base_scene,
+                Path(str(scene_path)),
+                self._config.camera_name,
+                variant,
+                prompt_override,
+                self._config.raster,
+            )
+            return scene, map_bounds, ground_snapper
+
+        scene = load_scene_bundle(
+            scene_path=scene_path,
+            camera_name=self._config.camera_name,
+            variant=variant,
+            prompt_override=prompt_override,
+            raster=self._config.raster,
+        )
+        map_bounds = build_map_bounds(scene)
+        ground_snapper = build_ground_snapper(scene)
+        self._store_geometry(scene_path, scene, map_bounds, ground_snapper)
+        return scene, map_bounds, ground_snapper
 
     @staticmethod
     def _scene_cache_key(
@@ -318,6 +348,27 @@ class InteractiveDriveApp:
             self._scene_cache[
                 self._scene_cache_key(scene_path, variant, prompt_override)
             ] = (scene, map_bounds, ground_snapper)
+
+    def _cached_geometry(
+        self, scene_path: object
+    ) -> tuple[SceneBundle, MapBounds | None, GroundSnapper | None] | None:
+        # Always on, unlike the --preload-scenes-gated ``_scene_cache``: one
+        # bundle per scene lets a live variant switch re-seed, not re-parse.
+        with self._scene_cache_lock:
+            return self._geometry_cache.get(str(scene_path))
+
+    def _store_geometry(
+        self,
+        scene_path: object,
+        scene: SceneBundle,
+        map_bounds: MapBounds | None,
+        ground_snapper: GroundSnapper | None,
+    ) -> None:
+        # First parse of a scene wins; later variants re-seed off it.
+        with self._scene_cache_lock:
+            self._geometry_cache.setdefault(
+                str(scene_path), (scene, map_bounds, ground_snapper)
+            )
 
     def _pump_presenter_until(self, done: threading.Event) -> None:
         """Pump events + a loading overlay until ``done`` is set or we close.

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -35,10 +35,10 @@ from omnidreams.scenes import local_scene_archive_path
 _PACKAGE_ROOT = Path(__file__).resolve().parent
 _CONFIGS_ROOT = _PACKAGE_ROOT / "configs"
 
-# UUID of the scene staged by ``omnidreams-prepare`` when no
-# ``--scene-uuid`` is specified and used as the demo's ``--scene``
-# default.
-DEFAULT_SCENE_UUID = "01d503d4-449b-46fc-8d78-9085e70d3554"
+# UUID of the scene staged by ``omnidreams-prepare`` when no ``--scene-uuid``
+# is specified and used as the demo's ``--scene`` default. A scene currently
+# published in nvidia/omni-dreams-scenes (clear-weather base archive).
+DEFAULT_SCENE_UUID = "0d404ff7-2b66-498c-b047-1ed8cded60d4"
 
 # Default scene path: shared cache dir under ``$FLASHDREAMS_CACHE_DIR/
 # omnidreams-scenes/clipgt-<uuid>.usdz``. The desktop demo and the
@@ -144,7 +144,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--variant",
         default="default",
-        help="Prompt / first-image variant (default, 1, 2, 3)",
+        help=(
+            "Scene variant to load: weather siblings (default, rain, snow) or "
+            "legacy in-archive numbered variants (1, 2, 3)."
+        ),
     )
     parser.add_argument("--prompt", default=None, help="Optional prompt override")
     parser.add_argument(

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -12,6 +12,7 @@ import struct
 import threading
 import time
 import zipfile
+from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -107,9 +108,12 @@ class SceneOption:
     variants: tuple[str, ...]
     thumbnail: Image.Image | None = None
     # Per-variant preview thumbnails keyed by variant slug, for the variant
-    # dropdown. Variants without a dedicated ``first_image_<variant>.png``
-    # map to the default image so every row still shows a preview.
+    # dropdown. Variants without a dedicated preview map to the default image
+    # so every row still shows a preview.
     variant_thumbnails: dict[str, Image.Image] = field(default_factory=dict)
+    # Variant slug -> its USDZ archive. Distinct sibling files for the current
+    # per-weather dataset; the single ``path`` for legacy in-zip-variant scenes.
+    variant_paths: dict[str, Path] = field(default_factory=dict)
 
 
 @dataclass
@@ -624,11 +628,36 @@ def _maybe_autostage_scene(scene: Path, *, scene_dir: Path, allow_skip: bool) ->
         )
     print(
         f"[interactive-drive] Scene '{stem}' not found locally; "
-        "auto-staging from Hugging Face (one-time download, ~30 MB)..."
+        "auto-staging from Hugging Face (one-time download)..."
     )
     from omnidreams.prepare import stage_scene
 
-    return stage_scene(bare_uuid, force=False)
+    staged_default = stage_scene(bare_uuid, force=False)
+    # Also stage the scene's other weather variants so the HUD shows a
+    # Default/Rain/Snow selector; discovery globs the cache dir for them.
+    try:
+        sibling_variants = [
+            variant
+            for uuid, variant in _scenes.list_available_scene_files()
+            if uuid == bare_uuid and variant != _scenes.SCENE_VARIANT_DEFAULT
+        ]
+    except Exception as exc:  # noqa: BLE001 - best-effort; base scene already staged
+        print(
+            f"[interactive-drive] could not enumerate scene variants ({exc}); "
+            "staged the base scene only.",
+            flush=True,
+        )
+        sibling_variants = []
+    for variant in sibling_variants:
+        try:
+            stage_scene(bare_uuid, variant=variant, force=False)
+        except Exception as exc:  # noqa: BLE001 - skip a variant, keep the rest
+            print(
+                f"[interactive-drive] failed to stage variant {variant!r} "
+                f"({exc}); skipping.",
+                flush=True,
+            )
+    return staged_default
 
 
 def main() -> None:
@@ -769,8 +798,9 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
 
     if args.preload_scenes:
         app.preload_scenes(
-            (opt.path, opt.variants[0] if opt.variants else "default", args.prompt)
+            (opt.path, variant, args.prompt)
             for opt in scene_options
+            for variant in (opt.variants or ("default",))
         )
         # Lock scene selection until every scene is cached so the user only
         # ever hits the instant (cache-hit) switch path.
@@ -911,8 +941,9 @@ def _run_streaming(args: argparse.Namespace) -> None:
 
     if args.preload_scenes:
         app.preload_scenes(
-            (opt.path, opt.variants[0] if opt.variants else "default", args.prompt)
+            (opt.path, variant, args.prompt)
             for opt in scene_options
+            for variant in (opt.variants or ("default",))
         )
         # Lock scene selection until every scene is cached so the user only
         # ever hits the instant (cache-hit) switch path.
@@ -1020,40 +1051,83 @@ def _discover_scene_options(
         paths.update(path.resolve() for path in scene_dir.glob("*.usdz"))
     if selected_scene.parent.is_dir():
         paths.update(path.resolve() for path in selected_scene.parent.glob("*.usdz"))
+
+    # Group archives by scene UUID so the per-weather sibling files
+    # (``clipgt-<uuid>-<variant>.usdz``) collapse into one scene with a variant
+    # selector. Single-archive scenes stay a group of one.
+    grouped: dict[str, dict[str, Path]] = {}
+    for path in sorted(paths):
+        uuid, variant = _scenes.parse_scene_stem(path.stem)
+        grouped.setdefault(uuid, {})[variant] = path
+
     options = tuple(
-        _scene_option(path, variants=_discover_variants(path)) for path in sorted(paths)
+        _scene_option_for_group(variant_paths)
+        for _uuid, variant_paths in sorted(grouped.items())
     )
     print(
         "[demo] discovered scenes: "
-        + (", ".join(scene.label for scene in options) if options else "<none>"),
+        + (
+            ", ".join(
+                f"{scene.label} [{', '.join(scene.variants)}]" for scene in options
+            )
+            if options
+            else "<none>"
+        ),
         flush=True,
     )
     return options
 
 
-def _scene_option(path: Path, *, variants: tuple[str, ...]) -> SceneOption:
-    variant_thumbnails = _load_variant_thumbnails(path, variants)
-    # Reuse the per-variant "default" thumbnail for the scene row when present
-    # so the scene and variant dropdowns agree, falling back to the standalone
-    # loader for bundles whose images don't parse into variants.
-    thumbnail = variant_thumbnails.get("default") or _load_scene_thumbnail(path)
+def _order_variants(variants: Iterable[str]) -> tuple[str, ...]:
+    """Order variant slugs with ``default`` first, then the rest sorted."""
+    unique = set(variants)
+    ordered = ["default"] if "default" in unique else []
+    ordered.extend(sorted(unique - {"default"}))
+    return tuple(ordered)
+
+
+def _scene_option_for_group(variant_paths: dict[str, Path]) -> SceneOption:
+    """Build one :class:`SceneOption` from a scene's variant archive(s).
+
+    Multiple siblings => the weather variants are the files. A single archive
+    => fall back to in-zip variant discovery (legacy / synthetic scenes).
+    """
+    if len(variant_paths) > 1:
+        variants = _order_variants(variant_paths.keys())
+        base_path = variant_paths.get("default") or variant_paths[variants[0]]
+        resolved_paths = dict(variant_paths)
+        variant_thumbnails = _load_variant_file_thumbnails(resolved_paths, variants)
+    else:
+        base_path = next(iter(variant_paths.values()))
+        variants = _discover_variants(base_path)
+        resolved_paths = {variant: base_path for variant in variants}
+        variant_thumbnails = _load_variant_thumbnails(base_path, variants)
+    # Use the first variant's preview for the scene row so the scene and
+    # variant dropdowns agree, falling back to the standalone loader.
+    thumbnail = (
+        variant_thumbnails.get(variants[0])
+        or variant_thumbnails.get("default")
+        or _load_scene_thumbnail(base_path)
+    )
     return SceneOption(
-        label=_scene_label(path),
-        path=path,
+        label=_scene_label(base_path),
+        path=base_path,
         variants=variants,
         thumbnail=thumbnail,
         variant_thumbnails=variant_thumbnails,
+        variant_paths=resolved_paths,
     )
 
 
 def _scene_label(path: Path) -> str:
     scene_names = {
-        "clipgt-0d404ff7-2b66-498c-b047-1ed8cded60d4": "Quiet Suburban Boulevard",
-        "clipgt-7bd1eb2f-c375-44ee-b4ca-55473e0773a9": "Late Night Arrival in the Neighborhood",
-        "clipgt-e2993759-36e1-4d97-868f-e2a737f1eb68": "Afternoon Commute Past the Park",
+        "0d404ff7-2b66-498c-b047-1ed8cded60d4": "Quiet Suburban Boulevard",
+        "7bd1eb2f-c375-44ee-b4ca-55473e0773a9": "Late Night Arrival in the Neighborhood",
+        "e2993759-36e1-4d97-868f-e2a737f1eb68": "Afternoon Commute Past the Park",
     }
-    scene_id = path.stem
-    return scene_names.get(scene_id, scene_id)
+    # Key by bare UUID so the label is stable across weather variant archives.
+    uuid, _variant = _scenes.parse_scene_stem(path.stem)
+    return scene_names.get(uuid, path.stem)
 
 
 def _discover_variants(scene_path: Path) -> tuple[str, ...]:
@@ -1164,6 +1238,28 @@ def _load_variant_thumbnails(
     return {variant: decoded.get(variant, default) for variant in variants}
 
 
+def _load_variant_file_thumbnails(
+    variant_paths: dict[str, Path], variants: tuple[str, ...]
+) -> dict[str, Image.Image]:
+    """Per-variant thumbnails when each variant is its own archive.
+
+    Each preview comes from that variant file's ``first_image.png``; variants
+    with no usable preview reuse the default. Empty mapping if nothing decoded.
+    """
+    decoded: dict[str, Image.Image] = {}
+    for variant in variants:
+        path = variant_paths.get(variant)
+        if path is None:
+            continue
+        thumb = _load_scene_thumbnail(path)
+        if thumb is not None:
+            decoded[variant] = thumb
+    if not decoded:
+        return {}
+    fallback = decoded.get("default") or next(iter(decoded.values()))
+    return {variant: decoded.get(variant, fallback) for variant in variants}
+
+
 def _make_thumbnail(image: Image.Image, size: tuple[int, int]) -> Image.Image:
     thumb = Image.new("RGB", size, (20, 20, 30))
     fitted = _fit_image(image, size)
@@ -1180,7 +1276,12 @@ def _make_thumbnail(image: Image.Image, size: tuple[int, int]) -> Image.Image:
 
 def _variant_label(variant: str) -> str:
     labels = {
-        "default": "Default",
+        # Per-weather variant archives.
+        "default": "Default (Clear)",
+        "clear": "Clear",
+        "snow": "Snowstorm",
+        "rain": "Night Rain",
+        # Legacy in-archive numbered variants.
         "1": "Bright Midday Sun",
         "2": "Snowstorm",
         "3": "Night with Heavy Rain",

--- a/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
@@ -46,7 +46,13 @@ from omnidreams.interactive_drive.types import (
     WorldTriangleList,
     WorldVehicleBBoxTrack,
 )
-from omnidreams.scenes import variant_from_stem
+from omnidreams.scenes import (
+    SCENE_FRAME_SUFFIXES,
+    SCENE_FRAMES_DIRNAME,
+    prompt_variant_for_scene_variant,
+    resolve_variant_archive,
+    variant_from_stem,
+)
 from PIL import Image
 
 _GROUND_MESH_NAME = "mesh_ground.ply"
@@ -78,16 +84,55 @@ def _points_from_records(points: list[dict[str, float]]) -> np.ndarray:
 
 
 def _load_initial_image(
-    zf: zipfile.ZipFile, variant: str, raster: RasterConfig
+    zf: zipfile.ZipFile, camera_name: str, variant: str, raster: RasterConfig
 ) -> np.ndarray:
-    images = _discover_first_images(zf)
-    name = images.get(variant) or images.get("default")
+    """Seed frame: the GT first camera frame, else the ``first_image`` render.
+
+    Prefers ``frames/<camera>/<ts>.jpeg`` so generation starts from the real
+    capture; falls back to ``first_image[_<variant>].png`` for older /
+    synthetic scenes with no per-camera frames.
+    """
+    name = _discover_initial_frame(zf, camera_name)
     if name is None:
-        raise FileNotFoundError("No first_image*.png found in the USDZ archive")
+        images = _discover_first_images(zf)
+        name = images.get(variant) or images.get("default")
+    if name is None:
+        raise FileNotFoundError(
+            "No frames/<camera>/*.jpeg or first_image*.png found in the USDZ archive"
+        )
     with Image.open(io.BytesIO(zf.read(name))) as image:
         rgb = image.convert("RGB")
         resized = rgb.resize(raster.resolution_wh, resample=Image.Resampling.BILINEAR)
         return np.asarray(resized, dtype=np.uint8)
+
+
+def _discover_initial_frame(zf: zipfile.ZipFile, camera_name: str) -> str | None:
+    """Earliest GT frame for ``camera_name`` (``None`` if the archive has none).
+
+    Frames are ``frames/<camera>/<ts_us>.jpeg``; the smallest timestamp is
+    the first frame. Accepts colon / underscore camera-name spellings.
+    """
+    clipgt_name, logical_name = normalize_camera_name(camera_name)
+    wanted_prefixes = tuple(
+        {
+            f"{SCENE_FRAMES_DIRNAME}/{name}/"
+            for name in (camera_name, logical_name, clipgt_name)
+        }
+    )
+    candidates = [
+        name
+        for name in zf.namelist()
+        if name.startswith(wanted_prefixes)
+        and Path(name).suffix.lower() in SCENE_FRAME_SUFFIXES
+    ]
+    if not candidates:
+        return None
+
+    def _frame_sort_key(name: str) -> tuple[int, str]:
+        stem = Path(name).stem
+        return (int(stem), name) if stem.isdigit() else (2**63 - 1, name)
+
+    return sorted(candidates, key=_frame_sort_key)[0]
 
 
 def _load_prompt(zf: zipfile.ZipFile, variant: str, prompt_override: str | None) -> str:
@@ -103,9 +148,7 @@ def _load_prompt(zf: zipfile.ZipFile, variant: str, prompt_override: str | None)
         )
         return prompt_override
     prompt_entries, ignored_files = _discover_prompt_entries(zf)
-    selected_variant = variant if variant in prompt_entries else None
-    if selected_variant is None and "default" in prompt_entries:
-        selected_variant = "default"
+    selected_variant = _select_prompt_variant(prompt_entries, variant)
     prompt_entry = (
         prompt_entries[selected_variant] if selected_variant is not None else None
     )
@@ -120,6 +163,24 @@ def _load_prompt(zf: zipfile.ZipFile, variant: str, prompt_override: str | None)
         ignored_files=ignored_files,
     )
     return prompt
+
+
+def _select_prompt_variant(
+    prompt_entries: dict[str, _PromptEntry], variant: str
+) -> str | None:
+    """Pick the in-archive prompt key for the requested scene variant.
+
+    Exact match wins first (legacy in-zip ``default`` / ``1`` / ``2``), else
+    the weather->prompt mapping, else ``"default"``, else ``None``.
+    """
+    if variant in prompt_entries:
+        return variant
+    mapped = prompt_variant_for_scene_variant(variant)
+    if mapped in prompt_entries:
+        return mapped
+    if "default" in prompt_entries:
+        return "default"
+    return None
 
 
 def _discover_prompts(zf: zipfile.ZipFile) -> dict[str, str]:
@@ -806,14 +867,16 @@ def load_scene_bundle(
     prompt_override: str | None,
     raster: RasterConfig,
 ) -> SceneBundle:
-    scene_path = Path(scene_path)
+    # Swap to the requested variant's sibling archive when present; legacy
+    # single-archive scenes resolve to the same path (variant picked in-zip).
+    scene_path = resolve_variant_archive(Path(scene_path), variant)
     with zipfile.ZipFile(scene_path, "r") as zf:
         metadata = _read_yaml(zf, "metadata.yaml")
         camera = _load_camera_calibration(zf, camera_name)
         initial_pose, initial_timestamp, initial_yaw, initial_speed = (
             _load_initial_state(zf)
         )
-        initial_rgb = _load_initial_image(zf, variant, raster)
+        initial_rgb = _load_initial_image(zf, camera_name, variant, raster)
         prompt = _load_prompt(zf, variant, prompt_override)
         line_layers, triangle_layers, polygon_layers = _load_map_layers(zf, raster)
         vehicle_bbox_tracks = _load_vehicle_bbox_tracks(zf)

--- a/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
@@ -7,7 +7,7 @@ import io
 import json
 import zipfile
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -899,6 +899,29 @@ def load_scene_bundle(
         vehicle_bbox_tracks=vehicle_bbox_tracks,
         ground_mesh_vertices=ground_mesh_vertices,
         ground_mesh_faces=ground_mesh_faces,
+    )
+
+
+def reseed_scene_bundle(
+    bundle: SceneBundle,
+    scene_path: Path,
+    camera_name: str,
+    variant: str,
+    prompt_override: str | None,
+    raster: RasterConfig,
+) -> SceneBundle:
+    """Re-seed an already-parsed ``bundle`` for a different weather variant.
+
+    Variants share all geometry; only the initial frame and prompt differ, so
+    this reads just those from the variant's archive and reuses the rest,
+    skipping the full re-parse and bounds/snapper rebuild.
+    """
+    scene_path = resolve_variant_archive(Path(scene_path), variant)
+    with zipfile.ZipFile(scene_path, "r") as zf:
+        initial_rgb = _load_initial_image(zf, camera_name, variant, raster)
+        prompt = _load_prompt(zf, variant, prompt_override)
+    return replace(
+        bundle, scene_path=scene_path, initial_rgb=initial_rgb, prompt=prompt
     )
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -329,6 +329,25 @@ _INDEX_HTML = """<!doctype html>
     padding: 6px 8px;
     font-size: 11px; line-height: 1.3;
   }
+  /* Weather-variant pills, shown only for multi-variant scenes. */
+  .scene-variants {
+    display: flex; flex-wrap: wrap; gap: 4px;
+    padding: 0 8px 8px 8px;
+  }
+  .variant-pill {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 999px;
+    color: white;
+    font-size: 10px;
+    padding: 2px 8px;
+    cursor: pointer;
+    pointer-events: auto;
+    user-select: none;
+    transition: background-color 0.1s, border-color 0.1s;
+  }
+  .variant-pill:hover { background: rgba(120, 200, 255, 0.3); border-color: rgba(120, 200, 255, 0.7); }
+  .variant-pill.loading { border-color: rgba(120, 200, 255, 1.0); opacity: 0.7; pointer-events: none; }
 </style>
 </head>
 <body>
@@ -484,29 +503,52 @@ async function fetchScenes() {
       label.className = 'scene-label';
       label.textContent = s.label || ('Scene ' + (i + 1));
       card.appendChild(label);
+      // Clicking the card (outside a pill) loads the default variant.
       card.addEventListener('click', () => loadScene(i, card));
+      const variants = Array.isArray(s.variants) ? s.variants : [];
+      if (variants.length > 1) {
+        const row = document.createElement('div');
+        row.className = 'scene-variants';
+        variants.forEach(v => {
+          const pill = document.createElement('button');
+          pill.className = 'variant-pill';
+          pill.type = 'button';
+          pill.textContent = variantLabel(v);
+          pill.addEventListener('click', e => {
+            e.stopPropagation();   // don't also trigger the card's default-variant load
+            loadScene(i, card, v, pill);
+          });
+          row.appendChild(pill);
+        });
+        card.appendChild(row);
+      }
       scenePickerList.appendChild(card);
     });
     scenePicker.classList.remove('hidden');
   } catch {}
 }
-async function loadScene(idx, card) {
+function variantLabel(v) {
+  const labels = {
+    default: 'Default', clear: 'Clear', snow: 'Snow', rain: 'Rain',
+  };
+  return labels[v] || (v.charAt(0).toUpperCase() + v.slice(1));
+}
+async function loadScene(idx, card, variant, pill) {
   const scene = SCENES[idx];
   if (!scene) return;
-  card.classList.add('loading');
+  (pill || card).classList.add('loading');
   try {
-    // Variant is omitted; the server falls back to the scene's first
-    // registered variant (typically ``default``). The streaming UI
-    // intentionally doesn't expose the variant selector.
-    await fetch('/scene/select?scene=' + encodeURIComponent(scene.path),
-                { method: 'GET', cache: 'no-store' });
+    let url = '/scene/select?scene=' + encodeURIComponent(scene.path);
+    // No variant -> server uses the scene's default; a pill selects one.
+    if (variant) url += '&variant=' + encodeURIComponent(variant);
+    await fetch(url, { method: 'GET', cache: 'no-store' });
   } catch {}
   // Tuck the panel away so the user gets the camera view back; the
   // scene transition itself is driven by the server-side loop. From
   // this point on, click-outside dismissal is enabled too.
   firstSceneLoaded = true;
   setScenePickerCollapsed(true);
-  setTimeout(() => { card.classList.remove('loading'); }, 1500);
+  setTimeout(() => { (pill || card).classList.remove('loading'); }, 1500);
 }
 fetchScenes();
 </script>
@@ -792,9 +834,9 @@ class MJPEGStreamingPresenter:
 
     # -- Internals --------------------------------------------------
 
-    def _publish(self, rgb_host_uint8: np.ndarray) -> None:
+    def _publish(self, rgb_host_uint8: object) -> None:
         buf = io.BytesIO()
-        Image.fromarray(rgb_host_uint8).save(
+        Image.fromarray(_as_rgb_host_uint8(rgb_host_uint8)).save(
             buf, format="JPEG", quality=self._jpeg_quality
         )
         jpeg = buf.getvalue()
@@ -803,7 +845,7 @@ class MJPEGStreamingPresenter:
             self._frame_count += 1
             self._frame_cond.notify_all()
 
-    def _publish_bev(self, bev_rgb_host_uint8: np.ndarray) -> None:
+    def _publish_bev(self, bev_rgb_host_uint8: object) -> None:
         """Encode the BEV minimap and stash it for ``/bev_stream`` waiters.
 
         BEV frames are tiny (<= 384x384) so JPEG encode is sub-millisecond
@@ -814,7 +856,9 @@ class MJPEGStreamingPresenter:
         edges clean is a good trade.
         """
         buf = io.BytesIO()
-        Image.fromarray(bev_rgb_host_uint8).save(buf, format="JPEG", quality=95)
+        Image.fromarray(_as_rgb_host_uint8(bev_rgb_host_uint8)).save(
+            buf, format="JPEG", quality=95
+        )
         jpeg = buf.getvalue()
         with self._frame_cond:
             self._latest_bev_jpeg = jpeg
@@ -1126,7 +1170,12 @@ def _make_handler(presenter: MJPEGStreamingPresenter) -> type[BaseHTTPRequestHan
             self.end_headers()
             last_seen = 0
             try:
-                while not presenter.should_close:
+                # Loop until shutdown (``wait_fn`` returns None only on
+                # ``_stop_event``). NOT gated on ``should_close``: that also
+                # flips True on a pending scene/variant change, and closing the
+                # connection there would freeze the browser's multipart <img>
+                # (it never auto-reconnects) mid-switch.
+                while True:
                     result = wait_fn(last_seen)
                     if result is None:
                         break
@@ -1180,7 +1229,21 @@ def _query_float(query: dict[str, list[str]], name: str) -> float:
         return 0.0
 
 
-def _with_status_overlay(rgb_host_uint8: np.ndarray, message: str | None) -> np.ndarray:
+def _as_rgb_host_uint8(frame: object) -> np.ndarray:
+    """Materialize a frame to ``(H, W, 3)`` uint8.
+
+    World-model frames are lazy GPU handles (``_LazyRGBFrame``) with
+    ``to_numpy()`` but no ``__array_interface__``, so ``Image.fromarray`` can't
+    take them directly. Mirrors the slangpy presenter.
+    """
+    to_numpy = getattr(frame, "to_numpy", None)
+    if callable(to_numpy):
+        frame = to_numpy()
+    return np.ascontiguousarray(np.asarray(frame, dtype=np.uint8)[..., :3])
+
+
+def _with_status_overlay(rgb_host_uint8: object, message: str | None) -> np.ndarray:
+    rgb_host_uint8 = _as_rgb_host_uint8(rgb_host_uint8)
     if message is None:
         return rgb_host_uint8
     return render_loading_overlay(rgb_host_uint8, message=message)

--- a/integrations/omnidreams/omnidreams/prepare.py
+++ b/integrations/omnidreams/omnidreams/prepare.py
@@ -31,9 +31,10 @@ from pathlib import Path
 
 from omnidreams.hf_org import DEFAULT_HF_ORG, apply_cli_to_env
 from omnidreams.scenes import (
+    SCENE_VARIANT_DEFAULT,
     hf_hub_download_scene,
     hf_scenes_repo_id,
-    list_available_scene_uuids,
+    list_available_scene_files,
     local_scene_archive_path,
     normalise_scene_uuid,
 )
@@ -81,9 +82,18 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Stage only this specific scene UUID from the scenes dataset. "
             "When omitted, every scene currently published is staged "
-            "(~1 GiB across all clips). The exact dataset depends on "
-            "--hf-org; for the default 'nvidia' org see "
+            "(all weather variants of each clip). The exact dataset depends "
+            "on --hf-org; for the default 'nvidia' org see "
             "https://huggingface.co/datasets/nvidia/omni-dreams-scenes/tree/main/scenes."
+        ),
+    )
+    parser.add_argument(
+        "--scene-variant",
+        default=None,
+        help=(
+            "With --scene-uuid, stage only this weather variant "
+            "('default', 'rain', 'snow'). When omitted, every published "
+            "variant of the selected scene (or of all scenes) is staged."
         ),
     )
     parser.add_argument(
@@ -137,14 +147,14 @@ def human_bytes(value: int) -> str:
     return f"{value} B"
 
 
-def scene_path(scene_uuid: str) -> Path:
-    """Absolute path the demo expects a staged USDZ scene to live at.
+def scene_path(scene_uuid: str, variant: str = SCENE_VARIANT_DEFAULT) -> Path:
+    """Absolute path the demo expects a staged USDZ scene variant to live at.
 
     Shared cache layout under ``$FLASHDREAMS_CACHE_DIR/omnidreams-scenes/``;
     see :func:`omnidreams.scenes.local_scene_archive_path` for the exact
     convention. Accepts either a bare UUID or a ``clipgt-<uuid>`` stem.
     """
-    return local_scene_archive_path(scene_uuid)
+    return local_scene_archive_path(scene_uuid, variant)
 
 
 def prewarm_huggingface_cache(
@@ -192,27 +202,25 @@ def prewarm_huggingface_cache(
         info(f"  \u2192 {local}")
 
 
-def stage_scene(scene_uuid: str, *, force: bool) -> Path:
-    """Download the scene USDZ from the HF dataset and materialise it under
-    ``$FLASHDREAMS_CACHE_DIR/omnidreams-scenes/clipgt-<uuid>.usdz`` so the
-    desktop demo's ``--scene`` arg points at a stable on-disk file.
+def stage_scene(
+    scene_uuid: str, *, variant: str = SCENE_VARIANT_DEFAULT, force: bool
+) -> Path:
+    """Download a scene variant's USDZ and copy it into the shared cache.
 
-    The HF download itself is content-addressed by ``huggingface_hub``,
-    so subsequent calls with the same UUID -- including the webrtc
-    server's ``_ensure_hf_webrtc_scene_synced`` -- are cache hits.
-
-    Accepts either a bare UUID or a ``clipgt-<uuid>`` stem; both
-    normalise to the bare form for consistent path / URL building.
+    Materialises ``clipgt-<uuid>[-<variant>].usdz`` under the scenes cache so
+    the demo's ``--scene`` arg points at a stable file. Accepts a bare UUID or
+    a ``clipgt-<uuid>`` stem.
     """
     bare_uuid = normalise_scene_uuid(scene_uuid)
-    dest = scene_path(bare_uuid)
+    dest = scene_path(bare_uuid, variant)
+    archive_name = dest.name
 
     if dest.exists() and not force:
         info(f"Scene already staged at {dest} ({human_bytes(dest.stat().st_size)}).")
         return dest
 
-    info(f"Downloading scene from {hf_scenes_repo_id()}: clipgt-{bare_uuid}.usdz")
-    cached = hf_hub_download_scene(bare_uuid)
+    info(f"Downloading scene from {hf_scenes_repo_id()}: {archive_name}")
+    cached = hf_hub_download_scene(bare_uuid, variant)
     # Copy (not symlink) into the cache root so the path referenced by
     # the demo command line is a real file robust to the HF cache moving
     # (e.g. user sets HF_HOME between runs).
@@ -263,14 +271,45 @@ def main() -> int:
             "and rerun, or pass --skip-scene and provide your own USDZ via "
             "the --scene flag to interactive_drive."
         )
+    elif args.scene_uuid is not None and args.scene_variant is not None:
+        stage_scene(args.scene_uuid, variant=args.scene_variant, force=args.force)
     elif args.scene_uuid is not None:
-        stage_scene(args.scene_uuid, force=args.force)
+        # All published variants of the requested scene.
+        bare_uuid = normalise_scene_uuid(args.scene_uuid)
+        variants = [
+            variant
+            for uuid, variant in list_available_scene_files()
+            if uuid == bare_uuid
+        ] or [SCENE_VARIANT_DEFAULT]
+        info(
+            f"Staging {len(variants)} variant(s) of {bare_uuid} "
+            f"from {hf_scenes_repo_id()}: {', '.join(variants)}."
+        )
+        for variant in variants:
+            stage_scene(bare_uuid, variant=variant, force=args.force)
+    elif args.scene_variant is not None:
+        # That variant across every scene that publishes it.
+        scene_files = [
+            (uuid, variant)
+            for uuid, variant in list_available_scene_files()
+            if variant == args.scene_variant
+        ]
+        info(
+            f"Staging {len(scene_files)} scene(s) (variant {args.scene_variant}) "
+            f"from {hf_scenes_repo_id()}."
+        )
+        for i, (uuid, variant) in enumerate(scene_files, start=1):
+            info(f"  [{i}/{len(scene_files)}] {uuid} ({variant})")
+            stage_scene(uuid, variant=variant, force=args.force)
     else:
-        uuids = list_available_scene_uuids()
-        info(f"Staging all {len(uuids)} scene(s) from {hf_scenes_repo_id()}.")
-        for i, uuid in enumerate(uuids, start=1):
-            info(f"  [{i}/{len(uuids)}] {uuid}")
-            stage_scene(uuid, force=args.force)
+        scene_files = list_available_scene_files()
+        info(
+            f"Staging all {len(scene_files)} scene archive(s) "
+            f"from {hf_scenes_repo_id()}."
+        )
+        for i, (uuid, variant) in enumerate(scene_files, start=1):
+            info(f"  [{i}/{len(scene_files)}] {uuid} ({variant})")
+            stage_scene(uuid, variant=variant, force=args.force)
 
     info("Workspace assets are ready.")
     return 0

--- a/integrations/omnidreams/omnidreams/prepare.py
+++ b/integrations/omnidreams/omnidreams/prepare.py
@@ -25,9 +25,12 @@ to ``nvidia/omni-dreams-scenes`` before running this helper.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import shutil
+import sys
 from pathlib import Path
+from types import ModuleType
 
 from omnidreams.hf_org import DEFAULT_HF_ORG, apply_cli_to_env
 from omnidreams.scenes import (
@@ -117,6 +120,16 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Skip pre-warming the Cosmos-Reason1 runtime text encoder (~14 GB). "
             "The runtime will download it lazily on first use."
+        ),
+    )
+    parser.add_argument(
+        "--perf",
+        action="store_true",
+        help=(
+            "Sync the pinned third-party CUDA sources required by the perf "
+            "manifest's native acceleration (example_world_model_perf.yaml). "
+            "Clones them into omnidreams_singleview/3rdparty/; the extension "
+            "itself compiles on first run. Requires a source checkout and git."
         ),
     )
     parser.add_argument(
@@ -230,6 +243,55 @@ def stage_scene(
     return dest
 
 
+def _sync_thirdparty_module() -> ModuleType:
+    """Load the standalone ``sync_thirdparty`` tool by path.
+
+    It lives in the ``omnidreams_singleview`` source tree (a sibling of the
+    ``omnidreams`` package, not an installed module), so it's loaded from its
+    file rather than imported.
+    """
+    tool_path = (
+        Path(__file__).resolve().parents[1]
+        / "omnidreams_singleview"
+        / "tools"
+        / "sync_thirdparty.py"
+    )
+    if not tool_path.is_file():
+        raise SystemExit(
+            "--perf requires the omnidreams_singleview sources, which ship "
+            f"only in a source checkout; not found at {tool_path}."
+        )
+    spec = importlib.util.spec_from_file_location(
+        "omnidreams_sync_thirdparty", tool_path
+    )
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"Could not load {tool_path}.")
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the tool's frozen dataclasses can resolve their
+    # own module via sys.modules during class creation.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def sync_perf_thirdparty(*, force: bool) -> None:
+    """Sync the pinned native CUDA sources the perf manifest builds against.
+
+    ``example_world_model_perf.yaml`` (``native_dit_acceleration: required``)
+    compiles against CUTLASS, SageAttention, SpargeAttn, and cudnn-frontend.
+    Clones them into ``omnidreams_singleview/3rdparty/``; the extension itself
+    builds on first run. Needs git + network.
+    """
+    sync = _sync_thirdparty_module()
+    try:
+        sources = sync.load_manifest()
+        info(f"Syncing {len(sources)} native third-party source(s) for --perf.")
+        for result in sync.sync_sources(sources, force=force):
+            info(f"  {result.source.name}: {result.commit[:12]} -> {result.path}")
+    except sync.ThirdPartySyncError as exc:
+        raise SystemExit(f"--perf third-party sync failed: {exc}") from exc
+
+
 def main() -> int:
     args = parse_args()
 
@@ -310,6 +372,10 @@ def main() -> int:
         for i, (uuid, variant) in enumerate(scene_files, start=1):
             info(f"  [{i}/{len(scene_files)}] {uuid} ({variant})")
             stage_scene(uuid, variant=variant, force=args.force)
+
+    # Independent of Hugging Face (git clones, no HF_TOKEN).
+    if args.perf:
+        sync_perf_thirdparty(force=args.force)
 
     info("Workspace assets are ready.")
     return 0

--- a/integrations/omnidreams/omnidreams/scenes.py
+++ b/integrations/omnidreams/omnidreams/scenes.py
@@ -42,6 +42,7 @@ disk.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Final
 
@@ -68,6 +69,30 @@ SCENE_PROMPT_FILENAME: Final[str] = "prompt.txt"
 # clipgt/``).
 SCENE_CLIPGT_DIRNAME: Final[str] = "clipgt"
 
+# Per-camera ground-truth frames live at ``frames/<camera>/<ts_us>.jpeg``;
+# scenes seed generation from the first frame instead of ``first_image.png``.
+SCENE_FRAMES_DIRNAME: Final[str] = "frames"
+SCENE_FRAME_SUFFIXES: Final[frozenset[str]] = frozenset({".jpeg", ".jpg", ".png"})
+
+# Slug for the base (no-suffix) scene archive.
+SCENE_VARIANT_DEFAULT: Final[str] = "default"
+
+# Weather variant -> 1-based prompt index inside the archive
+# (prompt1=clear, prompt2=snow, prompt3=rain). Unknown variants -> prompt 1.
+SCENE_VARIANT_PROMPT_INDEX: Final[dict[str, int]] = {
+    SCENE_VARIANT_DEFAULT: 1,
+    "snow": 2,
+    "rain": 3,
+}
+
+# Parses ``clipgt-<uuid>[-<variant>]``. Anchored on the canonical UUID shape
+# so the variant split doesn't bite into the UUID's hyphens; prefix optional.
+_CLIPGT_STEM_RE: Final = re.compile(
+    r"^(?:clipgt-)?"
+    r"(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+    r"(?:-(?P<variant>.+))?$"
+)
+
 # Convenience link to the canonical NVIDIA-hosted dataset browser. The
 # resolver below honours OMNI_DREAMS_HF_ORG when picking the actual repo
 # id; this URL is intentionally fixed at ``nvidia/`` because the public
@@ -88,28 +113,76 @@ def hf_scenes_repo_id(org: str | None = None) -> str:
     return hf_repo(kind="scenes", org=org)
 
 
+def parse_scene_stem(stem: str) -> tuple[str, str]:
+    """Split a ``clipgt-<uuid>[-<variant>]`` stem into ``(bare_uuid, variant)``.
+
+    Variant defaults to :data:`SCENE_VARIANT_DEFAULT` when there's no suffix.
+    Non-UUID inputs just get the ``clipgt-`` prefix stripped (so synthetic /
+    non-clipgt names still yield a sane bare id).
+    """
+    match = _CLIPGT_STEM_RE.match(stem.strip())
+    if match is not None:
+        return match.group("uuid"), (match.group("variant") or SCENE_VARIANT_DEFAULT)
+    return stem.strip().removeprefix("clipgt-"), SCENE_VARIANT_DEFAULT
+
+
 def normalise_scene_uuid(scene_uuid: str) -> str:
-    """Coerce either ``clipgt-<uuid>`` stems or bare ``<uuid>`` to the bare form.
+    """Coerce a ``clipgt-<uuid>[-<variant>]`` stem or bare ``<uuid>`` to the bare UUID.
 
-    The omni-dreams-scenes dataset stores files as
-    ``scenes/clipgt-<uuid>.usdz``, and the demo's default ``--scene`` path
-    uses the same ``clipgt-<uuid>.usdz`` filename locally. Users (and
-    internal callers using ``Path.stem`` on a local file) sometimes pass
-    the ``clipgt-`` prefix in; others (the webrtc server, the
-    ``--scene-uuid`` flag) pass the bare UUID. The downstream HF + local
-    path helpers below all assume the **bare** UUID form, so this
-    function normalises at the boundary.
+    Strips both the ``clipgt-`` prefix and any variant suffix; downstream HF /
+    local path helpers all assume the bare form.
     """
-    return scene_uuid.strip().removeprefix("clipgt-")
+    return parse_scene_stem(scene_uuid)[0]
 
 
-def scene_archive_filename(scene_uuid: str) -> str:
-    """HF-dataset path for one scene's USDZ archive.
+def scene_variant_from_stem(stem: str) -> str:
+    """Return just the variant slug parsed out of a clipgt archive stem."""
+    return parse_scene_stem(stem)[1]
 
-    Accepts either a bare UUID or a ``clipgt-<uuid>`` stem (see
-    :func:`normalise_scene_uuid`).
+
+def _variant_suffix(variant: str | None) -> str:
+    """Filename suffix for ``variant`` (``""`` for the default/base archive)."""
+    slug = (variant or SCENE_VARIANT_DEFAULT).strip()
+    return "" if slug in ("", SCENE_VARIANT_DEFAULT) else f"-{slug}"
+
+
+def scene_archive_filename(
+    scene_uuid: str, variant: str = SCENE_VARIANT_DEFAULT
+) -> str:
+    """HF-dataset path for one scene variant's USDZ archive.
+
+    ``variant`` selects a weather sibling (``-rain`` / ``-snow``); the default
+    maps to the base ``scenes/clipgt-<uuid>.usdz``.
     """
-    return f"scenes/clipgt-{normalise_scene_uuid(scene_uuid)}.usdz"
+    return f"scenes/clipgt-{normalise_scene_uuid(scene_uuid)}{_variant_suffix(variant)}.usdz"
+
+
+def prompt_variant_for_scene_variant(variant: str) -> str:
+    """Map a scene variant slug to the in-archive prompt key (``"1"``/``"2"``/``"3"``).
+
+    Weather variants map via :data:`SCENE_VARIANT_PROMPT_INDEX` so the seed
+    prompt matches the imagery; a numeric variant is returned as-is (legacy
+    in-archive selection), and unknown slugs fall back to ``"1"``.
+    """
+    slug = (variant or SCENE_VARIANT_DEFAULT).strip()
+    if slug.isdecimal():
+        return slug
+    return str(SCENE_VARIANT_PROMPT_INDEX.get(slug, 1))
+
+
+def resolve_variant_archive(scene_path: Path, variant: str) -> Path:
+    """Return the sibling USDZ for ``variant`` next to ``scene_path``.
+
+    Returns the matching ``clipgt-<uuid>[-<variant>].usdz`` sibling when it
+    exists on disk, else ``scene_path`` unchanged (legacy single-archive
+    scenes have no sibling; the loader picks the variant from within).
+    """
+    scene_path = Path(scene_path)
+    uuid, _current = parse_scene_stem(scene_path.stem)
+    candidate = scene_path.with_name(f"clipgt-{uuid}{_variant_suffix(variant)}.usdz")
+    if candidate != scene_path and candidate.exists():
+        return candidate
+    return scene_path
 
 
 # ---------------------------------------------------------------------------
@@ -137,14 +210,19 @@ def scenes_cache_root() -> Path:
     return FLASHDREAMS_CACHE_DIR / "omnidreams-scenes"
 
 
-def local_scene_archive_path(scene_uuid: str) -> Path:
+def local_scene_archive_path(
+    scene_uuid: str, variant: str = SCENE_VARIANT_DEFAULT
+) -> Path:
     """Where the desktop demo expects a staged scene archive to live.
 
-    ``<scenes_cache_root>/clipgt-<uuid>.usdz``. Matches the
-    ``clipgt-<uuid>.usdz`` naming the HF dataset uses so a user staring
-    at the cache dir sees the same filenames as on Hugging Face.
+    ``<scenes_cache_root>/clipgt-<uuid>[-<variant>].usdz``. Matches the
+    ``clipgt-<uuid>[-<variant>].usdz`` naming the HF dataset uses so a user
+    staring at the cache dir sees the same filenames as on Hugging Face.
     """
-    return scenes_cache_root() / f"clipgt-{normalise_scene_uuid(scene_uuid)}.usdz"
+    return (
+        scenes_cache_root()
+        / f"clipgt-{normalise_scene_uuid(scene_uuid)}{_variant_suffix(variant)}.usdz"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -196,23 +274,8 @@ def variant_from_stem(stem: str, prefix: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def list_available_scene_uuids() -> list[str]:
-    """Enumerate every ``scenes/clipgt-<uuid>.usdz`` file in the HF dataset.
-
-    Returns a sorted list of **bare** UUID strings (no ``clipgt-``
-    prefix, no ``scenes/`` path, no ``.usdz`` suffix). The bare form
-    matches what :func:`scene_archive_filename`,
-    :func:`local_scene_archive_path`, and
-    :func:`hf_hub_download_scene` expect as input.
-
-    Requires ``HF_TOKEN`` to be set because the dataset is gated. The
-    exact repo id is resolved via :func:`hf_scenes_repo_id`, so the
-    function honours ``OMNI_DREAMS_HF_ORG`` / the ``--hf-org`` CLI flag.
-
-    Imported lazily by callers (e.g. ``omnidreams-prepare``) so
-    the ``huggingface_hub`` dependency only matters when this function
-    is actually used.
-    """
+def _list_repo_scene_files() -> list[str]:
+    """Return every ``scenes/clipgt-*.usdz`` repo path in the HF dataset."""
     try:
         from huggingface_hub import HfApi
     except Exception as exc:  # pragma: no cover - huggingface_hub must be installed
@@ -226,32 +289,39 @@ def list_available_scene_uuids() -> list[str]:
     files = HfApi().list_repo_files(repo_id=repo_id, repo_type="dataset")
     path_prefix = "scenes/clipgt-"
     suffix = ".usdz"
-    uuids = [
-        path[len(path_prefix) : -len(suffix)]
-        for path in files
-        if path.startswith(path_prefix) and path.endswith(suffix)
+    return [
+        path for path in files if path.startswith(path_prefix) and path.endswith(suffix)
     ]
-    return sorted(uuids)
 
 
-def hf_hub_download_scene(scene_uuid: str) -> Path:
-    """Download one scene's USDZ archive from the resolved HF dataset.
+def list_available_scene_files() -> list[tuple[str, str]]:
+    """Enumerate every scene archive in the HF dataset as ``(uuid, variant)``.
 
-    Returns the local path inside ``huggingface_hub``'s content-addressed
-    cache (typically ``~/.cache/huggingface/hub/...``). Both demo paths
-    call this; the second caller for the same UUID gets a cache HIT and
-    no network traffic.
+    Sorted so each scene's base archive comes first. Requires ``HF_TOKEN``
+    (gated dataset); honours ``OMNI_DREAMS_HF_ORG`` / ``--hf-org``.
+    """
+    pairs = {parse_scene_stem(Path(path).stem) for path in _list_repo_scene_files()}
+    return sorted(
+        pairs,
+        key=lambda pair: (pair[0], "" if pair[1] == SCENE_VARIANT_DEFAULT else pair[1]),
+    )
 
-    Callers own what to do *after* download:
 
-    * ``omnidreams.prepare.stage_scene`` copies the cached
-      archive to :func:`local_scene_archive_path` so the demo's
-      ``--scene`` path is a stable real file.
-    * ``omnidreams.webrtc.session._ensure_hf_webrtc_scene_synced``
-      extracts the archive under :func:`scenes_cache_root` /
-      ``<uuid>/clipgt/`` for filesystem access.
+def list_available_scene_uuids() -> list[str]:
+    """Sorted unique bare scene UUIDs in the HF dataset (one per scene).
 
-    Accepts either a bare UUID or a ``clipgt-<uuid>`` stem.
+    Use :func:`list_available_scene_files` for the per-variant breakdown.
+    """
+    return sorted({uuid for uuid, _variant in list_available_scene_files()})
+
+
+def hf_hub_download_scene(
+    scene_uuid: str, variant: str = SCENE_VARIANT_DEFAULT
+) -> Path:
+    """Download one scene variant's USDZ from the HF dataset into the HF cache.
+
+    Returns the cached local path; repeat calls for the same UUID + variant
+    are cache hits. ``variant`` selects a weather sibling (``rain`` / ``snow``).
     """
     try:
         from huggingface_hub import hf_hub_download
@@ -265,6 +335,6 @@ def hf_hub_download_scene(scene_uuid: str) -> Path:
     cached = hf_hub_download(
         repo_id=hf_scenes_repo_id(),
         repo_type="dataset",
-        filename=scene_archive_filename(scene_uuid),
+        filename=scene_archive_filename(scene_uuid, variant),
     )
     return Path(cached)

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -70,7 +70,16 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help=(
             "Scene UUID for nvidia/omni-dreams-scenes. Expected dataset asset: "
-            "scenes/clipgt-<uuid>.usdz."
+            "scenes/clipgt-<uuid>[-<variant>].usdz."
+        ),
+    )
+    parser.add_argument(
+        "--scene-variant",
+        type=str,
+        default="default",
+        help=(
+            "Weather variant to serve: 'default' (clear), 'rain', or 'snow'. "
+            "Selects the matching sibling archive and weather prompt."
         ),
     )
     parser.add_argument("--device", type=str, default="cuda:0")
@@ -133,6 +142,7 @@ def build_runtime_config(
         pipeline_config_name=args.pipeline_config_name,
         scene_dir=args.scene_dir,
         scene_uuid=args.scene_uuid,
+        scene_variant=args.scene_variant,
         seed=args.seed,
         device=device_override or args.device,
         video_height=args.video_height,

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -38,10 +38,14 @@ from omnidreams.config import OMNIDREAMS_CONFIGS
 from omnidreams.scenes import (
     HF_DATASET_BROWSER_URL,
     SCENE_CLIPGT_DIRNAME,
+    SCENE_FRAME_SUFFIXES,
+    SCENE_FRAMES_DIRNAME,
     SCENE_IMAGE_SUFFIXES,
     SCENE_PROMPT_FILENAME,
+    SCENE_VARIANT_DEFAULT,
     hf_hub_download_scene,
     hf_scenes_repo_id,
+    prompt_variant_for_scene_variant,
     scenes_cache_root,
 )
 from omnidreams.transformer import CosmosTransformerConfig
@@ -66,7 +70,9 @@ from flashdreams.serving.webrtc.warmup import (
 _T = TypeVar("_T")
 DEFAULT_CLIENT_LIVENESS_TIMEOUT_S = 10.0
 _CLIENT_LIVENESS_CHECK_INTERVAL_S = 1.0
-DEFAULT_WEBRTC_SCENE_UUID = "065dcac9-ee67-4434-a835-c6b816c88e48"
+# Default scene (clear-weather base archive). Weather siblings are selected
+# via OmnidreamsRuntimeConfig.scene_variant / the server's --scene-variant.
+DEFAULT_WEBRTC_SCENE_UUID = "0d404ff7-2b66-498c-b047-1ed8cded60d4"
 # Re-export ``omnidreams.scenes`` constants under their pre-existing
 # ``WEBRTC_SCENES_*`` aliases so external imports (logs, tests, docs)
 # stay valid.
@@ -119,11 +125,53 @@ def _choose_existing_asset(
     )[0]
 
 
+def _camera_name_candidates(camera_name: str) -> tuple[str, ...]:
+    """Colon/underscore spellings of ``camera_name`` (dataset uses underscores)."""
+    underscore = camera_name.replace(":", "_")
+    colon = camera_name.replace("_", ":")
+    return tuple(dict.fromkeys((camera_name, underscore, colon)))
+
+
+def _first_frame_sort_key(path: Path) -> tuple[int, str]:
+    stem = path.stem
+    return (int(stem), path.name) if stem.isdigit() else (2**63 - 1, path.name)
+
+
+def _resolve_webrtc_first_frame(clipgt_dir: Path, camera_name: str) -> Path | None:
+    """Earliest GT frame under ``clipgt/frames/<camera>/``, else ``None``.
+
+    ``None`` when the bundle ships no such frames, so the caller can fall back
+    to ``first_image.*``.
+    """
+    frames_root = clipgt_dir / SCENE_FRAMES_DIRNAME
+    if not frames_root.is_dir():
+        return None
+    candidate_dirs = [
+        frames_root / name
+        for name in _camera_name_candidates(camera_name)
+        if (frames_root / name).is_dir()
+    ]
+    if not candidate_dirs:
+        # Fall back to any single camera directory present.
+        candidate_dirs = [path for path in sorted(frames_root.iterdir()) if path.is_dir()]
+    for directory in candidate_dirs:
+        frames = [
+            path
+            for path in directory.iterdir()
+            if path.is_file() and path.suffix.lower() in SCENE_FRAME_SUFFIXES
+        ]
+        if frames:
+            return sorted(frames, key=_first_frame_sort_key)[0]
+    return None
+
+
 def _resolve_webrtc_scene_assets(
     scene_dir: Path,
     *,
     prompt_filename: str,
     clipgt_dirname: str,
+    camera_name: str = "camera_front_wide_120fov",
+    variant: str = SCENE_VARIANT_DEFAULT,
 ) -> tuple[Path, Path, Path]:
     missing_assets = []
     clipgt_dir = scene_dir / clipgt_dirname
@@ -131,27 +179,34 @@ def _resolve_webrtc_scene_assets(
         missing_assets.append(str(scene_dir / clipgt_dirname))
         clipgt_dir = None
 
+    # Prefer the GT camera frame; fall back to ``first_image.*`` for bundles
+    # with no per-camera frames.
     first_frame_path = (
-        None
-        if clipgt_dir is None
-        else _choose_existing_asset(
+        None if clipgt_dir is None else _resolve_webrtc_first_frame(clipgt_dir, camera_name)
+    )
+    if first_frame_path is None and clipgt_dir is not None:
+        first_frame_path = _choose_existing_asset(
             clipgt_dir,
             fallback_stems=("first_image_1",),
             allowed_suffixes=WEBRTC_SCENE_IMAGE_SUFFIXES,
             preferred_stems=("first_image",),
         )
-    )
     if first_frame_path is None:
-        missing_assets.append(f"first_image.* under {clipgt_dir}/")
+        missing_assets.append(
+            f"frames/<camera>/*.jpeg or first_image.* under {clipgt_dir}/"
+        )
 
+    # Prompt matching the weather variant (``promptN.txt``); fall back to a
+    # bare ``prompt.txt`` for older bundles.
+    weather_prompt_stem = f"prompt{prompt_variant_for_scene_variant(variant)}"
     prompt_path = (
         None
         if clipgt_dir is None
         else _choose_existing_asset(
             clipgt_dir,
-            fallback_stems=("prompt1",),
+            fallback_stems=("prompt1", "prompt2", "prompt3", "prompt"),
             allowed_suffixes={".txt"},
-            preferred_stems=("prompt",),
+            preferred_stems=(weather_prompt_stem, "prompt"),
         )
     )
     if prompt_path is None:
@@ -203,13 +258,20 @@ def _safe_extract_zip(source: Path, destination: Path) -> None:
                 shutil.copyfileobj(src, dst)
 
 
+def _variant_dir_suffix(variant: str | None) -> str:
+    """Cache subdir / filename suffix for ``variant`` (``""`` for default)."""
+    slug = (variant or SCENE_VARIANT_DEFAULT).strip()
+    return "" if slug in ("", SCENE_VARIANT_DEFAULT) else f"-{slug}"
+
+
 def _extract_local_webrtc_scene_if_needed(
     scene_dir: Path,
     *,
     scene_uuid: str | None,
+    variant: str = SCENE_VARIANT_DEFAULT,
     clipgt_dirname: str,
 ) -> Path:
-    """Extract ``scene_uuid`` archive and normalize local WebRTC scene layout."""
+    """Extract the ``scene_uuid`` (+ variant) archive into the local layout."""
     if scene_uuid is None:
         return scene_dir
 
@@ -218,20 +280,31 @@ def _extract_local_webrtc_scene_if_needed(
     if not scene_dir.is_dir():
         raise FileNotFoundError(f"scene_dir does not exist: {scene_dir}")
 
+    suffix = _variant_dir_suffix(variant)
     expected_names = (
-        f"clipgt-{scene_uuid}.usdz",
-        f"{scene_uuid}.usdz",
+        f"clipgt-{scene_uuid}{suffix}.usdz",
+        f"{scene_uuid}{suffix}.usdz",
     )
     archive_path = _choose_existing_asset(scene_dir, exact_name=expected_names[0]) or (
         _choose_existing_asset(scene_dir, exact_name=expected_names[1])
     )
     if archive_path is None:
-        # Fall back to prefixed local naming like ``clipgt-<uuid>-v2.usdz``.
+        # Prefer the variant suffix but accept the base archive too.
         archive_path = _choose_existing_asset(
             scene_dir,
-            fallback_prefixes=(f"clipgt-{scene_uuid}", scene_uuid),
+            fallback_prefixes=(
+                f"clipgt-{scene_uuid}{suffix}",
+                f"{scene_uuid}{suffix}",
+                f"clipgt-{scene_uuid}",
+                scene_uuid,
+            ),
             allowed_suffixes={".usdz"},
-            preferred_stems=(f"clipgt-{scene_uuid}", scene_uuid),
+            preferred_stems=(
+                f"clipgt-{scene_uuid}{suffix}",
+                f"{scene_uuid}{suffix}",
+                f"clipgt-{scene_uuid}",
+                scene_uuid,
+            ),
         )
     if archive_path is None:
         raise FileNotFoundError(
@@ -239,7 +312,7 @@ def _extract_local_webrtc_scene_if_needed(
             f"{scene_dir}. Expected one of: {', '.join(expected_names)}."
         )
 
-    normalized_scene_dir = scene_dir / scene_uuid
+    normalized_scene_dir = scene_dir / f"{scene_uuid}{suffix}"
     normalized_clipgt_root = normalized_scene_dir / clipgt_dirname
     _safe_extract_zip(archive_path, normalized_clipgt_root)
     return normalized_scene_dir
@@ -248,37 +321,34 @@ def _extract_local_webrtc_scene_if_needed(
 def _ensure_hf_webrtc_scene_synced(
     scene_uuid: str,
     *,
+    variant: str = SCENE_VARIANT_DEFAULT,
     prompt_filename: str = SCENE_PROMPT_FILENAME,
     clipgt_dirname: str = SCENE_CLIPGT_DIRNAME,
 ) -> Path:
-    """Stage an HF scene into the local layout expected by WebRTC.
+    """Stage an HF scene variant into the WebRTC cache layout.
 
-    The HF repo / archive layout (``<org>/omni-dreams-scenes``,
-    ``scenes/clipgt-<uuid>.usdz``) is shared with the
-    ``omnidreams.interactive_drive`` desktop demo via
-    :mod:`omnidreams.scenes`; this function owns only the webrtc-side
-    cache layout (per-uuid extraction under
-    ``FLASHDREAMS_CACHE_DIR/omnidreams-scenes/<uuid>/clipgt/``).
+    Downloads ``scenes/clipgt-<uuid>[-<variant>].usdz`` and extracts it under
+    ``FLASHDREAMS_CACHE_DIR/omnidreams-scenes/<uuid>[-<variant>]/clipgt/``. The
+    per-uuid+variant directory coexists with the desktop demo's archive files
+    in the same root.
     """
+    del prompt_filename  # accepted for call-site symmetry; assets resolved later
     scene_uuid = scene_uuid.strip()
     assert scene_uuid, "scene_uuid must be set."
-    # ``scenes_cache_root()`` is the same root the desktop demo writes
-    # ``clipgt-<uuid>.usdz`` archives to (via
-    # ``omnidreams.prepare.stage_scene``); they coexist by name
-    # because the archive is a file while the webrtc extraction is a
-    # per-uuid directory.
+    suffix = _variant_dir_suffix(variant)
     cache_root = scenes_cache_root()
-    scene_dir = cache_root / scene_uuid
-    lock_path = cache_root / ".locks" / f"{scene_uuid}.lock"
+    scene_dir = cache_root / f"{scene_uuid}{suffix}"
+    lock_path = cache_root / ".locks" / f"{scene_uuid}{suffix}.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
     with FileLock(str(lock_path)):
-        archive_path = hf_hub_download_scene(scene_uuid)
+        archive_path = hf_hub_download_scene(scene_uuid, variant)
         _safe_extract_zip(archive_path, scene_dir / clipgt_dirname)
 
     logger.info(
-        "Synced Omnidreams WebRTC scene {} from Hugging Face ({}) to {}",
+        "Synced Omnidreams WebRTC scene {} (variant {}) from Hugging Face ({}) to {}",
         scene_uuid,
+        variant,
         hf_scenes_repo_id(),
         scene_dir,
     )
@@ -338,6 +408,8 @@ class OmnidreamsRuntimeConfig:
     )
     scene_dir: Path | None = None
     scene_uuid: str | None = None
+    # Weather variant slug (default/rain/snow): picks the sibling USDZ + prompt.
+    scene_variant: str = SCENE_VARIANT_DEFAULT
     seed: int | None = 42
     device: str = "cuda:0"
     video_height: int = 704
@@ -542,6 +614,7 @@ class OmnidreamsInferenceRuntime:
             scene_uuid = cfg.scene_uuid or DEFAULT_WEBRTC_SCENE_UUID
             scene_dir = _ensure_hf_webrtc_scene_synced(
                 scene_uuid,
+                variant=cfg.scene_variant,
                 prompt_filename=cfg.prompt_filename,
                 clipgt_dirname=cfg.clipgt_dirname,
             )
@@ -549,6 +622,7 @@ class OmnidreamsInferenceRuntime:
             scene_dir = _extract_local_webrtc_scene_if_needed(
                 cfg.scene_dir,
                 scene_uuid=cfg.scene_uuid,
+                variant=cfg.scene_variant,
                 clipgt_dirname=cfg.clipgt_dirname,
             )
 
@@ -557,6 +631,8 @@ class OmnidreamsInferenceRuntime:
             scene_dir,
             prompt_filename=cfg.prompt_filename,
             clipgt_dirname=cfg.clipgt_dirname,
+            camera_name=cfg.camera_name,
+            variant=cfg.scene_variant,
         )
         if cfg.pipeline_config_name not in OMNIDREAMS_CONFIGS:
             supported = ", ".join(sorted(OMNIDREAMS_CONFIGS))

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -153,7 +153,9 @@ def _resolve_webrtc_first_frame(clipgt_dir: Path, camera_name: str) -> Path | No
     ]
     if not candidate_dirs:
         # Fall back to any single camera directory present.
-        candidate_dirs = [path for path in sorted(frames_root.iterdir()) if path.is_dir()]
+        candidate_dirs = [
+            path for path in sorted(frames_root.iterdir()) if path.is_dir()
+        ]
     for directory in candidate_dirs:
         frames = [
             path
@@ -182,7 +184,9 @@ def _resolve_webrtc_scene_assets(
     # Prefer the GT camera frame; fall back to ``first_image.*`` for bundles
     # with no per-camera frames.
     first_frame_path = (
-        None if clipgt_dir is None else _resolve_webrtc_first_frame(clipgt_dir, camera_name)
+        None
+        if clipgt_dir is None
+        else _resolve_webrtc_first_frame(clipgt_dir, camera_name)
     )
     if first_frame_path is None and clipgt_dir is not None:
         first_frame_path = _choose_existing_asset(

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -364,6 +364,7 @@ def test_build_runtime_config_threads_hf_scene_args(tmp_path: Path) -> None:
         pipeline_config_name="omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf",
         scene_dir=tmp_path / "local-scene",
         scene_uuid="scene-123",
+        scene_variant="rain",
         seed=123,
         device="cuda:0",
         video_height=360,
@@ -379,6 +380,7 @@ def test_build_runtime_config_threads_hf_scene_args(tmp_path: Path) -> None:
 
     assert cfg.scene_dir == tmp_path / "local-scene"
     assert cfg.scene_uuid == "scene-123"
+    assert cfg.scene_variant == "rain"
     assert cfg.device == "cuda:7"
     assert cfg.video_height == 360
     assert cfg.video_width == 640
@@ -413,10 +415,11 @@ def test_runtime_uses_default_scene_uuid_when_scene_is_unspecified(
     def _fake_ensure_hf_webrtc_scene_synced(
         scene_uuid: str,
         *,
+        variant: str = "default",
         prompt_filename: str,
         clipgt_dirname: str,
     ) -> Path:
-        del prompt_filename, clipgt_dirname
+        del prompt_filename, clipgt_dirname, variant
         calls.append(scene_uuid)
         return staged_scene_dir
 
@@ -425,8 +428,10 @@ def test_runtime_uses_default_scene_uuid_when_scene_is_unspecified(
         *,
         prompt_filename: str,
         clipgt_dirname: str,
+        camera_name: str = "camera_front_wide_120fov",
+        variant: str = "default",
     ) -> tuple[Path, Path, Path]:
-        del prompt_filename, clipgt_dirname
+        del prompt_filename, clipgt_dirname, camera_name, variant
         clipgt_dir = scene_dir / "clipgt"
         return clipgt_dir, clipgt_dir / "first_image.png", clipgt_dir / "prompt.txt"
 
@@ -461,6 +466,7 @@ def test_build_runtime_config_clears_scene_uuid_for_local_scene(tmp_path: Path) 
         pipeline_config_name="omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf",
         scene_dir=tmp_path / "local-scene",
         scene_uuid=None,
+        scene_variant="default",
         seed=123,
         device="cuda:0",
         video_height=360,
@@ -476,6 +482,7 @@ def test_build_runtime_config_clears_scene_uuid_for_local_scene(tmp_path: Path) 
 
     assert cfg.scene_dir == tmp_path / "local-scene"
     assert cfg.scene_uuid is None
+    assert cfg.scene_variant == "default"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The `omni-dreams-scenes` dataset now ships each scene's weather variants as **separate USDZ files** (`clipgt-<uuid>.usdz`, `-rain`, `-snow`) instead of bundling variants inside one archive. This updates the webrtc and interactive_drive apps to consume the new layout.
- **GT frame as seed**: rollouts now start from the scene's ground-truth camera frame (`frames/<camera>/<ts>.jpeg`), falling back to `first_image.png` for older scenes.
- **Variants = files**: sibling archives are grouped by UUID into one scene with a `default / rain / snow` selector; each variant uses its weather-matched prompt (`prompt1/2/3.txt`).
- **webrtc**: new `--scene-variant` flag; default scene updated to a published UUID.
- **prepare**: stages all weather variants of a scene.
- **docs/READMEs**: refreshed stale scene UUIDs and documented `--scene-variant`.

## Test plan
- [x] `scenes` / `scene_loader` / `demo` / webrtc unit tests pass
- [x] End-to-end check: each variant loads its own archive, GT frame, and matching prompt; siblings group into one scene