### PR TITLE
Remove DrivingGen check from 40-case WorldLens baseline

### DIFF
--- a/integrations/omnidreams/eval_baselines/od-26.01-worldlens-40-v1.json
+++ b/integrations/omnidreams/eval_baselines/od-26.01-worldlens-40-v1.json
@@ -100,11 +100,6 @@
       "name": "worldlens_subject_ts_per_frame",
       "source": "worldlens.runs[split=od_26_01_worldlens_40].artifact_metrics[artifact=subject_consistency/repeat_0.json].ts_per_frame",
       "min_allowed": 0.84
-    },
-    {
-      "name": "drivinggen_fvd_lite_batch_00001",
-      "source": "drivinggen.fvd_lite[split=od_26_01_batch_00001].value",
-      "max_allowed": 450.0
     }
   ]
 }

--- a/integrations/omnidreams/tests/test_eval_baseline.py
+++ b/integrations/omnidreams/tests/test_eval_baseline.py
@@ -297,7 +297,7 @@ def test_shipped_od_26_01_baseline_passes_summary_fixture() -> None:
     report = check_summary_against_baseline(_summary(), baseline)
 
     assert report["passed"] is True
-    assert report["check_count"] == 16
+    assert report["check_count"] == 15
 
 
 def test_shipped_od_26_01_canary_baseline_passes_summary_fixture() -> None:


### PR DESCRIPTION
Drop the DrivingGen FVD-lite requirement from the OmniDreams 40-case
evaluation baseline so the baseline reflects the WorldLens-only nightly
quality gate.

DrivingGen remains useful as a separate regression signal, but it is not
ready to run as part of the scheduled GitLab nightly yet. Keeping the
baseline WorldLens-only avoids requiring DrivingGen metrics until that
path is hardened separately.