### PR TITLE
Adding command-line option for scene selection

### DIFF
--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -437,6 +437,20 @@ Then open `http://localhost:8080/`.
 For a richer browser frontend with lower latency, prefer the separate
 `omnidreams.webrtc.server` entry point.
 
+#### Fully headless: `--stream-mjpeg` with `--auto-start`
+
+By default the streaming mode waits for the browser scene picker before it
+loads anything, so a freshly launched server idles on "Select a scene to
+begin" until someone opens the page. To run with no GUI/browser interaction
+add `--auto-start`. It skips the scene selection and immediately loads `--scene` 
+(or the first scene discovered under `--scene-dir` when `--scene` is unset 
+or not yet staged):
+
+```bash
+uv run --package flashdreams-omnidreams interactive-drive \
+  --stream-mjpeg 8080 --auto-start --scene <clip-id-name-or-path>
+```
+
 The interactive-drive CUDA fast path is enabled by default. HDMap raster frames
 stay CUDA-backed for world-model conditioning, and both Vulkan presenters use
 SlangPy CUDA interop for generated RGB frames when the model output is still on

--- a/integrations/omnidreams/omnidreams/interactive_drive/README.md
+++ b/integrations/omnidreams/omnidreams/interactive_drive/README.md
@@ -442,8 +442,8 @@ For a richer browser frontend with lower latency, prefer the separate
 By default the streaming mode waits for the browser scene picker before it
 loads anything, so a freshly launched server idles on "Select a scene to
 begin" until someone opens the page. To run with no GUI/browser interaction
