### PR TITLE
fix(hy_worldplay): default to the distilled HY checkpoint

### DIFF
--- a/integrations/hy_worldplay/README.md
+++ b/integrations/hy_worldplay/README.md
@@ -79,7 +79,6 @@ That gives you:
 ```bash
 uv run flashdreams-run hy-worldplay-wan-i2v-5b \
     --example-data \
-    --ckpt-path /path/to/models/wan_distilled_model/model.pt \
     --num-chunk 1 \
     --output-dir outputs
 ```
@@ -93,11 +92,10 @@ to override either; the pose source is prefix-sliced to the rollout's
 `num_chunk * 4` latent budget, so the 33-entry sample drives any
 `num-chunk` up to 8.
 
-`--ckpt-path` is optional. Without it the pipeline loads the base
-Wan 2.2 TI2V-5B safetensors and HY's conditioners stay zero-init
-(strict identity, parity-safe against the base Wan 2.2 output). Pass
-`--ckpt-path` to load the distilled WAN-5B weights and exercise the
-full HY-WorldPlay stack.
+By default the pipeline downloads HY-WorldPlay's distilled WAN-5B
+checkpoint from `tencent/HY-WorldPlay` and runs the full HY-WorldPlay
+stack. `--ckpt-path` is an optional override pointing at a local
+`wan_distilled_model/model.pt` (e.g. a copy you pre-downloaded above).
 
 Per-runner `--help` lists every overridable field:
 
@@ -245,8 +243,10 @@ default. Phase 3 is future.
 
 3. **Phase 2b — native HY-WorldPlay integration.** All conditioners
    are wired into the static pipeline in `hy_worldplay.config` and
-   zero-initialised so a run without `--ckpt-path` is a strict
-   identity against the base Wan 2.2 TI2V-5B output.
+   zero-initialised, so they stay identity until trained weights load.
+   The default loads the distilled checkpoint; pointing `--ckpt-path`
+   at a base Wan 2.2 TI2V-5B checkpoint is a strict identity against
+   the base output.
 
    - **2b.1 / 2b.2.** Native runner over `PIPELINE_WAN22_TI2V_5B` +
      distilled 4-step Euler schedule swapped in on the native path.

--- a/integrations/hy_worldplay/hy_worldplay/_checkpoint.py
+++ b/integrations/hy_worldplay/hy_worldplay/_checkpoint.py
@@ -25,8 +25,20 @@ from wan22.config import wan22_ti2v_5b_dit_state_dict_transform
 from flashdreams.core.checkpoint.remap import remap_checkpoint_keys
 
 __all__ = [
+    "HY_WORLDPLAY_DISTILLED_CKPT_PATH",
     "hy_worldplay_distilled_state_dict_transform",
 ]
+
+HY_WORLDPLAY_DISTILLED_CKPT_PATH = (
+    "https://huggingface.co/tencent/HY-WorldPlay/resolve/main/"
+    "wan_distilled_model/model.pt"
+)
+"""Default distilled HY-WorldPlay WAN-5B checkpoint (HF ``tencent/HY-WorldPlay``).
+
+Loaded via :func:`hy_worldplay_distilled_state_dict_transform`. The repo is
+gated, so set ``HF_TOKEN`` to download. Override with ``--ckpt-path`` to point
+at a local ``model.pt``.
+"""
 
 
 # Three HY-specific rewrite rules layered on top of the base

--- a/integrations/hy_worldplay/hy_worldplay/config.py
+++ b/integrations/hy_worldplay/hy_worldplay/config.py
@@ -34,6 +34,10 @@ from hy_worldplay._action import (
     HyWorldPlayWanCtrlEncoderConfig,
     HyWorldPlayWanDiTNetworkConfig,
 )
+from hy_worldplay._checkpoint import (
+    HY_WORLDPLAY_DISTILLED_CKPT_PATH,
+    hy_worldplay_distilled_state_dict_transform,
+)
 from hy_worldplay.runner import HyWorldPlayWanI2VRunnerConfig
 
 __all__ = [
@@ -98,8 +102,10 @@ def _build_hy_worldplay_pipeline() -> WanInferencePipelineConfig:
             use_prope_blocks=True,
         ),
         dtype=base_t.dtype,
-        checkpoint_path=base_t.checkpoint_path,
-        state_dict_transform=base_t.state_dict_transform,
+        # Inference loads HY-WorldPlay's distilled WAN-5B weights by default;
+        # ``--ckpt-path`` overrides with a local ``model.pt``.
+        checkpoint_path=HY_WORLDPLAY_DISTILLED_CKPT_PATH,
+        state_dict_transform=hy_worldplay_distilled_state_dict_transform,
         batch_shape=base_t.batch_shape,
         # HY-WorldPlay autoregressive WAN-5B uses 4-latent chunks
         # (upstream's ``pred_latent_size=4``); not the base recipe's 21.

