### PR TITLE
Add interactive-drive latency tracing instrumentation

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/app.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/app.py
@@ -21,6 +21,7 @@ from omnidreams.interactive_drive.runtime.loop import (
     PresenterBackend,
     run_main_loop,
 )
+from omnidreams.interactive_drive.runtime.timing import TraceContext, TraceSink
 from omnidreams.interactive_drive.scene_loader import (
     load_scene_bundle,
     reseed_scene_bundle,
@@ -65,6 +66,7 @@ class InteractiveDriveApp:
         backend: RenderBackend,
         presenter: PresenterBackend | None = None,
         *,
+        trace_sink: TraceSink | None = None,
         close_presenter_on_exit: bool = True,
     ) -> None:
         """Construct the engine and begin model warmup.
@@ -107,7 +109,10 @@ class InteractiveDriveApp:
         # Scenes are bound later via load_scene; the model is never rebuilt
         # on a scene change.
         self._adapter = LocalVideoModelAdapter(backend)
-        self._pipeline = ChunkPipeline(self._adapter)
+        self._trace_context = (
+            None if trace_sink is None else TraceContext.create(trace_sink)
+        )
+        self._pipeline = ChunkPipeline(self._adapter, trace_context=self._trace_context)
         self._scene: SceneBundle | None = None
         self._map_bounds: MapBounds | None = None
         # Ground snapper for the current scene. Built once per scene (its
@@ -481,8 +486,12 @@ class InteractiveDriveApp:
                     oob_respawn_debounce_chunks=(
                         self._config.oob_respawn_debounce_chunks
                     ),
+                    stop_after_consumed_chunks=(
+                        self._config.stop_after_consumed_chunks
+                    ),
                 ),
                 loading_status=loading_status,
+                trace_context=self._trace_context,
             )
             if not reset_requested:
                 break

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
@@ -23,6 +23,7 @@ from omnidreams.interactive_drive.types import (
     PresentedFrame,
     SceneBundle,
     TrajectoryChunk,
+    VideoModelTimings,
 )
 from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
     FlashdreamsWorldModelSession,
@@ -171,6 +172,14 @@ class WorldModelRenderBackend(RenderBackend):
             frames=merged_frames,
             boundary_state_after_chunk=trajectory.boundary_state_after_chunk,
             source_name="omnidreams",
+            video_model_timings=VideoModelTimings(
+                condition_start_time=chunk_start,
+                condition_ready_time=raster_end,
+                model_start_time=raster_end,
+                model_ready_time=model_end,
+                merge_start_time=model_end,
+                merge_ready_time=merge_end,
+            ),
         )
 
     def render_next_chunk(self, trajectory: TrajectoryChunk) -> FrameChunk:
@@ -206,6 +215,14 @@ class WorldModelRenderBackend(RenderBackend):
             frames=merged_frames,
             boundary_state_after_chunk=trajectory.boundary_state_after_chunk,
             source_name="omnidreams",
+            video_model_timings=VideoModelTimings(
+                condition_start_time=chunk_start,
+                condition_ready_time=raster_end,
+                model_start_time=raster_end,
+                model_ready_time=model_end,
+                merge_start_time=model_end,
+                merge_ready_time=merge_end,
+            ),
         )
 
     def reset(self) -> None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -21,6 +21,7 @@ from omnidreams.interactive_drive.config import (
     WorldModelProfileConfig,
 )
 from omnidreams.interactive_drive.log import configure_logging
+from omnidreams.interactive_drive.runtime.timing import TraceSink
 from omnidreams.interactive_drive.synthetic_scene import build_synthetic_scene_to_temp
 from omnidreams.interactive_drive.world_model.manifest import load_world_model_manifest
 from omnidreams.scenes import local_scene_archive_path
@@ -214,6 +215,17 @@ def build_parser() -> argparse.ArgumentParser:
             "for a richer browser viewer prefer the separate "
             "``omnidreams.webrtc.server`` entry point. Implies --no-hud "
             "when launched via the demo wrapper."
+        ),
+    )
+    parser.add_argument(
+        "--stop-after-chunks",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Exit cleanly after consuming chunk index N from the present "
+            "queue. Used by internal latency tracing; chunk 0 is warmup, so "
+            "N yields N traced chunks (1..N)."
         ),
     )
     parser.add_argument(
@@ -443,6 +455,7 @@ def prepare_config_and_backend(
         world_model_offload_text_encoder=bool(args.offload_text_encoder),
         bev=bev_config,
         stream_mjpeg_bind=args.stream_mjpeg,
+        stop_after_consumed_chunks=args.stop_after_chunks,
         **_oob_kwargs(args),
     )
 
@@ -479,7 +492,7 @@ def prepare_config_and_backend(
     return config, backend
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace, trace_sink: TraceSink | None = None) -> None:
     """Execute the interactive-drive backend for ``args`` (single-scene ``--no-hud`` path).
 
     The HUD / streaming paths instead build one long-lived
