### PR TITLE
Fix interactive-drive variant reset, first-run status text, and checkpoint prewarm

### DIFF
--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -172,6 +172,28 @@ Run the demo and stream to your browser:
 Then open ``http://<server-ip>:8080/`` in any browser on the same
 network and pick a scene from the picker in the bottom-right.
 
+.. note::
+
+   **The first launch is slow.** The first time you start the demo, the world
+   model spends several minutes in a one-time optimization pass -- checkpoint
+   loading, ``torch.compile`` / CUDA-graph capture, and Triton autotuning --
+   before the view becomes interactive. The on-screen indicator shows
+   ``Loading world model...`` during warmup and then ``Optimizing world
+   model...`` while the first generated chunk is autotuned; this phase is
+   longest on the perf manifest. Subsequent launches are much faster because
+   the compiled kernels and CUDA graphs are cached and reused.
+
+.. note::
+
+   Add ``--offload-text-encoder`` to reduce peak VRAM usage by ~15 GB.
+   The text and first-frame encoders are run once per scene and freed before the
+   diffusion pipeline is built, and the resulting embeddings are cached and
+   reused across world-model resets.
+
+   Trade-off: the world model is rebuilt on each scene load instead of staying
+   resident, so the first load and scene/variant switches are slower. Prefer it
+   when VRAM-constrained; otherwise leave it off for faster switching.
+
 For execution using a consumer NVIDIA GPU that exposes a graphics stack,
 omit the ``--stream-mjpeg`` flag to open the demo in a local Vulkan window
 instead:

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -152,10 +152,14 @@ front end, flashdreams + flashdreams-omnidreams pipeline).
 `omnidreams-prepare` stages the requested scene USDZ from the
 resolved scenes dataset
 (`nvidia/omni-dreams-scenes` by default, or another authorized org when
-`OMNI_DREAMS_HF_ORG` / `--hf-org` points there) and pre-warms the
+`OMNI_DREAMS_HF_ORG` / `--hf-org` points there), pre-warms the
 Cosmos-Reason1 text encoder used at runtime (~14 GB of Hugging Face cache),
-so the first setup can take a while depending on your network. Flashdreams
-owns video checkpoint selection and cache layout for the selected recipe.
+and pre-downloads the world-model DiT checkpoint from
+`nvidia/omni-dreams-models` (a separate gated repo) so the first launch
+isn't blocked on the multi-GB fetch — and so a missing-access error surfaces
+here with an actionable hint rather than mid-demo. The first setup can take a
+while depending on your network. Flashdreams owns video checkpoint selection
+and cache layout for the selected recipe.
 
 > **Tip:** You can skip the `omnidreams-prepare` step for the
 > *default* scene — `interactive-drive` will auto-stage it from
@@ -181,7 +185,9 @@ Common `omnidreams-prepare` flags:
   own USDZ via `interactive-drive --scene`).
 
 If `omnidreams-prepare` fails with `401`, `403`, or a gated-repo
-error, verify `HF_TOKEN` and confirm access to `nvidia/omni-dreams-scenes`.
+error, verify `HF_TOKEN` and confirm you have requested (and been granted)
+access to **both** `nvidia/omni-dreams-scenes` and
+`nvidia/omni-dreams-models` — access to one is not access to the other.
 
 Once done, you should see the scene's variant archive(s) under the shared
 scenes cache, one per weather:

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -478,7 +478,7 @@ input-to-present timing while the demo runs:
 
 ```bash
 INTERACTIVE_DRIVE_PROFILE_INPUT_TO_PRESENT=1 \
-  uv run --no-sync --package flashdreams-omnidreams interactive-drive --autoload-scene
+  uv run --no-sync --package flashdreams-omnidreams interactive-drive --auto-start
 ```
 
 The log line is `[profile] e2e ...`. `wall_present_fps` counts only frames

--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -158,6 +158,10 @@ class InteractiveDriveApp:
         """``True`` once the scene-independent model warmup has completed."""
         return self._pipeline.model_ready.is_set()
 
