### PR TITLE
fix(hy_worldplay): RoPE memory frames at their true positions (fixes choppy native output) + Re-evaluated perfs

### DIFF
--- a/integrations/hy_worldplay/hy_worldplay/_action.py
+++ b/integrations/hy_worldplay/hy_worldplay/_action.py
@@ -579,15 +579,17 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
     ) -> None:
         """Populate each block's memory KV cache.
 
-        Runs :meth:`forward`'s patchify + time / action embedding + AdaLN
-        preamble, then calls :meth:`HyWorldPlayPRoPEBlock.prefill_memory_kv`
-        per block so each block's self-attention K/V land in its memory slot
-        at the collapsed RoPE positions ``[0, K * tokens_per_frame)``.
-        Cross-attention, FFN, and the head are skipped (not cached).
+        Mirrors :meth:`forward`'s patchify + time / action embedding + AdaLN
+        modulation preamble, then loops over blocks calling
+        :meth:`HyWorldPlayPRoPEBlock.prefill_memory_kv` so each block's
+        self-attention K/V land in its memory slot, RoPE-modulated at the
+        memory frames' true temporal positions. Cross-attention, FFN, and
+        the head are unobservable in the cache and are skipped on this path.
 
-        The caller slices the per-rollout history at
-        ``HyWorldPlayCtrl.memory_frame_indices`` and builds ``rope_freqs``
-        against the same collapsed positions.
+        The caller is responsible for slicing the per-rollout history at
+        ``HyWorldPlayCtrl.memory_frame_indices`` and for building
+        ``rope_freqs`` at those frames' true positions (their history
+        indices), which share the standard path's absolute coordinate frame.
 
         Args:
             x: Patchified memory latents, shape ``[..., L_mem, in_dim]``.
@@ -595,9 +597,10 @@ class HyWorldPlayWanDiTNetwork(WanDiTNetwork):
                 applied so the AdaLN modulation stays in the trained
                 distribution.
             cache: Per-block cache; only the ``memory`` slots are written.
-            rope_freqs: RoPE frequencies for the collapsed memory positions
-                ``[0, L_mem)``.
-            block_extra_kwargs: Unused; kept for symmetry with :meth:`forward`.
+            rope_freqs: RoPE frequencies at the memory frames' true temporal
+                positions (built by ``_build_memory_rope_freqs``).
+            block_extra_kwargs: Optional extras forwarded to the per-block
+                prefill (unused; kept for symmetry with :meth:`forward`).
             action: Optional action labels for the memory frames.
             viewmats: W2C extrinsics for the memory frames. Required when
                 ``use_prope_blocks=True``.
@@ -980,8 +983,8 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
         """Drive the memory KV prefill for the current chunk.
 
         Slices the clean-latent history at ``input.memory_frame_indices``,
-        builds collapsed-position RoPE freqs, slices ``viewmats`` / ``Ks`` /
-        ``action`` at the same indices, then dispatches into
+        builds RoPE freqs at those frames' true temporal positions, slices
+        ``viewmats`` / ``Ks`` / ``action`` at the same indices, then dispatches into
         :meth:`HyWorldPlayWanDiTNetwork.prefill_memory_kv_cache` for the
         conditional (and unconditional, when CFG is enabled) branch. Each
         block's memory cache is reset before being repopulated.
@@ -1050,11 +1053,20 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
             kind="action",
         )
 
-        # RoPE freqs for the collapsed memory positions ``[0, K)`` on the
-        # temporal axis.
-        rope_freqs = self._build_collapsed_rope_freqs(
+        # Build RoPE freqs at each memory frame's TRUE temporal position --
+        # its index in the clean-latent history -- matching the absolute
+        # positions the main path assigns via ``shift_t`` (offset =
+        # ar_idx * len_t). The memory cache is wiped and re-prefilled every
+        # chunk, so the K/V are recomputed each chunk; the only thing that
+        # was wrong was the RoPE position. The previous ``arange(K)`` roped
+        # each selected frame at its buffer-slot index, so a frame that was
+        # re-selected into a different slot got a different position (and a
+        # phase jump) from one chunk to the next -- the inter-chunk jolt.
+        # Keying off the frame index instead keeps a frame's encoding stable
+        # regardless of slot.
+        rope_freqs = self._build_memory_rope_freqs(
             cache=cache,
-            t_positions=torch.arange(K, dtype=torch.float32, device=memory_x.device),
+            t_positions=selected_idx_t.to(torch.float32),
         )
 
         # Clean-context timestep for memory positions; matches ``timestep``'s
@@ -1191,16 +1203,19 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
             )
         return rollout.index_select(-3, selected)
 
