### PR TITLE
Package LingBot WebRTC assets in wheels

### DIFF
--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -53,5 +53,13 @@ dev = [
 include = ["lingbot*"]
 exclude = ["tests"]
 
+[tool.setuptools.package-data]
+"lingbot.webrtc.web" = [
+    "*.html",
+    "*.css",
+    "*.js",
+    "assets/*.svg",
+]
+
 [tool.uv]
 managed = true


### PR DESCRIPTION
## Summary

Include the LingBot WebRTC web UI files in the flashdreams-lingbot wheel so runtime package lookups can serve the HTML, CSS, JS, and SVG assets after installation.

## Tests

- `uv build integrations/lingbot`