### PR TITLE
docs: update Discord invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ documentation edits are all welcome.
 Use [GitHub Issues](https://github.com/NVIDIA/flashdreams/issues) to report defects or request improvements.
 
 Join us on the [NVIDIA Omniverse Discord](https://discord.com/invite/nvidiaomniverse)
-to share your results and take part in technical discussion! Channel: [`#flashdreams`](https://discord.gg/yTdHDqFP)
+to share your results and take part in technical discussion! Channel: [`#flashdreams`](https://discord.gg/cMt2mHm4aN)
 
 ## Security
 

--- a/docs/source/community/discord.rst
+++ b/docs/source/community/discord.rst
@@ -26,6 +26,6 @@ If you are new, start with the
 Channels
 --------
 
-- `#flashdreams <https://discord.gg/yTdHDqFP>`_
-- `#omni-dreams <https://discord.gg/bsjzh4uZ>`_
-- `#world-model-chit-chat <https://discord.gg/APbw7EPk>`_
+- `#flashdreams <https://discord.gg/cMt2mHm4aN>`_
+- `#omnidreams <https://discord.gg/cruUPk9tuS>`_
+- `#world-models-chit-chat <https://discord.gg/AkcK7NVGQD>`_


### PR DESCRIPTION
## Summary
- update FlashDreams README Discord invite to the never-expire channel link
- update community Discord docs for #flashdreams, #omnidreams, and #world-models-chit-chat

## Tests
- not run (docs-only change)
