### PR TITLE
avoid checkin .doctrees to gh-pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -66,6 +66,11 @@ jobs:
         run: |
           uv run --no-project sphinx-build -b html docs/source _build
 
+      - name: Prune Sphinx cache artifacts from publish dir
+        # Prevent Sphinx cache/metadata from being published to gh-pages.
+        run: |
+          rm -rf _build/.doctrees
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         # Only publish for real landings on main, releases, or manual runs —


### PR DESCRIPTION
Update Doc build CI: Avoid checking in `.doctrees` into gh-pages can cut a ton of repo sizes:

before 
```
24M     ./main
242M    ./pr-preview
```

after prune out `.doctrees`
```
7.2M    ./main
113M    ./pr-preview
```