-    def _build_collapsed_rope_freqs(
+    def _build_memory_rope_freqs(
         self,
         cache: HyWorldPlayWan21TransformerCache,
         t_positions: Tensor,
     ) -> Tensor:
         """Compute RoPE frequencies for arbitrary temporal positions.
 
-        Uses the ``_freq_components(seq_t)`` primitive to build freqs at the
-        prefill's collapsed memory positions ``[0, K)``, which the base
-        ``shift_t(autoregressive_index)`` (chunk-aligned only) can't express.
+        The base :class:`RotaryPositionEmbedding3D` only exposes
+        ``shift_t(autoregressive_index)``, which produces freqs at
+        chunk-aligned positions. We reach into the
+        ``_freq_components(seq_t)`` primitive to build freqs at the memory
+        frames' true temporal positions (their clean-latent-history
+        indices), so they share the main path's absolute coordinate frame.
 
         Raises:
             NotImplementedError: ``rope_adapter`` is not

--- a/integrations/hy_worldplay/hy_worldplay/_action.py
+++ b/integrations/hy_worldplay/hy_worldplay/_action.py
@@ -1109,9 +1109,14 @@ class HyWorldPlayWan21Transformer(Wan21Transformer):
                 if isinstance(block_cache, HyWorldPlayPRoPEBlockCache):
                     block_cache.memory.reset()
 
-        # Narrow ``self.network`` to the HY-DiT type so the prefill entry
-        # point resolves.
+        # Narrow the parent's ``self.network`` (typed as ``Tensor | Module``
+        # by ``nn.Module``'s ``__getattr__`` overload) to the HY-DiT network
+        # so the memory-prefill entry point resolves.
+        # Unwrap torch.compile's OptimizedModule wrapper (present when
+        # compile_network=True) so isinstance resolves against the real class.
         network = self.network
+        if hasattr(network, "_orig_mod"):
+            network = network._orig_mod
         assert isinstance(network, HyWorldPlayWanDiTNetwork)
 
         # Conditional pass.

--- a/integrations/hy_worldplay/hy_worldplay/_camera.py
+++ b/integrations/hy_worldplay/hy_worldplay/_camera.py
@@ -69,10 +69,11 @@ __all__ = [
 class HyWorldPlayMemoryKVCache:
     """Per-block flat KV cache for HY-WorldPlay's reconstituted-context memory.
 
-    Stores K / V at RoPE-collapsed positions ``[0, len(selected) *
-    tokens_per_frame)`` -- no rolling window and no chunk indexing. Frozen
-    within a chunk's denoising loop; the prefill executor wipes and
-    repopulates it at the start of every chunk past the first.
+    Stores the selected memory frames' K / V (RoPE-modulated at the frames'
+    true temporal positions) as a flat ``len(selected) * tokens_per_frame``
+    sequence -- no rolling window. The prefill executor wipes and
+    repopulates it at the start of every chunk past the first; within a
+    chunk's denoising loop the contents are frozen.
 
     The standard-RoPE and PRoPE branches are stored independently so the
     dual-branch attention can address each without slicing a packed
@@ -352,7 +353,7 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
         Ks: Tensor | None,
         memory_kv_cache: HyWorldPlayMemoryKVCache,
     ) -> Tensor:
-        """Run the dual-branch self-attention at collapsed memory positions.
+        """Run the dual-branch self-attention over the selected memory frames.
 
         Projects, applies RoPE / PRoPE, writes both branches' K / V into
         ``memory_kv_cache``, then attends over the memory positions
@@ -363,12 +364,17 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
             x: Pre-norm-modulated input for the selected memory frames,
                 shape ``[..., L_mem, query_dim]`` where
                 ``L_mem == K * tokens_per_frame``.
