### PR TITLE
Add video-quality capability benchmark (skeleton)

### DIFF
--- a/configs/video_quality_benchmark.yml
+++ b/configs/video_quality_benchmark.yml
@@ -1,0 +1,92 @@
+schema_version: 1
+description: FlashDreams video-quality capability benchmark (example scenes).
+
+# Example/skeleton scenarios backed by 3 real single-view HD-map clips from the
+# public HF dataset nvidia/omni-dreams-samples (data/single_view/<uuid>). The
+# descriptions, prompts, and checks here are FAKED placeholders that only
+# exercise the plumbing; real answer-key checks are authored in a later pass.
+#
+# Run modes:
+#   --generator omnidreams              pulls each scene's *_hdmap.mp4 +
+#                                       first_frame.png from HF (needs HF_TOKEN in
+#                                       the environment + a GPU) and runs the real
+#                                       HD-map -> RGB inference.
+#   --generator synthetic_passthrough   (default) ignores the HD-map and makes a
+#                                       deterministic synthetic clip, for CPU/CI.
+suites:
+  - nightly
+  - per_commit
+  - vlm_experimental
+
+cases:
+  - id: omnidreams_sample_pedestrian
+    description: (example) Front-camera urban drive; check pedestrian presence.
+    category: pedestrian
+    suites: [nightly, per_commit]
+    generation:
+      recipe: omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf
+      total_blocks: 8
+      example_data_uuid: 239560dc-33d1-11ef-9720-00044bcbccac
+    assets:
+      prompt: "Front-facing dashcam, urban street with pedestrians, vehicles, and traffic signs; clear daylight, photorealistic."
+    checks:
+      - id: pedestrian_present
+        question: "Is there a pedestrian in the scene?"
+        expected: "yes"
+        evaluator: stub_presence
+        control_channel: structured
+        tier: presence
+      - id: pedestrian_on_hood
+        question: "Is a pedestrian standing on the hood of the ego vehicle?"
+        expected: "no"
+        evaluator: stub_presence
+        control_channel: structured
+        tier: attribute
+
+  - id: omnidreams_sample_vehicle
+    description: (example) Front-camera drive; check lead-vehicle presence.
+    category: vehicle
+    suites: [nightly]
+    generation:
+      recipe: omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf
+      total_blocks: 8
+      example_data_uuid: 23599139-948f-4681-b7f4-74794113086d
+    assets:
+      prompt: "Front-facing dashcam following traffic on a multi-lane road; clear daylight, photorealistic."
+    checks:
+      - id: lead_vehicle_present
+        question: "Is there a vehicle ahead of the ego vehicle?"
+        expected: "yes"
+        evaluator: stub_presence
+        control_channel: structured
+        tier: presence
+      - id: road_surface_visible
+        question: "Is the road surface visible ahead of the ego vehicle?"
+        expected: "yes"
+        evaluator: stub_presence
+        control_channel: structured
+        tier: presence
+
+  - id: omnidreams_sample_signage
+    description: (example) Front-camera drive; check traffic-sign legibility.
+    category: signage
+    suites: [nightly]
+    generation:
+      recipe: omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf
+      total_blocks: 8
+      example_data_uuid: 237a3c21-9c03-4d06-aab9-6c2ff407f660
+    assets:
+      prompt: "Front-facing dashcam approaching intersections with traffic signs; clear daylight, photorealistic."
+    checks:
+      - id: traffic_sign_present
+        question: "Is there a traffic sign visible?"
+        expected: "yes"
+        evaluator: stub_presence
+        control_channel: structured
+        tier: presence
+      - id: traffic_sign_legible
+        question: "Is at least one traffic sign legible?"
+        expected: "yes"
+        evaluator: stub_presence
+        control_channel: structured
+        tier: fidelity

