### PR TITLE
docs: surface the OmniDreams interactive-drive demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ You can also install FlashDreams as a library from PyPI:
 pip install flashdreams
 ```
 
+### Try the interactive driving demo
+
+Drive a world model in real time with the OmniDreams `interactive-drive` demo. See the
+**[interactive demo guide](https://nvidia.github.io/flashdreams/main/models/omnidreams.html#launch-the-interactive-demo)**.
+
 ## Supported models
 
 FlashDreams ships first-party integrations under

--- a/docs/source/quickstart/first_world_model.rst
+++ b/docs/source/quickstart/first_world_model.rst
@@ -63,6 +63,7 @@ Next steps
 Explore models:
 
 - :doc:`/models/index` - Browse all supported models, their specific launch commands, and configurations.
+- :doc:`/models/omnidreams` - Drive a world model in real time with the ``interactive-drive`` demo.
 
 For developers:
 


### PR DESCRIPTION
## Summary

Adds pointers to the OmniDreams `interactive-drive` demo so it's easier to find from the main entry points.

- **README**: new "Try the interactive driving demo" subsection at the end of Quickstart, linking to the interactive demo guide.
- **Quickstart docs** (`first_world_model.rst`): added an "Explore models" bullet pointing to the OmniDreams page.

No code changes. Verified `omnidreams.rst` is accurate against the current code; no edits needed there.