### PR TITLE
Fix Interactive Drive Scene Switching and Conditioning Reset

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -209,6 +209,12 @@ class InteractiveDriveApp:
             return False  # presenter closed mid-load
         if error:
             raise error[0]
+        if self._presenter.should_close:
+            # A newer scene/variant click may have arrived on the same tick the
+            # loader finished. Do not bind this now-stale bundle or it can flash
+            # one rollout from the previous selection before the outer loop sees
+            # ``pending_scene_change``.
+            return False
         self._scene, self._map_bounds, self._ground_snapper = (  # type: ignore[assignment]
             loaded[0],
             loaded[1],
@@ -222,6 +228,11 @@ class InteractiveDriveApp:
             self._map_bounds,
             self._ground_snapper,
         )
+        if self._presenter.should_close:
+            # Same guard after cache bookkeeping: if the user clicked again
+            # while we were committing the loaded bundle, leave the presenter in
+            # close/requested state for the outer loop to consume.
+            return False
         self._pipeline.request_scene(self._scene)
         return True
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/base.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/base.py
@@ -60,6 +60,23 @@ class RenderBackend(ABC):
         self.warmup_model()
         self.load_scene(scene)
 
+    def reset(self) -> None:
+        """Reset the current rollout while keeping the current scene conditioning.
+
+        Backends with per-rollout state should override this. The default is
+        a no-op so pure raster backends do not need reset-specific code.
+        """
+        return
+
+    def reset_scene_conditioning(self) -> None:
+        """Reset all state that must not carry across scene/variant changes.
+
+        Manual resets should normally keep the same prompt/first-frame
+        embeddings. Scene switches must not, so the local video adapter calls
+        this before binding a newly selected scene.
+        """
+        self.reset()
+
     @abstractmethod
     def render_first_chunk(self, trajectory: TrajectoryChunk) -> FrameChunk:
         raise NotImplementedError

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
@@ -206,6 +206,14 @@ class WorldModelRenderBackend(RenderBackend):
             source_name="omnidreams",
         )
 
+    def reset(self) -> None:
+        self._session.reset()
+        self._next_chunk_count = 0
+
+    def reset_scene_conditioning(self) -> None:
+        self._session.reset(clear_precomputed_embeddings=True)
+        self._next_chunk_count = 0
+
     def close(self) -> None:
         self._session.close()
         self._rasterizer.cleanup()

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import time
 from collections.abc import Sequence
 from pathlib import Path
@@ -95,6 +96,7 @@ class WorldModelRenderBackend(RenderBackend):
         # Per-scene conditioning prep. On the default path this is a no-op
         # (the prompt is re-embedded per rollout in the session); under
         # --offload-text-encoder it (re)builds the per-scene embeddings.
+        _log_prompt_handoff("load_scene.prepare_for_scene", scene)
         self._session.prepare_for_scene(
             initial_rgb=scene.initial_rgb, prompt=scene.prompt
         )
@@ -142,6 +144,7 @@ class WorldModelRenderBackend(RenderBackend):
                 f"dir={self._manifest.debug_condition_frame_dir}",
                 flush=True,
             )
+        _log_prompt_handoff("first_chunk.start", scene)
         model_frames = self._session.start(
             scene.initial_rgb, condition_frames, scene.prompt
         )
@@ -270,3 +273,18 @@ class WorldModelRenderBackend(RenderBackend):
                 )
             )
         return tuple(merged)
+
+
+def _log_prompt_handoff(stage: str, scene: SceneBundle) -> None:
+    prompt = scene.prompt
+    prompt_text = " ".join(prompt.split())
+    prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
+    print(
+        "[world-model] prompt_handoff "
+        f"stage={stage!r} "
+        f"scene={scene.scene_path.name!r} "
+        f"prompt_sha256={prompt_hash!r} "
+        f"length={len(prompt)} "
+        f"text={prompt_text!r}",
+        flush=True,
+    )

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -828,6 +828,7 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
     # default are honoured; a dropdown selection overrides it below.
     scene_path: Any = config.scene_path
     variant = _resolve_scene_variant(scene_options, scene_path, config.variant)
+    presenter.acknowledge_scene_change(scene_path, variant)
     try:
         # ``need_selection`` drives the scene-selection wait: True on first
         # launch (unless ``--autoload-scene``) and again every time the user