--- a/flashdreams/flashdreams/quality/video_quality/evaluators/__init__.py
+++ b/flashdreams/flashdreams/quality/video_quality/evaluators/__init__.py
@@ -1,28 +1,42 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Optional video-quality evaluator registry.
+"""Pluggable video-quality evaluator registry.
 
-The first implementation keeps learned/reference/VLM evaluators out of the
-blocking path. Future evaluators can register callables here without changing
-the runner loop.
+Evaluators are opaque to the benchmark runner: each implements the
+:class:`~flashdreams.quality.video_quality.evaluators.base.Evaluator` protocol and
+is looked up by name from the manifest. Real learned/reference/VLM evaluators can
+register here without changing the runner loop.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from flashdreams.quality.video_quality.evaluators.base import (
+    CheckResult,
+    Evaluator,
+    EvalSample,
+)
 
-Evaluator = Callable[..., dict[str, Any]]
+__all__ = [
+    "CheckResult",
+    "Evaluator",
+    "EvalSample",
+    "get_evaluator",
+    "register_default_evaluators",
+    "register_evaluator",
+    "registered_evaluators",
+]
 
 _EVALUATORS: dict[str, Evaluator] = {}
 
 
-def register_evaluator(name: str, evaluator: Evaluator) -> None:
-    """Register an optional evaluator by name."""
+def register_evaluator(
+    name: str, evaluator: Evaluator, *, replace: bool = False
+) -> None:
+    """Register an evaluator by name."""
     if not name:
         raise ValueError("Evaluator name must be non-empty")
-    if name in _EVALUATORS:
+    if name in _EVALUATORS and not replace:
         raise ValueError(f"Evaluator {name!r} is already registered")
     _EVALUATORS[name] = evaluator
 
@@ -32,9 +46,25 @@ def get_evaluator(name: str) -> Evaluator:
     try:
         return _EVALUATORS[name]
     except KeyError as exc:
-        raise KeyError(f"Unknown evaluator {name!r}") from exc
+        raise KeyError(
+            f"Unknown evaluator {name!r}; registered: {registered_evaluators()}"
+        ) from exc
 
 
 def registered_evaluators() -> tuple[str, ...]:
     """Return registered evaluator names."""
     return tuple(sorted(_EVALUATORS))
+
+
+def register_default_evaluators() -> None:
+    """Register built-in placeholder evaluators (idempotent).
+
+    These are skeleton stubs that satisfy the contract so the pipeline runs
+    end-to-end; real evaluators replace them in a later pass.
+    """
+    from flashdreams.quality.video_quality.evaluators.stub import (
+        StubPresenceEvaluator,
+    )
+
+    for evaluator in (StubPresenceEvaluator(),):
+        register_evaluator(evaluator.name, evaluator, replace=True)

--- a/flashdreams/flashdreams/quality/video_quality/evaluators/base.py
+++ b/flashdreams/flashdreams/quality/video_quality/evaluators/base.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime contract for video-quality benchmark evaluators (the black-box seam).
+
+An evaluator receives an :class:`EvalSample` (a generated clip plus its
+conditioning) and the subset of manifest
+:class:`~flashdreams.quality.video_quality.manifest.Check` items addressed to it,
+and returns one :class:`CheckResult` per check. The runner does not care *how* an
+evaluator decides -- a cheap heuristic, an object detector, or a hosted VLM all
+satisfy this same interface -- so real evaluators can be dropped in later without
+touching the pipeline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+import numpy.typing as npt
+
+from flashdreams.quality.video_quality.manifest import Check
+
+RGBVideo = npt.NDArray[np.uint8]
+
+
+@dataclass(frozen=True)
+class EvalSample:
+    """One generated clip plus everything an evaluator may inspect."""
+
+    scenario_id: str
+    frames: RGBVideo
+    fps: float | None = None
+    reference_frames: RGBVideo | None = None
+    conditioning: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """The outcome of one yes/no check against a generated clip."""
+
+    check_id: str
+    category: str
+    question: str
+    expected: str
+    answer: str
+    correct: bool
+    control_channel: str
+    tier: str
+    evaluator: str
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_check(
+        cls,
+        check: Check,
+        *,
+        answer: str,
+        evaluator: str,
+        detail: dict[str, Any] | None = None,
+    ) -> CheckResult:
+        """Build a result for ``check`` from an evaluator's raw ``answer``."""
+        normalized = answer.strip().lower()
+        return cls(
+            check_id=check.id,
+            category=check.category,
+            question=check.question,
+            expected=check.expected,
+            answer=normalized,
+            correct=normalized == check.expected.strip().lower(),
+            control_channel=check.control_channel,
+            tier=check.tier,
+            evaluator=evaluator,
+            detail=dict(detail or {}),
+        )
+
+
+@runtime_checkable
+class Evaluator(Protocol):
+    """Pluggable, opaque evaluator. Real impls (VLM/detector) land next week."""
+
+    name: str
+
+    def evaluate(
+        self, sample: EvalSample, checks: Sequence[Check]
+    ) -> list[CheckResult]:
+        """Answer ``checks`` for ``sample``; return one result per check."""
+        ...

--- a/flashdreams/flashdreams/quality/video_quality/evaluators/stub.py
+++ b/flashdreams/flashdreams/quality/video_quality/evaluators/stub.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Placeholder evaluators for pipe-cleaning the benchmark.
+
+These are deliberately fake: they satisfy the ``Evaluator`` contract and produce
+deterministic, varied yes/no answers so the end-to-end plumbing and KPI
+aggregation can be exercised before the real VLM/detector evaluators exist.
+REPLACE in the evaluator pass.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+import numpy as np
+
+from flashdreams.quality.video_quality.evaluators.base import CheckResult, EvalSample
+from flashdreams.quality.video_quality.manifest import Check
+
+
+class StubPresenceEvaluator:
+    """Deterministic fake 'object presence' evaluator (placeholder).
+
+    Answers are a stable pseudo-random function of (scenario, check, a cheap
+    frame signal) so a pipe-clean run yields a realistic mix of correct/incorrect
+    results without any real perception. This is NOT a real evaluator.
+    """
+
+    name = "stub_presence"
+
+    def evaluate(
+        self, sample: EvalSample, checks: Sequence[Check]
+    ) -> list[CheckResult]:
+        brightness = float(np.mean(sample.frames)) if sample.frames.size else 0.0
+        results: list[CheckResult] = []
+        for check in checks:
+            seed = f"{sample.scenario_id}:{check.id}:{int(brightness)}"
+            digest = hashlib.sha256(seed.encode()).digest()[0]
+            answer = "yes" if digest % 2 == 0 else "no"
+            results.append(
+                CheckResult.from_check(
+                    check,
+                    answer=answer,
+                    evaluator=self.name,
+                    detail={"placeholder": True, "mean_brightness": brightness},
+                )
+            )
+        return results

