### PR TITLE
Move Google Analytics tag to base.html

### DIFF
--- a/docs/source/_templates/base.html
+++ b/docs/source/_templates/base.html
@@ -1,0 +1,19 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+{% extends "!base.html" %}
+
+{# Google Analytics (GA4). Furo has no native analytics option, so the
+   gtag.js snippet is injected into <head> via the `extrahead` block. #}
+{% block extrahead %}
+{{ super() }}
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-Q44TKZ8777"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-Q44TKZ8777');
+</script>
+{% endblock %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -4,16 +4,3 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 {% extends "!layout.html" %}
-
-{# Google Analytics (GA4). Furo has no native analytics option, so the
-   gtag.js snippet is injected into <head> via the `extrahead` block. #}
-{% block extrahead %}
-{{ super() }}
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-Q44TKZ8777"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', 'G-Q44TKZ8777');
-</script>
-{% endblock %}


### PR DESCRIPTION
#248 added the Google Analytics tag to `layout.html` which is the Sphinx page template, but the furo theme used by the website does not extend that template, so the tag script does not show up on the site. 

Furo uses `base.html` as the base, so this moves the tag there, where it will actually be picked up by the site, confirmed using a local build of the site.