### PR TITLE
Improve disk-space preflights and ENOSPC messaging

### DIFF
--- a/flashdreams/flashdreams/core/checkpoint/load.py
+++ b/flashdreams/flashdreams/core/checkpoint/load.py
@@ -18,7 +18,7 @@
 import io
 import json
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ProcessPoolExecutor
 from typing import Literal, overload
 from urllib.parse import unquote, urlparse
@@ -33,12 +33,91 @@ from torch.distributed.checkpoint import FileSystemReader
 from torch.distributed.checkpoint import load as dcp_load
 from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 
+from flashdreams.core.io.disk import (
+    CACHE_MIN_FREE_ENV,
+    cache_min_free_bytes,
+    default_huggingface_cache_dir,
+    disk_space_error_from_exception,
+    ensure_free_disk,
+)
 from flashdreams.core.io.s3_filesystem import S3FileSystem, S3StorageReader
 
 _OMNIDREAMS_CHECKPOINT_CREDENTIAL_PATH = "credentials/s3_checkpoint.secret"
 _OMNIDREAMS_CHECKPOINT_LOCAL_CACHE_DIR = os.path.expanduser(
     os.getenv("FLASHDREAMS_CACHE_DIR", "~/.cache/flashdreams")
 )
+
+
+def _preflight_hf_cache(
+    *,
+    label: str,
+    settings: dict[str, object] | None = None,
+) -> int:
+    min_bytes = cache_min_free_bytes()
+    ensure_free_disk(
+        default_huggingface_cache_dir(),
+        required_bytes=min_bytes,
+        label=label,
+        env_vars=("HF_HOME", "HF_HUB_CACHE", CACHE_MIN_FREE_ENV),
+        settings=settings,
+    )
+    return min_bytes
+
+
+def _raise_hf_cache_disk_error(
+    exc: BaseException,
+    *,
+    label: str,
+    required_bytes: int,
+    settings: dict[str, object] | None = None,
+) -> None:
+    disk_error = disk_space_error_from_exception(
+        exc,
+        path=default_huggingface_cache_dir(),
+        label=label,
+        required_bytes=required_bytes,
+        env_vars=("HF_HOME", "HF_HUB_CACHE", CACHE_MIN_FREE_ENV),
+        settings=settings,
+    )
+    if disk_error is not None:
+        raise disk_error from exc
+
+
+def _preflight_local_cache_path(
+    path: str,
+    *,
+    label: str,
+    settings: dict[str, object] | None = None,
+) -> int:
+    min_bytes = cache_min_free_bytes()
+    ensure_free_disk(
+        os.path.dirname(path) or ".",
+        required_bytes=min_bytes,
+        label=label,
+        env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+        settings=settings,
+    )
+    return min_bytes
+
+
+def _raise_local_cache_disk_error(
+    exc: BaseException,
+    *,
+    path: str,
+    label: str,
+    required_bytes: int,
+    settings: dict[str, object] | None = None,
+) -> None:
+    disk_error = disk_space_error_from_exception(
+        exc,
+        path=path,
+        label=label,
+        required_bytes=required_bytes,
+        env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+        settings=settings,
+    )
+    if disk_error is not None:
+        raise disk_error from exc
 
 
 def _is_huggingface_checkpoint_url(path: str) -> bool:
@@ -100,12 +179,30 @@ def _hf_hub_download_shard_task(
 ) -> tuple[str, str]:
     """Picklable worker: download one shard; used by ProcessPoolExecutor."""
     repo_id, shard_file, subfolder, revision = args
