### PR TITLE
Fix interactive-drive HUD speed accuracy and add exit-scene control

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -288,8 +288,8 @@ per-axis activity strip -- so you can confirm the right device and watch each
 control move. It then listens while you move each control to capture the
 correct axes and directions (self-centering sticks and force-feedback wheels
 work because it peak-holds each axis' range rather than snapshotting after you
-let go), lets you bind reverse / reset buttons and test force feedback, then
-writes the profile to
+let go), lets you bind reverse / reset / exit-scene buttons and test force
+feedback, then writes the profile to
 `$FLASHDREAMS_CACHE_DIR/interactive-drive/wheels/` (by default under
 `~/.cache/flashdreams/`). The next `interactive-drive` launch discovers it
 automatically through the same `--wheel-profile auto` detection. The wizard
@@ -410,6 +410,7 @@ Controls (apply in all three modes):
 - `1` generated driving view
 - `2` HD map view
 - `R` reset rollout
+- `X` exit scene (return to the scene selector; HUD mode only)
 - `Esc` quit
 
 The browser control hint is static today, so it does not confirm every keydown

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -442,6 +442,14 @@ class InteractiveDriveApp:
                 oob_margin_m=self._config.oob_margin_m,
                 oob_warning_zone_m=self._config.oob_warning_zone_m,
             )
