### PR TITLE
docs: Remove leftover AI artifacts and dedupe repeated demo prompts in model docs

### DIFF
--- a/docs/source/developer_guides/inference_pipeline_overview.rst
+++ b/docs/source/developer_guides/inference_pipeline_overview.rst
@@ -20,8 +20,6 @@ This page outlines the major computation flow in the FlashDreams inference pipel
 It outlines the core concepts and APIs for building custom model integrations,
 or modifying existing ones.
 
-.. Figure creation trace: https://chatgpt.com/share/6a14ab0f-90bc-83e8-8145-c1a03b64f43a
-
 .. image:: /_static/diagrams/flashdreams-inference-pipeline-overview.jpg
    :alt: FlashDreams autoregressive inference pipeline overview.
    :class: zoomable

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,8 +92,6 @@ alive while input, model state, GPU inference, and output evolve together. This
 is useful for interactive simulation, robotics, autonomy, healthcare workflows,
 creative tools, virtual worlds, and game-like experiences.
 
-.. TODO: Vectorize this figure before final publication.
-.. Figure creation trace: https://chatgpt.com/share/6a124478-4730-83e8-ba21-33628c8f1f3b
 .. image:: /_static/diagrams/compare-offline-online-video-model-v2.jpg
    :alt: Offline one-shot video inference compared with online autoregressive world-model serving.
    :class: zoomable

--- a/docs/source/models/causal_forcing.rst
+++ b/docs/source/models/causal_forcing.rst
@@ -64,7 +64,6 @@ To run Causal-Forcing, launch one of the registered runner slugs via
    uv run --project integrations/causal_forcing \
        flashdreams-run \
        causal-forcing-wan2.1-t2v-1.3b-framewise \
-       --prompt "A cinematic closeup and detailed portrait of a reindeer standing in a snowy forest at sunset. The lighting is gorgeous and soft, with a golden backlight creating a warm and dreamy effect. Soft bokeh and lens flares add a magical touch, enhancing the cinematic quality of the image. The reindeer has a gentle expression, its fur glistening in the fading light. The background features a serene snowy landscape with tall trees silhouetted against the orange and pink hues of the setting sun. The color grade is rich and magical, capturing the essence of a winter wonderland at twilight. A close-up shot from a slightly elevated angle." \
        --pixel-height 480 --pixel-width 832 \
        --total-blocks 21
 
@@ -76,7 +75,6 @@ For multi-GPU inference, use ``torchrun`` on top of ``uv run flashdreams-run``
    uv run --project integrations/causal_forcing \
        torchrun --nproc_per_node=4 --no-python flashdreams-run \
        causal-forcing-wan2.1-t2v-1.3b-framewise \
-       --prompt "A cinematic closeup and detailed portrait of a reindeer standing in a snowy forest at sunset. The lighting is gorgeous and soft, with a golden backlight creating a warm and dreamy effect. Soft bokeh and lens flares add a magical touch, enhancing the cinematic quality of the image. The reindeer has a gentle expression, its fur glistening in the fading light. The background features a serene snowy landscape with tall trees silhouetted against the orange and pink hues of the setting sun. The color grade is rich and magical, capturing the essence of a winter wonderland at twilight. A close-up shot from a slightly elevated angle." \
        --pixel-height 480 --pixel-width 832 \
        --total-blocks 21
 
@@ -87,7 +85,6 @@ For I2V, run with the following command:
    uv run --project integrations/causal_forcing \
        flashdreams-run \
        causal-forcing-wan2.1-i2v-1.3b-framewise \
-       --prompt "A cinematic closeup and detailed portrait of a reindeer standing in a snowy forest at sunset. The lighting is gorgeous and soft, with a golden backlight creating a warm and dreamy effect. Soft bokeh and lens flares add a magical touch, enhancing the cinematic quality of the image. The reindeer has a gentle expression, its fur glistening in the fading light. The background features a serene snowy landscape with tall trees silhouetted against the orange and pink hues of the setting sun. The color grade is rich and magical, capturing the essence of a winter wonderland at twilight. A close-up shot from a slightly elevated angle." \
        --image-path https://raw.githubusercontent.com/thu-ml/Causal-Forcing/refs/heads/main/prompts/i2v/26-15/000001.png \
        --pixel-height 480 --pixel-width 832 \
        --total-blocks 21

--- a/docs/source/models/causal_wan22.rst
+++ b/docs/source/models/causal_wan22.rst
@@ -51,7 +51,6 @@ To run Causal Wan2.2, launch the registered runner slug via
    uv run --project integrations/fastvideo_causal_wan22 \
        flashdreams-run \
        fastvideo-causal-wan2.2-t2v-14b \
