### PR TITLE
Package OmniDreams WebRTC assets in wheels

### DIFF
--- a/integrations/omnidreams/omnidreams/webrtc/web/__init__.py
+++ b/integrations/omnidreams/omnidreams/webrtc/web/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Web UI package marker for wheel packaging."""

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -114,6 +114,7 @@ exclude = ["tests"]
 # workspace editable. Editable installs pick these up from the source
 # tree automatically.
 [tool.setuptools.package-data]
+"omnidreams.webrtc.web" = ["*.html", "*.css", "*.js"]
 "omnidreams.interactive_drive" = [
     "configs/*.yaml",
     "configs/wheels/*.yaml",


### PR DESCRIPTION
## Summary

Include the OmniDreams WebRTC web UI files in the flashdreams-omnidreams wheel so the server can serve the HTML, CSS, and JS assets after installation.

Fixes #302.

## Tests

- `uv build integrations/omnidreams`