### PR TITLE
Fix raster cuda-interop on resize

### DIFF
--- a/flashdreams/pyproject.toml
+++ b/flashdreams/pyproject.toml
@@ -57,9 +57,8 @@ dependencies = [
     # The maintainers ship a Windows-compatible drop-in under the
     # ``triton-windows`` package; pulling it on win32 keeps every
     # ``use_compile=True`` config path (encoder, decoder, DiT) working
-    # the same way it does on Linux. This is the same fix carried before
-    # on dev/truesight_alpa, scoped to the workspace member that owns
-    # the ``use_compile`` knob.
+    # the same way it does on Linux. This is scoped to the workspace
+    # member that owns the ``use_compile`` knob.
     "triton-windows>=3.5.0; sys_platform == 'win32'",
 ]
 
@@ -119,13 +118,12 @@ version = {attr = "flashdreams._version.__version__"}
 include = ["flashdreams*"]
 exclude = ["tests", "flashdreams._pytest_plugins*"]
 
-# PyPI's default ``torch`` is the CPU build on Windows. The truesight CUDA
-# extensions (built by ``uv run build-truesight``) need a CUDA-enabled
-# PyTorch so PyTorch's ``cpp_extension`` resolves ``CUDA_HOME`` from the
-# env (the gate is ``torch.version.cuda is not None``). On Linux the
+# PyPI's default ``torch`` is the CPU build on Windows. CUDA extensions need a
+# CUDA-enabled PyTorch so PyTorch's ``cpp_extension`` resolves ``CUDA_HOME``
+# from the env (the gate is ``torch.version.cuda is not None``). On Linux the
 # default wheel is already CUDA-enabled; on Windows we have to point at
-# NVIDIA's PyTorch index. Constrain by marker so the override only fires
-# on Windows -- Linux / NGC users keep the upstream wheel.
+# NVIDIA's PyTorch index. Constrain by marker so the override only fires on
+# Windows -- Linux / NGC users keep the upstream wheel.
 [[tool.uv.index]]
 name = "pytorch-cu130"
 url = "https://download.pytorch.org/whl/cu130"

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -388,8 +388,7 @@ SlangPy CUDA interop for generated RGB frames when the model output is still on
 CUDA:
 
 ```bash
-OMNIDREAMS_TRUESIGHT=1 \
-  uv run --no-sync --package flashdreams-omnidreams interactive-drive
+uv run --no-sync --package flashdreams-omnidreams interactive-drive
 ```
 
 Set `INTERACTIVE_DRIVE_DISABLE_CUDA_INTEROP=1` to force the conservative host
@@ -423,7 +422,6 @@ input-to-present timing while the demo runs:
 
 ```bash
 INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT=1 \
-  OMNIDREAMS_TRUESIGHT=1 \
   uv run --no-sync --package flashdreams-omnidreams interactive-drive --autoload-scene
 ```
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
@@ -185,7 +185,12 @@ class _LudusConditionRasterizerImpl:
         self._bev = bev
         self._device = torch.device("cuda:0")
         self._use_cuda_frames = not env_truthy(DISABLE_CUDA_INTEROP_ENV)