@@ -487,5 +500,5 @@ def run(args: argparse.Namespace) -> None:
     """
     configure_logging()
     config, backend = prepare_config_and_backend(args)
-    app = InteractiveDriveApp(config=config, backend=backend)
+    app = InteractiveDriveApp(config=config, backend=backend, trace_sink=trace_sink)
     app.run()

--- a/integrations/omnidreams/omnidreams/interactive_drive/config.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/config.py
@@ -126,6 +126,12 @@ class AppConfig:
     # the MJPEG streaming presenter (HTTP frames + keyboard) -- needed on
     # compute-only boxes with no Vulkan-capable GPU.
     stream_mjpeg_bind: str | None = None
+    # When set, the main loop exits cleanly after that many distinct
+    # chunk indices have been consumed off the present queue. Used by the
+    # internal LAG upload helper to produce deterministic, warmup-aware
+    # trace runs across machines instead of timing the run with a
+    # wall-clock sleep.
+    stop_after_consumed_chunks: int | None = None
     # Substring matched against the Vulkan adapter name to force the
     # presenter onto a specific GPU (e.g. "RTX PRO"); None lets SlangPy pick
     # the first enumerated adapter.

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -14,7 +14,12 @@ from omnidreams.interactive_drive.input.backend import InputBackend
 from omnidreams.interactive_drive.runtime.runtime_controls import RuntimeControls
 from omnidreams.interactive_drive.runtime.timing import (
     ChunkHistory,
+    ChunkPrediction,
     ChunkTimes,
+    TraceComponentValue,
+    TraceContext,
+    event_dependencies,
+    trace_time_ns,
 )
 from omnidreams.interactive_drive.simulation.backend import SimulationBackend
 from omnidreams.interactive_drive.types import DriverCommand, PresentedFrame
@@ -174,6 +179,10 @@ class LoopConfig:
     # auto-respawn fires. Default 1 matches alpasim (immediate respawn);
     # raise it to debounce measurement noise.
     oob_respawn_debounce_chunks: int = 1
+    # When set, the loop exits cleanly once chunk index N has been consumed
+    # off the present queue. Chunk 0 is warmup and excluded from the trace,
+    # so consuming chunks 0..N yields N traced chunks (1..N).
+    stop_after_consumed_chunks: int | None = None
 
 
 # OOB overlay strings, module-level so the HUD can match on them for styling.
@@ -192,8 +201,17 @@ def make_chunk_request(
     input_sample_time: float,
     chunk_history: ChunkHistory,
     config: LoopConfig,
+    input_sample_event: int | None = None,
+    trace_context: TraceContext | None = None,
 ) -> ChunkRequest:
     request_time = time.perf_counter()
+    request_event = _trace_main_instant(
+        trace_context,
+        "request",
+        time_value=request_time,
+        depends_on=event_dependencies(input_sample_event),
+        chunk_index=state.next_chunk_index,
+    )
     chunk_index = state.next_chunk_index
     chunk_size = config.initial_chunk_size if chunk_index == 0 else config.chunk_size
     trajectory = simulation.pose_chunk(
@@ -203,6 +221,18 @@ def make_chunk_request(
         extrapolation_offset_s=0.0,
     )
     request_poses_ready_time = time.perf_counter()
+    simulation_event = _trace_main_range(
+        trace_context,
+        "simulation_step",
+        begin_time=request_time,
+        end_time=request_poses_ready_time,
+        depends_on=event_dependencies(request_event),
+        chunk_index=chunk_index,
+        chunk_size=chunk_size,
+    )
+    prediction = ChunkPrediction.create(
+        request_time=request_time, frame_interval_s=config.frame_interval_s
+    )
     intended_present_times = [
         request_time + config.frame_interval_s * frame for frame in range(chunk_size)
     ]
@@ -212,11 +242,16 @@ def make_chunk_request(
         request_time=request_time,
         request_poses_ready_time=request_poses_ready_time,
         intended_present_times=intended_present_times,
+        prediction=prediction,
     )
     chunk_history.append(chunk_times)
     state.next_chunk_index += 1
     state.chunks_outstanding += 1
-    return ChunkRequest(trajectory=trajectory, chunk_times=chunk_times)
+    return ChunkRequest(
+        trajectory=trajectory,
+        chunk_times=chunk_times,
+        trace_dependency_event=simulation_event,
+    )
 
 
 def present_queued_frame(
@@ -224,6 +259,8 @@ def present_queued_frame(
     presenter: PresenterBackend,
     view_mode: str,
     oob_message: str | None = None,
+    trace_context: TraceContext | None = None,
+    trace_dependencies: list[int] | None = None,
 ) -> float:
     """Hand a freshly-dequeued frame to the presenter.
 