--- a/flashdreams/flashdreams/quality/video_quality/generation.py
+++ b/flashdreams/flashdreams/quality/video_quality/generation.py
@@ -90,6 +90,7 @@ class OmnidreamsGenerator:
 
     def generate(self, request: GenerationRequest) -> VideoMetricsInput:
         import dataclasses  # noqa: PLC0415
+        import gc  # noqa: PLC0415
         import tempfile  # noqa: PLC0415
         from pathlib import Path  # noqa: PLC0415
 
@@ -135,9 +136,21 @@ class OmnidreamsGenerator:
 
         cfg = dataclasses.replace(base, **overrides)
         runner = cfg.setup()
-        runner.run()
+        try:
+            runner.run()
+            canvas = media.read_video(str(output_dir / f"{recipe}.mp4"))
+        finally:
+            # Scenarios run sequentially and each call builds a fresh pipeline,
+            # so release it here or GPU memory accumulates across scenes (it
+            # looks like several models resident at once and OOMs). Build-once
+            # reuse is the proper follow-up; this just stops the leak.
+            del runner
+            gc.collect()
+            import torch  # noqa: PLC0415
 
-        canvas = media.read_video(str(output_dir / f"{recipe}.mp4"))
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
         # The runner stacks [HD-map (top), generated (bottom)] vertically; the
         # generated RGB is the lower ``pixel_height`` rows.
         generated = np.ascontiguousarray(canvas[:, cfg.pixel_height :, :, :3])

--- a/flashdreams/flashdreams/quality/video_quality/generation.py
+++ b/flashdreams/flashdreams/quality/video_quality/generation.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generator seam: turn a scenario's conditioning into a clip to evaluate.
+
+The runner calls a :class:`Generator` to produce the RGB clip it will score,
+replacing #317's evaluate-only ``NotImplementedError``. The real backends (gRPC
+replay against the omnidreams world-model server, or direct in-process
+``pipeline.generate``) land later; the skeleton ships a deterministic synthetic
+passthrough so the pipeline runs end-to-end without a GPU or model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+
+from flashdreams.quality.video_quality.manifest import VideoQualityCase
+from flashdreams.quality.video_quality.metrics import VideoMetricsInput, synthetic_video
+
+
+@dataclass(frozen=True)
+class GenerationRequest:
+    """Everything a generator needs to produce one scenario's clip."""
+
+    scenario_id: str
+    conditioning: dict[str, Any] = field(default_factory=dict)
+    source: dict[str, Any] = field(default_factory=dict)
+    generation: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class Generator(Protocol):
+    """Pluggable clip generator. Real backends (gRPC / in-process) land later."""
+
+    name: str
+
+    def generate(self, request: GenerationRequest) -> VideoMetricsInput:
+        """Produce an RGB clip for ``request``."""
+        ...
+
+
+class SyntheticPassthroughGenerator:
+    """Placeholder generator: deterministic synthetic clip, no model/GPU."""
+
+    name = "synthetic_passthrough"
+
+    def generate(self, request: GenerationRequest) -> VideoMetricsInput:
+        source = request.source
+        pattern = str(
+            request.conditioning.get("pattern")
+            or source.get("pattern")
+            or "textured_motion"
+        )
+        return synthetic_video(
+            pattern,
+            frames=int(source.get("frames", 16)),
+            height=int(source.get("height", 64)),
+            width=int(source.get("width", 64)),
+            fps=float(source.get("fps", 8)),
+            seed=int(source.get("seed", request.generation.get("seed", 0))),
+        )
+
+
+class OmnidreamsGenerator:
+    """Real batch HD-map -> RGB generator via the in-process ``flashdreams-run``
+    OmnidreamsRunner path (no gRPC server needed).
+
+    GPU-only: needs CUDA, the ``flashdreams-omnidreams`` package, and the gated
+    HF checkpoints (``nvidia/omni-dreams-models``) + sample data. It is registered
+    so the benchmark can select it with ``--generator omnidreams`` on the GPU
+    pool, while ``synthetic_passthrough`` stays the default for CPU/CI runs.
+
+    Asset convention (per scenario): ``assets.conditioning`` is the HD-map video
+    path and ``assets.first_frame`` is the seed frame. With neither set, the demo
+    ``example_data`` path lazy-fetches a bundled clip from Hugging Face.
+
+    Layering note: omnidreams is an integration package, so it is imported lazily;
+    this backend could later move behind an entry-point plugin.
+    """
+
+    name = "omnidreams"
+    default_recipe = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
+
+    def __init__(self, *, recipe: str | None = None, total_blocks: int = 20) -> None:
+        self._recipe = recipe or self.default_recipe
+        self._total_blocks = total_blocks
+
+    def generate(self, request: GenerationRequest) -> VideoMetricsInput:
+        import dataclasses  # noqa: PLC0415
+        import tempfile  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        import mediapy as media  # noqa: PLC0415
+
+        from omnidreams.config import OMNIDREAMS_RUNNERS  # noqa: PLC0415
+
+        recipe = str(request.generation.get("recipe") or self._recipe)
+        try:
+            base = OMNIDREAMS_RUNNERS[recipe]
+        except KeyError as exc:
+            raise KeyError(
+                f"Unknown omnidreams recipe {recipe!r}; registered: "
+                f"{tuple(sorted(OMNIDREAMS_RUNNERS))}"
+            ) from exc
+
+        total_blocks = int(request.generation.get("total_blocks", self._total_blocks))
+        output_dir = Path(tempfile.mkdtemp(prefix="omnidreams_gen_"))
+        overrides: dict[str, object] = {
+            "output_dir": output_dir,
+            "total_blocks": total_blocks,
+        }
+
+        hdmap = request.conditioning.get("conditioning")
+        first_frame = request.conditioning.get("first_frame")
+        if hdmap:
+            if not first_frame:
+                raise ValueError(
+                    f"{request.scenario_id}: omnidreams generator needs a first_frame "
+                    "asset alongside the HD-map conditioning video."
+                )
+            overrides["hdmap_video_paths"] = (Path(hdmap),)
+            overrides["first_frame_paths"] = (Path(first_frame),)
+        else:
+            overrides["example_data"] = True
+            uuid = request.generation.get("example_data_uuid")
+            if uuid:
+                overrides["example_data_uuid"] = str(uuid)
+
+        prompt = request.conditioning.get("prompt")
+        if prompt:
+            overrides["prompt"] = str(prompt)
+
+        cfg = dataclasses.replace(base, **overrides)
+        runner = cfg.setup()
+        runner.run()
+
+        canvas = media.read_video(str(output_dir / f"{recipe}.mp4"))
+        # The runner stacks [HD-map (top), generated (bottom)] vertically; the
+        # generated RGB is the lower ``pixel_height`` rows.
+        generated = np.ascontiguousarray(canvas[:, cfg.pixel_height :, :, :3])
+        return VideoMetricsInput(frames=generated, fps=float(cfg.output_fps))
+
+
+_GENERATORS: dict[str, Generator] = {
+    generator.name: generator
+    for generator in (SyntheticPassthroughGenerator(), OmnidreamsGenerator())
+}
+
+
+def get_generator(name: str) -> Generator:
+    """Return a registered generator backend."""
+    try:
+        return _GENERATORS[name]
+    except KeyError as exc:
+        raise KeyError(
+            f"Unknown generator {name!r}; registered: {tuple(sorted(_GENERATORS))}"
+        ) from exc
+
+
+def request_from_case(case: VideoQualityCase) -> GenerationRequest:
+    """Build a generation request from a manifest case's conditioning."""
+    conditioning = {
+        "prompt": case.assets.prompt,
+        "first_frame": case.assets.first_frame,
+        "conditioning": case.assets.conditioning,
+    }
+    return GenerationRequest(
+        scenario_id=case.id,
+        conditioning={k: v for k, v in conditioning.items() if v is not None},
+        source=dict(case.source),
+        generation=dict(case.generation),
+    )