-            rope_freqs: RoPE frequencies remapped to the collapsed
-                positions, shape ``[L_mem, 1, 1, head_dim]``.
-            viewmats: Per-memory-frame W2C matrices ``[batch, K, 4, 4]``,
-                already sliced to ``selected_frame_indices``.
-            Ks: Optional per-memory-frame intrinsics ``[batch, K, 3, 3]``.
-            memory_kv_cache: Cache to populate; both branches are written.
+            rope_freqs: RoPE frequencies at the memory frames' true temporal
+                positions, shape ``[L_mem, 1, 1, head_dim]``. The executor
+                builds this from the per-rollout RoPE adapter at the
+                selected frames' history indices.
+            viewmats: Per-memory-frame W2C matrices, shape
+                ``[batch, K, 4, 4]``. Already sliced to
+                ``selected_frame_indices`` by the executor.
+            Ks: Optional per-memory-frame intrinsics
+                ``[batch, K, 3, 3]``.
+            memory_kv_cache: Cache to populate. Both branches are
+                written.
 
         Returns:
             Attention output at the memory positions, summed over the
@@ -428,8 +434,9 @@ class HyWorldPlayPRoPESelfAttention(SelfAttention):
             _debug_dump.dump("prefill.block.k_prope_written", memory_kv_cache.k_prope)
             _debug_dump.dump("prefill.block.v_prope_written", memory_kv_cache.v_prope)
 
-        # Memory tokens are the only sequence at the collapsed positions,
-        # so K / V are the just-computed tensors (no cross-chunk concat).
+        # Standard RoPE-branch attention over the memory tokens themselves
+        # -- they are the only sequence in this prefill, so K / V are the
+        # just-computed tensors (no cross-chunk concatenation).
         q_rope = q_raw
         if rope_freqs is not None:
             q_rope = apply_rope_freqs(q_rope, rope_freqs, interleaved=True)
@@ -460,15 +467,21 @@ class HyWorldPlayPRoPEBlockCache(BlockCache):
 
     Three caches per block:
 
