### PR TITLE
Add OmniDreams WorldLens canary CI

### DIFF
--- a/.github/workflows/omnidreams-worldlens-canary.yml
+++ b/.github/workflows/omnidreams-worldlens-canary.yml
@@ -56,7 +56,7 @@ jobs:
             ffmpeg \
             gcc g++ ninja-build \
             libnccl-dev \
-            curl git ca-certificates unzip
+            curl wget git ca-certificates unzip
           rm -rf /var/lib/apt/lists/*
 
       - name: Setup proxy cache

--- a/.github/workflows/omnidreams-worldlens-canary.yml
+++ b/.github/workflows/omnidreams-worldlens-canary.yml
@@ -158,6 +158,38 @@ jobs:
             --baseline "${BASELINE}" \
             --output-json "${RUN_ROOT}/baseline-check.json"
 
+      - name: Trim uv cache for upload
+        if: always()
+        run: |
+          cache_dir="${UV_CACHE_DIR:-/github/home/.cache/uv}"
+          echo "=== Cache size before trim ==="
+          du -sh "${cache_dir}" || true
+          du -sh "${cache_dir}"/*/ 2>/dev/null || true
+
+          # Remove pre-built wheels; the proxy cache can re-download them
+          # faster than GitHub can upload and restore a multi-GB uv cache.
+          rm -rf "${cache_dir}/wheels-v6"
+
+          # Remove unzipped wheel archives; uv can re-extract these on demand.
+          rm -rf "${cache_dir}/archive-v0"
+
+          # Remove build artifacts from git checkouts that bloat the cache but
+          # are not needed for reuse.
+          find "${cache_dir}/git-v0/checkouts" \
+            \( -name "build" -o -name "*.egg-info" -o -name "__pycache__" \) \
+            -type d -exec rm -rf {} + 2>/dev/null || true
+
+          # Remove editable installs; workspace packages rebuild quickly.
+          rm -rf "${cache_dir}/sdists-v9/editable"
+
+          echo ""
+          echo "=== Cache size after trim ==="
+          du -sh "${cache_dir}" || true
+          du -sh "${cache_dir}"/*/ 2>/dev/null || true
+          echo ""
+          echo "=== Cached built wheels (sdists-v9) ==="
+          find "${cache_dir}/sdists-v9" -name "*.whl" -exec ls -lh {} \; 2>/dev/null || true
+
       - name: Upload canary artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/omnidreams-worldlens-canary.yml
+++ b/.github/workflows/omnidreams-worldlens-canary.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
+    paths:
+      - ".github/workflows/omnidreams-worldlens-canary.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "flashdreams/pyproject.toml"
+      - "integrations/omnidreams/**"
+      - "flashdreams/flashdreams/core/**"
+      - "flashdreams/flashdreams/infra/**"
+      - "flashdreams/flashdreams/recipes/taehv/**"
+      - "flashdreams/flashdreams/recipes/wan/**"
   merge_group:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/omnidreams-worldlens-canary.yml
+++ b/.github/workflows/omnidreams-worldlens-canary.yml
@@ -1,0 +1,177 @@
+name: OmniDreams WorldLens Canary
+
+on:
+  push:
+    branches:
+      - main
+      - "pull-request/[0-9]+"
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: canary3 WorldLens baseline
+    runs-on: linux-amd64-gpu-rtxpro6000-latest-2
+    timeout-minutes: 120
+    continue-on-error: true
+    container:
+      image: nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04
+      options: --gpus all
+    env:
+      UV_PROJECT_ENVIRONMENT: /tmp/flashdreams-venv
+      UV_LINK_MODE: copy
+      UV_PYTHON: "3.10"
+      MAX_JOBS: 8
+      RUN_ROOT: artifacts/omnidreams_worldlens_canary/run
+      SCRATCH_ROOT: /tmp/omnidreams-worldlens-scratch
+      SPLIT: od_26_01_canary3_tb4
+      TOTAL_BLOCKS: "4"
+      BASELINE: integrations/omnidreams/eval_baselines/od-26.01-canary3-tb4-v1.json
+      CANARY_UUID_REGEX: '"uuid": "(01d503d4-449b-46fc-8d78-9085e70d3554|02e075b9-fd24-426b-971b-7cfcb2074cc9|0499fb41-122d-4180-83af-f954a9974d3b)"'
+    steps:
+      - name: Detect GPU architecture
+        id: gpu-arch
+        run: |
+          nvidia-smi
+          compute_cap=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '[:space:]')
+          arch=$(echo "${compute_cap}" | tr -d '.')
+          echo "arch=${arch}" >> "$GITHUB_OUTPUT"
+          echo "Detected GPU compute capability: ${compute_cap} -> sm_${arch}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+            python3 python3-dev python3-venv \
+            ffmpeg \
+            gcc g++ ninja-build \
+            libnccl-dev \
+            curl git ca-certificates unzip
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-suffix: "omnidreams-worldlens-canary-sm${{ steps.gpu-arch.outputs.arch }}"
+          prune-cache: false
+
+      - name: Install dependencies
+        env:
+          NVTE_CUDA_ARCHS: ${{ steps.gpu-arch.outputs.arch }}
+        run: |
+          uv venv --clear
+          uv sync --extra dev
+
+      - name: Run OmniDreams WorldLens canary
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${RUN_ROOT}" "${SCRATCH_ROOT}"
+
+          oe() {
+            uv run --no-sync --package flashdreams-omnidreams omnidreams-eval "$@"
+          }
+
+          oe discover \
+            --output "${RUN_ROOT}/manifest-full.jsonl"
+
+          {
+            head -n 1 "${RUN_ROOT}/manifest-full.jsonl"
+            grep -E "${CANARY_UUID_REGEX}" "${RUN_ROOT}/manifest-full.jsonl"
+          } > "${RUN_ROOT}/manifest.jsonl"
+
+          line_count=$(wc -l < "${RUN_ROOT}/manifest.jsonl")
+          if [ "${line_count}" -ne 4 ]; then
+            echo "expected one manifest header plus 3 canary cases, got ${line_count} lines" >&2
+            exit 1
+          fi
+
+          oe plan-batches \
+            --manifest "${RUN_ROOT}/manifest.jsonl" \
+            --output "${RUN_ROOT}/batches.json" \
+            --batch-size 3
+
+          oe stage-batch \
+            --manifest "${RUN_ROOT}/manifest.jsonl" \
+            --batch-plan "${RUN_ROOT}/batches.json" \
+            --batch-id batch-00000 \
+            --scratch-root "${SCRATCH_ROOT}" \
+            --output "${RUN_ROOT}/staged/canary3.jsonl"
+
+          oe generate \
+            --staged-manifest "${RUN_ROOT}/staged/canary3.jsonl" \
+            --run-root "${RUN_ROOT}" \
+            --total-blocks "${TOTAL_BLOCKS}"
+
+          oe validate-generation \
+            --run-root "${RUN_ROOT}" \
+            --output "${RUN_ROOT}/validation.json"
+
+          oe setup-worldlens \
+            --cache-dir "${RUN_ROOT}/evaluators" \
+            --output "${RUN_ROOT}/worldlens-checkout.json"
+
+          oe prepare-worldlens \
+            --staged-manifest "${RUN_ROOT}/staged/canary3.jsonl" \
+            --run-root "${RUN_ROOT}" \
+            --worldlens-root "${RUN_ROOT}/evaluators/WorldLens" \
+            --split "${SPLIT}" \
+            --method-name omnidreams \
+            --write-config \
+            --force
+
+          uv run \
+            --package flashdreams-omnidreams \
+            --with hydra-core \
+            --with omegaconf \
+            --with openai-clip \
+            --with loguru \
+            --with decord \
+            --with tqdm \
+            omnidreams-eval worldlens-evaluate \
+              --worldlens-root "${RUN_ROOT}/evaluators/WorldLens" \
+              --split "${SPLIT}" \
+              --method-name omnidreams \
+              --python python
+
+          oe summarize-run \
+            --run-root "${RUN_ROOT}"
+
+          oe check-baseline \
+            --summary "${RUN_ROOT}/evaluation-summary.json" \
+            --baseline "${BASELINE}" \
+            --output-json "${RUN_ROOT}/baseline-check.json"
+
+      - name: Upload canary artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: omnidreams-worldlens-canary
+          path: |
+            ${{ env.RUN_ROOT }}/manifest.jsonl
+            ${{ env.RUN_ROOT }}/batches.json
+            ${{ env.RUN_ROOT }}/staged/canary3.jsonl
+            ${{ env.RUN_ROOT }}/validation.json
+            ${{ env.RUN_ROOT }}/evaluation-summary.json
+            ${{ env.RUN_ROOT }}/evaluation-summary.md
+            ${{ env.RUN_ROOT }}/baseline-check.json
+            ${{ env.RUN_ROOT }}/generated/*/generated.mp4
+            ${{ env.RUN_ROOT }}/generated/*/generation.json
+            ${{ env.RUN_ROOT }}/generated/*/flashdreams-run.log
+            ${{ env.RUN_ROOT }}/evaluators/WorldLens/cache/eval_logs/**
+            ${{ env.RUN_ROOT }}/evaluators/WorldLens/generated_results/omnidreams/stage_manifest.json
+            ${{ env.RUN_ROOT }}/evaluators/WorldLens/generated_results/omnidreams/*/*.json
+          if-no-files-found: ignore