--- a/flashdreams/flashdreams/quality/video_quality/manifest.py
+++ b/flashdreams/flashdreams/quality/video_quality/manifest.py
@@ -16,6 +16,8 @@ KNOWN_SUITES = frozenset(
 )
 KNOWN_THRESHOLD_OPS = frozenset({">", ">=", "<", "<=", "==", "!="})
 KNOWN_SEVERITIES = frozenset({"critical", "warning", "info"})
+KNOWN_CONTROL_CHANNELS = frozenset({"structured", "prompt", "first_frame", "unknown"})
+KNOWN_CHECK_TIERS = frozenset({"presence", "attribute", "fidelity", "dynamic"})
 
 
 @dataclass(frozen=True)
@@ -27,6 +29,27 @@ class Threshold:
     op: str
     value: float | bool | int | str
     severity: str
+
+
+@dataclass(frozen=True)
+class Check:
+    """One yes/no capability check the benchmark asks about a generated clip.
+
+    ``expected`` is the canonical answer derived from the scene spec (the answer
+    key); the evaluator named by ``evaluator`` produces an answer that is scored
+    against it. ``control_channel`` records how the capability is requested
+    (structured conditioning, text prompt, ...) so a low score can be read as a
+    model gap vs. an interface gap.
+    """
+
+    id: str
+    question: str
+    expected: str
+    evaluator: str
+    category: str
+    control_channel: str = "unknown"
+    tier: str = "presence"
+    target: str | None = None
 
 
 @dataclass(frozen=True)
@@ -75,6 +98,8 @@ class VideoQualityCase:
     generation: dict[str, Any]
     hf_dataset: str | None
     hf_revision: str | None
+    checks: tuple[Check, ...] = ()
+    category: str | None = None
 
     def belongs_to_suite(self, suite: str) -> bool:
         """Return whether this case should run for ``suite``."""
@@ -190,9 +215,9 @@ def _parse_case(
         for name, item in raw_windows.items()
     }
 