-    path = hf_hub_download(
-        repo_id=repo_id,
-        filename=shard_file,
-        subfolder=subfolder,
-        revision=revision,
+    settings: dict[str, object] = {
+        "repo": repo_id,
+        "filename": shard_file,
+        "revision": revision,
+    }
+    min_bytes = _preflight_hf_cache(
+        label="Hugging Face checkpoint shard cache",
+        settings=settings,
     )
+    try:
+        path = hf_hub_download(
+            repo_id=repo_id,
+            filename=shard_file,
+            subfolder=subfolder,
+            revision=revision,
+        )
+    except Exception as exc:
+        _raise_hf_cache_disk_error(
+            exc,
+            label="Hugging Face checkpoint shard cache",
+            required_bytes=min_bytes,
+            settings=settings,
+        )
+        raise
     return shard_file, path
 
 
@@ -119,6 +216,10 @@ def _parallel_hf_hub_download_shards(
     """Download unique shard files in parallel processes; returns shard -> local path."""
     if not shard_files:
         return {}
+    _preflight_hf_cache(
+        label="Hugging Face checkpoint shard cache",
+        settings={"repo": repo_id, "revision": revision},
+    )
     if len(shard_files) == 1:
         s = shard_files[0]
         _, path = _hf_hub_download_shard_task((repo_id, s, subfolder, revision))
@@ -189,12 +290,30 @@ def _load_sharded_safetensors_index_checkpoint(
             _parse_huggingface_checkpoint_url(checkpoint_path)
         )
         logger.info(f"Merging sharded safetensors from Hugging Face: {checkpoint_path}")
-        index_local = hf_hub_download(
-            repo_id=repo_id,
-            filename=index_filename,
-            subfolder=subfolder,
-            revision=revision,
+        settings: dict[str, object] = {
+            "repo": repo_id,
+            "filename": index_filename,
+            "revision": revision,
+        }
+        min_bytes = _preflight_hf_cache(
+            label="Hugging Face checkpoint index cache",
+            settings=settings,
         )
+        try:
+            index_local = hf_hub_download(
+                repo_id=repo_id,
+                filename=index_filename,
+                subfolder=subfolder,
+                revision=revision,
+            )
+        except Exception as exc:
+            _raise_hf_cache_disk_error(
+                exc,
+                label="Hugging Face checkpoint index cache",
+                required_bytes=min_bytes,
+                settings=settings,
+            )
+            raise
         with open(index_local) as f:
             index = json.load(f)
         weight_map = index.get("weight_map")
@@ -243,8 +362,12 @@ def _load_sharded_safetensors_index_checkpoint(
             map_location=map_location,
         )
 
-    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-    save_safetensors(merged, cache_path)
+    _save_to_local_cache(
+        merged,
+        cache_path,
+        ".safetensors",
+        label="merged sharded checkpoint cache",
+    )
     logger.info(f"Saved merged sharded checkpoint to: {cache_path}")
     return merged
 
@@ -292,12 +415,30 @@ def _download_checkpoint_from_huggingface_url(url: str) -> str:
     """Download a checkpoint from Hugging Face and return local cached path."""
     repo_id, filename, subfolder, revision = _parse_huggingface_checkpoint_url(url)
     logger.info(f"Downloading checkpoint from Hugging Face: {url}")
-    local_path = hf_hub_download(
-        repo_id=repo_id,
-        filename=filename,
-        subfolder=subfolder,
-        revision=revision,
+    settings: dict[str, object] = {
+        "repo": repo_id,
+        "filename": filename,
+        "revision": revision,
+    }
+    min_bytes = _preflight_hf_cache(
+        label="Hugging Face checkpoint cache",
+        settings=settings,
     )
+    try:
+        local_path = hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            subfolder=subfolder,
+            revision=revision,
+        )
+    except Exception as exc:
+        _raise_hf_cache_disk_error(
+            exc,
+            label="Hugging Face checkpoint cache",
+            required_bytes=min_bytes,
+            settings=settings,
+        )
+        raise
     logger.info(f"Checkpoint downloaded to local HF cache: {local_path}")
     return local_path
 
@@ -398,8 +539,12 @@ def load_distributed_checkpoint(
 
     # Cache the state dict locally if needed..
     if local_cache_checkpoint_path is not None:
-        os.makedirs(os.path.dirname(local_cache_checkpoint_path), exist_ok=True)
-        torch.save(model.state_dict(), local_cache_checkpoint_path)
+        _save_to_local_cache(
+            model.state_dict(),
+            local_cache_checkpoint_path,
+            ".pt",
+            label="distributed checkpoint cache",
+        )
         logger.info(f"Loaded successfully from the checkpoint: {checkpoint_path}")
         logger.info(f"Cached locally to {local_cache_checkpoint_path}")
     else:
@@ -477,8 +622,12 @@ def load_single_checkpoint(
         )
         # Cache to local
         if local_cache_path is not None:
-            os.makedirs(os.path.dirname(local_cache_path), exist_ok=True)
-            _save_to_local_cache(state_dict, local_cache_path, ext)
+            _save_to_local_cache(
+                state_dict,
+                local_cache_path,
+                ext,
+                label="checkpoint cache",
+            )
             logger.info(f"Cached checkpoint to: {local_cache_path}")
     else:
         state_dict = _load_checkpoint_from_local(checkpoint_path, ext, map_location)
@@ -520,13 +669,32 @@ def _load_checkpoint_from_s3(
 
 
 def _save_to_local_cache(
-    state_dict: dict[str, torch.Tensor], path: str, ext: str
+    state_dict: Mapping[str, torch.Tensor],
+    path: str,
+    ext: str,
+    *,
+    label: str = "checkpoint cache",
 ) -> None:
     """Save state dict to local cache."""
-    if ext == ".safetensors":
-        save_safetensors(state_dict, path)
-    else:
-        torch.save(state_dict, path)
+    min_bytes = _preflight_local_cache_path(
+        path,
+        label=label,
+        settings={"path": path},
+    )
+    try:
+        if ext == ".safetensors":
+            save_safetensors(dict(state_dict), path)
+        else:
+            torch.save(state_dict, path)
+    except Exception as exc:
+        _raise_local_cache_disk_error(
+            exc,
+            path=path,
+            label=label,
+            required_bytes=min_bytes,
+            settings={"path": path},
+        )
+        raise
 
 
 @overload

--- a/flashdreams/flashdreams/core/checkpoint/load.py
+++ b/flashdreams/flashdreams/core/checkpoint/load.py
@@ -216,14 +216,15 @@ def _parallel_hf_hub_download_shards(
     """Download unique shard files in parallel processes; returns shard -> local path."""
     if not shard_files:
         return {}
-    _preflight_hf_cache(
-        label="Hugging Face checkpoint shard cache",
-        settings={"repo": repo_id, "revision": revision},
-    )
     if len(shard_files) == 1:
         s = shard_files[0]
         _, path = _hf_hub_download_shard_task((repo_id, s, subfolder, revision))
         return {s: path}
+
+    _preflight_hf_cache(
+        label="Hugging Face checkpoint shard cache",
+        settings={"repo": repo_id, "revision": revision},
+    )
 
     env_cap = os.getenv("FLASHDREAMS_HF_SHARD_DOWNLOAD_WORKERS")
     if env_cap is not None:

--- a/flashdreams/flashdreams/core/checkpoint/load.py
+++ b/flashdreams/flashdreams/core/checkpoint/load.py
@@ -24,7 +24,7 @@ from typing import Literal, overload
 from urllib.parse import unquote, urlparse
 
 import torch
-from huggingface_hub import hf_hub_download
+from huggingface_hub import hf_hub_download, try_to_load_from_cache
 from loguru import logger
 from safetensors.torch import load as load_safetensors
 from safetensors.torch import load_file as load_safetensors_file
@@ -61,6 +61,66 @@ def _preflight_hf_cache(
         env_vars=("HF_HOME", "HF_HUB_CACHE", CACHE_MIN_FREE_ENV),
         settings=settings,
     )
+    return min_bytes
+
+
+def _hf_cache_filename(filename: str, subfolder: str | None) -> str:
+    return f"{subfolder.rstrip('/')}/{filename}" if subfolder else filename
+
+
+def _is_hf_file_cached(
+    *,
+    repo_id: str,
+    filename: str,
+    subfolder: str | None,
+    revision: str,
+) -> bool:
+    try:
+        cached = try_to_load_from_cache(
+            repo_id=repo_id,
+            filename=_hf_cache_filename(filename, subfolder),
+            revision=revision,
+        )
+    except Exception:
+        return False
+    return isinstance(cached, str) and os.path.exists(cached)
+
+
+def _preflight_checkpoint_cache_requirement(
+    *,
+    label: str,
+    min_free_gb: float | None,
+    settings: dict[str, object] | None = None,
+    local_cache_path: str | None = None,
+) -> int | None:
+    """Run a one-time first-run checkpoint storage preflight.
+
+    This is intentionally separate from the generic per-write 20 GiB reserve:
+    large sharded checkpoints consume space in stages, so reapplying a 200 GiB
+    requirement before every shard or merged-cache write would fail after an
+    otherwise valid partial download has already used disk.
+    """
+    if min_free_gb is None:
+        return None
+    min_bytes = cache_min_free_bytes(min_free_gb)
+    if min_bytes <= 0:
+        return min_bytes
+
+    ensure_free_disk(
+        default_huggingface_cache_dir(),
+        required_bytes=min_bytes,
+        label=label,
+        env_vars=("HF_HOME", "HF_HUB_CACHE", CACHE_MIN_FREE_ENV),
+        settings=settings,
+    )
+    if local_cache_path is not None:
+        ensure_free_disk(
+            os.path.dirname(local_cache_path) or ".",
+            required_bytes=min_bytes,
+            label=f"{label} merged cache",
+            env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+            settings=settings,
+        )
     return min_bytes
 
 
@@ -273,6 +333,7 @@ def _load_sharded_safetensors_index_checkpoint(
     checkpoint_path: str,
     local_cache_dir: str,
     map_location: str | torch.device,
+    checkpoint_min_free_gb: float | None = None,
 ) -> dict[str, torch.Tensor]:
     """Load HF-style sharded safetensors (index.json + shards) into one state dict."""
     if local_cache_dir is None:
@@ -296,6 +357,12 @@ def _load_sharded_safetensors_index_checkpoint(
             "filename": index_filename,
             "revision": revision,
         }
+        _preflight_checkpoint_cache_requirement(
+            label="Hugging Face sharded checkpoint cache",
+            min_free_gb=checkpoint_min_free_gb,
+            settings=settings,
+            local_cache_path=cache_path,
+        )
         min_bytes = _preflight_hf_cache(
             label="Hugging Face checkpoint index cache",
             settings=settings,
@@ -412,7 +479,11 @@ def _parse_huggingface_checkpoint_url(
     return repo_id, filename, subfolder, revision
 
 
-def _download_checkpoint_from_huggingface_url(url: str) -> str:
+def _download_checkpoint_from_huggingface_url(
+    url: str,
+    *,
+    checkpoint_min_free_gb: float | None = None,
+) -> str:
     """Download a checkpoint from Hugging Face and return local cached path."""
     repo_id, filename, subfolder, revision = _parse_huggingface_checkpoint_url(url)
     logger.info(f"Downloading checkpoint from Hugging Face: {url}")
@@ -421,6 +492,17 @@ def _download_checkpoint_from_huggingface_url(url: str) -> str:
         "filename": filename,
         "revision": revision,
     }
+    if not _is_hf_file_cached(
+        repo_id=repo_id,
+        filename=filename,
+        subfolder=subfolder,
+        revision=revision,
+    ):
+        _preflight_checkpoint_cache_requirement(
+            label="Hugging Face checkpoint cache",
+            min_free_gb=checkpoint_min_free_gb,
+            settings=settings,
+        )
     min_bytes = _preflight_hf_cache(
         label="Hugging Face checkpoint cache",
         settings=settings,
@@ -559,6 +641,7 @@ def load_single_checkpoint(
     local_cache_dir: str = _OMNIDREAMS_CHECKPOINT_LOCAL_CACHE_DIR,
     credential_path: str = _OMNIDREAMS_CHECKPOINT_CREDENTIAL_PATH,
     map_location: str | torch.device = "cpu",
+    checkpoint_min_free_gb: float | None = None,
 ) -> dict[str, torch.Tensor]:
     """Load a single-file checkpoint from local disk, S3, or a Hugging Face URL.
 
@@ -572,6 +655,9 @@ def load_single_checkpoint(
         local_cache_dir: Directory for S3 / merged-safetensors caches.
         credential_path: S3 credentials path.
         map_location: Device to map tensors to (``.pt`` / ``.pth`` / ``.ckpt`` only).
+        checkpoint_min_free_gb: Optional first-run free-space requirement in
+            GiB for Hugging Face checkpoint downloads. The
+            ``FLASHDREAMS_MIN_CACHE_FREE_GB`` environment override still wins.
 
     Returns:
         State dict.
@@ -587,7 +673,10 @@ def load_single_checkpoint(
                 "use a Hugging Face file URL or a local index path."
             )
         return _load_sharded_safetensors_index_checkpoint(
-            checkpoint_path, local_cache_dir, map_location
+            checkpoint_path,
+            local_cache_dir,
+            map_location,
+            checkpoint_min_free_gb=checkpoint_min_free_gb,
         )
 
     is_s3_path = checkpoint_path.startswith("s3://")
@@ -603,7 +692,10 @@ def load_single_checkpoint(
 
     # For Hugging Face URLs, use HF cache and then load locally.
     if is_hf_url:
-        local_path = _download_checkpoint_from_huggingface_url(checkpoint_path)
+        local_path = _download_checkpoint_from_huggingface_url(
+            checkpoint_path,
+            checkpoint_min_free_gb=checkpoint_min_free_gb,
+        )
         return _load_checkpoint_from_local(local_path, ext, map_location)
 
     # For S3 paths, check local cache first
@@ -707,6 +799,7 @@ def load_checkpoint(
     credential_path: str = _OMNIDREAMS_CHECKPOINT_CREDENTIAL_PATH,
     map_location: str | torch.device = "cpu",
     check_success: bool = False,
+    checkpoint_min_free_gb: float | None = None,
 ) -> dict[str, torch.Tensor]: ...
 
 
@@ -719,6 +812,7 @@ def load_checkpoint(
     credential_path: str = _OMNIDREAMS_CHECKPOINT_CREDENTIAL_PATH,
     map_location: str | torch.device = "cpu",
     check_success: bool = False,
+    checkpoint_min_free_gb: float | None = None,
 ) -> torch.nn.Module: ...
 
 
@@ -730,6 +824,7 @@ def load_checkpoint(
     credential_path: str = _OMNIDREAMS_CHECKPOINT_CREDENTIAL_PATH,
     map_location: str | torch.device = "cpu",
     check_success: bool = False,
+    checkpoint_min_free_gb: float | None = None,
 ) -> dict[str, torch.Tensor] | torch.nn.Module:
     """Load checkpoints from S3, local disk, or Hugging Face.
 
@@ -747,6 +842,9 @@ def load_checkpoint(
         credential_path: S3 credentials path.
         map_location: Device to map tensors to (single-file only).
         check_success: Verify DCP load actually changed weights.
+        checkpoint_min_free_gb: Optional first-run free-space requirement in
+            GiB for Hugging Face checkpoint downloads. The
+            ``FLASHDREAMS_MIN_CACHE_FREE_GB`` environment override still wins.
 
     Returns:
         State dict if ``model`` is ``None``, otherwise ``model`` with weights
@@ -778,6 +876,7 @@ def load_checkpoint(
             local_cache_dir=local_cache_dir,
             credential_path=credential_path,
             map_location=map_location,
+            checkpoint_min_free_gb=checkpoint_min_free_gb,
         )
         if model is not None:
             model.load_state_dict(state_dict)

--- a/flashdreams/flashdreams/core/io/disk.py
+++ b/flashdreams/flashdreams/core/io/disk.py
@@ -24,7 +24,9 @@ import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-DEFAULT_CACHE_MIN_FREE_GB = 100.0
+from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+
+DEFAULT_CACHE_MIN_FREE_GB = 20.0
 DEFAULT_OUTPUT_MIN_FREE_GB = 20.0
 DEFAULT_TMP_MIN_FREE_GB = 20.0
 
@@ -37,8 +39,6 @@ _DISK_ERROR_PHRASES = (
     "errno 28",
     "enospc",
     "disk quota exceeded",
-    "not enough free disk",
-    "insufficient disk space",
 )
 
 
@@ -78,10 +78,7 @@ def default_flashdreams_cache_dir() -> Path:
 
 def default_huggingface_cache_dir() -> Path:
     """Return the Hugging Face Hub cache directory used for model downloads."""
-    if "HF_HUB_CACHE" in os.environ:
-        return Path(os.path.expanduser(os.environ["HF_HUB_CACHE"]))
-    hf_home = Path(os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface")))
-    return hf_home / "hub"
+    return Path(HUGGINGFACE_HUB_CACHE).expanduser()
 
 
 def default_temp_dir() -> Path:

--- a/flashdreams/flashdreams/core/io/disk.py
+++ b/flashdreams/flashdreams/core/io/disk.py
@@ -1,0 +1,391 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Disk-space preflights and ENOSPC error formatting."""
+
+from __future__ import annotations
+
+import errno
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+DEFAULT_CACHE_MIN_FREE_GB = 150.0
+DEFAULT_OUTPUT_MIN_FREE_GB = 20.0
+DEFAULT_TMP_MIN_FREE_GB = 20.0
+
+CACHE_MIN_FREE_ENV = "FLASHDREAMS_MIN_CACHE_FREE_GB"
+OUTPUT_MIN_FREE_ENV = "FLASHDREAMS_MIN_OUTPUT_FREE_GB"
+TMP_MIN_FREE_ENV = "FLASHDREAMS_MIN_TMP_FREE_GB"
+
+_DISK_ERROR_PHRASES = (
+    "no space left on device",
+    "errno 28",
+    "enospc",
+    "disk quota exceeded",
+    "not enough free disk",
+    "insufficient disk space",
+)
+
+
+class DiskSpaceError(RuntimeError):
+    """User-facing disk-space failure with an actionable message."""
+
+
+def bytes_from_gib(gib: float) -> int:
+    """Convert GiB to bytes."""
+    return int(gib * 1024 * 1024 * 1024)
+
+
+def min_free_bytes_from_env(env_var: str, default_gb: float) -> int:
+    """Read a non-negative GiB threshold from ``env_var``."""
+    raw = os.environ.get(env_var)
+    if raw is None or raw == "":
+        return bytes_from_gib(default_gb)
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{env_var} must be a non-negative number of GiB (got {raw!r})"
+        ) from exc
+    if value < 0:
+        raise ValueError(
+            f"{env_var} must be a non-negative number of GiB (got {raw!r})"
+        )
+    return bytes_from_gib(value)
+
+
+def default_flashdreams_cache_dir() -> Path:
+    """Return the FlashDreams cache root."""
+    return Path(
+        os.path.expanduser(os.getenv("FLASHDREAMS_CACHE_DIR", "~/.cache/flashdreams"))
+    )
+
+
+def default_huggingface_cache_dir() -> Path:
+    """Return the Hugging Face Hub cache directory used for model downloads."""
+    if "HF_HUB_CACHE" in os.environ:
+        return Path(os.path.expanduser(os.environ["HF_HUB_CACHE"]))
+    hf_home = Path(os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface")))
+    return hf_home / "hub"
+
+
+def default_temp_dir() -> Path:
+    """Return the configured temporary directory."""
+    if "TMPDIR" in os.environ:
+        return Path(os.path.expanduser(os.environ["TMPDIR"]))
+    return Path(tempfile.gettempdir())
+
+
+def cache_min_free_bytes() -> int:
+    """Return the generic cache-space preflight threshold."""
+    return min_free_bytes_from_env(CACHE_MIN_FREE_ENV, DEFAULT_CACHE_MIN_FREE_GB)
+
+
+def output_min_free_bytes() -> int:
+    """Return the output directory preflight threshold."""
+    return min_free_bytes_from_env(OUTPUT_MIN_FREE_ENV, DEFAULT_OUTPUT_MIN_FREE_GB)
+
+
+def tmp_min_free_bytes() -> int:
+    """Return the temporary directory preflight threshold."""
+    return min_free_bytes_from_env(TMP_MIN_FREE_ENV, DEFAULT_TMP_MIN_FREE_GB)
+
+
+def _format_bytes(num_bytes: int | None) -> str:
+    if num_bytes is None:
+        return "unknown"
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024.0 or unit == "TiB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} TiB"
+
+
+def _nearest_existing_path(path: Path) -> Path | None:
+    path = path.expanduser()
+    if path.exists():
+        return path
+    for parent in path.parents:
+        if parent.exists():
+            return parent
+    return None
+
+
+def available_bytes(path: str | os.PathLike[str] | None) -> int | None:
+    """Return free bytes for ``path`` or its nearest existing parent."""
+    if path is None:
+        return None
+    usage_path = _nearest_existing_path(Path(path))
+    if usage_path is None:
+        return None
+    try:
+        return shutil.disk_usage(usage_path).free
+    except OSError:
+        return None
+
+
+def _env_lines(env_vars: Sequence[str]) -> list[str]:
+    lines: list[str] = []
+    for name in env_vars:
+        value = os.environ.get(name)
+        rendered = value if value not in (None, "") else "<unset>"
+        lines.append(f"  {name}: {rendered}")
+    return lines
+
+
+def _settings_lines(settings: Mapping[str, object] | None) -> list[str]:
+    if not settings:
+        return []
+    return [f"  {key}: {value}" for key, value in settings.items()]
+
+
+def _cause_text(exc: BaseException | None) -> str | None:
+    if exc is None:
+        return None
+    for item in _iter_exception_chain(exc):
+        if _is_single_disk_space_error(item):
+            text = f"{type(item).__name__}: {item}"
+            return text if len(text) <= 240 else f"{text[:237]}..."
+    text = f"{type(exc).__name__}: {exc}"
+    return text if len(text) <= 240 else f"{text[:237]}..."
+
+
+def format_disk_space_message(
+    *,
+    label: str,
+    path: str | os.PathLike[str] | None,
+    required_bytes: int | None,
+    available: int | None,
+    env_vars: Sequence[str] = (),
+    settings: Mapping[str, object] | None = None,
+    cause: BaseException | None = None,
+    preflight: bool = False,
+) -> str:
+    """Build a concise user-facing disk-space error message."""
+    first_line = (
+        f"ERROR: Not enough free disk for {label}."
+        if preflight
+        else f"ERROR: Disk space exhausted while writing {label}."
+    )
+    lines = [
+        first_line,
+        f"  Path:     {Path(path).expanduser() if path is not None else 'unknown'}",
+        f"  Free:     {_format_bytes(available)}",
+        f"  Required: {_format_bytes(required_bytes)}",
+    ]
+    cause_line = _cause_text(cause)
+    if cause_line:
+        lines.append(f"  Cause:    {cause_line}")
+
+    setting_lines = _settings_lines(settings)
+    env_setting_lines = _env_lines(env_vars)
+    if setting_lines or env_setting_lines:
+        lines.append("")
+        lines.append("Relevant settings:")
+        lines.extend(setting_lines)
+        lines.extend(env_setting_lines)
+
+    lines.append("")
+    lines.append(
+        "Move HF_HOME/HF_HUB_CACHE, FLASHDREAMS_CACHE_DIR, TMPDIR, or "
+        "--output-dir to a filesystem with more free space."
+    )
+    min_envs = [name for name in env_vars if name.startswith("FLASHDREAMS_MIN_")]
+    if min_envs:
+        lines.append(
+            "Set "
+            + " or ".join(f"{name}=0" for name in min_envs)
+            + " to skip the corresponding preflight."
+        )
+    return "\n".join(lines)
+
+
+def ensure_free_disk(
+    path: str | os.PathLike[str],
+    *,
+    required_bytes: int,
+    label: str,
+    env_vars: Sequence[str] = (),
+    settings: Mapping[str, object] | None = None,
+    mkdir: bool = True,
+) -> None:
+    """Ensure ``path`` has at least ``required_bytes`` free bytes.
+
+    ``required_bytes=0`` disables the threshold check but still creates
+    ``path`` when ``mkdir`` is true, matching the env-var override semantics
+    used by the setup scripts.
+    """
+    target = Path(path).expanduser()
+    if mkdir:
+        try:
+            target.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            raise_if_disk_space_error(
+                exc,
+                path=target,
+                label=label,
+                required_bytes=required_bytes,
+                env_vars=env_vars,
+                settings=settings,
+            )
+            raise
+
+    if required_bytes <= 0:
+        return
+
+    free = available_bytes(target)
+    if free is None or free >= required_bytes:
+        return
+
+    raise DiskSpaceError(
+        format_disk_space_message(
+            label=label,
+            path=target,
+            required_bytes=required_bytes,
+            available=free,
+            env_vars=env_vars,
+            settings=settings,
+            preflight=True,
+        )
+    )
+
+
+def preflight_runtime_write_paths(
+    *,
+    output_dir: str | os.PathLike[str] | None,
+) -> None:
+    """Preflight common runtime write-heavy directories."""
+    ensure_free_disk(
+        default_flashdreams_cache_dir(),
+        required_bytes=cache_min_free_bytes(),
+        label="FlashDreams cache",
+        env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+    )
+    ensure_free_disk(
+        default_temp_dir(),
+        required_bytes=tmp_min_free_bytes(),
+        label="temporary directory",
+        env_vars=("TMPDIR", "TEMP", "TMP", TMP_MIN_FREE_ENV),
+    )
+    if output_dir is not None:
+        ensure_free_disk(
+            output_dir,
+            required_bytes=output_min_free_bytes(),
+            label="output directory",
+            env_vars=(OUTPUT_MIN_FREE_ENV,),
+            settings={"--output-dir": Path(output_dir).expanduser()},
+        )
+
+
+def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
+    stack = [exc]
+    seen: set[int] = set()
+    out: list[BaseException] = []
+    while stack:
+        item = stack.pop()
+        ident = id(item)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        out.append(item)
+        cause = item.__cause__
+        context = item.__context__
+        if cause is not None:
+            stack.append(cause)
+        if context is not None:
+            stack.append(context)
+    return out
+
+
+def _is_single_disk_space_error(exc: BaseException) -> bool:
+    if isinstance(exc, DiskSpaceError):
+        return True
+    if isinstance(exc, OSError) and exc.errno == errno.ENOSPC:
+        return True
+    text = str(exc).lower()
+    return any(phrase in text for phrase in _DISK_ERROR_PHRASES)
+
+
+def is_disk_space_error(exc: BaseException) -> bool:
+    """Return whether ``exc`` or its chain indicates disk exhaustion."""
+    return any(_is_single_disk_space_error(item) for item in _iter_exception_chain(exc))
+
+
+def _exception_path(exc: BaseException) -> str | os.PathLike[str] | None:
+    for item in _iter_exception_chain(exc):
+        if isinstance(item, OSError):
+            for attr in ("filename", "filename2"):
+                value = getattr(item, attr, None)
+                if value:
+                    return os.fsdecode(value)
+    return None
+
+
+def disk_space_error_from_exception(
+    exc: BaseException,
+    *,
+    path: str | os.PathLike[str] | None = None,
+    label: str = "FlashDreams output",
+    required_bytes: int | None = None,
+    env_vars: Sequence[str] = (),
+    settings: Mapping[str, object] | None = None,
+) -> DiskSpaceError | None:
+    """Convert ENOSPC-like failures into :class:`DiskSpaceError`."""
+    if isinstance(exc, DiskSpaceError):
+        return exc
+    if not is_disk_space_error(exc):
+        return None
+
+    failing_path = path if path is not None else _exception_path(exc)
+    return DiskSpaceError(
+        format_disk_space_message(
+            label=label,
+            path=failing_path,
+            required_bytes=required_bytes,
+            available=available_bytes(failing_path),
+            env_vars=env_vars,
+            settings=settings,
+            cause=exc,
+            preflight=False,
+        )
+    )
+
+
+def raise_if_disk_space_error(
+    exc: BaseException,
+    *,
+    path: str | os.PathLike[str] | None = None,
+    label: str = "FlashDreams output",
+    required_bytes: int | None = None,
+    env_vars: Sequence[str] = (),
+    settings: Mapping[str, object] | None = None,
+) -> None:
+    """Raise :class:`DiskSpaceError` if ``exc`` looks like disk exhaustion."""
+    disk_error = disk_space_error_from_exception(
+        exc,
+        path=path,
+        label=label,
+        required_bytes=required_bytes,
+        env_vars=env_vars,
+        settings=settings,
+    )
+    if disk_error is not None:
+        raise disk_error from exc

--- a/flashdreams/flashdreams/core/io/disk.py
+++ b/flashdreams/flashdreams/core/io/disk.py
@@ -24,7 +24,7 @@ import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-DEFAULT_CACHE_MIN_FREE_GB = 150.0
+DEFAULT_CACHE_MIN_FREE_GB = 100.0
 DEFAULT_OUTPUT_MIN_FREE_GB = 20.0
 DEFAULT_TMP_MIN_FREE_GB = 20.0
 
@@ -116,7 +116,7 @@ def _format_bytes(num_bytes: int | None) -> str:
                 return f"{int(value)} {unit}"
             return f"{value:.1f} {unit}"
         value /= 1024.0
-    return f"{value:.1f} TiB"
+    raise AssertionError("unreachable")
 
 
 def _nearest_existing_path(path: Path) -> Path | None:
@@ -204,10 +204,17 @@ def format_disk_space_message(
         lines.extend(env_setting_lines)
 
     lines.append("")
-    lines.append(
-        "Move HF_HOME/HF_HUB_CACHE, FLASHDREAMS_CACHE_DIR, TMPDIR, or "
-        "--output-dir to a filesystem with more free space."
+    hint_targets = [
+        name for name in env_vars if not name.startswith("FLASHDREAMS_MIN_")
+    ]
+    if settings is not None:
+        hint_targets.extend(key for key in settings if key.startswith("--"))
+    hint = (
+        ", ".join(dict.fromkeys(hint_targets))
+        if hint_targets
+        else "the relevant cache or output directory"
     )
+    lines.append(f"Move {hint} to a filesystem with more free space.")
     min_envs = [name for name in env_vars if name.startswith("FLASHDREAMS_MIN_")]
     if min_envs:
         lines.append(
@@ -307,11 +314,10 @@ def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
         seen.add(ident)
         out.append(item)
         cause = item.__cause__
-        context = item.__context__
         if cause is not None:
             stack.append(cause)
-        if context is not None:
-            stack.append(context)
+        elif not item.__suppress_context__ and item.__context__ is not None:
+            stack.append(item.__context__)
     return out
 
 

--- a/flashdreams/flashdreams/core/io/disk.py
+++ b/flashdreams/flashdreams/core/io/disk.py
@@ -88,9 +88,17 @@ def default_temp_dir() -> Path:
     return Path(tempfile.gettempdir())
 
 
-def cache_min_free_bytes() -> int:
-    """Return the generic cache-space preflight threshold."""
-    return min_free_bytes_from_env(CACHE_MIN_FREE_ENV, DEFAULT_CACHE_MIN_FREE_GB)
+def cache_min_free_bytes(default_gb: float | None = None) -> int:
+    """Return the cache-space preflight threshold.
+
+    ``default_gb`` lets model-specific callers use a larger first-run
+    requirement while preserving the same ``FLASHDREAMS_MIN_CACHE_FREE_GB``
+    override used by the generic cache preflight.
+    """
+    return min_free_bytes_from_env(
+        CACHE_MIN_FREE_ENV,
+        DEFAULT_CACHE_MIN_FREE_GB if default_gb is None else default_gb,
+    )
 
 
 def output_min_free_bytes() -> int:

--- a/flashdreams/flashdreams/core/io/download.py
+++ b/flashdreams/flashdreams/core/io/download.py
@@ -33,6 +33,13 @@ from urllib.parse import urlsplit
 
 from loguru import logger
 
+from flashdreams.core.io.disk import (
+    CACHE_MIN_FREE_ENV,
+    cache_min_free_bytes,
+    ensure_free_disk,
+    raise_if_disk_space_error,
+)
+
 __all__ = ["download_to_cache"]
 
 
@@ -73,11 +80,20 @@ def download_to_cache(
         RuntimeError: if the download fails, times out, or the validator
             rejects the response. The original exception is chained.
     """
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = cache_dir.expanduser()
     filename = filename or Path(urlsplit(url).path).name or "downloaded_file.bin"
     local_path = cache_dir / filename
     if local_path.exists():
         return local_path
+
+    min_bytes = cache_min_free_bytes()
+    ensure_free_disk(
+        cache_dir,
+        required_bytes=min_bytes,
+        label="FlashDreams cache download",
+        env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+        settings={"url": url},
+    )
 
     logger.info(f"Downloading {url} -> {local_path}")
     # Stream into a sibling temp file, validate, then atomic-rename;
@@ -97,8 +113,28 @@ def download_to_cache(
             validator(tmp_path)
     except Exception as exc:
         tmp_path.unlink(missing_ok=True)
+        raise_if_disk_space_error(
+            exc,
+            path=local_path,
+            label="FlashDreams cache download",
+            required_bytes=min_bytes,
+            env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+            settings={"url": url},
+        )
         raise RuntimeError(
             f"Failed to download {url!r} into {local_path}: {exc}"
         ) from exc
-    os.replace(tmp_path, local_path)
+    try:
+        os.replace(tmp_path, local_path)
+    except Exception as exc:
+        tmp_path.unlink(missing_ok=True)
+        raise_if_disk_space_error(
+            exc,
+            path=local_path,
+            label="FlashDreams cache download",
+            required_bytes=min_bytes,
+            env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+            settings={"url": url},
+        )
+        raise
     return local_path

--- a/flashdreams/flashdreams/core/io/hf.py
+++ b/flashdreams/flashdreams/core/io/hf.py
@@ -33,6 +33,13 @@ from huggingface_hub import snapshot_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 
 from flashdreams.core.distributed import get_global_rank, is_distributed_initialized
+from flashdreams.core.io.disk import (
+    CACHE_MIN_FREE_ENV,
+    DiskSpaceError,
+    cache_min_free_bytes,
+    disk_space_error_from_exception,
+    ensure_free_disk,
+)
 
 
 def _str2bool(v: str | bool) -> bool:
@@ -82,16 +89,41 @@ def _download_snapshot(
     ignore_patterns: str | Sequence[str] | None,
 ) -> None:
     lock_file = _lock_path(repo_id, revision, cache_dir)
-    lock_file.parent.mkdir(parents=True, exist_ok=True)
-    with FileLock(str(lock_file)):
-        snapshot_download(
-            repo_id,
-            revision=revision,
-            cache_dir=str(cache_dir) if cache_dir is not None else None,
-            local_files_only=False,
-            allow_patterns=_normalize_patterns(allow_patterns),
-            ignore_patterns=_normalize_patterns(ignore_patterns),
+    cache_root = _hub_cache_dir(cache_dir)
+    min_bytes = cache_min_free_bytes()
+    settings: dict[str, object] = {"repo": repo_id}
+    if cache_dir is not None:
+        settings["cache_dir"] = Path(cache_dir).expanduser()
+    ensure_free_disk(
+        cache_root,
+        required_bytes=min_bytes,
+        label="Hugging Face cache",
+        env_vars=("HF_HOME", "HF_HUB_CACHE", CACHE_MIN_FREE_ENV),
+        settings=settings,
+    )
+    try:
+        lock_file.parent.mkdir(parents=True, exist_ok=True)
+        with FileLock(str(lock_file)):
+            snapshot_download(
+                repo_id,
+                revision=revision,
+                cache_dir=str(cache_dir) if cache_dir is not None else None,
+                local_files_only=False,
+                allow_patterns=_normalize_patterns(allow_patterns),
+                ignore_patterns=_normalize_patterns(ignore_patterns),
+            )
+    except Exception as exc:
+        disk_error = disk_space_error_from_exception(
+            exc,
+            path=cache_root,
+            label="Hugging Face cache",
+            required_bytes=min_bytes,
+            env_vars=("HF_HOME", "HF_HUB_CACHE", CACHE_MIN_FREE_ENV),
+            settings=settings,
         )
+        if disk_error is not None:
+            raise disk_error from exc
+        raise
 
 
 def maybe_download_hf_repo_on_rank0(
@@ -128,6 +160,8 @@ def maybe_download_hf_repo_on_rank0(
                 ignore_patterns=ignore_patterns,
             )
             payload = [{"error": None}]
+        except DiskSpaceError as exc:
+            payload = [{"error": str(exc), "disk_error": "1"}]
         except Exception as exc:
             payload = [{"error": f"{type(exc).__name__}: {exc}"}]
     else:
@@ -138,6 +172,8 @@ def maybe_download_hf_repo_on_rank0(
 
     error = payload[0]["error"]
     if error is not None:
+        if payload[0].get("disk_error"):
+            raise DiskSpaceError(error)
         raise RuntimeError(
             f"Rank 0 failed to download Hugging Face repo {repo_id_or_path!r}: {error}"
         )

--- a/flashdreams/flashdreams/core/io/s3_sync.py
+++ b/flashdreams/flashdreams/core/io/s3_sync.py
@@ -25,6 +25,12 @@ from urllib.parse import urlparse
 import torch.distributed as dist
 import tqdm
 
+from flashdreams.core.io.disk import (
+    CACHE_MIN_FREE_ENV,
+    cache_min_free_bytes,
+    ensure_free_disk,
+    raise_if_disk_space_error,
+)
 from flashdreams.core.io.s3_filesystem import S3FileSystem
 
 
@@ -109,7 +115,14 @@ def sync_s3_dir_to_local(
     obj_prefix = parsed_url.path.lstrip("/").removesuffix("/")
 
     cache_dir = os.path.expanduser(cache_dir)
-    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+    min_bytes = cache_min_free_bytes()
+    ensure_free_disk(
+        cache_dir,
+        required_bytes=min_bytes,
+        label="S3 local cache",
+        env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+        settings={"s3_dir": s3_dir, "cache_dir": cache_dir},
+    )
 
     should_download = world_rank == 0
     s3_fs = (
@@ -147,7 +160,18 @@ def sync_s3_dir_to_local(
         if not os.path.exists(dest_path):
             s3_obj = f"{s3_dir.removesuffix('/')}/{obj_suffix}"
             tqdm.tqdm.write(f"Downloading: {_shorten_path(s3_obj)}")
-            s3_fs.download_to_local(s3_uri=s3_obj, local_path=dest_path)
+            try:
+                s3_fs.download_to_local(s3_uri=s3_obj, local_path=dest_path)
+            except Exception as exc:
+                raise_if_disk_space_error(
+                    exc,
+                    path=dest_path,
+                    label="S3 local cache",
+                    required_bytes=min_bytes,
+                    env_vars=("FLASHDREAMS_CACHE_DIR", CACHE_MIN_FREE_ENV),
+                    settings={"s3_dir": s3_dir, "cache_dir": cache_dir},
+                )
+                raise
 
         try:
             _validate_local_file(local_path=dest_path, key=key)

--- a/flashdreams/flashdreams/infra/runner.py
+++ b/flashdreams/flashdreams/infra/runner.py
@@ -27,6 +27,7 @@ import torch
 import tyro
 
 from flashdreams.core.distributed import init as init_distributed
+from flashdreams.core.io.disk import preflight_runtime_write_paths
 from flashdreams.infra.config import InstantiateConfig, derive_config
 from flashdreams.infra.pipeline import (
     StreamInferencePipeline,
@@ -120,6 +121,7 @@ class Runner(ABC, Generic[RunnerConfigT, PipelineT]):
             self.global_rank = 0
             device = config.device
         self.is_rank_zero = self.global_rank == 0
+        preflight_runtime_write_paths(output_dir=config.output_dir)
 
         # Keep per-rank RNG streams distinct under torchrun without mutating
         # the caller's literal config.

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
@@ -134,6 +134,13 @@ class Wan21TransformerConfig(TransformerConfig):
     network: WanDiTNetworkConfig = field(default_factory=WanDiTNetwork1pt3BConfig)
     dtype: torch.dtype = torch.bfloat16
     checkpoint_path: str | None = None
+    checkpoint_min_free_gb: float | None = None
+    """Optional first-run disk preflight for checkpoint downloads.
+
+    ``None`` uses the generic cache reserve. Larger model integrations can set
+    this to their documented storage requirement; users can still override it
+    with ``FLASHDREAMS_MIN_CACHE_FREE_GB``.
+    """
 
     state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None
     """Pre-load state-dict remap (e.g. Self-Forcing's
@@ -260,7 +267,10 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         self.network.set_context_parallel_group(cp_group=self._cp_group)
 
         if config.checkpoint_path is not None:
-            state_dict = load_checkpoint(config.checkpoint_path)
+            state_dict = load_checkpoint(
+                config.checkpoint_path,
+                checkpoint_min_free_gb=config.checkpoint_min_free_gb,
+            )
             if config.state_dict_transform is not None:
                 state_dict = config.state_dict_transform(state_dict)
             self.network.load_state_dict(state_dict)

--- a/flashdreams/flashdreams/scripts/cli.py
+++ b/flashdreams/flashdreams/scripts/cli.py
@@ -39,11 +39,14 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import sys
+from collections.abc import Callable
 from typing import Annotated
 
 import tyro
 
 from flashdreams.configs.runner_configs import _annotated_base_runner_union
+from flashdreams.core.io.disk import disk_space_error_from_exception
 from flashdreams.infra.runner import RunnerConfig
 
 
@@ -60,6 +63,22 @@ def main(config: RunnerConfig, no_instantiate: bool = False) -> None:
         return
     runner = config.setup()
     runner.run()
+
+
+def _is_rank_zero() -> bool:
+    return int(os.environ.get("LOCAL_RANK", "0")) == 0
+
+
+def _run_with_disk_error_handling(fn: Callable[[], None]) -> None:
+    try:
+        fn()
+    except Exception as exc:
+        disk_error = disk_space_error_from_exception(exc)
+        if disk_error is not None:
+            if _is_rank_zero():
+                print(str(disk_error), file=sys.stderr)
+            raise SystemExit(1) from None
+        raise
 
 
 def entrypoint() -> None:
@@ -93,18 +112,17 @@ def entrypoint() -> None:
     # they print exactly once even though every rank parses argv. Every
     # rank still exits via ``sys.exit`` inside ``tyro.cli``; only the
     # printed output is gated.
-    is_rank_zero = int(os.environ.get("LOCAL_RANK", "0")) == 0
     args = tyro.cli(
         args_cls,
         prog="flashdreams-run",
         description=__doc__,
-        console_outputs=is_rank_zero,
+        console_outputs=_is_rank_zero(),
     )
     # ``args_cls`` is built dynamically so the static checker only
     # sees ``object``; ``getattr`` keeps the type narrowing local.
     runner_cfg: RunnerConfig = getattr(args, "runner")
     no_instantiate: bool = getattr(args, "no_instantiate")
-    main(runner_cfg, no_instantiate)
+    _run_with_disk_error_handling(lambda: main(runner_cfg, no_instantiate))
 
 
 if __name__ == "__main__":

--- a/flashdreams/tests/test_disk_space.py
+++ b/flashdreams/tests/test_disk_space.py
@@ -19,16 +19,25 @@ def _fake_disk_usage(*, free: int) -> SimpleNamespace:
     return SimpleNamespace(total=10 * 1024**3, used=10 * 1024**3 - free, free=free)
 
 
-def test_default_preflight_thresholds_match_flashdreams_storage_guidance(
+def test_default_preflight_thresholds_are_runtime_reserves(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(disk.CACHE_MIN_FREE_ENV, raising=False)
     monkeypatch.delenv(disk.OUTPUT_MIN_FREE_ENV, raising=False)
     monkeypatch.delenv(disk.TMP_MIN_FREE_ENV, raising=False)
 
-    assert disk.cache_min_free_bytes() == disk.bytes_from_gib(100)
+    assert disk.cache_min_free_bytes() == disk.bytes_from_gib(20)
     assert disk.output_min_free_bytes() == disk.bytes_from_gib(20)
     assert disk.tmp_min_free_bytes() == disk.bytes_from_gib(20)
+
+
+def test_huggingface_cache_dir_uses_hub_constant(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(disk, "HUGGINGFACE_HUB_CACHE", str(tmp_path / "hub"))
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "ignored"))
+
+    assert disk.default_huggingface_cache_dir() == tmp_path / "hub"
 
 
 def test_ensure_free_disk_reports_path_free_required_and_env(

--- a/flashdreams/tests/test_disk_space.py
+++ b/flashdreams/tests/test_disk_space.py
@@ -31,6 +31,16 @@ def test_default_preflight_thresholds_are_runtime_reserves(
     assert disk.tmp_min_free_bytes() == disk.bytes_from_gib(20)
 
 
+def test_model_cache_threshold_uses_model_default_unless_env_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(disk.CACHE_MIN_FREE_ENV, raising=False)
+    assert disk.cache_min_free_bytes(default_gb=200) == disk.bytes_from_gib(200)
+
+    monkeypatch.setenv(disk.CACHE_MIN_FREE_ENV, "5")
+    assert disk.cache_min_free_bytes(default_gb=200) == disk.bytes_from_gib(5)
+
+
 def test_huggingface_cache_dir_uses_hub_constant(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/flashdreams/tests/test_disk_space.py
+++ b/flashdreams/tests/test_disk_space.py
@@ -19,14 +19,14 @@ def _fake_disk_usage(*, free: int) -> SimpleNamespace:
     return SimpleNamespace(total=10 * 1024**3, used=10 * 1024**3 - free, free=free)
 
 
-def test_default_preflight_thresholds_match_omni_dreams_parity(
+def test_default_preflight_thresholds_match_flashdreams_storage_guidance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(disk.CACHE_MIN_FREE_ENV, raising=False)
     monkeypatch.delenv(disk.OUTPUT_MIN_FREE_ENV, raising=False)
     monkeypatch.delenv(disk.TMP_MIN_FREE_ENV, raising=False)
 
-    assert disk.cache_min_free_bytes() == disk.bytes_from_gib(150)
+    assert disk.cache_min_free_bytes() == disk.bytes_from_gib(100)
     assert disk.output_min_free_bytes() == disk.bytes_from_gib(20)
     assert disk.tmp_min_free_bytes() == disk.bytes_from_gib(20)
 
@@ -56,6 +56,7 @@ def test_ensure_free_disk_reports_path_free_required_and_env(
     assert "Required: 2.0 GiB" in message
     assert "FLASHDREAMS_CACHE_DIR:" in message
     assert f"{disk.CACHE_MIN_FREE_ENV}:" in message
+    assert "Move FLASHDREAMS_CACHE_DIR to a filesystem with more free space." in message
 
 
 def test_enospc_exception_chain_formats_cause_path_and_settings(
@@ -93,6 +94,19 @@ def test_enospc_exception_chain_formats_cause_path_and_settings(
     assert "Cause:    OSError: [Errno 28] No space left on device" in message
     assert "--output-dir:" in message
     assert "TMPDIR:" in message
+    assert "Move TMPDIR, --output-dir to a filesystem with more free space." in message
+
+
+def test_suppressed_enospc_context_is_not_treated_as_disk_error(
+    tmp_path,
+) -> None:
+    try:
+        try:
+            raise OSError(errno.ENOSPC, "No space left on device", str(tmp_path))
+        except OSError:
+            raise RuntimeError("real non-disk failure") from None
+    except RuntimeError as exc:
+        assert disk.disk_space_error_from_exception(exc) is None
 
 
 def test_cli_disk_handler_prints_message_without_traceback(

--- a/flashdreams/tests/test_disk_space.py
+++ b/flashdreams/tests/test_disk_space.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import errno
+from types import SimpleNamespace
+
+import pytest
+
+from flashdreams.core.io import disk
+from flashdreams.core.io.download import download_to_cache
+from flashdreams.scripts import cli
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def _fake_disk_usage(*, free: int) -> SimpleNamespace:
+    return SimpleNamespace(total=10 * 1024**3, used=10 * 1024**3 - free, free=free)
+
+
+def test_default_preflight_thresholds_match_omni_dreams_parity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(disk.CACHE_MIN_FREE_ENV, raising=False)
+    monkeypatch.delenv(disk.OUTPUT_MIN_FREE_ENV, raising=False)
+    monkeypatch.delenv(disk.TMP_MIN_FREE_ENV, raising=False)
+
+    assert disk.cache_min_free_bytes() == disk.bytes_from_gib(150)
+    assert disk.output_min_free_bytes() == disk.bytes_from_gib(20)
+    assert disk.tmp_min_free_bytes() == disk.bytes_from_gib(20)
+
+
+def test_ensure_free_disk_reports_path_free_required_and_env(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLASHDREAMS_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(
+        disk.shutil,
+        "disk_usage",
+        lambda path: _fake_disk_usage(free=512 * 1024**2),
+    )
+
+    with pytest.raises(disk.DiskSpaceError) as exc_info:
+        disk.ensure_free_disk(
+            tmp_path / "cache",
+            required_bytes=disk.bytes_from_gib(2),
+            label="FlashDreams cache",
+            env_vars=("FLASHDREAMS_CACHE_DIR", disk.CACHE_MIN_FREE_ENV),
+        )
+
+    message = str(exc_info.value)
+    assert "ERROR: Not enough free disk for FlashDreams cache." in message
+    assert f"Path:     {tmp_path / 'cache'}" in message
+    assert "Free:     512.0 MiB" in message
+    assert "Required: 2.0 GiB" in message
+    assert "FLASHDREAMS_CACHE_DIR:" in message
+    assert f"{disk.CACHE_MIN_FREE_ENV}:" in message
+
+
+def test_enospc_exception_chain_formats_cause_path_and_settings(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_path = tmp_path / "out.mp4"
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+    monkeypatch.setattr(
+        disk.shutil,
+        "disk_usage",
+        lambda path: _fake_disk_usage(free=0),
+    )
+
+    try:
+        raise RuntimeError("video writer failed") from OSError(
+            errno.ENOSPC,
+            "No space left on device",
+            str(output_path),
+        )
+    except RuntimeError as exc:
+        disk_error = disk.disk_space_error_from_exception(
+            exc,
+            label="output video",
+            required_bytes=disk.bytes_from_gib(1),
+            env_vars=("TMPDIR", disk.OUTPUT_MIN_FREE_ENV),
+            settings={"--output-dir": tmp_path},
+        )
+
+    assert disk_error is not None
+    message = str(disk_error)
+    assert "ERROR: Disk space exhausted while writing output video." in message
+    assert f"Path:     {output_path}" in message
+    assert "Free:     0 B" in message
+    assert "Required: 1.0 GiB" in message
+    assert "Cause:    OSError: [Errno 28] No space left on device" in message
+    assert "--output-dir:" in message
+    assert "TMPDIR:" in message
+
+
+def test_cli_disk_handler_prints_message_without_traceback(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _raise_disk_error() -> None:
+        raise disk.DiskSpaceError("ERROR: disk is full\n  Path: /tmp/out")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli._run_with_disk_error_handling(_raise_disk_error)
+
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "ERROR: disk is full" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_download_to_cache_converts_enospc(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Response:
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setenv(disk.CACHE_MIN_FREE_ENV, "0")
+    monkeypatch.setattr(
+        "flashdreams.core.io.download.urllib.request.urlopen",
+        lambda *args, **kwargs: _Response(),
+    )
+    monkeypatch.setattr(
+        "flashdreams.core.io.download.shutil.copyfileobj",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            OSError(errno.ENOSPC, "No space left on device")
+        ),
+    )
+
+    with pytest.raises(disk.DiskSpaceError) as exc_info:
+        download_to_cache("https://example.test/frame.png", cache_dir=tmp_path)
+
+    message = str(exc_info.value)
+    assert (
+        "ERROR: Disk space exhausted while writing FlashDreams cache download."
+        in message
+    )
+    assert "frame.png" in message
+    assert "https://example.test/frame.png" in message

--- a/flashdreams/tests/test_hf_io.py
+++ b/flashdreams/tests/test_hf_io.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import errno
+
 import pytest
 
 from flashdreams.core.io import hf as hf_io
@@ -13,6 +15,7 @@ pytestmark = pytest.mark.ci_cpu
 def _clear_hf_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
     monkeypatch.delenv("LOCAL_FILES_ONLY", raising=False)
+    monkeypatch.setenv(hf_io.CACHE_MIN_FREE_ENV, "0")
 
 
 def _mock_distributed(
@@ -156,6 +159,25 @@ def test_rank0_download_failure_is_broadcast(
         hf_io.maybe_download_hf_repo_on_rank0("org/model", cache_dir=tmp_path)
 
     assert broadcasts == [[{"error": "OSError: disk full"}]]
+
+
+def test_rank0_disk_space_failure_is_broadcast_as_disk_error(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_hf_env(monkeypatch)
+    broadcasts = _mock_distributed(monkeypatch, initialized=True, rank=0)
+
+    def _snapshot_download(*args, **kwargs) -> str:
+        raise OSError(errno.ENOSPC, "No space left on device", str(tmp_path))
+
+    monkeypatch.setattr(hf_io, "snapshot_download", _snapshot_download)
+
+    with pytest.raises(hf_io.DiskSpaceError, match="Hugging Face cache"):
+        hf_io.maybe_download_hf_repo_on_rank0("org/model", cache_dir=tmp_path)
+
+    assert len(broadcasts) == 1
+    assert broadcasts[0][0]["disk_error"] == "1"
+    assert "No space left on device" in str(broadcasts[0][0]["error"])
 
 
 def test_rank0_failure_reaches_nonzero_rank(

--- a/integrations/lingbot/lingbot/transformer/__init__.py
+++ b/integrations/lingbot/lingbot/transformer/__init__.py
@@ -35,6 +35,9 @@ from .impl.network import (
     LingbotWorldDiTNetworkConfig,
 )
 
+LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB = 200.0
+"""First-run storage budget documented for LingBot-World model caches."""
+
 
 @dataclass(kw_only=True)
 class LingbotWorldTransformerCache(Wan21TransformerCache):
@@ -72,6 +75,7 @@ class LingbotWorldTransformerConfig(Wan21TransformerConfig):
     network: LingbotWorldDiTNetworkConfig = field(
         default_factory=LingbotWorldDiTNetwork14BConfig
     )
+    checkpoint_min_free_gb: float | None = LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB
 
 
 class LingbotWorldTransformer(Wan21Transformer):

--- a/integrations/lingbot/tests/test_smoke.py
+++ b/integrations/lingbot/tests/test_smoke.py
@@ -25,6 +25,7 @@ import pytest
 import tomli as tomllib
 from lingbot import config as config_mod
 from lingbot.config import RUNNER_CONFIGS
+from lingbot.transformer import LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB
 
 from flashdreams.infra.runner import RunnerConfig
 
@@ -54,6 +55,13 @@ def test_runners_have_descriptions() -> None:
         slug for slug, cfg in RUNNER_CONFIGS.items() if not cfg.description.strip()
     ]
     assert not empty, f"runners missing description: {empty}"
+
+
+def test_lingbot_configs_carry_documented_checkpoint_disk_requirement() -> None:
+    """LingBot's large checkpoint should preflight its documented first-run budget."""
+    for cfg in RUNNER_CONFIGS.values():
+        transformer = cfg.pipeline.diffusion_model.transformer
+        assert transformer.checkpoint_min_free_gb == LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB
 
 
 def test_entry_points_match_module_literals() -> None:

--- a/integrations/lingbot/tests/test_smoke.py
+++ b/integrations/lingbot/tests/test_smoke.py
@@ -25,7 +25,10 @@ import pytest
 import tomli as tomllib
 from lingbot import config as config_mod
 from lingbot.config import RUNNER_CONFIGS
-from lingbot.transformer import LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB
+from lingbot.transformer import (
+    LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB,
+    LingbotWorldTransformerConfig,
+)
 
 from flashdreams.infra.runner import RunnerConfig
 
@@ -61,7 +64,10 @@ def test_lingbot_configs_carry_documented_checkpoint_disk_requirement() -> None:
     """LingBot's large checkpoint should preflight its documented first-run budget."""
     for cfg in RUNNER_CONFIGS.values():
         transformer = cfg.pipeline.diffusion_model.transformer
-        assert transformer.checkpoint_min_free_gb == LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB
+        assert isinstance(transformer, LingbotWorldTransformerConfig)
+        assert (
+            transformer.checkpoint_min_free_gb == LINGBOT_WORLD_MIN_CHECKPOINT_FREE_GB
+        )
 
 
 def test_entry_points_match_module_literals() -> None:


### PR DESCRIPTION
Add shared disk-space helpers for cache, temp, output, HF, checkpoint,
and S3 write paths. Convert ENOSPC-style failures into concise actionable
errors from flashdreams-run, including path, free space, required minimum,
and relevant env/config settings.

Add CPU tests for preflight formatting, CLI traceback suppression, URL cache
ENOSPC handling, and distributed HF disk-error propagation.