-    * ``self_attn`` -- inherited; standard RoPE-branch K / V for the
-      current chunk's tokens.
-    * ``prope_self_attn`` -- mirrors ``self_attn``'s layout but stores the
-      *already-PRoPE-transformed* K / V for the current chunk.
-    * ``memory`` -- flat per-block cache holding the prefilled K / V from
-      the selected memory frames at RoPE-collapsed positions ``[0, K)``.
-      The dual-branch attention prepends these to ``self_attn`` /
-      ``prope_self_attn`` so the context is
-      ``[memory K/V, current chunk K/V]`` along ``seq_dim=-3``.
+    * ``self_attn`` -- inherited from :class:`BlockCache`, stores the
+      standard RoPE-branch K / V for the *current chunk's* tokens.
+      Reused across denoising steps within a chunk; reset at chunk
+      start by the HY transformer's predict_flow.
+    * ``prope_self_attn`` -- mirrors the layout of ``self_attn`` but
+      stores the *already-PRoPE-transformed* K / V for the current
+      chunk so each AR step pays the per-frame projection cost once.
+    * ``memory`` -- separate, flat per-block cache that stores the
+      prefilled K / V from the selected memory frames, RoPE-modulated at
+      the frames' true temporal positions. Wiped at chunk start by the
+      prefill executor and repopulated from
+      :class:`HyWorldPlayCtrl.memory_frame_indices`. The dual-branch
+      attention prepends these K / V to ``self_attn`` /
+      ``prope_self_attn`` for the actual attention call, so the total
+      context is ``[memory K/V, current chunk K/V]`` along ``seq_dim=-3``.
     """
 
     prope_self_attn: BlockKVCache = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
@@ -665,23 +678,26 @@ class HyWorldPlayPRoPEBlock(Block):
         Ks: Tensor | None,
         cache: "HyWorldPlayPRoPEBlockCache",
     ) -> Tensor:
-        """Run the full block forward at the collapsed memory positions.
+        """Run the full block forward over the selected memory frames.
 
         Mirrors :meth:`forward` so each successive block's K / V
         projections see an already-attended hidden state. The dual-branch
         self-attn writes both branches' K / V into ``cache.memory`` as a
-        side effect; ``cache.self_attn`` / ``cache.prope_self_attn`` are
-        left untouched, since collapsed positions don't belong in the
-        rolling current-chunk cache.
+        side effect; ``cache.cross_attn`` is read for the cross-attention
+        text (and I2V image) K / V; ``cache.self_attn`` /
+        ``cache.prope_self_attn`` are intentionally untouched -- the
+        prefilled memory K / V don't belong in the rolling current-chunk
+        cache.
 
         Args:
             x: Pre-AdaLN input for the K selected memory frames,
                 shape ``[..., L_mem, D]``.
-            e: AdaLN modulation tensor for those frames.
-            rope_freqs: RoPE frequencies pre-sliced to the collapsed
-                memory positions.
-            viewmats: Per-memory-frame W2C extrinsics, already sliced to
-                the selected indices.
+            e: AdaLN modulation tensor for those frames (same contract
+                as :meth:`forward`).
+            rope_freqs: RoPE frequencies at the memory frames' true temporal
+                positions.
+            viewmats: Per-memory-frame W2C extrinsics (already sliced
+                to the selected indices).
             Ks: Optional per-memory-frame intrinsics.
             cache: The block's per-rollout cache.
 

--- a/integrations/hy_worldplay/hy_worldplay/_camera.py
+++ b/integrations/hy_worldplay/hy_worldplay/_camera.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Any
 
 import torch
 import torch.nn as nn

--- a/integrations/hy_worldplay/hy_worldplay/config.py
+++ b/integrations/hy_worldplay/hy_worldplay/config.py
@@ -114,7 +114,19 @@ def _build_hy_worldplay_pipeline() -> WanInferencePipelineConfig:
         h_extrapolation_ratio=base_t.h_extrapolation_ratio,
         w_extrapolation_ratio=base_t.w_extrapolation_ratio,
         compile_network=base_t.compile_network,
-        use_cuda_graph=base_t.use_cuda_graph,
+        # CUDA-graph capture is unsafe on the HY-WorldPlay memory-prefill
+        # path. The ``CUDAGraphWrapper`` captures pointers into the KV
+        # cache, but HY re-runs ``prefill_memory_kv_cache`` every chunk: it
+        # resets+repopulates each PRoPE block's memory KV from a *different*
+        # FOV-selected frame set (``select_mem_frames_wan``), reallocating
+        # the underlying storage. A graph captured on one chunk then replays
+        # against another chunk's stale/freed memory-KV slots, decoding to a
+        # "shatter" of speckle corruption (deterministic across seeds and
+        # prompts; only the captured/replayed chunks are hit, so it presents
+        # as one or two garbled chunks mid-rollout). Disabling capture keeps
+        # ``compile_network`` (Inductor) -- still ~4x faster diffuse than
+        # vendor -- without the unsafe replay. See ``HY_DEBUG_DISABLE_CUDA_GRAPH``.
+        use_cuda_graph=False,
         cuda_graph_warmup_iters=base_t.cuda_graph_warmup_iters,
         stamp_image_latent=base_t.stamp_image_latent,
         concat_image_mask_to_latent=base_t.concat_image_mask_to_latent,

--- a/integrations/hy_worldplay/tests/parity_check/bench.sh
+++ b/integrations/hy_worldplay/tests/parity_check/bench.sh
@@ -60,6 +60,10 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 HY_REPO_DIR="${HY_REPO_DIR:-${SCRIPT_DIR}/HY-WorldPlay}"
 HF_MODELS_DIR="${HF_MODELS_DIR:-${HY_REPO_DIR}/hf_models}"
 CKPT_PATH="${CKPT_PATH:-${HF_MODELS_DIR}/wan_distilled_model/model.pt}"
+# Keep the HF cache local so the bench is self-contained and never needs
+# write access to ~/.cache/huggingface (which may be permission-denied on
+# shared machines).
+export HF_HOME="${HF_HOME:-${SCRIPT_DIR}/hf_cache}"
 
 IMAGE_PATH="${IMAGE_PATH:-${REPO_ROOT}/data_local/cat_surf.jpg}"
 # ``num_chunk=2`` is the largest setting that fits both legs in 44

--- a/integrations/hy_worldplay/tests/parity_check/bench_8chunk_walking.md
+++ b/integrations/hy_worldplay/tests/parity_check/bench_8chunk_walking.md
@@ -1,0 +1,49 @@
+# HY-WorldPlay WAN-5B I2V — native vs vendor perf (8-chunk, "a person walking")
+
+Machine: single **GB300** (AArch64 / SBSA), driver 595.71.05, torch 2.11.0+cu130.
+Both legs: cuDNN SDPA + `torch.compile` (Inductor). Native runs with
+`use_cuda_graph=False` — see the CUDA-graph corruption fix in
+`config.py` (graph capture is unsafe on the per-chunk memory-prefill path).
+
+**Config:** `num_chunk=8`, `pose=w-31`, `seed=0`, 704×1280, prompt
+`"a person walking"`, warmup-discard 5 (post-warmup medians over chunks 5–7).
+Inputs: `HY-WorldPlay/assets/img/{1.png, 2.png, 5.jpeg, 6.jpeg, 10.png}`.
+
+Generated with `bench_pairs.sh` (drives `bench.sh` — upstream `wan/generate.py`
+via `run.sh` + the native plugin — once per image). Per-image artifacts
+(native + vendor MP4 + stats JSON) under `outputs/bench_pairs_walking/<stem>/`.
+
+> **Metric basis:** `DiT (diffuse)` is the per-AR-step (per-chunk) median
+> reported by `bench_summary.py`, i.e. all denoising forwards for one chunk.
+> This is a different basis from PR #231's per-forward numbers; compare
+> ratios, not absolute ms, against that PR.
+
+## Per-stage medians (across the 5 images)
+
+| stage | native | vendor | speedup |
+|-------|--------|--------|---------|
+| DiT (diffuse) | 5085 ms | 27939 ms | **5.49×** |
+| VAE decode | 2712 ms | 3195 ms | 1.18× |
+| **DiT + VAE / chunk** | **7797 ms** | **31135 ms** | **3.99×** |
+
+## Per-input results
+
+| image | DiT nat/ven (ms) | VAE nat/ven (ms) | ratio (DiT+VAE) | mean `\|Δ\|` |
+|-------|------------------|------------------|-----------------|--------------|
+| `1.png`  | 5121 / 27939 | 2712 / 3192 | 3.97× | 36.0 |
+| `2.png`  | 4941 / 28021 | 2711 / 3196 | 4.08× | 28.4 |
+| `5.jpeg` | 4962 / 27909 | 2712 / 3195 | 4.05× | 36.4 |
+| `6.jpeg` | 5407 / 27932 | 2712 / 3187 | 3.83× | 21.4 |
+| `10.png` | 5085 / 28007 | 2712 / 3200 | 4.00× | 46.8 |
+| **median** | **5085 / 27939** | **2712 / 3195** | **4.00×** | **36.0** |
+
+`mean |Δ|` is the per-pixel mean absolute difference (uint8 / 255) between the
+native and vendor MP4s — cumulative bf16 autoregressive drift across 8 chunks,
+not a per-frame error bar. Peak GPU memory ≈ 45 GiB both legs.
+
+## Visual check
+
+All 5 native rollouts were spot-checked at the chunk-2 and chunk-5 boundaries
+(the sites of the pre-fix CUDA-graph speckle corruption): every chunk renders
+coherently — the subject walks through its scene with no shatter artifacts.
+The `use_cuda_graph=False` fix holds across all inputs.

--- a/integrations/hy_worldplay/tests/parity_check/bench_8chunk_walking.md
+++ b/integrations/hy_worldplay/tests/parity_check/bench_8chunk_walking.md
@@ -30,20 +30,25 @@ via `run.sh` + the native plugin — once per image). Per-image artifacts
 
 | image | DiT nat/ven (ms) | VAE nat/ven (ms) | ratio (DiT+VAE) | mean `\|Δ\|` |
 |-------|------------------|------------------|-----------------|--------------|
-| `1.png`  | 5121 / 27939 | 2712 / 3192 | 3.97× | 36.0 |
-| `2.png`  | 4941 / 28021 | 2711 / 3196 | 4.08× | 28.4 |
-| `5.jpeg` | 4962 / 27909 | 2712 / 3195 | 4.05× | 36.4 |
-| `6.jpeg` | 5407 / 27932 | 2712 / 3187 | 3.83× | 21.4 |
-| `10.png` | 5085 / 28007 | 2712 / 3200 | 4.00× | 46.8 |
-| **median** | **5085 / 27939** | **2712 / 3195** | **4.00×** | **36.0** |
+| `1.png`  | 5121 / 27939 | 2712 / 3192 | 3.97× | 27.8 |
+| `2.png`  | 4941 / 28021 | 2711 / 3196 | 4.08× | 22.6 |
+| `5.jpeg` | 4962 / 27909 | 2712 / 3195 | 4.05× | 25.7 |
+| `6.jpeg` | 5407 / 27932 | 2712 / 3187 | 3.83× | 16.6 |
+| `10.png` | 5085 / 28007 | 2712 / 3200 | 4.00× | 24.0 |
+| **median** | **5085 / 27939** | **2712 / 3195** | **4.00×** | **24.0** |
 
 `mean |Δ|` is the per-pixel mean absolute difference (uint8 / 255) between the
 native and vendor MP4s — cumulative bf16 autoregressive drift across 8 chunks,
 not a per-frame error bar. Peak GPU memory ≈ 45 GiB both legs.
 
+Parity is measured with the Wan 2.2 VAE patchify channel-order fix (#338) on the
+native leg; before that fix a ~2px VAE-decode checkerboard inflated the median
+to 36.0. Perf (DiT / VAE timings, speedups) is unchanged by that fix — it is an
+einops axis swap with no compute cost — so only the `mean |Δ|` column moved.
+
 ## Visual check
 
-All 5 native rollouts were spot-checked at the chunk-2 and chunk-5 boundaries
-(the sites of the pre-fix CUDA-graph speckle corruption): every chunk renders
-coherently — the subject walks through its scene with no shatter artifacts.
-The `use_cuda_graph=False` fix holds across all inputs.
+All 5 native rollouts (regenerated with #338) are checkerboard-free; chunk-2 /
+chunk-5 boundaries (the former CUDA-graph speckle sites) also render coherently.
+Both the `use_cuda_graph=False` and the VAE patchify-order fixes hold across all
+inputs.

--- a/integrations/hy_worldplay/tests/parity_check/run.sh
+++ b/integrations/hy_worldplay/tests/parity_check/run.sh
@@ -124,13 +124,14 @@ echo "[setup] ensuring Python deps via uv sync (isolated venv)"
 ( cd "${SCRIPT_DIR}" && uv sync )
 
 if [[ "${SKIP_HEAVY_DEPS:-0}" != "1" ]]; then
-    echo "[setup] installing vendor-only heavy deps (sageattention, cloudpickle, accelerate, transformers==4.57.6)"
+    echo "[setup] installing vendor-only heavy deps (sageattention, cloudpickle, accelerate, transformers==4.57.6, torchvision==0.26.0)"
     echo "        set SKIP_HEAVY_DEPS=1 to skip if you only need the native plugin"
     ( cd "${SCRIPT_DIR}" && uv pip install \
         sageattention \
         cloudpickle \
         "accelerate>=0.30" \
-        "transformers==4.57.6" )
+        "transformers==4.57.6" \
+        "torchvision==0.26.0" --no-deps )
 else
     echo "[setup] SKIP_HEAVY_DEPS=1 -> assuming vendor heavy deps already installed (or running native plugin only)"
 fi

--- a/integrations/hy_worldplay/tests/test_prefill.py
+++ b/integrations/hy_worldplay/tests/test_prefill.py
@@ -276,14 +276,7 @@ def test_dual_branch_attention_short_circuits_empty_memory_cache() -> None:
     here (the fused RoPE kernel is CUDA-only so we can't pin attention
     bit-identity from CPU).
     """
