### PR TITLE
Package LingBot WebRTC assets in wheel builds

### DIFF
--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -53,5 +53,13 @@ dev = [
 include = ["lingbot*"]
 exclude = ["tests"]
 
+[tool.setuptools.package-data]
+"lingbot.webrtc.web" = [
+    "*.html",
+    "*.css",
+    "*.js",
+    "assets/*.svg",
+]
+
 [tool.uv]
 managed = true


### PR DESCRIPTION
## Summary
- include LingBot WebRTC static assets in wheel builds

## Why
The LingBot WebRTC server serves its viewer from the package-local `lingbot/webrtc/web` directory. The repository contains the HTML, CSS, JS, and SVG assets for that page, but wheel builds currently omit them.

That means non-editable installs can import the server code but cannot serve the packaged WebRTC UI correctly. This change only fixes the built wheel contents and keeps the runtime behavior the same.

## Validation
- `python3 -m pip wheel integrations/lingbot --no-deps -w /tmp/lingbot-wheelcheck`
- inspected the rebuilt wheel and confirmed these files are included:
  - `lingbot/webrtc/web/request_session.html`
  - `lingbot/webrtc/web/request_session.css`
  - `lingbot/webrtc/web/request_session.js`
  - `lingbot/webrtc/web/assets/horizontal-dark.svg`
  - `lingbot/webrtc/web/assets/horizontal-light.svg`