-    raw_thresholds = value.get("thresholds")
-    if not isinstance(raw_thresholds, list) or not raw_thresholds:
-        raise ValueError(f"{case_context}.thresholds must be a non-empty list")
+    raw_thresholds = value.get("thresholds", [])
+    if not isinstance(raw_thresholds, list):
+        raise ValueError(f"{case_context}.thresholds must be a list")
     thresholds = tuple(
         _parse_threshold(item, context=case_context) for item in raw_thresholds
     )
@@ -207,6 +232,26 @@ def _parse_case(
     if duplicate_thresholds:
         raise ValueError(
             f"{case_context} has duplicate threshold ids: {duplicate_thresholds}"
+        )
+
+    case_category = _optional_str(value, "category")
+    raw_checks = value.get("checks", [])
+    if not isinstance(raw_checks, list):
+        raise ValueError(f"{case_context}.checks must be a list")
+    checks = tuple(
+        _parse_check(item, context=case_context, case_category=case_category)
+        for item in raw_checks
+    )
+    check_ids = [check.id for check in checks]
+    duplicate_checks = sorted(
+        {check_id for check_id in check_ids if check_ids.count(check_id) > 1}
+    )
+    if duplicate_checks:
+        raise ValueError(f"{case_context} has duplicate check ids: {duplicate_checks}")
+
+    if not thresholds and not checks:
+        raise ValueError(
+            f"{case_context} must declare at least one threshold or check"
         )
 
     source = _optional_mapping(value, "source")
@@ -226,6 +271,8 @@ def _parse_case(
         generation=_optional_mapping(value, "generation"),
         hf_dataset=hf_dataset,
         hf_revision=_optional_str(value, "hf_revision"),
+        checks=checks,
+        category=case_category,
     )
 
 
@@ -294,6 +341,39 @@ def _parse_threshold(value: Any, *, context: str) -> Threshold:
         op=op,
         value=threshold_value,
         severity=severity,
+    )
+
+
+def _parse_check(value: Any, *, context: str, case_category: str | None) -> Check:
+    if not isinstance(value, dict):
+        raise ValueError(f"{context}.checks entries must be mappings")
+    check_id = _required_str(value, "id", context=f"{context}.check")
+    check_context = f"{context}.check {check_id!r}"
+    category = _optional_str(value, "category") or case_category
+    if not category:
+        raise ValueError(
+            f"{check_context} needs a category (on the check or the case)"
+        )
+    control_channel = _optional_str(value, "control_channel") or "unknown"
+    if control_channel not in KNOWN_CONTROL_CHANNELS:
+        raise ValueError(
+            f"{check_context} has unknown control_channel {control_channel!r}; "
+            f"known: {sorted(KNOWN_CONTROL_CHANNELS)}"
+        )
+    tier = _optional_str(value, "tier") or "presence"
+    if tier not in KNOWN_CHECK_TIERS:
+        raise ValueError(
+            f"{check_context} has unknown tier {tier!r}; known: {sorted(KNOWN_CHECK_TIERS)}"
+        )
+    return Check(
+        id=check_id,
+        question=_required_str(value, "question", context=check_context),
+        expected=_required_str(value, "expected", context=check_context),
+        evaluator=_required_str(value, "evaluator", context=check_context),
+        category=category,
+        control_channel=control_channel,
+        tier=tier,
+        target=_optional_str(value, "target"),
     )
 
 