-    from hy_worldplay._camera import (
-        HyWorldPlayMemoryKVCache,
-        HyWorldPlayPRoPESelfAttention,
-    )
-
-    attn = HyWorldPlayPRoPESelfAttention(
-        query_dim=64, n_heads=2, head_dim=32, eps=1e-6, apply_rope_before_kvcache=True
-    )
+    from hy_worldplay._camera import HyWorldPlayMemoryKVCache
 
     empty_memory = HyWorldPlayMemoryKVCache()
     assert empty_memory.is_empty
@@ -727,8 +720,6 @@ def test_encoder_attaches_rollout_buffers_to_ctrl() -> None:
 
     # Stub the parent's forward so we don't have to spin up a VAE --
     # this test only exercises the action / viewmats / Ks attach paths.
-    from hy_worldplay._action import HyWorldPlayCtrl
-
     from flashdreams.recipes.wan.autoencoder.i2v import I2VCtrl
 
     # 16 latent frames total (= 4 chunks of len_t=4) so we can test

--- a/integrations/hy_worldplay/tests/test_prefill.py
+++ b/integrations/hy_worldplay/tests/test_prefill.py
@@ -382,6 +382,67 @@ def test_index_rollout_buffer_slices_action_at_rollout_indices() -> None:
     assert torch.equal(sliced, torch.tensor([[0, 3, 5]]))
 
 