+    def first_chunk_produced(self) -> bool:
+        """``True`` once the model has produced its first generated chunk."""
+        return self._pipeline.first_chunk_produced.is_set()
+
     def load_scene(
         self, scene_path: object, variant: str, prompt_override: str | None
     ) -> bool:
@@ -507,12 +511,15 @@ class InteractiveDriveApp:
     def _loading_status_message(self) -> str:
         """Phase text shown over the loading frame until the first chunk.
 
-        World-model warmup takes priority; once the model is resident a
-        scene (re)load only uploads geometry and renders the first chunk,
-        so the lighter "Loading scene..." message is shown instead.
+        ``"Loading world model..."`` during warmup, then ``"Optimizing world
+        model..."`` while the first generated chunk pays its one-time
+        compile / CUDA-graph / autotune cost (only for backends that flag it),
+        then the cheaper ``"Loading scene..."`` for every load after that.
         """
         if not self.model_ready():
             return "Loading world model..."
+        if self._backend.optimizes_on_first_chunk and not self.first_chunk_produced():
+            return "Optimizing world model..."
         return "Loading scene..."
 
     def _resetting_status_message(self) -> str:

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/base.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/base.py
@@ -39,6 +39,18 @@ class RenderBackend(ABC):
         """
         return True
 
+    @property
+    def optimizes_on_first_chunk(self) -> bool:
+        """Whether the first generated chunk pays a one-time optimization cost.
+
+        ``True`` for backends (e.g. the world model) whose first chunk after
+        warmup triggers torch.compile / CUDA-graph capture / Triton autotuning,
+        so the demo can show "Optimizing world model..." instead of "Loading
+        scene..." until it lands. ``False`` (the default, e.g. raster) skips
+        that phase text.
+        """
+        return False
+
     @abstractmethod
     def warmup_model(self) -> None:
         """Load/compile the scene-independent model. Called once per process."""

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
@@ -59,6 +59,12 @@ class WorldModelRenderBackend(RenderBackend):
     def can_prewarm(self) -> bool:
         return self._session.can_prewarm
 
+    @property
+    def optimizes_on_first_chunk(self) -> bool:
+        # First chunk triggers compile / CUDA-graph capture / Triton autotune,
+        # which can take minutes on the first launch.
+        return True
+
     def warmup_model(self) -> None:
         if self._manifest.resolution_wh != self._raster.resolution_wh:
             raise ValueError(

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -509,7 +509,7 @@ def build_parser() -> argparse.ArgumentParser:
       :func:`omnidreams.interactive_drive.cli.build_parser`. These
       flags apply whether the user runs the supervised HUD wrapper or
       the bare backend with ``--no-hud`` / ``--stream-mjpeg``.
-    * Supervisor / HUD args (``--scene-dir``, ``--autoload-scene``,
+    * Supervisor / HUD args (``--scene-dir``, ``--auto-start``,
       ``--cuda-visible-devices``, ``--wheel-*``, ``--no-wheel``) that
       only matter when a HUD viewer is running. They're harmlessly
       ignored under ``--no-hud`` / ``--stream-mjpeg``.
@@ -561,10 +561,24 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--autoload-scene",
+        "--auto-start",
+        dest="auto_start",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Start loading --scene immediately. By default the HUD opens on Load Scene.",
+        help=(
+            "Start loading --scene immediately instead of opening the HUD on"
+            " Load Scene. Distinct from --preload-scenes (which only warms the"
+            " parse cache in the background)."
+        ),
+    )
+    parser.add_argument(
+        # Deprecated alias for --auto-start; kept so existing scripts/docs
+        # don't break. The old name was easily confused with --preload-scenes.
+        "--autoload-scene",
+        dest="auto_start",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--preload-scenes",
@@ -810,7 +824,7 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
 
     # Construct the presenter UPFRONT, before any backend, so the demo
     # can open the HUD window in "Load Scene" mode and wait for the
-    # user to pick a scene from the dropdown when ``--autoload-scene``
+    # user to pick a scene from the dropdown when ``--auto-start``
     # is off. The placeholder ``KeyboardState`` is rebound to each
     # successive ``InteractiveDriveApp``'s real keyboard via
     # ``presenter.bind_keyboard`` in the factory below; no engine is
@@ -876,12 +890,17 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
     presenter.acknowledge_scene_change(scene_path, variant)
     try:
         # ``need_selection`` drives the scene-selection wait: True on first
-        # launch (unless ``--autoload-scene``) and again every time the user
+        # launch (unless ``--auto-start``) and again every time the user
         # exits a scene back to the selector. While waiting the engine is
         # idle, so the video model stops generating -- the whole point of the
         # exit-scene affordance for long-running demos -- without closing the
         # window or dropping the warmed model.
-        need_selection = not args.autoload_scene
+        need_selection = not args.auto_start
+        # --auto-start + --preload-scenes: wait for the preloader to finish
+        # before the auto-load below so it hits the cache instead of racing
+        # the background thread with a second parse of the same USDZ.
+        if args.auto_start and app.preload_in_progress():
+            presenter.wait_while_preloading(app.preload_in_progress)
         while True:
             if need_selection:
                 request = presenter.wait_for_scene_selection()

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -464,7 +464,7 @@ class SlangPyHudPresenter:
         self._has_camera_frame = False
         # ``_engine_active`` is False during the initial scene-selection
         # wait (when the user hasn't picked a scene yet AND
-        # ``--autoload-scene`` was off) and during the brief gap between
+        # ``--auto-start`` was off) and during the brief gap between
         # scene changes. Drives the camera-area placeholder text together
         # with the model-warmup state below. Toggled by the demo wrapper
         # via :meth:`set_engine_active` around each scene's run.
@@ -2606,7 +2606,7 @@ class SlangPyHudPresenter:
     def wait_for_scene_selection(self) -> tuple[Any, str] | None:
         """Run a chrome-only event loop until the user picks a scene.
 
