### PR TITLE
Add synthetic interactive-drive world model

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -604,5 +604,9 @@ automatically — the subpackage's `tests/conftest.py` auto-stamps each test
 with the right workspace CI-tier marker based on its existing
 `gpu` / `xvfb` markers.
 
+Pass `--synthetic-model` (or `synthetic_model: true` in the manifest) to run
+the world model on local random-initialized weights, so latency/code-path
+tests run with no checkpoint downloads.
+
 The hook does not auto-fix. Use `./scripts/check.sh --fix` to clean up lint and
 format issues explicitly.

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -154,6 +154,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--synthetic-model",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Override the world-model manifest's synthetic_model setting. "
+            "Synthetic mode uses local default-initialized model weights and "
+            "synthetic embeddings while keeping the manifest's performance knobs."
+        ),
+    )
+    parser.add_argument(
         "--official-hdmap-dir",
         type=Path,
         default=None,
@@ -468,6 +478,8 @@ def prepare_config_and_backend(
         if config.manifest_path is None:
             raise SystemExit("--manifest is required for the omnidreams backend")
         manifest = load_world_model_manifest(config.manifest_path)
+        if args.synthetic_model is not None:
+            manifest = replace(manifest, synthetic_model=bool(args.synthetic_model))
         if args.official_hdmap_dir is not None:
             manifest = replace(
                 manifest, debug_condition_frame_dir=args.official_hdmap_dir.resolve()

--- a/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model_synthetic.yaml
+++ b/integrations/omnidreams/omnidreams/interactive_drive/configs/example_world_model_synthetic.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+# Mirror of example_world_model_perf.yaml with synthetic_model enabled, so the
+# interactive-drive latency path runs on local random-initialized weights with
+# no checkpoint downloads. synthetic_model swaps only weight sources, not perf
+# knobs. To avoid drift, prefer running the real manifest with the flag:
+#   interactive-drive --manifest example_world_model_perf.yaml --synthetic-model
+synthetic_model: true
+resolution_wh: [1168, 640]
+fps: 30
+num_frames_per_block: 8
+compile_net: true
+light_vae: true
+encode_with_pixel_shuffle: false
+local_attn_size: 6
+skip_finalize_kv_cache: true
+sink_size: 0
+denoising_steps: [1000, 100]
+upsampling_enabled: false
+upsampling_scale: 4
+device: cuda:0
+seed_for_every_rollout:
+
+native_dit_acceleration: required
+native_dit_backend: fp8_kvcache_cudnn
+native_dit_attention_backend: cudnn
+
+native_vae_encoder: disabled

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -15,6 +15,10 @@ from loguru import logger
 from omnidreams.interactive_drive.config import WorldModelProfileConfig
 from omnidreams.interactive_drive.cuda_host_prefetch import CudaHostPrefetch
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
+from omnidreams.interactive_drive.world_model.synthetic_fixture import (
+    build_synthetic_world_model_assets,
+    default_synthetic_asset_dir,
+)
 
 PipelineFactory = Callable[[WorldModelManifest, WorldModelProfileConfig], Any]
 _VIEW_NAMES = ["camera_front_wide_120fov"]
@@ -79,6 +83,9 @@ def _pipeline_config_log_line(
     scheduler = config.diffusion_model.scheduler
     encoder = config.encoder
     image_encoder = config.image_encoder
+    encoder_native = getattr(encoder, "native_vae_acceleration", None)
+    image_encoder_native = getattr(image_encoder, "native_vae_acceleration", None)
+    native_backend = getattr(encoder, "native_vae_backend", None)
     return (
         "[flashdreams-session] resolved pipeline config "
         f"selected_recipe={config_name} "
@@ -90,9 +97,9 @@ def _pipeline_config_log_line(
         f"compile_network={transformer.compile_network} "
         f"use_cuda_graph={transformer.use_cuda_graph} "
         f"denoising_steps={list(scheduler.denoising_timesteps)} "
-        f"encoder_native_vae={encoder.native_vae_acceleration} "
-        f"image_encoder_native_vae={image_encoder.native_vae_acceleration} "
-        f"native_vae_backend={encoder.native_vae_backend}"
+        f"encoder_native_vae={encoder_native} "
+        f"image_encoder_native_vae={image_encoder_native} "
+        f"native_vae_backend={native_backend}"
     )
 
 
@@ -158,12 +165,75 @@ def _build_pipeline_config(
             f"{config_name} uses flashdreams default denoising steps [1000, 450]; "
             f"got {manifest.denoising_steps}."
         )
+    if manifest.synthetic_model:
+        config = _apply_synthetic_model_overrides(
+            config,
+            manifest=manifest,
+            config_name=base_config_name,
+            derive_config=derive_config,
+        )
     logger.info(
         _pipeline_config_log_line(
             config,
             config_name=config_name,
             base_config_name=base_config_name,
         ),
+    )
+    return config
+
+
+def _apply_synthetic_model_overrides(
+    config: Any,
+    *,
+    manifest: WorldModelManifest,
+    config_name: str,
+    derive_config: Callable[..., Any],
+) -> Any:
+    # Raise rather than ``assert`` so the guard survives ``python -O``.
+    if config.encoder is None:
+        raise ValueError("synthetic Omnidreams config requires an encoder")
+    if config.decoder is None:
+        raise ValueError("synthetic Omnidreams config requires a decoder")
+
+    width, height = manifest.resolution_wh
+    assets = build_synthetic_world_model_assets(
+        default_synthetic_asset_dir(config_name=config_name),
+        encoder_cfg=config.encoder,
+        decoder_cfg=config.decoder,
+        native_vae_fp8=manifest.native_vae_encoder == "fp8",
+        pixel_height=height,
+        pixel_width=width,
+        device=manifest.device,
+    )
+    text_encoder = getattr(config, "text_encoder", None)
+    text_max_length = int(getattr(text_encoder, "max_length", 512))
+
+    encoder_patch: dict[str, object] = {}
+    if assets.encoder_checkpoint_path is not None:
+        encoder_patch["checkpoint_path"] = str(assets.encoder_checkpoint_path)
+    if assets.native_vae_fp8_state_path is not None:
+        encoder_patch["native_vae_fp8_state_path"] = str(
+            assets.native_vae_fp8_state_path
+        )
+
+    decoder_patch: dict[str, object] = {
+        "checkpoint_path": str(assets.decoder_checkpoint_path),
+        "state_dict_transform": None,
+    }
+
+    # ``synthetic_text_max_length`` is a real OmnidreamsPipelineConfig field, so
+    # thread it through derive_config alongside the encoder swap rather than
+    # mutating the config afterwards. The text encoder is dropped here, so this
+    # is the only surviving record of the production sequence length that
+    # ``_synthetic_embeddings_for_pipeline`` needs to size the zero embeddings.
+    config = derive_config(
+        config,
+        text_encoder=None,
+        image_encoder=None,
+        encoder=encoder_patch,
+        decoder=decoder_patch,
+        diffusion_model=dict(transformer=dict(checkpoint_path=None)),
+        synthetic_text_max_length=text_max_length,
     )
     return config
 
@@ -320,6 +390,67 @@ def _to_model_range(tensor: torch.Tensor, *, device: torch.device) -> torch.Tens
     return tensor / 127.5 - 1.0
 
 
+def _synthetic_embeddings_for_pipeline(
+    pipeline: Any,
+    manifest: WorldModelManifest,
+) -> dict[str, torch.Tensor | None]:
+    transformer = pipeline.diffusion_model.transformer
+    transformer_cfg = transformer.config
+    network_cfg = transformer_cfg.network
+    text_dim = (
+        int(network_cfg.crossattn_proj_in_channels)
+        if network_cfg.use_crossattn_projection
+        else int(network_cfg.crossattn_emb_channels)
+    )
+    # Set by _apply_synthetic_model_overrides; read strictly (no silent default)
+    # so a missing value fails loudly instead of mis-sizing the embeddings.
+    text_max_length = pipeline.config.synthetic_text_max_length
+    if text_max_length is None:
+        raise RuntimeError(
+            "synthetic_text_max_length is unset; _apply_synthetic_model_overrides "
+            "must run before synthetic cache initialization"
+        )
+    text_tokens = int(text_max_length)
+    batch_size = int(np.prod(transformer_cfg.batch_shape))
+    num_views = int(transformer_cfg.num_views) * int(getattr(pipeline, "V_size", 1))
+    latent_channels = int(network_cfg.in_channels)
+    decoder = pipeline.decoder
+    if decoder is None:
+        raise RuntimeError("synthetic_model requires a video decoder")
+    compression = int(decoder.spatial_compression_ratio)
+    width, height = manifest.resolution_wh
+    if height % compression or width % compression:
+        raise ValueError(
+            "synthetic_model resolution_wh must be divisible by decoder "
+            f"spatial compression {compression}, got {(width, height)}"
+        )
+    latent_height = height // compression
+    latent_width = width // compression
+    dtype = transformer_cfg.dtype
+    device = pipeline.device
+
+    text_embeddings = torch.zeros(
+        (batch_size, num_views, text_tokens, text_dim),
+        device=device,
+        dtype=dtype,
+    )
+    image_embeddings = torch.zeros(
+        (batch_size, num_views, 1, latent_channels, latent_height, latent_width),
+        device=device,
+        dtype=dtype,
+    )
+    negative_text_embeddings = (
+        torch.zeros_like(text_embeddings)
+        if transformer_cfg.requires_negative_text_embeddings
+        else None
+    )
+    return {
+        "text_embeddings": text_embeddings,
+        "image_embeddings": image_embeddings,
+        "negative_text_embeddings": negative_text_embeddings,
+    }
+
+
 class FlashdreamsWorldModelSession:
     """Thin adapter from interactive-drive chunking to flashdreams AlpadreamsPipeline."""
 
@@ -355,7 +486,11 @@ class FlashdreamsWorldModelSession:
         # prepare_for_scene so the one-shot encoders are freed before the
         # AR pipeline is allocated (peak-VRAM ordering); every other path
         # builds the pipeline eagerly with no scene needed.
-        return self._pipeline_factory is not None or not self._offload_text_encoder
+        return (
+            self.manifest.synthetic_model
+            or self._pipeline_factory is not None
+            or not self._offload_text_encoder
+        )
 
     def warmup_model(self) -> None:
         """Build the scene-independent diffusion pipeline (weights + compile).
@@ -368,7 +503,7 @@ class FlashdreamsWorldModelSession:
         start = time.perf_counter()
         if self._pipeline_factory is not None:
             self._pipeline = self._pipeline_factory(self.manifest, self._profile_config)
-        elif self._offload_text_encoder:
+        elif self._offload_text_encoder and not self.manifest.synthetic_model:
             return
         else:
             config = _build_pipeline_config(self.manifest, self._profile_config)
@@ -390,6 +525,8 @@ class FlashdreamsWorldModelSession:
         (precompute embeddings -> free encoders -> build pipeline) to keep
         peak VRAM low; the factory test path recomputes lazily in ``start``.
         """
+        if self.manifest.synthetic_model:
+            return
         if not self._offload_text_encoder:
             return
         self._precomputed_embeddings = None
@@ -517,6 +654,8 @@ class FlashdreamsWorldModelSession:
         self._pipeline = None
 
     def _initialize_cache(self, initial_rgb: object, prompt: str) -> Any:
+        if self.manifest.synthetic_model:
+            return self._initialize_synthetic_cache()
         if self._offload_text_encoder:
             embeddings = self._ensure_precomputed_embeddings(initial_rgb, prompt)
             initialize_cache_from_embeddings = getattr(
@@ -536,6 +675,25 @@ class FlashdreamsWorldModelSession:
         return self.pipeline.initialize_cache(
             text=[[prompt]],
             image=self._initial_rgb_tensor(initial_rgb),
+            view_names=_VIEW_NAMES,
+        )
+
+    def _initialize_synthetic_cache(self) -> Any:
+        initialize_cache_from_embeddings = getattr(
+            self.pipeline, "initialize_cache_from_embeddings", None
+        )
+        if not callable(initialize_cache_from_embeddings):
+            raise RuntimeError(
+                "synthetic_model requires flashdreams initialize_cache_from_embeddings()."
+            )
+        embeddings = _synthetic_embeddings_for_pipeline(
+            self.pipeline,
+            self.manifest,
+        )
+        return initialize_cache_from_embeddings(
+            text_embeddings=embeddings["text_embeddings"],
+            image_embeddings=embeddings["image_embeddings"],
+            negative_text_embeddings=embeddings["negative_text_embeddings"],
             view_names=_VIEW_NAMES,
         )
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
@@ -146,6 +146,7 @@ def _parse_native_vae_encoder(raw: object) -> str:
 @dataclass(frozen=True)
 class WorldModelManifest:
     debug_condition_frame_dir: Path | None = None
+    synthetic_model: bool = False
     resolution_wh: tuple[int, int] = _DEFAULT_RESOLUTION_WH
     fps: int = 30
     num_frames_per_block: int = 8
@@ -196,6 +197,7 @@ def load_world_model_manifest(path: str | Path) -> WorldModelManifest:
             data.get("debug_condition_frame_dir"),
             manifest_dir=manifest_dir,
         ),
+        synthetic_model=bool(data.get("synthetic_model", False)),
         resolution_wh=resolution,
         fps=int(data.get("fps", 30)),
         num_frames_per_block=int(data.get("num_frames_per_block", 8)),

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/synthetic_fixture.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/synthetic_fixture.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Offline synthetic assets for interactive-drive world-model latency runs."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import os
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import save_file
+
+from flashdreams.recipes.taehv import TeahvVAEDecoderConfig
+from flashdreams.recipes.taehv.impl import TAEHV
+from flashdreams.recipes.wan.autoencoder import vae as wan_vae_module
+from flashdreams.recipes.wan.autoencoder.vae import (
+    WanVAEDecoderConfig,
+    WanVAEEncoderConfig,
+)
+
+_DEFAULT_SYNTHETIC_SEED = 20260611
+_CACHE_SUBDIR = "synthetic_world_model"
+
+
+@dataclass(frozen=True)
+class SyntheticWorldModelAssets:
+    """Local checkpoint-like files used by a synthetic world-model config."""
+
+    encoder_checkpoint_path: Path | None
+    decoder_checkpoint_path: Path
+    native_vae_fp8_state_path: Path | None = None
+
+
+def default_synthetic_asset_dir(*, config_name: str) -> Path:
+    """Return the cache directory for synthetic assets for a config slug."""
+
+    cache_root = Path(
+        os.environ.get("FLASHDREAMS_CACHE_DIR", "~/.cache/flashdreams")
+    ).expanduser()
+    return cache_root / _CACHE_SUBDIR / config_name
+
+
+def build_synthetic_world_model_assets(
+    out_dir: Path,
+    *,
+    encoder_cfg: Any,
+    decoder_cfg: Any,
+    native_vae_fp8: bool = False,
+    pixel_height: int | None = None,
+    pixel_width: int | None = None,
+    device: torch.device | str = "cpu",
+    seed: int = _DEFAULT_SYNTHETIC_SEED,
+) -> SyntheticWorldModelAssets:
+    """Materialize complete offline weights matching the selected recipe.
+
+    The generated files are local single-file checkpoints consumed by the
+    normal production configs. They intentionally change only weight values,
+    not runtime flags such as compile, CUDA graph, or native acceleration.
+    """
+
+    out_dir = out_dir.expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    encoder_path = _maybe_build_wan_encoder_checkpoint(
+        out_dir,
+        encoder_cfg=encoder_cfg,
+        seed=seed,
+    )
+    decoder_path = _build_decoder_checkpoint(
+        out_dir,
+        decoder_cfg=decoder_cfg,
+        seed=seed + 1,
+    )
+    native_fp8_path = None
+    if native_vae_fp8:
+        if encoder_path is None:
+            raise TypeError("native VAE fp8 synthetic state requires a Wan VAE encoder")
+        if pixel_height is None or pixel_width is None:
+            raise ValueError("pixel_height and pixel_width are required for fp8 export")
+        native_fp8_path = _build_native_vae_fp8_state(
+            out_dir,
+            encoder_cfg=encoder_cfg,
+            encoder_checkpoint_path=encoder_path,
+            pixel_height=pixel_height,
+            pixel_width=pixel_width,
+            device=torch.device(device),
+        )
+
+    return SyntheticWorldModelAssets(
+        encoder_checkpoint_path=encoder_path,
+        decoder_checkpoint_path=decoder_path,
+        native_vae_fp8_state_path=native_fp8_path,
+    )
+
+
+def _config_uses_lightvae(config: Any) -> bool:
+    """Return whether ``config`` selects the lightvae VAE variant.
+
+    This intentionally mirrors production's own detection: ``WanVAEEncoder``
+    and ``WanVAEDecoder`` both choose the architecture with
+    ``"lightvae" in config.checkpoint_path`` (see
+    ``flashdreams/recipes/wan/autoencoder/vae.py``). Matching that exact rule
+    is the invariant that guarantees the synthetic checkpoint is generated for
+    the same architecture the production loader will reconstruct, so their keys
+    and shapes line up. The ``or ""`` is only None-safety -- production assumes
+    ``checkpoint_path`` is set -- and does not change which configs are treated
+    as lightvae. If production ever changes its detection, change it here too.
+    """
+
+    return "lightvae" in (getattr(config, "checkpoint_path", None) or "")
+
+
+_ARCH_FINGERPRINT_FIELDS = (
+    "base_dim",
+    "decoder_base_dim",
+    "z_dim",
+    "patch_size",
+    "is_residual",
+    "latent_mean",
+    "latent_std",
+    "checkpoint_path",
+)
+
+
+def _arch_fingerprint(*configs: Any, **extra: Any) -> str:
+    """Short hash of the shape-determining config fields.
+
+    Synthetic assets are cached per recipe slug and the cache persists across
+    CI runs (it lives under ``FLASHDREAMS_CACHE_DIR``). Embedding this
+    fingerprint in each filename means an in-place architectural change to a
+    recipe -- one that keeps the same slug but alters tensor shapes -- yields a
+    new filename and rebuilds, instead of the production loader silently failing
+    to load a stale checkpoint at warmup.
+    """
+
+    payload: list[Any] = []
+    for config in configs:
+        payload.append(type(config).__name__)
+        payload.extend(
+            (name, repr(getattr(config, name)))
+            for name in _ARCH_FINGERPRINT_FIELDS
+            if hasattr(config, name)
+        )
+    payload.extend(sorted(extra.items()))
+    digest = hashlib.sha256(repr(payload).encode("utf-8")).hexdigest()
+    return digest[:12]
+
+
+# Serializes the global ``load_checkpoint`` swap below. ``WanVAE.__init__`` has
+# no skip-load option, so the swap is unavoidable; the lock is held across the
+# whole build so two concurrent builders cannot interleave the set/restore and
+# leave the no-op installed permanently (which would silently hand every later
+# real WanVAE an empty state dict and random weights).
+_LOAD_CHECKPOINT_SWAP_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def _suppressed_checkpoint_load() -> Iterator[None]:
+    """Build ``WanVAE`` without reading a checkpoint.
+
+    The VAE is constructed only to capture its default-initialized architecture
+    before we overwrite the weights, so the module-level ``load_checkpoint``
+    (which would fail -- the synthetic file does not exist yet) is swapped for a
+    no-op returning an empty state dict. The swap mutates process-global state,
+    so it runs under ``_LOAD_CHECKPOINT_SWAP_LOCK``. A local set/restore keeps
+    ``unittest.mock`` out of this production module.
+    """
+
+    with _LOAD_CHECKPOINT_SWAP_LOCK:
+        original = wan_vae_module.load_checkpoint
+        wan_vae_module.load_checkpoint = lambda *args, **kwargs: {}
+        try:
+            yield
+        finally:
+            wan_vae_module.load_checkpoint = original
+
+
+def _maybe_build_wan_encoder_checkpoint(
+    out_dir: Path,
+    *,
+    encoder_cfg: Any,
+    seed: int,
+) -> Path | None:
+    if not isinstance(encoder_cfg, WanVAEEncoderConfig):
+        return None
+    use_lightvae = _config_uses_lightvae(encoder_cfg)
+    fingerprint = _arch_fingerprint(encoder_cfg)
+    stem = "synthetic_lightvae_encoder" if use_lightvae else "synthetic_vae_encoder"
+    path = out_dir / f"{stem}_{fingerprint}.safetensors"
+    if path.exists():
+        return path
+
+    vae = _new_wan_vae_from_encoder_config(encoder_cfg)
+    _materialize_and_initialize(vae, seed=seed)
+    _save_state_dict(path, vae.state_dict())
+    return path
+
+
+def _build_decoder_checkpoint(
+    out_dir: Path,
+    *,
+    decoder_cfg: Any,
+    seed: int,
+) -> Path:
+    if isinstance(decoder_cfg, TeahvVAEDecoderConfig):
+        fingerprint = _arch_fingerprint(decoder_cfg)
+        path = out_dir / f"synthetic_lighttae_decoder_{fingerprint}.safetensors"
+        if not path.exists():
+            taehv = TAEHV(
+                checkpoint_path=None,
+                use_cuda_graph=False,
+                use_compile=False,
+            )
+            _materialize_and_initialize(taehv, seed=seed)
+            _save_state_dict(path, taehv.state_dict())
+        return path
+
+    if isinstance(decoder_cfg, WanVAEDecoderConfig):
+        fingerprint = _arch_fingerprint(decoder_cfg)
+        path = out_dir / f"synthetic_vae_decoder_{fingerprint}.safetensors"
+        if not path.exists():
+            vae = _new_wan_vae_from_decoder_config(decoder_cfg)
+            _materialize_and_initialize(vae, seed=seed)
+            _save_state_dict(path, vae.state_dict())
+        return path
+
+    raise TypeError(
+        f"unsupported synthetic decoder config: {type(decoder_cfg).__name__}"
+    )
+
+
+def _new_wan_vae_from_encoder_config(config: WanVAEEncoderConfig) -> Any:
+    use_lightvae = _config_uses_lightvae(config)
+    with _suppressed_checkpoint_load():
+        return wan_vae_module.WanVAE(
+            vae_path=(
+                "synthetic_lightvae_encoder.safetensors"
+                if use_lightvae
+                else "synthetic_vae_encoder.safetensors"
+            ),
+            use_lightvae=use_lightvae,
+            use_cuda_graph=False,
+            use_compile=False,
+            enable_encoder=True,
+            enable_decoder=False,
+            base_dim=config.base_dim,
+            z_dim=config.z_dim,
+            patch_size=config.patch_size,
+            is_residual=config.is_residual,
+            latent_mean=config.latent_mean,
+            latent_std=config.latent_std,
+            state_dict_transform=None,
+        )
+
+
+def _new_wan_vae_from_decoder_config(config: WanVAEDecoderConfig) -> Any:
+    use_lightvae = _config_uses_lightvae(config)
+    with _suppressed_checkpoint_load():
+        return wan_vae_module.WanVAE(
+            vae_path="synthetic_vae_decoder.safetensors",
+            use_lightvae=use_lightvae,
+            use_cuda_graph=False,
+            use_compile=False,
+            enable_encoder=False,
+            enable_decoder=True,
+            base_dim=config.base_dim,
+            decoder_base_dim=config.decoder_base_dim,
+            z_dim=config.z_dim,
+            patch_size=config.patch_size,
+            is_residual=config.is_residual,
+            latent_mean=config.latent_mean,
+            latent_std=config.latent_std,
+            state_dict_transform=None,
+        )
+
+
+def _materialize_and_initialize(module: torch.nn.Module, *, seed: int) -> None:
+    """Allocate meta parameters and buffers on CPU and fill them deterministically.
+
+    ``to_empty`` leaves both parameters and buffers backed by uninitialized
+    storage, so zero the buffers too; otherwise any persistent buffer (e.g. a
+    BatchNorm running stat) would be serialized with garbage.
+    """
+
+    module.to_empty(device="cpu")
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    with torch.no_grad():
+        for parameter in module.parameters():
+            if parameter.is_floating_point():
+                parameter.normal_(mean=0.0, std=0.02, generator=generator)
+            else:
+                parameter.zero_()
+        for buffer in module.buffers():
+            buffer.zero_()
+    module.eval().requires_grad_(False)
+
+
+def _save_state_dict(path: Path, state_dict: dict[str, torch.Tensor]) -> None:
+    tensors = {
+        name: tensor.detach().cpu().contiguous()
+        for name, tensor in state_dict.items()
+        if not name.startswith(("_encoder_call.", "_decoder_call."))
+        if not tensor.is_complex() and not tensor.is_quantized
+    }
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    save_file(tensors, str(tmp_path))
+    tmp_path.replace(path)
+
+
+def _build_native_vae_fp8_state(
+    out_dir: Path,
+    *,
+    encoder_cfg: WanVAEEncoderConfig,
+    encoder_checkpoint_path: Path,
+    pixel_height: int,
+    pixel_width: int,
+    device: torch.device,
+) -> Path:
+    fingerprint = _arch_fingerprint(
+        encoder_cfg,
+        pixel_height=pixel_height,
+        pixel_width=pixel_width,
+    )
+    path = out_dir / f"synthetic_lightvae_fp8_state_{fingerprint}.pt"
+    if path.exists():
+        return path
+
+    export = _load_lightvae_fp8_export_module()
+    from flashdreams.infra.config import derive_config
+
+    cfg = derive_config(
+        encoder_cfg,
+        checkpoint_path=str(encoder_checkpoint_path),
+        dtype=torch.float16,
+        use_compile=False,
+        use_cuda_graph=False,
+        native_vae_acceleration="disabled",
+        native_vae_fp8_state_path=None,
+    )
+    encoder = cfg.setup().to(device).eval()
+    video = torch.zeros(
+        (1, 3, 13, pixel_height, pixel_width),
+        device=device,
+        dtype=torch.float16,
+    )
+    amax = export._collect_activation_amax(encoder.vae, video)
+    state = export._build_fp8_state(
+        encoder.vae.state_dict(),
+        export._activation_scales(amax, scale_max=24.0),
+        scale_max=24.0,
+    )
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    torch.save(state, tmp_path)
+    tmp_path.replace(path)
+    return path
+
+
+_LIGHTVAE_FP8_EXPORT_SYMBOLS = (
+    "_collect_activation_amax",
+    "_build_fp8_state",
+    "_activation_scales",
+)
+
+
+def _load_lightvae_fp8_export_module() -> Any:
+    script_path = (
+        Path(__file__).resolve().parents[3] / "scripts" / "export_lightvae_fp8_state.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "omnidreams_synthetic_export_lightvae_fp8_state",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    missing = [
+        name for name in _LIGHTVAE_FP8_EXPORT_SYMBOLS if not hasattr(module, name)
+    ]
+    if missing:
+        raise RuntimeError(
+            f"{script_path} is missing expected helpers {missing}; the synthetic "
+            "fp8 VAE path depends on these symbols staying in sync with the script."
+        )
+    return module
+
+
+__all__ = [
+    "SyntheticWorldModelAssets",
+    "build_synthetic_world_model_assets",
+    "default_synthetic_asset_dir",
+]

--- a/integrations/omnidreams/omnidreams/pipeline.py
+++ b/integrations/omnidreams/omnidreams/pipeline.py
@@ -102,6 +102,15 @@ class OmnidreamsPipelineConfig(StreamInferencePipelineConfig):
     """One-shot Wan VAE first-frame encoder. Pin its checkpoint to the
     VAE the network was trained against. ``None`` skips loading."""
 
+    synthetic_text_max_length: int | None = None
+    """Text token count for the interactive-drive synthetic latency path.
+
+    ``None`` on every real run, where the text encoder produces the
+    embeddings. The synthetic path drops the text encoder and instead builds
+    zero text embeddings, so it records the production sequence length here
+    (via ``derive_config``) to keep the embedding shape -- and therefore the
+    measured cost -- identical to a real run."""
+
 
 class OmnidreamsPipeline(
     StreamInferencePipeline[

--- a/integrations/omnidreams/tests/interactive_drive/test_app_smoke.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_app_smoke.py
@@ -19,7 +19,9 @@ from omnidreams.interactive_drive.scene_fixture import build_synthetic_scene_usd
 from pyvirtualdisplay.display import Display
 
 _WARMUP_SENTINEL = "[chunk-pipeline] warmup done"
+_WORLD_MODEL_LATENCY_SENTINEL = "[flashdreams-session] continue block_index=1"
 _WARMUP_TIMEOUT_S = 90.0
+_WORLD_MODEL_TIMEOUT_S = 600.0
 _LIVE_DURATION_S = 3.0
 _SHUTDOWN_TIMEOUT_S = 15.0
 
@@ -94,7 +96,7 @@ def _run_raster_ui_smoke(scene_path: Path) -> None:
             [
                 sys.executable,
                 "-m",
-                "interactive_drive",
+                "omnidreams.interactive_drive",
                 # ``python -m omnidreams.interactive_drive`` now goes through the
                 # demo wrapper which opens a pygame HUD by default and
                 # only spawns the backend when the user clicks ``Load
@@ -167,6 +169,85 @@ def _run_raster_ui_smoke(scene_path: Path) -> None:
         display.stop()
 
 
+def _run_synthetic_world_model_latency_smoke(scene_path: Path) -> None:
+    """Run the synthetic world model through the interactive-drive latency path."""
+    display = Display(backend="xvfb", size=(1280, 720), visible=False)
+    display.start()
+    try:
+        env = os.environ.copy()
+        assert "DISPLAY" in env, (
+            "pyvirtualdisplay did not publish DISPLAY after start()"
+        )
+        env.setdefault("HF_HUB_OFFLINE", "1")
+        env.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "omnidreams.interactive_drive",
+                "--no-hud",
+                "--scene",
+                str(scene_path),
+                "--backend",
+                "omnidreams",
+                "--manifest",
+                "example_world_model_synthetic.yaml",
+                "--synthetic-model",
+                "--profile-world-model",
+                "--stop-after-chunks",
+                "2",
+                "--camera",
+                "camera_front_wide_120fov",
+                "--variant",
+                "1",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            bufsize=0,
+        )
+        assert process.stdout is not None
+
+        output_lines: list[str] = []
+        output_lock = threading.Lock()
+        reader = threading.Thread(
+            target=_pump_stream,
+            args=(process.stdout, output_lines, output_lock),
+            name="interactive_drive-world-model-smoke-reader",
+            daemon=True,
+        )
+        reader.start()
+
+        try:
+            _wait_for_sentinel(
+                process=process,
+                output_lines=output_lines,
+                output_lock=output_lock,
+                sentinel=_WORLD_MODEL_LATENCY_SENTINEL,
+                timeout_s=_WORLD_MODEL_TIMEOUT_S,
+            )
+        finally:
+            if process.poll() is None:
+                process.send_signal(signal.SIGTERM)
+            try:
+                process.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+            reader.join(timeout=5.0)
+
+        output = _joined(output_lines, output_lock)
+        assert "Traceback (most recent call last)" not in output, (
+            f"App logged a Python traceback:\n{output}"
+        )
+        assert process.returncode in (0, -signal.SIGTERM, -signal.SIGKILL), (
+            f"Unexpected exit code {process.returncode}:\n{output}"
+        )
+    finally:
+        display.stop()
+
+
 @pytest.mark.gpu
 @pytest.mark.xvfb
 # Opportunistic: runs opportunistically when the production USDZ has been
@@ -187,3 +268,14 @@ def test_interactive_drive_raster_ui_smoke_synthetic_scene(tmp_path: Path) -> No
     """Smoke test against a USDZ built in-process by ``build_synthetic_scene_usdz``."""
     scene_path = build_synthetic_scene_usdz(tmp_path / "synthetic_scene.usdz")
     _run_raster_ui_smoke(scene_path)
+
+
+# gpu + xvfb -> routed to ``manual`` by conftest (see pytest_collection_modifyitems):
+# the public GPU CI runner image isn't guaranteed to have Xvfb, so don't pin an
+# explicit ``ci_gpu`` tier here. The real CI latency coverage runs internally
+# under ``xvfb-run`` in the benchmark job.
+@pytest.mark.gpu
+@pytest.mark.xvfb
+def test_interactive_drive_synthetic_world_model_latency_smoke(tmp_path: Path) -> None:
+    scene_path = build_synthetic_scene_usdz(tmp_path / "synthetic_scene.usdz")
+    _run_synthetic_world_model_latency_smoke(scene_path)

--- a/integrations/omnidreams/tests/interactive_drive/test_manifest.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_manifest.py
@@ -27,9 +27,17 @@ class WorldModelManifestTest(unittest.TestCase):
             self.assertEqual(manifest.num_frames_per_block, 8)
             self.assertEqual(manifest.denoising_steps, [1000, 500])
             self.assertEqual(manifest.resolution_wh, (1280, 704))
+            self.assertFalse(manifest.synthetic_model)
             self.assertEqual(manifest.native_dit_acceleration, "disabled")
             self.assertEqual(manifest.native_vae_encoder, "disabled")
             self.assertIsNone(manifest.native_vae_fp8_state_path)
+
+    def test_loads_synthetic_model_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.yaml"
+            path.write_text("synthetic_model: true\n", encoding="utf-8")
+            manifest = load_world_model_manifest(path)
+            self.assertTrue(manifest.synthetic_model)
 
     def test_loads_native_dit_knobs(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/integrations/omnidreams/tests/interactive_drive/test_synthetic_fixture.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_synthetic_fixture.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import torch
+from omnidreams.interactive_drive.world_model.synthetic_fixture import (
+    build_synthetic_world_model_assets,
+)
+from omnidreams.vae_native import OmnidreamsWanVAEEncoderConfig
+
+from flashdreams.core.checkpoint import load as checkpoint_load
+from flashdreams.recipes.taehv import TeahvVAEDecoderConfig
+
+
+def _has_meta_state(module: torch.nn.Module) -> bool:
+    return any(t.is_meta for t in module.parameters()) or any(
+        t.is_meta for t in module.buffers()
+    )
+
+
+def test_synthetic_fixture_round_trips_offline(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+
+    def fail_hf_download(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("synthetic fixture must not download from Hugging Face")
+
+    monkeypatch.setattr(checkpoint_load, "hf_hub_download", fail_hf_download)
+
+    encoder_cfg = OmnidreamsWanVAEEncoderConfig(
+        dtype=torch.float32,
+        use_compile=False,
+        use_cuda_graph=False,
+        native_vae_acceleration="disabled",
+    )
+    decoder_cfg = TeahvVAEDecoderConfig(
+        dtype=torch.float32,
+        use_compile=False,
+        use_cuda_graph=False,
+        state_dict_transform=None,
+    )
+
+    assets = build_synthetic_world_model_assets(
+        tmp_path,
+        encoder_cfg=encoder_cfg,
+        decoder_cfg=decoder_cfg,
+    )
+
+    assert assets.encoder_checkpoint_path is not None
+    assert assets.encoder_checkpoint_path.is_file()
+    assert assets.decoder_checkpoint_path.is_file()
+
+    encoder = OmnidreamsWanVAEEncoderConfig(
+        checkpoint_path=str(assets.encoder_checkpoint_path),
+        dtype=torch.float32,
+        use_compile=False,
+        use_cuda_graph=False,
+        native_vae_acceleration="disabled",
+    ).setup()
+    decoder = TeahvVAEDecoderConfig(
+        checkpoint_path=str(assets.decoder_checkpoint_path),
+        dtype=torch.float32,
+        use_compile=False,
+        use_cuda_graph=False,
+        state_dict_transform=None,
+    ).setup()
+
+    assert not _has_meta_state(encoder)
+    assert not _has_meta_state(decoder)
+
+    video = torch.zeros((1, 1, 5, 3, 32, 32), dtype=torch.float32)
+    latent = encoder(video)
+    assert latent.shape[:4] == (1, 1, 2, 16)
+
+    decoded = decoder(torch.zeros((1, 1, 2, 16, 4, 4), dtype=torch.float32))
+    assert decoded.shape[:4] == (1, 1, 5, 3)

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import omnidreams.interactive_drive.world_model.flashdreams_adapter as adapter_module
@@ -18,6 +19,9 @@ from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
     _select_config_name,
 )
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
+from omnidreams.interactive_drive.world_model.synthetic_fixture import (
+    SyntheticWorldModelAssets,
+)
 
 
 class _FakePipeline:
@@ -61,8 +65,46 @@ class _FakePipeline:
         self.finalize_calls.append((autoregressive_index, cache))
 
 
+class _FakeSyntheticPipeline(_FakePipeline):
+    def __init__(self) -> None:
+        super().__init__()
+        self.config = SimpleNamespace(synthetic_text_max_length=7)
+        self.decoder = SimpleNamespace(spatial_compression_ratio=8)
+        network = SimpleNamespace(
+            use_crossattn_projection=True,
+            crossattn_proj_in_channels=11,
+            crossattn_emb_channels=13,
+            in_channels=5,
+        )
+        transformer_config = SimpleNamespace(
+            network=network,
+            batch_shape=(1,),
+            num_views=1,
+            dtype=torch.float32,
+            requires_negative_text_embeddings=False,
+        )
+        transformer = SimpleNamespace(config=transformer_config)
+        self.diffusion_model = SimpleNamespace(transformer=transformer)
+        self.V_size = 1
+
+
 def _manifest() -> WorldModelManifest:
     return WorldModelManifest()
+
+
+def _contains_hf_url(value: object) -> bool:
+    if isinstance(value, str):
+        return "huggingface.co" in value
+    if isinstance(value, (list, tuple, set)):
+        return any(_contains_hf_url(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            _contains_hf_url(key) or _contains_hf_url(item)
+            for key, item in value.items()
+        )
+    if hasattr(value, "__dict__"):
+        return any(_contains_hf_url(item) for item in vars(value).values())
+    return False
 
 
 def test_select_config_name_uses_omnidreams_recipe_slugs() -> None:
@@ -136,6 +178,66 @@ def test_build_pipeline_config_can_select_native_vae_encoder() -> None:
     assert config.encoder.native_vae_backend == "fp8"
 
 
+def test_build_pipeline_config_synthetic_swaps_only_weight_sources(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    assets = SyntheticWorldModelAssets(
+        encoder_checkpoint_path=tmp_path / "synthetic_lightvae_encoder.safetensors",
+        decoder_checkpoint_path=tmp_path / "synthetic_lighttae_decoder.safetensors",
+    )
+    assets.encoder_checkpoint_path.touch()
+    assets.decoder_checkpoint_path.touch()
+
+    def fake_assets(*_args: object, **_kwargs: object) -> SyntheticWorldModelAssets:
+        return assets
+
+    monkeypatch.setattr(
+        adapter_module,
+        "build_synthetic_world_model_assets",
+        fake_assets,
+    )
+
+    manifest = replace(
+        _manifest(),
+        synthetic_model=True,
+        skip_finalize_kv_cache=True,
+        native_dit_acceleration="required",
+        native_dit_backend="bf16",
+        native_dit_attention_backend="cudnn",
+    )
+    real = _build_pipeline_config(
+        replace(manifest, synthetic_model=False),
+        profile=WorldModelProfileConfig(),
+    )
+    synthetic = _build_pipeline_config(manifest, profile=WorldModelProfileConfig())
+
+    real_transformer = real.diffusion_model.transformer
+    synthetic_transformer = synthetic.diffusion_model.transformer
+    assert synthetic_transformer.checkpoint_path is None
+    assert synthetic.text_encoder is None
+    assert synthetic.image_encoder is None
+    assert synthetic.encoder.checkpoint_path == str(assets.encoder_checkpoint_path)
+    assert synthetic.decoder.checkpoint_path == str(assets.decoder_checkpoint_path)
+    assert synthetic.decoder.state_dict_transform is None
+    assert synthetic.synthetic_text_max_length == real.text_encoder.max_length
+
+    for field in (
+        "compile_network",
+        "use_cuda_graph",
+        "skip_finalize_kv_cache",
+        "native_dit_acceleration",
+        "native_dit_backend",
+        "native_dit_attention_backend",
+    ):
+        assert getattr(synthetic_transformer, field) == getattr(real_transformer, field)
+    assert synthetic.encoder.use_compile == real.encoder.use_compile
+    assert synthetic.encoder.use_cuda_graph == real.encoder.use_cuda_graph
+    assert synthetic.decoder.use_compile == real.decoder.use_compile
+    assert synthetic.decoder.use_cuda_graph == real.decoder.use_cuda_graph
+    assert not _contains_hf_url(synthetic)
+
+
 def test_native_vae_encoder_requires_light_vae_recipe() -> None:
     with pytest.raises(ValueError, match="native_vae_encoder=fp8 requires light_vae"):
         _build_pipeline_config(
@@ -172,6 +274,32 @@ def test_session_uses_flashdreams_pipeline_for_rollout() -> None:
 
     session.close()
     assert fake_pipeline.finalize_calls == [(0, "cache"), (1, "cache")]
+
+
+def test_session_synthetic_model_initializes_cache_from_synthetic_embeddings() -> None:
+    fake_pipeline = _FakeSyntheticPipeline()
+    manifest = replace(_manifest(), synthetic_model=True, resolution_wh=(64, 32))
+    session = FlashdreamsWorldModelSession(
+        manifest,
+        offload_text_encoder=True,
+        pipeline_factory=lambda manifest, profile: fake_pipeline,
+    )
+    assert session.can_prewarm is True
+    session.warmup_model()
+
+    initial_rgb = np.zeros((2, 3, 3), dtype=np.uint8)
+    first_condition_frames = [np.zeros((2, 3, 3), dtype=np.uint8) for _ in range(5)]
+
+    session.start(initial_rgb, first_condition_frames, "demo prompt")
+
+    assert fake_pipeline.initialize_calls == []
+    assert fake_pipeline.precompute_calls == []
+    assert len(fake_pipeline.initialize_from_embeddings_calls) == 1
+    call = fake_pipeline.initialize_from_embeddings_calls[0]
+    assert tuple(call["text_embeddings"].shape) == (1, 1, 7, 11)
+    assert tuple(call["image_embeddings"].shape) == (1, 1, 1, 5, 4, 8)
+    assert call["negative_text_embeddings"] is None
+    assert call["view_names"] == ["camera_front_wide_120fov"]
 
 
 def test_session_synchronizes_generated_frame_events_before_return(monkeypatch) -> None:


### PR DESCRIPTION
Enable offline interactive-drive latency runs by swapping only the model weight sources: the DiT initializes random weights (checkpoint_path=None) and the VAE/TAE load locally generated default-initialized checkpoints, while torch.compile, CUDA graphs, and native fp8 acceleration stay exactly as a real run configures them. Combined with --synthetic-scene and config-derived synthetic embeddings, the full world-model render and tracing path runs without any checkpoint or scene downloads.

Add the --synthetic-model flag, the example_world_model_synthetic.yaml manifest, the offline asset fixture, CPU tests, and a GPU smoke test covering the path.