-        if not self._use_cuda_frames:
+        if self._use_cuda_frames:
+            print(
+                "[rasterizer] cuda_backend=enabled; returning lazy CUDA raster frames",
+                flush=True,
+            )
+        else:
             print(
                 f"[rasterizer] cuda_backend=disabled by {DISABLE_CUDA_INTEROP_ENV}; "
                 "using host raster frames",

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -877,7 +877,7 @@ class SlangPyHudPresenter:
         # texture is only the final HUD swapchain upload target.
         self._display_texture = display_texture
         if size_changed:
-            self._retire_cuda_hud_interop_after_resize()
+            self._recreate_cuda_hud_interop_after_resize(width, height)
         # Drop the chrome panel cache (its size depends on screen size)
         # and reallocate the canvas. Other caches are size-independent.
         self._panel_chrome_cache_key = None
@@ -1176,16 +1176,23 @@ class SlangPyHudPresenter:
         actual = self._window.size
         return self._normalise_present_size(actual.x, actual.y)
 
-    def _retire_cuda_hud_interop_after_resize(self) -> None:
+    def _recreate_cuda_hud_interop_after_resize(self, width: int, height: int) -> None:
         if self._cuda_hud_interop is None:
             return
         self._retired_cuda_hud_interops.append(self._cuda_hud_interop)
         self._cuda_hud_interop = None
+        self._cuda_hud_interop = self._create_cuda_hud_interop(width, height)
+        if self._cuda_hud_interop is not None:
+            print(
+                "[presenter] hud_cuda_interop=recreated after window resize",
+                flush=True,
+            )
+            self._cuda_hud_resize_logged = False
+            return
         if not self._cuda_hud_resize_logged:
             print(
                 "[presenter] hud_cuda_interop=disabled after window resize; "
-                "using host HUD upload so model CUDA graph resources are not "
-                "recreated during interactive resizing",
+                "could not recreate shared CUDA/Vulkan resources",
                 flush=True,
             )
             self._cuda_hud_resize_logged = True

--- a/integrations/omnidreams/tests/interactive_drive/test_presenter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_presenter.py
@@ -244,6 +244,29 @@ def test_model_rgb_does_not_materialize_host_frame_when_cuda_source_is_pending()
     assert lazy.numpy_calls == 0
 
 
+def test_hud_recreates_cuda_interop_after_resize() -> None:
+    presenter = _hud_presenter_without_window()
+    old_interop = object()
+    new_interop = object()
+    created_sizes: list[tuple[int, int]] = []
+    presenter._cuda_hud_interop = old_interop
+    presenter._retired_cuda_hud_interops = []
+    presenter._cuda_hud_resize_logged = True
+
+    def create_interop(width: int, height: int) -> object:
+        created_sizes.append((width, height))
+        return new_interop
+
+    presenter._create_cuda_hud_interop = create_interop
+
+    presenter._recreate_cuda_hud_interop_after_resize(123, 456)
+
+    assert presenter._retired_cuda_hud_interops == [old_interop]
+    assert presenter._cuda_hud_interop is new_interop
+    assert created_sizes == [(123, 456)]
+    assert presenter._cuda_hud_resize_logged is False
+
+
 def test_model_rgb_does_not_fallback_to_host_when_interop_buffers_are_busy() -> None:
     presenter = _presenter_without_window()
     lazy = _LazyFrame()
@@ -381,15 +404,17 @@ def test_hud_world_model_loading_pumps_events_and_presents_placeholder() -> None
     ]
 
 
-def test_hud_resize_updates_presenter_texture_without_recreating_cuda_interop() -> None:
+def test_hud_resize_updates_presenter_texture_and_recreates_cuda_interop() -> None:
     presenter = _hud_presenter_without_window()
     configured: list[tuple[int, int]] = []
+    created: list[tuple[int, int]] = []
 
     class _Interop:
         def close(self) -> None:
             raise AssertionError("resize should not destroy CUDA interop in place")
 
     interop = _Interop()
+    new_interop = _Interop()
     presenter._configured_size = (1920, 1080)
     presenter._surface_format = object()
     presenter._display_texture = "old-texture"
@@ -412,6 +437,9 @@ def test_hud_resize_updates_presenter_texture_without_recreating_cuda_interop() 
         width,
         height,
     )
+    presenter._create_cuda_hud_interop = lambda width, height: (
+        created.append((width, height)) or new_interop
+    )
 
     assert presenter._apply_resize(1000, 700)
 
@@ -419,7 +447,8 @@ def test_hud_resize_updates_presenter_texture_without_recreating_cuda_interop() 
     assert presenter._configured_size == (1000, 700)
     assert presenter._display_texture == ("texture", 1000, 700)
     assert presenter._canvas.size == (1000, 700)
-    assert presenter._cuda_hud_interop is None
+    assert created == [(1000, 700)]
+    assert presenter._cuda_hud_interop is new_interop
     assert presenter._retired_cuda_hud_interops == [interop]
 
 


### PR DESCRIPTION
This commit fixes raster CUDA interop after HUD window resize by recreating the
shared CUDA/Vulkan interop resources for the resized window instead of falling
back to the host path.