@@ -1195,17 +1196,46 @@ def _resolve_scene_variant(
     Numbered scenes no longer carry a bare ``default`` entry, so a configured
     ``--variant default`` (or anything the scene lacks) falls back to the
     scene's first variant rather than a selection the dropdown can't show.
+    For weather sibling archives, the path itself is also a source of truth:
+    ``clipgt-...-snow.usdz`` with the default CLI variant should start as
+    ``snow``, not silently load the clear/base archive.
     """
+    for option in scene_options:
+        path_variant = _scene_option_variant_for_path(option, scene_path)
+        if path_variant is None:
+            continue
+        if variant in option.variants:
+            if variant == "default" and path_variant != "default":
+                return path_variant
+            return variant
+        if path_variant in option.variants:
+            return path_variant
+        return option.variants[0] if option.variants else variant
+    return variant
+
+
+def _scene_option_variant_for_path(option: SceneOption, scene_path: Any) -> str | None:
     try:
         resolved = Path(str(scene_path)).resolve()
     except OSError:
         resolved = None
-    for option in scene_options:
-        if option.path == resolved or str(option.path) == str(scene_path):
-            if variant in option.variants:
-                return variant
-            return option.variants[0] if option.variants else variant
-    return variant
+    raw = str(scene_path)
+
+    # ``variant_paths`` is the authoritative map for weather sibling archives.
+    # For legacy single-archive scenes it maps every in-zip variant to the same
+    # path, so the first variant intentionally matches the old fallback.
+    for variant, path in option.variant_paths.items():
+        if _same_scene_path(path, raw, resolved):
+            return variant
+    if _same_scene_path(option.path, raw, resolved):
+        if "default" in option.variants:
+            return "default"
+        return option.variants[0] if option.variants else None
+    return None
+
+
+def _same_scene_path(path: Path, raw: str, resolved: Path | None) -> bool:
+    return (resolved is not None and path == resolved) or str(path) == raw
 
 
 def _load_scene_thumbnail(scene_path: Path) -> Image.Image | None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -503,6 +503,8 @@ def run_main_loop(
 
     while not presenter.should_close:
         presenter.process_events()
+        if presenter.should_close:
+            break
         if runtime_controls.consume_reset_request():
             return True
         sampled = input_backend.sample()

--- a/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/scene_loader.py
@@ -100,6 +100,12 @@ def _load_initial_image(
         raise FileNotFoundError(
             "No frames/<camera>/*.jpeg or first_image*.png found in the USDZ archive"
         )
+    _log_initial_frame_selection(
+        zf,
+        variant=variant,
+        camera_name=camera_name,
+        source=name,
+    )
     with Image.open(io.BytesIO(zf.read(name))) as image:
         rgb = image.convert("RGB")
         resized = rgb.resize(raster.resolution_wh, resample=Image.Resampling.BILINEAR)
@@ -232,6 +238,24 @@ def _log_prompt_selection(
         f"ignored_files={ignored_files or '<none>'!r} "
         f"length={len(prompt)} "
         f"text={prompt_text!r}",
+        flush=True,
+    )
+
+
+def _log_initial_frame_selection(
+    zf: zipfile.ZipFile,
+    *,
+    variant: str,
+    camera_name: str,
+    source: str,
+) -> None:
+    scene_name = Path(str(zf.filename)).name if zf.filename is not None else "<archive>"
+    print(
+        "[scene_loader] initial_frame "
+        f"scene={scene_name!r} "
+        f"requested_variant={variant!r} "
+        f"camera={camera_name!r} "
+        f"source={source!r}",
         flush=True,
     )
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -2120,7 +2120,7 @@ class SlangPyHudPresenter:
             top = items_top + idx * item_h
             rect = (sx, top, sr, top + item_h)
             self._scene_item_rects.append((rect, scene))
-            if scene.path == self._current_scene:
+            if self._scene_option_matches_current(scene):
                 draw.rectangle(rect, fill=ACTIVE_BG + (255,))
             elif scene.label == self._hovered_scene_label:
                 draw.rectangle(rect, fill=HOVER_BG + (255,))
@@ -2214,9 +2214,18 @@ class SlangPyHudPresenter:
 
     def _current_scene_option(self) -> Any:
         for option in self._scene_options:
-            if option.path == self._current_scene:
+            if self._scene_option_matches_current(option):
                 return option
         return None
+
+    def _scene_option_matches_current(self, option: Any) -> bool:
+        current = self._current_scene
+        if option.path == current or str(option.path) == str(current):
+            return True
+        for path in getattr(option, "variant_paths", {}).values():
+            if path == current or str(path) == str(current):
+                return True
+        return False
 
     def _update_speed(self, wheel_state: Any) -> None:
         # Drive the digit from the *authoritative* ego speed the simulation

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -114,9 +114,10 @@ class ChunkPipeline:
         with self._generation_lock:
             return self._generation
 
-    def _bump_generation(self) -> None:
+    def _bump_generation(self) -> int:
         with self._generation_lock:
             self._generation += 1
+            return self._generation
 
     @property
     def frame_queue(self) -> "queue.Queue[QueuedFrame]":
@@ -134,10 +135,22 @@ class ChunkPipeline:
         """
         self._raise_worker_error_if_any()
         # Supersede any in-flight / queued render so its frames are dropped
-        # rather than briefly shown over the new scene's load.
-        self._bump_generation()
+        # rather than briefly shown over the new scene's load. The generation
+        # also guards queued scene-load commands themselves: a click can arrive
+        # while a previous load is still sitting behind model warmup, and that
+        # old load must not bind its prompt/seed after the newer selection wins.
+        submit_generation = self._bump_generation()
 
         def load_scene_command(backend: VideoModelBackend) -> bool:
+            if submit_generation != self.current_generation:
+                print(
+                    "[chunk-pipeline] skip stale scene load "
+                    f"scene={scene.scene_path.name!r} "
+                    f"submit_generation={submit_generation} "
+                    f"current_generation={self.current_generation}",
+                    flush=True,
+                )
+                return True
             backend.load_scene(scene)
             return True
 
@@ -152,6 +165,15 @@ class ChunkPipeline:
 
         def render_command(backend: VideoModelBackend) -> bool:
             chunk_times.chunk_render_start_time = time.perf_counter()
+            if submit_generation != self.current_generation:
+                chunk_times.chunk_ready_time = time.perf_counter()
+                print(
+                    "[chunk-pipeline] skip stale render "
+                    f"submit_generation={submit_generation} "
+                    f"current_generation={self.current_generation}",
+                    flush=True,
+                )
+                return True
             frame_chunk = backend.render_chunk(trajectory)
             chunk_times.chunk_ready_time = time.perf_counter()
             # Drop the output if a reset / scene switch superseded this chunk

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -119,6 +119,16 @@ class ChunkPipeline:
             self._generation += 1
             return self._generation
 
+    def _clear_frame_queue(self) -> int:
+        """Drop already-produced frames superseded by a reset / scene switch."""
+        cleared = 0
+        while True:
+            try:
+                self._frame_queue.get_nowait()
+            except queue.Empty:
+                return cleared
+            cleared += 1
+
     @property
     def frame_queue(self) -> "queue.Queue[QueuedFrame]":
         self._raise_worker_error_if_any()
@@ -140,6 +150,13 @@ class ChunkPipeline:
         # while a previous load is still sitting behind model warmup, and that
         # old load must not bind its prompt/seed after the newer selection wins.
         submit_generation = self._bump_generation()
+        cleared = self._clear_frame_queue()
+        if cleared:
+            print(
+                "[chunk-pipeline] cleared stale frame queue "
+                f"frames={cleared} generation={submit_generation}",
+                flush=True,
+            )
 
         def load_scene_command(backend: VideoModelBackend) -> bool:
             if submit_generation != self.current_generation:
@@ -208,7 +225,14 @@ class ChunkPipeline:
         FIFO so the next rollout starts from a clean cache.
         """
         self._raise_worker_error_if_any()
-        self._bump_generation()
+        generation = self._bump_generation()
+        cleared = self._clear_frame_queue()
+        if cleared:
+            print(
+                "[chunk-pipeline] cleared stale frame queue "
+                f"frames={cleared} generation={generation}",
+                flush=True,
+            )
 
         def reset_command(backend: VideoModelBackend) -> bool:
             backend.reset()

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/local.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/local.py
@@ -27,6 +27,9 @@ class LocalVideoModelAdapter:
         self._backend.warmup_model()
 
     def load_scene(self, scene: SceneBundle) -> None:
+        # Scene/variant switches must not carry over rollout cache, text/image
+        # embeddings, or first-chunk state from the previous selection.
+        self._backend.reset_scene_conditioning()
         self._backend.load_scene(scene)
         # A scene (re)load restarts the rollout: the next chunk must be a
         # first chunk so the world-model session re-initialises its cache
@@ -40,4 +43,5 @@ class LocalVideoModelAdapter:
         return self._backend.render_next_chunk(trajectory)
 
     def reset(self) -> None:
+        self._backend.reset()
         self._is_first_chunk = True

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -478,10 +478,17 @@ class FlashdreamsWorldModelSession:
             )
         return model_frames
 
-    def reset(self) -> None:
+    def reset(self, *, clear_precomputed_embeddings: bool = False) -> None:
         self._cache = None
         self._pending_finalization_index = None
         self._next_block_index = 0
+        if clear_precomputed_embeddings:
+            self._precomputed_embeddings = None
+            print(
+                "[flashdreams-session] reset scene conditioning; "
+                "will rerun text/image encoders for the next scene",
+                flush=True,
+            )
 
     def close(self) -> None:
         if self._cache is not None and self._pending_finalization_index is not None:

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -60,6 +60,7 @@ from omnidreams.transformer import (
 from omnidreams.transformer.impl.network import CosmosDiTNetworkCache
 from torch import Tensor
 
+from flashdreams.core.attention import BlockKVCache
 from flashdreams.core.distributed.context_parallel import (
     cat_outputs_cp,
     split_inputs_cp,
@@ -416,7 +417,12 @@ def _make_cosmos_streaming_workspace(
 
 
 class _CosmosNetworkShapeOps(torch.nn.Module):
-    """Weightless replacement for CosmosDiTNetwork patch/unpatch helpers."""
+    """Lightweight replacement for CosmosDiTNetwork patch/cache helpers.
+
+    FP8 native execution can drop the full PyTorch DiT after the first rollout,
+    but scene switches still need fresh cross-attention K/V from the new text
+    context. Keep only the small projection subset needed for cache init.
+    """
 
     def __init__(
         self,
@@ -425,11 +431,13 @@ class _CosmosNetworkShapeOps(torch.nn.Module):
         device: torch.device,
         dtype: torch.dtype,
         cache_templates: tuple[CosmosDiTNetworkCache, ...] = (),
+        cross_cache_weights: Mapping[str, Tensor] | None = None,
     ) -> None:
         super().__init__()
         self.config = config
         self._cache_templates = cache_templates
         self._cache_template_index = 0
+        self._cross_cache_weights = dict(cross_cache_weights or {})
         self._device_anchor = torch.nn.Parameter(
             torch.empty(0, device=device, dtype=dtype),
             requires_grad=False,
@@ -452,8 +460,7 @@ class _CosmosNetworkShapeOps(torch.nn.Module):
         sink_size: int,
         context: Tensor,
     ) -> CosmosDiTNetworkCache:
-        """Clone the pre-release cache template for a new FP8 rollout."""
-        del context
+        """Clone the geometry template and rebuild prompt-dependent K/V."""
         if self._cache_template_index >= len(self._cache_templates):
             raise RuntimeError(
                 "optimized native FP8 DiT released the upstream network before a "
@@ -472,7 +479,54 @@ class _CosmosNetworkShapeOps(torch.nn.Module):
                 "optimized native FP8 DiT cache template geometry does not match "
                 "the requested rollout reset geometry."
             )
-        return _clone_network_cache(template)
+        cache = _clone_network_cache(template)
+        context = self._project_crossattn_context(context)
+        for block_idx, block_cache in enumerate(cache.block_caches):
+            block_cache.cross_attn = self._make_cross_attn_cache(block_idx, context)
+        return cache
+
+    def _weight(self, key: str, *, like: Tensor) -> Tensor:
+        try:
+            weight = self._cross_cache_weights[key]
+        except KeyError as exc:
+            raise RuntimeError(
+                "optimized native FP8 DiT cannot rebuild cross-attention cache "
+                f"after releasing the PyTorch network; missing weight {key!r}."
+            ) from exc
+        return weight.to(device=like.device, dtype=like.dtype)
+
+    def _project_crossattn_context(self, context: Tensor) -> Tensor:
+        if not getattr(self.config, "use_crossattn_projection", False):
+            return context
+        weight = self._weight("crossattn_proj.0.weight", like=context)
+        bias = self._weight("crossattn_proj.0.bias", like=context)
+        return F.gelu(F.linear(context, weight, bias))
+
+    def _make_cross_attn_cache(self, block_idx: int, context: Tensor) -> BlockKVCache:
+        prefix = f"blocks.{block_idx}.cross_attn."
+        k_weight = self._weight(prefix + "k_proj.weight", like=context)
+        v_weight = self._weight(prefix + "v_proj.weight", like=context)
+        k_norm_weight = self._weight(prefix + "k_norm.weight", like=context)
+
+        batch_shape = context.shape[:-2]
+        batch_size = math.prod(batch_shape)
+        token_count = int(context.shape[-2])
+        inner_dim = int(k_weight.shape[0])
+        num_heads = int(self.config.num_heads)
+        if inner_dim % num_heads != 0:
+            raise RuntimeError(
+                f"cross-attention inner_dim={inner_dim} is not divisible by "
+                f"num_heads={num_heads}"
+            )
+        head_dim = inner_dim // num_heads
+        k = F.linear(context, k_weight).reshape(
+            batch_size, token_count, num_heads, head_dim
+        )
+        k = F.rms_norm(k, (head_dim,), weight=k_norm_weight, eps=1e-6)
+        v = F.linear(context, v_weight).reshape(
+            batch_size, token_count, num_heads, head_dim
+        )
+        return BlockKVCache.from_tensor(k.contiguous(), v.contiguous(), seq_dim=-3)
 
     def patchify_and_maybe_split_cp(
         self,
@@ -732,6 +786,7 @@ class OptimizedDiTExecutor:
         self._sparge_hybrid_phase = 0
 
         self._optimized_weights: dict[str, Tensor] | None = None
+        self._cross_cache_weights: dict[str, Tensor] | None = None
         self._bf16_runtime: dict[str, Any] | None = None
         self._fp8_runtime: dict[str, Any] | None = None
         self._bf16_runtime_device: torch.device | None = None
@@ -995,6 +1050,7 @@ class OptimizedDiTExecutor:
         """Snapshot ``self.network.state_dict()`` once. Idempotent."""
         if self._optimized_weights is None:
             state_dict = self.network.state_dict()
+            self._snapshot_cross_cache_weights(state_dict)
             if self._uses_fp8_dit:
                 from cosmos_fp8_utils import (
                     prepare_cosmos_quantized_streaming_weights,
@@ -1029,6 +1085,25 @@ class OptimizedDiTExecutor:
                 self._optimized_weights = prepare_cosmos_streaming_weights(state_dict)
         return self._optimized_weights
 
+    def _snapshot_cross_cache_weights(self, state_dict: Mapping[str, Tensor]) -> None:
+        if self._cross_cache_weights is not None:
+            return
+        keys: list[str] = []
+        if getattr(self.network.config, "use_crossattn_projection", False):
+            keys.extend(["crossattn_proj.0.weight", "crossattn_proj.0.bias"])
+        for block_idx in range(int(self.config.network.num_blocks)):
+            prefix = f"blocks.{block_idx}.cross_attn."
+            keys.extend(
+                [
+                    prefix + "k_proj.weight",
+                    prefix + "v_proj.weight",
+                    prefix + "k_norm.weight",
+                ]
+            )
+        self._cross_cache_weights = {
+            key: state_dict[key].detach().contiguous() for key in keys
+        }
+
     def _drop_redundant_bf16_prepared_weights(self) -> None:
         """Remove BF16 prepared aliases superseded by FP8 prepared weights."""
         if self._optimized_weights is None:
@@ -1053,6 +1128,7 @@ class OptimizedDiTExecutor:
             device=next(self.network.parameters()).device,
             dtype=self.config.dtype,
             cache_templates=self._optimized_network_cache_templates,
+            cross_cache_weights=self._cross_cache_weights,
         )
         # After release, optimized native's own _optimized_call owns CUDA graph capture.
         # The parent graph wrappers point at the freed PyTorch network and

--- a/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
@@ -3,6 +3,8 @@
 
 import threading
 import time
+from dataclasses import replace
+from pathlib import Path
 
 import numpy as np
 from omnidreams.interactive_drive._pipeline_fakes import (
@@ -11,7 +13,7 @@ from omnidreams.interactive_drive._pipeline_fakes import (
     minimal_scene,
 )
 from omnidreams.interactive_drive.runtime.timing import ChunkPrediction, ChunkTimes
-from omnidreams.interactive_drive.types import FrameChunk, PresentedFrame
+from omnidreams.interactive_drive.types import FrameChunk, PresentedFrame, SceneBundle
 from omnidreams.interactive_drive.video_model.chunk_pipeline import (
     ChunkPipeline,
     ChunkRequest,
@@ -30,7 +32,7 @@ class _GatedBackend:
     def warmup_model(self) -> None:
         self.warmup_model_calls += 1
 
-    def load_scene(self, scene: object) -> None:
+    def load_scene(self, scene: SceneBundle) -> None:
         del scene
 
     def reset(self) -> None:
@@ -48,6 +50,41 @@ class _GatedBackend:
             frames=(frame,),
             boundary_state_after_chunk=trajectory.boundary_state_after_chunk,
             source_name="gated",
+        )
+
+
+class _GatedWarmupBackend:
+    """Backend whose warmup blocks so scene loads can queue behind it."""
+
+    def __init__(self) -> None:
+        self.warmup_started = threading.Event()
+        self.release_warmup = threading.Event()
+        self.scene_loaded = threading.Event()
+        self.loaded_prompts: list[str] = []
+        self.render_calls = 0
+
+    def warmup_model(self) -> None:
+        self.warmup_started.set()
+        self.release_warmup.wait(timeout=5.0)
+
+    def load_scene(self, scene: SceneBundle) -> None:
+        self.loaded_prompts.append(scene.prompt)
+        self.scene_loaded.set()
+
+    def reset(self) -> None:
+        return
+
+    def render_chunk(self, trajectory: object) -> FrameChunk:
+        self.render_calls += 1
+        frame = PresentedFrame(
+            timestamp_us=0,
+            rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+            depth_host_f32=None,
+        )
+        return FrameChunk(
+            frames=(frame,),
+            boundary_state_after_chunk=trajectory.boundary_state_after_chunk,
+            source_name="gated-warmup",
         )
 
 
@@ -139,3 +176,28 @@ def test_chunk_pipeline_drops_superseded_render_after_reset() -> None:
     # The in-flight render belonged to the pre-reset generation, so its
     # frame is dropped rather than queued.
     assert pipeline.frame_queue.qsize() == 0
+
+
+def test_chunk_pipeline_skips_stale_scene_load_queued_behind_warmup() -> None:
+    backend = _GatedWarmupBackend()
+    pipeline = ChunkPipeline(backend)
+    assert backend.warmup_started.wait(timeout=1.0)
+
+    default_scene = replace(
+        minimal_scene(), scene_path=Path("clipgt-scene.usdz"), prompt="clear"
+    )
+    snow_scene = replace(
+        minimal_scene(), scene_path=Path("clipgt-scene-snow.usdz"), prompt="snow"
+    )
+
+    pipeline.request_scene(default_scene)
+    pipeline.request_pose_chunk(
+        ChunkRequest(trajectory=make_trajectory(1), chunk_times=_chunk_times(1))
+    )
+    pipeline.request_scene(snow_scene)
+    backend.release_warmup.set()
+    assert backend.scene_loaded.wait(timeout=1.0)
+    pipeline.shutdown()
+
+    assert backend.loaded_prompts == ["snow"]
+    assert backend.render_calls == 0

--- a/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
@@ -88,6 +88,18 @@ class _GatedWarmupBackend:
         )
 
 
+def _wait_for_queue_size(pipeline: ChunkPipeline, size: int) -> None:
+    deadline = time.perf_counter() + 1.0
+    while time.perf_counter() < deadline:
+        if pipeline.frame_queue.qsize() >= size:
+            return
+        time.sleep(0.01)
+    raise AssertionError(
+        f"timed out waiting for frame queue size {size}; "
+        f"actual={pipeline.frame_queue.qsize()}"
+    )
+
+
 def _chunk_times(chunk_size: int) -> ChunkTimes:
     now = time.perf_counter()
     return ChunkTimes.create(
@@ -175,6 +187,38 @@ def test_chunk_pipeline_drops_superseded_render_after_reset() -> None:
     assert backend.reset_calls == 1
     # The in-flight render belonged to the pre-reset generation, so its
     # frame is dropped rather than queued.
+    assert pipeline.frame_queue.qsize() == 0
+
+
+def test_chunk_pipeline_reset_clears_already_queued_frames() -> None:
+    backend = FakeVideoModelBackend(frames_per_render=2)
+    pipeline = ChunkPipeline(backend)
+    pipeline.request_scene(minimal_scene())
+    pipeline.request_pose_chunk(
+        ChunkRequest(trajectory=make_trajectory(2), chunk_times=_chunk_times(2))
+    )
+    _wait_for_queue_size(pipeline, 2)
+
+    pipeline.reset()
+    pipeline.shutdown()
+
+    assert backend.reset_calls == 1
+    assert pipeline.frame_queue.qsize() == 0
+
+
+def test_chunk_pipeline_scene_change_clears_already_queued_frames() -> None:
+    backend = FakeVideoModelBackend(frames_per_render=2)
+    pipeline = ChunkPipeline(backend)
+    pipeline.request_scene(minimal_scene())
+    pipeline.request_pose_chunk(
+        ChunkRequest(trajectory=make_trajectory(2), chunk_times=_chunk_times(2))
+    )
+    _wait_for_queue_size(pipeline, 2)
+
+    pipeline.request_scene(replace(minimal_scene(), prompt="new scene"))
+    pipeline.shutdown()
+
+    assert backend.load_scene_calls == 2
     assert pipeline.frame_queue.qsize() == 0
 
 

--- a/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnidreams.interactive_drive.demo import SceneOption, _resolve_scene_variant
+
+
+def test_resolve_scene_variant_prefers_weather_archive_path_for_default(
+    tmp_path: Path,
+) -> None:
+    scene_uuid = "0d404ff7-2b66-498c-b047-1ed8cded60d4"
+    base = (tmp_path / f"clipgt-{scene_uuid}.usdz").resolve()
+    snow = (tmp_path / f"clipgt-{scene_uuid}-snow.usdz").resolve()
+    option = SceneOption(
+        label="Quiet Suburban Boulevard",
+        path=base,
+        variants=("default", "rain", "snow"),
+        variant_paths={"default": base, "snow": snow},
+    )
+
+    assert _resolve_scene_variant((option,), snow, "default") == "snow"
+
+
+def test_resolve_scene_variant_keeps_explicit_weather_choice(tmp_path: Path) -> None:
+    scene_uuid = "0d404ff7-2b66-498c-b047-1ed8cded60d4"
+    base = (tmp_path / f"clipgt-{scene_uuid}.usdz").resolve()
+    snow = (tmp_path / f"clipgt-{scene_uuid}-snow.usdz").resolve()
+    rain = (tmp_path / f"clipgt-{scene_uuid}-rain.usdz").resolve()
+    option = SceneOption(
+        label="Quiet Suburban Boulevard",
+        path=base,
+        variants=("default", "rain", "snow"),
+        variant_paths={"default": base, "rain": rain, "snow": snow},
+    )
+
+    assert _resolve_scene_variant((option,), snow, "rain") == "rain"
+
+
+def test_resolve_scene_variant_legacy_option_without_variant_paths(
+    tmp_path: Path,
+) -> None:
+    scene = (tmp_path / "legacy.usdz").resolve()
+    option = SceneOption(label="legacy", path=scene, variants=("1", "2"))
+
+    assert _resolve_scene_variant((option,), scene, "default") == "1"
+    assert _resolve_scene_variant((option,), scene, "2") == "2"

--- a/integrations/omnidreams/tests/interactive_drive/test_local_video_model.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_local_video_model.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import numpy as np
+from omnidreams.interactive_drive._pipeline_fakes import make_trajectory, minimal_scene
+from omnidreams.interactive_drive.types import FrameChunk, PresentedFrame, SceneBundle
+from omnidreams.interactive_drive.video_model.local import LocalVideoModelAdapter
+
+
+class _Backend:
+    def __init__(self) -> None:
+        self.load_scene_calls = 0
+        self.reset_calls = 0
+        self.reset_scene_conditioning_calls = 0
+        self.first_chunk_calls = 0
+        self.next_chunk_calls = 0
+
+    @property
+    def can_prewarm(self) -> bool:
+        return True
+
+    def warmup_model(self) -> None:
+        return
+
+    def load_scene(self, scene: SceneBundle) -> None:
+        del scene
+        self.load_scene_calls += 1
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+    def reset_scene_conditioning(self) -> None:
+        self.reset_scene_conditioning_calls += 1
+
+    def render_first_chunk(self, trajectory: object) -> FrameChunk:
+        self.first_chunk_calls += 1
+        return _frame_chunk(trajectory)
+
+    def render_next_chunk(self, trajectory: object) -> FrameChunk:
+        self.next_chunk_calls += 1
+        return _frame_chunk(trajectory)
+
+
+def _frame_chunk(trajectory: object) -> FrameChunk:
+    frame = PresentedFrame(
+        timestamp_us=0,
+        rgb_host_uint8=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_host_f32=None,
+    )
+    return FrameChunk(
+        frames=(frame,),
+        boundary_state_after_chunk=trajectory.boundary_state_after_chunk,
+        source_name="fake",
+    )
+
+
+def test_scene_load_resets_scene_conditioning_before_binding_scene() -> None:
+    backend = _Backend()
+    adapter = LocalVideoModelAdapter(backend)
+
+    adapter.load_scene(minimal_scene())
+
+    assert backend.reset_scene_conditioning_calls == 1
+    assert backend.load_scene_calls == 1
+    assert backend.reset_calls == 0
+
+
+def test_scene_load_and_manual_reset_restart_first_chunk() -> None:
+    backend = _Backend()
+    adapter = LocalVideoModelAdapter(backend)
+    trajectory = make_trajectory(1)
+
+    adapter.load_scene(minimal_scene())
+    adapter.render_chunk(trajectory)
+    adapter.render_chunk(trajectory)
+    adapter.reset()
+    adapter.render_chunk(trajectory)
+    adapter.load_scene(minimal_scene())
+    adapter.render_chunk(trajectory)
+
+    assert backend.first_chunk_calls == 3
+    assert backend.next_chunk_calls == 1
+    assert backend.reset_calls == 1
+    assert backend.reset_scene_conditioning_calls == 2

--- a/integrations/omnidreams/tests/interactive_drive/test_native_dit_cache.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_native_dit_cache.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+from omnidreams.transformer.impl.modules import BlockCache
+from omnidreams.transformer.impl.network import CosmosDiTNetworkCache
+from omnidreams_singleview.python.optimized_dit import _CosmosNetworkShapeOps
+
+from flashdreams.core.attention import BlockKVCache
+
+
+def test_shape_ops_rebuilds_cross_attention_cache_from_context() -> None:
+    config = SimpleNamespace(
+        num_heads=2,
+        patch_temporal=1,
+        patch_spatial=1,
+        use_crossattn_projection=False,
+    )
+    stale_context = torch.full((1, 1, 3, 4), -1.0)
+    new_context = torch.arange(12, dtype=torch.float32).reshape(1, 1, 3, 4)
+    k_weight = torch.eye(4)
+    v_weight = 2.0 * torch.eye(4)
+    k_norm_weight = torch.ones(2)
+
+    stale_cross = _cross_cache(stale_context, k_weight, v_weight, k_norm_weight)
+    template = CosmosDiTNetworkCache(
+        block_caches=[
+            BlockCache(
+                self_attn=BlockKVCache(
+                    k_shape=(1, 2, 2, 2),
+                    v_shape=(1, 2, 2, 2),
+                    seq_dim=-3,
+                    chunk_size=1,
+                    window_size=2,
+                    sink_size=0,
+                    device="cpu",
+                    dtype=torch.float32,
+                ),
+                cross_attn=stale_cross,
+            )
+        ]
+    )
+    shape_ops = _CosmosNetworkShapeOps(
+        config,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        cache_templates=(template,),
+        cross_cache_weights={
+            "blocks.0.cross_attn.k_proj.weight": k_weight,
+            "blocks.0.cross_attn.v_proj.weight": v_weight,
+            "blocks.0.cross_attn.k_norm.weight": k_norm_weight,
+        },
+    )
+
+    cache = shape_ops.initialize_cache(
+        chunk_size=1,
+        window_size=2,
+        sink_size=0,
+        context=new_context,
+    )
+
+    expected_cross = _cross_cache(new_context, k_weight, v_weight, k_norm_weight)
+    assert torch.allclose(
+        cache.block_caches[0].cross_attn.cached_k(), expected_cross.cached_k()
+    )
+    assert torch.allclose(
+        cache.block_caches[0].cross_attn.cached_v(), expected_cross.cached_v()
+    )
+    assert not torch.allclose(
+        cache.block_caches[0].cross_attn.cached_k(), stale_cross.cached_k()
+    )
+
+
+def _cross_cache(
+    context: torch.Tensor,
+    k_weight: torch.Tensor,
+    v_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+) -> BlockKVCache:
+    batch_size = 1
+    token_count = int(context.shape[-2])
+    num_heads = 2
+    head_dim = 2
+    k = F.linear(context, k_weight).reshape(
+        batch_size, token_count, num_heads, head_dim
+    )
+    k = F.rms_norm(k, (head_dim,), weight=k_norm_weight, eps=1e-6)
+    v = F.linear(context, v_weight).reshape(
+        batch_size, token_count, num_heads, head_dim
+    )
+    return BlockKVCache.from_tensor(k.contiguous(), v.contiguous(), seq_dim=-3)

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -238,3 +238,31 @@ def test_session_offload_reuses_precomputed_embeddings_after_reset() -> None:
     )
 
     session.close()
+
+
+def test_session_offload_reruns_embeddings_after_scene_conditioning_reset() -> None:
+    fake_pipeline = _FakePipeline()
+    session = FlashdreamsWorldModelSession(
+        _manifest(),
+        offload_text_encoder=True,
+        pipeline_factory=lambda manifest, profile: fake_pipeline,
+    )
+    session.warmup_model()
+
+    initial_rgb = np.zeros((2, 3, 3), dtype=np.uint8)
+    first_condition_frames = [np.zeros((2, 3, 3), dtype=np.uint8) for _ in range(5)]
+
+    session.start(initial_rgb, first_condition_frames, "clear prompt")
+    session.reset(clear_precomputed_embeddings=True)
+    session.start(initial_rgb, first_condition_frames, "snow prompt")
+
+    assert len(fake_pipeline.precompute_calls) == 2
+    assert fake_pipeline.precompute_calls[0]["text"] == [["clear prompt"]]
+    assert fake_pipeline.precompute_calls[1]["text"] == [["snow prompt"]]
+    assert len(fake_pipeline.initialize_from_embeddings_calls) == 2
+    assert (
+        fake_pipeline.initialize_from_embeddings_calls[1]["text_embeddings"]
+        is not fake_pipeline.initialize_from_embeddings_calls[0]["text_embeddings"]
+    )
+
+    session.close()


### PR DESCRIPTION
# Fix Interactive Drive Scene Switching and Conditioning Reset

## Summary

Fixes intermittent interactive-drive scene/variant switch failures where a newly selected variant, such as `snow`, could race with old queued work or inherit stale world-model conditioning from a previous scene.

This PR makes scene switching generation-safe and conditioning-safe:

- Guards queued scene-load and render commands so stale work cannot bind or render the wrong scene after a newer selection wins.
- Stops the main loop immediately after a scene-change event so it does not enqueue one extra old-scene chunk.
- Resolves weather sibling archives, for example `clipgt-...-snow.usdz`, to the correct variant/prompt even when the requested variant is still `default`.
- Clears stale output frames on reset/scene switch so old frames are not presented after a new scene is selected.
- Resets prompt/image conditioning on scene changes while preserving fast manual rollout resets.
- Rebuilds prompt-dependent cross-attention K/V caches after native FP8 DiT releases the full BF16 PyTorch network.

## Root Cause

There were two related failure modes.

First, scene selection could race with model warmup and queued work. A stale default scene load or render command could still run after the user selected a newer variant. This made backend logs show a default/no-snow scene and prompt even after the UI printed a snow switch.

Second, native FP8 DiT can release the full BF16 PyTorch network after preparing its optimized FP8 weight snapshot. The weight snapshot is prompt-independent, but cross-attention K/V caches are prompt-dependent. After release, the lightweight shape/cache helper was cloning old cache templates instead of rebuilding cross-attention K/V from the new text context. That allowed visual conditioning, such as snow, to carry across scene switches even when logs showed the new prompt was handed to the backend.

## Changes

- Add generation checks before worker-side `load_scene` and `render_chunk` calls in `ChunkPipeline`.
- Clear queued frames when resetting or switching scenes.
- Add backend reset hooks that distinguish manual rollout reset from scene-conditioning reset.
- Make `LocalVideoModelAdapter.load_scene()` reset scene conditioning before binding the new scene.
- Clear offloaded text/image embeddings when a scene switch requires new conditioning.
- Teach FP8 native DiT shape ops to keep only the small cross-attention projection subset needed after network release.
- Rebuild per-block cross-attention K/V caches from the current prompt context instead of reusing stale template K/V.
- Improve scene-loader variant resolution and scene handoff observability.

## Validation

Added regression coverage for:

- Weather sibling archive variant resolution.
- Stale scene loads queued behind model warmup.
- Stale renders queued behind superseded generations.
- Clearing already queued frames on reset and scene switch.
- Scene loads resetting conditioning before first chunk generation.
- Offloaded embeddings rerunning after scene-conditioning reset.
- Native FP8 shape ops rebuilding cross-attention cache from the current context.