-       --prompt "A stylish woman strolls down a bustling Tokyo street, the warm glow of neon lights and animated city signs casting vibrant reflections. She wears a sleek black leather jacket paired with a flowing red dress and black boots, her black purse slung over her shoulder. Sunglasses perched on her nose and a bold red lipstick add to her confident, casual demeanor. The street is damp and reflective, creating a mirror-like effect that enhances the colorful lights and shadows. Pedestrians move about, adding to the lively atmosphere. The scene is captured in a dynamic medium shot with the woman walking slightly to one side, highlighting her graceful strides." \
        --pixel-height 480 --pixel-width 832 \
        --total-blocks 7
 
@@ -70,7 +69,6 @@ For multi-GPU inference, use ``torchrun`` on top of ``uv run flashdreams-run``
    uv run --project integrations/fastvideo_causal_wan22 \
        torchrun --nproc_per_node=4 --no-python flashdreams-run \
        fastvideo-causal-wan2.2-t2v-14b \
-       --prompt "A stylish woman strolls down a bustling Tokyo street, the warm glow of neon lights and animated city signs casting vibrant reflections. She wears a sleek black leather jacket paired with a flowing red dress and black boots, her black purse slung over her shoulder. Sunglasses perched on her nose and a bold red lipstick add to her confident, casual demeanor. The street is damp and reflective, creating a mirror-like effect that enhances the colorful lights and shadows. Pedestrians move about, adding to the lively atmosphere. The scene is captured in a dynamic medium shot with the woman walking slightly to one side, highlighting her graceful strides." \
        --pixel-height 480 --pixel-width 832 \
        --total-blocks 21
 

--- a/docs/source/models/cosmos_predict2.rst
+++ b/docs/source/models/cosmos_predict2.rst
@@ -70,8 +70,7 @@ To run Cosmos-Predict2.5, launch one of the registered runner slugs via
 
    uv run --project integrations/cosmos_predict2 \
        flashdreams-run \
-       cosmos2-t2v-2b-720p \
-       --prompt "A high-definition video captures the precision of robotic welding in an industrial setting. The first frame showcases a robotic arm, equipped with a welding torch, positioned over a large metal structure. The welding process is in full swing, with bright sparks and intense light illuminating the scene, creating a vivid display of blue and white hues. A significant amount of smoke billows around the welding area, partially obscuring the view but emphasizing the heat and activity. The background reveals parts of the workshop environment, including a ventilation system and various pieces of machinery, indicating a busy and functional industrial workspace. As the video progresses, the robotic arm maintains its steady position, continuing the welding process and moving to its left. The welding torch consistently emits sparks and light, and the smoke continues to rise, diffusing slightly as it moves upward. The metal surface beneath the torch shows ongoing signs of heating and melting. The scene retains its industrial ambiance, with the welding sparks and smoke dominating the visual field, underscoring the ongoing nature of the welding operation."
+       cosmos2-t2v-2b-720p
 
 For multi-GPU inference, use ``torchrun`` on top of ``uv run flashdreams-run``
 (taking 4 GPUs as an example):
@@ -80,8 +79,7 @@ For multi-GPU inference, use ``torchrun`` on top of ``uv run flashdreams-run``
 
    uv run --project integrations/cosmos_predict2 \
        torchrun --nproc_per_node=4 --no-python flashdreams-run \
-       cosmos2-t2v-2b-720p \
-       --prompt "A high-definition video captures the precision of robotic welding in an industrial setting. The first frame showcases a robotic arm, equipped with a welding torch, positioned over a large metal structure. The welding process is in full swing, with bright sparks and intense light illuminating the scene, creating a vivid display of blue and white hues. A significant amount of smoke billows around the welding area, partially obscuring the view but emphasizing the heat and activity. The background reveals parts of the workshop environment, including a ventilation system and various pieces of machinery, indicating a busy and functional industrial workspace. As the video progresses, the robotic arm maintains its steady position, continuing the welding process and moving to its left. The welding torch consistently emits sparks and light, and the smoke continues to rise, diffusing slightly as it moves upward. The metal surface beneath the torch shows ongoing signs of heating and melting. The scene retains its industrial ambiance, with the welding sparks and smoke dominating the visual field, underscoring the ongoing nature of the welding operation."
+       cosmos2-t2v-2b-720p
 
 For I2V, run with the following command:
 
@@ -90,8 +88,7 @@ For I2V, run with the following command:
    uv run --project integrations/cosmos_predict2 \
        flashdreams-run \
        cosmos2-i2v-2b-720p \