--- a/.github/workflows/omnidreams-worldlens-canary.yml
+++ b/.github/workflows/omnidreams-worldlens-canary.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: linux-amd64-gpu-rtxpro6000-latest-2
     timeout-minutes: 120
     continue-on-error: true
+    defaults:
+      run:
+        shell: bash
     container:
       image: nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04
       options: --gpus all
@@ -90,7 +93,7 @@ jobs:
 
           {
             head -n 1 "${RUN_ROOT}/manifest-full.jsonl"
-            grep -E "${CANARY_UUID_REGEX}" "${RUN_ROOT}/manifest-full.jsonl"
+            grep -E "${CANARY_UUID_REGEX}" "${RUN_ROOT}/manifest-full.jsonl" || true
           } > "${RUN_ROOT}/manifest.jsonl"
 
           line_count=$(wc -l < "${RUN_ROOT}/manifest.jsonl")

--- a/flashdreams/flashdreams/infra/encoder/text/cosmos_reason1.py
+++ b/flashdreams/flashdreams/infra/encoder/text/cosmos_reason1.py
@@ -22,19 +22,18 @@ from typing import Annotated
 
 import torch
 import tyro
+from flashdreams.core.io.hf import maybe_download_hf_repo_on_rank0
+from flashdreams.infra.encoder import Encoder, EncoderConfig
 from loguru import logger
 from torch import Tensor
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
-
-from flashdreams.core.io.hf import maybe_download_hf_repo_on_rank0
-from flashdreams.infra.encoder import Encoder, EncoderConfig
 
 
 @dataclass(kw_only=True)
 class CosmosReason1TextEncoderConfig(EncoderConfig):
     """Config for the Cosmos-Reason1 text encoder."""
 
