### PR TITLE
Fix the BlockKVCache steady state triggers recompiling

### DIFF
--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -100,15 +100,7 @@ class BlockKVCache:
         """Number of valid cached tokens visible to attention."""
         if self._curr_chunk_idx is None:
             return self._n_cached
-        if self.is_steady_state():
-            return self._k.shape[self.seq_dim]
-        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._n_cached + self.chunk_size
-        if self._curr_chunk_idx == self._prev_chunk_idx:
-            return self._n_cached
-        raise ValueError(
-            f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-        )
+        return self._visible_end()
 
     @property
     def write_end(self) -> int:
@@ -187,53 +179,72 @@ class BlockKVCache:
             self._k[dst_slice] = self._k[src_slice].clone()
             self._v[dst_slice] = self._v[src_slice].clone()
 
-    def _overwrite_rightmost_steady(self, k: Tensor, v: Tensor) -> None:
-        """Write the new chunk into the rightmost positions (steady-state, after roll)."""
-        total_size = self._k.shape[self.seq_dim]
-        assert total_size == self._n_cached, (
-            f"Expected full cache: {total_size=} != {self._n_cached=}"
+    def _current_chunk_overlaps_sink(self) -> bool:
+        assert self._curr_chunk_idx is not None, (
+            "Must call before_update() before checking sink overlap"
         )
-        write_end = total_size
-        write_start = write_end - self.chunk_size
-        if write_start > self.sink_size:
-            sl_write = self._seq_slice(write_start, write_end)
-            self._k[sl_write] = k
-            self._v[sl_write] = v
+        return (
+            self.sink_size > 0
+            and self._curr_chunk_idx * self.chunk_size
+            < self.sink_size
+        )
+
+    def _current_write_bounds(self) -> tuple[int, int]:
+        """Return the physical cache range written by the current update."""
+        assert self._curr_chunk_idx is not None, (
+            "Must call before_update() before computing write bounds"
+        )
+        total_size = self._k.shape[self.seq_dim]
+        assert self.chunk_size <= total_size, (
+            f"chunk_size ({self.chunk_size}) must be <= cache size ({total_size})"
+        )
+
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            write_start = torch.sym_min(self._n_cached, total_size - self.chunk_size)
+            write_end = write_start + self.chunk_size
+        elif self._curr_chunk_idx == self._prev_chunk_idx:
+            write_end = torch.sym_min(self._n_cached, total_size)
+            write_start = torch.sym_max(write_end - self.chunk_size, 0)
         else:
-            # The input token overlaps with the sink tokens, so we only keep partial of it.
-            # Note: here we assume the sink tokens have already been written to the cache.
-            # It is safe to assume this because this function will never be called for the
-            # first chunk, and we assume the first chunk should be enough to cover the sink tokens.
+            raise ValueError(
+                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+            )
+        return write_start, write_end
+
+    def _write_current_chunk(self, k: Tensor, v: Tensor) -> None:
+        """Write the current chunk through a filling/steady compatible path."""
+        write_start, write_end = self._current_write_bounds()
+        read_start = 0
+        read_end = write_end - write_start
+
+        if (
+            self.sink_size > 0
+            and not self._current_chunk_overlaps_sink()
+            and write_start < self.sink_size
+        ):
             write_start = self.sink_size
             keep_size = write_end - write_start
             read_end = self.chunk_size
             read_start = read_end - keep_size
-            sl_read = self._seq_slice(read_start, read_end)
-            sl_write = self._seq_slice(write_start, write_end)
-            self._k[sl_write] = k[sl_read]
-            self._v[sl_write] = v[sl_read]
 
-    def _overwrite_rightmost_filling(self, k: Tensor, v: Tensor) -> None:
-        """Write the new chunk into the rightmost positions (filling phase)."""
-        write_end = self._n_cached
-        write_start = write_end - self.chunk_size
-        assert write_start >= 0, (
-            f"write [{write_start}:{write_end}) out of bounds for buffer size {self.sink_size + self.window_size}"
-        )
-        sl = self._seq_slice(write_start, write_end)
-        self._k[sl] = k
-        self._v[sl] = v
+        sl_read = self._seq_slice(read_start, read_end)
+        sl_write = self._seq_slice(write_start, write_end)
+        self._k[sl_write] = k[sl_read]
+        self._v[sl_write] = v[sl_read]
 
-    def _append_to_end(self, k: Tensor, v: Tensor) -> None:
-        """Append the new chunk to the end of the cache (filling phase)."""
-        write_start = self._n_cached
-        write_end = write_start + self.chunk_size
-        assert write_end <= self.sink_size + self.window_size, (
-            f"write [{write_start}:{write_end}) out of bounds for buffer size {self.sink_size + self.window_size}"
+    def _visible_end(self) -> int:
+        """Right edge of cached tokens visible to attention during this update."""
+        assert self._curr_chunk_idx is not None, (
+            "Must call before_update() before computing visible cache size"
         )
-        sl = self._seq_slice(write_start, write_end)
-        self._k[sl] = k
-        self._v[sl] = v
+        total_size = self._k.shape[self.seq_dim]
+        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
+            return torch.sym_min(self._n_cached + self.chunk_size, total_size)
+        if self._curr_chunk_idx == self._prev_chunk_idx:
+            return torch.sym_min(self._n_cached, total_size)
+        raise ValueError(
+            f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
+        )
 
     def is_steady_state(self) -> bool:
         """Return True if the cache is full (steady-state phase)."""
@@ -300,17 +311,7 @@ class BlockKVCache:
             f"Expected input v to have chunk_size ({chunk_size_v}) at seq_dim ({self.seq_dim}), "
             f"got {chunk_size_v} != {self.chunk_size}"
         )
-        if self.is_steady_state():
-            self._overwrite_rightmost_steady(k, v)
-        else:
-            if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-                self._append_to_end(k, v)
-            elif self._curr_chunk_idx == self._prev_chunk_idx:
-                self._overwrite_rightmost_filling(k, v)
-            else:
-                raise ValueError(
-                    f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-                )
+        self._write_current_chunk(k, v)
 
     def after_update(self, chunk_idx: int) -> None:
         """
@@ -344,31 +345,13 @@ class BlockKVCache:
         """
         Return cached keys for attention (valid prefix in filling phase, full buffer in steady-state).
         """
-        if self.is_steady_state():
-            return self._k
-        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._k[self._seq_slice(0, self._n_cached + self.chunk_size)]
-        elif self._curr_chunk_idx == self._prev_chunk_idx:
-            return self._k[self._seq_slice(0, self._n_cached)]
-        else:
-            raise ValueError(
-                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-            )
+        return self._k[self._seq_slice(0, self._visible_end())]
 
     def cached_v(self) -> Tensor:
         """
         Return cached values for attention (valid prefix in filling phase, full buffer in steady-state).
         """
-        if self.is_steady_state():
-            return self._v
-        if self._curr_chunk_idx == self._prev_chunk_idx + 1:
-            return self._v[self._seq_slice(0, self._n_cached + self.chunk_size)]
-        elif self._curr_chunk_idx == self._prev_chunk_idx:
-            return self._v[self._seq_slice(0, self._n_cached)]
-        else:
-            raise ValueError(
-                f"{self._curr_chunk_idx=} should be either {self._prev_chunk_idx + 1} or {self._prev_chunk_idx}."
-            )
+        return self._v[self._seq_slice(0, self._visible_end())]
 
     def reset(self) -> None:
         """Reset the cache to its initial empty state."""

--- a/flashdreams/flashdreams/core/attention/kvcache.py
+++ b/flashdreams/flashdreams/core/attention/kvcache.py
@@ -185,8 +185,7 @@ class BlockKVCache:
         )
         return (
             self.sink_size > 0
-            and self._curr_chunk_idx * self.chunk_size
-            < self.sink_size
+            and self._curr_chunk_idx * self.chunk_size < self.sink_size
         )
 
     def _current_write_bounds(self) -> tuple[int, int]:

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -328,7 +328,7 @@ def test_block_kvcache_cudagraph_matches_baseline(
     window_size: int,
 ) -> None:
     """BlockKVCache with CUDA graph (steady-state path) should match baseline.
-    
+
     To print out the torch.compile events run with
 
     uv run --group test pytest flashdreams/tests/test_kvcache.py::test_block_kvcache_compile_cudagraph_matches_baseline -vv -s -o log_cli=true --log-cli-level=INFO
@@ -516,9 +516,7 @@ def test_block_kvcache_compile_cudagraph_matches_baseline(
         active_cache.update(k, v)
         return active_cache.cached_k(), active_cache.cached_v()
 
-    compiled_cache_step = torch.compile(
-        cache_step, mode="max-autotune-no-cudagraphs"
-    )
+    compiled_cache_step = torch.compile(cache_step, mode="max-autotune-no-cudagraphs")
 
     def run_cache_step(
         new_k: torch.Tensor,

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -17,7 +17,10 @@
 Unit tests for BlockKVCache.
 """
 
-from typing import Any, cast
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 import torch
@@ -27,6 +30,11 @@ from flashdreams.core.attention.rope import (
     KVCacheRelativeRotaryPositionEmbedding3D,
     RotaryPositionEmbedding3D,
 )
+
+_LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from torch._dynamo.callback import CallbackArgs
 
 
 class _NaiveKVCache:
@@ -426,3 +434,176 @@ def test_block_kvcache_cudagraph_matches_baseline(
 
     # make sure the graph is captured.
     assert graph is not None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for cudagraph test"
+)
+@pytest.mark.ci_gpu
+def test_block_kvcache_compile_cudagraph_matches_baseline(
+    dtype: torch.dtype,
+) -> None:
+    """BlockKVCache with torch.compile and CUDA graph should match baseline."""
+    import torch._dynamo as dynamo
+
+    device = torch.device("cuda")
+    batch, n_heads = 2, 4
+    dim_k, dim_v = 8, 16
+    chunk_size = 8
+    sink_size, window_size = 0, 24
+    buffer_size = window_size + sink_size
+
+    k_shape = (batch, buffer_size, n_heads, dim_k)
+    v_shape = (batch, buffer_size, n_heads, dim_v)
+
+    cache = BlockKVCache(
+        k_shape=k_shape,
+        v_shape=v_shape,
+        seq_dim=1,
+        chunk_size=chunk_size,
+        window_size=window_size,
+        sink_size=sink_size,
+        device=device,
+        dtype=dtype,
+    )
+    naive = _NaiveKVCache(
+        window_size=window_size,
+        chunk_size=chunk_size,
+        sink_size=sink_size,
+    )
+
+    steady_k = torch.empty(
+        batch, chunk_size, n_heads, dim_k, device=device, dtype=dtype
+    )
+    steady_v = torch.empty(
+        batch, chunk_size, n_heads, dim_v, device=device, dtype=dtype
+    )
+    graph: torch.cuda.CUDAGraph | None = None
+    graph_outputs: tuple[torch.Tensor, torch.Tensor] | None = None
+    warmup_iters = 3
+    num_chunks = 8
+
+    compile_events: list[tuple[int | None, str, str, str]] = []
+    cudagraph_capture_events: list[tuple[int | None, str]] = []
+    current_chunk_idx: int | None = None
+    current_phase = ""
+
+    def on_compile_start(args: CallbackArgs) -> None:
+        compile_events.append(
+            (
+                current_chunk_idx,
+                current_phase,
+                str(args.callback_trigger),
+                args.compile_id,
+            )
+        )
+        _LOGGER.info(
+            "torch.compile triggered at chunk_idx=%s phase=%s trigger=%s compile_id=%s",
+            current_chunk_idx,
+            current_phase,
+            args.callback_trigger,
+            args.compile_id,
+        )
+
+    def cache_step(
+        active_cache: BlockKVCache, k: torch.Tensor, v: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        active_cache.update(k, v)
+        return active_cache.cached_k(), active_cache.cached_v()
+
+    compiled_cache_step = torch.compile(
+        cache_step, mode="max-autotune-no-cudagraphs"
+    )
+
+    def run_cache_step(
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        nonlocal graph, graph_outputs
+
+        if cache.is_steady_state():
+            steady_k.copy_(new_k)
+            steady_v.copy_(new_v)
+            if graph is None:
+                _LOGGER.info(
+                    "warming compiled steady-state path before CUDA graph capture at chunk_idx=%s phase=%s",
+                    current_chunk_idx,
+                    current_phase,
+                )
+                s = torch.cuda.Stream()
+                s.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(s):
+                    for _ in range(warmup_iters):
+                        compiled_cache_step(cache, steady_k, steady_v)
+                torch.cuda.current_stream().wait_stream(s)
+                compile_event_count_before_capture = len(compile_events)
+                cudagraph_capture_events.append((current_chunk_idx, current_phase))
+                _LOGGER.info(
+                    "capturing CUDA graph at chunk_idx=%s phase=%s",
+                    current_chunk_idx,
+                    current_phase,
+                )
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    graph_outputs = compiled_cache_step(cache, steady_k, steady_v)
+                assert len(compile_events) == compile_event_count_before_capture
+            else:
+                graph.replay()
+            assert graph_outputs is not None
+            return graph_outputs
+
+        return compiled_cache_step(cache, new_k, new_v)
+
+    dynamo.on_compile_start(on_compile_start)
+    try:
+        for chunk_idx in range(num_chunks):
+            _LOGGER.info("Running chunk %s", chunk_idx)
+            current_chunk_idx = chunk_idx
+            cache.before_update(chunk_idx)
+            try:
+                current_phase = "append"
+                new_k = torch.randn(
+                    batch, chunk_size, n_heads, dim_k, device=device, dtype=dtype
+                )
+                new_v = torch.randn(
+                    batch, chunk_size, n_heads, dim_v, device=device, dtype=dtype
+                )
+
+                naive.update(chunk_idx, new_k, new_v)
+                k_baseline = naive.cached_k()
+                v_baseline = naive.cached_v()
+
+                k_api, v_api = run_cache_step(new_k, new_v)
+                torch.testing.assert_close(k_api, k_baseline)
+                torch.testing.assert_close(v_api, v_baseline)
+
+                current_phase = "overwrite"
+                new_k = torch.randn(
+                    batch, chunk_size, n_heads, dim_k, device=device, dtype=dtype
+                )
+                new_v = torch.randn(
+                    batch, chunk_size, n_heads, dim_v, device=device, dtype=dtype
+                )
+
+                naive.update(chunk_idx, new_k, new_v)
+                k_baseline = naive.cached_k()
+                v_baseline = naive.cached_v()
+
+                k_api, v_api = run_cache_step(new_k, new_v)
+                torch.testing.assert_close(k_api, k_baseline)
+                torch.testing.assert_close(v_api, v_baseline)
+            finally:
+                cache.after_update(chunk_idx)
+                current_chunk_idx = None
+                current_phase = ""
+    finally:
+        dynamo.callback_handler.remove_start_callback(on_compile_start)
+
+    assert graph is not None
+    assert cudagraph_capture_events == [(3, "append")]
+    assert any(chunk_idx == 0 for chunk_idx, *_ in compile_events)
+    _LOGGER.info(
+        "torch.compile events: %s; CUDA graph capture events: %s",
+        compile_events,
+        cudagraph_capture_events,
+    )

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -327,7 +327,12 @@ def test_block_kvcache_cudagraph_matches_baseline(
     sink_size: int,
     window_size: int,
 ) -> None:
-    """BlockKVCache with CUDA graph (steady-state path) should match baseline."""
+    """BlockKVCache with CUDA graph (steady-state path) should match baseline.
+    
+    To print out the torch.compile events run with
+
+    uv run --group test pytest flashdreams/tests/test_kvcache.py::test_block_kvcache_compile_cudagraph_matches_baseline -vv -s -o log_cli=true --log-cli-level=INFO
+    """
     device = torch.device("cuda")
     batch, n_heads = 2, 4
     dim_k, dim_v = 8, 16

--- a/flashdreams/tests/test_kvcache.py
+++ b/flashdreams/tests/test_kvcache.py
@@ -327,12 +327,7 @@ def test_block_kvcache_cudagraph_matches_baseline(
     sink_size: int,
     window_size: int,
 ) -> None:
-    """BlockKVCache with CUDA graph (steady-state path) should match baseline.
-
-    To print out the torch.compile events run with
-
-    uv run --group test pytest flashdreams/tests/test_kvcache.py::test_block_kvcache_compile_cudagraph_matches_baseline -vv -s -o log_cli=true --log-cli-level=INFO
-    """
+    """BlockKVCache with CUDA graph (steady-state path) should match baseline."""
     device = torch.device("cuda")
     batch, n_heads = 2, 4
     dim_k, dim_v = 8, 16
@@ -448,7 +443,14 @@ def test_block_kvcache_cudagraph_matches_baseline(
 def test_block_kvcache_compile_cudagraph_matches_baseline(
     dtype: torch.dtype,
 ) -> None:
-    """BlockKVCache with torch.compile and CUDA graph should match baseline."""
+    """BlockKVCache with torch.compile and CUDA graph should match baseline.
+
+    To print out the torch.compile events run with
+
+    uv run --group test pytest \
+        flashdreams/tests/test_kvcache.py::test_block_kvcache_compile_cudagraph_matches_baseline \
+        -vv -s -o log_cli=true --log-cli-level=INFO
+    """
     import torch._dynamo as dynamo
 
     device = torch.device("cuda")


### PR DESCRIPTION
## Summary

Resolves #166

This MR reduces unnecessary `torch.compile` recompiles in `BlockKVCache` by removing the filling-vs-steady-state branch from the compiled cache update/read path.

Previously, `BlockKVCache.update()` branched on `is_steady_state()`:

```python
if self.is_steady_state():
    self._overwrite_rightmost_steady(k, v)
else:
    ...
```

That made Dynamo specialize on cache state such as `_n_cached`. In Omnidreams, this caused an extra recompile when entering steady state: the filling graph traced at AR1 was valid for `_n_cached < total_size`, but AR3 reached `_n_cached == total_size` and had to recompile.

This change replaces the branch with symbolic write bounds:

```python
write_start = torch.sym_min(self._n_cached, total_size - self.chunk_size)
write_end = write_start + self.chunk_size
```

So both filling and steady-state writes use the same compiled path.

## Why This Works

For a sink-free cache with:

chunk_size = 7040
total_size = 21120

The old behavior had separate logical paths:

- AR1: _n_cached = 7040   -> append [7040:14080]
- AR2: _n_cached = 14080  -> append [14080:21120]
- AR3: _n_cached = 21120  -> steady overwrite [14080:21120]

The AR1 graph was guarded for the append path, so AR3 triggered a new compile.

With symbolic bounds:

- AR1: min(7040, 14080)  = 7040   -> write [7040:14080]
- AR2: min(14080, 14080) = 14080  -> write [14080:21120]
- AR3: min(21120, 14080) = 14080  -> write [14080:21120]

All three cases are represented by the same expression, so Dynamo does not need a separate steady-state graph.

## Why torch.sym_min / torch.sym_max

Plain Python min() / max() can force Python to choose a branch during tracing, which may introduce guards like:

```python
_n_cached <= total_size - chunk_size
```

That is exactly the kind of specialization that causes recompiles.

`torch.sym_min()` / `torch.sym_max()` keep the bounds symbolic, allowing one compiled graph to cover both filling and steady-state values of _n_cached.

## Scope

This keeps the change local to the compiled path:

- `update()` now writes through unified symbolic bounds.
- `cached_k()` / `cached_v()` use symbolic visible bounds.
- `before_update()` / `after_update()` still own cache state progression outside the compiled Omnidreams network path.

## Validation

A new unit test:
```
uv run --group test pytest flashdreams/tests/test_kvcache.py::test_block_kvcache_compile_cudagraph_matches_baseline -vv -s -o log_cli=true --log-cli-level=INFO
```

After:

> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 0
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:505 torch.compile triggered at chunk_idx=0 phase=append trigger=CallbackTrigger.DYNAMO compile_id=0/0
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 1
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:505 torch.compile triggered at chunk_idx=1 phase=append trigger=CallbackTrigger.DYNAMO compile_id=0/1
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 2
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:505 torch.compile triggered at chunk_idx=2 phase=append trigger=CallbackTrigger.DYNAMO compile_id=0/2
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 3
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:531 warming compiled steady-state path before CUDA graph capture at chunk_idx=3 phase=append
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:544 capturing CUDA graph at chunk_idx=3 phase=append
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 4
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 5
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 6
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:563 Running chunk 7
> INFO     flashdreams.tests.test_kvcache:test_kvcache.py:608 torch.compile events: [(0, 'append', 'CallbackTrigger.DYNAMO', '0/0'), (1, 'append', 'CallbackTrigger.DYNAMO', '0/1'),(2, 'append', 'CallbackTrigger.DYNAMO', '0/2')]; CUDA graph capture events: [(3, 'append')]


Also tested with Omnidreams:

```bash
uv run --project integrations/omnidreams     flashdreams-run     omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf     --example-data True     --example_data_uuid "239560dc-33d1-11ef-9720-00044bcbccac"     --total-blocks 20
```  

before: AR3 diffuse is 54766.906ms (trigger recompile)

> AR 0 encode 51750.957 ms diffuse 54861.090 ms decode 23795.559 ms finalize 517.858 ms | total(w/o finalize) 130407.605 ms total 130925.463 ms | GPU mem alloc 34.567 GiB reserved 39.590 GiB peak 37.435 GiB
> AR 1 encode 33080.516 ms diffuse 61137.977 ms decode 19518.947 ms finalize 35.396 ms | total(w/o finalize) 113737.439 ms total 113772.835 ms | GPU mem alloc 34.568 GiB reserved 39.592 GiB peak 37.435 GiB
> AR 2 encode 51.383 ms diffuse 104.192 ms decode 5.160 ms finalize 40.144 ms | total(w/o finalize) 160.735 ms total 200.879 ms | GPU mem alloc 34.568 GiB reserved 41.305 GiB peak 37.435 GiB
> AR 3 encode 27.428 ms diffuse 54766.906 ms decode 23.794 ms finalize 62.752 ms | total(w/o finalize) 54818.128 ms total 54880.880 ms | GPU mem alloc 34.641 GiB reserved 42.088 GiB peak 37.435 GiB
> AR 4 encode 26.472 ms diffuse 77.498 ms decode 5.045 ms finalize 38.750 ms | total(w/o finalize) 109.015 ms total 147.765 ms | GPU mem alloc 34.641 GiB reserved 42.092 GiB peak 37.435 GiB

after: AR3 diffuse is 77.055ms

> AR 0 encode 58.201 ms diffuse 54822.320 ms decode 112.615 ms finalize 326.995 ms | total(w/o finalize) 54993.136 ms total 55320.130 ms | GPU mem alloc 34.031 GiB reserved 39.932 GiB peak 37.431 GiB
> AR 1 encode 45.635 ms diffuse 54749.875 ms decode 10.951 ms finalize 33.102 ms | total(w/o finalize) 54806.460 ms total 54839.562 ms | GPU mem alloc 34.032 GiB reserved 39.934 GiB peak 37.472 GiB
> AR 2 encode 45.496 ms diffuse 96.947 ms decode 11.727 ms finalize 38.169 ms | total(w/o finalize) 154.170 ms total 192.338 ms | GPU mem alloc 34.032 GiB reserved 39.934 GiB peak 37.472 GiB
> AR 3 encode 47.727 ms diffuse 77.055 ms decode 11.863 ms finalize 71.520 ms | total(w/o finalize) 136.646 ms total 208.166 ms | GPU mem alloc 34.064 GiB reserved 35.523 GiB peak 37.472 GiB
> AR 4 encode 46.799 ms diffuse 76.638 ms decode 11.649 ms finalize 37.662 ms | total(w/o finalize) 135.086 ms total 172.748 ms | GPU mem alloc 34.064 GiB reserved 40.271 GiB peak 37.504 GiB
