### PR TITLE
Website: Replace hover-to-zoom with click-to-zoom

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1660,7 +1660,7 @@ body.fd-page-landing .fd-split-text .highlight {
     }
 }
 
-/* -- Image hover-to-zoom (JS-driven overlay) ----------------------------- */
+/* -- Image click-to-zoom (JS-driven overlay) ----------------------------- */
 
 img.zoomable,
 .zoomable img,
@@ -1678,11 +1678,13 @@ img.zoomable,
     background: rgba(0, 0, 0, 0.55);
     opacity: 0;
     pointer-events: none;
+    cursor: zoom-out;
     transition: opacity 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 
 .img-zoom-overlay.visible {
     opacity: 1;
+    pointer-events: auto;
 }
 
 .img-zoom-clone {

--- a/docs/source/_static/js/image_zoom.js
+++ b/docs/source/_static/js/image_zoom.js
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 /**
- * Hover-to-zoom for documentation images and videos (opt-in).
+ * Click-to-zoom for documentation images and videos (opt-in).
  *
  * Only elements inside a .zoomable container (or with the class directly)
- * participate. On mouseenter the element's full-resolution version is shown
- * in a fixed overlay. The overlay never captures pointer events -- the
- * cursor stays on the source element, so mouseleave fires reliably.
+ * participate. Clicking the element shows its full-resolution version in a
+ * fixed overlay. Clicking the zoomed overlay (or pressing Escape) zooms back
+ * out.
  */
 (function () {
   "use strict";
@@ -17,12 +17,12 @@ SPDX-License-Identifier: Apache-2.0
   var overlay = null;
   var clone = null;
   var activeEl = null;
-  var showTimer = null;
-  var SHOW_DELAY = 120; // ms before showing (avoids flash on quick pass-through)
 
   function createOverlay() {
     overlay = document.createElement("div");
     overlay.className = "img-zoom-overlay";
+    // Clicking anywhere on the zoomed overlay closes it.
+    overlay.addEventListener("click", hide);
     document.body.appendChild(overlay);
   }
 
@@ -58,8 +58,6 @@ SPDX-License-Identifier: Apache-2.0
   }
 
   function hide() {
-    clearTimeout(showTimer);
-    showTimer = null;
     if (!overlay) return;
     overlay.classList.remove("visible");
     activeEl = null;
@@ -90,22 +88,18 @@ SPDX-License-Identifier: Apache-2.0
                   document.querySelector("[role='main']") ||
                   document.body;
 
-    content.addEventListener("mouseenter", function (e) {
+    content.addEventListener("click", function (e) {
       var target = e.target;
       if (isZoomTarget(target)) {
-        clearTimeout(showTimer);
-        showTimer = setTimeout(function () {
-          show(target);
-        }, SHOW_DELAY);
+        e.preventDefault();
+        show(target);
       }
-    }, true);
+    });
 
-    content.addEventListener("mouseleave", function (e) {
-      var target = e.target;
-      if (target === activeEl || (showTimer && isZoomTarget(target))) {
-        hide();
-      }
-    }, true);
+    // Pressing Escape zooms back out.
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && activeEl) hide();
+    });
   }
 
   if (document.readyState === "loading") {


### PR DESCRIPTION
Replaces the JS that zooms into images when hovered over with the mouse with JS that zooms in/out of images when clicked.

Before: https://nvidia.github.io/flashdreams/pr-preview/pr-284/index.html
After: https://nvidia.github.io/flashdreams/pr-preview/pr-310/index.html
