### PR TITLE
interactive-drive: materialize lazy RGB frame before JPEG encode

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -794,7 +794,10 @@ class MJPEGStreamingPresenter:
 
     def _publish(self, rgb_host_uint8: np.ndarray) -> None:
         buf = io.BytesIO()
-        Image.fromarray(rgb_host_uint8).save(
+        # The no-overlay path forwards a lazy GPU-backed frame wrapper that
+        # exposes ``__array__`` but not ``__array_interface__``; coerce to a
+        # real ndarray so ``Image.fromarray`` works (no-op for plain arrays).
+        Image.fromarray(np.asarray(rgb_host_uint8)).save(
             buf, format="JPEG", quality=self._jpeg_quality
         )
         jpeg = buf.getvalue()

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -817,7 +817,12 @@ class MJPEGStreamingPresenter:
         edges clean is a good trade.
         """
         buf = io.BytesIO()
-        Image.fromarray(bev_rgb_host_uint8).save(buf, format="JPEG", quality=95)
+        # Same lazy-frame coercion as ``_publish``: the BEV frame can arrive as
+        # a ``_LazyRasterFrame`` (exposes ``__array__`` but not
+        # ``__array_interface__``), which ``Image.fromarray`` can't consume.
+        Image.fromarray(np.asarray(bev_rgb_host_uint8)).save(
+            buf, format="JPEG", quality=95
+        )
         jpeg = buf.getvalue()
         with self._frame_cond:
             self._latest_bev_jpeg = jpeg


### PR DESCRIPTION
## Summary
- Fixes a crash on the first rendered frame of the `interactive-drive` MJPEG stream: `AttributeError: '_LazyRGBFrame' object has no attribute '__array_interface__'`.
- The streaming presenter's no-overlay path (`_with_status_overlay` with `message is None`) forwards the `_LazyRGBFrame` wrapper straight to `_publish`. That wrapper implements `__array__` but not `__array_interface__`, which `PIL.Image.fromarray` requires.
- Coerce with `np.asarray(...)` at the single publish chokepoint: a no-op for plain ndarrays, and it triggers `__array__` to materialize the lazy GPU-backed frame.

## Test plan
- [ ] Launch `interactive-drive --stream-mjpeg 8080` and confirm the stream renders frames (previously crashed at first present).
- [ ] Verify status-overlay frames (idle/loading) still render correctly.