### PR TITLE
Update CODE_OF_CONDUCT link to be absolute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,7 +385,7 @@ disclosure process in
 ## Code of Conduct
 
 This project follows the
-[Code of Conduct](CODE_OF_CONDUCT.md).
+[Code of Conduct](https://github.com/NVIDIA/flashdreams/blob/main/CODE_OF_CONDUCT.md).
 By participating in this project — including issues, discussions, and
 pull requests — you agree to abide by it. Please report concerns to the
 maintainers via the address listed in the Code of Conduct.


### PR DESCRIPTION
Updates relative link to `CODE_OF_CONDUCT.md` in `CONTRIBUTING.md` to be an absolute link to GitHub so that the link is accessible from the `contribute.rst` page on the website, since the path to `CODE_OF_CONDUCT.md` is relative to `CONTRIBUTING.md` but not `contribute.rst`.