+            # Publish the freshly-built initial state up front so read-side
+            # speed readouts (the HUD speed digit, the browser ``/state``
+            # endpoint) reflect a reset / respawn immediately. Without this
+            # the last telemetry from the previous rollout would linger on
+            # screen through the "Resetting..." window until the new rollout
+            # requested its first chunk -- the "reset doesn't reset the
+            # displayed speed" symptom.
+            self._keyboard.update_telemetry(simulation.current_state)
             input_backend = KeyboardInputBackend(self._keyboard)
             reset_requested = run_main_loop(
                 presenter=self._presenter,

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -256,6 +256,7 @@ class WheelBridge:
         self._threshold = float(profile.threshold)
         self._reverse_buttons = {int(b) for b in profile.reverse_buttons}
         self._reset_buttons = {int(b) for b in profile.reset_buttons}
+        self._exit_buttons = {int(b) for b in profile.exit_buttons}
         self._reverse = False
         self._button_states: dict[int, int] = {}
         self._ffb = AutocenterFFB()
@@ -360,6 +361,10 @@ class WheelBridge:
             request_reset = getattr(self._control, "request_reset", None)
             if request_reset is not None:
                 request_reset()
+        elif code in self._exit_buttons:
+            request_exit_scene = getattr(self._control, "request_exit_scene", None)
+            if request_exit_scene is not None:
+                request_exit_scene()
 
     def _publish_controls(self) -> None:
         steering = self._normalize_steering(self._raw_axes[self._steering_axis])
@@ -812,26 +817,37 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
     scene_path: Any = config.scene_path
     variant = _resolve_scene_variant(scene_options, scene_path, config.variant)
     try:
-        # Initial scene-selection wait: if the user didn't pass
-        # ``--autoload-scene``, open the HUD and let them pick a scene from
-        # the dropdown while the model warms in the background.
-        if not args.autoload_scene:
-            request = presenter.wait_for_scene_selection()
-            if request is None:
-                return  # window closed before any scene was loaded
-            scene_path, variant = request
-            presenter.acknowledge_scene_change(scene_path, variant)
-
+        # ``need_selection`` drives the scene-selection wait: True on first
+        # launch (unless ``--autoload-scene``) and again every time the user
+        # exits a scene back to the selector. While waiting the engine is
+        # idle, so the video model stops generating -- the whole point of the
+        # exit-scene affordance for long-running demos -- without closing the
+        # window or dropping the warmed model.
+        need_selection = not args.autoload_scene
         while True:
+            if need_selection:
+                request = presenter.wait_for_scene_selection()
+                if request is None:
+                    break  # window closed before any scene was loaded
+                scene_path, variant = request
+                presenter.acknowledge_scene_change(scene_path, variant)
+                need_selection = False
+
             presenter.set_engine_active(True)
             # load_scene parses the USDZ on a background thread while keeping
             # the window responsive; it returns False if the window closed
             # (or a new scene was requested) before the parse finished, so
-            # we skip run_scene and let the pending-change check below decide
-            # whether to switch scenes or exit.
+            # we skip run_scene and let the pending checks below decide
+            # whether to exit the scene, switch scenes, or quit.
             if app.load_scene(scene_path, variant, args.prompt):
                 app.run_scene()
             presenter.set_engine_active(False)
+            if presenter.pending_exit_scene:
+                # ``x`` / bound exit button: tear down the rollout and go
+                # back to the selector over the same presenter.
+                presenter.acknowledge_exit_scene()
+                need_selection = True
+                continue
             requested = presenter.pending_scene_change
             if requested is None:
                 # Window closed (X / ESC) during load or run; we're done.

--- a/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
@@ -36,6 +36,13 @@ class KeyboardState:
         self._view_mode = "rgb"
         self._drive_command: DriverCommand | None = None
         self._reset_pending = False
+        # Rising-edge "exit the current scene and return to the scene
+        # selector" request, set by a wheel/controller's bound exit button
+        # (the HUD's ``x`` key calls the presenter directly). The presenter
+        # drains it on the main thread each ``process_events`` and converts
+        # it into its own exit-to-selection signal, mirroring how
+        # ``_reset_pending`` is drained by the runtime loop.
+        self._exit_scene_pending = False
         # Output telemetry slot. ``None`` means the simulation hasn't
         # produced a chunk yet (warmup window) -- callers render an empty
         # speed readout in that case.
@@ -56,6 +63,17 @@ class KeyboardState:
         with self._lock:
             self._reset_pending = True
 
+    def request_exit_scene(self) -> None:
+        """Request a return to the scene selector from a bound device button."""
+        with self._lock:
+            self._exit_scene_pending = True
+
+    def consume_exit_scene_request(self) -> bool:
+        with self._lock:
+            pending = self._exit_scene_pending
+            self._exit_scene_pending = False
+            return pending
+
     def set_drive_command(self, command: DriverCommand | None) -> None:
         with self._lock:
             self._drive_command = command
@@ -70,6 +88,16 @@ class KeyboardState:
         """
         with self._lock:
             self._vehicle_state = state
+
+    def clear_telemetry(self) -> None:
+        """Drop the published vehicle state (back to the pre-first-chunk state).
+
+        Called when a rollout is torn down (scene switch / exit to selector)
+        so read-side speed readouts fall back to their empty state instead of
+        lingering on the just-ended rollout's last reading.
+        """
+        with self._lock:
+            self._vehicle_state = None
 
     @property
     def vehicle_state(self) -> VehicleState | None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/input/wheel_profiles.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input/wheel_profiles.py
@@ -91,6 +91,11 @@ class WheelProfile:
     # evdev button codes (EV_KEY) bound to actions; empty when unbound.
     reverse_buttons: tuple[int, ...] = ()
     reset_buttons: tuple[int, ...] = ()
+    # Button(s) that exit the running scene and return to the scene
+    # selector (the HUD's ``x`` key does the same). Lets long-running
+    # demos drop back to "select a scene" from the wheel without a
+    # keyboard.
+    exit_buttons: tuple[int, ...] = ()
     # Steering feel: output scale (``< 1`` = less sensitive) and a center
     # deadzone fraction (hides analog-stick drift on game controllers).
     steering_range: float = 1.0
@@ -266,6 +271,7 @@ def _profile_from_data(data: dict, fallback_name: str) -> WheelProfile:
         is_default=bool(data.get("is_default", False)),
         reverse_buttons=tuple(int(b) for b in data.get("reverse_buttons", ()) or ()),
         reset_buttons=tuple(int(b) for b in data.get("reset_buttons", ()) or ()),
+        exit_buttons=tuple(int(b) for b in data.get("exit_buttons", ()) or ()),
         steering_range=float(data.get("steering_range", 1.0)),
         steering_deadzone=float(data.get("steering_deadzone", 0.0)),
     )
@@ -317,6 +323,7 @@ def wheel_profile_to_yaml_dict(profile: WheelProfile) -> dict:
         "threshold": profile.threshold,
         "reverse_buttons": list(profile.reverse_buttons),
         "reset_buttons": list(profile.reset_buttons),
+        "exit_buttons": list(profile.exit_buttons),
         "steering_range": profile.steering_range,
         "steering_deadzone": profile.steering_deadzone,
     }

--- a/integrations/omnidreams/omnidreams/interactive_drive/input_config/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input_config/app.py
@@ -701,12 +701,18 @@ class ConfigApp:
             wraplength=680,
             justify="left",
             text=(
-                "Optionally bind one button to toggle reverse and one to reset / "
-                "respawn. Click Bind, then press the button on your device. Leave "
-                "unbound to skip -- you can always reset with the R key."
+                "Optionally bind one button to toggle reverse, one to reset / "
+                "respawn, and one to exit the scene (back to the scene selector). "
+                "Click Bind, then press the button on your device. Leave unbound "
+                "to skip -- you can always reset with the R key and exit with the "
+                "X key."
             ),
         ).pack(anchor="w", pady=(0, 8))
-        for key, label in (("reverse", "Reverse"), ("reset", "Reset / respawn")):
+        for key, label in (
+            ("reverse", "Reverse"),
+            ("reset", "Reset / respawn"),
+            ("exit", "Exit scene"),
+        ):
             frame = ttk.LabelFrame(self.content, text=label, padding=(10, 6))
             frame.pack(fill="x", pady=4)
             result = tk.StringVar(value=self._button_summary(key))
@@ -936,6 +942,7 @@ class ConfigApp:
         if step == "buttons":
             self.state.setdefault("reverse_buttons", ())
             self.state.setdefault("reset_buttons", ())
+            self.state.setdefault("exit_buttons", ())
             return True, ""
         if step == "ffb":
             self._ffb_stop()
@@ -982,6 +989,7 @@ class ConfigApp:
             is_default=self.state["is_default"],
             reverse_buttons=tuple(self.state.get("reverse_buttons", ())),
             reset_buttons=tuple(self.state.get("reset_buttons", ())),
+            exit_buttons=tuple(self.state.get("exit_buttons", ())),
             steering_range=float(self.state.get("steering_range", 1.0)),
             steering_deadzone=float(self.state.get("steering_deadzone", 0.0)),
         )

--- a/integrations/omnidreams/omnidreams/interactive_drive/input_config/capture.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input_config/capture.py
@@ -142,6 +142,7 @@ def build_profile(
     is_default: bool,
     reverse_buttons: tuple[int, ...] = (),
     reset_buttons: tuple[int, ...] = (),
+    exit_buttons: tuple[int, ...] = (),
     steering_range: float = 1.0,
     steering_deadzone: float = 0.0,
     threshold: float = 0.12,
@@ -164,6 +165,7 @@ def build_profile(
         is_default=bool(is_default),
         reverse_buttons=tuple(int(b) for b in reverse_buttons),
         reset_buttons=tuple(int(b) for b in reset_buttons),
+        exit_buttons=tuple(int(b) for b in exit_buttons),
         steering_range=float(steering_range),
         steering_deadzone=float(steering_deadzone),
     )

--- a/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/simulation/ego_vehicle_kinematics.py
@@ -45,7 +45,19 @@ def integrate_vehicle(
         speed = 0.0
     elif command.manual_control:
         intended_direction = -1.0 if command.reverse else 1.0
-        if command.throttle > 0.01:
+        # Brake wins over throttle: holding both pedals together must bleed
+        # speed toward a stop, not build it. This matches real-car behaviour
+        # and the HUD / wheel target-speed integrators in ``demo.py`` (which
+        # already gate acceleration on the brake being released), so the
+        # displayed speed and the ego stay consistent when gas + brake are
+        # pressed at once.
+        if command.brake > 0.01:
+            decel = 12.0 * command.brake * dt_s
+            if speed > 0:
+                speed = max(0.0, speed - decel)
+            elif speed < 0:
+                speed = min(0.0, speed + decel)
+        elif command.throttle > 0.01:
             max_speed = vehicle.max_speed_mps
             accel = 2.0 * command.throttle * dt_s
             if speed * intended_direction < 0:
@@ -65,12 +77,6 @@ def integrate_vehicle(
                     )
                     taper = max(0.05, 0.5 * (1.0 - excess) ** 3)
                 speed += intended_direction * accel * taper
-        elif command.brake > 0.01:
-            decel = 12.0 * command.brake * dt_s
-            if speed > 0:
-                speed = max(0.0, speed - decel)
-            elif speed < 0:
-                speed = min(0.0, speed + decel)
         else:
             creep_target = (
                 4.47  # 10 mph, matching the HUD and AlpaSim manual-driver crawl.

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -100,6 +100,9 @@ WHEEL_ROTATION_QUANTUM_DEG = 3
 # pygame HUD used; keeps input latency low without burning a core.
 EVENT_POLL_INTERVAL_S = 0.005
 
+# Metres-per-second to miles-per-hour, for the speed digit.
+MPS_TO_MPH = 2.2369362920544
+
 # Drive-key release debounce window. See the
 # ``_pending_drive_releases`` field documentation in
 # :class:`SlangPyHudPresenter`.
@@ -273,6 +276,12 @@ class KeyboardStateDriveSink:
         # Lets a wheel/controller's bound reset button trigger the same
         # rollout reset the ``R`` key does.
         self._keyboard.request_reset()
+
+    def request_exit_scene(self) -> None:
+        # Lets a wheel/controller's bound exit button drop back to the scene
+        # selector, the same as the ``X`` key. The presenter drains this on
+        # its event-pump thread and converts it into an exit-to-selection.
+        self._keyboard.request_exit_scene()
 
     # The methods below are no-ops in-process because the slangpy HUD
     # writes pygame-style key events directly to ``KeyboardState`` from
@@ -481,6 +490,13 @@ class SlangPyHudPresenter:
         # and re-enters the engine over the SAME presenter so the slangpy
         # window (and the warmed model) stay alive.
         self._pending_scene_change: tuple[Any, str] | None = None
+        # Exit-to-selection request set by the ``x`` key or a wheel's bound
+        # exit button. The outer demo loop checks this (ahead of
+        # ``pending_scene_change``) after each ``app.run_scene`` returns: when
+        # set it tears down the rollout and re-enters the scene selector over
+        # the SAME presenter, so a long-running demo can stop the video model
+        # generating without closing the window or reloading the model.
+        self._pending_exit_scene = False
 
         self._key_codes = self._build_key_codes()
         # Drive-key release debounce. Some SDL3 builds send a
@@ -503,6 +519,13 @@ class SlangPyHudPresenter:
 
     def process_events(self) -> None:
         self._window.process_events()
+        # A wheel/controller's bound exit button posts its request onto the
+        # shared ``KeyboardState`` from the wheel reader thread; drain it here
+        # on the main thread and convert it into the presenter's own
+        # exit-to-selection signal (the ``x`` key takes the direct path in
+        # ``_on_keyboard_event``).
+        if self._keyboard.consume_exit_scene_request():
+            self.exit_scene()
 
     def prepare_frame(self, frame: PresentedFrame, view_mode: str) -> None:
         rgb = self._select_view_rgb(frame, view_mode)
@@ -2177,10 +2200,26 @@ class SlangPyHudPresenter:
         return None
 
     def _update_speed(self, wheel_state: Any) -> None:
-        # Magnitude: the digit shows speed, and reverse is conveyed by the
-        # "R" indicator, so a reverse target reads as a positive number that
+        # Drive the digit from the *authoritative* ego speed the simulation
+        # publishes once per chunk (``KeyboardState.vehicle_state``), so the
+        # readout always matches the vehicle the user is actually watching --
+        # the same source the browser/MJPEG ``/state`` readout already uses.
+        # The HUD's own ``target_speed_mps`` integrator (``wheel_state``) is a
+        # separate model that drifts from the ego and never resets on R /
+        # respawn, which is exactly the mismatch we're fixing here; it stays
+        # responsible only for force-feedback and the pedal chrome.
+        #
+        # Magnitude only: the digit shows speed and reverse is conveyed by the
+        # "R" indicator, so a reverse ego reads as a positive number that
         # dips to 0 at the direction change.
-        target_mph = abs(wheel_state.target_speed_mps) * 2.2369362920544
+        telemetry = self._keyboard.vehicle_state
+        if telemetry is not None:
+            target_mph = abs(telemetry.speed_mps) * MPS_TO_MPH
+        else:
+            # No chunk yet (warmup / between scenes): hold at zero rather than
+            # showing the integrator's creep-to-10mph target before the ego
+            # has actually moved.
+            target_mph = 0.0
         delta = target_mph - self._speed_mph
         self._speed_mph += delta * 0.18
 
@@ -2196,6 +2235,7 @@ class SlangPyHudPresenter:
             "s": _lookup_key(spy.KeyCode, "s"),
             "d": _lookup_key(spy.KeyCode, "d"),
             "r": _lookup_key(spy.KeyCode, "r"),
+            "x": _lookup_key(spy.KeyCode, "x"),
             "space": _lookup_key(spy.KeyCode, "space"),
             "up": _lookup_key(spy.KeyCode, "up", "arrow_up"),
             "down": _lookup_key(spy.KeyCode, "down", "arrow_down"),
@@ -2257,6 +2297,8 @@ class SlangPyHudPresenter:
             self._keyboard.set_view_mode("rgb")
         elif self._key_matches(key, "r"):
             self._keyboard.request_reset()
+        elif self._key_matches(key, "x"):
+            self.exit_scene()
 
     def _expire_pending_drive_releases(self) -> None:
         """Commit any debounced release whose grace window has passed.
@@ -2429,6 +2471,8 @@ class SlangPyHudPresenter:
         self._args.scene = scene_path
         self._args.variant = variant
         self._pending_scene_change = (scene_path, variant)
+        # An explicit scene pick supersedes any pending exit-to-selection.
+        self._pending_exit_scene = False
         self._should_close_flag = True
         # Drop the wheel-set DriverCommand so input state is clean for
         # the next scene -- otherwise a stale steer/throttle could
@@ -2440,6 +2484,47 @@ class SlangPyHudPresenter:
     def pending_scene_change(self) -> tuple[Any, str] | None:
         """``(scene_path, variant)`` if a dropdown click is pending, else None."""
         return self._pending_scene_change
+
+    def exit_scene(self) -> None:
+        """Request a return to the scene selector, keeping the window alive.
+
+        Mirrors :meth:`_signal_scene_change`: flips the close flag so
+        :func:`run_main_loop` exits and ``app.run_scene`` returns, but sets
+        ``_pending_exit_scene`` (instead of ``_pending_scene_change``) so the
+        demo's outer loop re-enters :meth:`wait_for_scene_selection` rather
+        than loading a new scene. No-op unless a scene is actually running, so
+        pressing ``x`` (or a bound exit button) at the selector does nothing.
+        """
+        if not self._engine_active:
+            return
+        self._pending_exit_scene = True
+        # An explicit exit overrides any scene change picked in the same tick.
+        self._pending_scene_change = None
+        self._should_close_flag = True
+        # Clean input state so a stale steer/throttle can't leak into the
+        # next scene the user eventually picks.
+        self._keyboard.set_drive_command(None)
+
+    @property
+    def pending_exit_scene(self) -> bool:
+        """True when the user asked to exit back to the scene selector."""
+        return self._pending_exit_scene
+
+    def acknowledge_exit_scene(self) -> None:
+        """Clear the exit request and reopen the window for scene selection.
+
+        Called by the demo's outer loop just before it re-enters
+        :meth:`wait_for_scene_selection`. Resets the close flag (so the
+        selection loop runs) and drops the displayed speed so the selector
+        doesn't show the just-exited rollout's last reading.
+        """
+        self._pending_exit_scene = False
+        self._should_close_flag = False
+        self._speed_mph = 0.0
+        # Drop the just-exited rollout's telemetry so the selector shows a
+        # zero speed rather than ramping back toward the last reading.
+        self._keyboard.clear_telemetry()
+        self._pending_drive_releases.clear()
 
     def set_model_status(
         self, *, can_prewarm: bool, ready_probe: Callable[[], bool]
@@ -2532,6 +2617,7 @@ class SlangPyHudPresenter:
         so the chrome reflects the new selection.
         """
         self._pending_scene_change = None
+        self._pending_exit_scene = False
         self._should_close_flag = False
         self._current_scene = scene_path
         self._selected_variant = variant
@@ -2552,6 +2638,10 @@ class SlangPyHudPresenter:
         self._panel_chrome_cache = None
         self._has_camera_frame = False
         self._speed_mph = 0.0
+        # Forget the previous rollout's speed so the digit doesn't ramp back
+        # toward it while the new scene loads; the new rollout republishes
+        # telemetry as soon as it starts.
+        self._keyboard.clear_telemetry()
         self._pending_drive_releases.clear()
 
     def set_wheel(self, wheel: Any | None) -> None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -2515,16 +2515,14 @@ class SlangPyHudPresenter:
 
         Called by the demo's outer loop just before it re-enters
         :meth:`wait_for_scene_selection`. Resets the close flag (so the
-        selection loop runs) and drops the displayed speed so the selector
-        doesn't show the just-exited rollout's last reading.
+        selection loop runs) and drops all per-rollout view state so the
+        selector shows the clean "Ready - pick a scene" / "WAITING FOR
+        BEV..." state rather than ghosting the just-exited rollout's last
+        camera frame, BEV minimap, and speed.
         """
         self._pending_exit_scene = False
         self._should_close_flag = False
-        self._speed_mph = 0.0
-        # Drop the just-exited rollout's telemetry so the selector shows a
-        # zero speed rather than ramping back toward the last reading.
-        self._keyboard.clear_telemetry()
-        self._pending_drive_releases.clear()
+        self._reset_scene_view_state()
 
     def set_model_status(
         self, *, can_prewarm: bool, ready_probe: Callable[[], bool]
@@ -2621,9 +2619,21 @@ class SlangPyHudPresenter:
         self._should_close_flag = False
         self._current_scene = scene_path
         self._selected_variant = variant
+        self._reset_scene_view_state()
+
+    def _reset_scene_view_state(self) -> None:
+        """Drop all per-rollout view state so the next state starts clean.
+
+        Shared by :meth:`acknowledge_scene_change` (new scene about to load)
+        and :meth:`acknowledge_exit_scene` (returning to the selector). Clears
+        the camera frame, BEV minimap, cached chrome, speed digit, and
+        telemetry so the camera area falls back to its placeholder ("Ready -
+        pick a scene" / "Loading Scene...") and the BEV panel to "WAITING FOR
+        BEV..." instead of ghosting the just-ended rollout's last frame.
+        """
         self._scene_dropdown_open = False
         self._variant_dropdown_open = False
-        # The new backend renders into a fresh ``rgb_host_uint8`` buffer
+        # The next backend renders into a fresh ``rgb_host_uint8`` buffer
         # so the camera resize cache (keyed on ``id(buffer)``) is now
         # stale; drop it. Same for the BEV cache.
         self._camera_resize_cache_key = None
@@ -2632,15 +2642,14 @@ class SlangPyHudPresenter:
         self._latest_bev_pil = None
         self._bev_panel_cache_key = None
         self._bev_panel_cache = None
-        # Panel chrome shows the new scene label, so its cache key
-        # changes naturally; explicitly invalidate to be safe.
+        # Panel chrome shows the scene label, so its cache key changes
+        # naturally; explicitly invalidate to be safe.
         self._panel_chrome_cache_key = None
         self._panel_chrome_cache = None
         self._has_camera_frame = False
         self._speed_mph = 0.0
         # Forget the previous rollout's speed so the digit doesn't ramp back
-        # toward it while the new scene loads; the new rollout republishes
-        # telemetry as soon as it starts.
+        # toward it; a new rollout republishes telemetry as soon as it starts.
         self._keyboard.clear_telemetry()
         self._pending_drive_releases.clear()
 

--- a/integrations/omnidreams/tests/interactive_drive/test_core_control.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_core_control.py
@@ -48,6 +48,40 @@ def test_sample_chunk_trajectory_advances_pose_and_time() -> None:
     assert chunk.boundary_state_after_chunk.speed_mps > 0.0
 
 
+def test_manual_brake_overrides_throttle_to_a_stop() -> None:
+    """Gas + brake pressed together must bleed speed toward a stop.
+
+    Regression for the HUD/ego mismatch: the manual-control branch used to
+    give throttle priority, so holding both pedals built speed. Brake now
+    wins, matching the HUD's speed readout and real-car behaviour.
+    """
+    vehicle = VehicleConfig()
+    state = VehicleState(
+        x_m=0.0, y_m=0.0, z_m=0.0, yaw_rad=0.0, speed_mps=10.0, steer_rad=0.0
+    )
+    both = DriverCommand(throttle=1.0, brake=1.0, manual_control=True)
+
+    decelerating = integrate_vehicle(state, both, dt_s=0.1, vehicle=vehicle)
+    assert decelerating.speed_mps < state.speed_mps
+
+    # Held long enough, the vehicle comes to rest rather than creeping.
+    for _ in range(200):
+        state = integrate_vehicle(state, both, dt_s=0.1, vehicle=vehicle)
+    assert state.speed_mps == pytest.approx(0.0, abs=1e-6)
+
+
+def test_manual_throttle_only_still_accelerates() -> None:
+    """Throttle without brake keeps its acceleration behaviour."""
+    vehicle = VehicleConfig()
+    state = VehicleState(
+        x_m=0.0, y_m=0.0, z_m=0.0, yaw_rad=0.0, speed_mps=0.0, steer_rad=0.0
+    )
+    throttle = DriverCommand(throttle=1.0, brake=0.0, manual_control=True)
+
+    advanced = integrate_vehicle(state, throttle, dt_s=0.1, vehicle=vehicle)
+    assert advanced.speed_mps > state.speed_mps
+
+
 def test_integrate_vehicle_accumulates_steering_gradually() -> None:
     vehicle = VehicleConfig(
         max_steer_rad=0.5, steer_rate_rad_per_s=1.0, steer_return_rate_rad_per_s=0.5

--- a/integrations/omnidreams/tests/interactive_drive/test_input_config_capture.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_input_config_capture.py
@@ -99,6 +99,7 @@ def test_build_profile_assembles_axis_map_and_flags() -> None:
         is_default=False,
         reverse_buttons=(304,),
         reset_buttons=(305,),
+        exit_buttons=(306,),
     )
     assert profile.axis_map == {"steering": 0x00, "throttle": 0x05, "brake": 0x02}
     assert profile.inverted_pedals is False
@@ -106,3 +107,4 @@ def test_build_profile_assembles_axis_map_and_flags() -> None:
     assert profile.detection_patterns == ("Generic Gamepad",)
     assert profile.reverse_buttons == (304,)
     assert profile.reset_buttons == (305,)
+    assert profile.exit_buttons == (306,)

--- a/integrations/omnidreams/tests/interactive_drive/test_keyboard_state.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_keyboard_state.py
@@ -44,3 +44,21 @@ def test_view_mode_reflects_set_view_mode() -> None:
     assert keyboard.view_mode == "rgb"
     keyboard.set_view_mode("hdmap")
     assert keyboard.view_mode == "hdmap"
+
+
+def test_consume_exit_scene_request_returns_false_when_none_pending() -> None:
+    keyboard = KeyboardState()
+    assert keyboard.consume_exit_scene_request() is False
+
+
+def test_consume_exit_scene_request_returns_true_once_per_request() -> None:
+    """The presenter drains the wheel-button exit request exactly once.
+
+    Same rising-edge contract as reset: a single exit-to-selection must not
+    re-fire across ticks once consumed.
+    """
+    keyboard = KeyboardState()
+    keyboard.request_exit_scene()
+    keyboard.request_exit_scene()
+    assert keyboard.consume_exit_scene_request() is True
+    assert keyboard.consume_exit_scene_request() is False

--- a/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_wheel_profiles.py
@@ -42,6 +42,7 @@ def _wheel_profile() -> WheelProfile:
         is_default=True,
         reverse_buttons=(294,),
         reset_buttons=(300,),
+        exit_buttons=(307,),
         steering_range=0.7,
         steering_deadzone=0.1,
     )
@@ -84,6 +85,7 @@ def test_yaml_dict_has_loader_schema_shape() -> None:
         "threshold",
         "reverse_buttons",
         "reset_buttons",
+        "exit_buttons",
         "steering_range",
         "steering_deadzone",
     }
@@ -92,6 +94,7 @@ def test_yaml_dict_has_loader_schema_shape() -> None:
     assert data["ffb"] == {"enabled": True, "gain": 0.6}
     assert data["reverse_buttons"] == [294]
     assert data["reset_buttons"] == [300]
+    assert data["exit_buttons"] == [307]
     assert data["steering_range"] == 0.7
     assert data["steering_deadzone"] == 0.1
 


### PR DESCRIPTION
## Summary

Fixes the interactive-drive HUD speed readout so it matches the ego vehicle, corrects gas+brake behaviour, makes reset clear the displayed speed, and adds an "exit scene" control that returns to the scene selector (for long-running demos where the video model shouldn't keep generating indefinitely).

## What changed

### Speed accuracy (HUD ↔ ego)
- The slangpy HUD speed digit read a **separate, parallel** speed integrator (`KeyboardDriveState`/`WheelBridge.target_speed_mps`) that drifted from the actual vehicle. It now reads the **authoritative ego speed** from `KeyboardState.vehicle_state` — the same telemetry the browser/MJPEG `/state` readout already uses — so the digit always matches the ego.
- `integrate_vehicle` now gives **brake priority** in the manual-control branch: holding gas + brake together bleeds speed to a stop instead of building speed, matching real-car behaviour and the HUD readout.

### Reset clears the displayed speed
- Pressing `R` (or OOB respawn) previously left the digit on a stale value because the parallel integrator was never reset. The loop now publishes the fresh initial state on every rollout (re)build, and the HUD forgets the prior rollout's telemetry on scene change / exit, so the readout reflects the reset immediately.

### Exit-scene control
- New **`X`** keyboard binding (HUD) returns to the "select a scene" state without closing the window or reloading the world model — the rollout is torn down so the model stops generating, ideal for long-running demos. Re-selecting a scene reuses the warmed model and cached geometry.
- The exit action is also a **configurable button** in `interactive-drive-configuration` (new "Exit scene" binding alongside reverse/reset), persisted as `exit_buttons` in the wheel/controller profile, so a wheel or gamepad button can trigger it.
- Exiting resets the camera and BEV minimap state so the selector shows the clean "Ready - pick a scene" / "WAITING FOR BEV..." view instead of ghosting the last frame.

## Controls

| Key | Action |
|---|---|
| `X` | Exit scene → back to the scene selector (HUD mode) |

(Plus the equivalent configurable wheel/controller button via `interactive-drive-configuration`.)

## Testing
- Added/updated unit tests: brake-priority and throttle behaviour in `integrate_vehicle`, `KeyboardState` exit-scene request plumbing, and `exit_buttons` profile serialization + capture.
- CPU test subset green: `pytest integrations/omnidreams/tests/interactive_drive -m "not gpu and not xvfb"`.

## Notes
- `README.md` controls + configuration-wizard docs updated to mention the exit-scene key and button.