-       --prompt "A high-definition video captures the precision of robotic welding in an industrial setting. The first frame showcases a robotic arm, equipped with a welding torch, positioned over a large metal structure. The welding process is in full swing, with bright sparks and intense light illuminating the scene, creating a vivid display of blue and white hues. A significant amount of smoke billows around the welding area, partially obscuring the view but emphasizing the heat and activity. The background reveals parts of the workshop environment, including a ventilation system and various pieces of machinery, indicating a busy and functional industrial workspace. As the video progresses, the robotic arm maintains its steady position, continuing the welding process and moving to its left. The welding torch consistently emits sparks and light, and the smoke continues to rise, diffusing slightly as it moves upward. The metal surface beneath the torch shows ongoing signs of heating and melting. The scene retains its industrial ambiance, with the welding sparks and smoke dominating the visual field, underscoring the ongoing nature of the welding operation." \
-       --image-path https://media.githubusercontent.com/media/nvidia-cosmos/cosmos-predict2.5/refs/heads/main/assets/base/robot_welding.jpg \
+       --image-path https://media.githubusercontent.com/media/nvidia-cosmos/cosmos-predict2.5/refs/heads/main/assets/base/robot_welding.jpg
 
 We provide the following variants:
 

--- a/docs/source/models/self_forcing.rst
+++ b/docs/source/models/self_forcing.rst
@@ -65,7 +65,6 @@ To run Self-Forcing, launch one of the registered runner slugs via
    uv run --project integrations/self_forcing \
        flashdreams-run \
        self-forcing-wan2.1-t2v-1.3b \
-       --prompt "A stylish woman strolls down a bustling Tokyo street, the warm glow of neon lights and animated city signs casting vibrant reflections. She wears a sleek black leather jacket paired with a flowing red dress and black boots, her black purse slung over her shoulder. Sunglasses perched on her nose and a bold red lipstick add to her confident, casual demeanor. The street is damp and reflective, creating a mirror-like effect that enhances the colorful lights and shadows. Pedestrians move about, adding to the lively atmosphere. The scene is captured in a dynamic medium shot with the woman walking slightly to one side, highlighting her graceful strides." \
        --pixel-height 480 --pixel-width 832 \
        --total-blocks 7
 
@@ -92,7 +91,6 @@ For multi-GPU inference, use:
    uv run --project integrations/self_forcing \
        torchrun --nproc_per_node=4 --no-python flashdreams-run \
        self-forcing-wan2.1-t2v-1.3b \
-       --prompt "A stylish woman strolls down a bustling Tokyo street, the warm glow of neon lights and animated city signs casting vibrant reflections. She wears a sleek black leather jacket paired with a flowing red dress and black boots, her black purse slung over her shoulder. Sunglasses perched on her nose and a bold red lipstick add to her confident, casual demeanor. The street is damp and reflective, creating a mirror-like effect that enhances the colorful lights and shadows. Pedestrians move about, adding to the lively atmosphere. The scene is captured in a dynamic medium shot with the woman walking slightly to one side, highlighting her graceful strides." \
        --pixel-height 480 --pixel-width 832 \
        --total-blocks 7
 

--- a/docs/source/models/wan21.rst
+++ b/docs/source/models/wan21.rst
@@ -52,7 +52,6 @@ To run Wan2.1, launch one of the registered runner slugs via
    uv run --project integrations/wan21 \
        flashdreams-run \
        wan21-t2v-1.3b-480p \
-       --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
        --pixel-height 832 --pixel-width 480
 
 For multi-GPU inference, use ``torchrun`` on top of ``uv run flashdreams-run``
@@ -63,7 +62,6 @@ For multi-GPU inference, use ``torchrun`` on top of ``uv run flashdreams-run``
    uv run --project integrations/wan21 \
        torchrun --nproc_per_node=4 --no-python flashdreams-run \
        wan21-t2v-1.3b-480p \
-       --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
        --pixel-height 832 --pixel-width 480
 
 For I2V, run with the following command:
@@ -73,7 +71,6 @@ For I2V, run with the following command:
    uv run --project integrations/wan21 \
        flashdreams-run \
        wan21-i2v-14b-480p \
-       --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
        --image-path https://raw.githubusercontent.com/Wan-Video/Wan2.1/main/examples/i2v_input.JPG \
        --pixel-height 832 --pixel-width 480
 


### PR DESCRIPTION
## Summary
A companion audit (same NVIDIA-staff author, documentation label) flags style/verbosity problems: AI-generation artifacts (TODO comments and chatgpt.com 'figure creation trace' links left in .rst sources) and the same long demo prompt repeated 2-5 times across model pages. The issue gives a clear done-criterion: rg -n 'chatgpt.com' docs/ integrations/ should return nothing, and run blocks should drop --prompt where it equals the runner default.

Fixes #320
