### PR TITLE
docs: add System Requirements section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ environments, and more.
 
 https://github.com/user-attachments/assets/2b000ce9-effe-4cc9-a227-5b4619413e4d
 
+## System Requirements
+
+- NVIDIA GPU with **80 GB VRAM or more** (e.g. H100 80GB), see notes below.
+- NVIDIA driver from the **R580 series or newer** (compatible with CUDA 13.x)
+- **CUDA 13.x** (PyTorch `2.11.0+cu130` and the `nvidia-*-cu13` libraries are
+  resolved by `uv sync`. A system CUDA toolkit is needed only for the
+  developer extras and is included in `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`)
+- **Python >= 3.10** 
+- **PyTorch >= 2.11.0+cu130** (`>= 2.9` for bare PyPI library install)
+- Linux x86-64 or arm64
+- **100 GB+ free storage space** recommended for environment and model checkpoints.
+- Docker with the
+  [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+  (optional, only for the container workflow)
+
+> Development and testing were performed on GPUs with **80 GB of VRAM or more**.
+> Inference can fail (out-of-memory) on consumer and even enthusiast GPUs.
+> Per-model GPU and VRAM requirements are listed on each model page in
+> [the model gallery](https://nvidia.github.io/flashdreams/main/models/index.html).
+
 ## Quickstart
 
 The complete setup is in

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/user-attachments/assets/2b000ce9-effe-4cc9-a227-5b4619413e4d
 - **CUDA 13.x** (PyTorch `2.11.0+cu130` and the `nvidia-*-cu13` libraries are
   resolved by `uv sync`. A system CUDA toolkit is needed only for the
   developer extras and is included in `nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`)
-- **Python >= 3.10** 
+- **Python >= 3.10**
 - **PyTorch >= 2.11.0+cu130** (`>= 2.9` for bare PyPI library install)
 - Linux x86-64 or arm64
 - **100 GB+ free storage space** recommended for environment and model checkpoints.


### PR DESCRIPTION
## Summary

Adds a **System Requirements** section to the top-level README, before Quickstart, so users can confirm hardware/software prerequisites before installing.

Requirements were derived from `pyproject.toml`, the per-integration `pyproject.toml` files, `uv.lock`, and `docker/`:

- **GPU/VRAM** — 80 GB VRAM or more (e.g. H100 80GB); inference can OOM on consumer/enthusiast GPUs
- **Driver** — R580 series or newer (CUDA 13.x compatible)
- **CUDA 13.x** — PyTorch `2.11.0+cu130` + `nvidia-*-cu13` libs resolved by `uv sync`; system CUDA toolkit only needed for dev extras (shipped in the `docker/` image)
- **Python >= 3.10**, **PyTorch >= 2.11.0+cu130** (`>= 2.9` for bare PyPI install)
- **Linux x86-64 or arm64** (arm64 covers Grace-based platforms, e.g. GB300)
- **100 GB+ free storage** for environment and model checkpoints
- **Docker + NVIDIA Container Toolkit** (optional, container workflow only)

A blockquote restates the 80 GB development/testing baseline and points to the per-model pages in the model gallery for individual GPU/VRAM requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)