### PR TITLE
fix(wan): correct Wan 2.2 VAE patchify channel order (removes 2px checkerboard)

### DIFF
--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -701,9 +701,14 @@ def _patchify(x: Tensor, patch_size: int) -> Tensor:
     if patch_size == 1:
         return x
     assert x.ndim == 5, f"_patchify expects [B, C, T, H, W]; got {tuple(x.shape)}"
+    # Channel order must be ``(c pw ph)`` to match the Wan 2.2 VAE checkpoint /
+    # diffusers ``AutoencoderKLWan`` convention (``patchify`` permute
+    # ``(0,1,6,4,2,3,5)``). Using ``(c ph pw)`` transposes each ``patch_size``-
+    # square sub-pixel block relative to the trained conv weights, which decodes
+    # to a fixed ~2px checkerboard on every frame.
     return rearrange(
         x,
-        "b c t (h ph) (w pw) -> b (c ph pw) t h w",
+        "b c t (h ph) (w pw) -> b (c pw ph) t h w",
         ph=patch_size,
         pw=patch_size,
     )
@@ -714,9 +719,11 @@ def _unpatchify(x: Tensor, patch_size: int) -> Tensor:
     if patch_size == 1:
         return x
     assert x.ndim == 5, f"_unpatchify expects [B, C, T, H, W]; got {tuple(x.shape)}"
+    # Inverse of :func:`_patchify`; channel order ``(c pw ph)`` matches the
+    # Wan 2.2 VAE checkpoint / diffusers convention (see :func:`_patchify`).
     return rearrange(
         x,
-        "b (c ph pw) t h w -> b c t (h ph) (w pw)",
+        "b (c pw ph) t h w -> b c t (h ph) (w pw)",
         ph=patch_size,
         pw=patch_size,
     )


### PR DESCRIPTION
## Problem
The flashdreams Wan 2.2 VAE produced a fixed ~2px checkerboard/stipple on **every** decoded frame (visible on flat regions — sky, road, walls). diffusers `AutoencoderKLWan` decodes the **identical checkpoint + latent** cleanly.

## Root cause
`_patchify`/`_unpatchify` (`recipes/wan/autoencoder/vae.py`) folded the spatial patch into channels as `(c ph pw)`, but the checkpoint convs are trained for the diffusers convention `(c pw ph)` (its `patchify` permute is `(0,1,6,4,2,3,5)`). The swapped patch axes transpose every `patch_size`-square sub-pixel block relative to the trained weights → checkerboard.

## Fix
Swap `ph`↔`pw` in both rearrange patterns (one axis-order change per function).

## Verification
- **VAE roundtrip** (encode→decode, no diffusion): flashdreams was checkerboarded, diffusers clean → with the fix, flashdreams matches diffusers (clean).
- **Cross-test** (diffusers-encode → flashdreams-decode) isolated it to our decode.
- **Full HY-WorldPlay generation** (8-chunk): checkerboard gone.

## Scope
Affects every model using the Wan 2.2 VAE with `patch_size=2`. Downstream: HY-WorldPlay sample/parity videos (PR #318, #336) should be regenerated.