-    _target: Annotated[type["CosmosReason1TextEncoder"], tyro.conf.Suppress] = field(
+    _target: Annotated[type, tyro.conf.Suppress] = field(
         default_factory=lambda: CosmosReason1TextEncoder
     )
 

--- a/flashdreams/flashdreams/infra/encoder/text/cosmos_reason1.py
+++ b/flashdreams/flashdreams/infra/encoder/text/cosmos_reason1.py
@@ -18,8 +18,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Annotated
 
 import torch
+import tyro
 from loguru import logger
 from torch import Tensor
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
@@ -32,7 +34,7 @@ from flashdreams.infra.encoder import Encoder, EncoderConfig
 class CosmosReason1TextEncoderConfig(EncoderConfig):
     """Config for the Cosmos-Reason1 text encoder."""
 
-    _target: type["CosmosReason1TextEncoder"] = field(
+    _target: Annotated[type["CosmosReason1TextEncoder"], tyro.conf.Suppress] = field(
         default_factory=lambda: CosmosReason1TextEncoder
     )
 

--- a/flashdreams/flashdreams/infra/encoder/text/cosmos_reason1.py
+++ b/flashdreams/flashdreams/infra/encoder/text/cosmos_reason1.py
@@ -22,11 +22,12 @@ from typing import Annotated
 
 import torch
 import tyro
-from flashdreams.core.io.hf import maybe_download_hf_repo_on_rank0
-from flashdreams.infra.encoder import Encoder, EncoderConfig
 from loguru import logger
 from torch import Tensor
 from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+
+from flashdreams.core.io.hf import maybe_download_hf_repo_on_rank0
+from flashdreams.infra.encoder import Encoder, EncoderConfig
 
 
 @dataclass(kw_only=True)

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from typing import Annotated
 
 import torch
 from torch import Tensor
+import tyro
 
 from flashdreams.infra.decoder import DecoderConfig, StreamingVideoDecoder
 from flashdreams.recipes.taehv.checkpoint import (
@@ -58,7 +60,9 @@ slice the live model expects."""
 class TeahvVAEDecoderConfig(DecoderConfig):
     """Config for the TAEHV decoder."""
 
-    _target: type["TeahvVAEDecoder"] = field(default_factory=lambda: TeahvVAEDecoder)
+    _target: Annotated[type["TeahvVAEDecoder"], tyro.conf.Suppress] = field(
+        default_factory=lambda: TeahvVAEDecoder
+    )
 
     checkpoint_path: str = AVAILABLE_TAEHV_CHECKPOINT_PATHS["lighttae"]
     """Path to a pretrained TAEHV checkpoint. Defaults to the ``lighttae`` weights."""

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -22,9 +22,7 @@ from dataclasses import dataclass, field
 from typing import Annotated
 
 import torch
-from torch import Tensor
 import tyro
-
 from flashdreams.infra.decoder import DecoderConfig, StreamingVideoDecoder
 from flashdreams.recipes.taehv.checkpoint import (
     StateDictTransform,
@@ -33,6 +31,7 @@ from flashdreams.recipes.taehv.checkpoint import (
     truncate_oversize_tgrow_weights,
 )
 from flashdreams.recipes.taehv.impl import TAEHV, TAEHVCache
+from torch import Tensor
 
 AVAILABLE_TAEHV_CHECKPOINT_PATHS = {
     "lighttae": "https://huggingface.co/lightx2v/Autoencoders/resolve/main/lighttaew2_1.pth",
@@ -60,7 +59,7 @@ slice the live model expects."""
 class TeahvVAEDecoderConfig(DecoderConfig):
     """Config for the TAEHV decoder."""
 
-    _target: Annotated[type["TeahvVAEDecoder"], tyro.conf.Suppress] = field(
+    _target: Annotated[type, tyro.conf.Suppress] = field(
         default_factory=lambda: TeahvVAEDecoder
     )
 

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -23,6 +23,8 @@ from typing import Annotated
 
 import torch
 import tyro
+from torch import Tensor
+
 from flashdreams.infra.decoder import DecoderConfig, StreamingVideoDecoder
 from flashdreams.recipes.taehv.checkpoint import (
     StateDictTransform,
@@ -31,7 +33,6 @@ from flashdreams.recipes.taehv.checkpoint import (
     truncate_oversize_tgrow_weights,
 )
 from flashdreams.recipes.taehv.impl import TAEHV, TAEHVCache
-from torch import Tensor
 
 AVAILABLE_TAEHV_CHECKPOINT_PATHS = {
     "lighttae": "https://huggingface.co/lightx2v/Autoencoders/resolve/main/lighttaew2_1.pth",

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Literal, Optional, TypedDict, get_args
+from typing import Annotated, Callable, Dict, Literal, Optional, TypedDict, get_args
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import tyro
 from einops import rearrange
 from torch import Tensor
 
@@ -1279,7 +1280,9 @@ class WanVAEEncoderConfig(EncoderConfig):
     :class:`Wan22TI2V5BVAEEncoderConfig` for the pre-rolled set.
     """
 
-    _target: type["WanVAEEncoder"] = field(default_factory=lambda: WanVAEEncoder)
+    _target: Annotated[type["WanVAEEncoder"], tyro.conf.Suppress] = field(
+        default_factory=lambda: WanVAEEncoder
+    )
 
     checkpoint_path: str = AVAILABLE_WAN_VAE_CHECKPOINT_PATHS["vae"]
     dtype: torch.dtype = torch.bfloat16
@@ -1412,7 +1415,9 @@ class WanVAEDecoderConfig(DecoderConfig):
     =256`` and the residual up-stage with ``DupUp3D`` shortcut.
     """
 
-    _target: type["WanVAEDecoder"] = field(default_factory=lambda: WanVAEDecoder)
+    _target: Annotated[type["WanVAEDecoder"], tyro.conf.Suppress] = field(
+        default_factory=lambda: WanVAEDecoder
+    )
 
     checkpoint_path: str = AVAILABLE_WAN_VAE_CHECKPOINT_PATHS["vae"]
     dtype: torch.dtype = torch.bfloat16

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -36,8 +36,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import tyro
 from einops import rearrange
-from torch import Tensor
-
 from flashdreams.core.checkpoint.load import load_checkpoint
 from flashdreams.infra.compile import compile_module
 from flashdreams.infra.cuda_graph import CUDAGraphWrapper, set_or_copy
@@ -51,6 +49,7 @@ from flashdreams.infra.encoder import (
     StreamingEncoderCache,
     StreamingVideoEncoder,
 )
+from torch import Tensor
 
 # Wan 2.2 TI2V 5B's VAE ships in the diffusers Wan-AI repo. The
 # loader pulls the diffusers safetensors shard and remaps keys via
@@ -1280,7 +1279,7 @@ class WanVAEEncoderConfig(EncoderConfig):
     :class:`Wan22TI2V5BVAEEncoderConfig` for the pre-rolled set.
     """
 
-    _target: Annotated[type["WanVAEEncoder"], tyro.conf.Suppress] = field(
+    _target: Annotated[type, tyro.conf.Suppress] = field(
         default_factory=lambda: WanVAEEncoder
     )
 
@@ -1415,7 +1414,7 @@ class WanVAEDecoderConfig(DecoderConfig):
     =256`` and the residual up-stage with ``DupUp3D`` shortcut.
     """
 
-    _target: Annotated[type["WanVAEDecoder"], tyro.conf.Suppress] = field(
+    _target: Annotated[type, tyro.conf.Suppress] = field(
         default_factory=lambda: WanVAEDecoder
     )
 

--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -36,6 +36,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 import tyro
 from einops import rearrange
+from torch import Tensor
+
 from flashdreams.core.checkpoint.load import load_checkpoint
 from flashdreams.infra.compile import compile_module
 from flashdreams.infra.cuda_graph import CUDAGraphWrapper, set_or_copy
@@ -49,7 +51,6 @@ from flashdreams.infra.encoder import (
     StreamingEncoderCache,
     StreamingVideoEncoder,
 )
-from torch import Tensor
 
 # Wan 2.2 TI2V 5B's VAE ships in the diffusers Wan-AI repo. The
 # loader pulls the diffusers safetensors shard and remaps keys via

--- a/integrations/omnidreams/README.md
+++ b/integrations/omnidreams/README.md
@@ -47,12 +47,14 @@ OmniDreams scene batches:
 5. Validate generated artifacts and runner logs.
 6. Stage/run DrivingGen FVD-lite and WorldLens consistency evaluators.
 7. Write a JSON and Markdown summary report.
+8. Optionally compare the summary against a checked-in metric baseline.
 
 The high-level workflow is:
 
 ```bash
 RUN=/trees/$USER/od-runs/od-26.01
 SCRATCH=/local_nvme/$USER/omnidreams-eval-scratch
+BASELINE=integrations/omnidreams/eval_baselines/od-26.01-worldlens-40-v1.json
 
 uv run --package flashdreams-omnidreams omnidreams-eval discover \
   --output "$RUN/manifest.jsonl"
@@ -73,12 +75,17 @@ uv run --package flashdreams-omnidreams omnidreams-eval generate \
   --staged-manifest "$RUN/staged/batch-00000.jsonl" \
   --run-root "$RUN"
 
-uv run --package flashdreams-omnidreams omnidreams-eval validate-generated \
+uv run --package flashdreams-omnidreams omnidreams-eval validate-generation \
   --run-root "$RUN" \
   --output "$RUN/validation.json"
 
 uv run --package flashdreams-omnidreams omnidreams-eval summarize-run \
   --run-root "$RUN"
+
+uv run --package flashdreams-omnidreams omnidreams-eval check-baseline \
+  --summary "$RUN/evaluation-summary.json" \
+  --baseline "$BASELINE" \
+  --output-json "$RUN/baseline-check.json"
 ```
 
 External evaluator setup is intentionally separate from FlashDreams generation,
@@ -109,6 +116,10 @@ Interpret the report as follows:
   1.0 as an idealized upper bound. They are useful standalone video-consistency
   signals, but they do not directly measure closed-loop simulator quality,
   path correctness, off-road behavior, or collisions.
+- `check-baseline` compares a run summary against a JSON file containing the
+  accepted metric envelope. Keep generated clips as run artifacts, not in the
+  baseline JSON; the baseline should contain only expected metric values and
+  tolerances.
 
 ## Run interactive-drive (desktop demo)
 

--- a/integrations/omnidreams/eval_baselines/od-26.01-canary3-tb4-v1.json
+++ b/integrations/omnidreams/eval_baselines/od-26.01-canary3-tb4-v1.json
@@ -1,0 +1,122 @@
+{
+  "kind": "omnidreams_eval_baseline",
+  "schema_version": 1,
+  "baseline_id": "od-26.01-canary3-tb4-v1",
+  "description": "Initial metric envelope for the 3-scene NuRec 26.01 OmniDreams per-commit canary.",
+  "dataset": {
+    "repo": "nvidia/PhysicalAI-Autonomous-Vehicles-NuRec",
+    "revision": "26.01",
+    "subpath": "sample_set/26.01_release",
+    "camera": "camera_front_wide_120fov"
+  },
+  "run_shape": {
+    "case_count": 3,
+    "total_blocks": 4,
+    "generated_frames": 29
+  },
+  "scene_uuids": [
+    "01d503d4-449b-46fc-8d78-9085e70d3554",
+    "02e075b9-fd24-426b-971b-7cfcb2074cc9",
+    "0499fb41-122d-4180-83af-f954a9974d3b"
+  ],
+  "checks": [
+    {
+      "name": "generated_clip_count",
+      "source": "generated.generated_mp4_count",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "generated_case_directories",
+      "source": "generated.case_directories",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "validation_case_count",
+      "source": "validation.case_count",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "validation_failures",
+      "source": "validation.failure_count",
+      "op": "==",
+      "expected": 0
+    },
+    {
+      "name": "expected_frames_from_steps",
+      "source": "validation.expected_frames_from_steps[29]",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "runner_written_frames",
+      "source": "validation.runner_written_frames[29]",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "total_blocks",
+      "source": "validation.total_blocks[4]",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "worldlens_stage_case_count",
+      "source": "worldlens.stage_manifest.case_count",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "worldlens_stage_frame_mismatches",
+      "source": "worldlens.stage_manifest.frame_count_mismatch_count",
+      "op": "==",
+      "expected": 0
+    },
+    {
+      "name": "worldlens_generated_frame_count",
+      "source": "worldlens.stage_manifest.generated_frame_counts[0]",
+      "op": "==",
+      "expected": 29
+    },
+    {
+      "name": "worldlens_reference_frame_count",
+      "source": "worldlens.stage_manifest.reference_frame_counts[0]",
+      "op": "==",
+      "expected": 29
+    },
+    {
+      "name": "worldlens_temporal_video_count",
+      "source": "worldlens.runs[split=od_26_01_canary3_tb4].artifact_metrics[artifact=temporal_consistency/repeat_0.json].video_count",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "worldlens_subject_video_count",
+      "source": "worldlens.runs[split=od_26_01_canary3_tb4].artifact_metrics[artifact=subject_consistency/repeat_0.json].video_count",
+      "op": "==",
+      "expected": 3
+    },
+    {
+      "name": "worldlens_temporal_consistency_per_frame",
+      "source": "worldlens.runs[split=od_26_01_canary3_tb4].artifact_metrics[artifact=temporal_consistency/repeat_0.json].temporal_consistency_per_frame",
+      "min_allowed": 0.95
+    },
+    {
+      "name": "worldlens_temporal_ts_per_frame",
+      "source": "worldlens.runs[split=od_26_01_canary3_tb4].artifact_metrics[artifact=temporal_consistency/repeat_0.json].ts_per_frame",
+      "min_allowed": 0.75
+    },
+    {
+      "name": "worldlens_subject_consistency_per_frame",
+      "source": "worldlens.runs[split=od_26_01_canary3_tb4].artifact_metrics[artifact=subject_consistency/repeat_0.json].temporal_consistency_per_frame",
+      "min_allowed": 0.95
+    },
+    {
+      "name": "worldlens_subject_ts_per_frame",
+      "source": "worldlens.runs[split=od_26_01_canary3_tb4].artifact_metrics[artifact=subject_consistency/repeat_0.json].ts_per_frame",
+      "min_allowed": 0.85
+    }
+  ]
+}

--- a/integrations/omnidreams/eval_baselines/od-26.01-worldlens-40-v1.json
+++ b/integrations/omnidreams/eval_baselines/od-26.01-worldlens-40-v1.json
@@ -1,0 +1,110 @@
+{
+  "kind": "omnidreams_eval_baseline",
+  "schema_version": 1,
+  "baseline_id": "od-26.01-worldlens-40-v1",
+  "description": "Initial metric envelope for the 40-case NuRec 26.01 OmniDreams nightly evaluation.",
+  "dataset": {
+    "repo": "nvidia/PhysicalAI-Autonomous-Vehicles-NuRec",
+    "revision": "26.01",
+    "subpath": "sample_set/26.01_release",
+    "camera": "camera_front_wide_120fov"
+  },
+  "run_shape": {
+    "case_count": 40,
+    "total_blocks": 20,
+    "generated_frames": 157
+  },
+  "checks": [
+    {
+      "name": "generated_clip_count",
+      "source": "generated.generated_mp4_count",
+      "op": "==",
+      "expected": 40
+    },
+    {
+      "name": "generated_case_directories",
+      "source": "generated.case_directories",
+      "op": "==",
+      "expected": 40
+    },
+    {
+      "name": "validation_case_count",
+      "source": "validation.case_count",
+      "op": "==",
+      "expected": 40
+    },
+    {
+      "name": "validation_failures",
+      "source": "validation.failure_count",
+      "op": "==",
+      "expected": 0
+    },
+    {
+      "name": "expected_frames_from_steps",
+      "source": "validation.expected_frames_from_steps[157]",
+      "op": "==",
+      "expected": 40
+    },
+    {
+      "name": "runner_written_frames",
+      "source": "validation.runner_written_frames[157]",
+      "op": "==",
+      "expected": 40
+    },
+    {
+      "name": "total_blocks",
+      "source": "validation.total_blocks[20]",
+      "op": "==",
+      "expected": 40
+    },
+    {
+      "name": "worldlens_stage_case_count",
+      "source": "worldlens.stage_manifest.case_count",
+      "op": "==",
+      "expected": 40
+    },
+    {
+      "name": "worldlens_stage_frame_mismatches",
+      "source": "worldlens.stage_manifest.frame_count_mismatch_count",
+      "op": "==",
+      "expected": 0
+    },
+    {
+      "name": "worldlens_generated_frame_count",
+      "source": "worldlens.stage_manifest.generated_frame_counts[0]",
+      "op": "==",
+      "expected": 157
+    },
+    {
+      "name": "worldlens_reference_frame_count",
+      "source": "worldlens.stage_manifest.reference_frame_counts[0]",
+      "op": "==",
+      "expected": 157
+    },
+    {
+      "name": "worldlens_temporal_consistency_per_frame",
+      "source": "worldlens.runs[split=od_26_01_worldlens_40].artifact_metrics[artifact=temporal_consistency/repeat_0.json].temporal_consistency_per_frame",
+      "min_allowed": 0.94
+    },
+    {
+      "name": "worldlens_temporal_ts_per_frame",
+      "source": "worldlens.runs[split=od_26_01_worldlens_40].artifact_metrics[artifact=temporal_consistency/repeat_0.json].ts_per_frame",
+      "min_allowed": 0.8
+    },
+    {
+      "name": "worldlens_subject_consistency_per_frame",
+      "source": "worldlens.runs[split=od_26_01_worldlens_40].artifact_metrics[artifact=subject_consistency/repeat_0.json].temporal_consistency_per_frame",
+      "min_allowed": 0.93
+    },
+    {
+      "name": "worldlens_subject_ts_per_frame",
+      "source": "worldlens.runs[split=od_26_01_worldlens_40].artifact_metrics[artifact=subject_consistency/repeat_0.json].ts_per_frame",
+      "min_allowed": 0.84
+    },
+    {
+      "name": "drivinggen_fvd_lite_batch_00001",
+      "source": "drivinggen.fvd_lite[split=od_26_01_batch_00001].value",
+      "max_allowed": 450.0
+    }
+  ]
+}

--- a/integrations/omnidreams/omnidreams/encoder/pixel_shuffle.py
+++ b/integrations/omnidreams/omnidreams/encoder/pixel_shuffle.py
@@ -24,15 +24,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Annotated, Literal
 
-from einops import rearrange
-from torch import Tensor
 import tyro
-
+from einops import rearrange
 from flashdreams.infra.encoder import (
     EncoderConfig,
     StreamingEncoderCache,
     StreamingVideoEncoder,
 )
+from torch import Tensor
 
 
 @dataclass(kw_only=True)
@@ -47,7 +46,7 @@ class PixelShuffleVAEEncoderCache(StreamingEncoderCache):
 class PixelShuffleVAEEncoderConfig(EncoderConfig):
     """Config for the pixel-shuffle pseudo-VAE encoder."""
 
-    _target: Annotated[type["PixelShuffleVAEEncoder"], tyro.conf.Suppress] = field(
+    _target: Annotated[type, tyro.conf.Suppress] = field(
         default_factory=lambda: PixelShuffleVAEEncoder
     )
 

--- a/integrations/omnidreams/omnidreams/encoder/pixel_shuffle.py
+++ b/integrations/omnidreams/omnidreams/encoder/pixel_shuffle.py
@@ -22,10 +22,11 @@ and unshuffle each frame's 8x8 spatial blocks into channels.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Annotated, Literal
 
 from einops import rearrange
 from torch import Tensor
+import tyro
 
 from flashdreams.infra.encoder import (
     EncoderConfig,
@@ -46,7 +47,7 @@ class PixelShuffleVAEEncoderCache(StreamingEncoderCache):
 class PixelShuffleVAEEncoderConfig(EncoderConfig):
     """Config for the pixel-shuffle pseudo-VAE encoder."""
 
-    _target: type["PixelShuffleVAEEncoder"] = field(
+    _target: Annotated[type["PixelShuffleVAEEncoder"], tyro.conf.Suppress] = field(
         default_factory=lambda: PixelShuffleVAEEncoder
     )
 

--- a/integrations/omnidreams/omnidreams/encoder/pixel_shuffle.py
+++ b/integrations/omnidreams/omnidreams/encoder/pixel_shuffle.py
@@ -26,12 +26,13 @@ from typing import Annotated, Literal
 
 import tyro
 from einops import rearrange
+from torch import Tensor
+
 from flashdreams.infra.encoder import (
     EncoderConfig,
     StreamingEncoderCache,
     StreamingVideoEncoder,
 )
-from torch import Tensor
 
 
 @dataclass(kw_only=True)

--- a/integrations/omnidreams/omnidreams/eval/baseline.py
+++ b/integrations/omnidreams/omnidreams/eval/baseline.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Baseline comparison helpers for OmniDreams evaluation summaries."""
+
+from __future__ import annotations
+
+import json
+import operator
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+BASELINE_SCHEMA_VERSION = 1
+CHECK_REPORT_SCHEMA_VERSION = 1
+
+_OPERATORS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">": operator.gt,
+    ">=": operator.ge,
+    "<": operator.lt,
+    "<=": operator.le,
+}
+_NUMERIC_OPERATORS = {">", ">=", "<", "<="}
+
+
+@dataclass(frozen=True)
+class BaselineCheckResult:
+    """Result for one expected-metric check."""
+
+    name: str
+    source: str
+    severity: str
+    passed: bool
+    actual: Any = None
+    expected: Any = None
+    op: str | None = None
+    min_allowed: Any = None
+    max_allowed: Any = None
+    tolerance: Any = None
+    relative_tolerance: Any = None
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_json(path: Path) -> Any:
+    """Load a JSON document from ``path``."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_baseline_check_json(report: Mapping[str, Any], output: Path) -> None:
+    """Write a baseline check report JSON artifact."""
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def check_summary_against_baseline(
+    summary: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+    *,
+    summary_path: Path | None = None,
+    baseline_path: Path | None = None,
+) -> dict[str, Any]:
+    """Compare an evaluation summary against a checked-in metric baseline."""
+
+    checks = baseline.get("checks")
+    if not isinstance(checks, list):
+        raise ValueError("baseline must contain a list field named 'checks'")
+
+    results = [_evaluate_check(summary, check) for check in checks]
+    critical_failures = sum(
+        1
+        for result in results
+        if not result.passed and result.severity.lower() == "critical"
+    )
+    warning_failures = sum(
+        1
+        for result in results
+        if not result.passed and result.severity.lower() != "critical"
+    )
+    return {
+        "kind": "omnidreams_eval_baseline_check",
+        "schema_version": CHECK_REPORT_SCHEMA_VERSION,
+        "baseline_id": baseline.get("baseline_id"),
+        "baseline_path": str(baseline_path) if baseline_path is not None else None,
+        "summary_path": str(summary_path) if summary_path is not None else None,
+        "passed": critical_failures == 0,
+        "critical_failures": critical_failures,
+        "warning_failures": warning_failures,
+        "check_count": len(results),
+        "checks": [result.to_dict() for result in results],
+    }
+
+
+def format_baseline_check_report(report: Mapping[str, Any]) -> str:
+    """Render a compact Markdown report for terminal output and logs."""
+
+    status = "PASS" if report.get("passed") else "FAIL"
+    lines = [
+        f"Baseline check: {status}",
+    ]
+    baseline_id = report.get("baseline_id")
+    if baseline_id:
+        lines.append(f"Baseline: `{baseline_id}`")
+    lines.extend(
+        [
+            "",
+            "| Status | Severity | Check | Actual | Expected |",
+            "| --- | --- | --- | ---: | --- |",
+        ]
+    )
+    for result in report.get("checks", []):
+        check_passed = bool(result.get("passed"))
+        severity = str(result.get("severity", "critical"))
+        row_status = "PASS" if check_passed else (
+            "FAIL" if severity.lower() == "critical" else "WARN"
+        )
+        lines.append(
+            "| "
+            f"{row_status} | "
+            f"{severity} | "
+            f"`{result.get('name', '')}` | "
+            f"{_format_value(result.get('actual'))} | "
+            f"{_format_expectation(result)} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def resolve_summary_path(summary: Mapping[str, Any], path: str) -> Any:
+    """Resolve a baseline source path against a summary object.
+
+    The path language is intentionally small:
+
+    - ``a.b.c`` looks up nested mapping keys.
+    - ``items[0]`` selects a list index.
+    - ``items[key=value]`` selects the first mapping in a list with a matching key.
+    - ``items[value]`` selects a mapping by common identity keys such as
+      ``artifact``, ``split``, ``name``, ``id``, or ``metric``.
+    """
+
+    if not path:
+        raise ValueError("summary path must not be empty")
+    current: Any = summary
+    for segment in _split_path(path):
+        key, selectors = _parse_segment(segment)
+        if key:
+            current = _mapping_get(current, key)
+        for selector in selectors:
+            current = _apply_selector(current, selector)
+    return current
+
+
+def _evaluate_check(
+    summary: Mapping[str, Any], raw_check: Mapping[str, Any]
+) -> BaselineCheckResult:
+    if not isinstance(raw_check, Mapping):
+        raise ValueError("each baseline check must be an object")
+    source = raw_check.get("source") or raw_check.get("path")
+    if not isinstance(source, str) or not source:
+        raise ValueError("each baseline check must define a non-empty 'source'")
+
+    name = str(raw_check.get("name") or source)
+    severity = str(raw_check.get("severity") or "critical")
+
+    try:
+        actual = resolve_summary_path(summary, source)
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        return BaselineCheckResult(
+            name=name,
+            source=source,
+            severity=severity,
+            passed=False,
+            message=str(exc),
+        )
+
+    op = raw_check.get("op")
+    expected = raw_check.get("expected", raw_check.get("value"))
+    min_allowed = raw_check.get("min_allowed")
+    max_allowed = raw_check.get("max_allowed")
+    tolerance = raw_check.get("tolerance")
+    relative_tolerance = raw_check.get("relative_tolerance")
+
+    if op is not None:
+        if not isinstance(op, str) or op not in _OPERATORS:
+            raise ValueError(f"unsupported baseline operator for {name!r}: {op!r}")
+        if "expected" not in raw_check and "value" not in raw_check:
+            raise ValueError(f"baseline check {name!r} with op {op!r} needs expected")
+        passed, message = _compare_operator(actual, expected, op)
+    elif min_allowed is not None or max_allowed is not None:
+        passed, message = _compare_range(actual, min_allowed, max_allowed)
+    elif tolerance is not None or relative_tolerance is not None:
+        if "expected" not in raw_check and "value" not in raw_check:
+            raise ValueError(f"baseline check {name!r} with tolerance needs expected")
+        passed, message = _compare_tolerance(
+            actual,
+            expected,
+            tolerance=tolerance,
+            relative_tolerance=relative_tolerance,
+        )
+    elif "expected" in raw_check or "value" in raw_check:
+        passed = actual == expected
+        message = "" if passed else f"expected {expected!r}, got {actual!r}"
+    else:
+        raise ValueError(
+            f"baseline check {name!r} must define op, range, tolerance, or expected"
+        )
+
+    return BaselineCheckResult(
+        name=name,
+        source=source,
+        severity=severity,
+        passed=passed,
+        actual=actual,
+        expected=expected,
+        op=op,
+        min_allowed=min_allowed,
+        max_allowed=max_allowed,
+        tolerance=tolerance,
+        relative_tolerance=relative_tolerance,
+        message=message,
+    )
+
+
+def _compare_operator(actual: Any, expected: Any, op: str) -> tuple[bool, str]:
+    if op in _NUMERIC_OPERATORS and (
+        not _is_number(actual) or not _is_number(expected)
+    ):
+        return False, f"operator {op!r} requires numeric actual and expected"
+    passed = bool(_OPERATORS[op](actual, expected))
+    message = "" if passed else f"expected actual {op} {expected!r}, got {actual!r}"
+    return passed, message
+
+
+def _compare_range(
+    actual: Any, min_allowed: Any, max_allowed: Any
+) -> tuple[bool, str]:
+    if not _is_number(actual):
+        return False, "range check requires numeric actual value"
+    if min_allowed is not None:
+        if not _is_number(min_allowed):
+            return False, "min_allowed must be numeric"
+        if actual < min_allowed:
+            return False, f"actual {actual!r} is below min_allowed {min_allowed!r}"
+    if max_allowed is not None:
+        if not _is_number(max_allowed):
+            return False, "max_allowed must be numeric"
+        if actual > max_allowed:
+            return False, f"actual {actual!r} is above max_allowed {max_allowed!r}"
+    return True, ""
+
+
+def _compare_tolerance(
+    actual: Any,
+    expected: Any,
+    *,
+    tolerance: Any,
+    relative_tolerance: Any,
+) -> tuple[bool, str]:
+    if not _is_number(actual) or not _is_number(expected):
+        return False, "tolerance check requires numeric actual and expected"
+    allowed = 0.0
+    if tolerance is not None:
+        if not _is_number(tolerance):
+            return False, "tolerance must be numeric"
+        allowed = max(allowed, float(tolerance))
+    if relative_tolerance is not None:
+        if not _is_number(relative_tolerance):
+            return False, "relative_tolerance must be numeric"
+        allowed = max(allowed, abs(float(expected)) * float(relative_tolerance))
+    delta = abs(float(actual) - float(expected))
+    passed = delta <= allowed
+    message = "" if passed else (
+        f"actual {actual!r} differs from expected {expected!r} by {delta:g}, "
+        f"allowed {allowed:g}"
+    )
+    return passed, message
+
+
+def _split_path(path: str) -> list[str]:
+    out: list[str] = []
+    start = 0
+    bracket_depth = 0
+    for index, char in enumerate(path):
+        if char == "[":
+            bracket_depth += 1
+        elif char == "]":
+            bracket_depth -= 1
+            if bracket_depth < 0:
+                raise ValueError(f"unbalanced selector in path: {path}")
+        elif char == "." and bracket_depth == 0:
+            out.append(path[start:index])
+            start = index + 1
+    if bracket_depth:
+        raise ValueError(f"unbalanced selector in path: {path}")
+    out.append(path[start:])
+    if any(not segment for segment in out):
+        raise ValueError(f"empty path segment in: {path}")
+    return out
+
+
+def _parse_segment(segment: str) -> tuple[str, list[str]]:
+    if "[" not in segment:
+        return segment, []
+    key = segment[: segment.index("[")]
+    selectors: list[str] = []
+    rest = segment[len(key) :]
+    while rest:
+        if not rest.startswith("["):
+            raise ValueError(f"invalid selector segment: {segment}")
+        close = rest.find("]")
+        if close < 0:
+            raise ValueError(f"unclosed selector segment: {segment}")
+        selectors.append(rest[1:close])
+        rest = rest[close + 1 :]
+    return key, selectors
+
+
+def _mapping_get(value: Any, key: str) -> Any:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"cannot look up key {key!r} on non-object {type(value).__name__}")
+    if key not in value:
+        raise KeyError(f"summary path key not found: {key}")
+    return value[key]
+
+
+def _apply_selector(value: Any, selector: str) -> Any:
+    selector = selector.strip()
+    if not selector:
+        raise ValueError("empty selector")
+    if isinstance(value, Mapping):
+        key = _strip_quotes(selector)
+        if key not in value:
+            raise KeyError(f"summary path key not found: {key}")
+        return value[key]
+    if not _is_sequence(value):
+        raise TypeError(
+            f"cannot apply selector [{selector}] to {type(value).__name__}"
+        )
+    if selector.lstrip("-").isdigit():
+        return value[int(selector)]
+    if "=" in selector:
+        key, expected = selector.split("=", 1)
+        return _find_mapping_by_key(value, key.strip(), _strip_quotes(expected.strip()))
+    return _find_mapping_by_identity(value, _strip_quotes(selector))
+
+
+def _find_mapping_by_key(items: Sequence[Any], key: str, expected: str) -> Any:
+    for item in items:
+        if isinstance(item, Mapping) and str(item.get(key)) == expected:
+            return item
+    raise KeyError(f"no list item has {key}={expected!r}")
+
+
+def _find_mapping_by_identity(items: Sequence[Any], expected: str) -> Any:
+    for key in ("name", "id", "split", "artifact", "metric"):
+        try:
+            return _find_mapping_by_key(items, key, expected)
+        except KeyError:
+            continue
+    raise KeyError(f"no list item matched selector {expected!r}")
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _is_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _format_expectation(result: Mapping[str, Any]) -> str:
+    min_allowed = result.get("min_allowed")
+    max_allowed = result.get("max_allowed")
+    if min_allowed is not None or max_allowed is not None:
+        if min_allowed is not None and max_allowed is not None:
+            return f"{_format_value(min_allowed)}..{_format_value(max_allowed)}"
+        if min_allowed is not None:
+            return f">= {_format_value(min_allowed)}"
+        return f"<= {_format_value(max_allowed)}"
+    op = result.get("op")
+    if op:
+        return f"{op} {_format_value(result.get('expected'))}"
+    tolerance = result.get("tolerance")
+    relative_tolerance = result.get("relative_tolerance")
+    if tolerance is not None or relative_tolerance is not None:
+        parts = [f"target {_format_value(result.get('expected'))}"]
+        if tolerance is not None:
+            parts.append(f"abs {_format_value(tolerance)}")
+        if relative_tolerance is not None:
+            parts.append(f"rel {_format_value(relative_tolerance)}")
+        return ", ".join(parts)
+    return _format_value(result.get("expected"))
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    if value is None:
+        return ""
+    return str(value)

--- a/integrations/omnidreams/omnidreams/eval/baseline.py
+++ b/integrations/omnidreams/omnidreams/eval/baseline.py
@@ -104,7 +104,7 @@ def format_baseline_check_report(report: Mapping[str, Any]) -> str:
     """Render a compact Markdown report for terminal output and logs."""
 
     status = "PASS" if report.get("passed") else "FAIL"
-    lines = [
+    lines: list[str] = [
         f"Baseline check: {status}",
     ]
     baseline_id = report.get("baseline_id")
@@ -120,8 +120,10 @@ def format_baseline_check_report(report: Mapping[str, Any]) -> str:
     for result in report.get("checks", []):
         check_passed = bool(result.get("passed"))
         severity = str(result.get("severity", "critical"))
-        row_status = "PASS" if check_passed else (
-            "FAIL" if severity.lower() == "critical" else "WARN"
+        row_status = (
+            "PASS"
+            if check_passed
+            else ("FAIL" if severity.lower() == "critical" else "WARN")
         )
         lines.append(
             "| "
@@ -240,9 +242,7 @@ def _compare_operator(actual: Any, expected: Any, op: str) -> tuple[bool, str]:
     return passed, message
 
 
-def _compare_range(
-    actual: Any, min_allowed: Any, max_allowed: Any
-) -> tuple[bool, str]:
+def _compare_range(actual: Any, min_allowed: Any, max_allowed: Any) -> tuple[bool, str]:
     if not _is_number(actual):
         return False, "range check requires numeric actual value"
     if min_allowed is not None:
@@ -278,9 +278,13 @@ def _compare_tolerance(
         allowed = max(allowed, abs(float(expected)) * float(relative_tolerance))
     delta = abs(float(actual) - float(expected))
     passed = delta <= allowed
-    message = "" if passed else (
-        f"actual {actual!r} differs from expected {expected!r} by {delta:g}, "
-        f"allowed {allowed:g}"
+    message = (
+        ""
+        if passed
+        else (
+            f"actual {actual!r} differs from expected {expected!r} by {delta:g}, "
+            f"allowed {allowed:g}"
+        )
     )
     return passed, message
 
@@ -326,7 +330,9 @@ def _parse_segment(segment: str) -> tuple[str, list[str]]:
 
 def _mapping_get(value: Any, key: str) -> Any:
     if not isinstance(value, Mapping):
-        raise TypeError(f"cannot look up key {key!r} on non-object {type(value).__name__}")
+        raise TypeError(
+            f"cannot look up key {key!r} on non-object {type(value).__name__}"
+        )
     if key not in value:
         raise KeyError(f"summary path key not found: {key}")
     return value[key]
@@ -342,9 +348,7 @@ def _apply_selector(value: Any, selector: str) -> Any:
             raise KeyError(f"summary path key not found: {key}")
         return value[key]
     if not _is_sequence(value):
-        raise TypeError(
-            f"cannot apply selector [{selector}] to {type(value).__name__}"
-        )
+        raise TypeError(f"cannot apply selector [{selector}] to {type(value).__name__}")
     if selector.lstrip("-").isdigit():
         return value[int(selector)]
     if "=" in selector:
@@ -376,7 +380,9 @@ def _strip_quotes(value: str) -> str:
 
 
 def _is_sequence(value: Any) -> bool:
-    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+    return isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    )
 
 
 def _is_number(value: Any) -> bool:

--- a/integrations/omnidreams/omnidreams/eval/cli.py
+++ b/integrations/omnidreams/omnidreams/eval/cli.py
@@ -13,6 +13,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+from omnidreams.eval.baseline import (
+    check_summary_against_baseline,
+    format_baseline_check_report,
+    load_json,
+    write_baseline_check_json,
+)
 from omnidreams.eval.batches import (
     cases_for_batch,
     parse_byte_size,
@@ -483,6 +489,34 @@ def _cmd_summarize_run(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_check_baseline(args: argparse.Namespace) -> int:
+    summary = load_json(args.summary)
+    baseline = load_json(args.baseline)
+    if not isinstance(summary, dict):
+        print("summary JSON must be an object", file=sys.stderr)
+        return 1
+    if not isinstance(baseline, dict):
+        print("baseline JSON must be an object", file=sys.stderr)
+        return 1
+    try:
+        report = check_summary_against_baseline(
+            summary,
+            baseline,
+            summary_path=args.summary,
+            baseline_path=args.baseline,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if args.output_json is not None:
+        write_baseline_check_json(report, args.output_json)
+        if not args.quiet:
+            print(f"wrote baseline check JSON -> {args.output_json}")
+    if not args.quiet:
+        print(format_baseline_check_report(report), end="")
+    return 0 if report["passed"] else 1
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="omnidreams-eval")
     sub = parser.add_subparsers(required=True)
@@ -745,6 +779,20 @@ def _build_parser() -> argparse.ArgumentParser:
         help="also print the Markdown report to stdout",
     )
     summarize.set_defaults(func=_cmd_summarize_run)
+
+    check_baseline = sub.add_parser(
+        "check-baseline",
+        help="compare an evaluation summary against a checked-in baseline JSON",
+    )
+    check_baseline.add_argument("--summary", type=Path, required=True)
+    check_baseline.add_argument("--baseline", type=Path, required=True)
+    check_baseline.add_argument("--output-json", type=Path, default=None)
+    check_baseline.add_argument(
+        "--quiet",
+        action="store_true",
+        help="only write --output-json and exit status; do not print the table",
+    )
+    check_baseline.set_defaults(func=_cmd_check_baseline)
 
     return parser
 

--- a/integrations/omnidreams/omnidreams/eval/drivinggen.py
+++ b/integrations/omnidreams/omnidreams/eval/drivinggen.py
@@ -14,7 +14,7 @@ import sys
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Sequence
 
 from omnidreams.eval.manifest import StagedCase
 
@@ -53,8 +53,9 @@ def ensure_drivinggen_checkout(
 ) -> DrivingGenCheckout:
     """Clone/fetch DrivingGen and checkout ``revision``."""
 
-    target = cache_dir / "DrivingGen"
     cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = cache_dir.resolve()
+    target = cache_dir / "DrivingGen"
     if not (target / ".git").exists():
         _run(["git", "clone", repo_url, str(target)], cwd=cache_dir)
     elif fetch:

--- a/integrations/omnidreams/omnidreams/eval/generation.py
+++ b/integrations/omnidreams/omnidreams/eval/generation.py
@@ -122,10 +122,26 @@ def _run_generation_command(result: GenerationResult, *, stream_logs: bool) -> N
             check=False,
         )
     if completed.returncode:
+        _print_log_tail(result.log_path)
         raise RuntimeError(
             f"flashdreams-run failed for {result.uuid} with exit code "
             f"{completed.returncode}; see {result.log_path}"
         )
+
+
+def _print_log_tail(path: Path, *, line_count: int = 80) -> None:
+    """Print the tail of a subprocess log before surfacing a failure."""
+
+    if not path.exists():
+        return
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return
+    print(f"=== tail {line_count} lines of {path} ===")
+    for line in lines[-line_count:]:
+        print(line)
+    print(f"=== end tail of {path} ===")
 
 
 def extract_generated_video(stacked_video_path: Path, output_path: Path) -> None:

--- a/integrations/omnidreams/omnidreams/eval/worldlens.py
+++ b/integrations/omnidreams/omnidreams/eval/worldlens.py
@@ -51,8 +51,9 @@ def ensure_worldlens_checkout(
 ) -> WorldLensCheckout:
     """Clone/fetch WorldLens and checkout ``revision``."""
 
-    target = cache_dir / "WorldLens"
     cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = cache_dir.resolve()
+    target = cache_dir / "WorldLens"
     if not (target / ".git").exists():
         _run(["git", "clone", repo_url, str(target)], cwd=cache_dir)
     elif fetch:
@@ -494,7 +495,7 @@ def _validate_slug(value: str, label: str) -> str:
 def _validate_camera_name(value: str) -> str:
     if not value or not re.fullmatch(r"[A-Z0-9_]+", value):
         raise ValueError(
-            f"camera_name must contain only uppercase letters, numbers, and underscores"
+            "camera_name must contain only uppercase letters, numbers, and underscores"
         )
     return value
 

--- a/integrations/omnidreams/tests/test_eval_baseline.py
+++ b/integrations/omnidreams/tests/test_eval_baseline.py
@@ -80,6 +80,59 @@ def _summary() -> dict[str, object]:
     }
 
 
+def _canary_summary() -> dict[str, object]:
+    return {
+        "generated": {
+            "case_directories": 3,
+            "generated_mp4_count": 3,
+        },
+        "validation": {
+            "case_count": 3,
+            "expected_frames_from_steps": {
+                "29": 3,
+            },
+            "failure_count": 0,
+            "runner_written_frames": {
+                "29": 3,
+            },
+            "total_blocks": {
+                "4": 3,
+            },
+        },
+        "worldlens": {
+            "runs": [
+                {
+                    "split": "od_26_01_canary3_tb4",
+                    "artifact_metrics": [
+                        {
+                            "artifact": "subject_consistency/repeat_0.json",
+                            "temporal_consistency_per_frame": 0.9799064011091277,
+                            "ts_per_frame": 0.9036903977394104,
+                            "video_count": 3,
+                        },
+                        {
+                            "artifact": "temporal_consistency/repeat_0.json",
+                            "temporal_consistency_per_frame": 0.9731416248139881,
+                            "ts_per_frame": 0.8190207282702128,
+                            "video_count": 3,
+                        },
+                    ],
+                },
+            ],
+            "stage_manifest": {
+                "case_count": 3,
+                "frame_count_mismatch_count": 0,
+                "generated_frame_counts": [
+                    29,
+                ],
+                "reference_frame_counts": [
+                    29,
+                ],
+            },
+        },
+    }
+
+
 def _passing_baseline() -> dict[str, object]:
     return {
         "kind": "omnidreams_eval_baseline",
@@ -241,3 +294,17 @@ def test_shipped_od_26_01_baseline_passes_summary_fixture() -> None:
 
     assert report["passed"] is True
     assert report["check_count"] == 16
+
+
+def test_shipped_od_26_01_canary_baseline_passes_summary_fixture() -> None:
+    baseline_path = (
+        Path(__file__).resolve().parents[1]
+        / "eval_baselines"
+        / "od-26.01-canary3-tb4-v1.json"
+    )
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    report = check_summary_against_baseline(_canary_summary(), baseline)
+
+    assert report["passed"] is True
+    assert report["check_count"] == 17

--- a/integrations/omnidreams/tests/test_eval_baseline.py
+++ b/integrations/omnidreams/tests/test_eval_baseline.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from omnidreams.eval.baseline import (
+    check_summary_against_baseline,
+    format_baseline_check_report,
+    resolve_summary_path,
+)
+from omnidreams.eval.cli import _build_parser
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def _summary() -> dict[str, object]:
+    return {
+        "generated": {
+            "case_directories": 40,
+            "generated_mp4_count": 40,
+        },
+        "validation": {
+            "case_count": 40,
+            "expected_frames_from_steps": {
+                "157": 40,
+            },
+            "failure_count": 0,
+            "runner_written_frames": {
+                "157": 40,
+            },
+            "total_blocks": {
+                "20": 40,
+            },
+        },
+        "drivinggen": {
+            "fvd_lite": [
+                {
+                    "split": "od_26_01_batch_00001",
+                    "value": 388.13717153675134,
+                },
+                {
+                    "split": "od_26_01_smoke20",
+                    "value": 477.4306044078767,
+                },
+            ],
+        },
+        "worldlens": {
+            "runs": [
+                {
+                    "split": "od_26_01_worldlens_40",
+                    "artifact_metrics": [
+                        {
+                            "artifact": "subject_consistency/repeat_0.json",
+                            "temporal_consistency_per_frame": 0.9443080609091199,
+                            "ts_per_frame": 0.8726091176271439,
+                        },
+                        {
+                            "artifact": "temporal_consistency/repeat_0.json",
+                            "temporal_consistency_per_frame": 0.9520937014848758,
+                            "ts_per_frame": 0.8295900329947472,
+                        },
+                    ],
+                },
+            ],
+            "stage_manifest": {
+                "case_count": 40,
+                "frame_count_mismatch_count": 0,
+                "generated_frame_counts": [
+                    157,
+                ],
+                "reference_frame_counts": [
+                    157,
+                ],
+            },
+        },
+    }
+
+
+def _passing_baseline() -> dict[str, object]:
+    return {
+        "kind": "omnidreams_eval_baseline",
+        "schema_version": 1,
+        "baseline_id": "od-26.01-worldlens-40-v1",
+        "checks": [
+            {
+                "name": "generated_clip_count",
+                "source": "generated.generated_mp4_count",
+                "op": "==",
+                "expected": 40,
+            },
+            {
+                "name": "validation_failures",
+                "source": "validation.failure_count",
+                "op": "==",
+                "expected": 0,
+            },
+            {
+                "name": "worldlens_temporal_consistency",
+                "source": (
+                    "worldlens.runs[split=od_26_01_worldlens_40]"
+                    ".artifact_metrics[artifact=temporal_consistency/repeat_0.json]"
+                    ".temporal_consistency_per_frame"
+                ),
+                "expected": 0.9521,
+                "tolerance": 0.001,
+            },
+            {
+                "name": "drivinggen_fvd_lite",
+                "source": "drivinggen.fvd_lite[split=od_26_01_batch_00001].value",
+                "max_allowed": 430.0,
+            },
+        ],
+    }
+
+
+def test_resolve_summary_path_supports_indices_and_list_filters() -> None:
+    summary = _summary()
+
+    assert resolve_summary_path(summary, "worldlens.runs[0].split") == (
+        "od_26_01_worldlens_40"
+    )
+    assert resolve_summary_path(
+        summary,
+        "validation.expected_frames_from_steps[157]",
+    ) == 40
+    assert resolve_summary_path(
+        summary,
+        "worldlens.runs[od_26_01_worldlens_40]"
+        ".artifact_metrics[temporal_consistency/repeat_0.json].ts_per_frame",
+    ) == pytest.approx(0.8295900329947472)
+
+
+def test_check_summary_against_baseline_passes_ranges_and_tolerances() -> None:
+    report = check_summary_against_baseline(_summary(), _passing_baseline())
+
+    assert report["passed"] is True
+    assert report["critical_failures"] == 0
+    assert report["check_count"] == 4
+    assert {check["name"] for check in report["checks"]} == {
+        "generated_clip_count",
+        "validation_failures",
+        "worldlens_temporal_consistency",
+        "drivinggen_fvd_lite",
+    }
+
+
+def test_check_summary_against_baseline_fails_critical_checks() -> None:
+    baseline = _passing_baseline()
+    checks = baseline["checks"]
+    assert isinstance(checks, list)
+    checks[-1] = {
+        "name": "drivinggen_fvd_lite",
+        "source": "drivinggen.fvd_lite[split=od_26_01_batch_00001].value",
+        "max_allowed": 300.0,
+    }
+
+    report = check_summary_against_baseline(_summary(), baseline)
+
+    assert report["passed"] is False
+    assert report["critical_failures"] == 1
+    text = format_baseline_check_report(report)
+    assert "Baseline check: FAIL" in text
+    assert "`drivinggen_fvd_lite`" in text
+
+
+def test_warning_failures_do_not_fail_the_report() -> None:
+    baseline = {
+        "checks": [
+            {
+                "name": "non_blocking_worldlens_target",
+                "source": (
+                    "worldlens.runs[od_26_01_worldlens_40]"
+                    ".artifact_metrics[temporal_consistency/repeat_0.json]"
+                    ".temporal_consistency_per_frame"
+                ),
+                "min_allowed": 0.99,
+                "severity": "warning",
+            }
+        ]
+    }
+
+    report = check_summary_against_baseline(_summary(), baseline)
+
+    assert report["passed"] is True
+    assert report["critical_failures"] == 0
+    assert report["warning_failures"] == 1
+
+
+def test_check_baseline_cli_writes_report_and_returns_nonzero_on_failure(
+    tmp_path: Path,
+) -> None:
+    summary_path = tmp_path / "summary.json"
+    baseline_path = tmp_path / "baseline.json"
+    output_path = tmp_path / "baseline-check.json"
+    summary_path.write_text(json.dumps(_summary()) + "\n", encoding="utf-8")
+    baseline = _passing_baseline()
+    checks = baseline["checks"]
+    assert isinstance(checks, list)
+    checks[0] = {
+        "name": "generated_clip_count",
+        "source": "generated.generated_mp4_count",
+        "op": "==",
+        "expected": 41,
+    }
+    baseline_path.write_text(json.dumps(baseline) + "\n", encoding="utf-8")
+
+    parser = _build_parser()
+    args = parser.parse_args(
+        [
+            "check-baseline",
+            "--summary",
+            str(summary_path),
+            "--baseline",
+            str(baseline_path),
+            "--output-json",
+            str(output_path),
+            "--quiet",
+        ]
+    )
+
+    assert args.func(args) == 1
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["passed"] is False
+    assert report["summary_path"] == str(summary_path)
+    assert report["baseline_path"] == str(baseline_path)
+
+
+def test_shipped_od_26_01_baseline_passes_summary_fixture() -> None:
+    baseline_path = (
+        Path(__file__).resolve().parents[1]
+        / "eval_baselines"
+        / "od-26.01-worldlens-40-v1.json"
+    )
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    report = check_summary_against_baseline(_summary(), baseline)
+
+    assert report["passed"] is True
+    assert report["check_count"] == 16

--- a/integrations/omnidreams/tests/test_eval_baseline.py
+++ b/integrations/omnidreams/tests/test_eval_baseline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 from omnidreams.eval.baseline import (
@@ -176,10 +177,13 @@ def test_resolve_summary_path_supports_indices_and_list_filters() -> None:
     assert resolve_summary_path(summary, "worldlens.runs[0].split") == (
         "od_26_01_worldlens_40"
     )
-    assert resolve_summary_path(
-        summary,
-        "validation.expected_frames_from_steps[157]",
-    ) == 40
+    assert (
+        resolve_summary_path(
+            summary,
+            "validation.expected_frames_from_steps[157]",
+        )
+        == 40
+    )
     assert resolve_summary_path(
         summary,
         "worldlens.runs[od_26_01_worldlens_40]"
@@ -203,7 +207,7 @@ def test_check_summary_against_baseline_passes_ranges_and_tolerances() -> None:
 
 def test_check_summary_against_baseline_fails_critical_checks() -> None:
     baseline = _passing_baseline()
-    checks = baseline["checks"]
+    checks = cast(list[dict[str, object]], baseline["checks"])
     assert isinstance(checks, list)
     checks[-1] = {
         "name": "drivinggen_fvd_lite",
@@ -251,7 +255,7 @@ def test_check_baseline_cli_writes_report_and_returns_nonzero_on_failure(
     output_path = tmp_path / "baseline-check.json"
     summary_path.write_text(json.dumps(_summary()) + "\n", encoding="utf-8")
     baseline = _passing_baseline()
-    checks = baseline["checks"]
+    checks = cast(list[dict[str, object]], baseline["checks"])
     assert isinstance(checks, list)
     checks[0] = {
         "name": "generated_clip_count",

--- a/integrations/omnidreams/tests/test_eval_tooling.py
+++ b/integrations/omnidreams/tests/test_eval_tooling.py
@@ -395,6 +395,86 @@ def test_patch_drivinggen_checkout_makes_checkpoints_configurable(
     ) in fid_text
 
 
+def test_worldlens_checkout_uses_absolute_clone_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(args: list[str], *, cwd: Path) -> None:
+        calls.append((args, cwd))
+        assert cwd.is_absolute()
+        if args[:2] == ["git", "clone"]:
+            target = Path(args[3])
+            assert target.is_absolute()
+            (target / ".git").mkdir(parents=True)
+
+    def fake_run_capture(args: list[str], *, cwd: Path) -> str:
+        calls.append((args, cwd))
+        assert cwd.is_absolute()
+        return "worldlens-commit\n"
+
+    monkeypatch.setattr(worldlens, "_run", fake_run)
+    monkeypatch.setattr(worldlens, "_run_capture", fake_run_capture)
+
+    checkout = worldlens.ensure_worldlens_checkout(
+        cache_dir=Path("relative/cache"),
+        repo_url="https://example.invalid/worldlens.git",
+        revision="test-rev",
+        install_config=False,
+    )
+
+    assert checkout.path == (tmp_path / "relative/cache/WorldLens").resolve()
+    assert calls[0][0] == [
+        "git",
+        "clone",
+        "https://example.invalid/worldlens.git",
+        str(checkout.path),
+    ]
+    assert calls[1] == (["git", "checkout", "test-rev"], checkout.path)
+
+
+def test_drivinggen_checkout_uses_absolute_clone_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(args: list[str], *, cwd: Path) -> None:
+        calls.append((args, cwd))
+        assert cwd.is_absolute()
+        if args[:2] == ["git", "clone"]:
+            target = Path(args[3])
+            assert target.is_absolute()
+            (target / ".git").mkdir(parents=True)
+
+    def fake_run_capture(args: list[str], *, cwd: Path) -> str:
+        calls.append((args, cwd))
+        assert cwd.is_absolute()
+        return "drivinggen-commit\n"
+
+    monkeypatch.setattr(drivinggen, "_run", fake_run)
+    monkeypatch.setattr(drivinggen, "_run_capture", fake_run_capture)
+
+    checkout = drivinggen.ensure_drivinggen_checkout(
+        cache_dir=Path("relative/cache"),
+        repo_url="https://example.invalid/drivinggen.git",
+        revision="test-rev",
+        patch_checkout=False,
+    )
+
+    assert checkout.path == (tmp_path / "relative/cache/DrivingGen").resolve()
+    assert calls[0][0] == [
+        "git",
+        "clone",
+        "https://example.invalid/drivinggen.git",
+        str(checkout.path),
+    ]
+    assert calls[1] == (["git", "checkout", "test-rev"], checkout.path)
+
+
 def test_run_video_metrics_captures_output_to_log(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/integrations/omnidreams/tests/test_video_vae_tyro_cli.py
+++ b/integrations/omnidreams/tests/test_video_vae_tyro_cli.py
@@ -15,12 +15,17 @@
 
 import pytest
 import tyro
+from dataclasses import field, make_dataclass
+from typing import Annotated, Any
+from omnidreams.config import RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE
 from omnidreams.encoder.pixel_shuffle import (
     PixelShuffleVAEEncoder,
     PixelShuffleVAEEncoderConfig,
 )
+from omnidreams.runner import OmnidreamsRunnerConfig
 
 from flashdreams.infra.config import InstantiateConfig
+from flashdreams.infra.runner import RunnerConfig
 from flashdreams.recipes.taehv import (
     TeahvVAEDecoder,
     TeahvVAEDecoderConfig,
@@ -56,3 +61,27 @@ def test_pixelshuffle_cli_accepts_frame_selection_override() -> None:
         args=["--frame-selection-mode", "first_frame"],
     )
     assert config.frame_selection_mode == "first_frame"
+
+
+def test_omnidreams_lighttae_runner_cli_defaults_parse() -> None:
+    runner = RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE
+    subcommand_union: Any = tyro.extras.subcommand_type_from_defaults(
+        defaults={runner.runner_name: runner},
+        descriptions={runner.runner_name: runner.description},
+        prefix_names=False,
+        sort_subcommands=True,
+    )
+    union: Any = tyro.conf.SuppressFixed[tyro.conf.FlagConversionOff[subcommand_union]]
+    args_cls = make_dataclass(
+        "FlashdreamsRunArgsForTest",
+        [
+            ("runner", Annotated[union, tyro.conf.arg(name="")]),
+            ("no_instantiate", bool, field(default=False)),
+        ],
+    )
+
+    args = tyro.cli(args_cls, args=[runner.runner_name])
+    config: RunnerConfig = getattr(args, "runner")
+
+    assert isinstance(config, OmnidreamsRunnerConfig)
+    assert config.runner_name == runner.runner_name

--- a/integrations/omnidreams/tests/test_video_vae_tyro_cli.py
+++ b/integrations/omnidreams/tests/test_video_vae_tyro_cli.py
@@ -13,17 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-import tyro
 from dataclasses import field, make_dataclass
 from typing import Annotated, Any
-from omnidreams.config import RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE
-from omnidreams.encoder.pixel_shuffle import (
-    PixelShuffleVAEEncoder,
-    PixelShuffleVAEEncoderConfig,
-)
-from omnidreams.runner import OmnidreamsRunnerConfig
 
+import pytest
+import tyro
 from flashdreams.infra.config import InstantiateConfig
 from flashdreams.infra.runner import RunnerConfig
 from flashdreams.recipes.taehv import (
@@ -31,6 +25,12 @@ from flashdreams.recipes.taehv import (
     TeahvVAEDecoderConfig,
 )
 from flashdreams.recipes.wan.autoencoder.vae import WanVAEEncoder, WanVAEEncoderConfig
+from omnidreams.config import RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE
+from omnidreams.encoder.pixel_shuffle import (
+    PixelShuffleVAEEncoder,
+    PixelShuffleVAEEncoderConfig,
+)
+from omnidreams.runner import OmnidreamsRunnerConfig
 
 pytestmark = pytest.mark.ci_cpu
 

--- a/integrations/omnidreams/tests/test_video_vae_tyro_cli.py
+++ b/integrations/omnidreams/tests/test_video_vae_tyro_cli.py
@@ -18,6 +18,13 @@ from typing import Annotated, Any
 
 import pytest
 import tyro
+from omnidreams.config import RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE
+from omnidreams.encoder.pixel_shuffle import (
+    PixelShuffleVAEEncoder,
+    PixelShuffleVAEEncoderConfig,
+)
+from omnidreams.runner import OmnidreamsRunnerConfig
+
 from flashdreams.infra.config import InstantiateConfig
 from flashdreams.infra.runner import RunnerConfig
 from flashdreams.recipes.taehv import (
@@ -25,12 +32,6 @@ from flashdreams.recipes.taehv import (
     TeahvVAEDecoderConfig,
 )
 from flashdreams.recipes.wan.autoencoder.vae import WanVAEEncoder, WanVAEEncoderConfig
-from omnidreams.config import RUNNER_SV_2STEPS_CHUNK2_LOC6_LIGHTVAE_LIGHTTAE
-from omnidreams.encoder.pixel_shuffle import (
-    PixelShuffleVAEEncoder,
-    PixelShuffleVAEEncoderConfig,
-)
-from omnidreams.runner import OmnidreamsRunnerConfig
 
 pytestmark = pytest.mark.ci_cpu
 


### PR DESCRIPTION
Add a non-blocking GPU workflow that runs a 3-scene OmniDreams
WorldLens canary on the fixed NuRec 26.01 split. The workflow discovers
the Hugging Face scene manifest, filters the selected UUIDs, generates
short TOTAL_BLOCKS=4 clips, runs validation and WorldLens consistency
metrics, summarizes the run, and checks the results against a checked-in
canary baseline.

Also add the initial canary baseline JSON and test coverage to ensure
the baseline checker accepts the expected summary shape and metrics.