--- a/flashdreams/flashdreams/quality/video_quality/run_benchmark.py
+++ b/flashdreams/flashdreams/quality/video_quality/run_benchmark.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the manifest-driven video-quality *capability* benchmark.
+
+Skeleton/plumbing built on top of #317's harness: for each scenario it generates
+a clip (via a pluggable :class:`~...generation.Generator`), runs the scenario's
+yes/no checks through pluggable evaluators, and rolls the results into a canon
+KPI + capability coverage map. The generator and evaluators are placeholder stubs
+for now; the contracts and aggregation are the real deliverable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from collections import defaultdict
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from flashdreams.quality.video_quality.evaluators import (
+    get_evaluator,
+    register_default_evaluators,
+)
+from flashdreams.quality.video_quality.evaluators.base import CheckResult, EvalSample
+from flashdreams.quality.video_quality.generation import (
+    Generator,
+    get_generator,
+    request_from_case,
+)
+from flashdreams.quality.video_quality.manifest import (
+    Check,
+    VideoQualityCase,
+    load_manifest,
+)
+from flashdreams.quality.video_quality.metrics import compute_video_metrics
+from flashdreams.quality.video_quality.scoring import aggregate_kpi, score_scenario
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    register_default_evaluators()
+    started_at = time.time()
+    manifest = load_manifest(args.manifest)
+    cases = manifest.select_cases(suite=args.suite, case_id=args.case_id)
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generator = get_generator(args.generator)
+
+    scenarios: list[dict[str, Any]] = []
+    scenario_results: list[dict[str, Any]] = []
+    for case in cases:
+        scenario, results = _run_scenario(
+            case,
+            generator=generator,
+            output_dir=output_dir / case.id,
+            pass_threshold=args.scenario_pass_threshold,
+        )
+        scenarios.append(scenario)
+        scenario_results.append(
+            {"id": case.id, "decision": scenario["decision"], "check_results": results}
+        )
+
+    aggregate = aggregate_kpi(
+        scenario_results, pass_threshold=args.scenario_pass_threshold
+    )
+    kpi = aggregate["kpi"]
+    decision = "fail" if kpi["failed"] else "pass"
+    run = {
+        "schema_version": 2,
+        "kind": "video_quality_benchmark",
+        "decision": decision,
+        "manifest_path": str(args.manifest),
+        "suite": args.suite,
+        "case_id": args.case_id,
+        "generator": generator.name,
+        "github": _github_metadata(),
+        "started_at_unix": started_at,
+        "duration_s": time.time() - started_at,
+        "output_dir": str(output_dir),
+        "kpi": kpi,
+        "coverage": aggregate["coverage"],
+        "scenarios": scenarios,
+    }
+    _write_json(output_dir / "benchmark.json", run)
+
+    print(
+        f"video-quality benchmark {decision}: "
+        f"{kpi['scenario_count']} scenario(s), "
+        f"pass_rate={_fmt(kpi['scenario_pass_rate'])}, "
+        f"overall_accuracy={_fmt(kpi['overall_accuracy'])}; "
+        f"report={output_dir / 'benchmark.json'}"
+    )
+    return 1 if decision == "fail" and args.fail_on_regression else 0
+
+
+def _run_scenario(
+    case: VideoQualityCase,
+    *,
+    generator: Generator,
+    output_dir: Path,
+    pass_threshold: float,
+) -> tuple[dict[str, Any], list[CheckResult]]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    request = request_from_case(case)
+    clip = generator.generate(request)
+    sample = EvalSample(
+        scenario_id=case.id,
+        frames=clip.frames,
+        fps=clip.fps,
+        conditioning=request.conditioning,
+        metadata={"generator": generator.name},
+    )
+
+    # Quality/coherence axis (reuse #317 metrics) alongside the canon/checks axis.
+    quality_metrics = compute_video_metrics(
+        clip.frames,
+        fps=clip.fps,
+        windows=case.windows,
+        metric_groups=case.metrics or None,
+    )
+
+    by_evaluator: dict[str, list[Check]] = defaultdict(list)
+    for check in case.checks:
+        by_evaluator[check.evaluator].append(check)
+    results: list[CheckResult] = []
+    for evaluator_name, checks in by_evaluator.items():
+        results.extend(get_evaluator(evaluator_name).evaluate(sample, checks))
+
+    decision = score_scenario(results, pass_threshold=pass_threshold)
+    scenario = {
+        "id": case.id,
+        "category": case.category,
+        "description": case.description,
+        "suites": list(case.suites),
+        "control_channels": sorted({c.control_channel for c in case.checks}),
+        "generator": generator.name,
+        "decision": decision,
+        "quality_metrics": quality_metrics,
+        "checks": [asdict(r) for r in results],
+    }
+    _write_json(output_dir / "scenario.json", scenario)
+    return scenario, results
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("configs/video_quality_benchmark.yml"),
+        help="Path to the benchmark case manifest.",
+    )
+    parser.add_argument(
+        "--suite",
+        default="nightly",
+        help="Suite label to run (e.g. nightly, per_commit, vlm_experimental).",
+    )
+    parser.add_argument("--case-id", help="Optional single case id to run.")
+    parser.add_argument(
+        "--generator",
+        default="synthetic_passthrough",
+        help="Generator backend name (placeholder default until real backends land).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/video_quality_benchmark"),
+        help="Directory for the run report and per-scenario artifacts.",
+    )
+    parser.add_argument(
+        "--scenario-pass-threshold",
+        type=float,
+        default=1.0,
+        help="Fraction of a scenario's checks that must be correct to pass.",
+    )
+    parser.add_argument(
+        "--fail-on-regression",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Exit non-zero when scenarios fail (off by default while evaluators are stubs).",
+    )
+    return parser.parse_args(argv)
+
+
+def _github_metadata() -> dict[str, str | None]:
+    return {
+        "commit_sha": os.environ.get("GITHUB_SHA"),
+        "ref": os.environ.get("GITHUB_REF"),
+        "event_name": os.environ.get("GITHUB_EVENT_NAME"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "job": os.environ.get("GITHUB_JOB"),
+        "actor": os.environ.get("GITHUB_ACTOR"),
+    }
+
+
+def _fmt(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.3f}"
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(value, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/flashdreams/flashdreams/quality/video_quality/scoring.py
+++ b/flashdreams/flashdreams/quality/video_quality/scoring.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Aggregate per-scenario check results into the benchmark KPI + coverage map.
+
+The KPI is a *faithfulness/canon accuracy*: the fraction of yes/no checks the
+generated video gets right, reported overall, per category, and as a scenario
+pass-rate. The coverage map rolls accuracy up by (category x control_channel) so
+a low cell reads as a model gap vs. an interface gap.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from flashdreams.quality.video_quality.evaluators.base import CheckResult
+
+
+def score_scenario(
+    results: Sequence[CheckResult], *, pass_threshold: float
+) -> dict[str, Any]:
+    """Grade one scenario from its check results."""
+    total = len(results)
+    correct = sum(1 for r in results if r.correct)
+    score = correct / total if total else None
+    passed = score is not None and score >= pass_threshold
+    return {
+        "check_count": total,
+        "checks_correct": correct,
+        "score": score,
+        "status": "pass" if passed else "fail",
+        "failed_check_ids": sorted(r.check_id for r in results if not r.correct),
+    }
+
+
+def aggregate_kpi(
+    scenarios: Sequence[dict[str, Any]], *, pass_threshold: float
+) -> dict[str, Any]:
+    """Roll per-scenario results into the headline KPI + coverage map.
+
+    Each item in ``scenarios`` is a dict with keys ``id``, ``decision`` (the
+    output of :func:`score_scenario`), and ``check_results`` (a list of
+    :class:`CheckResult`).
+    """
+    all_results: list[CheckResult] = []
+    per_category: dict[str, dict[str, int]] = {}
+    coverage: dict[str, dict[str, dict[str, int]]] = {}
+    passed_scenarios = 0
+
+    for scenario in scenarios:
+        results = list(scenario["check_results"])
+        all_results.extend(results)
+        if scenario["decision"]["status"] == "pass":
+            passed_scenarios += 1
+        for r in results:
+            cat = per_category.setdefault(r.category, {"checks": 0, "correct": 0})
+            cat["checks"] += 1
+            cat["correct"] += int(r.correct)
+            cell = coverage.setdefault(r.category, {}).setdefault(
+                r.control_channel, {"checks": 0, "correct": 0}
+            )
+            cell["checks"] += 1
+            cell["correct"] += int(r.correct)
+
+    total_checks = len(all_results)
+    total_correct = sum(1 for r in all_results if r.correct)
+    overall_accuracy = total_correct / total_checks if total_checks else None
+
+    category_accuracy = {
+        cat: (v["correct"] / v["checks"] if v["checks"] else None)
+        for cat, v in per_category.items()
+    }
+    present = [a for a in category_accuracy.values() if a is not None]
+    macro = sum(present) / len(present) if present else None
+
+    scenario_count = len(scenarios)
+    scenario_pass_rate = (
+        passed_scenarios / scenario_count if scenario_count else None
+    )
+    critical_failures = sum(
+        1 for r in all_results if r.tier == "presence" and not r.correct
+    )
+
+    kpi = {
+        "scenario_count": scenario_count,
+        "passed": passed_scenarios,
+        "failed": scenario_count - passed_scenarios,
+        "check_count": total_checks,
+        "checks_correct": total_correct,
+        "overall_accuracy": overall_accuracy,
+        "macro_category_accuracy": macro,
+        "scenario_pass_rate": scenario_pass_rate,
+        # Single attempt today; pass@k (k samples) lands with the real generator.
+        "pass_at_1": scenario_pass_rate,
+        "critical_failures": critical_failures,
+        "scenario_pass_threshold": pass_threshold,
+        "per_category": {
+            cat: {
+                "checks": per_category[cat]["checks"],
+                "correct": per_category[cat]["correct"],
+                "accuracy": category_accuracy[cat],
+            }
+            for cat in sorted(per_category)
+        },
+    }
+    coverage_map = {
+        cat: {
+            channel: {
+                "checks": cell["checks"],
+                "correct": cell["correct"],
+                "accuracy": (
+                    cell["correct"] / cell["checks"] if cell["checks"] else None
+                ),
+            }
+            for channel, cell in sorted(channels.items())
+        }
+        for cat, channels in sorted(coverage.items())
+    }
+    return {"kpi": kpi, "coverage": coverage_map}

--- a/flashdreams/tests/test_video_quality_benchmark.py
+++ b/flashdreams/tests/test_video_quality_benchmark.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flashdreams.quality.video_quality.evaluators import (
+    get_evaluator,
+    register_default_evaluators,
+)
+from flashdreams.quality.video_quality.evaluators.base import CheckResult, EvalSample
+from flashdreams.quality.video_quality.manifest import Check, load_manifest
+from flashdreams.quality.video_quality.run_benchmark import main
+from flashdreams.quality.video_quality.scoring import aggregate_kpi, score_scenario
+
+pytestmark = pytest.mark.ci_cpu
+
+BENCHMARK_MANIFEST = Path("configs/video_quality_benchmark.yml")
+
+
+def _result(check_id, category, channel, correct, *, tier="presence") -> CheckResult:
+    return CheckResult(
+        check_id=check_id,
+        category=category,
+        question="q?",
+        expected="yes",
+        answer="yes" if correct else "no",
+        correct=correct,
+        control_channel=channel,
+        tier=tier,
+        evaluator="stub_presence",
+    )
+
+
+def test_benchmark_manifest_loads_checks() -> None:
+    manifest = load_manifest(BENCHMARK_MANIFEST)
+    cases = manifest.select_cases(suite="nightly")
+    assert len(cases) == 3
+
+    for case in cases:
+        assert case.category  # every case is categorized
+        assert case.thresholds == ()  # checks-only cases, thresholds optional
+        assert case.checks  # at least one check per case
+        for check in case.checks:
+            assert check.expected in {"yes", "no"}
+            assert check.evaluator  # names an evaluator to dispatch to
+
+    # Example scenes carry an example_data_uuid for the omnidreams generator.
+    assert any(case.generation.get("example_data_uuid") for case in cases)
+
+
+def test_score_scenario_counts_correct() -> None:
+    results = [
+        _result("a", "ped", "structured", True),
+        _result("b", "ped", "structured", False),
+    ]
+    decision = score_scenario(results, pass_threshold=1.0)
+    assert decision["check_count"] == 2
+    assert decision["checks_correct"] == 1
+    assert decision["score"] == 0.5
+    assert decision["status"] == "fail"
+    assert decision["failed_check_ids"] == ["b"]
+
+
+def test_aggregate_kpi_rolls_up_by_category_and_channel() -> None:
+    s1 = [
+        _result("a", "ped", "structured", True),
+        _result("b", "ped", "structured", True),
+    ]
+    s2 = [_result("c", "animal", "prompt", False)]
+    scenarios = [
+        {"id": "s1", "decision": score_scenario(s1, pass_threshold=1.0), "check_results": s1},
+        {"id": "s2", "decision": score_scenario(s2, pass_threshold=1.0), "check_results": s2},
+    ]
+    agg = aggregate_kpi(scenarios, pass_threshold=1.0)
+    kpi = agg["kpi"]
+    assert kpi["scenario_count"] == 2
+    assert kpi["check_count"] == 3
+    assert kpi["checks_correct"] == 2
+    assert kpi["overall_accuracy"] == pytest.approx(2 / 3)
+    assert kpi["per_category"]["ped"]["accuracy"] == 1.0
+    assert kpi["per_category"]["animal"]["accuracy"] == 0.0
+    assert kpi["scenario_pass_rate"] == 0.5
+    assert agg["coverage"]["ped"]["structured"]["checks"] == 2
+    assert agg["coverage"]["animal"]["prompt"]["accuracy"] == 0.0
+
+
+def test_stub_evaluator_is_contract_faithful() -> None:
+    register_default_evaluators()
+    evaluator = get_evaluator("stub_presence")
+    sample = EvalSample(
+        scenario_id="s", frames=np.zeros((4, 8, 8, 3), dtype=np.uint8), fps=8.0
+    )
+    check = Check(
+        id="c", question="q?", expected="yes", evaluator="stub_presence", category="ped"
+    )
+    results = evaluator.evaluate(sample, [check])
+    assert len(results) == 1
+    assert results[0].answer in {"yes", "no"}
+    assert isinstance(results[0].correct, bool)
+
+
+def test_run_benchmark_end_to_end(tmp_path: Path) -> None:
+    exit_code = main(
+        [
+            "--manifest",
+            str(BENCHMARK_MANIFEST),
+            "--suite",
+            "nightly",
+            "--output-dir",
+            str(tmp_path),
+            "--no-fail-on-regression",
+        ]
+    )
+    assert exit_code == 0
+
+    report = json.loads((tmp_path / "benchmark.json").read_text())
+    assert report["kind"] == "video_quality_benchmark"
+    assert report["kpi"]["scenario_count"] == 3
+    assert report["kpi"]["overall_accuracy"] is not None
+    assert report["coverage"]  # non-empty (category x control_channel) map
+    assert len(report["scenarios"]) == 3
+    for scenario in report["scenarios"]:
+        assert scenario["checks"]
+        assert "quality_metrics" in scenario

--- a/tools/video_quality/run_benchmark.py
+++ b/tools/video_quality/run_benchmark.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI wrapper for the installable video-quality benchmark runner."""
+
+from flashdreams.quality.video_quality.run_benchmark import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Layers a capability/canon benchmark on top of the #317 video-quality harness: each scenario generates a clip, runs yes/no **checks** through pluggable evaluators, and rolls the results into a KPI + capability coverage map.

Plumbing and contracts are real; the generator, evaluators, and example scenes are placeholder-grade for pipe-cleaning. Real VLM/detector evaluators and scene answer keys land next.

## What's included
- **Evaluator contract** — `EvalSample` / `Evaluator` / `CheckResult` + typed registry (the black-box seam).
- **Manifest** — additive `checks` / `category`; thresholds become optional when a case declares checks (backward compatible with #317).
- **Scoring** — KPI (overall / macro / per-category accuracy, scenario pass-rate, pass@1) + coverage map (category × control_channel).
- **Generator seam** — synthetic passthrough stub (CPU/CI default) + a real in-process Omnidreams backend using the `flashdreams-run` HD-map→RGB path (no gRPC server).
- **CLI + example manifest** — `run_benchmark` + tools shim; 3 real `nvidia/omni-dreams-samples` scenes (faked info + checks); CPU tests.

## Run
- CPU pipe-clean: `uv run python -m tools.video_quality.run_benchmark --suite nightly`
- GPU (real HD-map→RGB): `HF_TOKEN=… uv run --project integrations/omnidreams python -m tools.video_quality.run_benchmark --suite nightly --generator omnidreams`