### PR TITLE
docs: add per-model VRAM and PyTorch requirements

### DIFF
--- a/docs/source/models/causal_forcing.rst
+++ b/docs/source/models/causal_forcing.rst
@@ -39,6 +39,12 @@ interactive video generation.
      <a href="https://thu-ml.github.io/CausalForcing.github.io/">Causal-Forcing project page</a>.
    </p>
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~24 GB.
+- **PyTorch**: >= 2.9.
+
 Installation
 ------------
 

--- a/docs/source/models/causal_wan22.rst
+++ b/docs/source/models/causal_wan22.rst
@@ -26,6 +26,12 @@ Causal Wan2.2
 CausalWan2.2 is a `FastVideo <https://github.com/hao-ai-lab/FastVideo>`_-released
 14B MoE causal-diffusion variant of Wan 2.2 with 8-step inference.
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~112 GB.
+- **PyTorch**: >= 2.9.
+
 Installation
 ------------
 

--- a/docs/source/models/cosmos_predict2.rst
+++ b/docs/source/models/cosmos_predict2.rst
@@ -46,6 +46,12 @@ algorithm.
      <a href="https://research.nvidia.com/labs/cosmos-lab/cosmos-predict2.5/">Cosmos-Predict2.5 project page</a>.
    </p>
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~80 GB.
+- **PyTorch**: >= 2.9.
+
 Installation
 ------------
 

--- a/docs/source/models/flashvsr.rst
+++ b/docs/source/models/flashvsr.rst
@@ -40,6 +40,12 @@ gap, and a tiny conditional decoder for fast reconstruction.
      <a href="https://github.com/OpenImagingLab/FlashVSR">FlashVSR official repository</a>.
    </p>
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~24 GB.
+- **PyTorch**: >= 2.9.
+
 Installation
 ------------
 

--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -39,6 +39,12 @@ Introduced by `Robbyant <https://technology.robbyant.com/>`_, LingBot-World is a
      <a href="https://technology.robbyant.com/lingbot-world">LingBot-World project page</a>.
    </p>
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~120 GB (single 80 GB GPU may OOM).
+- **PyTorch**: >= 2.9.
+
 Installation
 ------------
 

--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -42,7 +42,7 @@ Introduced by `Robbyant <https://technology.robbyant.com/>`_, LingBot-World is a
 Requirements
 ------------
 
-- **Minimum VRAM**: ~120 GB (single 80 GB GPU may OOM).
+- **Minimum VRAM**: ~120 GB.
 - **PyTorch**: >= 2.9.
 
 Installation

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -42,6 +42,12 @@ throughput.
      <a href="https://research.nvidia.com/labs/sil/projects/omnidreams-blog/">OmniDreams project page</a>.
    </p>
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~48 GB.
+- **PyTorch**: >= 2.11.
+
 Installation
 ------------
 

--- a/docs/source/models/self_forcing.rst
+++ b/docs/source/models/self_forcing.rst
@@ -40,6 +40,12 @@ gap and enabling efficient streaming generation quality.
      <a href="https://self-forcing.github.io/">Self-Forcing project page</a>.
    </p>
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~24 GB.
+- **PyTorch**: >= 2.9.
+
 Installation
 ------------
 

--- a/docs/source/models/wan21.rst
+++ b/docs/source/models/wan21.rst
@@ -27,6 +27,12 @@ Wan2.1
 Wan2.1 is a bidirectional video generation model, supporting both
 text-to-video (T2V) and image-to-video (I2V) tasks.
 
+Requirements
+------------
+
+- **Minimum VRAM**: ~46 GB.
+- **PyTorch**: >= 2.9.
+
 Installation
 ------------
 


### PR DESCRIPTION
## Summary

Adds a **Requirements** section (Minimum VRAM + PyTorch version) to each model page under `docs/source/models/`. Addresses the review feedback that GPU/VRAM requirements need to be specific, and complements the repo-level System Requirements with per-model numbers.

## Changes

Added a `Requirements` block above `Installation` on all 8 model pages:

| Model | Minimum VRAM | PyTorch |
|---|---|---|
| Self-Forcing | ~24 GB | >= 2.9 |
| Causal-Forcing | ~24 GB | >= 2.9 |
| FlashVSR | ~24 GB | >= 2.9 |
| Wan2.1 | ~46 GB | >= 2.9 |
| OmniDreams | ~48 GB | >= 2.11 |
| Cosmos-Predict2.5 | ~80 GB | >= 2.9 |
| Causal Wan2.2 | ~112 GB | >= 2.9 |
| LingBot-World | ~120 GB | >= 2.9 |

## Notes

- VRAM figures measured via `nvidia-smi` (Self-Forcing, Causal-Forcing, FlashVSR, Wan2.1, OmniDreams on RTX 6000 Ada; Cosmos, Causal Wan2.2, LingBot on GB300).
- PyTorch pins taken from each integration's `pyproject.toml` (OmniDreams requires `>= 2.11`; the rest inherit core `>= 2.9`).
- The larger numbers are conservative (reserved memory at idle) and may exceed true active peak; can be tightened later with a `torch.cuda.max_memory_allocated()` measurement at full utilization.