-        Used when ``--autoload-scene`` is False (the default) and on
+        Used when ``--auto-start`` is False (the default) and on
         the very first launch: we open the slangpy window with the
         HUD chrome but no engine, render a "Load Scene" placeholder
         in the camera area, and wait for the user to pick a scene from
@@ -2631,6 +2631,26 @@ class SlangPyHudPresenter:
                 self._present_canvas()
                 time.sleep(EVENT_POLL_INTERVAL_S)
             return None
+        finally:
+            self.set_engine_active(prior_engine_active)
+
+    def wait_while_preloading(self, in_progress: Callable[[], bool]) -> None:
+        """Pump the "Preloading scenes..." chrome until ``in_progress()`` clears.
+
+        Used by ``--auto-start`` + ``--preload-scenes`` so the auto-loaded
+        scene waits for the background preloader to finish (and is served from
+        its cache) instead of racing it with a second parse of the same USDZ.
+        Returns early if the window closes. Keeps the engine inactive so the
+        camera area shows the locked "Preloading scenes..." placeholder.
+        """
+        prior_engine_active = self._engine_active
+        self.set_engine_active(False)
+        try:
+            while in_progress() and not self.should_close:
+                self.process_events()
+                self._render_canvas(None)
+                self._present_canvas()
+                time.sleep(EVENT_POLL_INTERVAL_S)
         finally:
             self.set_engine_active(prior_engine_active)
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -2531,14 +2531,27 @@ class SlangPyHudPresenter:
 
         Called by the demo's outer loop just before it re-enters
         :meth:`wait_for_scene_selection`. Resets the close flag (so the
-        selection loop runs) and drops all per-rollout view state so the
-        selector shows the clean "Ready - pick a scene" / "WAITING FOR
-        BEV..." state rather than ghosting the just-exited rollout's last
-        camera frame, BEV minimap, and speed.
+        selection loop runs), resets the selected variant, and drops all
+        per-rollout view state so the selector shows the clean "Ready - pick a
+        scene" / "WAITING FOR BEV..." state rather than ghosting the
+        just-exited rollout's last camera frame, BEV minimap, and speed.
         """
         self._pending_exit_scene = False
         self._should_close_flag = False
+        self._reset_selected_variant_to_default()
         self._reset_scene_view_state()
+
+    def _reset_selected_variant_to_default(self) -> None:
+        """Point ``_selected_variant`` at the current scene's first variant.
+
+        Otherwise the "Variant:" header keeps showing the exited rollout's
+        weather variant, which a fresh scene pick (always ``scene.variants[0]``)
+        won't load. Falls back to ``"default"`` if the scene can't be resolved.
+        """
+        option = self._current_scene_option()
+        self._selected_variant = (
+            option.variants[0] if option is not None and option.variants else "default"
+        )
 
     def set_model_status(
         self, *, can_prewarm: bool, ready_probe: Callable[[], bool]

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -205,6 +205,10 @@ class ChunkPipeline:
             # rollout the user has already moved on from.
             if submit_generation != self.current_generation:
                 return True
+            # Latch before enqueuing so a consumer can't dequeue and present
+            # the first frame while first_chunk_produced() still reads False.
+            if frame_chunk.frames:
+                self._first_chunk_produced.set()
             for frame_index, frame in enumerate(frame_chunk.frames):
                 frame_times = chunk_times.frames[frame_index]
                 frame_times.image_ready_time = time.perf_counter()
@@ -216,8 +220,6 @@ class ChunkPipeline:
                         generation=submit_generation,
                     )
                 )
-            if frame_chunk.frames:
-                self._first_chunk_produced.set()
             return True
 
         self._command_queue.put(render_command)

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -88,6 +88,10 @@ class ChunkPipeline:
         # Lets callers overlap the scene-selection wait with the model load
         # and show a "ready" affordance once the model is resident.
         self._model_ready = threading.Event()
+        # Set once the worker queues its first generated chunk -- i.e. the
+        # one-time first-chunk optimization is done. Never cleared; the model
+        # stays optimized across resets and scene switches.
+        self._first_chunk_produced = threading.Event()
         # Monotonic generation bumped on every reset / scene switch. Renders
         # submitted under an older generation are superseded: their frames
         # are dropped instead of presented, so a reset or scene load doesn't
@@ -108,6 +112,11 @@ class ChunkPipeline:
     def model_ready(self) -> threading.Event:
         """Event set when scene-independent model warmup has completed."""
         return self._model_ready
+
+    @property
+    def first_chunk_produced(self) -> threading.Event:
+        """Event set once the worker has queued its first generated chunk."""
+        return self._first_chunk_produced
 
     @property
     def current_generation(self) -> int:
@@ -207,6 +216,8 @@ class ChunkPipeline:
                         generation=submit_generation,
                     )
                 )
+            if frame_chunk.frames:
+                self._first_chunk_produced.set()
             return True
 
         self._command_queue.put(render_command)

--- a/integrations/omnidreams/omnidreams/prepare.py
+++ b/integrations/omnidreams/omnidreams/prepare.py
@@ -56,7 +56,7 @@ def hf_prewarm_urls() -> tuple[str, ...]:
     """
     try:
         from omnidreams.config import AVAILABLE_OMNIDREAMS_CHECKPOINT_PATHS
