### PR TITLE
docs(hy_worldplay/wan22): tighten AI-generated comments and docstrings

### DIFF
--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -1532,11 +1532,8 @@ class WanVAEDecoder(StreamingVideoDecoder[WanVAECache]):
 
 
 # Diffusers ``AutoencoderKLWan`` (Wan 2.2 5B) -> flashdreams ``WanVAE``
-# key remap. The production configs below use upstream's
-# ``Wan2.2_VAE.pth`` whose layout matches our model directly (no remap
-# needed); this dict + :func:`wan22_ti2v_5b_vae_state_dict_transform`
-# are kept in tree as an opt-in fallback for callers who'd rather
-# point at the diffusers safetensors shard.
+# key remap, applied by :func:`wan22_ti2v_5b_vae_state_dict_transform`
+# (the production VAE load path).
 _WAN22_TI2V_5B_VAE_KEY_REMAP: dict[str, str] = {
     # Top-level quant convs.
     r"^quant_conv\.(.*)$": r"conv1.\1",
@@ -1551,12 +1548,8 @@ _WAN22_TI2V_5B_VAE_KEY_REMAP: dict[str, str] = {
     r"^encoder\.conv_out\.(.*)$": r"encoder.head.2.\1",
     r"^decoder\.norm_out\.(.*)$": r"decoder.head.0.\1",
     r"^decoder\.conv_out\.(.*)$": r"decoder.head.2.\1",
-    # Mid block: diffusers stores ``resnets.{0,1}`` + ``attentions.0``
-    # while our Sequential is (Residual, Attention, Residual) ->
-    # indices (0, 1, 2). ``WanMidBlock.forward`` runs resnets[0], then
-    # (attentions[0], resnets[1]), so the ordering matches our
-    # (middle.0, middle.2) layout. Per-field remap mirrors the
-    # down/up-block resnets below.
+    # Mid block: diffusers ``resnets.{0,1}`` + ``attentions.0`` map to our
+    # ``middle`` Sequential (Residual, Attention, Residual) at indices 0/1/2.
     r"^encoder\.mid_block\.resnets\.0\.norm1\.(.*)$": r"encoder.middle.0.residual.0.\1",
     r"^encoder\.mid_block\.resnets\.0\.conv1\.(.*)$": r"encoder.middle.0.residual.2.\1",
     r"^encoder\.mid_block\.resnets\.0\.norm2\.(.*)$": r"encoder.middle.0.residual.3.\1",
@@ -1579,17 +1572,9 @@ _WAN22_TI2V_5B_VAE_KEY_REMAP: dict[str, str] = {
     r"^decoder\.mid_block\.resnets\.1\.conv2\.(.*)$": r"decoder.middle.2.residual.6.\1",
     r"^decoder\.mid_block\.resnets\.1\.conv_shortcut\.(.*)$": r"decoder.middle.2.shortcut.\1",
     r"^decoder\.mid_block\.attentions\.0\.(.*)$": r"decoder.middle.1.\1",
-    # Per-residual-block field remap: diffusers ``conv1 / conv2 /
-    # norm1 / norm2 / conv_shortcut`` -> our Sequential entries.
-    # The Sequential layout in ResidualBlock.__init__ is:
-    #   0: RMS_norm (norm1)
-    #   1: SiLU
-    #   2: CausalConv3d (conv1)
-    #   3: RMS_norm (norm2)
-    #   4: SiLU
-    #   5: Dropout
-    #   6: CausalConv3d (conv2)
-    # Plus ``shortcut`` (renamed from diffusers ``conv_shortcut``).
+    # Per-residual-block field remap. ResidualBlock's Sequential is:
+    #   0 norm1, 2 conv1, 3 norm2, 6 conv2 (1/4 SiLU, 5 Dropout).
+    # diffusers ``conv_shortcut`` -> our ``shortcut``.
     r"^encoder\.down_blocks\.(\d+)\.resnets\.(\d+)\.norm1\.(.*)$": (
         r"encoder.downsamples.\1.resnets.\2.residual.0.\3"
     ),
@@ -1643,17 +1628,9 @@ def wan22_ti2v_5b_vae_state_dict_transform(
     """Remap a diffusers ``AutoencoderKLWan`` state-dict to ``WanVAE`` keys.
 
     Applied automatically when :class:`Wan22TI2V5BVAEEncoderConfig` /
-    :class:`Wan22TI2V5BVAEDecoderConfig` load the upstream
-    ``Wan-AI/Wan2.2-TI2V-5B-Diffusers/vae/diffusion_pytorch_model.safetensors``
-    checkpoint. The mapping is purely structural -- no tensors are
-    copied or reshaped.
-
-    Note:
-        Patterns are applied in iteration order via
-        :func:`flashdreams.core.checkpoint.remap.remap_checkpoint_keys`.
-        Any key without a matching pattern passes through unchanged,
-        which surfaces as a ``load_state_dict`` ``unexpected_keys``
-        warning so missing remap entries are easy to spot.
+    :class:`Wan22TI2V5BVAEDecoderConfig` load the diffusers VAE checkpoint.
+    Renames keys only -- no tensors are copied or reshaped. Unmatched keys
+    pass through and surface as ``unexpected_keys`` on load.
     """
     from flashdreams.core.checkpoint.remap import remap_checkpoint_keys
 

--- a/integrations/hy_worldplay/hy_worldplay/_action.py
+++ b/integrations/hy_worldplay/hy_worldplay/_action.py
@@ -47,27 +47,18 @@ from flashdreams.recipes.wan.transformer.wan21 import (
 )
 
 _HY_STABILIZATION_TIMESTEP: int = 14
-"""Near-clean AdaLN timestep applied to memory K/V during the
-reconstituted-context KV prefill; vendor's ``t_ctx = stabilization_level - 1``.
-Modulating memory tokens at this near-zero noise level keeps the model in its
-trained distribution; using the noisy denoising timestep instead would scale
-memory K/V as if those frames were still being denoised."""
+"""Near-clean AdaLN timestep applied to memory K/V during the memory KV
+prefill, keeping memory tokens in the model's trained distribution."""
 
 
 def _fp32_sequential(seq: nn.Sequential, x: Tensor) -> Tensor:
     """Run ``seq`` (chained ``nn.Linear`` + dtype-stable activations) in fp32.
 
-    Vendor lists ``time_embedder`` in ``_keep_in_fp32_modules`` so its
-    Linear weights stay in fp32; flashdreams coerces every parameter to
-    the model dtype (bf16) at load, so we upcast input and weights here
-    to match vendor's accumulation precision. The output is fp32;
-    callers ``.type_as(x)`` at the boundary.
-
-    Only supports ``Linear -> Activation -> Linear`` /
-    ``Activation -> Linear`` layouts (Wan 2.1 ``time_embedding`` /
-    ``time_projection`` and HY ``action_embedding``). Layers with
-    dtype-coupled state (e.g. layer norms) need the broader treatment
-    in :func:`hy_worldplay._camera._fp32_layer_norm`.
+    Upcasts input and Linear weights to fp32 and returns an fp32 output;
+    callers ``.type_as(x)`` at the boundary. Only supports
+    ``Linear -> Activation -> Linear`` / ``Activation -> Linear`` layouts;
+    layers with dtype-coupled state (e.g. layer norms) need
+    :func:`hy_worldplay._camera._fp32_layer_norm`.
     """
     out = x.to(torch.float32)
     for module in seq:
@@ -146,9 +137,7 @@ class HyWorldPlayWanCtrlEncoder(I2VCtrlEncoder):
         self._action_labels: Tensor | None = None
         self._viewmats: Tensor | None = None
         self._intrinsics: Tensor | None = None
-        # Knobs + Monte-Carlo point cloud are bound externally via
-        # ``set_memory_config``; ``None`` disables selection so the
-        # encoder emits ``memory_frame_indices=None`` on every AR step.
+        # Bound via ``set_memory_config``; ``None`` disables selection.
         self._memory_config: _MemoryConfig | None = None
 
     def set_action_labels(self, labels: Tensor) -> None:
@@ -267,8 +256,8 @@ class HyWorldPlayWanCtrlEncoder(I2VCtrlEncoder):
         self._memory_config = None
 
     def initialize_autoregressive_cache(self) -> I2VCtrlEncoderCache:
-        # Bound action / camera / memory state is owned by the runner
-        # across rollouts; we deliberately do not clear it here.
+        # Bound action / camera / memory state is owned by the runner across
+        # rollouts and is intentionally not cleared here.
         return super().initialize_autoregressive_cache()
 
     @torch.no_grad()
@@ -316,10 +305,8 @@ class HyWorldPlayWanCtrlEncoder(I2VCtrlEncoder):
             autoregressive_index=autoregressive_index, current_frame_idx=start
         )
 
-        # Expose the bound full-trajectory tensors so the prefill driver
-        # can index them at ``memory_frame_indices`` (which live in
-        # *rollout* coordinates). Moving them to the latent's device once
-        # per AR step amortises the transfer over all prefill calls.
+        # Expose the full-trajectory tensors (in rollout coordinates) so the
+        # prefill driver can index them at ``memory_frame_indices``.
         rollout_viewmats: Tensor | None = (
             self._viewmats.to(device=device) if self._viewmats is not None else None
         )
@@ -349,47 +336,34 @@ class HyWorldPlayWanCtrlEncoder(I2VCtrlEncoder):
     ) -> list[int] | None:
         """Pick the historical frame indices for this AR step's KV prefill.
 
-        Three branches, mirroring vendor's gating:
-
-        * AR step 0 (no history): return ``None``.
-        * Memory configured *and* past the warm-up window
-          (``current_frame_idx >= context_window_length``): run the
-          FOV-overlap selector against the bound camera history.
-        * Otherwise return ``list(range(0, current_frame_idx))`` --
-          the all-history fall-back, required on the HY path because
-          :meth:`HyWorldPlayWan21Transformer.finalize_kv_cache` skips
-          the base rolling-KV update and
-          :meth:`HyWorldPlayWan21TransformerCache.start` wipes each
-          block's rolling self-attention cache at chunk boundaries.
-
-        Returns ``None`` when camera data is not bound: the prefill
-        executor indexes the per-rollout buffers, so without them there
-        is no prefill to run (the dual-branch and action paths are
-        themselves no-ops in that configuration).
+        Returns:
+            ``None`` on AR step 0 or when camera data is not bound (no
+            prefill to run). When memory selection is armed and past the
+            warm-up window (``current_frame_idx >= context_window_length``),
+            the FOV-overlap selector's choice. Otherwise the all-history
+            fall-back ``list(range(0, current_frame_idx))``, required
+            because the HY path wipes each block's rolling self-attention
+            cache at chunk boundaries.
         """
         if autoregressive_index == 0 or current_frame_idx == 0:
             return None
         if self._viewmats is None:
             return None
-        # FOV-based selection branch.
         if (
             self._memory_config is not None
             and current_frame_idx >= self._memory_config.context_window_length
         ):
             cfg = self._memory_config
-            # Vendor's FOV selector takes a flat ``[n_latents, 4, 4]``
-            # history; collapse leading batch axes by selecting slot 0
-            # (vendor also ignores per-batch trajectories).
+            # The FOV selector takes a flat ``[n_latents, 4, 4]`` history;
+            # collapse leading batch axes by selecting slot 0.
             viewmats_history = self._viewmats
             while viewmats_history.ndim > 3:
                 viewmats_history = viewmats_history[0]
-            # Lazy-imported so numpy + FOV math stay out of the import
-            # graph when memory selection is disabled.
+            # Lazy import so numpy + FOV math stay out of the import graph
+            # when memory selection is disabled.
             from hy_worldplay._memory import select_memory_frame_indices
 
-            # ``.numpy()`` rejects bf16; cast to fp32 here. Selection
-            # precision is not the bottleneck relative to the bf16 dtype
-            # used downstream by attention.
+            # ``.numpy()`` rejects bf16; cast to fp32.
             return select_memory_frame_indices(
                 viewmats_history.detach().to(dtype=torch.float32).cpu().numpy(),
                 current_frame_idx=current_frame_idx,
@@ -402,15 +376,13 @@ class HyWorldPlayWanCtrlEncoder(I2VCtrlEncoder):
                 device=cfg.device,
             )
 
-        # All-history fall-back; critical for cross-chunk attention on
-        # the HY path (see docstring).
+        # All-history fall-back; see docstring.
         return list(range(0, current_frame_idx))
 
 
 @dataclass(frozen=True)
 class _MemoryConfig:
-    """Memory-selection knobs bound on the encoder. Frozen: the selection policy is
-    deterministic given the camera history and these knobs."""
+    """Memory-selection knobs bound on the encoder."""
 
     points_local: Tensor
     context_window_length: int
@@ -456,9 +428,8 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
     """
 
     def __init__(self, config: HyWorldPlayWanDiTNetworkConfig) -> None:
-        # Stash ``use_prope_blocks`` before ``super().__init__()`` because
-        # the base constructor calls ``self._build_block`` while wiring up
-        # the block stack.
+        # Stash ``use_prope_blocks`` before ``super().__init__()`` because the
+        # base constructor calls ``self._build_block`` while wiring the stack.
         nn.Module.__init__(self)
         self._hy_use_prope_blocks = config.use_prope_blocks
         super().__init__(config)
@@ -467,9 +438,8 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
             nn.SiLU(),
             nn.Linear(self.dim, self.dim),
         )
-        # Zero-init the residual head so the action branch is an identity
-        # at construction time (matches vendor's
-        # ``add_discrete_action_parameters``).
+        # Zero-init the residual head so the action branch is an identity at
+        # construction time.
         zero_linear = self.action_embedding[-1]
         assert isinstance(zero_linear, nn.Linear)
         nn.init.zeros_(zero_linear.weight)
@@ -478,8 +448,8 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
 
     def _build_block(self, layer_idx: int) -> Block:
         if self._hy_use_prope_blocks:
-            # Lazy-imported so action-only configurations don't pay the
-            # PRoPE block module's import cost.
+            # Lazy import so action-only configs don't pay the PRoPE block's
+            # import cost.
             from hy_worldplay._camera import HyWorldPlayPRoPEBlock
 
             return HyWorldPlayPRoPEBlock(
@@ -539,9 +509,7 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
         per_token_timestep = (
             timesteps.ndim > len(batch_shape) and timesteps.shape[-1] == L
         )
-        # Vendor's ``_keep_in_fp32_modules`` keeps ``time_embedder`` in
-        # fp32. Mirror that here; ``time_projection`` (vendor's
-        # ``time_proj``) is not on vendor's fp32 list and stays in bf16.
+        # ``time_embedding`` runs in fp32; ``time_projection`` stays in bf16.
         e_fp32 = _fp32_sequential(
             self.time_embedding,
             sinusoidal_embedding_1d(self.freq_dim, timesteps).to(torch.float32),
@@ -550,9 +518,7 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
 
         if action is not None:
             action_e = self._compute_action_embedding(action=action, x=x, L=L)
-            # Vendor performs this add in bf16; mirror that by casting
-            # ``e`` to ``x.dtype`` before the add (done by ``type_as``
-            # above).
+            # Add in bf16 (``e`` was cast to ``x.dtype`` by ``type_as`` above).
             e = e + action_e
             per_token_timestep = True
 
@@ -566,8 +532,8 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
             head_e = torch.broadcast_to(e, batch_shape + (self.dim,)).unsqueeze(-2)
         block_e = torch.broadcast_to(e0, block_e_shape)
 
-        # Thread camera data per-block when PRoPE blocks are active.
-        # Copy ``block_extra_kwargs`` rather than mutate the caller's dict.
+        # Thread camera data per-block when PRoPE blocks are active; copy
+        # ``block_extra_kwargs`` rather than mutate the caller's dict.
         block_kwargs = dict(block_extra_kwargs)
         if self._hy_use_prope_blocks:
             if viewmats is None:
@@ -611,38 +577,34 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
         viewmats: Tensor | None = None,
         Ks: Tensor | None = None,
     ) -> None:
-        """Populate each block's reconstituted-context memory cache.
+        """Populate each block's memory KV cache.
 
-        Mirrors :meth:`forward`'s patchify + time / action embedding + AdaLN
-        modulation preamble, then loops over blocks calling
-        :meth:`HyWorldPlayPRoPEBlock.prefill_memory_kv` so each block's
-        self-attention K/V land in its memory slot at the collapsed RoPE
-        positions ``[0, K * tokens_per_frame)``. Cross-attention, FFN, and
-        the head are unobservable in the cache and are skipped on this path.
+        Runs :meth:`forward`'s patchify + time / action embedding + AdaLN
+        preamble, then calls :meth:`HyWorldPlayPRoPEBlock.prefill_memory_kv`
+        per block so each block's self-attention K/V land in its memory slot
+        at the collapsed RoPE positions ``[0, K * tokens_per_frame)``.
+        Cross-attention, FFN, and the head are skipped (not cached).
 
-        The caller is responsible for slicing the per-rollout history at
-        ``HyWorldPlayCtrl.memory_frame_indices`` and for building
-        ``rope_freqs`` against the same collapsed positions (*not* the
-        standard chunk positions ``[i*len_t, (i+1)*len_t)``).
+        The caller slices the per-rollout history at
+        ``HyWorldPlayCtrl.memory_frame_indices`` and builds ``rope_freqs``
+        against the same collapsed positions.
 
         Args:
-            x: Patchified memory latents with shape ``[..., L_mem, in_dim]``.
-            timesteps: Scalar broadcast or per-token clean-context timestep
-                (vendor's ``stabilization_level``); applied to memory tokens
-                so the AdaLN modulation stays in the trained distribution.
+            x: Patchified memory latents, shape ``[..., L_mem, in_dim]``.
+            timesteps: Scalar broadcast or per-token clean-context timestep,
+                applied so the AdaLN modulation stays in the trained
+                distribution.
             cache: Per-block cache; only the ``memory`` slots are written.
-            rope_freqs: RoPE frequencies remapped to the collapsed memory
-                positions ``[0, L_mem)``.
-            block_extra_kwargs: Optional extras forwarded to the per-block
-                prefill (unused; kept for symmetry with :meth:`forward`).
+            rope_freqs: RoPE frequencies for the collapsed memory positions
+                ``[0, L_mem)``.
+            block_extra_kwargs: Unused; kept for symmetry with :meth:`forward`.
             action: Optional action labels for the memory frames.
             viewmats: W2C extrinsics for the memory frames. Required when
                 ``use_prope_blocks=True``.
             Ks: Per-frame intrinsics for the memory frames.
 
         Raises:
-            RuntimeError: ``use_prope_blocks`` is not set (memory caches are
-                only owned by PRoPE blocks).
+            RuntimeError: ``use_prope_blocks`` is not set.
             ValueError: ``viewmats`` is ``None``.
         """
         assert self._parameters_updated_after_loading_checkpoint, (
@@ -695,9 +657,8 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
                 "by selected_frame_indices before calling."
             )
 
-        # No before_update / after_update on the per-block rolling caches
-        # here -- the prefill writes only into cache[block_idx].memory,
-        # which has its own reset/write cycle owned by the executor.
+        # No before_update / after_update here: the prefill writes only into
+        # cache[block_idx].memory, which the executor resets/writes separately.
         from hy_worldplay import _debug_dump
 
         for block_idx, block in enumerate(self.blocks):
@@ -715,11 +676,8 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
                 f"{type(block_cache).__name__}"
             )
             _debug_dump.set_context(phase="prefill", block_idx=block_idx)
-            # ``prefill_memory_kv`` runs the full block so the evolving
-            # hidden state propagates block-to-block like vendor's
-            # ``is_cache=True`` forward. The final-block return value is
-            # discarded; only the per-block ``cache.memory`` side effects
-            # matter for the subsequent chunk's forward.
+            # Run the full block so the hidden state propagates block-to-block;
+            # only the per-block ``cache.memory`` side effects are kept.
             x = block.prefill_memory_kv(
                 x=x,
                 e=block_e,
@@ -739,10 +697,9 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
     ) -> Tensor:
         """Lift per-latent-frame action labels to a per-token additive term.
 
-        Sinusoidally encodes the integer labels, runs them through the
-        zero-residual MLP, then ``repeat_interleave``s across the
-        ``tokens_per_frame`` slots of each latent frame on the post-patchify
-        token axis.
+        Sinusoidally encodes the integer labels, runs them through the action
+        MLP, then ``repeat_interleave``s across the ``tokens_per_frame`` slots
+        of each latent frame on the post-patchify token axis.
 
         Raises:
             NotImplementedError: ``cp_size > 1``; multi-rank action
@@ -773,15 +730,11 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
 class HyWorldPlayWan21TransformerCache(Wan21TransformerCache):
     """Per-rollout cache for the HY-WorldPlay transformer.
 
-    Adds three reconstituted-context state slots
-    (``clean_latent_history`` / ``finished_chunks`` / ``hy_chunk_size_t`` /
-    ``hy_tokens_per_frame``) and a prefill latch
-    (``prefill_completed_for_chunk``) on top of the base
-    :class:`Wan21TransformerCache`. Also overrides :meth:`start` to wipe
-    each block's rolling self-attention cache at every chunk boundary
-    past the first -- cross-chunk context arrives via the dedicated
-    memory cache, so the rolling window only ever holds the current
-    chunk's tokens.
+    Adds clean-latent-history state and a prefill latch on top of the base
+    :class:`Wan21TransformerCache`. :meth:`start` wipes each block's rolling
+    self-attention cache at every chunk boundary past the first, so the
+    rolling window only ever holds the current chunk's tokens; cross-chunk
+    context arrives via the dedicated memory cache.
     """
 
     clean_latent_history: Tensor | None = None
@@ -794,26 +747,19 @@ class HyWorldPlayWan21TransformerCache(Wan21TransformerCache):
     :attr:`clean_latent_history`."""
 
     hy_chunk_size_t: int = 0
-    """Pre-patchify temporal chunk size (``len_t``) for the current rollout.
-    Cached so the prefill executor can map per-frame indices to per-token
-    offsets without re-reading the transformer config."""
+    """Pre-patchify temporal chunk size (``len_t``) for the current rollout."""
 
     hy_tokens_per_frame: int = 0
-    """Post-patchify tokens per latent frame,
-    ``(height // kh) * (width // kw)``. Cached for the same reason as
-    :attr:`hy_chunk_size_t`."""
+    """Post-patchify tokens per latent frame, ``(height // kh) * (width // kw)``."""
 
     prefill_completed_for_chunk: int = -1
-    """``autoregressive_index`` of the chunk whose memory KV prefill has
-    already run; ``-1`` before the first prefill of the rollout. Used by
-    :meth:`HyWorldPlayWan21Transformer.predict_flow` to skip redundant
-    prefill calls on the 2nd/3rd/... denoising step of a chunk (memory K/V
-    are stable across scheduler steps so one call per chunk suffices)."""
+    """``autoregressive_index`` of the chunk whose memory KV prefill has already
+    run; ``-1`` before the first prefill. One prefill per chunk suffices since
+    memory K/V are stable across scheduler steps."""
 
     def start(self, autoregressive_index: int) -> None:
-        # Reset per-block rolling self-attention caches at every chunk
-        # boundary past the first; the dedicated memory cache supplies
-        # the cross-chunk context.
+        # Reset per-block rolling self-attention caches at every chunk boundary
+        # past the first; the dedicated memory cache supplies cross-chunk context.
         if autoregressive_index > 0:
             self._reset_per_block_rolling_caches(autoregressive_index)
         self.prefill_completed_for_chunk = -1
@@ -822,13 +768,10 @@ class HyWorldPlayWan21TransformerCache(Wan21TransformerCache):
     def _reset_per_block_rolling_caches(self, autoregressive_index: int) -> None:
         """Wipe each block's ``self_attn`` / ``prope_self_attn`` for the new chunk.
 
-        Also pokes ``_prev_chunk_idx`` to ``autoregressive_index - 1`` so
-        the subsequent ``before_update(autoregressive_index)`` in
-        :meth:`Wan21TransformerCache.start` accepts the transition (the
-        cache's monotonic-chunk-index assertion would otherwise fire
-        against the ``-1`` value left by ``reset()``).
+        Sets ``_prev_chunk_idx`` to ``autoregressive_index - 1`` so the
+        subsequent ``before_update`` in :meth:`Wan21TransformerCache.start`
+        passes its monotonic-chunk-index assertion.
         """
-        # Local import to avoid a top-level circular dep.
         from hy_worldplay._camera import HyWorldPlayPRoPEBlockCache
 
         for net_cache in (self.network_cache, self.network_cache_uncond):
@@ -856,16 +799,12 @@ class HyWorldPlayWan21TransformerConfig(Wan21TransformerConfig):
 class HyWorldPlayWan21Transformer(Wan21Transformer):
     """Wan 2.1 transformer that threads action, camera, and memory through the network.
 
-    Extends :class:`Wan21Transformer` with the reconstituted-context KV
-    prefill executor and the plumbing needed to keep
-    :class:`HyWorldPlayCtrl`'s extra fields alive across the patchify
-    pass. The per-rollout cache (:class:`HyWorldPlayWan21TransformerCache`)
-    accumulates patchified clean latents from past chunks; before the
-    first denoising step of each chunk past the first, the prefill driver
-    slices that history at ``memory_frame_indices`` and seeds each
-    PRoPE block's memory KV cache so the rolling window (which the HY
-    cache wipes at every chunk boundary) is the only thing the
-    forward needs to refill.
+    Extends :class:`Wan21Transformer` with the memory KV prefill executor and
+    the plumbing to keep :class:`HyWorldPlayCtrl`'s extra fields alive across
+    the patchify pass. The per-rollout cache accumulates patchified clean
+    latents from past chunks; before the first denoising step of each chunk
+    past the first, the prefill driver slices that history at
+    ``memory_frame_indices`` and seeds each PRoPE block's memory KV cache.
     """
 
     def initialize_autoregressive_cache(
@@ -881,9 +820,8 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
         """Build a :class:`HyWorldPlayWan21TransformerCache` for a new rollout.
 
         Stamps the per-rollout spatial layout into ``hy_chunk_size_t`` /
-        ``hy_tokens_per_frame`` so the prefill executor can map memory
-        frame indices to post-patchify token ranges without re-reading
-        the transformer config.
+        ``hy_tokens_per_frame`` so the prefill executor can map memory frame
+        indices to post-patchify token ranges.
         """
         base = super().initialize_autoregressive_cache(
             height=height,
@@ -926,7 +864,7 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
             isinstance(cache, HyWorldPlayWan21TransformerCache)
             and cache.prefill_completed_for_chunk != ar_idx
         )
-        # Bind chunk + step context so per-block dumps below carry it.
+        # Bind chunk + step context so per-block dumps carry it.
         _debug_dump.set_context(
             ar_idx=ar_idx,
             is_first_step_of_chunk=is_first_step,
@@ -953,10 +891,7 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
             _debug_dump.dump("predict_flow.noisy_latent", noisy_latent)
             _debug_dump.dump("predict_flow.timestep", timestep)
         network_extra_kwargs = dict(network_extra_kwargs or {})
-        # Run the reconstituted-context prefill once at the first
-        # denoising step of each chunk past the first; the
-        # ``prefill_completed_for_chunk`` latch suppresses re-runs on
-        # subsequent scheduler steps within the chunk.
+        # Run the memory prefill once per chunk (latch suppresses re-runs).
         if (
             isinstance(cache, HyWorldPlayWan21TransformerCache)
             and isinstance(input, HyWorldPlayCtrl)
@@ -992,12 +927,9 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
     ) -> None:
         """Append the chunk's clean latent to the history and skip the rolling-cache update.
 
-        Base ``Wan21Transformer.finalize_kv_cache`` re-runs the network at
-        the context-noise timestep to stamp clean K/V into the rolling
-        window. The HY path wipes that rolling window at every chunk start
-        (see :meth:`HyWorldPlayWan21TransformerCache.start`) and provides
-        cross-chunk context through the dedicated memory cache, so the
-        re-run is wasted work.
+        The base implementation's rolling-window re-run is skipped: the HY
+        path wipes that window at every chunk start and provides cross-chunk
+        context through the dedicated memory cache.
         """
         if isinstance(cache, HyWorldPlayWan21TransformerCache):
             cache.clean_latent_history = self._append_clean_latent_to_history(
@@ -1006,8 +938,7 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
             )
             cache.finished_chunks += 1
             return
-        # Defensive fall-through for any non-HY cache; the runner always
-        # builds an HY cache when this transformer is in use.
+        # Defensive fall-through for any non-HY cache.
         super().finalize_kv_cache(
             noisy_latent=noisy_latent,
             timestep=timestep,
@@ -1021,11 +952,9 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
                 return x
             patched_latent = self.patchify_and_maybe_split_cp(x.latent)
             patched_mask = self.patchify_and_maybe_split_cp(x.mask)
-            # action / viewmats / Ks / memory_frame_indices and the
-            # rollout_* siblings are per-latent-frame metadata and do not
-            # participate in the patchify reshape; pass them through
-            # unchanged so the PRoPE and memory-prefill consumers see the
-            # same layouts they would on a fresh ctrl.
+            # action / viewmats / Ks / memory_frame_indices and the rollout_*
+            # siblings are per-latent-frame metadata and don't participate in
+            # the patchify reshape; pass them through unchanged.
             return HyWorldPlayCtrl(
                 latent=patched_latent,
                 mask=patched_mask,
@@ -1048,7 +977,7 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
         input: HyWorldPlayCtrl,
         timestep: Tensor,
     ) -> None:
-        """Drive the reconstituted-context KV prefill for the current chunk.
+        """Drive the memory KV prefill for the current chunk.
 
         Slices the clean-latent history at ``input.memory_frame_indices``,
         builds collapsed-position RoPE freqs, slices ``viewmats`` / ``Ks`` /
@@ -1059,13 +988,12 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
 
         Args:
             cache: Active per-rollout cache; ``clean_latent_history`` must
-                already contain at least the memory frames being indexed.
+                already contain the memory frames being indexed.
             input: Patchified per-AR-step ctrl payload with non-empty
                 ``memory_frame_indices``.
             timestep: Current denoising-step tensor. Used only for its
                 ``dtype`` / ``device`` / batch shape; memory positions are
-                modulated at :data:`_HY_STABILIZATION_TIMESTEP` instead
-                (vendor's ``t_ctx = stabilization_level - 1``).
+                modulated at :data:`_HY_STABILIZATION_TIMESTEP` instead.
         """
         assert input.memory_frame_indices is not None, (
             "prefill_memory_kv_cache requires non-None memory_frame_indices"
@@ -1082,8 +1010,7 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
         history = cache.clean_latent_history  # [..., total_L, in_dim]
         total_L = history.shape[-2]
         max_frame = total_L // tokens_per_frame
-        # Defensive bounds check; the encoder's selector should already
-        # only emit in-range indices.
+        # Defensive bounds check; the selector should only emit in-range indices.
         for idx in selected:
             assert 0 <= idx < max_frame, (
                 f"memory frame index {idx} out of range for history of "
@@ -1091,21 +1018,16 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
                 f"tokens-per-frame)."
             )
 
-        # Slice the history at each selected frame's token range. The
-        # history is laid out frame-major along the token axis so frame
-        # ``idx`` occupies ``[idx*tokens_per_frame, (idx+1)*tokens_per_frame)``.
+        # Slice each selected frame's token range; the history is frame-major
+        # along the token axis.
         token_ranges = [
             history[..., idx * tokens_per_frame : (idx + 1) * tokens_per_frame, :]
             for idx in selected
         ]
         memory_x = torch.cat(token_ranges, dim=-2)  # [..., K*TPF, in_dim]
 
-        # Slice the per-rollout camera + action tensors (frame-granular)
-        # at the same indices. ``_index_rollout_buffer`` prefers the
-        # rollout-scoped buffer and falls back to the per-AR-step slice
-        # when the encoder didn't bind the corresponding conditioner --
-        # in that case the downstream consumer treats the slice as a
-        # no-op so the (parity-incorrect) fallback values don't matter.
+        # Slice the per-rollout camera + action tensors (frame-granular) at the
+        # same indices.
         selected_idx_t = torch.as_tensor(
             selected, dtype=torch.long, device=memory_x.device
         )
@@ -1128,23 +1050,20 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
             kind="action",
         )
 
-        # Build RoPE freqs for the collapsed memory positions ``[0, K)``
-        # on the temporal axis; the spatial axes use a fresh-zeroed
-        # grid inside ``_build_collapsed_rope_freqs``.
+        # RoPE freqs for the collapsed memory positions ``[0, K)`` on the
+        # temporal axis.
         rope_freqs = self._build_collapsed_rope_freqs(
             cache=cache,
             t_positions=torch.arange(K, dtype=torch.float32, device=memory_x.device),
         )
 
-        # Clean-context timestep applied to memory positions; matches
-        # ``timestep``'s dtype / device / batch so the network's
-        # ``sinusoidal_embedding_1d(...).type_as(x)`` path stays on the
-        # same compute graph.
+        # Clean-context timestep for memory positions; matches ``timestep``'s
+        # dtype / device / batch.
         context_timestep = torch.full_like(
             timestep, fill_value=_HY_STABILIZATION_TIMESTEP
         )
 
-        # Env-var-gated debug dump for prefill inputs; see _debug_dump.py.
+        # Env-var-gated debug dump for prefill inputs.
         from hy_worldplay import _debug_dump
 
         if _debug_dump.enabled():
@@ -1167,8 +1086,8 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
             if memory_action is not None:
                 _debug_dump.dump("prefill.memory_action", memory_action)
 
-        # Reset each branch's per-block memory cache before the prefill
-        # so a previous chunk's leftover content can't leak in.
+        # Reset each branch's per-block memory cache so a previous chunk's
+        # content can't leak in.
         from hy_worldplay._camera import HyWorldPlayPRoPEBlockCache
 
         for net_cache in (cache.network_cache, cache.network_cache_uncond):
@@ -1178,9 +1097,8 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
                 if isinstance(block_cache, HyWorldPlayPRoPEBlockCache):
                     block_cache.memory.reset()
 
-        # Narrow the parent's ``self.network`` (typed as ``Tensor | Module``
-        # by ``nn.Module``'s ``__getattr__`` overload) to the HY-DiT network
-        # so the memory-prefill entry point resolves.
+        # Narrow ``self.network`` to the HY-DiT type so the prefill entry
+        # point resolves.
         network = self.network
         assert isinstance(network, HyWorldPlayWanDiTNetwork)
 
@@ -1213,9 +1131,8 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
     ) -> Tensor:
         """Append the finalized chunk's patchified clean latent to the history.
 
-        Detaches before concatenating so the history outlives the
-        chunk's autograd graph; concatenation is along the post-patchify
-        token axis (``dim=-2``).
+        Detaches before concatenating (along the post-patchify token axis,
+        ``dim=-2``) so the history outlives the chunk's autograd graph.
         """
         if history is None:
             return clean_latent.detach().clone()
@@ -1231,23 +1148,20 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
     ) -> Tensor | None:
         """Slice a per-rollout metadata buffer at the selected memory-frame indices.
 
-        Prefers the rollout-scoped buffer; falls back to the per-AR-step
-        slice when the rollout buffer is ``None``. The fallback is
-        parity-incorrect (it indexes the current chunk's slice rather
-        than the full rollout) but only runs when the corresponding
-        conditioner is disabled, in which case the downstream consumer
-        treats the slice as a no-op.
+        Prefers the rollout-scoped buffer; falls back to the per-AR-step slice
+        (unindexed) when ``rollout`` is ``None``, which only happens when the
+        corresponding conditioner is disabled and the consumer treats the
+        slice as a no-op.
 
         Args:
             rollout: Full-trajectory buffer (e.g.
-                ``[*batch_shape, F_total, 4, 4]`` for viewmats). Indexed
-                at ``selected`` along the frame axis when present.
-            per_step: Per-AR-step slice used as fallback when ``rollout``
-                is ``None``.
+                ``[*batch_shape, F_total, 4, 4]`` for viewmats), indexed at
+                ``selected`` along the frame axis when present.
+            per_step: Per-AR-step slice used as fallback when ``rollout`` is
+                ``None``.
             selected: ``LongTensor`` of memory frame indices in rollout
                 coordinates, shape ``[K]``.
-            kind: Tensor kind name (``"viewmats"`` / ``"Ks"`` /
-                ``"action"``) for error messages.
+            kind: Tensor kind name for error messages.
 
         Returns:
             Indexed tensor with shape ``[*batch_shape, K, ...]`` (matrices)
@@ -1261,9 +1175,6 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
         if rollout is None and per_step is None:
             return None
         if rollout is None:
-            # Conditioner disabled but the prefill is still running on
-            # behalf of another conditioner; the per-step slice flows
-            # through unindexed and the consumer treats it as a no-op.
             return per_step
 
         # Action is integer-typed with the frame on the trailing axis;
@@ -1287,16 +1198,14 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
     ) -> Tensor:
         """Compute RoPE frequencies for arbitrary temporal positions.
 
-        The base :class:`RotaryPositionEmbedding3D` only exposes
-        ``shift_t(autoregressive_index)``, which produces freqs at
-        chunk-aligned positions. We reach into the
-        ``_freq_components(seq_t)`` primitive to build freqs at the
-        prefill's collapsed memory positions ``[0, K)``.
+        Uses the ``_freq_components(seq_t)`` primitive to build freqs at the
+        prefill's collapsed memory positions ``[0, K)``, which the base
+        ``shift_t(autoregressive_index)`` (chunk-aligned only) can't express.
 
         Raises:
             NotImplementedError: ``rope_adapter`` is not
-                :class:`RotaryPositionEmbedding3D` or has context
-                parallel enabled.
+                :class:`RotaryPositionEmbedding3D` or has context parallel
+                enabled.
         """
         rope = cache.rope_adapter
         from flashdreams.core.attention.rope import RotaryPositionEmbedding3D
@@ -1321,12 +1230,5 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
         self,
         cache: HyWorldPlayWan21TransformerCache,
     ) -> bool:
-        """Return ``True`` on the first denoising step of the current chunk.
-
-        Reads the
-        :attr:`HyWorldPlayWan21TransformerCache.prefill_completed_for_chunk`
-        latch, which ``cache.start`` resets to ``-1`` at every chunk
-        boundary and which the prefill driver bumps to the current
-        ``autoregressive_index`` after running once.
-        """
+        """Return ``True`` on the first denoising step of the current chunk."""
         return cache.prefill_completed_for_chunk != cache.autoregressive_index

--- a/integrations/hy_worldplay/hy_worldplay/_camera.py
+++ b/integrations/hy_worldplay/hy_worldplay/_camera.py
@@ -40,11 +40,8 @@ from hy_worldplay._prope import prope_qkv
 def _fp32_layer_norm(x: Tensor, norm: nn.LayerNorm) -> Tensor:
     """Run ``norm`` in float32 regardless of input / weight dtype, returning fp32.
 
-    Vendor performs AdaLN in FP32; mirror that here by casting both the
-    input and any affine parameters to fp32 for the norm call. Returns
-    the fp32 normalised tensor so callers can keep the subsequent AdaLN
-    ``scale_shift`` blend in fp32 too; the final ``.type_as(x)`` cast
-    happens at the AdaLN output boundary.
+    Casts both the input and any affine parameters to fp32 so callers can
+    keep the subsequent AdaLN ``scale_shift`` blend in fp32 too.
     """
     weight = norm.weight.float() if norm.weight is not None else None
     bias = norm.bias.float() if norm.bias is not None else None
@@ -73,17 +70,16 @@ class HyWorldPlayMemoryKVCache:
     """Per-block flat KV cache for HY-WorldPlay's reconstituted-context memory.
 
     Stores K / V at RoPE-collapsed positions ``[0, len(selected) *
-    tokens_per_frame)`` -- no rolling window and no chunk indexing. The
-    prefill executor wipes and repopulates it at the start of every
-    chunk past the first; within a chunk's denoising loop the contents
-    are frozen.
+    tokens_per_frame)`` -- no rolling window and no chunk indexing. Frozen
+    within a chunk's denoising loop; the prefill executor wipes and
+    repopulates it at the start of every chunk past the first.
 
     The standard-RoPE and PRoPE branches are stored independently so the
     dual-branch attention can address each without slicing a packed
-    tensor. Tensor layout is ``[batch, S, n_heads, head_dim]`` where
-    ``S == len(selected_frame_indices) * tokens_per_frame`` -- matches
-    :meth:`BlockKVCache.cached_k` so both caches can be concatenated
-    along ``seq_dim=-3`` without a reshape.
+    tensor. Layout ``[batch, S, n_heads, head_dim]`` with
+    ``S == len(selected_frame_indices) * tokens_per_frame`` matches
+    :meth:`BlockKVCache.cached_k`, so both caches concatenate along
+    ``seq_dim=-3`` without a reshape.
     """
 
     k_rope: Tensor | None = None
@@ -138,19 +134,15 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
     """Self-attention with a parallel PRoPE-projected branch.
 
     Owns a second output projection :attr:`o_prope` (zero-initialised so
-    the PRoPE branch is a strict no-op at random init) on top of the
-    inherited Q / K / V / o projections from :class:`MultiHeadAttention`.
-    The PRoPE branch reuses the same Q / K / V tensors (HY-WorldPlay
-    weights load once into ``q`` / ``k`` / ``v`` / ``norm_q`` /
-    ``norm_k``) and only differs in how those tensors are pre- and
+    the PRoPE branch is a no-op until trained weights load) on top of the
+    inherited Q / K / V / o projections. The PRoPE branch reuses the same
+    Q / K / V tensors and only differs in how they are pre- and
     post-processed for attention.
 
-    A second :class:`BlockKVCache` (created alongside the stock cache by
-    :meth:`HyWorldPlayPRoPEBlock.initialize_cache`) stores the
-    *already-PRoPE-transformed* K / V from previous AR steps so each AR
-    step only transforms its current chunk's K / V. The query side is
-    transformed fresh every call because it uses the current chunk's
-    extrinsics + intrinsics.
+    A second :class:`BlockKVCache` stores the *already-PRoPE-transformed*
+    K / V from previous AR steps, so each step only transforms its current
+    chunk's K / V. The query side is transformed fresh every call since it
+    uses the current chunk's extrinsics + intrinsics.
     """
 
     def __init__(
@@ -168,16 +160,15 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
             eps=eps,
             apply_rope_before_kvcache=apply_rope_before_kvcache,
         )
-        # Zero-init the PRoPE-branch output projection so the camera
-        # path adds zero residual until a distilled checkpoint loads
-        # non-zero weights for it.
+        # Zero-init so the PRoPE branch adds zero residual until trained
+        # weights load.
         self.o_prope = nn.Linear(self.inner_dim, self.query_dim)
         nn.init.zeros_(self.o_prope.weight)
         if self.o_prope.bias is not None:
             nn.init.zeros_(self.o_prope.bias)
 
-        # Independent attention op for the PRoPE branch keeps CP routing
-        # symmetric across branches without sharing internal state.
+        # Independent attention op so CP routing stays symmetric across
+        # branches without sharing internal state.
         self.attn_op_prope = ContextParallelAttention(
             qkv_format="bshd", backend="cudnn"
         )
@@ -233,9 +224,8 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
                 per-AR-step latent-frame count (``len_t``).
             Ks: Optional per-frame intrinsics ``[batch, cameras, 3, 3]``.
             memory_kv_cache: Optional reconstituted-context memory cache.
-                When populated, the prefilled K / V are prepended to
-                ``kv_cache`` / ``prope_kv_cache`` along ``seq_dim=-3``
-                before the attention call so the sequence becomes
+                When populated, the prefilled K / V are prepended along
+                ``seq_dim=-3`` so the sequence becomes
                 ``[memory K/V, current K/V]``. ``None`` or empty leaves
                 the dual-branch path unchanged.
 
@@ -283,10 +273,8 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
             )
         kv_cache.update(k_for_rope_cache, v_raw)
 
-        # PRoPE expects ``[batch, num_heads, seqlen, head_dim]``; the
-        # cache stores ``[batch, seqlen, num_heads, head_dim]``. Transpose
-        # in for the PRoPE math and back out before the cache write so the
-        # cache layout matches the standard branch.
+        # PRoPE math runs in bhsd; transpose in, then back to the bshd
+        # cache layout before the write.
         q_prope, k_prope_bhsd, v_prope_bhsd, apply_fn_o = prope_qkv(
             q_raw.transpose(1, 2),
             k_raw.transpose(1, 2),
@@ -311,15 +299,13 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
         else:
             cached_k = kv_cache.cached_k()
         cached_v = kv_cache.cached_v()
-        # Prepend the prefilled memory K / V (if any) so the attention
-        # sees ``[memory_K, current_K]`` along the sequence dim.
+        # Prepend prefilled memory K / V (if any) -> ``[memory, current]``.
         if _debug_dump.enabled():
             _debug_dump.dump("attn.q_rope_post", q_rope)
             _debug_dump.dump("attn.cached_k_pre_mem_concat", cached_k)
             _debug_dump.dump("attn.cached_v_pre_mem_concat", cached_v)
         if memory_kv_cache is not None and memory_kv_cache.has_rope_kv:
-            # ``has_rope_kv`` guarantees both branches are populated; the
-            # asserts narrow ``Tensor | None`` for ``torch.cat``.
+            # Asserts narrow ``Tensor | None`` for ``torch.cat``.
             assert memory_kv_cache.k_rope is not None
             assert memory_kv_cache.v_rope is not None
             if _debug_dump.enabled():
@@ -351,10 +337,7 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
             prope_cached_k,
             prope_cached_v,
         )
-        # ``apply_fn_o`` expects ``[batch, num_heads, seqlen, head_dim]``;
-        # the cudnn-backed attn op returns ``[batch, seqlen, num_heads,
-        # head_dim]``. Transpose for the matmul and back for the final
-        # flatten + projection.
+        # ``apply_fn_o`` consumes bhsd; the cudnn attn op returns bshd.
         out_prope = apply_fn_o(out_prope.transpose(1, 2)).transpose(1, 2)
         out_prope = out_prope.reshape(batch_shape + (L, n * d))
         out_prope = self.o_prope(out_prope)
@@ -371,35 +354,26 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
     ) -> Tensor:
         """Run the dual-branch self-attention at collapsed memory positions.
 
-        Drives the full attention pipeline (project, apply RoPE / PRoPE,
-        write K / V into ``memory_kv_cache``, then attend over those
-        memory positions themselves) so the returned hidden state can
-        feed the next block's prefill input. The K / V written here are
-        what chunk-1+ ``forward_dual_branch`` calls will prepend.
+        Projects, applies RoPE / PRoPE, writes both branches' K / V into
+        ``memory_kv_cache``, then attends over the memory positions
+        themselves. The K / V written here are what chunk-1+
+        ``forward_dual_branch`` calls prepend.
 
         Args:
             x: Pre-norm-modulated input for the selected memory frames,
                 shape ``[..., L_mem, query_dim]`` where
                 ``L_mem == K * tokens_per_frame``.
             rope_freqs: RoPE frequencies remapped to the collapsed
-                positions, shape ``[L_mem, 1, 1, head_dim]``. The
-                executor builds this from the per-rollout RoPE adapter
-                using ``current_start=0`` /
-                ``current_end=K * tokens_per_frame``.
-            viewmats: Per-memory-frame W2C matrices, shape
-                ``[batch, K, 4, 4]``. Already sliced to
-                ``selected_frame_indices`` by the executor.
-            Ks: Optional per-memory-frame intrinsics
-                ``[batch, K, 3, 3]``.
-            memory_kv_cache: Cache to populate. Both branches are
-                written.
+                positions, shape ``[L_mem, 1, 1, head_dim]``.
+            viewmats: Per-memory-frame W2C matrices ``[batch, K, 4, 4]``,
+                already sliced to ``selected_frame_indices``.
+            Ks: Optional per-memory-frame intrinsics ``[batch, K, 3, 3]``.
+            memory_kv_cache: Cache to populate; both branches are written.
 
         Returns:
             Attention output at the memory positions, summed over the
             standard-RoPE and PRoPE branches, shape
-            ``[..., L_mem, query_dim]``. The block caller chains this
-            into the post-attention residual + cross-attn + FFN to
-            evolve the hidden state for the next block's prefill.
+            ``[..., L_mem, query_dim]``.
         """
         if self.is_context_parallel_enabled():
             raise NotImplementedError(
@@ -434,9 +408,8 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
             k_for_rope = apply_rope_freqs(k_for_rope, rope_freqs, interleaved=True)
         memory_kv_cache.write_rope(k_for_rope, v_raw)
 
-        # PRoPE branch: transpose to ``[batch, num_heads, seqlen,
-        # head_dim]`` for the math, store post-transform K / V back in
-        # the cache layout (``[batch, seqlen, num_heads, head_dim]``).
+        # PRoPE math runs in bhsd; store post-transform K / V back in the
+        # bshd cache layout.
         q_prope, k_prope_bhsd, v_prope_bhsd, apply_fn_o = prope_qkv(
             q_raw.transpose(1, 2),
             k_raw.transpose(1, 2),
@@ -455,10 +428,8 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
             _debug_dump.dump("prefill.block.k_prope_written", memory_kv_cache.k_prope)
             _debug_dump.dump("prefill.block.v_prope_written", memory_kv_cache.v_prope)
 
-        # Standard RoPE-branch attention over the memory positions
-        # themselves -- the memory tokens are the only sequence at the
-        # collapsed positions, so K / V are the just-computed tensors
-        # (no cross-chunk concatenation).
+        # Memory tokens are the only sequence at the collapsed positions,
+        # so K / V are the just-computed tensors (no cross-chunk concat).
         q_rope = q_raw
         if rope_freqs is not None:
             q_rope = apply_rope_freqs(q_rope, rope_freqs, interleaved=True)
@@ -466,11 +437,8 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
         out_rope = out_rope.reshape(batch_shape + (L, n * d))
         out_rope = self.o(out_rope)
 
-        # PRoPE-branch attention. ``prope_qkv`` returns Q / K / V as
-        # ``[batch, num_heads, seqlen, head_dim]``; attn_op_prope
-        # consumes bshd, so the K / V are transposed back. ``apply_fn_o``
-        # needs bhsd again, then we transpose for the final
-        # ``[..., L, n*d]`` flatten + projection.
+        # ``prope_qkv`` returns bhsd; attn_op_prope consumes bshd and
+        # ``apply_fn_o`` consumes bhsd, hence the transposes.
         out_prope = self.attn_op_prope(
             q_prope.transpose(1, 2),
             k_prope_bhsd.transpose(1, 2),
@@ -492,21 +460,15 @@ class HyWorldPlayPRoPEBlockCache(BlockCache):
 
     Three caches per block:
 
-    * ``self_attn`` -- inherited from :class:`BlockCache`, stores the
-      standard RoPE-branch K / V for the *current chunk's* tokens.
-      Reused across denoising steps within a chunk; reset at chunk
-      start by the HY transformer's predict_flow.
-    * ``prope_self_attn`` -- mirrors the layout of ``self_attn`` but
-      stores the *already-PRoPE-transformed* K / V for the current
-      chunk so each AR step pays the per-frame projection cost once.
-    * ``memory`` -- separate, flat per-block cache that stores the
-      prefilled K / V from the selected memory frames at RoPE-collapsed
-      positions ``[0, K)``. Wiped at chunk start by the prefill
-      executor and repopulated from
-      :class:`HyWorldPlayCtrl.memory_frame_indices`. The dual-branch
-      attention prepends these K / V to ``self_attn`` /
-      ``prope_self_attn`` for the actual attention call, so the total
-      context is ``[memory K/V, current chunk K/V]`` along ``seq_dim=-3``.
+    * ``self_attn`` -- inherited; standard RoPE-branch K / V for the
+      current chunk's tokens.
+    * ``prope_self_attn`` -- mirrors ``self_attn``'s layout but stores the
+      *already-PRoPE-transformed* K / V for the current chunk.
+    * ``memory`` -- flat per-block cache holding the prefilled K / V from
+      the selected memory frames at RoPE-collapsed positions ``[0, K)``.
+      The dual-branch attention prepends these to ``self_attn`` /
+      ``prope_self_attn`` so the context is
+      ``[memory K/V, current chunk K/V]`` along ``seq_dim=-3``.
     """
 
     prope_self_attn: BlockKVCache = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
@@ -514,7 +476,7 @@ class HyWorldPlayPRoPEBlockCache(BlockCache):
 
     memory: HyWorldPlayMemoryKVCache = field(default_factory=HyWorldPlayMemoryKVCache)
     """Reconstituted-context memory cache. Empty on chunk 0; repopulated
-    at the start of every chunk past the first by the prefill executor."""
+    by the prefill executor at the start of every later chunk."""
 
     def __post_init__(self) -> None:
         if self.prope_self_attn is None:
@@ -534,10 +496,9 @@ class HyWorldPlayPRoPEBlockCache(BlockCache):
     def reset_current_chunk(self) -> None:
         """Reset both per-chunk K / V caches to empty (filling) state.
 
-        The memory cache is *not* touched here -- it has its own
-        :meth:`HyWorldPlayMemoryKVCache.reset` that the prefill executor
-        calls before repopulating, so the two lifecycles stay
-        independent.
+        The memory cache is not touched here; it has its own
+        :meth:`HyWorldPlayMemoryKVCache.reset` with an independent
+        lifecycle driven by the prefill executor.
         """
         self.self_attn.reset()
         self.prope_self_attn.reset()
@@ -548,14 +509,13 @@ class HyWorldPlayPRoPEBlock(Block):
 
     Replaces the stock :class:`SelfAttention` with
     :class:`HyWorldPlayPRoPESelfAttention` and overrides
-    :meth:`initialize_cache` / :meth:`forward` so the PRoPE branch's
-    independent KV cache is created and threaded alongside the standard
-    one. Cross-attention + FFN are inherited unchanged.
+    :meth:`initialize_cache` / :meth:`forward` to create and thread the
+    PRoPE branch's independent KV cache. Cross-attention + FFN are
+    inherited unchanged.
 
-    The block accepts ``viewmats`` and ``Ks`` as forward kwargs (passed
-    via :attr:`WanDiTNetwork.forward`'s ``block_extra_kwargs``); with
-    ``o_prope`` zero-initialised the block is observationally a no-op
-    versus the standard one until HY-WorldPlay weights are loaded.
+    Accepts ``viewmats`` and ``Ks`` as forward kwargs. With ``o_prope``
+    zero-initialised the block is a no-op versus the standard one until
+    HY-WorldPlay weights are loaded.
     """
 
     self_attn: HyWorldPlayPRoPESelfAttention
@@ -579,9 +539,8 @@ class HyWorldPlayPRoPEBlock(Block):
             i2v=i2v,
             apply_rope_before_kvcache=apply_rope_before_kvcache,
         )
-        # Replace the stock self-attn with the dual-branch variant after
-        # super().__init__ so any checkpoint loader addressing weights by
-        # name (e.g. ``blocks.{i}.self_attn.q.weight``) still resolves
+        # Replace after super().__init__ so checkpoint weights addressed
+        # by name (e.g. ``blocks.{i}.self_attn.q.weight``) still resolve
         # the inherited Q / K / V / o projections.
         self.self_attn = HyWorldPlayPRoPESelfAttention(
             query_dim=dim,
@@ -648,8 +607,8 @@ class HyWorldPlayPRoPEBlock(Block):
             "We expect to have called update_parameters_after_loading_checkpoint() "
             "before running the forward pass"
         )
-        # Report missing camera data first; otherwise the cache-type
-        # assertion below would mask the real misconfiguration.
+        # Check camera data before the cache-type assert so a missing
+        # ``viewmats`` reports the real misconfiguration.
         if viewmats is None:
             raise ValueError(
                 "HyWorldPlayPRoPEBlock.forward requires viewmats. "
@@ -662,17 +621,12 @@ class HyWorldPlayPRoPEBlock(Block):
             "Did HyWorldPlayWanDiTNetwork.initialize_cache run?"
         )
 
-        # Vendor performs AdaLN in FP32; mirror that here by computing
-        # the modulation table, norm + scale + shift, residual gates, and
-        # FFN residual in float32 before casting back at each boundary.
+        # AdaLN runs in fp32: modulation table, norm + scale + shift,
+        # residual gates, and FFN residual, cast back at each boundary.
         e_chunks = [
             c.squeeze(-2) for c in (self.modulation + e).float().chunk(6, dim=-2)
         ]
 
-        # norm1 has no affine params (elementwise_affine=False) so a
-        # direct ``norm1(x.float())`` would also work; route through the
-        # helper for symmetry with the norm3 / norm2 call sites that
-        # *do* need the weight cast.
         y = (_fp32_layer_norm(x, self.norm1) * (1 + e_chunks[1]) + e_chunks[0]).type_as(
             x
         )
@@ -687,12 +641,9 @@ class HyWorldPlayPRoPEBlock(Block):
         )
         x = (x.float() + y.float() * e_chunks[2]).type_as(x)
 
-        # Cross-attn residual stays in bf16 (matches vendor); only the
-        # norm before attn2 runs in fp32 because the affine weights on
-        # ``norm3`` are loaded in bf16.
-        # ``norm3`` is typed ``LayerNorm | Identity`` on the parent
-        # ``Block`` (depending on ``cross_attn_norm``); the PRoPE block
-        # is always built with ``cross_attn_norm=True`` so narrow here.
+        # Cross-attn residual stays in bf16; only the norm before attn2
+        # runs in fp32. The PRoPE block is always built with
+        # ``cross_attn_norm=True``, so ``norm3`` is a ``LayerNorm`` here.
         assert isinstance(self.norm3, nn.LayerNorm)
         x = x + self.cross_attn(
             _fp32_layer_norm(x, self.norm3).type_as(x),
@@ -716,32 +667,27 @@ class HyWorldPlayPRoPEBlock(Block):
     ) -> Tensor:
         """Run the full block forward at the collapsed memory positions.
 
-        Mirrors :meth:`forward` exactly so each successive block's K / V
+        Mirrors :meth:`forward` so each successive block's K / V
         projections see an already-attended hidden state. The dual-branch
         self-attn writes both branches' K / V into ``cache.memory`` as a
-        side effect; ``cache.cross_attn`` is read for the cross-attention
-        text (and I2V image) K / V; ``cache.self_attn`` /
-        ``cache.prope_self_attn`` are intentionally untouched -- the
-        prefill operates at collapsed positions that don't belong in the
+        side effect; ``cache.self_attn`` / ``cache.prope_self_attn`` are
+        left untouched, since collapsed positions don't belong in the
         rolling current-chunk cache.
 
         Args:
             x: Pre-AdaLN input for the K selected memory frames,
                 shape ``[..., L_mem, D]``.
-            e: AdaLN modulation tensor for those frames (same contract
-                as :meth:`forward`).
+            e: AdaLN modulation tensor for those frames.
             rope_freqs: RoPE frequencies pre-sliced to the collapsed
                 memory positions.
-            viewmats: Per-memory-frame W2C extrinsics (already sliced
-                to the selected indices).
+            viewmats: Per-memory-frame W2C extrinsics, already sliced to
+                the selected indices.
             Ks: Optional per-memory-frame intrinsics.
             cache: The block's per-rollout cache.
 
         Returns:
             Hidden state ``[..., L_mem, D]`` evolved through the full
-            block. Caller threads this into the next block's prefill
-            call; the network's prefill driver discards the final-block
-            output.
+            block, for the next block's prefill call.
         """
         if viewmats is None:
             raise ValueError(
@@ -749,9 +695,8 @@ class HyWorldPlayPRoPEBlock(Block):
                 "the prefill executor must slice the per-rollout viewmats "
                 "by selected_frame_indices before calling."
             )
-        # FP32 AdaLN; same rationale as :meth:`forward`. Without this
-        # match, the memory K / V cache would carry per-block bf16
-        # rounding drift that the next chunk's forward attends over.
+        # FP32 AdaLN, matching :meth:`forward` so the memory K / V cache
+        # carries no per-block bf16 rounding drift.
         e_chunks = [
             c.squeeze(-2) for c in (self.modulation + e).float().chunk(6, dim=-2)
         ]
@@ -768,8 +713,8 @@ class HyWorldPlayPRoPEBlock(Block):
         )
         x = (x.float() + y.float() * e_chunks[2]).type_as(x)
 
-        # See note in ``forward``: ``cross_attn_norm=True`` for the PRoPE
-        # block, so ``norm3`` is always ``LayerNorm`` here.
+        # ``cross_attn_norm=True`` for the PRoPE block, so ``norm3`` is a
+        # ``LayerNorm`` here.
         assert isinstance(self.norm3, nn.LayerNorm)
         x = x + self.cross_attn(
             _fp32_layer_norm(x, self.norm3).type_as(x),

--- a/integrations/hy_worldplay/hy_worldplay/_checkpoint.py
+++ b/integrations/hy_worldplay/hy_worldplay/_checkpoint.py
@@ -29,18 +29,12 @@ __all__ = [
 ]
 
 
-# Three HY-specific rewrite rules layered on top of the base
-# Wan 2.2 TI2V 5B remap (which handles the standard
-# ``WanTransformer3DModel`` <-> ``WanDiTNetwork`` mapping):
-#
-# * ``condition_embedder.action_embedder.linear_{1,2}`` ->
-#   ``action_embedding.{0,2}`` -- standard Wan MLP indexing (linear,
-#   SiLU, linear); the SiLU at index 1 has no parameters and is elided.
-# * ``blocks.{i}.attn1.to_out_prope.0`` ->
-#   ``blocks.{i}.self_attn.o_prope`` -- upstream's ``to_out_prope`` is
-#   an ``nn.Sequential`` whose first element is the linear; our
-#   :attr:`HyWorldPlayPRoPESelfAttention.o_prope` is the linear
-#   directly, so we drop the ``.0.`` middle hop.
+# HY-specific rewrites layered on the base Wan 2.2 TI2V-5B remap:
+# * ``action_embedder.linear_{1,2}`` -> ``action_embedding.{0,2}``
+#   (Wan MLP indexing; the parameterless SiLU at index 1 is elided).
+# * ``attn1.to_out_prope.0`` -> ``self_attn.o_prope`` -- upstream's
+#   ``to_out_prope`` is an ``nn.Sequential``; ``o_prope`` is the bare
+#   linear, so drop the ``.0.`` hop.
 _HY_WORLDPLAY_HY_KEY_REMAP: dict[str, str] = {
     r"^condition_embedder\.action_embedder\.linear_1\.(.*)$": (
         r"action_embedding.0.\1"
@@ -59,41 +53,28 @@ def hy_worldplay_distilled_state_dict_transform(
 ) -> dict[str, torch.Tensor]:
     """Remap the distilled WAN-5B checkpoint to :class:`HyWorldPlayWanDiTNetwork` keys.
 
-    Accepts either the raw envelope returned by ``torch.load`` on
-    upstream's ``wan_distilled_model/model.pt`` (top-level
-    ``generator`` / ``generator_ema`` subkeys) or a pre-stripped
-    state-dict whose keys already start at the model root (e.g.
-    ``model.blocks.0.attn1.to_q.weight`` or even
-    ``blocks.0.attn1.to_q.weight``).
+    Accepts either the raw ``torch.load`` envelope (top-level
+    ``generator`` / ``generator_ema`` subkeys) or a state-dict whose
+    keys already start at the model root.
 
     Returns:
         Flat ``dict[str, Tensor]`` keyed by
-        :class:`HyWorldPlayWanDiTNetwork` parameter names; safe to load
-        with :meth:`torch.nn.Module.load_state_dict` under
-        ``strict=True``.
+        :class:`HyWorldPlayWanDiTNetwork` parameter names; loadable
+        under ``strict=True``.
     """
-    # 1. Unwrap the distilled-checkpoint envelope. Pinning to
-    # ``generator`` (not the EMA copy) matches upstream's load path
-    # bit-for-bit.
+    # Unwrap the envelope; pin to ``generator`` (not the EMA copy).
     if "generator" in state_dict and "generator_ema" in state_dict:
         state_dict = state_dict["generator"]
 
-    # 2. Strip training-time prefixes. ``model.`` is the outer training
-    # module's wrapper; ``_fsdp_wrapped_module.`` is the FSDP artefact
-    # and can appear anywhere along a key (FSDP wraps individual
-    # blocks, e.g. ``blocks.0._fsdp_wrapped_module.attn1.to_q.weight``),
-    # so it gets a global string replace rather than a prefix strip.
+    # Strip training-time prefixes. ``_fsdp_wrapped_module.`` can appear
+    # mid-key (FSDP wraps individual blocks), so replace it globally.
     stripped: dict[str, torch.Tensor] = {}
     for key, value in state_dict.items():
         new_key = key.removeprefix("model.").replace("_fsdp_wrapped_module.", "")
         stripped[new_key] = value
 
-    # 3. Apply the base 5B diffusers -> WanDiTNetwork remap. Covers
-    # everything except the HY-specific action / PRoPE deltas handled
-    # in step 4.
+    # Apply the base 5B diffusers -> WanDiTNetwork remap, then the
+    # HY-specific rules; regex-rule remapping leaves non-matching keys
+    # alone, so the two compose cleanly.
     base_remapped = wan22_ti2v_5b_dit_state_dict_transform(stripped)
-
-    # 4. Layer the HY-specific rewrites on top. ``remap_checkpoint_keys``
-    # is regex-rule-based and leaves non-matching keys alone, so the
-    # base + HY rules compose cleanly.
     return remap_checkpoint_keys(base_remapped, _HY_WORLDPLAY_HY_KEY_REMAP)

--- a/integrations/hy_worldplay/hy_worldplay/_debug_dump.py
+++ b/integrations/hy_worldplay/hy_worldplay/_debug_dump.py
@@ -13,19 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Env-var-gated, CUDA-graph-safe tensor-dump harness for HY-WorldPlay parity diagnosis.
+"""Env-var-gated, CUDA-graph-safe tensor-dump harness for HY-WorldPlay diagnostics.
 
 Set ``HY_DEBUG_DUMP=/path/to/file.jsonl`` (or any truthy value to dump
 to ``hy_debug_dump.jsonl`` in CWD) to enable. Every :func:`dump` call
 appends a single JSON line with tensor stats (shape, dtype, abs_mean,
-mean, std, min, max, first-32 flat values). Disabled by default so
-production and parity runs pay zero overhead, and silently no-ops
-during CUDA graph capture so dump calls embedded in the graph-captured
-forward don't invalidate the capture.
-
-The vendor side gets parallel dumps via
-``tests/parity_check/dump_patch.py``, which monkey-patches the same
-call sites in the vendor source tree.
+mean, std, min, max, first-32 flat values). Disabled by default so runs
+pay zero overhead, and silently no-ops during CUDA graph capture so
+dump calls embedded in the graph-captured forward don't invalidate it.
 """
 
 from __future__ import annotations

--- a/integrations/hy_worldplay/hy_worldplay/_memory.py
+++ b/integrations/hy_worldplay/hy_worldplay/_memory.py
@@ -13,26 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""HY-WorldPlay reconstituted-context memory frame-index selection.
+"""HY-WorldPlay memory frame-index selection for autoregressive denoising.
 
-At the start of denoising for a non-first AR chunk, picks which
-historical frame indices the transformer attends to via KV cache.
-The selection combines:
+Picks which historical frame indices the transformer attends to for a
+non-first AR chunk. The selection combines:
 
 * **Temporal context** -- the most recent ``temporal_context_size``
-  frames before the current chunk, kept unconditionally for
-  short-range continuity.
+  frames before the current chunk, kept unconditionally.
 * **FOV-overlap memory** -- of all older 4-frame clips, score each by
-  the mean ``1 - FOV overlap`` (a Monte-Carlo similarity over a fixed
-  point cloud around the current camera) between the clip's 1st / 3rd
-  frame and the predicted clip's frames, then greedy-pick clips in
-  ascending distance until ``memory_frames - temporal_context_size``
-  frames are collected.
+  the mean ``1 - FOV overlap`` between the clip and the predicted clip,
+  then greedy-pick clips in ascending distance until
+  ``memory_frames - temporal_context_size`` frames are collected.
 
-All routines accept an explicit ``device`` so GPU callers can
-pre-allocate ``points_local`` alongside the rest of the pipeline.
-``device=None`` keeps everything on CPU, which is slower but lets the
-algorithm be unit-tested without a GPU.
+Routines accept an explicit ``device``; ``None`` keeps everything on CPU.
 """
 
 from __future__ import annotations
@@ -121,16 +114,9 @@ def generate_points_in_sphere(
 def _rotation_to_pitch_yaw_deg(R: Tensor) -> tuple[Tensor, Tensor]:
     """Extract ``(pitch, yaw)`` in degrees from a 3x3 W2C rotation matrix.
 
-    Conventions:
-
-    * X = right, Y = up, Z = forward (computer-vision convention).
-    * Yaw is in the XZ plane (``atan2(x, z)``).
-    * Pitch is the elevation above horizontal
-      (``atan2(y, sqrt(x**2 + z**2))``).
-
-    The camera's forward vector in the world frame is the third column
-    of the C2W rotation, which is the third row of the W2C rotation
-    (``R.T[:, 2] == R[2, :]``).
+    CV convention (X right, Y up, Z forward): yaw in the XZ plane,
+    pitch the elevation above horizontal. Uses the camera forward vector
+    (third column of the C2W rotation).
     """
     R_c2w = R.T
     fwd = R_c2w[:, 2]
@@ -188,8 +174,7 @@ def calculate_fov_overlap_similarity(
     w2c_curr_t = torch.as_tensor(w2c_curr, device=device)
     w2c_hist_t = torch.as_tensor(w2c_hist, device=device)
 
-    # Re-frame both poses into the current camera's coordinate system
-    # so the point cloud stays in a consistent local frame across calls.
+    # Re-frame both poses into the current camera's local coordinate system.
     c2w_curr = torch.linalg.inv(w2c_curr_t)
     c2w_hist = torch.linalg.inv(w2c_hist_t)
     C_inv = w2c_curr_t
@@ -217,9 +202,8 @@ def calculate_fov_overlap_similarity(
         points_world, P_hist, pitch_hist, yaw_hist, fov_half_h, fov_half_v
     )
 
-    # Distance gate: only count historical points within 8.0 units of the
-    # historical camera, to prune far-away viewpoints that happen to
-    # share an angular bin with the current view.
+    # Distance gate: drop historical points beyond 8.0 units so far-away
+    # viewpoints sharing an angular bin don't inflate the overlap.
     dist_mask = torch.norm(points_world - P_hist[None, :], dim=1) < 8.0
     in_fov_hist = in_fov_hist & dist_mask
 
@@ -252,27 +236,21 @@ def select_memory_frame_indices(
     ``[current_frame_idx, current_frame_idx + pred_latent_size)``.
 
     Args:
-        w2c: All per-frame world-to-camera matrices for the full
-            rollout, shape ``[num_total_frames, 4, 4]``. May be a numpy
-            array (cheap) or a torch tensor (avoids a copy on the GPU
-            path).
-        current_frame_idx: Index of the *first* frame the current AR
-            step is about to generate. Must satisfy
-            ``3 <= current_frame_idx < num_total_frames``.
+        w2c: Per-frame world-to-camera matrices for the full rollout,
+            shape ``[num_total_frames, 4, 4]``.
+        current_frame_idx: Index of the first frame this AR step
+            generates. Must satisfy ``3 <= current_frame_idx < num_total_frames``.
         points_local: Pre-sampled Monte-Carlo sphere points, shape
-            ``[N, 3]``. Build once per pipeline via
-            :func:`generate_points_in_sphere` and reuse across AR steps.
-        memory_frames: Total budget of historical frame indices to
-            return (temporal context + FOV-selected).
-        temporal_context_size: Number of most-recent past frames kept
-            unconditionally.
-        pred_latent_size: Latent frames the current AR step predicts;
-            sizes the query clip against which historical clips are
-            scored.
+            ``[N, 3]``; build once via :func:`generate_points_in_sphere`
+            and reuse across AR steps.
+        memory_frames: Total budget of frame indices to return
+            (temporal context + FOV-selected).
+        temporal_context_size: Most-recent past frames kept unconditionally.
+        pred_latent_size: Latent frames this AR step predicts; sizes the
+            query clip against which historical clips are scored.
         fov_h_deg: Horizontal FOV (degrees) for the overlap metric.
         fov_v_deg: Vertical FOV (degrees) for the overlap metric.
-        device: Optional torch device for the FOV-overlap computation;
-            ``None`` (default) keeps everything on CPU.
+        device: FOV-overlap compute device; ``None`` keeps everything on CPU.
 
     Returns:
         Sorted ``list[int]`` of length ``memory_frames``
@@ -349,10 +327,7 @@ def select_memory_frame_indices(
 
     combined = set(context_indices) | set(memory_indices)
     final = sorted(combined)
-    # Invariant: temporal context + FOV-selected sets must sum exactly
-    # to ``memory_frames``. The greedy ``extend(range(start, start+4))``
-    # loop above may over-shoot ``fov_budget`` by up to 3 (it breaks
-    # *after* adding a clip), so misconfigured budgets surface here.
+    # Invariant: temporal context + FOV-selected must sum to ``memory_frames``.
     assert len(final) == memory_frames, (
         f"memory selection produced {len(final)} frames; expected "
         f"memory_frames={memory_frames} "
@@ -366,12 +341,7 @@ def select_memory_frame_indices(
 
 
 def coerce_indices(indices: Sequence[int] | Tensor) -> list[int]:
-    """Normalise a frame-index container to a plain ``list[int]``.
-
-    Keeps :attr:`HyWorldPlayCtrl.memory_frame_indices` type-stable across
-    the encoder / transformer boundary regardless of whether the producer
-    returned a torch tensor or a numpy array.
-    """
+    """Normalise a frame-index container (tensor or sequence) to ``list[int]``."""
     if isinstance(indices, Tensor):
         return [int(x) for x in indices.tolist()]
     return [int(x) for x in indices]

--- a/integrations/hy_worldplay/hy_worldplay/_pose.py
+++ b/integrations/hy_worldplay/hy_worldplay/_pose.py
@@ -196,7 +196,7 @@ def parse_pose_data(
             produce *at least* this many entries; any extra trailing
             poses are ignored (the first ``n_latents`` are used).
         third_person: When ``True``, only emit translation classes for
-            frames with small yaw / pitch (matches upstream's ``tps`` flag).
+            frames with small yaw / pitch.
 
     Returns:
         Tuple ``(w2c, K, action_labels)``:
@@ -231,9 +231,7 @@ def parse_pose_data(
             "num_chunk."
         )
     # A pose source longer than the rollout is fine: take the first
-    # ``n_latents`` poses. This is vendor's prefix-slice behaviour and
-    # lets upstream's fixed-length sample (e.g. the 33-entry
-    # ``test_forward_32_latents.json``) drive a shorter ``num_chunk`` run.
+    # ``n_latents`` poses.
     keys = keys[:n_latents]
 
     c2w_list: list[np.ndarray] = []

--- a/integrations/hy_worldplay/hy_worldplay/_prope.py
+++ b/integrations/hy_worldplay/hy_worldplay/_prope.py
@@ -15,14 +15,8 @@
 
 r"""PRoPE-style projective positional encoding for multi-view attention.
 
-Ports the bit pattern of ``hyvideo/prope/camera_rope.py::prope_qkv`` from
-`PRoPE: Projective Positional Encoding for Multiview Transformers
-<https://github.com/Tencent-Hunyuan/HY-WorldPlay/blob/main/hyvideo/prope/camera_rope.py>`_
-(MIT-licensed) so the native HY-WorldPlay path can apply per-camera
-projective transforms to Q/K/V before attention without importing the
-upstream HY-WorldPlay tree at runtime.
-
-The transform is a block-diagonal matrix multiply on the per-head feature
+Applies per-camera projective transforms to Q/K/V before attention. The
+transform is a block-diagonal matrix multiply on the per-head feature
 axis: each camera's tokens get multiplied by a 4×4 matrix derived from
 that camera's world-to-camera extrinsic and (optional) intrinsic. The
 matrices are
@@ -32,16 +26,10 @@ matrices are
 * ``P_T = P.transpose(-1, -2)`` (applied to query)
 
 so the attention score :math:`Q P_q \cdot K^T P_{k}^{-T}` evaluates to the
-upstream pair-wise projective positional encoding. The post-attention
-output is multiplied by ``P`` of the query's camera to undo the input
-basis change.
-
-Numeric semantics mirror upstream exactly: same einsum order, same
-single-precision cast points, same block-diagonal partitioning on the
-``head_dim`` axis (which must be divisible by 4 because the projection
-matrices are 4×4). Tests under
-``integrations/hy_worldplay/tests/test_prope.py`` cross-check this port
-against a numpy reference.
+pair-wise projective positional encoding. The post-attention output is
+multiplied by ``P`` of the query's camera to undo the input basis change.
+``head_dim`` must be divisible by 4 because the projection matrices are
+4×4.
 """
 
 from __future__ import annotations
@@ -75,14 +63,12 @@ def prope_qkv(
         viewmats: Per-camera world-to-camera ``SE(3)`` matrices, shape
             ``[batch, cameras, 4, 4]``. The token axis must satisfy
             ``seqlen % cameras == 0`` so each camera owns a contiguous
-            block of ``seqlen // cameras`` tokens. ``cameras`` here is the
-            number of latent frames covered by ``q`` (typically the
-            per-AR-step frame count); cached K/V from earlier AR steps
-            must already be PRoPE-transformed and is concatenated by the
-            caller *after* this function returns.
+            block of ``seqlen // cameras`` tokens. ``cameras`` is the
+            number of latent frames covered by ``q``; cached K/V from
+            earlier AR steps must already be PRoPE-transformed and is
+            concatenated by the caller *after* this function returns.
         Ks: Optional camera intrinsics ``[batch, cameras, 3, 3]``. When
-            ``None`` the formula degenerates to the GTA / no-intrinsic
-            variant (matching upstream's ``Ks=None`` branch).
+            ``None`` the formula degenerates to the no-intrinsic variant.
 
     Returns:
         ``(q_prope, k_prope, v_prope, apply_fn_o)`` where the first three
@@ -129,10 +115,9 @@ def build_prope_apply_fns(
 
     Returns three callables (``apply_fn_q``, ``apply_fn_kv``,
     ``apply_fn_o``) that each take a ``[batch, num_heads, seqlen, head_dim]``
-    tensor and apply the corresponding tiled 4×4 matrix per camera. Pulled
-    out as a public entry point so callers that cache transforms across
-    multiple attention layers (e.g. PRoPE multi-block transformers) can
-    pay the matrix-prep cost once.
+    tensor and apply the corresponding tiled 4×4 matrix per camera. Use
+    this directly to pay the matrix-prep cost once when reusing transforms
+    across multiple attention layers.
     """
     batch, cameras, _, _ = viewmats.shape
     assert head_dim % 4 == 0, (
@@ -141,21 +126,17 @@ def build_prope_apply_fns(
     )
 
     if Ks is not None:
-        # Drop the principal point so PRoPE only encodes the focal-length /
-        # rotation / translation parts of the camera; the principal point
-        # is intentionally renormalised to (0, 0) in the lifted matrix --
-        # upstream's pose preprocessor already shifts (cx, cy) to (0.5, 0.5)
-        # so the per-frame K passed in here carries focal info only.
+        # Keep only the focal lengths so PRoPE encodes focal / rotation /
+        # translation; the principal point is dropped (callers pass K with
+        # cx/cy already renormalised).
         Ks_norm = torch.zeros_like(Ks)
         Ks_norm[..., 0, 0] = Ks[..., 0, 0]
         Ks_norm[..., 1, 1] = Ks[..., 1, 1]
         Ks_norm[..., 2, 2] = 1.0
         Ks_norm = Ks_norm.to(dtype=Ks.dtype)
 
-        # P = lift(K) @ viewmats is the image<-world transform; we keep
-        # both P (for the output projection / query) and P_inv (for K/V)
-        # so the einsum at attention time evaluates the upstream
-        # PRoPE formula bit-for-bit.
+        # P = lift(K) @ viewmats is the image<-world transform; keep both
+        # P (for the output projection / query) and P_inv (for K/V).
         P = torch.einsum("...ij,...jk->...ik", _lift_K(Ks_norm), viewmats)
         P_T = P.transpose(-1, -2).to(dtype=viewmats.dtype)
         P_inv = torch.einsum(
@@ -164,8 +145,7 @@ def build_prope_apply_fns(
             _lift_K(_invert_K(Ks_norm)),
         ).to(dtype=viewmats.dtype)
     else:
-        # Intrinsic-free variant -- matches upstream's GTA formula
-        # (``Ks=None`` branch in ``hyvideo/prope/camera_rope.py``).
+        # Intrinsic-free variant.
         P = viewmats
         P_T = P.transpose(-1, -2)
         P_inv = _invert_SE3(viewmats)
@@ -177,9 +157,7 @@ def build_prope_apply_fns(
     return apply_fn_q, apply_fn_kv, apply_fn_o
 
 
-## ---------------------------------------------------------------------------
 ## Internal helpers
-## ---------------------------------------------------------------------------
 
 
 def _apply_tiled_projmat(
@@ -230,11 +208,8 @@ def _invert_SE3(transforms: Tensor) -> Tensor:
 def _lift_K(Ks: Tensor) -> Tensor:
     """Embed 3x3 camera intrinsics into 4x4 homogeneous form.
 
-    Uses ``Ks.dtype`` for the allocation (upstream's
-    ``torch.zeros`` would default to float32 and silently downcast a
-    float64 input on the ``out[..., :3, :3] = Ks`` write; we want
-    numerically-correct behaviour at any precision while staying
-    bit-identical to upstream at fp32 / bf16).
+    Allocates in ``Ks.dtype`` so a float64 input is not silently
+    downcast.
     """
     assert Ks.shape[-2:] == (3, 3)
     out = torch.zeros(Ks.shape[:-2] + (4, 4), device=Ks.device, dtype=Ks.dtype)

--- a/integrations/hy_worldplay/hy_worldplay/config.py
+++ b/integrations/hy_worldplay/hy_worldplay/config.py
@@ -47,19 +47,15 @@ def _build_hy_worldplay_pipeline() -> WanInferencePipelineConfig:
     """Deep-copy the Wan 2.2 TI2V-5B recipe and layer the full HY-WorldPlay stack on top.
 
     Swaps in the distilled 4-step Euler scheduler, the action / camera
-    HY encoder, and the HY transformer + DiT network (with PRoPE blocks
-    enabled). Field-by-field copy on the transformer is intentional: a
-    plain :func:`derive_config` can't change the dataclass *type*, and
-    silently dropping a future addition to
-    :class:`Wan21TransformerConfig` on the HY side would be hard to
-    catch.
+    HY encoder, and the HY transformer + DiT network (PRoPE blocks
+    enabled). The transformer is copied field-by-field rather than
+    derived: :func:`derive_config` can't change the dataclass type, and
+    an explicit copy fails loudly if a base field is added.
     """
     pipeline = copy.deepcopy(PIPELINE_WAN22_TI2V_5B)
     pipeline.name = "hy-worldplay-wan-i2v-5b"
 
-    # Distilled WAN-5B fixed-timestep schedule (upstream's ``few_step=True``
-    # branch in ``pipeline_wan_w_mem_relative_rope.py``). The base recipe
-    # stays on UniPC for non-HY callers.
+    # Distilled WAN-5B fixed-timestep schedule (base recipe stays on UniPC).
     pipeline.diffusion_model.scheduler = FlowMatchEulerDiscreteSchedulerConfig(
         num_inference_steps=4,
         fixed_timesteps=(1000.0, 960.0, 888.8889, 727.2728, 0.0),
@@ -71,9 +67,8 @@ def _build_hy_worldplay_pipeline() -> WanInferencePipelineConfig:
     )
 
     base_t = pipeline.diffusion_model.transformer
-    # Narrow ``TransformerConfig`` (the slot's static type) to the
-    # Wan-2.2 TI2V-5B's concrete config so ty resolves the subclass-only
-    # attributes copied across below.
+    # Narrow to the concrete config so the subclass-only attributes
+    # copied below resolve.
     assert isinstance(base_t, Wan21TransformerConfig)
     base_n = base_t.network
     assert isinstance(base_n, WanDiTNetworkConfig)
@@ -101,14 +96,11 @@ def _build_hy_worldplay_pipeline() -> WanInferencePipelineConfig:
         checkpoint_path=base_t.checkpoint_path,
         state_dict_transform=base_t.state_dict_transform,
         batch_shape=base_t.batch_shape,
-        # HY-WorldPlay autoregressive WAN-5B uses 4-latent chunks
-        # (upstream's ``pred_latent_size=4``); not the base recipe's 21.
-        # Mismatched ``len_t`` gives different total frame counts and
-        # RoPE positions.
+        # 4-latent AR chunks (not the base recipe's 21); sets total
+        # frame counts and RoPE positions.
         len_t=4,
-        # Distilled WAN-5B bakes CFG into the checkpoint and runs a
-        # single conditional forward per step; ``guidance_scale=1.0``
-        # skips the uncond branch + combine.
+        # CFG is baked into the distilled checkpoint; ``1.0`` skips the
+        # uncond branch.
         guidance_scale=1.0,
         # Match the rolling KV window to a single chunk.
         window_size_t=4,
@@ -123,11 +115,8 @@ def _build_hy_worldplay_pipeline() -> WanInferencePipelineConfig:
         ti2v_first_frame_per_token_timestep=(
             base_t.ti2v_first_frame_per_token_timestep
         ),
-        # Upstream's HY pipeline runs the first-frame context at the
-        # stabilisation sigma ``stabilization_level - 1 = 14`` (vendor
-        # ``pipeline_wan_w_mem_relative_rope.py`` lines 680, 892); the
-        # distilled checkpoint's AdaLN table at the first frame is
-        # fitted to it.
+        # First-frame context runs at the stabilisation sigma 14, which
+        # the distilled checkpoint's AdaLN table is fitted to.
         first_frame_timestep_value=14.0,
     )
     return pipeline

--- a/integrations/hy_worldplay/hy_worldplay/runner.py
+++ b/integrations/hy_worldplay/hy_worldplay/runner.py
@@ -45,18 +45,15 @@ DEFAULT_PROMPT = (
     "First-person view walking around ancient Athens, with Greek "
     "architecture and marble structures"
 )
-"""Upstream ``wan/generate.py`` ``--input`` default. Kept byte-for-byte
-identical -- including no trailing period -- so UMT5 tokenization
-matches the reference output (trailing ``.`` adds an extra token and
-shifts conditioning by ~5/255)."""
+"""Default text prompt. No trailing period -- a trailing ``.`` adds a
+UMT5 token and shifts conditioning."""
 
 DEFAULT_POSE = "w-15"
-"""Default camera trajectory: 15 forward steps (+ the identity input
-frame) = 16 latents, matching the default ``num_chunk=4`` rollout. With
-``--example-data`` this is swapped for upstream's sample pose JSON."""
+"""Default camera trajectory: 15 forward steps + the identity input
+frame = 16 latents, matching the default ``num_chunk=4`` rollout. With
+``--example-data`` this is swapped for the sample pose JSON."""
 
 
-# Repo root = ``<this file>.parents[3]`` (``flashdreams/integrations/hy_worldplay/hy_worldplay/runner.py``).
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 EXAMPLE_DATA_BASE_URL = (
@@ -71,9 +68,9 @@ _EXAMPLE_IMAGE_FILENAME = "test.png"
 """Upstream's default ``--image_path`` fixture (704x1280)."""
 
 _EXAMPLE_POSE_FILENAME = "test_forward_32_latents.json"
-"""Upstream's sample camera trajectory (``assets/pose/``); 33 entries
-(32 forward-motion latents + the identity input frame). Long enough to
-drive any ``num_chunk <= 8`` rollout via the parser's prefix slice."""
+"""Sample camera trajectory; 33 entries (32 forward-motion latents +
+the identity input frame), enough for any ``num_chunk <= 8`` rollout
+via the parser's prefix slice."""
 
 
 def preprocess_first_frame(
@@ -83,9 +80,7 @@ def preprocess_first_frame(
 ) -> Tensor:
     """Load and resize the first-frame image to ``WanI2VCtrlEncoder``'s input shape.
 
-    Aspect-ratio policy is fit + centre-crop, matching upstream's
-    ``hyvideo/utils/image.py`` so native and vendor see the same
-    conditioning frame for matching pixel sizes.
+    Aspect-ratio policy is scale-to-fill + centre-crop.
 
     Returns:
         ``[1, 1, 3, H, W]`` float32 tensor in ``[-1, 1]``. The leading
@@ -99,8 +94,8 @@ def preprocess_first_frame(
     src_w, src_h = img.size
     target_h, target_w = pixel_height, pixel_width
 
-    # Scale-to-fill (the longer side hits the target; the shorter side
-    # overflows and is centre-cropped). Mirrors upstream's resize policy.
+    # Scale-to-fill: the longer side hits the target, the shorter side
+    # overflows and is centre-cropped.
     scale = max(target_h / src_h, target_w / src_w)
     new_h = int(round(src_h * scale))
     new_w = int(round(src_w * scale))
@@ -118,8 +113,8 @@ def preprocess_first_frame(
 def _pil_to_numpy(img: object) -> object:
     """Convert a PIL image to a numpy array, importing numpy lazily.
 
-    The lazy import keeps numpy off the module surface so CPU smoke
-    sub-venvs without pillow / numpy can still import the module.
+    The lazy import keeps numpy off the module surface so environments
+    without pillow / numpy can still import the module.
     """
     import numpy as np
 
@@ -146,18 +141,14 @@ def _write_mp4(video: Tensor, out_path: Path, *, fps: int) -> None:
 
     Note:
         Frames must be float in ``[0, 1]``: ``export_to_video``
-        internally multiplies ndarray frames by 255 before
-        ``.astype(np.uint8)``, so passing uint8 ``[0, 255]`` overflows
-        and produces visibly shifted RGB means (~40 units per channel
-        for typical pixel values).
+        multiplies ndarray frames by 255 before ``.astype(np.uint8)``,
+        so uint8 ``[0, 255]`` input overflows.
     """
     import numpy as np
     from diffusers.utils import export_to_video
 
     if video.dim() > 4:
-        # Squeeze leading batch axes one at a time (asserting size 1)
-        # so the error message is precise if a future batch > 1 config
-        # sneaks through.
+        # Squeeze leading batch axes one at a time, asserting size 1.
         while video.dim() > 4:
             assert video.shape[0] == 1, (
                 f"_write_mp4 expects batch_size=1; got leading shape {video.shape[0]}."
@@ -182,36 +173,31 @@ class HyWorldPlayWanI2VRunnerConfig(RunnerConfig):
     non-empty line is used."""
 
     image_path: Path | None = None
-    """First-frame RGB image. Required (HY-WorldPlay WAN-5B is I2V-only)
-    unless :attr:`example_data` is ``True``, in which case the runner
-    lazy-downloads upstream's ``assets/img/test.png`` fixture from the
-    HY-WorldPlay GitHub repo at run time and uses that as the default."""
+    """First-frame RGB image. Required (WAN-5B is I2V-only) unless
+    :attr:`example_data` is ``True``, which lazy-downloads the sample
+    fixture and uses it as the default."""
 
     example_data: bool = False
-    """When ``True``, lazy-download upstream's bundled sample
-    first-frame image into ``data_local/hy_worldplay/`` (rank-0 only,
-    gitignored) and fill :attr:`image_path` from it when unset. Use
-    for the README demo; pass ``--image-path`` explicitly for
-    production runs."""
+    """When ``True``, lazy-download the bundled sample first-frame image
+    into ``data_local/hy_worldplay/`` (rank-0 only, gitignored) and fill
+    :attr:`image_path` from it when unset."""
 
     pose: str = DEFAULT_POSE
     """Camera trajectory as a pose-string (e.g. ``"w-15"``,
-    ``"w-3, right-1, d-4"``) or the path to a JSON file produced by
-    upstream's ``hyvideo/generate_custom_trajectory.py``. The parser
-    prepends an identity pose for the input frame, so ``w-N`` produces
-    ``N + 1`` latents; the rollout consumes ``num_chunk * 4`` and a
-    longer source is prefix-sliced. With ``--example-data`` left at the
-    default, the runner swaps in upstream's sample pose JSON."""
+    ``"w-3, right-1, d-4"``) or a path to a trajectory JSON file. The
+    parser prepends an identity pose for the input frame, so ``w-N``
+    produces ``N + 1`` latents; the rollout consumes ``num_chunk * 4``
+    and a longer source is prefix-sliced. With ``--example-data`` left
+    at the default, the sample pose JSON is used."""
 
     num_chunk: int = 4
     """Autoregressive chunks to roll out; each chunk emits 4 latents
     (~16 decoded frames)."""
 
     num_frames: int = 961
-    """Latent budget reserved for the longest vendor-aligned rollout.
-    Only consumed by the ``HY_VENDOR_NOISE_MODE=1`` diagnostic, which
-    pre-draws noise at the same shape vendor's ``prepare_latents`` would
-    use; non-diagnostic runs ignore this field."""
+    """Frame budget for the noise tensor. Only consumed by the
+    ``HY_VENDOR_NOISE_MODE=1`` diagnostic; non-diagnostic runs ignore
+    this field."""
 
     pixel_height: int = 704
     """Output video pixel height."""
@@ -232,25 +218,23 @@ class HyWorldPlayWanI2VRunnerConfig(RunnerConfig):
     :attr:`RunnerConfig.offset_seed_by_global_rank` is set."""
 
     ckpt_path: Path | None = None
-    """Optional path to HY-WorldPlay's distilled
-    ``wan_distilled_model/model.pt``. When set, the runner reroutes the
-    transformer's ``checkpoint_path`` + ``state_dict_transform`` to load
-    the distilled weights at construction time. When ``None``, the
-    pipeline loads the base Wan 2.2 TI2V-5B safetensors and HY's
-    conditioners stay zero-init (strict identity, parity-safe)."""
+    """Optional path to the distilled ``wan_distilled_model/model.pt``.
+    When set, the runner reroutes the transformer's ``checkpoint_path``
+    + ``state_dict_transform`` to load the distilled weights at
+    construction time. When ``None``, the pipeline loads the base Wan
+    2.2 TI2V-5B safetensors and HY's conditioners stay zero-init (strict
+    identity)."""
 
     memory_frames: int = 16
     """Total memory-frame budget per AR step (temporal context +
-    FOV-selected). Matches upstream's
-    ``select_mem_frames_wan(..., memory_frames=16)``."""
+    FOV-selected)."""
 
     temporal_context_size: int = 12
     """Recent-frames portion of the memory budget, kept unconditionally
     each AR step."""
 
     memory_pred_latent_size: int = 4
-    """Query-clip size for the FOV-overlap scorer (matches upstream's
-    ``pred_latent_size=4``)."""
+    """Query-clip size for the FOV-overlap scorer."""
 
     memory_fov_h_deg: float = 60.0
     """Horizontal FOV (degrees) for the selection-time overlap."""
@@ -263,8 +247,7 @@ class HyWorldPlayWanI2VRunnerConfig(RunnerConfig):
     the FOV-overlap scorer."""
 
     memory_points_radius: float = 8.0
-    """Radius of the Monte-Carlo sphere; matches upstream's
-    ``generate_points_in_sphere(50_000, 8.0)``."""
+    """Radius of the Monte-Carlo sphere."""
 
 
 class HyWorldPlayWanI2VRunner(
@@ -272,22 +255,16 @@ class HyWorldPlayWanI2VRunner(
 ):
     """Drive :data:`PIPELINE_HY_WORLDPLAY_WAN_I2V_5B` end-to-end for the I2V case.
 
-    Inherits the standard :class:`Runner` machinery (torchrun bootstrap,
-    distributed init, per-rank seed offset, ``pipeline.setup()`` +
-    ``.to(device).eval()``) and supplies a single :meth:`run` method
-    that resolves the prompt and first frame, calls
-    ``pipeline.initialize_cache``, drives the AR loop with ``generate``
-    + ``finalize``, and writes an mp4 on rank 0.
+    Inherits the standard :class:`Runner` machinery and supplies a
+    single :meth:`run` method that resolves the prompt and first frame,
+    calls ``pipeline.initialize_cache``, drives the AR loop with
+    ``generate`` + ``finalize``, and writes an mp4 on rank 0.
 
-    The fully-swapped HY encoder / transformer / DiT network (with PRoPE
-    blocks) is wired statically in :mod:`hy_worldplay.config`; this
-    runner binds the per-rollout payloads (action labels, viewmats +
-    intrinsics, memory-selection knobs) on the encoder before the AR
-    loop starts. When :attr:`HyWorldPlayWanI2VRunnerConfig.ckpt_path` is
-    supplied, ``__init__`` routes the transformer's checkpoint slot at
-    HY's distilled ``.pt`` and the matching state-dict transform before
-    the base ``Runner.__init__`` builds the pipeline; ``None`` keeps the
-    base diffusers checkpoint (HY conditioners stay zero-init identity).
+    The HY encoder / transformer / DiT network is wired statically in
+    :mod:`hy_worldplay.config`; this runner binds the per-rollout
+    payloads (action labels, viewmats + intrinsics, memory-selection
+    knobs) on the encoder before the AR loop starts. See ``__init__``
+    for the :attr:`HyWorldPlayWanI2VRunnerConfig.ckpt_path` handling.
     """
 
     config: HyWorldPlayWanI2VRunnerConfig
@@ -295,11 +272,10 @@ class HyWorldPlayWanI2VRunner(
     def __init__(self, config: HyWorldPlayWanI2VRunnerConfig) -> None:
         """Route the distilled checkpoint into the pipeline, then defer to :class:`Runner`.
 
-        When ``config.ckpt_path`` is set, derives a copy of the runner
-        config with the transformer's ``checkpoint_path`` +
-        ``state_dict_transform`` rewritten to load HY's distilled
-        ``.pt`` (instead of the base Wan 2.2 TI2V-5B safetensors)
-        before the base ``__init__`` builds the pipeline.
+        When ``config.ckpt_path`` is set, derives a config copy with the
+        transformer's ``checkpoint_path`` + ``state_dict_transform``
+        rewritten to load the distilled ``.pt`` before the base
+        ``__init__`` builds the pipeline.
         """
         if config.ckpt_path is not None:
             from flashdreams.infra.config import derive_config
@@ -330,16 +306,11 @@ class HyWorldPlayWanI2VRunner(
 
         cfg = self.config
         # ``HY_DEBUG_DISABLE_CUDA_GRAPH=1`` disables the per-network
-        # CUDAGraphWrapper so env-var-gated tensor dumps in
-        # :mod:`_debug_dump` (file I/O + host-synchronous ``.item()``
-        # calls) don't crash CUDA stream capture with
-        # ``cudaErrorStreamCaptureInvalidated``.
+        # CUDAGraphWrapper so diagnostic tensor dumps (file I/O +
+        # host-sync ``.item()`` calls) don't invalidate stream capture.
         if os.environ.get("HY_DEBUG_DISABLE_CUDA_GRAPH", "") == "1":
             # CUDA-graph state lives on the inner ``Wan21Transformer``,
-            # not on the :class:`DiffusionModel` wrapper (scheduler +
-            # transformer) exposed via ``self.pipeline.diffusion_model``;
-            # reach through one level so the disable actually takes
-            # effect.
+            # not the ``DiffusionModel`` wrapper; reach through one level.
             diffusion_model = getattr(self.pipeline, "diffusion_model", None)
             wan_transformer = getattr(diffusion_model, "transformer", None)
             if wan_transformer is not None and hasattr(wan_transformer, "network"):
@@ -370,12 +341,8 @@ class HyWorldPlayWanI2VRunner(
 
         first_param = next(self.pipeline.parameters())
         device = first_param.device
-        # The VAE encoder runs in the pipeline's parameter dtype (bf16 /
-        # fp16 in production, fp32 in the CPU smoke); the float32 tensor
-        # produced by ``preprocess_first_frame`` would fail the
-        # ``F.conv3d`` dtype check in the residual VAE's first
-        # ``CausalConv3d``. Cast here so the cast-once cost stays in
-        # the runner rather than the per-AR-step encode path.
+        # Cast to the pipeline's parameter dtype so the VAE encoder's
+        # first ``CausalConv3d`` doesn't trip the ``F.conv3d`` dtype check.
         image = preprocess_first_frame(
             cfg.image_path, cfg.pixel_height, cfg.pixel_width
         ).to(device=device, dtype=first_param.dtype)
@@ -388,13 +355,10 @@ class HyWorldPlayWanI2VRunner(
             width=None,
         )
 
-        # The pipeline is statically HY-swapped (see
-        # :mod:`hy_worldplay.config`), so the per-rollout payloads are
-        # always bound: action labels for the AdaLN add, viewmats +
-        # intrinsics for the PRoPE branch, and the memory-selection
-        # knobs for the FOV-overlap scorer. With zero-init weights (no
-        # ``ckpt_path``) each conditioner is a strict identity, so this
-        # is still parity-safe against the base Wan 2.2 TI2V-5B output.
+        # Bind the per-rollout payloads on the (statically HY-swapped)
+        # encoder: action labels for the AdaLN add, viewmats +
+        # intrinsics for PRoPE, memory-selection knobs for the
+        # FOV-overlap scorer.
         self._bind_action_labels()
         self._bind_camera_data()
         self._bind_memory_config(device=device)
@@ -404,12 +368,8 @@ class HyWorldPlayWanI2VRunner(
         )
 
         chunks: list[Tensor] = []
-        # Per-chunk encode/diffuse/decode/finalize timing comes from the
-        # pipeline's own profiler (``enable_sync_and_profile=True`` on
-        # the recipe config). Each :meth:`StreamInferencePipeline.finalize`
-        # call returns the per-stage ms dict for that AR step; collect
-        # them into ``stats_history`` and dump as JSON, mirroring the
-        # ``integrations/omnidreams`` pattern.
+        # Each ``finalize`` returns the per-stage ms dict for that AR
+        # step; collect into ``stats_history`` and dump as JSON.
         stats_history: list[dict[str, float]] = []
         if torch.cuda.is_available():
             torch.cuda.reset_peak_memory_stats()
@@ -418,10 +378,9 @@ class HyWorldPlayWanI2VRunner(
             for ar_idx in range(cfg.num_chunk):
                 chunk = self.pipeline.generate(ar_idx, cache)
                 chunks.append(chunk)
-                # ``finalize`` records the chunk's CUDA events + advances
-                # the KV cache. Called on every chunk (incl. the last)
-                # for consistent stats; the trailing KV advance is a
-                # cheap one-block forward.
+                # ``finalize`` records the chunk's CUDA events and
+                # advances the KV cache; called on every chunk
+                # (including the last) for consistent stats.
                 stats = self.pipeline.finalize(ar_idx, cache)
                 if stats is not None:
                     stats_history.append({"autoregressive_index": ar_idx, **stats})
@@ -447,11 +406,10 @@ class HyWorldPlayWanI2VRunner(
             )
 
     def _fetch_example_image(self) -> Path:
-        """Lazy-download upstream's bundled ``assets/img/test.png`` on rank 0.
+        """Lazy-download the bundled sample first-frame image on rank 0.
 
-        Mirrors :func:`lingbot.runner._ensure_example_data_downloaded`'s
-        rank-0-download + barrier-all-ranks pattern; the cached file is
-        reused across rollouts.
+        Rank-0 downloads, all ranks barrier; the cached file is reused
+        across rollouts.
         """
         cache_dir = EXAMPLE_DATA_DIR_LOCAL
         if self.is_rank_zero:
@@ -465,7 +423,7 @@ class HyWorldPlayWanI2VRunner(
         return cache_dir / _EXAMPLE_IMAGE_FILENAME
 
     def _fetch_example_pose(self) -> Path:
-        """Lazy-download upstream's sample ``assets/pose/`` trajectory on rank 0.
+        """Lazy-download the sample camera trajectory on rank 0.
 
         Symmetric to :meth:`_fetch_example_image`. The parser prefix-
         slices this 33-entry file to the rollout's ``num_chunk * 4``
@@ -504,13 +462,9 @@ class HyWorldPlayWanI2VRunner(
         encoder, n_latents = self._resolve_encoder_and_n_latents()
         assert isinstance(encoder, HyWorldPlayWanCtrlEncoder)
         viewmats, Ks, _ = parse_pose_data(self.config.pose, n_latents)
-        # Cast to the pipeline dtype so PRoPE math + cudnn attention
-        # don't kick the network into fp64. ``parse_pose_data`` emits
-        # ``[n_latents, 4, 4]`` / ``[n_latents, 3, 3]`` without a batch
-        # axis; :func:`hy_worldplay._prope.prope_qkv`
-        # requires ``[batch=1, cameras, 4, 4]``, so an ``unsqueeze(0)``
-        # here lifts both the per-step slice and the per-rollout buffer
-        # to the rank PRoPE expects.
+        # Cast to the pipeline dtype (keep PRoPE math + cudnn attention
+        # off fp64) and ``unsqueeze(0)`` the batch axis that
+        # :func:`hy_worldplay._prope.prope_qkv` expects.
         target_dtype = next(self.pipeline.parameters()).dtype
         encoder.set_camera_data(
             viewmats.to(dtype=target_dtype).unsqueeze(0),
@@ -520,12 +474,10 @@ class HyWorldPlayWanI2VRunner(
     def _bind_memory_config(self, *, device: torch.device) -> None:
         """Arm reconstituted-context memory selection on the encoder.
 
-        Builds the Monte-Carlo point cloud once (size + radius mirror
-        upstream's ``generate_points_in_sphere`` call) and hands it
-        plus the rest of the selection knobs to
-        :meth:`HyWorldPlayWanCtrlEncoder.set_memory_config`; the
-        encoder then computes per-AR-step ``memory_frame_indices`` on
-        demand.
+        Builds the Monte-Carlo point cloud once and hands it plus the
+        selection knobs to
+        :meth:`HyWorldPlayWanCtrlEncoder.set_memory_config`; the encoder
+        then computes per-AR-step ``memory_frame_indices`` on demand.
         """
         from hy_worldplay._action import HyWorldPlayWanCtrlEncoder
         from hy_worldplay._memory import generate_points_in_sphere
@@ -558,17 +510,13 @@ class HyWorldPlayWanI2VRunner(
         """Build a context manager that overrides the diffusion noise per chunk.
 
         When ``HY_VENDOR_NOISE_MODE=1`` the runner pre-draws the full
-        multi-chunk noise tensor with the same shape and seed as
-        vendor's ``prepare_latents`` (a single
-        ``randn([1, 48, T, H_lat, W_lat])`` over all chunks) and
-        patchifies a per-AR-step slice. Inside the chunk loop the
-        returned context manager monkey-patches ``torch.randn`` to
-        return the pre-computed slice whenever the request matches the
-        diffusion model's ``latent_shape``; all other randn calls fall
-        through to the original implementation.
+        multi-chunk noise tensor in one ``randn`` call and patchifies a
+        per-AR-step slice. The returned context manager monkey-patches
+        ``torch.randn`` to return the pre-computed slice whenever the
+        request matches the diffusion model's ``latent_shape``; all
+        other randn calls fall through to the original.
 
-        Returns ``nullcontext()`` when the env var is unset, leaving
-        the pipeline to draw noise from its private ``torch.Generator``.
+        Returns ``nullcontext()`` when the env var is unset.
         """
         import math
         import os
@@ -593,14 +541,11 @@ class HyWorldPlayWanI2VRunner(
         # 16x spatial compression for the WAN-5B residual VAE.
         h_lat = cfg.pixel_height // 16
         w_lat = cfg.pixel_width // 16
-        # Vendor's prepare_latents draws the full ``num_latent_frames``
-        # of noise in one randn call, independent of how many chunks
-        # the rollout actually consumes. Replicate the full tensor here
-        # so the RNG stream lines up bit-for-bit; a smaller
-        # ``randn(num_chunk * len_t, ...)`` would put each subsequent
-        # channel slice at a different flat-memory offset and break
-        # parity. ``num_latent_frames = (num_frames - 1) // 4 + 1``
-        # reflects the WAN-5B residual VAE's 4x temporal compression.
+        # Draw the full frame budget in one randn call (not just the
+        # consumed chunks) so the RNG stream stays bit-aligned; a
+        # smaller draw shifts each channel slice's flat offset.
+        # ``(num_frames - 1) // 4 + 1`` is the VAE's 4x temporal
+        # compression.
         vendor_full_t = (cfg.num_frames - 1) // 4 + 1
         unpatched_shape = (
             1,
@@ -624,10 +569,8 @@ class HyWorldPlayWanI2VRunner(
         if cfg.offset_seed_by_global_rank and self.global_rank != 0:
             seed = seed + self.global_rank
 
-        # Draw the full noise tensor in fp32 to mirror vendor's
-        # ``randn_tensor(..., dtype=torch.float32)`` then cast to the
-        # diffusion model's dtype. ``torch.manual_seed`` matches
-        # vendor's global-RNG seed at the top of ``predict``.
+        # Draw in fp32 then cast to the diffusion model's dtype;
+        # ``torch.manual_seed`` seeds the global RNG.
         torch.manual_seed(seed)
         big_noise_fp32 = torch.randn(
             unpatched_shape,
@@ -635,12 +578,9 @@ class HyWorldPlayWanI2VRunner(
             device=device,
         )
 
-        # Patchify per chunk to match the format
-        # ``DiffusionModel.generate`` would otherwise draw directly via
-        # ``randn(latent_shape)``. Vendor's patch embedding applies the
-        # same ``... (t kt) c (h kh) (w kw) -> ... (t h w) (c kt kh kw)``
-        # rearrange, so replicating it on the unpatched slice keeps
-        # per-position bit values aligned between native and vendor.
+        # Patchify per chunk into the layout ``DiffusionModel.generate``
+        # would otherwise draw via ``randn(latent_shape)``, applying the
+        # patch embedding's rearrange so per-position bit values align.
         chunk_noise_queue: list[Tensor] = []
         for ar_idx in range(cfg.num_chunk):
             chunk_slice = big_noise_fp32[
@@ -656,9 +596,8 @@ class HyWorldPlayWanI2VRunner(
                 kh=kh,
                 kw=kw,
             )
-            # Drop the batch axis when the transformer's batch_shape is
-            # empty; native's ``latent_shape = (L, D)`` in that case and
-            # the reshape below would otherwise complain.
+            # Drop the batch axis when ``batch_shape`` is empty;
+            # ``latent_shape = (L, D)`` in that case.
             if not transformer_cfg.batch_shape:
                 patched = patched.squeeze(0)
             chunk_noise_queue.append(patched.to(dtype=dtype))
@@ -700,10 +639,8 @@ class HyWorldPlayWanI2VRunner(
     def _resolve_encoder_and_n_latents(self) -> tuple[object, int]:
         """Return ``(encoder, n_latents)`` after asserting the static HY swap took.
 
-        The HY encoder / transformer are wired into
-        :data:`PIPELINE_HY_WORLDPLAY_WAN_I2V_5B` at module import, so a
-        failure here means a caller built their own pipeline config
-        without the HY swap.
+        A failure here means a caller built a pipeline config without
+        the HY swap from :mod:`hy_worldplay.config`.
         """
         from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerConfig
         from hy_worldplay._action import HyWorldPlayWanCtrlEncoder

--- a/integrations/wan22/wan22/config.py
+++ b/integrations/wan22/wan22/config.py
@@ -15,22 +15,14 @@
 
 """Pre-rolled Wan pipeline configs.
 
-Phase 2a deliverable: the Wan 2.2 TI2V 5B recipe. The pipeline reuses
-the existing :class:`WanInferencePipeline` (no new module needed): the
-TI2V mode is expressed as a configuration of the I2V control encoder
-(now driven by the 5B 16x / 48ch / residual / patchify VAE) plus the
-existing transformer's ``stamp_image_latent`` mask-inject path, with a
-new ``ti2v_first_frame_per_token_timestep`` flag that flips the AR-0
-scheduler timestep into a per-token tensor (``t=0`` at the first-frame
-conditioning tokens, scheduler ``t`` elsewhere). The diffusers
-checkpoints under
-``Wan-AI/Wan2.2-TI2V-5B-Diffusers/{vae,transformer}`` load directly via
-the :func:`wan22_ti2v_5b_dit_state_dict_transform` (DiT) and
-:func:`wan22_ti2v_5b_vae_state_dict_transform` (VAE) remaps.
-
-The recipe ships as importable config constants only; downstream
-runners (``flashdreams-run`` slugs, plugin integrations such as
-``hy_worldplay`` phase 2b) layer the I/O wrapper on top.
+The Wan 2.2 TI2V-5B recipe, shipped as importable config constants.
+TI2V mode reuses :class:`WanInferencePipeline`: the I2V control encoder
+(over the 5B VAE) seeds the first frame, and the transformer conditions
+on it via ``stamp_image_latent`` and ``ti2v_first_frame_per_token_timestep``
+(frame-0 tokens see ``t=0``, the rest denoise at the scheduler step). The
+``Wan-AI/Wan2.2-TI2V-5B-Diffusers`` checkpoints load through the DiT and
+VAE remap transforms. Downstream runners (e.g. ``hy_worldplay``) layer the
+I/O wrapper on top.
 """
 
 from __future__ import annotations
@@ -57,19 +49,12 @@ WAN22_TI2V_5B_DIT_DIFFUSERS_PATH = (
     "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers/resolve/main/"
     "transformer/diffusion_pytorch_model.safetensors"
 )
-"""HF diffusers safetensors shard for the Wan 2.2 TI2V 5B DiT.
-
-The 5B variant ships as a single safetensors file (no sharded index)
-under the ``transformer/`` subfolder of the ``Wan-AI`` diffusers repo."""
+"""HF diffusers checkpoint for the Wan 2.2 TI2V-5B DiT (``transformer/`` subfolder)."""
 
 
-# Diffusers ``WanTransformer3DModel`` -> bare ``WanDiTNetwork`` state-
-# dict remap. The diffusers checkpoint stores the same submodules as
-# ours under different paths: condition embedders, scale/shift table,
-# attention projections (``attn1``/``attn2``), and FFN. The mapping is
-# identical to FastVideo's Wan 2.2 14B remap because both 5B and 14B
-# checkpoints inherit the same diffusers ``WanTransformer3DModel``
-# layout -- only the layer counts and channel counts differ.
+# Diffusers ``WanTransformer3DModel`` -> ``WanDiTNetwork`` key remap:
+# condition embedders, scale/shift table, attention projections
+# (``attn1``/``attn2``), and FFN.
 _WAN22_TI2V_5B_DIT_KEY_REMAP: dict[str, str] = {
     r"^condition_embedder\.text_embedder\.linear_1\.(.*)$": r"text_embedding.0.\1",
     r"^condition_embedder\.text_embedder\.linear_2\.(.*)$": r"text_embedding.2.\1",
@@ -102,13 +87,9 @@ _WAN22_TI2V_5B_DIT_KEY_REMAP: dict[str, str] = {
 def wan22_ti2v_5b_dit_state_dict_transform(
     state_dict: dict[str, torch.Tensor],
 ) -> dict[str, torch.Tensor]:
-    """Remap a diffusers Wan 2.2 TI2V 5B DiT state-dict to ``WanDiTNetwork`` keys.
+    """Remap a diffusers Wan 2.2 TI2V-5B DiT state-dict to ``WanDiTNetwork`` keys.
 
-    Wan 2.2 5B and 14B share the upstream diffusers DiT layout, so this
-    is structurally the same remap FastVideo's 14B MoE config uses --
-    only the layer / channel counts of the downstream config differ.
-    The remap is applied automatically when
-    :data:`PIPELINE_WAN22_TI2V_5B` loads the upstream
+    Applied automatically when :data:`PIPELINE_WAN22_TI2V_5B` loads the
     ``Wan-AI/Wan2.2-TI2V-5B-Diffusers/transformer`` checkpoint.
     """
     return remap_checkpoint_keys(state_dict, _WAN22_TI2V_5B_DIT_KEY_REMAP)
@@ -117,23 +98,15 @@ def wan22_ti2v_5b_dit_state_dict_transform(
 PIPELINE_WAN22_TI2V_5B = WanInferencePipelineConfig(
     name="wan22-ti2v-5b",
     enable_sync_and_profile=True,
-    # The streaming I2V control encoder reuses the standard Wan
-    # ``I2VCtrlEncoder``: AR step 0 encodes the first frame into latent
-    # index 0 and stamps a one-hot mask, AR step >= 1 emits an all-
-    # zero mask so the in-network ``stamp_image_latent`` blend
-    # collapses to identity. Wrapped around the 5B 16x VAE encoder
-    # (``Wan22TI2V5BVAEEncoderConfig``), this is the TI2V first-frame
-    # seed pipeline -- no CLIP image branch required.
+    # Streaming I2V control encoder over the 5B VAE: AR step 0 encodes the
+    # first frame into latent 0 with a one-hot stamp mask; later steps emit
+    # a zero mask so the in-network ``stamp_image_latent`` blend is identity.
     encoder=WanI2VCtrlEncoderConfig(
         encoder=Wan22TI2V5BVAEEncoderConfig(),
     ),
     decoder=Wan22TI2V5BVAEDecoderConfig(),
-    # Wan 2.2 TI2V 5B has no CLIP cross-attention branch; the first
-    # frame is conditioned via the VAE latent seed + per-token t=0,
-    # not via CLIP image features. Leaving ``image_encoder=None``
-    # disables both the CLIP one-shot encoder and the matching DiT
-    # cross-attention branch (see
-    # ``WanDiTNetworkTI2V5BConfig.cross_attn_enable_img=False``).
+    # No CLIP image branch: ``image_encoder=None`` also disables the matching
+    # DiT cross-attention branch (``cross_attn_enable_img=False``).
     image_encoder=None,
     diffusion_model=DiffusionModelConfig(
         seed=42,
@@ -145,17 +118,12 @@ PIPELINE_WAN22_TI2V_5B = WanInferencePipelineConfig(
             len_t=21,
             window_size_t=21,
             guidance_scale=5.0,
-            # The TI2V 5B recipe combines the existing mask-inject
-            # stamp (clean image latent re-injected every denoising
-            # step) with the new per-token timestep override (frame-0
-            # tokens see ``t=0`` while the rest of the chunk denoises
-            # at the scheduler step). Together they implement Wan 2.2
-            # 5B's "VAE-seeded first-frame + per-token t=0" recipe.
+            # First-frame conditioning: re-inject the clean image latent each
+            # step (stamp) and give frame-0 tokens ``t=0`` while the rest
+            # denoise at the scheduler step.
             stamp_image_latent=True,
             ti2v_first_frame_per_token_timestep=True,
-            # No channel-concat I2V layout: 5B's first frame is
-            # injected via the stamp path, not by appending mask +
-            # image-latent channels to the network input.
+            # 5B injects the first frame via the stamp path, not channel-concat.
             concat_image_mask_to_latent=False,
         ),
         scheduler=FlowMatchUniPCSchedulerConfig(
@@ -164,14 +132,11 @@ PIPELINE_WAN22_TI2V_5B = WanInferencePipelineConfig(
         ),
     ),
 )
-"""Wan 2.2 TI2V 5B inference pipeline (HF Wan-AI diffusers checkpoint).
+"""Wan 2.2 TI2V-5B inference pipeline (Wan-AI diffusers checkpoint).
 
-A single AR step is sufficient for the standard 81-frame /
-640x1280 TI2V rollout (``len_t == window_size_t == 21``), matching
-upstream's defaults. The recipe is the prerequisite for
-``integrations/hy_worldplay`` phase 2b, which layers HY-WorldPlay's
-action + camera-trajectory + reconstituted-context-memory deltas on
-top of this pipeline.
+One AR step covers the standard 81-frame / 640x1280 rollout
+(``len_t == window_size_t == 21``). Base recipe for
+``integrations/hy_worldplay``.
 """
 
 WAN_CONFIGS: dict[str, WanInferencePipelineConfig] = {


### PR DESCRIPTION
Separate doc-cleanup pass requested by @liruilong940607 in the PR #224 review — trim the agent's chain-of-thought / historical narration from comments and docstrings across the HY-WorldPlay + wan22 integration (in the spirit of the omnidreams deslop, #292).