--- a/integrations/hy_worldplay/hy_worldplay/runner.py
+++ b/integrations/hy_worldplay/hy_worldplay/runner.py
@@ -232,12 +232,12 @@ class HyWorldPlayWanI2VRunnerConfig(RunnerConfig):
     :attr:`RunnerConfig.offset_seed_by_global_rank` is set."""
 
     ckpt_path: Path | None = None
-    """Optional path to HY-WorldPlay's distilled
-    ``wan_distilled_model/model.pt``. When set, the runner reroutes the
-    transformer's ``checkpoint_path`` + ``state_dict_transform`` to load
-    the distilled weights at construction time. When ``None``, the
-    pipeline loads the base Wan 2.2 TI2V-5B safetensors and HY's
-    conditioners stay zero-init (strict identity, parity-safe)."""
+    """Local override for HY-WorldPlay's distilled
+    ``wan_distilled_model/model.pt``. When ``None`` (default), the
+    pipeline downloads the distilled WAN-5B checkpoint from HF
+    ``tencent/HY-WorldPlay``; set this to load a local copy instead, in
+    which case the runner reroutes the transformer's ``checkpoint_path``
+    to the given path at construction time."""
 
     memory_frames: int = 16
     """Total memory-frame budget per AR step (temporal context +
@@ -293,13 +293,13 @@ class HyWorldPlayWanI2VRunner(
     config: HyWorldPlayWanI2VRunnerConfig
 
     def __init__(self, config: HyWorldPlayWanI2VRunnerConfig) -> None:
-        """Route the distilled checkpoint into the pipeline, then defer to :class:`Runner`.
+        """Route a local checkpoint override into the pipeline, then defer to :class:`Runner`.
 
-        When ``config.ckpt_path`` is set, derives a copy of the runner
-        config with the transformer's ``checkpoint_path`` +
-        ``state_dict_transform`` rewritten to load HY's distilled
-        ``.pt`` (instead of the base Wan 2.2 TI2V-5B safetensors)
-        before the base ``__init__`` builds the pipeline.
+        The static pipeline already loads HY's distilled checkpoint by
+        default. When ``config.ckpt_path`` is set, derives a copy of the
+        runner config with the transformer's ``checkpoint_path`` rewritten
+        to the given local ``.pt`` before the base ``__init__`` builds the
+        pipeline.
         """
         if config.ckpt_path is not None:
             from flashdreams.infra.config import derive_config
@@ -392,9 +392,10 @@ class HyWorldPlayWanI2VRunner(
         # :mod:`hy_worldplay.config`), so the per-rollout payloads are
         # always bound: action labels for the AdaLN add, viewmats +
         # intrinsics for the PRoPE branch, and the memory-selection
-        # knobs for the FOV-overlap scorer. With zero-init weights (no
-        # ``ckpt_path``) each conditioner is a strict identity, so this
-        # is still parity-safe against the base Wan 2.2 TI2V-5B output.
+        # knobs for the FOV-overlap scorer. The default distilled
+        # checkpoint gives these conditioners trained weights; pointing
+        # ``ckpt_path`` at a base Wan 2.2 checkpoint instead falls back to
+        # their zero-init identity (parity-safe against the base output).
         self._bind_action_labels()
         self._bind_camera_data()
         self._bind_memory_config(device=device)

--- a/integrations/hy_worldplay/tests/test_smoke.py
+++ b/integrations/hy_worldplay/tests/test_smoke.py
@@ -186,19 +186,21 @@ def test_static_pipeline_is_distinct_from_base() -> None:
     )
 
 
-def test_runner_uses_base_checkpoint_without_ckpt_path() -> None:
-    """No ``ckpt_path`` keeps the base 5B diffusers safetensors + remap on the static pipeline."""
-    from wan22.config import (
-        WAN22_TI2V_5B_DIT_DIFFUSERS_PATH,
-        wan22_ti2v_5b_dit_state_dict_transform,
+def test_runner_uses_distilled_checkpoint_without_ckpt_path() -> None:
+    """No ``ckpt_path`` loads the distilled HY-WorldPlay checkpoint + HY remap by default."""
+    from hy_worldplay._checkpoint import (
+        HY_WORLDPLAY_DISTILLED_CKPT_PATH,
+        hy_worldplay_distilled_state_dict_transform,
     )
 
     from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerConfig
 
     transformer = PIPELINE_HY_WORLDPLAY_WAN_I2V_5B.diffusion_model.transformer
     assert isinstance(transformer, Wan21TransformerConfig)
-    assert transformer.checkpoint_path == WAN22_TI2V_5B_DIT_DIFFUSERS_PATH
-    assert transformer.state_dict_transform is wan22_ti2v_5b_dit_state_dict_transform
+    assert transformer.checkpoint_path == HY_WORLDPLAY_DISTILLED_CKPT_PATH
+    assert (
+        transformer.state_dict_transform is hy_worldplay_distilled_state_dict_transform
+    )
     assert RUNNER_HY_WORLDPLAY_WAN_I2V_5B.ckpt_path is None
 
 
@@ -229,9 +231,9 @@ def test_runner_config_accepts_ckpt_path() -> None:
     # ``HyWorldPlayWanI2VRunner.__init__``).
     transformer = cfg.pipeline.diffusion_model.transformer
     assert isinstance(transformer, Wan21TransformerConfig)
-    from wan22.config import WAN22_TI2V_5B_DIT_DIFFUSERS_PATH
+    from hy_worldplay._checkpoint import HY_WORLDPLAY_DISTILLED_CKPT_PATH
 
-    assert transformer.checkpoint_path == WAN22_TI2V_5B_DIT_DIFFUSERS_PATH
+    assert transformer.checkpoint_path == HY_WORLDPLAY_DISTILLED_CKPT_PATH
 
 
 def test_entry_point_registered() -> None:


### PR DESCRIPTION
The static pipeline now defaults its transformer checkpoint to HY-WorldPlay's distilled WAN-5B weights (HF `tencent/HY-WorldPlay`, via `hy_worldplay_distilled_state_dict_transform`) instead of inheriting the base Wan 2.2 diffusers safetensors. `--ckpt-path` becomes a local override; the base-checkpoint identity path still works through it.
