### PR TITLE
ci: add /lint-fix workflow for auto-fixable lint failures

### DIFF
--- a/.github/scripts/sync_version.py
+++ b/.github/scripts/sync_version.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import re
 import sys
+from argparse import ArgumentParser
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -111,6 +112,26 @@ def sync_version(version: str) -> list[Path]:
 
 
 def main() -> None:
+    global REPO_ROOT
+
+    parser = ArgumentParser(
+        description=(
+            "Sync flashdreams package versions to the canonical "
+            "flashdreams/flashdreams/_version.py value."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help=(
+            "Repository root to update. Defaults to the repository containing "
+            "this script."
+        ),
+    )
+    args = parser.parse_args()
+    REPO_ROOT = args.repo_root.resolve()
+
     version = read_canonical_version()
     changed = sync_version(version)
     if changed:

--- a/.github/scripts/sync_version.py
+++ b/.github/scripts/sync_version.py
@@ -55,9 +55,9 @@ _TOML_VERSION_RE = re.compile(r'^(version\s*=\s*)"[^"]*"', re.MULTILINE)
 _TOML_NAME_RE = re.compile(r'^name\s*=\s*"([^"]+)"', re.MULTILINE)
 
 
-def read_canonical_version() -> str:
+def read_canonical_version(repo_root: Path) -> str:
     """Read the version string from flashdreams/_version.py."""
-    version_file = REPO_ROOT / "flashdreams" / "flashdreams" / "_version.py"
+    version_file = repo_root / "flashdreams" / "flashdreams" / "_version.py"
     text = version_file.read_text()
     match = _VERSION_RE.search(text)
     if not match:
@@ -66,19 +66,19 @@ def read_canonical_version() -> str:
     return match.group(1)
 
 
-def find_pyproject_files() -> list[Path]:
+def find_pyproject_files(repo_root: Path) -> list[Path]:
     """Return all pyproject.toml files under the repo root."""
-    return sorted(REPO_ROOT.rglob("pyproject.toml"))
+    return sorted(repo_root.rglob("pyproject.toml"))
 
 
-def should_skip(path: Path, text: str) -> bool:
+def should_skip(path: Path, text: str, repo_root: Path) -> bool:
     """Return True if this pyproject.toml should not be version-synced."""
-    rel_path = path.relative_to(REPO_ROOT)
+    rel_path = path.relative_to(repo_root)
     # Skip the root workspace config (has no [project] section).
-    if path == REPO_ROOT / "pyproject.toml":
+    if path == repo_root / "pyproject.toml":
         return True
     # Skip the canonical source itself.
-    if path == REPO_ROOT / "flashdreams" / "pyproject.toml":
+    if path == repo_root / "flashdreams" / "pyproject.toml":
         return True
     # Skip integration test harnesses (e.g. integrations/*/tests/**).
     if (
@@ -97,12 +97,12 @@ def should_skip(path: Path, text: str) -> bool:
     return False
 
 
-def sync_version(version: str) -> list[Path]:
+def sync_version(repo_root: Path, version: str) -> list[Path]:
     """Update all pyproject.toml files and return the list of changed paths."""
     changed: list[Path] = []
-    for path in find_pyproject_files():
+    for path in find_pyproject_files(repo_root):
         text = path.read_text()
-        if should_skip(path, text):
+        if should_skip(path, text, repo_root):
             continue
         new_text = _TOML_VERSION_RE.sub(rf'\g<1>"{version}"', text)
         if new_text != text:
@@ -112,8 +112,6 @@ def sync_version(version: str) -> list[Path]:
 
 
 def main() -> None:
-    global REPO_ROOT
-
     parser = ArgumentParser(
         description=(
             "Sync flashdreams package versions to the canonical "
@@ -130,13 +128,13 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
-    REPO_ROOT = args.repo_root.resolve()
+    repo_root = args.repo_root.resolve()
 
-    version = read_canonical_version()
-    changed = sync_version(version)
+    version = read_canonical_version(repo_root)
+    changed = sync_version(repo_root, version)
     if changed:
         for path in changed:
-            rel = path.relative_to(REPO_ROOT)
+            rel = path.relative_to(repo_root)
             print(f"Updated {rel} -> {version}")
         # Non-zero exit tells pre-commit that files were modified.
         sys.exit(1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,27 @@ jobs:
           uv sync --extra dev --group lint \
             --no-install-package transformer-engine-torch
 
-      - name: Run linter checks
+      - name: Run linter checks (comment /lint-fix to auto-fix)
         run: |
           # Container runs as root but the workspace is owned by the runner
           # uid -- git refuses to operate without safe.directory.
           git config --global --add safe.directory "$(pwd)"
+          set +e
           uv run --no-sync pre-commit run -a
+          status=$?
+          set -e
+
+          if [ "${status}" -ne 0 ]; then
+            echo "::notice title=Auto-fix available::Some lint failures can be fixed automatically. A maintainer can comment /lint-fix on the PR to open an automated fix PR."
+            {
+              echo "## Linter checks failed"
+              echo
+              echo "Some pre-commit failures can be fixed automatically."
+              echo "A maintainer can comment \`/lint-fix\` on the PR to open an automated fix PR for formatting, imports, and version-sync changes."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          exit "${status}"
 
       - name: Install remaining system dependencies
         run: |

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -1,0 +1,183 @@
+name: Lint Fix
+
+on:
+  repository_dispatch:
+    types: [lint-fix-command]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  lint-fix:
+    if: >-
+      github.repository == 'NVIDIA/flashdreams' &&
+      github.event.client_payload.github.payload.repository.full_name == 'NVIDIA/flashdreams' &&
+      github.event.client_payload.pull_request.base.repo.full_name == 'NVIDIA/flashdreams'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          path: pr-branch
+          persist-credentials: false
+
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA/flashdreams
+          ref: ${{ github.event.client_payload.pull_request.base.ref }}
+          path: target-branch
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Run fixable pre-commit hooks
+        id: fixers
+        working-directory: pr-branch
+        env:
+          PRE_COMMIT_HOME: ${{ runner.temp }}/pre-commit
+        run: |
+          set -euo pipefail
+
+          config="${RUNNER_TEMP}/flashdreams-lint-fix-pre-commit.yaml"
+          cp ../target-branch/.pre-commit-config.yaml "${config}"
+          command -v uvx >/dev/null
+
+          {
+            echo "## Lint fix"
+            echo
+            echo "Ran fixable pre-commit hooks from the target branch against this PR branch."
+            echo
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          run_hook() {
+            local hook_id="$1"
+            local status=0
+
+            echo "::group::pre-commit ${hook_id}"
+            set +e
+            uvx --from pre-commit==4.3.0 pre-commit run \
+              --config "${config}" \
+              "${hook_id}" \
+              --all-files
+            status=$?
+            set -e
+            echo "::endgroup::"
+
+            if [ "${status}" -eq 0 ]; then
+              echo "- \`${hook_id}\`: clean" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "- \`${hook_id}\`: exited with ${status}; this is expected when files are rewritten" >> "${GITHUB_STEP_SUMMARY}"
+            fi
+          }
+
+          run_hook trailing-whitespace
+          run_hook end-of-file-fixer
+          run_hook ruff-fix
+          run_hook ruff-format
+
+          sync_status=0
+          echo "::group::sync-version"
+          set +e
+          python ../target-branch/.github/scripts/sync_version.py --repo-root .
+          sync_status=$?
+          set -e
+          echo "::endgroup::"
+
+          if [ "${sync_status}" -eq 0 ]; then
+            echo "- \`sync-version\`: clean" >> "${GITHUB_STEP_SUMMARY}"
+          elif [ "${sync_status}" -eq 1 ]; then
+            echo "- \`sync-version\`: updated package versions" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "- \`sync-version\`: failed with ${sync_status}" >> "${GITHUB_STEP_SUMMARY}"
+            exit "${sync_status}"
+          fi
+
+          echo >> "${GITHUB_STEP_SUMMARY}"
+          if git diff --quiet; then
+            echo "No automatic lint fixes were produced." >> "${GITHUB_STEP_SUMMARY}"
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Automatic lint fixes were produced:" >> "${GITHUB_STEP_SUMMARY}"
+            git diff --stat | tee -a "${GITHUB_STEP_SUMMARY}"
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Check bot token
+        if: steps.fixers.outputs.changed == 'true'
+        env:
+          FLASHDREAMS_BOT_PAT: ${{ secrets.FLASHDREAMS_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FLASHDREAMS_BOT_PAT:-}" ]; then
+            echo "::error title=Missing bot token::Set FLASHDREAMS_BOT_PAT so /lint-fix can push a fix branch and open a PR."
+            exit 1
+          fi
+
+      - name: Resolve bot identity
+        if: steps.fixers.outputs.changed == 'true'
+        id: bot
+        env:
+          FLASHDREAMS_BOT_PAT: ${{ secrets.FLASHDREAMS_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          bot_info="$(curl -fsSL \
+            -H "Authorization: Bearer ${FLASHDREAMS_BOT_PAT}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user)"
+          bot_name="$(echo "${bot_info}" | jq --raw-output '.login')"
+          bot_identity="$(echo "${bot_info}" | jq --raw-output '.login + " <" + (.id|tostring) + "+" + .login + "@users.noreply.github.com>"')"
+          echo "name=${bot_name}" >> "${GITHUB_OUTPUT}"
+          echo "identity=${bot_identity}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create lint fix pull request
+        if: steps.fixers.outputs.changed == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.FLASHDREAMS_BOT_PAT }}
+          path: pr-branch
+          commit-message: "lint fixes"
+          committer: ${{ steps.bot.outputs.identity }}
+          author: ${{ steps.bot.outputs.identity }}
+          signoff: true
+          title: "Apply lint fixes for PR #${{ github.event.client_payload.pull_request.number }}"
+          body: "Automated lint fixes for ${{ github.event.client_payload.pull_request.html_url }}"
+          branch: lint-fix-${{ github.event.client_payload.pull_request.number }}-${{ github.event.client_payload.pull_request.head.ref }}
+          base: ${{ github.event.client_payload.pull_request.head.ref }}
+          push-to-fork: ${{ steps.bot.outputs.name }}/flashdreams
+          delete-branch: true
+
+      - name: Comment on PR
+        if: always()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: NVIDIA/flashdreams
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: |
+            ${{
+              steps.fixers.conclusion != 'success'
+              && format('Lint fix failed before creating a PR. Check the workflow run: https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id)
+              || (steps.fixers.outputs.changed != 'true'
+                  && 'No automatic lint fixes were produced. The remaining failures likely need manual changes.'
+              || (steps.create-pr.conclusion != 'success'
+                  && format('Failed to create the lint-fix pull request. Check the workflow run: https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id)
+                  || (steps.create-pr.outputs.pull-request-url != ''
+                      && format('Lint fixes are ready: {0}', steps.create-pr.outputs.pull-request-url)
+                      || 'No automatic lint fixes were produced. The remaining failures likely need manual changes.')))
+            }}
+
+      - name: Add reaction
+        if: steps.create-pr.conclusion == 'success' && steps.create-pr.outputs.pull-request-url != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions-edit-mode: replace
+          reactions: hooray

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -17,7 +17,26 @@ jobs:
       github.event.client_payload.pull_request.base.repo.full_name == 'NVIDIA/flashdreams'
     runs-on: ubuntu-latest
     steps:
+      - name: Check PR branch scope
+        id: pr-scope
+        env:
+          HEAD_REPO: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          if [ "${HEAD_REPO}" = "NVIDIA/flashdreams" ]; then
+            echo "supported=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "supported=false" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Lint fix"
+              echo
+              echo "\`/lint-fix\` can only update PR branches in NVIDIA/flashdreams."
+              echo "This PR branch is in \`${HEAD_REPO}\`, so no automatic fix PR was created."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
       - name: Checkout PR branch
+        if: steps.pr-scope.outputs.supported == 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
@@ -26,6 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout target branch
+        if: steps.pr-scope.outputs.supported == 'true'
         uses: actions/checkout@v4
         with:
           repository: NVIDIA/flashdreams
@@ -34,21 +54,24 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv
+        if: steps.pr-scope.outputs.supported == 'true'
         uses: astral-sh/setup-uv@v6
 
       - name: Run fixable pre-commit hooks
+        if: steps.pr-scope.outputs.supported == 'true'
         id: fixers
         working-directory: pr-branch
         env:
           PRE_COMMIT_HOME: ${{ runner.temp }}/pre-commit
           UV_CACHE_DIR: ${{ runner.temp }}/uv-cache
-          UV_TOOL_DIR: ${{ runner.temp }}/uv-tools
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/lint-fix-venv
         run: |
           set -euo pipefail
 
           config="${RUNNER_TEMP}/flashdreams-lint-fix-pre-commit.yaml"
           cp ../target-branch/.pre-commit-config.yaml "${config}"
-          command -v uvx >/dev/null
+          command -v uv >/dev/null
+          uv sync --project ../target-branch --only-group lint --frozen
 
           {
             echo "## Lint fix"
@@ -66,7 +89,7 @@ jobs:
             echo "::group::pre-commit ${hook_id}"
             git diff --binary > "${before_diff}"
             set +e
-            uvx --from pre-commit==4.3.0 pre-commit run \
+            uv run --project ../target-branch --no-sync pre-commit run \
               --config "${config}" \
               "${hook_id}" \
               --all-files
@@ -97,7 +120,7 @@ jobs:
           sync_status=0
           echo "::group::sync-version"
           set +e
-          python ../target-branch/.github/scripts/sync_version.py --repo-root .
+          uv run --project ../target-branch --no-sync python ../target-branch/.github/scripts/sync_version.py --repo-root .
           sync_status=$?
           set -e
           echo "::endgroup::"
@@ -122,7 +145,7 @@ jobs:
           fi
 
       - name: Check bot token
-        if: steps.fixers.outputs.changed == 'true'
+        if: steps.pr-scope.outputs.supported == 'true' && steps.fixers.outputs.changed == 'true'
         env:
           FLASHDREAMS_BOT_PAT: ${{ secrets.FLASHDREAMS_BOT_PAT }}
         run: |
@@ -133,7 +156,7 @@ jobs:
           fi
 
       - name: Resolve bot identity
-        if: steps.fixers.outputs.changed == 'true'
+        if: steps.pr-scope.outputs.supported == 'true' && steps.fixers.outputs.changed == 'true'
         id: bot
         env:
           FLASHDREAMS_BOT_PAT: ${{ secrets.FLASHDREAMS_BOT_PAT }}
@@ -148,8 +171,25 @@ jobs:
           echo "name=${bot_name}" >> "${GITHUB_OUTPUT}"
           echo "identity=${bot_identity}" >> "${GITHUB_OUTPUT}"
 
+      - name: Choose fix branch
+        if: steps.pr-scope.outputs.supported == 'true' && steps.fixers.outputs.changed == 'true'
+        id: fix-branch
+        env:
+          HEAD_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+        run: |
+          set -euo pipefail
+          raw="lint-fix-${PR_NUMBER}-${HEAD_REF}"
+          branch="$(printf '%s' "${raw}" | sed -E 's/[^A-Za-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+          branch="${branch:0:240}"
+          if [ -z "${branch}" ]; then
+            echo "::error title=Invalid fix branch::Could not build a valid lint-fix branch name."
+            exit 1
+          fi
+          echo "name=${branch}" >> "${GITHUB_OUTPUT}"
+
       - name: Create lint fix pull request
-        if: steps.fixers.outputs.changed == 'true'
+        if: steps.pr-scope.outputs.supported == 'true' && steps.fixers.outputs.changed == 'true'
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
@@ -161,10 +201,21 @@ jobs:
           signoff: true
           title: "Apply lint fixes for PR #${{ github.event.client_payload.pull_request.number }}"
           body: "Automated lint fixes for ${{ github.event.client_payload.pull_request.html_url }}"
-          branch: lint-fix-${{ github.event.client_payload.pull_request.number }}-${{ github.event.client_payload.pull_request.head.ref }}
+          branch: ${{ steps.fix-branch.outputs.name }}
           base: ${{ github.event.client_payload.pull_request.head.ref }}
           push-to-fork: ${{ steps.bot.outputs.name }}/flashdreams
           delete-branch: true
+
+      - name: Find lint fix comment
+        if: always()
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: NVIDIA/flashdreams
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- flashdreams-lint-fix -->"
 
       - name: Comment on PR
         if: always()
@@ -172,10 +223,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: NVIDIA/flashdreams
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.client_payload.pull_request.number }}
+          edit-mode: replace
           body: |
+            <!-- flashdreams-lint-fix -->
             ${{
-              steps.fixers.conclusion != 'success'
+              steps.pr-scope.outputs.supported != 'true'
+              && format('`/lint-fix` can only update PR branches in NVIDIA/flashdreams. This PR branch is in `{0}`, so no automatic fix PR was created. Use the copied internal PR from the `/ok to test` flow, or apply fixes manually.', github.event.client_payload.pull_request.head.repo.full_name)
+              || (steps.fixers.conclusion != 'success'
               && format('Lint fix failed before creating a PR. Check the workflow run: https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id)
               || (steps.fixers.outputs.changed != 'true'
                   && 'No automatic lint fixes were produced. The remaining failures likely need manual changes.'
@@ -183,7 +239,7 @@ jobs:
                   && format('Failed to create the lint-fix pull request. Check the workflow run: https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id)
                   || (steps.create-pr.outputs.pull-request-url != ''
                       && format('Lint fixes are ready: {0}', steps.create-pr.outputs.pull-request-url)
-                      || 'No automatic lint fixes were produced. The remaining failures likely need manual changes.')))
+                      || 'No automatic lint fixes were produced. The remaining failures likely need manual changes.'))))
             }}
 
       - name: Add reaction

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -41,6 +41,8 @@ jobs:
         working-directory: pr-branch
         env:
           PRE_COMMIT_HOME: ${{ runner.temp }}/pre-commit
+          UV_CACHE_DIR: ${{ runner.temp }}/uv-cache
+          UV_TOOL_DIR: ${{ runner.temp }}/uv-tools
         run: |
           set -euo pipefail
 
@@ -58,8 +60,11 @@ jobs:
           run_hook() {
             local hook_id="$1"
             local status=0
+            local before_diff="${RUNNER_TEMP}/${hook_id}.before.diff"
+            local after_diff="${RUNNER_TEMP}/${hook_id}.after.diff"
 
             echo "::group::pre-commit ${hook_id}"
+            git diff --binary > "${before_diff}"
             set +e
             uvx --from pre-commit==4.3.0 pre-commit run \
               --config "${config}" \
@@ -71,8 +76,16 @@ jobs:
 
             if [ "${status}" -eq 0 ]; then
               echo "- \`${hook_id}\`: clean" >> "${GITHUB_STEP_SUMMARY}"
-            else
+            elif [ "${status}" -eq 1 ]; then
+              git diff --binary > "${after_diff}"
+              if cmp -s "${before_diff}" "${after_diff}"; then
+                echo "- \`${hook_id}\`: failed without producing automatic fixes" >> "${GITHUB_STEP_SUMMARY}"
+                return 1
+              fi
               echo "- \`${hook_id}\`: exited with ${status}; this is expected when files are rewritten" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "- \`${hook_id}\`: failed with ${status}" >> "${GITHUB_STEP_SUMMARY}"
+              return "${status}"
             fi
           }
 

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -5,7 +5,7 @@ on:
     types: [lint-fix-command]
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 
@@ -144,33 +144,6 @@ jobs:
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Check bot token
-        if: steps.pr-scope.outputs.supported == 'true' && steps.fixers.outputs.changed == 'true'
-        env:
-          FLASHDREAMS_BOT_PAT: ${{ secrets.FLASHDREAMS_BOT_PAT }}
-        run: |
-          set -euo pipefail
-          if [ -z "${FLASHDREAMS_BOT_PAT:-}" ]; then
-            echo "::error title=Missing bot token::Set FLASHDREAMS_BOT_PAT so /lint-fix can push a fix branch and open a PR."
-            exit 1
-          fi
-
-      - name: Resolve bot identity
-        if: steps.pr-scope.outputs.supported == 'true' && steps.fixers.outputs.changed == 'true'
-        id: bot
-        env:
-          FLASHDREAMS_BOT_PAT: ${{ secrets.FLASHDREAMS_BOT_PAT }}
-        run: |
-          set -euo pipefail
-          bot_info="$(curl -fsSL \
-            -H "Authorization: Bearer ${FLASHDREAMS_BOT_PAT}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/user)"
-          bot_name="$(echo "${bot_info}" | jq --raw-output '.login')"
-          bot_identity="$(echo "${bot_info}" | jq --raw-output '.login + " <" + (.id|tostring) + "+" + .login + "@users.noreply.github.com>"')"
-          echo "name=${bot_name}" >> "${GITHUB_OUTPUT}"
-          echo "identity=${bot_identity}" >> "${GITHUB_OUTPUT}"
-
       - name: Choose fix branch
         if: steps.pr-scope.outputs.supported == 'true' && steps.fixers.outputs.changed == 'true'
         id: fix-branch
@@ -193,17 +166,14 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.FLASHDREAMS_BOT_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: pr-branch
           commit-message: "lint fixes"
-          committer: ${{ steps.bot.outputs.identity }}
-          author: ${{ steps.bot.outputs.identity }}
           signoff: true
           title: "Apply lint fixes for PR #${{ github.event.client_payload.pull_request.number }}"
           body: "Automated lint fixes for ${{ github.event.client_payload.pull_request.html_url }}"
           branch: ${{ steps.fix-branch.outputs.name }}
           base: ${{ github.event.client_payload.pull_request.head.ref }}
-          push-to-fork: ${{ steps.bot.outputs.name }}/flashdreams
           delete-branch: true
 
       - name: Find lint fix comment

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,40 @@
+name: Slash Command Dispatch
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  slash-command-dispatch:
+    if: github.repository == 'NVIDIA/flashdreams'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        id: scd
+        uses: peter-evans/slash-command-dispatch@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          config: >
+            [
+              {
+                "command": "lint-fix",
+                "permission": "write",
+                "issue_type": "pull-request"
+              }
+            ]
+
+      - name: Edit comment with error message
+        if: steps.scd.outputs.error-message
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            > ${{ steps.scd.outputs.error-message }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,9 @@ short ping comment.
 - Formatting is enforced by `ruff` via pre-commit (`uv run pre-commit
   run -a`). The CI will reject unformatted code; running pre-commit
   locally is the easiest way to avoid surprises.
+- If CI reports fixable pre-commit changes, a maintainer can comment
+  `/lint-fix` on the PR to open an automated fix PR for formatting,
+  imports, and version-sync updates.
 - Prefer small, well-named functions over long functions with comments
   explaining each block. Comments should explain *why*, not *what*.
 - Tests live in `flashdreams/tests/` and `integrations/*/tests/`. Use


### PR DESCRIPTION
Add a PR comment command that runs fixable pre-commit hooks against the
PR branch and opens a bot PR with the resulting changes. The workflow
uses trusted target-branch tooling, covers formatting/import/version-sync
fixes, and leaves non-fixable ty or REUSE failures for manual repair.

Also surface the /lint-fix hint in CI output and CONTRIBUTING.md.