### PR TITLE
build: bump flasdreams version to 0.1.0

### DIFF
--- a/flashdreams/flashdreams/_version.py
+++ b/flashdreams/flashdreams/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0rc1"
+__version__ = "0.1.0"

--- a/integrations/causal_forcing/pyproject.toml
+++ b/integrations/causal_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-causal-forcing"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "Causal-Forcing chunkwise / framewise streaming T2V + I2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/cosmos_predict2/pyproject.toml
+++ b/integrations/cosmos_predict2/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-cosmos-predict2"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "Cosmos-Predict2 T2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/fastvideo_causal_wan22/pyproject.toml
+++ b/integrations/fastvideo_causal_wan22/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-fastvideo-causal-wan22"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "FastVideo CausalWan 2.2 14B MoE distilled streaming T2V inference, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/flashvsr/pyproject.toml
+++ b/integrations/flashvsr/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-flashvsr"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "FlashVSR streaming video super-resolution (LR projector + Wan 2.1 DiT + TC decoder), packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/hy_worldplay/pyproject.toml
+++ b/integrations/hy_worldplay/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-hy-worldplay"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "HY-WorldPlay (HY-World 1.5) interactive world model integration for flashdreams (WAN 2.2 5B I2V variant)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-lingbot"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "Lingbot World streaming camera-control I2V integration + WebRTC server for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-omnidreams"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "Omnidreams inference with flashdreams (webrtc / gRPC servers + the interactive-drive desktop demo)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/self_forcing/pyproject.toml
+++ b/integrations/self_forcing/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-self-forcing"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "Self-Forcing distilled streaming T2V inference for Wan 2.1 1.3B, packaged as a flashdreams plugin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/wan21/pyproject.toml
+++ b/integrations/wan21/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-wan21"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "Wan 2.1 T2V + I2V non-streaming inference plugin for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/wan22/pyproject.toml
+++ b/integrations/wan22/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flashdreams-wan22"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "Wan 2.2 TI2V-5B inference recipe config for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Updates the version from `0.1.0rc1` (release candidate) to the stable release `0.1.0` across the core `flashdreams` package and all plugin integrations. No other code changes are included.

Version updates:

* Updated `__version__` in `flashdreams/_version.py` to `0.1.0`.
* Updated the `version` field to `0.1.0` in the following plugin `pyproject.toml` files:
  - `integrations/causal_forcing/pyproject.toml`
  - `integrations/cosmos_predict2/pyproject.toml`
  - `integrations/fastvideo_causal_wan22/pyproject.toml`
  - `integrations/flashvsr/pyproject.toml`
  - `integrations/hy_worldplay/pyproject.toml`
  - `integrations/lingbot/pyproject.toml`
  - `integrations/omnidreams/pyproject.toml`
  - `integrations/self_forcing/pyproject.toml`
  - `integrations/wan21/pyproject.toml`
  - `integrations/wan22/pyproject.toml`