### PR TITLE
refactor(omnidreams/webrtc): serve packaged web assets via importlib.resources

### DIFF
--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -123,18 +123,22 @@ def create_app(
     manager = session_manager or OmnidreamsWebRTCSessionManager()
 
     resource_stack = ExitStack()
-    web_dir = resource_stack.enter_context(as_file(WEB_DIR_RESOURCE))
+    try:
+        web_dir = resource_stack.enter_context(as_file(WEB_DIR_RESOURCE))
 
-    app = create_webrtc_app(
-        web_dir=web_dir,
-        session_manager=manager,
-        preload_name="Omnidreams",
-        request_session_url=request_session_url,
-    )
-    app["package_resource_stack"] = resource_stack
-    app.on_cleanup.append(_close_package_resources)
-    if REPO_ASSETS_DIR.is_dir():
-        app.router.add_static("/assets/", REPO_ASSETS_DIR, show_index=False)
+        app = create_webrtc_app(
+            web_dir=web_dir,
+            session_manager=manager,
+            preload_name="Omnidreams",
+            request_session_url=request_session_url,
+        )
+        if REPO_ASSETS_DIR.is_dir():
+            app.router.add_static("/assets/", REPO_ASSETS_DIR, show_index=False)
+        app["package_resource_stack"] = resource_stack
+        app.on_cleanup.append(_close_package_resources)
+    except Exception:
+        resource_stack.close()
+        raise
     return app
 
 

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import os
+from contextlib import ExitStack
+from importlib.resources import as_file, files
 from pathlib import Path
 
 import torch
@@ -28,7 +30,8 @@ from flashdreams.serving.webrtc.bootstrap import (
 )
 from flashdreams.serving.webrtc.server import WebRTCSessionManager, create_webrtc_app
 
-WEB_DIR = Path(__file__).resolve().parent / "web"
+WEB_DIR_RESOURCE = files("omnidreams.webrtc").joinpath("web")
+# Wheel-installed deployments skip this optional mount when the repo root is absent.
 REPO_ASSETS_DIR = Path(__file__).resolve().parents[4] / "assets"
 
 
@@ -108,18 +111,28 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+async def _close_package_resources(app: web.Application) -> None:
+    app["package_resource_stack"].close()
+
+
 def create_app(
     *,
     request_session_url: str,
     session_manager: WebRTCSessionManager | None = None,
 ) -> web.Application:
     manager = session_manager or OmnidreamsWebRTCSessionManager()
+
+    resource_stack = ExitStack()
+    web_dir = resource_stack.enter_context(as_file(WEB_DIR_RESOURCE))
+
     app = create_webrtc_app(
-        web_dir=WEB_DIR,
+        web_dir=web_dir,
         session_manager=manager,
         preload_name="Omnidreams",
         request_session_url=request_session_url,
     )
+    app["package_resource_stack"] = resource_stack
+    app.on_cleanup.append(_close_package_resources)
     if REPO_ASSETS_DIR.is_dir():
         app.router.add_static("/assets/", REPO_ASSETS_DIR, show_index=False)
     return app

--- a/integrations/omnidreams/tests/test_webrtc_server_routes.py
+++ b/integrations/omnidreams/tests/test_webrtc_server_routes.py
@@ -80,11 +80,44 @@ def test_create_app_keeps_package_web_resource_materialized() -> None:
         assert len(static_resources) == 1
         web_dir = static_resources[0].get_info()["directory"]
         assert web_dir.is_dir()
-        assert "Omnidreams WebRTC Drive" in (
-            web_dir / "request_session.html"
-        ).read_text()
+        assert (
+            "Omnidreams WebRTC Drive" in (web_dir / "request_session.html").read_text()
+        )
     finally:
         app["package_resource_stack"].close()
+
+
+def test_create_app_closes_package_resource_when_app_creation_fails(
+    monkeypatch, tmp_path
+) -> None:
+    class TrackedResource:
+        closed = False
+
+        def __enter__(self):
+            return tmp_path
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.closed = True
+
+    tracked_resource = TrackedResource()
+
+    def raise_app_creation_failure(**_kwargs):
+        raise RuntimeError("app creation failed")
+
+    monkeypatch.setattr(webrtc_server, "as_file", lambda _resource: tracked_resource)
+    monkeypatch.setattr(
+        webrtc_server,
+        "create_webrtc_app",
+        raise_app_creation_failure,
+    )
+
+    with pytest.raises(RuntimeError, match="app creation failed"):
+        create_app(
+            session_manager=FakeSessionManager(),
+            request_session_url="http://127.0.0.1:8080/request_session",
+        )
+
+    assert tracked_resource.closed
 
 
 def test_create_app_skips_absent_repo_assets_mount(monkeypatch, tmp_path) -> None:
@@ -106,8 +139,7 @@ def test_create_app_skips_absent_repo_assets_mount(monkeypatch, tmp_path) -> Non
                 info.get("path", ""),
             )
             assert not any(
-                str(candidate) == "/assets"
-                or str(candidate).startswith("/assets/")
+                str(candidate) == "/assets" or str(candidate).startswith("/assets/")
                 for candidate in candidates
             )
     finally:

--- a/integrations/omnidreams/tests/test_webrtc_server_routes.py
+++ b/integrations/omnidreams/tests/test_webrtc_server_routes.py
@@ -4,10 +4,16 @@
 from __future__ import annotations
 
 import logging
+from contextlib import ExitStack
 
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
-from omnidreams.webrtc.server import configure_logging, create_app
+from omnidreams.webrtc import server as webrtc_server
+from omnidreams.webrtc.server import (
+    _close_package_resources,
+    configure_logging,
+    create_app,
+)
 
 from flashdreams.serving.webrtc.server import SessionBusyError
 
@@ -54,6 +60,58 @@ async def _build_client(manager: FakeSessionManager) -> TestClient:
     client = TestClient(server)
     await client.start_server()
     return client
+
+
+def test_create_app_keeps_package_web_resource_materialized() -> None:
+    app = create_app(
+        session_manager=FakeSessionManager(),
+        request_session_url="http://127.0.0.1:8080/request_session",
+    )
+    try:
+        assert isinstance(app["package_resource_stack"], ExitStack)
+        assert _close_package_resources in app.on_cleanup
+
+        static_resources = [
+            resource
+            for resource in app.router.resources()
+            if getattr(resource, "canonical", "") == "/static"
+            or resource.get_info().get("prefix") in {"/static", "/static/"}
+        ]
+        assert len(static_resources) == 1
+        web_dir = static_resources[0].get_info()["directory"]
+        assert web_dir.is_dir()
+        assert "Omnidreams WebRTC Drive" in (
+            web_dir / "request_session.html"
+        ).read_text()
+    finally:
+        app["package_resource_stack"].close()
+
+
+def test_create_app_skips_absent_repo_assets_mount(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        webrtc_server,
+        "REPO_ASSETS_DIR",
+        tmp_path / "missing-assets",
+    )
+    app = create_app(
+        session_manager=FakeSessionManager(),
+        request_session_url="http://127.0.0.1:8080/request_session",
+    )
+    try:
+        for resource in app.router.resources():
+            info = resource.get_info()
+            candidates = (
+                getattr(resource, "canonical", ""),
+                info.get("prefix", ""),
+                info.get("path", ""),
+            )
+            assert not any(
+                str(candidate) == "/assets"
+                or str(candidate).startswith("/assets/")
+                for candidate in candidates
+            )
+    finally:
+        app["package_resource_stack"].close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Refactors the Omnidreams WebRTC server to discover its packaged `web/` directory through `importlib.resources` instead of `Path(__file__)`, following the canonical pattern from #329.

`server.py` now:
- Resolves the bundled assets with `files("omnidreams.webrtc").joinpath("web")` and materializes them via `as_file(...)` inside an `ExitStack`.
- Stores the stack on the aiohttp app (`app["package_resource_stack"]`) and closes it from an `on_cleanup` handler, so the directory stays valid for the app's entire lifetime and is cleaned up on shutdown.
- Keeps the `create_app` signature and the public route surface unchanged.

## Why

As called out in #329, deriving packaged assets from `Path(__file__).resolve()` can break in non-standard installs (zip-imports, editable wheels, relocated site-packages). The `importlib.resources` path resolves correctly regardless of how the package is laid out on disk, and the `ExitStack`/`as_file` wrapping is the defensive layer the issue describes for cases where the resource is not already a real filesystem path.

## Backward-compatible `/assets/` mount

The optional repo-root `REPO_ASSETS_DIR = Path(__file__).resolve().parents[4] / "assets"` mount is left intact and remains guarded by `if REPO_ASSETS_DIR.is_dir():`. In a checkout it still mounts `/assets/`; in a wheel-installed deployment where the repo root is absent, the mount is simply skipped rather than raising. A short comment notes this.

## Tests

Two focused tests added to `test_webrtc_server_routes.py`:
- `test_create_app_keeps_package_web_resource_materialized` — asserts the `ExitStack` is registered on the app, the `_close_package_resources` cleanup is wired into `on_cleanup`, and the materialized `web/` directory is real and readable.
- `test_create_app_skips_absent_repo_assets_mount` — monkeypatches `REPO_ASSETS_DIR` to a missing path (installed-wheel layout) and asserts `create_app` still constructs and registers no `/assets/` route.

The existing route assertions are unchanged and continue to exercise the new path automatically through the aiohttp `TestServer`/`TestClient` lifecycle.

## Scope

This PR covers the omnidreams `webrtc/server.py` case the issue centers on (the closest sibling to #328). The other `__file__` sites listed in the issue (lingbot, hy_worldplay, flashvsr, interactive_drive CLI, ludus_renderer JIT) each need their own resource-bundling decisions and are intentionally left out of this change.

AI was used for assistance.

Refs #329