+def test_prefill_rope_positions_track_frame_identity_not_slot() -> None:
+    """Memory prefill must RoPE-modulate each frame at its TRUE temporal position.
+
+    The position must be the frame's clean-latent-history index, not the
+    buffer slot it lands in. Slot-based positions (the old ``arange(K)``)
+    gave a frame a different encoding whenever the selected set was
+    re-chosen, which made the native rollout choppy at chunk boundaries.
+    Here we capture the ``t_positions`` the driver hands to
+    ``_build_memory_rope_freqs`` and assert it equals the selected frame
+    indices -- and that a frame keeps its position regardless of slot.
+    """
+    import types
+
+    from hy_worldplay._action import HyWorldPlayWan21Transformer
+
+    transformer = HyWorldPlayWan21Transformer.__new__(HyWorldPlayWan21Transformer)
+
+    tokens_per_frame = 4
+    history = torch.randn(1, 6 * tokens_per_frame, 16)  # 6 frames
+    cache = types.SimpleNamespace(
+        clean_latent_history=history,
+        hy_tokens_per_frame=tokens_per_frame,
+    )
+
+    captured: dict[str, torch.Tensor] = {}
+
+    class _Stop(Exception):
+        pass
+
+    def _capture(*, cache, t_positions):  # noqa: ANN001 (test stub)
+        captured["t"] = t_positions.detach().clone()
+        raise _Stop()
+
+    transformer._build_memory_rope_freqs = _capture  # type: ignore[assignment]
+
+    def positions_for(selected: list[int]) -> list[float]:
+        inp = types.SimpleNamespace(
+            memory_frame_indices=selected,
+            rollout_viewmats=None,
+            viewmats=None,
+            rollout_Ks=None,
+            Ks=None,
+            rollout_action=None,
+            action=None,
+        )
+        with pytest.raises(_Stop):
+            transformer.prefill_memory_kv_cache(
+                cache=cache,  # type: ignore[arg-type]
+                input=inp,  # type: ignore[arg-type]
+                timestep=torch.zeros(1),
+            )
+        return captured["t"].tolist()
+
+    # Positions are the selected frame indices themselves, not arange(K).
+    assert positions_for([1, 3]) == [1.0, 3.0]
+    assert positions_for([0, 2, 5]) == [0.0, 2.0, 5.0]
+    # Identity-stability: frame 3 keeps position 3 whether it's in slot 1
+    # (set [1, 3]) or slot 0 (set [3, 5]) -- the property the fix restores.
+    assert positions_for([1, 3])[1] == positions_for([3, 5])[0] == 3.0
+
+
 def test_index_rollout_buffer_slices_matrices_at_frame_axis() -> None:
     """``_index_rollout_buffer`` indexes viewmats / Ks at axis -3 (the F axis).
 


### PR DESCRIPTION
Fixes the choppiness on PR #231.

## Root cause
Memory prefill RoPE-rotated each selected frame at its **buffer-slot index** (`arange(K)`), not its frame identity. Frames are re-selected every chunk, so a frame's slot — and thus its positional phase — jumped chunk-to-chunk, jolting the scene on each window slide.

## Fix
Rotate each memory frame at its **true temporal position** (clean-latent-history index), matching the main path's `shift_t` offset. One-liner in `_action.py`: `t_positions=torch.arange(K, ...)` → `selected_idx_t.to(torch.float32)`. Plus two fixes for the compiled path: `use_cuda_graph=False` (graph capture replayed stale per-chunk memory-KV pointers → speckle corruption) and unwrap `OptimizedModule._orig_mod` before the `isinstance` guard. CPU regression test added; full HY suite 94 passed / 4 skipped.

## Perf — 8-chunk native vs vendor (GB300)
`num_chunk=8`, `pose=w-31`, `seed=0`, 704×1280, `"a person walking"`, post-warmup medians (chunks 5–7). Both legs: cuDNN SDPA + `torch.compile`.

| stage | native | vendor | speedup |
|-------|--------|--------|---------|
| DiT (diffuse) | 5085 ms | 27939 ms | **5.49×** |
| VAE decode | 2712 ms | 3195 ms | 1.18× |
| **DiT + VAE / chunk** | **7797 ms** | **31135 ms** | **3.99×** |

| image | DiT nat/ven (ms) | VAE nat/ven (ms) | ratio (DiT+VAE) | mean \|Δ\| |
|-------|------------------|------------------|-----------------|------------|
| `1.png`  | 5121 / 27939 | 2712 / 3192 | 3.97× | 27.8 |
| `2.png`  | 4941 / 28021 | 2711 / 3196 | 4.08× | 22.6 |
| `5.jpeg` | 4962 / 27909 | 2712 / 3195 | 4.05× | 25.7 |
| `6.jpeg` | 5407 / 27932 | 2712 / 3187 | 3.83× | 16.6 |
| `10.png` | 5085 / 28007 | 2712 / 3200 | 4.00× | 24.0 |
| **median** | **5085 / 27939** | **2712 / 3195** | **4.00×** | **24.0** |

`DiT (diffuse)` = per-chunk median (≠ PR #231's per-forward basis; compare ratios). `mean |Δ|` = per-pixel uint8/255 diff of the two MP4s (cumulative bf16 drift over 8 chunks). All chunks render cleanly. Full report: `integrations/hy_worldplay/tests/parity_check/bench_8chunk_walking.md`.

## Native vs vendor video pairs

| image | native | vendor |
|-------|--------|--------|
| `1.png` | <video src="https://github.com/user-attachments/assets/d2451eeb-1d3a-4d28-a045-c5db0e5d5f47" controls width="360"></video> | <video src="https://github.com/user-attachments/assets/292166e8-db8b-4c49-affa-8e54a2d1b640" controls width="360"></video> |
| `2.png` | <video src="https://github.com/user-attachments/assets/f08bcccc-16aa-4c5b-bc58-ba7a88e5e289" controls width="360"></video> | <video src="https://github.com/user-attachments/assets/783cce43-3c3c-48f6-80b1-946a1dc1dfd3" controls width="360"></video> |
| `5.jpeg` | <video src="https://github.com/user-attachments/assets/9b61ff93-6bb3-4e7b-8417-ea93ec65bcfc" controls width="360"></video> | <video src="https://github.com/user-attachments/assets/188eb8b8-d693-4801-8cfc-36997792ddc6" controls width="360"></video> |
| `10.png` | <video src="https://github.com/user-attachments/assets/9d127fd8-a0cc-4d87-9236-2724c2106c50" controls width="360"></video> | <video src="https://github.com/user-attachments/assets/33ddb821-28e3-46e3-b4bf-0ec53168ee27" controls width="360"></video> |



_Parity refreshed with the Wan 2.2 VAE patchify-order fix (#338) on the native leg: median `|Δ|` 36.0 → 24.0 / 255 (the removed ~2px decode checkerboard had inflated it). Perf/speedup table unchanged (the fix is a zero-cost einops axis swap). The embedded video pairs above are pre-fix and should be re-uploaded from the regenerated clips._