-    except Exception as exc:  # pragma: no cover - config must be importable
+    except ImportError as exc:  # pragma: no cover - config must be importable
         raise RuntimeError(
             "Unable to import omnidreams.config to resolve world-model "
             "checkpoint URLs; run `uv sync --package flashdreams-omnidreams` "

--- a/integrations/omnidreams/omnidreams/prepare.py
+++ b/integrations/omnidreams/omnidreams/prepare.py
@@ -16,10 +16,12 @@ Stages the resources both demo paths share:
   :class:`CosmosReason1TextEncoderConfig` so the prewarm files satisfy
   the runtime ``from_pretrained(revision=...)`` call (otherwise the
   ~14 GB warm-up downloads HEAD and the runtime re-fetches at launch).
+* The world-model DiT checkpoint(s) the runtime loads from
+  ``nvidia/omni-dreams-models`` (see :func:`hf_prewarm_urls`).
 
 Re-running is safe: any asset already present on disk is skipped.
-Scene staging goes through Hugging Face; set ``HF_TOKEN`` with access
-to ``nvidia/omni-dreams-scenes`` before running this helper.
+Staging goes through Hugging Face; set ``HF_TOKEN`` with access to both
+``nvidia/omni-dreams-scenes`` and ``nvidia/omni-dreams-models`` first.
 """
 
 from __future__ import annotations
@@ -44,8 +46,32 @@ from omnidreams.scenes import (
 
 
 def hf_prewarm_urls() -> tuple[str, ...]:
-    """Hugging Face files the flashdreams-backed runtime lazily downloads."""
-    return ()
+    """World-model DiT checkpoint URLs the runtime would otherwise fetch lazily.
+
+    Pulled live off :data:`omnidreams.config.AVAILABLE_OMNIDREAMS_CHECKPOINT_PATHS`
+    so they track whatever the runtime loads. Pre-warming them here keeps the
+    first launch off the multi-GB download path and surfaces gated-repo access
+    errors at setup time. ``MISSING`` sentinels (internal-only checkpoints) and
+    non-Hugging-Face values are skipped.
+    """
+    try:
+        from omnidreams.config import AVAILABLE_OMNIDREAMS_CHECKPOINT_PATHS
+    except Exception as exc:  # pragma: no cover - config must be importable
+        raise RuntimeError(
+            "Unable to import omnidreams.config to resolve world-model "
+            "checkpoint URLs; run `uv sync --package flashdreams-omnidreams` "
+            "from the flashdreams workspace root first."
+        ) from exc
+
+    urls: list[str] = []
+    seen: set[str] = set()
+    for value in AVAILABLE_OMNIDREAMS_CHECKPOINT_PATHS.values():
+        if not value.startswith("https://huggingface.co/"):
+            continue
+        if value not in seen:
+            seen.add(value)
+            urls.append(value)
+    return tuple(urls)
 
 
 def _cosmos_reason1_prewarm_targets() -> tuple[tuple[str, str], ...]:

--- a/integrations/omnidreams/tests/interactive_drive/test_app_loading_status.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_app_loading_status.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from omnidreams.interactive_drive.app import InteractiveDriveApp
+
+
+def _event(set_: bool) -> threading.Event:
+    event = threading.Event()
+    if set_:
+        event.set()
+    return event
+
+
+def _app(*, optimizes: bool, model_ready: bool, first_chunk: bool) -> InteractiveDriveApp:
+    """Window-less app wired with just the state the loading status reads."""
+    app = InteractiveDriveApp.__new__(InteractiveDriveApp)
+    app._pipeline = SimpleNamespace(  # type: ignore[attr-defined]
+        model_ready=_event(model_ready),
+        first_chunk_produced=_event(first_chunk),
+    )
+    app._backend = SimpleNamespace(optimizes_on_first_chunk=optimizes)  # type: ignore[attr-defined]
+    return app
+
+
+def test_loading_status_world_model_phases() -> None:
+    warming = _app(optimizes=True, model_ready=False, first_chunk=False)
+    assert warming._loading_status_message() == "Loading world model..."
+
+    # Warm but no first chunk yet -- the phase that previously misread "Loading
+    # scene..." while the model was actually autotuning.
+    optimizing = _app(optimizes=True, model_ready=True, first_chunk=False)
+    assert optimizing._loading_status_message() == "Optimizing world model..."
+
+    loaded = _app(optimizes=True, model_ready=True, first_chunk=True)
+    assert loaded._loading_status_message() == "Loading scene..."
+
+
+def test_loading_status_skips_optimize_phase_for_non_optimizing_backend() -> None:
+    raster = _app(optimizes=False, model_ready=True, first_chunk=False)
+    assert raster._loading_status_message() == "Loading scene..."

--- a/integrations/omnidreams/tests/interactive_drive/test_app_loading_status.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_app_loading_status.py
@@ -16,7 +16,9 @@ def _event(set_: bool) -> threading.Event:
     return event
 
 
-def _app(*, optimizes: bool, model_ready: bool, first_chunk: bool) -> InteractiveDriveApp:
+def _app(
+    *, optimizes: bool, model_ready: bool, first_chunk: bool
+) -> InteractiveDriveApp:
     """Window-less app wired with just the state the loading status reads."""
     app = InteractiveDriveApp.__new__(InteractiveDriveApp)
     app._pipeline = SimpleNamespace(  # type: ignore[attr-defined]

--- a/integrations/omnidreams/tests/interactive_drive/test_app_smoke.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_app_smoke.py
@@ -98,7 +98,7 @@ def _run_raster_ui_smoke(scene_path: Path) -> None:
                 # ``python -m omnidreams.interactive_drive`` now goes through the
                 # demo wrapper which opens a pygame HUD by default and
                 # only spawns the backend when the user clicks ``Load
-                # Scene`` (or passes ``--autoload-scene``). The smoke
+                # Scene`` (or passes ``--auto-start``). The smoke
                 # test exercises the bare backend, so opt out of the
                 # HUD; the raster backend then prints the warmup
                 # sentinel directly to this process's stdout.

--- a/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
@@ -222,6 +222,40 @@ def test_chunk_pipeline_scene_change_clears_already_queued_frames() -> None:
     assert pipeline.frame_queue.qsize() == 0
 
 
+def test_chunk_pipeline_sets_first_chunk_produced_after_first_chunk() -> None:
+    backend = FakeVideoModelBackend(frames_per_render=1)
+    pipeline = ChunkPipeline(backend)
+    assert pipeline.model_ready.wait(timeout=1.0)
+    # Warmup done, but no generated chunk yet -> still in the optimize phase.
+    assert not pipeline.first_chunk_produced.is_set()
+
+    pipeline.request_scene(minimal_scene())
+    pipeline.request_pose_chunk(
+        ChunkRequest(trajectory=make_trajectory(1), chunk_times=_chunk_times(1))
+    )
+    pipeline.frame_queue.get(timeout=1.0)
+    assert pipeline.first_chunk_produced.wait(timeout=1.0)
+    pipeline.shutdown()
+
+
+def test_chunk_pipeline_first_chunk_produced_unset_for_superseded_render() -> None:
+    backend = _GatedBackend()
+    pipeline = ChunkPipeline(backend)
+    pipeline.request_scene(minimal_scene())
+    pipeline.request_pose_chunk(
+        ChunkRequest(trajectory=make_trajectory(1), chunk_times=_chunk_times(1))
+    )
+    # Reset supersedes the in-flight render, so its frames are dropped and the
+    # optimize-phase latch must not flip on a chunk the user never saw.
+    assert backend.render_started.wait(timeout=1.0)
+    pipeline.reset()
+    backend.release.set()
+    pipeline.shutdown()
+
+    assert pipeline.frame_queue.qsize() == 0
+    assert not pipeline.first_chunk_produced.is_set()
+
+
 def test_chunk_pipeline_skips_stale_scene_load_queued_behind_warmup() -> None:
     backend = _GatedWarmupBackend()
     pipeline = ChunkPipeline(backend)

--- a/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
@@ -5,7 +5,21 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from omnidreams.interactive_drive.demo import SceneOption, _resolve_scene_variant
+from omnidreams.interactive_drive.demo import (
+    SceneOption,
+    _resolve_scene_variant,
+    build_parser,
+)
+
+
+def test_auto_start_flag_and_deprecated_alias() -> None:
+    parser = build_parser()
+
+    assert parser.parse_args([]).auto_start is False
+    assert parser.parse_args(["--auto-start"]).auto_start is True
+    # --autoload-scene is kept as a backward-compatible alias for --auto-start.
+    assert parser.parse_args(["--autoload-scene"]).auto_start is True
+    assert parser.parse_args(["--no-autoload-scene"]).auto_start is False
 
 
 def test_resolve_scene_variant_prefers_weather_archive_path_for_default(

--- a/integrations/omnidreams/tests/interactive_drive/test_presenter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_presenter.py
@@ -543,3 +543,71 @@ def test_hud_model_rgb_falls_back_to_host_when_cuda_path_raises() -> None:
     assert presented == [lazy]
     assert presenter._cuda_hud_interop is None
     assert close_calls == 1
+
+
+class _ExitSceneKeyboard:
+    def __init__(self) -> None:
+        self.cleared = 0
+
+    def clear_telemetry(self) -> None:
+        self.cleared += 1
+
+
+def _hud_presenter_for_exit(selected_variant: str) -> SlangPyHudPresenter:
+    """Window-less HUD presenter wired with just the state exit-to-selector touches."""
+    from pathlib import Path
+
+    from omnidreams.interactive_drive.demo import SceneOption
+
+    presenter = _hud_presenter_without_window()
+    scene_path = Path("clipgt-0d404ff7-2b66-498c-b047-1ed8cded60d4.usdz")
+    option = SceneOption(
+        label="Quiet Suburban Boulevard",
+        path=scene_path,
+        variants=("default", "rain", "snow"),
+        variant_paths={"default": scene_path},
+    )
+    presenter._scene_options = (option,)
+    presenter._current_scene = scene_path
+    presenter._selected_variant = selected_variant
+    presenter._pending_exit_scene = True
+    presenter._should_close_flag = True
+    presenter._keyboard = _ExitSceneKeyboard()
+    # State cleared by _reset_scene_view_state.
+    presenter._scene_dropdown_open = True
+    presenter._variant_dropdown_open = True
+    presenter._camera_resize_cache_key = object()
+    presenter._camera_resize_cache = object()
+    presenter._latest_camera_pil = object()
+    presenter._latest_bev_pil = object()
+    presenter._bev_panel_cache_key = object()
+    presenter._bev_panel_cache = object()
+    presenter._panel_chrome_cache_key = object()
+    presenter._panel_chrome_cache = object()
+    presenter._has_camera_frame = True
+    presenter._speed_mph = 42.0
+    presenter._pending_drive_releases = {"w": 1.0}
+    return presenter
+
+
+def test_acknowledge_exit_scene_resets_variant_to_scene_default() -> None:
+    # Exiting a rain/snow rollout must not leave the selector header stuck on
+    # the exited variant.
+    presenter = _hud_presenter_for_exit(selected_variant="rain")
+
+    presenter.acknowledge_exit_scene()
+
+    assert presenter._selected_variant == "default"
+    assert presenter._pending_exit_scene is False
+    assert presenter._should_close_flag is False
+    assert presenter._has_camera_frame is False
+
+
+def test_acknowledge_exit_scene_falls_back_to_default_when_scene_unknown() -> None:
+    presenter = _hud_presenter_for_exit(selected_variant="snow")
+    # Current scene no longer matches any discovered option.
+    presenter._scene_options = ()
+
+    presenter.acknowledge_exit_scene()
+
+    assert presenter._selected_variant == "default"

--- a/integrations/omnidreams/tests/interactive_drive/test_presenter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_presenter.py
@@ -611,3 +611,47 @@ def test_acknowledge_exit_scene_falls_back_to_default_when_scene_unknown() -> No
     presenter.acknowledge_exit_scene()
 
     assert presenter._selected_variant == "default"
+
+
+def _hud_presenter_for_preload() -> SlangPyHudPresenter:
+    presenter = _hud_presenter_without_window()
+    presenter._engine_active = True
+    presenter._should_close_flag = False
+    presenter._window = SimpleNamespace(should_close=lambda: False)
+    presenter.process_events = lambda: None
+    presenter._present_canvas = lambda *a, **k: None
+    return presenter
+
+
+def test_wait_while_preloading_pumps_until_in_progress_clears() -> None:
+    presenter = _hud_presenter_for_preload()
+    renders = 0
+
+    def render(_status: object) -> None:
+        nonlocal renders
+        renders += 1
+
+    presenter._render_canvas = render
+
+    states = iter([True, True, False])
+    presenter.wait_while_preloading(lambda: next(states))
+
+    assert renders == 2
+    assert presenter._engine_active is True  # restored to its prior value
+
+
+def test_wait_while_preloading_stops_when_window_closes() -> None:
+    presenter = _hud_presenter_for_preload()
+    presenter._should_close_flag = True
+    renders = 0
+
+    def render(_status: object) -> None:
+        nonlocal renders
+        renders += 1
+
+    presenter._render_canvas = render
+
+    # Still "in progress", but a closed window must short-circuit the wait.
+    presenter.wait_while_preloading(lambda: True)
+
+    assert renders == 0

--- a/integrations/omnidreams/tests/test_prepare.py
+++ b/integrations/omnidreams/tests/test_prepare.py
@@ -29,9 +29,9 @@ def test_hf_prewarm_urls_includes_world_model_checkpoint() -> None:
     # at runtime instead of being staged here.
     urls = hf_prewarm_urls()
 
-    assert any(
-        "omni-dreams-models" in url and url.endswith(".pt") for url in urls
-    ), f"expected an omni-dreams-models checkpoint in {urls!r}"
+    assert any("omni-dreams-models" in url and url.endswith(".pt") for url in urls), (
+        f"expected an omni-dreams-models checkpoint in {urls!r}"
+    )
 
 
 def test_hf_prewarm_urls_only_returns_hf_file_urls() -> None:

--- a/integrations/omnidreams/tests/test_prepare.py
+++ b/integrations/omnidreams/tests/test_prepare.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cheap checks for the ``omnidreams-prepare`` setup helper."""
+
+from __future__ import annotations
+
+import pytest
+from omnidreams.config import AVAILABLE_OMNIDREAMS_CHECKPOINT_PATHS
+from omnidreams.prepare import hf_prewarm_urls
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_hf_prewarm_urls_includes_world_model_checkpoint() -> None:
+    # Regression guard: this used to return () and the checkpoint 401'd lazily
+    # at runtime instead of being staged here.
+    urls = hf_prewarm_urls()
+
+    assert any(
+        "omni-dreams-models" in url and url.endswith(".pt") for url in urls
+    ), f"expected an omni-dreams-models checkpoint in {urls!r}"
+
+
+def test_hf_prewarm_urls_only_returns_hf_file_urls() -> None:
+    urls = hf_prewarm_urls()
+
+    assert urls
+    assert all(url.startswith("https://huggingface.co/") for url in urls)
+    assert "MISSING" not in urls
+    assert len(urls) == len(set(urls))
+
+
+def test_hf_prewarm_urls_match_available_checkpoint_paths() -> None:
+    # Stays in lockstep with the recipe config, minus the "MISSING" sentinels.
+    real_urls = {
+        value
+        for value in AVAILABLE_OMNIDREAMS_CHECKPOINT_PATHS.values()
+        if value.startswith("https://huggingface.co/")
+    }
+
+    assert set(hf_prewarm_urls()) == real_urls


### PR DESCRIPTION
Closes #293
Closes #294
Closes #299

## Summary

Three small interactive-drive fixes (plus docs and regression tests):

- **Variant selector stuck after exit-scene.** Exiting a scene back to the
  selector left the HUD's `Variant:` header showing the just-exited
  `rain`/`snow` choice even though the default scene was displayed.
  `acknowledge_exit_scene()` now resets the selected variant to the scene's
  first variant (matching what the next scene pick actually loads).

- **"Loading scene…" shown during the first-run autotune.** On first launch
  the world model spends minutes in a one-time `torch.compile` / CUDA-graph /
  Triton-autotune pass *after* warmup, which was mislabeled "Loading scene…".
  Added an `Optimizing world model…` phase: backends opt in via a new
  `optimizes_on_first_chunk` flag, and the pipeline latches
  `first_chunk_produced` once the first generated chunk is queued. Surfaces
  uniformly across the HUD, `--no-hud`, and `--stream-mjpeg` presenters.

- **World-model checkpoint not staged by `omnidreams-prepare`.**
  `hf_prewarm_urls()` returned `()`, so the gated `nvidia/omni-dreams-models`
  DiT checkpoint was only fetched lazily at runtime (and 401'd deep in the
  stack). It now pulls the checkpoint URL(s) live from the recipe config, so
  the first launch isn't blocked on the multi-GB download and gated-repo
  access errors surface at setup time with an actionable hint.

## Docs

- Document the first-run optimization wait and the `Loading world model…` →
  `Optimizing world model…` indicator sequence.
- Document `--offload-text-encoder`: ~15 GB peak-VRAM savings and the
  trade-off (model rebuilt per scene load instead of staying resident).
- Note that `omnidreams-prepare` now stages the checkpoint, and that access to
  **both** `nvidia/omni-dreams-scenes` and `nvidia/omni-dreams-models` is
  required.