@@ -237,9 +274,27 @@ def present_queued_frame(
     frame_times = queued_frame.chunk_times.frames[queued_frame.frame_index]
     frame_times.sample_display_pose_time = time.perf_counter()
     display_frame = _frame_with_overlay(queued_frame.frame, oob_message)
+    present_call_begin_time = time.perf_counter()
     presenter.present_frame(display_frame, view_mode=view_mode)
     present_time = time.perf_counter()
     frame_times.present_time = present_time
+    if trace_context is not None:
+        if frame_times.image_ready_time is None:
+            raise RuntimeError("queued frame is missing image_ready_time")
+        chunk_times = queued_frame.chunk_times
+        _trace_main_range(
+            trace_context,
+            "present_frame",
+            begin_time=present_call_begin_time,
+            end_time=present_time,
+            depends_on=[] if trace_dependencies is None else trace_dependencies,
+            chunk_index=chunk_times.chunk_index,
+            frame_index=queued_frame.frame_index,
+            per_frame_error_ms=(present_time - frame_times.intended_present_time)
+            * 1000.0,
+            input_sample_time_ns=trace_time_ns(chunk_times.input_sample_time),
+            image_ready_time_ns=trace_time_ns(frame_times.image_ready_time),
+        )
     if _profile_input_to_present_enabled():
         _record_input_to_present_for_profile(
             present_time=present_time,
@@ -406,6 +461,7 @@ def run_main_loop(
     pipeline: ChunkPipeline,
     config: LoopConfig,
     loading_status: Callable[[], str | None] | None = None,
+    trace_context: TraceContext | None = None,
 ) -> bool:
     """Drive the request -> render -> present pipeline.
 
@@ -424,6 +480,8 @@ def run_main_loop(
     last_presented_frame: PresentedFrame = initial_presented_frame
     ready_frames: deque[QueuedFrame] = deque()
     chunk_history = ChunkHistory(config.history_capacity)
+    last_input_sample_event: int | None = None
+    last_present_wait_event: int | None = None
     if _profile_input_to_present_enabled():
         reset_input_to_present_profile_window()
 
@@ -433,7 +491,19 @@ def run_main_loop(
             break
         if runtime_controls.consume_reset_request():
             return True
+        active_trace = (
+            trace_context if state.last_consumed_chunk_index is not None else None
+        )
+        input_sample_begin = time.perf_counter()
         sampled = input_backend.sample()
+        input_sample_end = time.perf_counter()
+        last_input_sample_event = _trace_main_range(
+            active_trace,
+            "input_sample",
+            begin_time=input_sample_begin,
+            end_time=input_sample_end,
+            depends_on=[],
+        )
 
         # Keep one chunk in flight.
         if should_request_chunk(state):
@@ -444,6 +514,8 @@ def run_main_loop(
                 input_sample_time=sampled.sample_time,
                 chunk_history=chunk_history,
                 config=config,
+                input_sample_event=last_input_sample_event,
+                trace_context=active_trace,
             )
             pipeline.request_pose_chunk(chunk_request)
             # The pose chunk just advanced authoritative state, so refresh the
@@ -465,25 +537,57 @@ def run_main_loop(
 
         now = time.perf_counter()
         if now < state.next_present_time:
+            wait_begin = now
             time.sleep(
                 min(config.poll_timeout_s, max(0.0, state.next_present_time - now))
+            )
+            wait_end = time.perf_counter()
+            last_present_wait_event = _trace_main_range(
+                active_trace,
+                "present_wait",
+                begin_time=wait_begin,
+                end_time=wait_end,
+                depends_on=[],
             )
             continue
 
         if ready_frames:
             queued_frame = ready_frames.popleft()
+            chunk_transitioned = (
+                queued_frame.chunk_times.chunk_index != state.last_consumed_chunk_index
+            )
             if queued_frame.chunk_times.chunk_index != state.last_consumed_chunk_index:
                 state.last_consumed_chunk_index = queued_frame.chunk_times.chunk_index
                 state.chunks_outstanding = max(0, state.chunks_outstanding - 1)
+            present_trace = (
+                trace_context if queued_frame.chunk_times.chunk_index >= 1 else None
+            )
             present_queued_frame(
                 queued_frame,
                 presenter,
                 view_mode=view_mode,
                 oob_message=state.oob_message,
+                trace_context=present_trace,
+                trace_dependencies=event_dependencies(
+                    queued_frame.worker_ready_event_id,
+                    last_present_wait_event,
+                ),
             )
+            last_present_wait_event = None
             last_presented_frame = queued_frame.frame
             state.frame_count += 1
+            if (
+                chunk_transitioned
+                and config.stop_after_consumed_chunks is not None
+                and state.last_consumed_chunk_index is not None
+                and state.last_consumed_chunk_index >= config.stop_after_consumed_chunks
+            ):
+                return False
         else:
+            # A re-present consumes the preceding sleep just like a real
+            # present, so drop it instead of carrying it forward as a
+            # dependency of some later, unrelated present.
+            last_present_wait_event = None
             # Re-present the last frame with the current overlay: OOB warning
             # wins, else the loading-phase status until the first real frame.
             # The merged frame is local so ``last_presented_frame`` is unchanged.
@@ -501,3 +605,61 @@ def run_main_loop(
 
         state.next_present_time += config.frame_interval_s
     return False
+
+
+def _trace_main_instant(
+    trace_context: TraceContext | None,
+    name: str,
+    *,
+    time_value: float,
+    depends_on: list[int],
+    chunk_index: int,
+) -> int | None:
+    if trace_context is None:
+        return None
+    return trace_context.add_instant(
+        name,
+        thread=trace_context.main_thread,
+        time_ns=trace_time_ns(time_value),
+        depends_on=depends_on,
+        chunk_index=chunk_index,
+    )
+
+
+def _trace_main_range(
+    trace_context: TraceContext | None,
+    name: str,
+    *,
+    begin_time: float,
+    end_time: float,
+    depends_on: list[int],
+    chunk_index: int | None = None,
+    chunk_size: int | None = None,
+    frame_index: int | None = None,
+    per_frame_error_ms: float | None = None,
+    input_sample_time_ns: int | None = None,
+    image_ready_time_ns: int | None = None,
+) -> int | None:
+    if trace_context is None:
+        return None
+    components: dict[str, TraceComponentValue] = {}
+    if chunk_index is not None:
+        components["chunk_index"] = chunk_index
+    if chunk_size is not None:
+        components["chunk_size"] = chunk_size
+    if frame_index is not None:
+        components["frame_index"] = frame_index
+    if per_frame_error_ms is not None:
+        components["per_frame_error_ms"] = per_frame_error_ms
+    if input_sample_time_ns is not None:
+        components["input_sample_time_ns"] = input_sample_time_ns
+    if image_ready_time_ns is not None:
+        components["image_ready_time_ns"] = image_ready_time_ns
+    return trace_context.add_range(
+        name,
+        thread=trace_context.main_thread,
+        begin_ns=trace_time_ns(begin_time),
+        end_ns=trace_time_ns(end_time),
+        depends_on=depends_on,
+        **components,
+    )

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/timing.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/timing.py
@@ -11,6 +11,18 @@ correlation, no copying or re-association).
 
 from collections import deque
 from dataclasses import dataclass
+from threading import Lock
+from typing import Protocol
+
+TraceComponentValue = str | int | float | bool | None
+
+
+def trace_time_ns(seconds: float) -> int:
+    return int(seconds * 1_000_000_000)
+
+
+def event_dependencies(*events: int | None) -> list[int]:
+    return [event for event in events if event is not None]
 
 
 @dataclass
@@ -22,6 +34,35 @@ class FrameTimes:
     present_time: float | None = None
 
 
+@dataclass(frozen=True)
+class ChunkPrediction:
+    """Predicted timestamps for a chunk's pipeline stages.
+
+    Stage 1 only predicts ``first_present`` (when the chunk's first frame
+    will reach the screen). The Stage 2 design adds intermediate
+    EMA-summed milestones (``request -> render_start -> chunk_ready ->
+    decode_first -> first_present``) per ``alpasim.frame_timing``; new
+    fields land here as named attributes when that work arrives.
+
+    Use :meth:`create` rather than constructing directly: the prediction
+    formula lives there so it stays beside the data it produces.
+    """
+
+    first_present: float
+
+    @classmethod
+    def create(
+        cls, *, request_time: float, frame_interval_s: float
+    ) -> "ChunkPrediction":
+        """Stage 1 prediction: ``first_present = request_time + frame_interval_s``.
+
+        Placeholder for the Stage 2 EMA-summed prediction chain; the
+        signature stays the same so callers don't change when Stage 2
+        lands and the body grows to consume EMA latency stats.
+        """
+        return cls(first_present=request_time + frame_interval_s)
+
+
 @dataclass
 class ChunkTimes:
     chunk_index: int
@@ -29,6 +70,7 @@ class ChunkTimes:
     request_time: float
     request_poses_ready_time: float
     frames: list[FrameTimes]
+    prediction: ChunkPrediction | None = None
     chunk_render_start_time: float | None = None
     chunk_ready_time: float | None = None
 
@@ -40,6 +82,7 @@ class ChunkTimes:
         request_time: float,
         request_poses_ready_time: float,
         intended_present_times: list[float],
+        prediction: ChunkPrediction | None = None,
     ) -> "ChunkTimes":
         frames = [
             FrameTimes(frame_index=index, intended_present_time=time_value)
@@ -51,6 +94,7 @@ class ChunkTimes:
             request_time=request_time,
             request_poses_ready_time=request_poses_ready_time,
             frames=frames,
+            prediction=prediction,
         )
 
 
@@ -60,3 +104,83 @@ class ChunkHistory:
 
     def append(self, chunk: ChunkTimes) -> None:
         self._deque.append(chunk)
+
+
+class TraceSink(Protocol):
+    def add_thread(self, name: str) -> int: ...
+
+    def add_instant(
+        self,
+        name: str,
+        *,
+        thread: int,
+        time_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int: ...
+
+    def add_range(
+        self,
+        name: str,
+        *,
+        thread: int,
+        begin_ns: int,
+        end_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int: ...
+
+
+@dataclass(frozen=True)
+class TraceContext:
+    sink: TraceSink
+    main_thread: int
+    worker_thread: int
+    lock: Lock
+
+    @classmethod
+    def create(cls, sink: TraceSink) -> "TraceContext":
+        return cls(
+            sink=sink,
+            main_thread=sink.add_thread("main"),
+            worker_thread=sink.add_thread("pipeline-worker"),
+            lock=Lock(),
+        )
+
+    def add_instant(
+        self,
+        name: str,
+        *,
+        thread: int,
+        time_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int:
+        with self.lock:
+            return self.sink.add_instant(
+                name,
+                thread=thread,
+                time_ns=time_ns,
+                depends_on=depends_on,
+                **components,
+            )
+
+    def add_range(
+        self,
+        name: str,
+        *,
+        thread: int,
+        begin_ns: int,
+        end_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int:
+        with self.lock:
+            return self.sink.add_range(
+                name,
+                thread=thread,
+                begin_ns=begin_ns,
+                end_ns=end_ns,
+                depends_on=depends_on,
+                **components,
+            )

--- a/integrations/omnidreams/omnidreams/interactive_drive/types.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/types.py
@@ -208,10 +208,21 @@ class PresentedFrame:
 
 
 @dataclass(frozen=True)
+class VideoModelTimings:
+    condition_start_time: float
+    condition_ready_time: float
+    model_start_time: float
+    model_ready_time: float
+    merge_start_time: float
+    merge_ready_time: float
+
+
+@dataclass(frozen=True)
 class FrameChunk:
     frames: tuple[PresentedFrame, ...]
     boundary_state_after_chunk: VehicleState
     source_name: str
+    video_model_timings: VideoModelTimings | None = None
 
 
 @dataclass(frozen=True)

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -9,7 +9,12 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from loguru import logger
-from omnidreams.interactive_drive.runtime.timing import ChunkTimes
+from omnidreams.interactive_drive.runtime.timing import (
+    ChunkTimes,
+    TraceContext,
+    event_dependencies,
+    trace_time_ns,
+)
 from omnidreams.interactive_drive.types import (
     FrameChunk,
     PresentedFrame,
@@ -50,6 +55,7 @@ class ChunkRequest:
 
     trajectory: TrajectoryChunk
     chunk_times: ChunkTimes
+    trace_dependency_event: int | None = None
 
 
 @dataclass(frozen=True)
@@ -61,6 +67,7 @@ class QueuedFrame:
     # switch bumps the generation; the loop drops frames whose generation
     # no longer matches so stale rollout/scene frames aren't presented.
     generation: int = 0
+    worker_ready_event_id: int | None = None
 
 
 # Worker commands are closures that take the backend and return ``True`` to
@@ -70,8 +77,11 @@ _WorkerCommand = Callable[["VideoModelBackend"], bool]
 
 
 class ChunkPipeline:
-    def __init__(self, backend: VideoModelBackend) -> None:
+    def __init__(
+        self, backend: VideoModelBackend, trace_context: TraceContext | None = None
+    ) -> None:
         self._backend = backend
+        self._trace_context = trace_context
         # Unbounded so ``put`` never blocks the worker against shutdown.
         # TODO: gate in-flight work at the request site (frame-level, alpasim
         # style) instead of the loop's chunk-level ``chunks_outstanding`` gate.
@@ -182,10 +192,15 @@ class ChunkPipeline:
 
         chunk_times = request.chunk_times
         trajectory = request.trajectory
+        trace_dependency_event = request.trace_dependency_event
         submit_generation = self.current_generation
 
         def render_command(backend: VideoModelBackend) -> bool:
-            chunk_times.chunk_render_start_time = time.perf_counter()
+            trace_context = (
+                self._trace_context if chunk_times.chunk_index >= 1 else None
+            )
+            render_start = time.perf_counter()
+            chunk_times.chunk_render_start_time = render_start
             if submit_generation != self.current_generation:
                 chunk_times.chunk_ready_time = time.perf_counter()
                 logger.info(
@@ -194,8 +209,59 @@ class ChunkPipeline:
                     f"current_generation={self.current_generation}",
                 )
                 return True
+            queue_wait_event = None
+            if trace_context is not None:
+                queue_wait_event = trace_context.add_range(
+                    "queue_wait",
+                    thread=trace_context.worker_thread,
+                    begin_ns=trace_time_ns(chunk_times.request_poses_ready_time),
+                    end_ns=trace_time_ns(render_start),
+                    depends_on=event_dependencies(trace_dependency_event),
+                    chunk_index=chunk_times.chunk_index,
+                )
             frame_chunk = backend.render_chunk(trajectory)
-            chunk_times.chunk_ready_time = time.perf_counter()
+            render_end = time.perf_counter()
+            chunk_times.chunk_ready_time = render_end
+            worker_ready_event_id = None
+            if trace_context is not None:
+                chunk_render_event = trace_context.add_range(
+                    "chunk_render",
+                    thread=trace_context.worker_thread,
+                    begin_ns=trace_time_ns(render_start),
+                    end_ns=trace_time_ns(render_end),
+                    depends_on=event_dependencies(queue_wait_event),
+                    chunk_index=chunk_times.chunk_index,
+                    chunk_size=len(trajectory.timestamps_us),
+                    input_sample_time_ns=trace_time_ns(chunk_times.input_sample_time),
+                    source=frame_chunk.source_name,
+                )
+                worker_ready_event_id = chunk_render_event
+                timings = frame_chunk.video_model_timings
+                if timings is not None:
+                    condition_event = trace_context.add_range(
+                        "condition_raster",
+                        thread=trace_context.worker_thread,
+                        begin_ns=trace_time_ns(timings.condition_start_time),
+                        end_ns=trace_time_ns(timings.condition_ready_time),
+                        depends_on=event_dependencies(queue_wait_event),
+                        chunk_index=chunk_times.chunk_index,
+                    )
+                    model_event = trace_context.add_range(
+                        "model_generate",
+                        thread=trace_context.worker_thread,
+                        begin_ns=trace_time_ns(timings.model_start_time),
+                        end_ns=trace_time_ns(timings.model_ready_time),
+                        depends_on=event_dependencies(condition_event),
+                        chunk_index=chunk_times.chunk_index,
+                    )
+                    worker_ready_event_id = trace_context.add_range(
+                        "frame_merge",
+                        thread=trace_context.worker_thread,
+                        begin_ns=trace_time_ns(timings.merge_start_time),
+                        end_ns=trace_time_ns(timings.merge_ready_time),
+                        depends_on=event_dependencies(model_event),
+                        chunk_index=chunk_times.chunk_index,
+                    )
             # Drop the output if a reset / scene switch superseded this chunk
             # while it was queued or rendering -- its frames belong to a
             # rollout the user has already moved on from.
@@ -214,6 +280,7 @@ class ChunkPipeline:
                         chunk_times=chunk_times,
                         frame_index=frame_index,
                         generation=submit_generation,
+                        worker_ready_event_id=worker_ready_event_id,
                     )
                 )
             return True
@@ -252,7 +319,15 @@ class ChunkPipeline:
             warmup_start = time.perf_counter()
             logger.info("[chunk-pipeline] warmup start")
             self._backend.warmup_model()
-            warmup_elapsed_ms = (time.perf_counter() - warmup_start) * 1000.0
+            warmup_end = time.perf_counter()
+            if self._trace_context is not None:
+                self._trace_context.add_range(
+                    "worker_warmup",
+                    thread=self._trace_context.worker_thread,
+                    begin_ns=trace_time_ns(warmup_start),
+                    end_ns=trace_time_ns(warmup_end),
+                )
+            warmup_elapsed_ms = (warmup_end - warmup_start) * 1000.0
             logger.info(
                 f"[chunk-pipeline] warmup done elapsed_ms={warmup_elapsed_ms:.1f}",
             )

--- a/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_chunk_pipeline.py
@@ -3,7 +3,7 @@
 
 import threading
 import time
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import numpy as np
@@ -12,12 +12,76 @@ from omnidreams.interactive_drive._pipeline_fakes import (
     make_trajectory,
     minimal_scene,
 )
-from omnidreams.interactive_drive.runtime.timing import ChunkTimes
+from omnidreams.interactive_drive.runtime.timing import (
+    ChunkTimes,
+    TraceComponentValue,
+    TraceContext,
+)
 from omnidreams.interactive_drive.types import FrameChunk, PresentedFrame, SceneBundle
 from omnidreams.interactive_drive.video_model.chunk_pipeline import (
     ChunkPipeline,
     ChunkRequest,
 )
+
+
+@dataclass(frozen=True)
+class _TraceEvent:
+    name: str
+    depends_on: list[int]
+    components: dict[str, TraceComponentValue]
+
+
+class _RecordingTraceSink:
+    def __init__(self) -> None:
+        self.threads: list[str] = []
+        self.events: list[_TraceEvent] = []
+
+    def add_thread(self, name: str) -> int:
+        self.threads.append(name)
+        return len(self.threads) - 1
+
+    def add_instant(
+        self,
+        name: str,
+        *,
+        thread: int,
+        time_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int:
+        del thread, time_ns
+        return self._append_event(name, depends_on, components)
+
+    def add_range(
+        self,
+        name: str,
+        *,
+        thread: int,
+        begin_ns: int,
+        end_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int:
+        del thread
+        event_components = dict(components)
+        event_components["begin_ns"] = begin_ns
+        event_components["end_ns"] = end_ns
+        return self._append_event(name, depends_on, event_components)
+
+    def _append_event(
+        self,
+        name: str,
+        depends_on: list[int] | None,
+        components: dict[str, TraceComponentValue],
+    ) -> int:
+        self.events.append(
+            _TraceEvent(
+                name=name,
+                depends_on=[] if depends_on is None else depends_on,
+                components=components,
+            )
+        )
+        return len(self.events) - 1
 
 
 class _GatedBackend:
@@ -278,3 +342,35 @@ def test_chunk_pipeline_skips_stale_scene_load_queued_behind_warmup() -> None:
 
     assert backend.loaded_prompts == ["snow"]
     assert backend.render_calls == 0
+
+
+def test_chunk_pipeline_emits_worker_trace_ranges() -> None:
+    sink = _RecordingTraceSink()
+    trace_context = TraceContext.create(sink)
+    backend = FakeVideoModelBackend(frames_per_render=1)
+    pipeline = ChunkPipeline(backend, trace_context=trace_context)
+    pipeline.request_scene(minimal_scene())
+    chunk_times = _chunk_times(chunk_size=1)
+    chunk_times.chunk_index = 1
+    pipeline.request_pose_chunk(
+        ChunkRequest(
+            trajectory=make_trajectory(1),
+            chunk_times=chunk_times,
+            trace_dependency_event=123,
+        )
+    )
+
+    queued = pipeline.frame_queue.get(timeout=1.0)
+    pipeline.shutdown()
+
+    assert queued.worker_ready_event_id is not None
+    names = [event.name for event in sink.events]
+    assert "worker_warmup" in names
+    assert "queue_wait" in names
+    assert "chunk_render" in names
+    queue_wait = sink.events[names.index("queue_wait")]
+    chunk_render = sink.events[names.index("chunk_render")]
+    assert queue_wait.depends_on == [123]
+    assert chunk_render.depends_on == [names.index("queue_wait")]
+    assert chunk_render.components["chunk_index"] == 1
+    assert chunk_render.components["source"] == "fake"

--- a/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_latency_loop.py
@@ -3,7 +3,7 @@
 
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from types import SimpleNamespace
 
 import numpy as np
@@ -20,7 +20,12 @@ from omnidreams.interactive_drive.runtime.loop import (
     present_queued_frame,
     run_main_loop,
 )
-from omnidreams.interactive_drive.runtime.timing import ChunkTimes
+from omnidreams.interactive_drive.runtime.timing import (
+    ChunkPrediction,
+    ChunkTimes,
+    TraceComponentValue,
+    TraceContext,
+)
 from omnidreams.interactive_drive.types import (
     DriverCommand,
     PresentedFrame,
@@ -84,6 +89,66 @@ def _loop_config(*, frame_interval_s: float) -> LoopConfig:
 class _PresentRecord:
     frame: PresentedFrame
     view_mode: str
+
+
+@dataclass(frozen=True)
+class _TraceEvent:
+    name: str
+    depends_on: list[int]
+    components: dict[str, TraceComponentValue]
+
+
+class _RecordingTraceSink:
+    def __init__(self) -> None:
+        self.threads: list[str] = []
+        self.events: list[_TraceEvent] = []
+
+    def add_thread(self, name: str) -> int:
+        self.threads.append(name)
+        return len(self.threads) - 1
+
+    def add_instant(
+        self,
+        name: str,
+        *,
+        thread: int,
+        time_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int:
+        del thread, time_ns
+        return self._append_event(name, depends_on, components)
+
+    def add_range(
+        self,
+        name: str,
+        *,
+        thread: int,
+        begin_ns: int,
+        end_ns: int,
+        depends_on: list[int] | None = None,
+        **components: TraceComponentValue,
+    ) -> int:
+        del thread
+        event_components = dict(components)
+        event_components["begin_ns"] = begin_ns
+        event_components["end_ns"] = end_ns
+        return self._append_event(name, depends_on, event_components)
+
+    def _append_event(
+        self,
+        name: str,
+        depends_on: list[int] | None,
+        components: dict[str, TraceComponentValue],
+    ) -> int:
+        self.events.append(
+            _TraceEvent(
+                name=name,
+                depends_on=[] if depends_on is None else depends_on,
+                components=components,
+            )
+        )
+        return len(self.events) - 1
 
 
 class _CountingPresenter:
@@ -202,8 +267,10 @@ def _drive_loop(
     simulation: _FakeSimulation,
     initial: PresentedFrame,
     frame_interval_s: float,
+    trace_context: TraceContext | None = None,
+    stop_after_consumed_chunks: int | None = None,
 ) -> bool:
-    pipeline = ChunkPipeline(backend)
+    pipeline = ChunkPipeline(backend, trace_context=trace_context)
     pipeline.request_scene(minimal_scene())
     try:
         return run_main_loop(
@@ -213,7 +280,11 @@ def _drive_loop(
             input_backend=_FakeInputBackend(),
             simulation=simulation,
             pipeline=pipeline,
-            config=_loop_config(frame_interval_s=frame_interval_s),
+            config=replace(
+                _loop_config(frame_interval_s=frame_interval_s),
+                stop_after_consumed_chunks=stop_after_consumed_chunks,
+            ),
+            trace_context=trace_context,
         )
     finally:
         pipeline.shutdown()
@@ -445,6 +516,7 @@ def test_loop_stamps_full_timing_chain_on_same_chunktimes_instance(
         request_time: float,
         request_poses_ready_time: float,
         intended_present_times: list[float],
+        prediction: ChunkPrediction | None = None,
     ) -> ChunkTimes:
         instance = original_create(
             chunk_index=chunk_index,
@@ -452,6 +524,7 @@ def test_loop_stamps_full_timing_chain_on_same_chunktimes_instance(
             request_time=request_time,
             request_poses_ready_time=request_poses_ready_time,
             intended_present_times=intended_present_times,
+            prediction=prediction,
         )
         captured.append(instance)
         return instance
@@ -502,3 +575,43 @@ def test_loop_stamps_full_timing_chain_on_same_chunktimes_instance(
     assert chunk_ready <= image_ready
     assert image_ready <= sample_display
     assert sample_display <= present
+
+
+def test_loop_traces_present_wait_as_sleep_range_dependency() -> None:
+    sink = _RecordingTraceSink()
+    trace_context = TraceContext.create(sink)
+    initial = _make_frame()
+    presenter = _CountingPresenter(present_budget=_backend_frame_wait_budget())
+    controls = _FakeRuntimeControls()
+
+    result = _drive_loop(
+        presenter=presenter,
+        controls=controls,
+        backend=FakeVideoModelBackend(frames_per_render=1, rgb_value=11),
+        simulation=_FakeSimulation(),
+        initial=initial,
+        frame_interval_s=0.001,
+        trace_context=trace_context,
+        stop_after_consumed_chunks=2,
+    )
+
+    assert result is False
+    names = [event.name for event in sink.events]
+    assert "present_wait" in names
+    assert "present_frame" in names
+    wait_indices = {
+        event_index
+        for event_index, event in enumerate(sink.events)
+        if event.name == "present_wait"
+    }
+    wait = sink.events[min(wait_indices)]
+    present = next(
+        event
+        for event in sink.events
+        if event.name == "present_frame" and wait_indices.intersection(event.depends_on)
+    )
+    assert wait.components["end_ns"] >= wait.components["begin_ns"]
+    assert present.components["chunk_index"] >= 1
+    # The present_frame event carries the chunk's image-ready timestamp so the
+    # chunk-ready -> present latency is recoverable from the trace.
+    assert present.components["image_ready_time_ns"] > 0


### PR DESCRIPTION
Instrument the interactive-drive main loop and pipeline worker to emit trace events (input sample, request, simulation step, queue wait, chunk render, worker warmup, present wait/frame) via a TraceSink/TraceContext interface, threaded through the app, loop, and chunk pipeline. Carry per-chunk VideoModelTimings so the world-model backend can break the render range into condition/model/merge sub-ranges.

Add a deterministic --stop-after-chunks stop condition so traces cover a fixed workload.