### PR TITLE
Fix OmniDreams package name references

### DIFF
--- a/integrations/omnidreams/README.md
+++ b/integrations/omnidreams/README.md
@@ -92,7 +92,7 @@ directory. Pass `--scene_dir <path>` to use a pre-staged local scene instead.
 From the workspace root, run:
 
 ```bash
-uv run --package flash-omnidreams torchrun --nproc_per_node 1 -m omnidreams.grpc.server --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf --host 0.0.0.0 --port 50051
+uv run --package flashdreams-omnidreams torchrun --nproc_per_node 1 -m omnidreams.grpc.server --pipeline_config_name omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf --host 0.0.0.0 --port 50051
 ```
 
 The server implements `omnidreams.grpc.protos.video_model.WorldModelService`

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -212,7 +212,7 @@ def _precompute_embeddings_from_config(
         from omnidreams.constants import NEGATIVE_PROMPT
     except ModuleNotFoundError as exc:
         raise RuntimeError(
-            "The flash-omnidreams package is required for --offload-text-encoder."
+            "The flashdreams-omnidreams package is required for --offload-text-encoder."
         ) from exc
 
     device = torch.device(manifest.device)


### PR DESCRIPTION
Fixes two stale OmniDreams package-name references from `flash-omnidreams` to the current workspace package name, `flashdreams-omnidreams`.