-add `--auto-start`. It skips the scene selection and immediately loads `--scene` 
-(or the first scene discovered under `--scene-dir` when `--scene` is unset 
+add `--auto-start`. It skips the scene selection and immediately loads `--scene`
+(or the first scene discovered under `--scene-dir` when `--scene` is unset
 or not yet staged):
 
 ```bash

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -984,9 +984,7 @@ def _run_streaming(args: argparse.Namespace) -> None:
             if app.preload_in_progress():
                 presenter.wait_while_preloading(app.preload_in_progress)
             scene_path = config.scene_path
-            variant = _resolve_scene_variant(
-                scene_options, scene_path, config.variant
-            )
+            variant = _resolve_scene_variant(scene_options, scene_path, config.variant)
             presenter.acknowledge_scene_change(scene_path, variant)
             logger.info(
                 f"[demo] streaming auto-start scene -> {scene_path.name} "

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -975,23 +975,41 @@ def _run_streaming(args: argparse.Namespace) -> None:
         presenter.set_scene_selection_locked(app.preload_in_progress)
 
     try:
-        # Don't auto-load: always wait for the browser to pick the first
-        # scene. There's no Vulkan window to show progress in, so the
-        # presenter publishes an idle overlay frame ("Loading world
-        # model..." while warmup runs in the background, then "Select a
-        # scene to begin") so connected browsers have something to render
-        # while the wait spins.
-        logger.info(
-            "[demo] streaming presenter waiting for first scene selection...",
-        )
-        request = presenter.wait_for_scene_selection()
-        if request is None:
-            return  # presenter closed before any selection (Ctrl-C)
-        scene_path, variant = request
-        presenter.acknowledge_scene_change(scene_path, variant)
-        logger.info(
-            f"[demo] streaming initial scene -> {scene_path.name} variant={variant!r}",
-        )
+        if args.auto_start:
+            # Headless / scriptable start: skip the browser scene picker and
+            # load the resolved ``--scene`` (or the first discovered scene)
+            # immediately. This lets the demo run with no GUI/browser.
+            # --auto-start + --preload-scenes: let the preloader finish first
+            # so the auto-load hits the cache instead of racing a second parse.
+            if app.preload_in_progress():
+                presenter.wait_while_preloading(app.preload_in_progress)
+            scene_path = config.scene_path
+            variant = _resolve_scene_variant(
+                scene_options, scene_path, config.variant
+            )
+            presenter.acknowledge_scene_change(scene_path, variant)
+            logger.info(
+                f"[demo] streaming auto-start scene -> {scene_path.name} "
+                f"variant={variant!r}",
+            )
+        else:
+            # Don't auto-load: always wait for the browser to pick the first
+            # scene. There's no Vulkan window to show progress in, so the
+            # presenter publishes an idle overlay frame ("Loading world
+            # model..." while warmup runs in the background, then "Select a
+            # scene to begin") so connected browsers have something to render
+            # while the wait spins.
+            logger.info(
+                "[demo] streaming presenter waiting for first scene selection...",
+            )
+            request = presenter.wait_for_scene_selection()
+            if request is None:
+                return  # presenter closed before any selection (Ctrl-C)
+            scene_path, variant = request
+            presenter.acknowledge_scene_change(scene_path, variant)
+            logger.info(
+                f"[demo] streaming initial scene -> {scene_path.name} variant={variant!r}",
+            )
 
         while True:
             # load_scene parses the USDZ on a background thread while the

--- a/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
@@ -8,7 +8,6 @@ import types
 from pathlib import Path
 
 import pytest
-
 from omnidreams.interactive_drive import demo as demo_mod
 from omnidreams.interactive_drive.demo import (
     SceneOption,
@@ -150,7 +149,9 @@ def test_run_streaming_auto_start_skips_scene_picker(
     # the auto-start path must wait for the preloader, then False afterwards.
     app = _FakeApp(preload_states=(True, False) if preloading else (False,))
 
-    monkeypatch.setattr(demo_mod, "_apply_cuda_visible_devices_inplace", lambda _v: None)
+    monkeypatch.setattr(
+        demo_mod, "_apply_cuda_visible_devices_inplace", lambda _v: None
+    )
     monkeypatch.setattr(demo_mod, "_resolve_demo_paths", lambda _a: None)
     monkeypatch.setattr(demo_mod, "_discover_scene_options", lambda *_a: (option,))
     monkeypatch.setattr(

--- a/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
@@ -74,13 +74,20 @@ class _FakePresenter:
     def __init__(self, **_kwargs: object) -> None:
         self.wait_for_scene_selection_calls = 0
         self.acknowledged: list[tuple[Path, str]] = []
+        # Probe callables passed to wait_while_preloading, plus an ordered
+        # call log so a test can assert the preload wait happens *before* the
+        # scene is acknowledged.
+        self.wait_while_preloading_probes: list[object] = []
+        self.calls: list[str] = []
         self.closed = False
 
     def set_model_status(self, **_kwargs: object) -> None: ...
 
     def set_scene_selection_locked(self, *_args: object) -> None: ...
 
-    def wait_while_preloading(self, *_args: object) -> None: ...
+    def wait_while_preloading(self, probe: object) -> None:
+        self.wait_while_preloading_probes.append(probe)
+        self.calls.append("wait_while_preloading")
 
     def wait_for_scene_selection(self) -> tuple[Path, str] | None:
         # The whole point of --auto-start is that this never runs; record any
@@ -90,9 +97,10 @@ class _FakePresenter:
 
     def acknowledge_scene_change(self, scene_path: Path, variant: str) -> None:
         self.acknowledged.append((scene_path, variant))
+        self.calls.append("acknowledge_scene_change")
 
     @property
-    def pending_scene_change(self) -> None:
+    def pending_scene_change(self) -> tuple[Path, str] | None:
         return None  # one rollout, then the loop exits
 
     def close(self) -> None:
@@ -102,14 +110,21 @@ class _FakePresenter:
 class _FakeApp:
     can_prewarm = False
 
-    def __init__(self, **_kwargs: object) -> None:
+    def __init__(
+        self, preload_states: tuple[bool, ...] = (False,), **_kwargs: object
+    ) -> None:
         self.loaded: list[tuple[Path, str]] = []
         self.ran = 0
+        # Successive return values for preload_in_progress(); the auto-start
+        # path checks it once before deciding to wait on the preloader.
+        self._preload_states = list(preload_states)
 
     def model_ready(self) -> bool:
         return True
 
     def preload_in_progress(self) -> bool:
+        if self._preload_states:
+            return self._preload_states.pop(0)
         return False
 
     def load_scene(self, scene_path: Path, variant: str, _prompt: object) -> bool:
@@ -122,15 +137,18 @@ class _FakeApp:
     def shutdown(self) -> None: ...
 
 
+@pytest.mark.parametrize("preloading", [False, True])
 def test_run_streaming_auto_start_skips_scene_picker(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, preloading: bool
 ) -> None:
     scene = tmp_path / "scene.usdz"
     scene.write_bytes(b"")
     option = SceneOption(label="scene", path=scene, variants=("default",))
 
     presenter = _FakePresenter()
-    app = _FakeApp()
+    # When preloading, preload_in_progress() reports True on the first check so
+    # the auto-start path must wait for the preloader, then False afterwards.
+    app = _FakeApp(preload_states=(True, False) if preloading else (False,))
 
     monkeypatch.setattr(demo_mod, "_apply_cuda_visible_devices_inplace", lambda _v: None)
     monkeypatch.setattr(demo_mod, "_resolve_demo_paths", lambda _a: None)
@@ -171,3 +189,13 @@ def test_run_streaming_auto_start_skips_scene_picker(
     assert app.ran == 1
     assert presenter.acknowledged[0] == (scene, "default")
     assert presenter.closed
+
+    if preloading:
+        # The preload wait fires with the app's own probe, before the scene
+        # is acknowledged/loaded.
+        assert presenter.wait_while_preloading_probes == [app.preload_in_progress]
+        assert presenter.calls.index("wait_while_preloading") < presenter.calls.index(
+            "acknowledge_scene_change"
+        )
+    else:
+        assert presenter.wait_while_preloading_probes == []

--- a/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
@@ -3,8 +3,13 @@
 
 from __future__ import annotations
 
+import argparse
+import types
 from pathlib import Path
 
+import pytest
+
+from omnidreams.interactive_drive import demo as demo_mod
 from omnidreams.interactive_drive.demo import (
     SceneOption,
     _resolve_scene_variant,
@@ -61,3 +66,108 @@ def test_resolve_scene_variant_legacy_option_without_variant_paths(
 
     assert _resolve_scene_variant((option,), scene, "default") == "1"
     assert _resolve_scene_variant((option,), scene, "2") == "2"
+
+
+class _FakePresenter:
+    """Records the scene-selection calls ``_run_streaming`` makes."""
+
+    def __init__(self, **_kwargs: object) -> None:
+        self.wait_for_scene_selection_calls = 0
+        self.acknowledged: list[tuple[Path, str]] = []
+        self.closed = False
+
+    def set_model_status(self, **_kwargs: object) -> None: ...
+
+    def set_scene_selection_locked(self, *_args: object) -> None: ...
+
+    def wait_while_preloading(self, *_args: object) -> None: ...
+
+    def wait_for_scene_selection(self) -> tuple[Path, str] | None:
+        # The whole point of --auto-start is that this never runs; record any
+        # call so the test can assert the picker was skipped.
+        self.wait_for_scene_selection_calls += 1
+        return None
+
+    def acknowledge_scene_change(self, scene_path: Path, variant: str) -> None:
+        self.acknowledged.append((scene_path, variant))
+
+    @property
+    def pending_scene_change(self) -> None:
+        return None  # one rollout, then the loop exits
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeApp:
+    can_prewarm = False
+
+    def __init__(self, **_kwargs: object) -> None:
+        self.loaded: list[tuple[Path, str]] = []
+        self.ran = 0
+
+    def model_ready(self) -> bool:
+        return True
+
+    def preload_in_progress(self) -> bool:
+        return False
+
+    def load_scene(self, scene_path: Path, variant: str, _prompt: object) -> bool:
+        self.loaded.append((scene_path, variant))
+        return True
+
+    def run_scene(self) -> None:
+        self.ran += 1
+
+    def shutdown(self) -> None: ...
+
+
+def test_run_streaming_auto_start_skips_scene_picker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scene = tmp_path / "scene.usdz"
+    scene.write_bytes(b"")
+    option = SceneOption(label="scene", path=scene, variants=("default",))
+
+    presenter = _FakePresenter()
+    app = _FakeApp()
+
+    monkeypatch.setattr(demo_mod, "_apply_cuda_visible_devices_inplace", lambda _v: None)
+    monkeypatch.setattr(demo_mod, "_resolve_demo_paths", lambda _a: None)
+    monkeypatch.setattr(demo_mod, "_discover_scene_options", lambda *_a: (option,))
+    monkeypatch.setattr(
+        demo_mod._cli,
+        "prepare_config_and_backend",
+        lambda _a: (
+            types.SimpleNamespace(scene_path=scene, variant="default"),
+            object(),
+        ),
+    )
+    monkeypatch.setattr(demo_mod, "InteractiveDriveApp", lambda **_k: app)
+    # The streaming presenter is imported lazily inside _run_streaming
+    import omnidreams.interactive_drive.input.keyboard as kbd_mod
+    import omnidreams.interactive_drive.streaming_presenter as sp_mod
+
+    monkeypatch.setattr(sp_mod, "MJPEGStreamingPresenter", lambda **_k: presenter)
+    monkeypatch.setattr(sp_mod, "parse_bind", lambda _v: ("127.0.0.1", 8080))
+    monkeypatch.setattr(kbd_mod, "KeyboardState", lambda *_a, **_k: object())
+
+    args = argparse.Namespace(
+        cuda_visible_devices="",
+        scene_dir=tmp_path,
+        scene=scene,
+        backend="placeholder",
+        manifest=None,
+        stream_mjpeg="8080",
+        preload_scenes=False,
+        prompt=None,
+        auto_start=True,
+    )
+
+    demo_mod._run_streaming(args)
+
+    assert presenter.wait_for_scene_selection_calls == 0
+    assert app.loaded == [(scene, "default")]
+    assert app.ran == 1
+    assert presenter.acknowledged[0] == (scene, "default")
+    assert presenter.closed


### PR DESCRIPTION
This MR is a follow-up to this developer's request: https://github.com/NVIDIA/flashdreams/issues/333

- Added command line option for scene selection
- Added unit test to verify it works using mock setup
- Updated README.md documentation