### PR TITLE
fix(omnidreams): support native windows demo

### DIFF
--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
@@ -15,6 +15,7 @@
 
 """JIT compilation of the C++/CUDA plugin for Ludus renderer."""
 
+import glob
 import os
 import time
 
@@ -23,6 +24,37 @@ import torch.utils.cpp_extension
 from loguru import logger
 
 _cached_plugin = None
+_dll_directory_handles = []
+_dll_directory_paths: set[str] = set()
+
+
+def _add_windows_dll_directory(path: str) -> None:
+    if not path or not os.path.isdir(path):
+        return
+    normalized = os.path.normcase(os.path.abspath(path))
+    if normalized in _dll_directory_paths:
+        return
+    _dll_directory_handles.append(os.add_dll_directory(path))
+    _dll_directory_paths.add(normalized)
+
+
+def _ensure_windows_dll_directories() -> None:
+    """Keep dependent Torch/CUDA DLL directories visible to extension import."""
+    if not hasattr(os, "add_dll_directory"):
+        return
+
+    _add_windows_dll_directory(os.path.join(os.path.dirname(torch.__file__), "lib"))
+
+    cuda_bins: list[str] = []
+    for env_name in ("CUDA_HOME", "CUDA_PATH"):
+        cuda_home = os.environ.get(env_name)
+        if cuda_home:
+            cuda_bins.append(os.path.join(cuda_home, "bin"))
+    for path in os.environ.get("PATH", "").split(os.pathsep):
+        if glob.glob(os.path.join(path, "cudart64_*.dll")):
+            cuda_bins.append(path)
+    for path in cuda_bins:
+        _add_windows_dll_directory(path)
 
 
 def _get_plugin():
@@ -67,6 +99,7 @@ def _get_plugin():
                     "Could not locate a supported Microsoft Visual C++ installation"
                 )
             os.environ["PATH"] += ";" + cl_path
+        _ensure_windows_dll_directories()
 
     # Compiler options.
     common_defines = ["-DNVDR_TORCH", "-DFW_DO_NOT_OVERRIDE_NEW_DELETE"]

--- a/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
+++ b/integrations/omnidreams/ludus-renderer/ludus_renderer/_ops/_plugin.py
@@ -17,6 +17,7 @@
 
 import glob
 import os
+import subprocess
 import time
 
 import torch
@@ -29,18 +30,19 @@ _dll_directory_paths: set[str] = set()
 
 
 def _add_windows_dll_directory(path: str) -> None:
-    if not path or not os.path.isdir(path):
+    add_dll_directory = getattr(os, "add_dll_directory", None)
+    if add_dll_directory is None or not path or not os.path.isdir(path):
         return
     normalized = os.path.normcase(os.path.abspath(path))
     if normalized in _dll_directory_paths:
         return
-    _dll_directory_handles.append(os.add_dll_directory(path))
+    _dll_directory_handles.append(add_dll_directory(path))
     _dll_directory_paths.add(normalized)
 
 
 def _ensure_windows_dll_directories() -> None:
     """Keep dependent Torch/CUDA DLL directories visible to extension import."""
-    if not hasattr(os, "add_dll_directory"):
+    if getattr(os, "add_dll_directory", None) is None:
         return
 
     _add_windows_dll_directory(os.path.join(os.path.dirname(torch.__file__), "lib"))
@@ -92,7 +94,15 @@ def _get_plugin():
             if paths:
                 return sorted(paths, key=get_sort_key)[-1]
 
-        if os.system("where cl.exe >nul 2>nul") != 0:
+        if (
+            subprocess.run(
+                ["where.exe", "cl.exe"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            ).returncode
+            != 0
+        ):
             cl_path = find_cl_path()
             if cl_path is None:
                 raise RuntimeError(
@@ -117,14 +127,17 @@ def _get_plugin():
             "-lineinfo",
             # Suppress nvcc warning about __device__ functions redeclared without
             # __device__ in out-of-line template definitions (Math.hpp MatrixBase).
-            "-diag-suppress", "20037",
+            "-diag-suppress",
+            "20037",
         ]
     else:
         cc_opts = common_defines + ["-Wall", "-Werror", "-Wno-psabi"]
         cuda_opts = common_defines + [
             "-lineinfo",
-            "-Xcompiler", "-Wall,-Werror,-Wno-psabi",
-            "-diag-suppress", "20037",
+            "-Xcompiler",
+            "-Wall,-Werror,-Wno-psabi",
+            "-diag-suppress",
+            "20037",
         ]
 
     # Linker options and source files.
@@ -161,7 +174,9 @@ def _get_plugin():
     plugin_name = "ludus_renderer_plugin"
     build_directory = None
     try:
-        build_directory = torch.utils.cpp_extension._get_build_directory(plugin_name, False)
+        build_directory = torch.utils.cpp_extension._get_build_directory(
+            plugin_name, False
+        )
         lock_fn = os.path.join(build_directory, "lock")
         logger.info(
             "Loading Ludus renderer extension {}; build_directory={}.",
@@ -175,7 +190,9 @@ def _get_plugin():
                 lock_fn,
             )
     except Exception as exc:
-        logger.debug("Could not inspect Ludus renderer extension build directory: {}", exc)
+        logger.debug(
+            "Could not inspect Ludus renderer extension build directory: {}", exc
+        )
 
     # Speed up compilation on Windows
     if os.name == "nt":
@@ -184,11 +201,14 @@ def _get_plugin():
             import distutils._msvccompiler
             import functools
 
-            if not hasattr(distutils._msvccompiler._get_vc_env, "__wrapped__"):
-                distutils._msvccompiler._get_vc_env = functools.lru_cache()(
-                    distutils._msvccompiler._get_vc_env
+            get_vc_env = getattr(distutils._msvccompiler, "_get_vc_env", None)
+            if get_vc_env is not None and not hasattr(get_vc_env, "__wrapped__"):
+                setattr(
+                    distutils._msvccompiler,
+                    "_get_vc_env",
+                    functools.lru_cache()(get_vc_env),
                 )
-        except:
+        except Exception:
             pass
 
     # Compile and cache

--- a/integrations/omnidreams/omnidreams/interactive_drive/demo.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/demo.py
@@ -43,6 +43,7 @@ from omnidreams.interactive_drive.input.wheel_profiles import (
     user_wheel_profiles_dir,
 )
 from omnidreams.interactive_drive.log import configure_logging
+from omnidreams.interactive_drive.synthetic_scene import build_synthetic_scene_to_temp
 from omnidreams.scenes import normalise_scene_uuid, scenes_cache_root
 from PIL import Image
 
@@ -736,6 +737,7 @@ def _run_slangpy_hud(args: argparse.Namespace) -> None:
 
     _apply_cuda_visible_devices_inplace(args.cuda_visible_devices)
     _resolve_demo_paths(args)
+    _materialize_synthetic_scene_for_picker(args)
     scene_options = _discover_scene_options(args.scene_dir, args.scene)
     if not args.scene.exists() and scene_options:
         args.scene = scene_options[0].path
@@ -892,6 +894,7 @@ def _run_streaming(args: argparse.Namespace) -> None:
 
     _apply_cuda_visible_devices_inplace(args.cuda_visible_devices)
     _resolve_demo_paths(args)
+    _materialize_synthetic_scene_for_picker(args)
     scene_options = _discover_scene_options(args.scene_dir, args.scene)
     if not args.scene.exists() and scene_options:
         args.scene = scene_options[0].path
@@ -1058,6 +1061,32 @@ def _resolve_demo_paths(args: argparse.Namespace) -> None:
         args.manifest = _cli.resolve_manifest_path(args.manifest)
     if args.control_assets_dir is not None:
         args.control_assets_dir = _project_path(args.control_assets_dir)
+
+
+def _materialize_synthetic_scene_for_picker(args: argparse.Namespace) -> None:
+    """Build ``--synthetic-scene`` before scene-picker discovery.
+
+    The single-scene ``--no-hud`` path lets ``cli.prepare_config_and_backend``
+    materialize the synthetic USDZ. HUD and MJPEG modes discover scenes first
+    so the picker can show options before a scene is loaded; those modes need
+    the temporary USDZ to exist before discovery runs.
+    """
+    if not args.synthetic_scene:
+        return
+    scene_path = build_synthetic_scene_to_temp(
+        initial_rgb_path=args.synthetic_initial_rgb,
+        prompt=args.synthetic_prompt,
+    )
+    logger.info(
+        "[interactive-drive] synthetic scene materialised at {}",
+        scene_path,
+    )
+    args.scene = scene_path
+    # The synthetic inputs have been consumed into the temp USDZ. Clear them so
+    # the later shared backend builder treats the scene as a normal archive.
+    args.synthetic_scene = False
+    args.synthetic_initial_rgb = None
+    args.synthetic_prompt = None
 
 
 def _project_path(path: Path) -> Path:

--- a/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
+++ b/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
@@ -22,6 +22,8 @@ import hashlib
 import importlib.util
 import json
 import os
+import shutil
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -58,6 +60,8 @@ _native_build_module: ModuleType | None = None
 _extension: ModuleType | None = None
 _extension_load_error: Exception | None = None
 _state_lock = threading.RLock()
+_dll_directory_handles: list[object] = []
+_dll_directory_paths: set[str] = set()
 
 
 def _native_build() -> ModuleType:
@@ -132,6 +136,217 @@ def _first_library_dir(library_name: str, candidates: tuple[Path, ...]) -> Path 
         if (directory / library_name).is_file():
             return directory
     return None
+
+
+def _first_file(candidates: tuple[Path, ...]) -> Path | None:
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+def _add_windows_dll_directory(path: Path) -> None:
+    add_dll_directory = getattr(os, "add_dll_directory", None)
+    if os.name != "nt" or add_dll_directory is None or not path.is_dir():
+        return
+    normalized = str(path.resolve()).casefold()
+    if normalized in _dll_directory_paths:
+        return
+    _dll_directory_handles.append(add_dll_directory(str(path)))
+    _dll_directory_paths.add(normalized)
+
+
+def _add_windows_cuda_dll_directories(cudnn_package_dir: Path | None) -> None:
+    if os.name != "nt":
+        return
+    torch_package_dir = _python_package_dir("torch")
+    if torch_package_dir is not None:
+        _add_windows_dll_directory(torch_package_dir / "lib")
+    cuda_package_dir = _python_package_dir("nvidia.cu13")
+    if cuda_package_dir is not None:
+        _add_windows_dll_directory(cuda_package_dir / "bin" / "x86_64")
+    if cudnn_package_dir is not None:
+        _add_windows_dll_directory(cudnn_package_dir / "bin")
+
+
+def _dumpbin_export_names(output: str) -> list[str]:
+    names: list[str] = []
+    in_exports = False
+    for line in output.splitlines():
+        if "ordinal hint RVA" in line:
+            in_exports = True
+            continue
+        if not in_exports:
+            continue
+        parts = line.split()
+        if len(parts) < 4 or not parts[0].isdigit():
+            continue
+        names.append(parts[3])
+    return names
+
+
+def _windows_import_library_from_dll(dll_path: Path, output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lib_path = output_dir / f"{dll_path.stem}.lib"
+    def_path = output_dir / f"{dll_path.stem}.def"
+    if lib_path.is_file() and lib_path.stat().st_mtime >= dll_path.stat().st_mtime:
+        return lib_path
+
+    dumpbin = shutil.which("dumpbin.exe") or shutil.which("dumpbin")
+    lib_tool = shutil.which("lib.exe") or shutil.which("lib")
+    if dumpbin is None or lib_tool is None:
+        raise RuntimeError(
+            "Cannot build cuDNN import library: dumpbin.exe and lib.exe must be "
+            "available in the active Visual Studio build environment."
+        )
+
+    result = subprocess.run(
+        [dumpbin, "/exports", str(dll_path)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    exports = _dumpbin_export_names(result.stdout)
+    if not exports:
+        raise RuntimeError(
+            f"Cannot build cuDNN import library: no exports in {dll_path}"
+        )
+
+    def_path.write_text(
+        "LIBRARY " + dll_path.name + "\nEXPORTS\n" + "\n".join(exports) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    subprocess.run(
+        [lib_tool, f"/def:{def_path}", "/machine:x64", f"/out:{lib_path}"],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return lib_path
+
+
+def _nvcc_release(output: str) -> tuple[int, int] | None:
+    marker = "release "
+    start = output.find(marker)
+    if start < 0:
+        return None
+    version = output[start + len(marker) :].split(",", 1)[0].strip()
+    parts = version.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+
+
+def _ensure_windows_cuda13_toolkit() -> None:
+    if os.name != "nt":
+        return
+    nvcc = shutil.which("nvcc.exe") or shutil.which("nvcc")
+    if nvcc is None:
+        raise RuntimeError(
+            "OmniDreams native Windows builds require a full CUDA 13 toolkit "
+            "with nvcc.exe available on PATH."
+        )
+
+    result = subprocess.run(
+        [nvcc, "--version"],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    output = result.stdout + result.stderr
+    release = _nvcc_release(output)
+    if release is not None and release[0] >= 13:
+        return
+    found = f"{release[0]}.{release[1]}" if release is not None else "unknown"
+    raise RuntimeError(
+        "OmniDreams native Windows builds require CUDA 13 nvcc.exe. "
+        f"Found CUDA {found} at {nvcc}. The CUDA 13 Python wheels are not "
+        "enough for native extension compilation; install the full CUDA 13 "
+        "toolkit and put its bin directory first on PATH."
+    )
+
+
+def _cudnn_include_dir(cudnn_package_dir: Path | None) -> Path | None:
+    if cudnn_package_dir is None:
+        return None
+    include_dir = cudnn_package_dir / "include"
+    return include_dir if (include_dir / "cudnn.h").is_file() else None
+
+
+def _cudnn_link_flags(
+    cudnn_package_dir: Path | None,
+    *,
+    build_dir: Path,
+) -> list[str]:
+    if os.name == "nt":
+        if cudnn_package_dir is None:
+            return ["cudnn.lib"]
+        import_lib = _first_file(
+            (
+                cudnn_package_dir / "lib" / "cudnn.lib",
+                cudnn_package_dir / "lib" / "x64" / "cudnn.lib",
+            )
+        )
+        if import_lib is not None:
+            return [str(import_lib)]
+        dll_path = _first_file((cudnn_package_dir / "bin" / "cudnn64_9.dll",))
+        if dll_path is None:
+            return ["cudnn.lib"]
+        generated_lib = _windows_import_library_from_dll(
+            dll_path,
+            build_dir / "generated_import_libs",
+        )
+        return [str(generated_lib)]
+
+    cudnn_lib = (
+        cudnn_package_dir / "lib"
+        if cudnn_package_dir is not None
+        and (cudnn_package_dir / "lib" / "libcudnn.so.9").is_file()
+        else None
+    )
+    return [
+        *([] if cudnn_lib is None else [f"-L{cudnn_lib}"]),
+        "-lcudnn" if cudnn_lib is None else "-l:libcudnn.so.9",
+    ]
+
+
+def _cuda_link_flags(
+    cudnn_package_dir: Path | None,
+    *,
+    build_dir: Path,
+) -> list[str]:
+    if os.name == "nt":
+        return [
+            "cublas.lib",
+            "cublasLt.lib",
+            *_cudnn_link_flags(cudnn_package_dir, build_dir=build_dir),
+            "cuda.lib",
+            "nvrtc.lib",
+        ]
+
+    cuda_driver_lib = _first_library_dir(
+        "libcuda.so",
+        (
+            Path("/usr/lib/wsl/lib"),
+            Path("/usr/lib/x86_64-linux-gnu"),
+            Path("/usr/local/cuda/lib64"),
+        ),
+    )
+    return [
+        "-lcublas",
+        "-lcublasLt",
+        *_cudnn_link_flags(cudnn_package_dir, build_dir=build_dir),
+        *([] if cuda_driver_lib is None else [f"-L{cuda_driver_lib}"]),
+        "-lcuda",
+        "-lnvrtc",
+    ]
 
 
 def build_info(
@@ -315,6 +530,8 @@ def load_extension(
         _extension_load_error = None
 
         try:
+            _ensure_windows_cuda13_toolkit()
+
             from torch.utils.cpp_extension import load as load_torch_extension
 
             thirdparty_info = validate_thirdparty()
@@ -328,31 +545,13 @@ def load_extension(
                 Path(thirdparty_info["cudnn-frontend"]["path"]) / "include"
             )
             cudnn_package_dir = _python_package_dir("nvidia.cudnn")
-            cudnn_include = (
-                cudnn_package_dir / "include"
-                if cudnn_package_dir is not None
-                and (cudnn_package_dir / "include" / "cudnn.h").is_file()
-                else None
-            )
-            cudnn_lib = (
-                cudnn_package_dir / "lib"
-                if cudnn_package_dir is not None
-                and (cudnn_package_dir / "lib" / "libcudnn.so.9").is_file()
-                else None
-            )
-            cuda_driver_lib = _first_library_dir(
-                "libcuda.so",
-                (
-                    Path("/usr/lib/wsl/lib"),
-                    Path("/usr/lib/x86_64-linux-gnu"),
-                    Path("/usr/local/cuda/lib64"),
-                ),
-            )
+            cudnn_include = _cudnn_include_dir(cudnn_package_dir)
             extension_build_dir = _native_build().torch_extension_build_dir(
                 extension_name,
                 build_root=build_root,
             )
             extension_build_dir.mkdir(parents=True, exist_ok=True)
+            _add_windows_cuda_dll_directories(cudnn_package_dir)
 
             with _scoped_torch_max_jobs(max_jobs), _scoped_cuda_arch_list():
                 _extension = load_torch_extension(
@@ -446,13 +645,10 @@ def load_extension(
                         "-DOMNIDREAMS_SINGLEVIEW_HAS_SPARGE=1",
                     ],
                     extra_ldflags=[
-                        "-lcublas",
-                        "-lcublasLt",
-                        *([] if cudnn_lib is None else [f"-L{cudnn_lib}"]),
-                        "-lcudnn" if cudnn_lib is None else "-l:libcudnn.so.9",
-                        *([] if cuda_driver_lib is None else [f"-L{cuda_driver_lib}"]),
-                        "-lcuda",
-                        "-lnvrtc",
+                        *_cuda_link_flags(
+                            cudnn_package_dir,
+                            build_dir=extension_build_dir,
+                        ),
                     ],
                     with_cuda=True,
                     verbose=verbose,

--- a/integrations/omnidreams/omnidreams_singleview/patches/cutlass/sm120-tma-pool.patch
+++ b/integrations/omnidreams/omnidreams_singleview/patches/cutlass/sm120-tma-pool.patch
@@ -36,9 +36,9 @@ index 3be30af7..47abafee 100644
 --- a/include/cute/atom/copy_traits_sm90_tma.hpp
 +++ b/include/cute/atom/copy_traits_sm90_tma.hpp
 @@ -44,6 +44,11 @@
-
+ 
  #include <cutlass/cuda_host_adapter.hpp>
-
+ 
 +// OmniDreams patch: host-side TMA descriptor pool used to keep descriptors
 +// in `.global` state space, working around the nvcc 13.x SM120 spill bug.
 +#include <cute/atom/detail/tma_descriptor_pool.hpp>
@@ -46,9 +46,9 @@ index 3be30af7..47abafee 100644
 +
  namespace cute
  {
-
+ 
 @@ -94,6 +98,14 @@ struct SM90_TMA_LOAD_OP : SM90_TMA_LOAD {};
-
+ 
  // The non-executable SM90_TMA_LOAD with tma_desc and no tma_mbar
  // Use .with(tma_mbar) to construct an executable version
 +//
@@ -64,14 +64,14 @@ index 3be30af7..47abafee 100644
  {
 @@ -106,7 +118,8 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
    using RefLayout = SrcLayout;
-
+ 
    // SM90_TMA_LOAD arguments
 -  TmaDescriptor tma_desc_;
 +  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory (was: TmaDescriptor by value).
 +  TmaDescriptor const* tma_desc_;
    using AuxParams = AuxParams_;
    AuxParams aux_params_;
-
+ 
 @@ -114,7 +127,7 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
    CUTE_HOST_DEVICE constexpr
    TmaDescriptor const*
@@ -79,7 +79,7 @@ index 3be30af7..47abafee 100644
 -    return &tma_desc_;
 +    return tma_desc_;
    }
-
+ 
    // Construct an executable SM90_TMA_LOAD with tma_mbar
 @@ -125,7 +138,7 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
      [[maybe_unused]] uint16_t const& multicast_mask = 0,
@@ -88,12 +88,12 @@ index 3be30af7..47abafee 100644
 -    return {&tma_desc_, &tma_mbar, static_cast<uint64_t>(cache_hint)};
 +    return {tma_desc_, &tma_mbar, static_cast<uint64_t>(cache_hint)};
    }
-
+ 
    // Construct an executable SM90_TMA_LOAD with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
 @@ -157,11 +170,14 @@ struct Copy_Traits<SM90_TMA_LOAD, NumBitsPerTMA, AuxParams_>
                Tensor<TS,SLayout> const& src,
                Tensor<TD,DLayout>      & dst) = delete;
-
+ 
 -  // Construct with updated TMA descriptor only (no barrier change)
 +  // Construct with updated TMA descriptor only (no barrier change).
 +  // OmniDreams patch: with pointer storage, we just store the new pointer directly
@@ -106,9 +106,9 @@ index 3be30af7..47abafee 100644
 +    return {new_tma_desc, aux_params_};
    }
  };
-
+ 
 @@ -252,6 +268,9 @@ struct SM90_TMA_LOAD_MULTICAST_OP : SM90_TMA_LOAD_MULTICAST {};
-
+ 
  // The non-executable SM90_TMA_LOAD_MULTICAST with tma_desc and no tma_mbar
  // Use .with(tma_mbar, multicast_mask) to construct an executable version
 +//
@@ -119,14 +119,14 @@ index 3be30af7..47abafee 100644
  {
 @@ -264,7 +283,8 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST, NumBitsPerTMA, AuxParams_>
    using RefLayout = SrcLayout;
-
+ 
    // SM90_TMA_LOAD_MULTICAST arguments
 -  TmaDescriptor tma_desc_;
 +  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory.
 +  TmaDescriptor const* tma_desc_;
    using AuxParams = AuxParams_;
    AuxParams aux_params_;
-
+ 
 @@ -272,7 +292,7 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST, NumBitsPerTMA, AuxParams_>
    CUTE_HOST_DEVICE constexpr
    TmaDescriptor const*
@@ -134,7 +134,7 @@ index 3be30af7..47abafee 100644
 -    return &tma_desc_;
 +    return tma_desc_;
    }
-
+ 
    // Construct an executable SM90_TMA_LOAD_MULTICAST with tma_mbar
 @@ -282,7 +302,7 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST, NumBitsPerTMA, AuxParams_>
      uint64_t& tma_load_mbar,
@@ -143,11 +143,11 @@ index 3be30af7..47abafee 100644
 -    return {&tma_desc_, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint)};
 +    return {tma_desc_, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint)};
    }
-
+ 
    // Construct an executable SM90_TMA_LOAD_MULTICAST_OP with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
 @@ -354,6 +374,9 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST_OP, NumBitsPerTMA>
  struct SM90_TMA_STORE_PTR : SM90_TMA_STORE {};
-
+ 
  // The executable SM90_TMA_STORE with tma_desc
 +//
 +// OmniDreams patch: see comment on Copy_Traits<SM90_TMA_LOAD>. Same
@@ -157,14 +157,14 @@ index 3be30af7..47abafee 100644
  {
 @@ -366,7 +389,8 @@ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
    using RefLayout = SrcLayout;
-
+ 
    // SM90_TMA_STORE arguments
 -  TmaDescriptor tma_desc_;
 +  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory.
 +  TmaDescriptor const* tma_desc_;
    using AuxParams = AuxParams_;
    AuxParams aux_params_;
-
+ 
 @@ -374,7 +398,7 @@ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
    CUTE_HOST_DEVICE constexpr
    TmaDescriptor const*
@@ -172,12 +172,12 @@ index 3be30af7..47abafee 100644
 -    return &tma_desc_;
 +    return tma_desc_;
    }
-
+ 
    // Generate the TMA coord tensor
 @@ -403,7 +427,8 @@ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
      static_assert(is_smem<TS>::value, "Expected smem src for SM90_TMA_STORE");
      //static_assert(is_gmem<TD>::value, "Expected gmem dst for SM90_TMA_STORE");  // TMA spoofed src tensor
-
+ 
 -    void const* const desc_ptr = &(traits.tma_desc_);
 +    // OmniDreams patch: tma_desc_ is already a pointer; no address-of needed.
 +    void const* const desc_ptr = traits.tma_desc_;
@@ -186,7 +186,7 @@ index 3be30af7..47abafee 100644
  #if 0
 @@ -465,6 +490,9 @@ struct Copy_Traits<SM90_TMA_STORE_PTR, NumBitsPerTMA>
  //////////////////////////////////////////////////////////////////////////////
-
+ 
  // The executable SM90_TMA_REDUCE_ADD with tma_desc
 +//
 +// OmniDreams patch: see comment on Copy_Traits<SM90_TMA_LOAD>. Same
@@ -196,14 +196,14 @@ index 3be30af7..47abafee 100644
  {
 @@ -479,7 +507,8 @@ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
    using RefLayout = SrcLayout;
-
+ 
    // SM90_TMA_REDUCE_ADD arguments
 -  TmaDescriptor tma_desc_;
 +  // OmniDreams patch: pointer to descriptor in cudaMalloc'd global memory.
 +  TmaDescriptor const* tma_desc_;
    using AuxParams = AuxParams_;
    AuxParams aux_params_;
-
+ 
 @@ -487,7 +516,7 @@ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
    CUTE_HOST_DEVICE constexpr
    TmaDescriptor const*
@@ -211,22 +211,22 @@ index 3be30af7..47abafee 100644
 -    return &tma_desc_;
 +    return tma_desc_;
    }
-
+ 
    // Generate the TMA coord tensor
 @@ -513,7 +542,8 @@ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
             int32_t(c0), int32_t(c1), int32_t(c2), int32_t(c3), int32_t(c4), src_ptr);
  #endif
-
+ 
 -    SM90_TMA_REDUCE_ADD::copy(&tma_desc_,
 +    // OmniDreams patch: tma_desc_ is already a pointer; no address-of needed.
 +    SM90_TMA_REDUCE_ADD::copy(tma_desc_,
                           src_ptr, get<Is>(dst_coord)...);
    }
-
+ 
 @@ -1151,7 +1181,31 @@ make_tma_copy_atom(CopyOp,
    using Traits = Copy_Traits<CopyOp, cute::C<num_bits_per_tma>, decltype(aux_params)>;
    using Atom   = Copy_Atom<Traits, typename GEngine::value_type>;
-
+ 
 -  Traits tma_traits{tma_desc, aux_params};
 +  // OmniDreams patch: pin the host-built TMA descriptor into a cudaMalloc'd
 +  // global-memory slot so that subsequent kernel-side accesses (prefetch /
@@ -253,6 +253,58 @@ index 3be30af7..47abafee 100644
 +                "OmniDreams patch: TMA descriptor pool unavailable under NVRTC. "
 +                "Compile this kernel ahead-of-time instead.");
 +#endif
-
+ 
  #if 0
    print("num_bits_per_tma :  "); print(num_bits_per_tma); print("\n");
+diff --git a/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_mma_transform.hpp b/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_mma_transform.hpp
+index 2ec1049b..3597958c 100644
+--- a/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_mma_transform.hpp
++++ b/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_mma_transform.hpp
+@@ -480,7 +480,7 @@ public:
+     return grid_shape;
+   }
+ 
+-  static constexpr
++  static
+   dim3
+   get_block_shape() {
+     return dim3(MaxThreadsPerBlock, 1, 1);
+diff --git a/include/cutlass/gemm/kernel/sm100_sparse_gemm_tma_warpspecialized.hpp b/include/cutlass/gemm/kernel/sm100_sparse_gemm_tma_warpspecialized.hpp
+index a5f6eb9b..544950de 100644
+--- a/include/cutlass/gemm/kernel/sm100_sparse_gemm_tma_warpspecialized.hpp
++++ b/include/cutlass/gemm/kernel/sm100_sparse_gemm_tma_warpspecialized.hpp
+@@ -443,7 +443,7 @@ public:
+         params.hw_info);
+   }
+ 
+-  static constexpr
++  static
+   dim3
+   get_block_shape() {
+     return dim3(MaxThreadsPerBlock, 1, 1);
+diff --git a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp
+index 06fd138d..3e66a305 100644
+--- a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp
++++ b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp
+@@ -479,7 +479,7 @@ public:
+     return grid_shape;
+   }
+ 
+-  static constexpr
++  static
+   dim3
+   get_block_shape() {
+     return dim3(MaxThreadsPerBlock, 1, 1);
+diff --git a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp
+index ae93b2ff..2acf366e 100644
+--- a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp
++++ b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp
+@@ -393,7 +393,7 @@ public:
+         params.hw_info);
+   }
+ 
+-  static constexpr
++  static
+   dim3
+   get_block_shape() {
+     return dim3(MaxThreadsPerBlock, 1, 1);

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "grpcio-tools>=1.50",
     "grpcio>=1.50",
     "nvidia-cudnn-frontend==1.22.1",
+    "nvidia-cudnn-cu13==9.23.2.1; sys_platform == 'win32'",
     "opencv-python-headless>=4.5",
     "shapely>=2.0",
     # Runtime deps for the ``omnidreams.interactive_drive`` desktop demo

--- a/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_demo_scene_selection.py
@@ -11,6 +11,7 @@ import pytest
 from omnidreams.interactive_drive import demo as demo_mod
 from omnidreams.interactive_drive.demo import (
     SceneOption,
+    _materialize_synthetic_scene_for_picker,
     _resolve_scene_variant,
     build_parser,
 )
@@ -181,6 +182,9 @@ def test_run_streaming_auto_start_skips_scene_picker(
         preload_scenes=False,
         prompt=None,
         auto_start=True,
+        synthetic_scene=False,
+        synthetic_initial_rgb=None,
+        synthetic_prompt=None,
     )
 
     demo_mod._run_streaming(args)
@@ -200,3 +204,39 @@ def test_run_streaming_auto_start_skips_scene_picker(
         )
     else:
         assert presenter.wait_while_preloading_probes == []
+
+
+def test_materialize_synthetic_scene_for_picker_consumes_synthetic_args(
+    monkeypatch, tmp_path: Path
+) -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "--synthetic-scene",
+            "--synthetic-initial-rgb",
+            "seed.png",
+            "--synthetic-prompt",
+            "drive forward",
+        ]
+    )
+    built_scene = tmp_path / "synthetic.usdz"
+    calls: list[tuple[Path | None, str | None]] = []
+
+    def fake_build_synthetic_scene_to_temp(
+        *, initial_rgb_path: Path | None = None, prompt: str | None = None
+    ) -> Path:
+        calls.append((initial_rgb_path, prompt))
+        return built_scene
+
+    monkeypatch.setattr(
+        "omnidreams.interactive_drive.demo.build_synthetic_scene_to_temp",
+        fake_build_synthetic_scene_to_temp,
+    )
+
+    _materialize_synthetic_scene_for_picker(args)
+
+    assert calls == [(Path("seed.png"), "drive forward")]
+    assert args.scene == built_scene
+    assert args.synthetic_scene is False
+    assert args.synthetic_initial_rgb is None
+    assert args.synthetic_prompt is None

--- a/integrations/omnidreams/tests/test_ludus_renderer_plugin.py
+++ b/integrations/omnidreams/tests/test_ludus_renderer_plugin.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import os
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,7 @@ import pytest
 pytestmark = pytest.mark.ci_cpu
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only DLL search path behavior")
 def test_windows_dll_directory_handles_are_kept_alive(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/integrations/omnidreams/tests/test_ludus_renderer_plugin.py
+++ b/integrations/omnidreams/tests/test_ludus_renderer_plugin.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_windows_dll_directory_handles_are_kept_alive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from ludus_renderer._ops import _plugin
+
+    torch_lib = tmp_path / "torch" / "lib"
+    torch_lib.mkdir(parents=True)
+    torch_init = tmp_path / "torch" / "__init__.py"
+    torch_init.write_text("", encoding="utf-8")
+    cuda_bin = tmp_path / "cuda" / "bin"
+    cuda_bin.mkdir(parents=True)
+    (cuda_bin / "cudart64_12.dll").write_text("", encoding="utf-8")
+    handles: list[object] = []
+    added: list[str] = []
+
+    def fake_add_dll_directory(path: str) -> object:
+        handle = object()
+        handles.append(handle)
+        added.append(str(Path(path)))
+        return handle
+
+    monkeypatch.setattr(_plugin.os, "name", "nt")
+    monkeypatch.setattr(_plugin.os, "add_dll_directory", fake_add_dll_directory)
+    monkeypatch.setattr(_plugin.torch, "__file__", str(torch_init))
+    monkeypatch.setattr(_plugin, "_dll_directory_handles", [])
+    monkeypatch.setattr(_plugin, "_dll_directory_paths", set())
+    monkeypatch.setenv("CUDA_PATH", str(tmp_path / "cuda"))
+    monkeypatch.setenv("PATH", str(cuda_bin))
+
+    _plugin._ensure_windows_dll_directories()
+    _plugin._ensure_windows_dll_directories()
+
+    assert added == [str(torch_lib), str(cuda_bin)]
+    assert _plugin._dll_directory_handles == handles

--- a/uv.lock
+++ b/uv.lock
@@ -1568,6 +1568,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
+    { name = "nvidia-cudnn-cu13", version = "9.23.2.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32' or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "nvidia-cudnn-frontend" },
     { name = "opencv-python-headless" },
     { name = "pillow" },
@@ -1608,6 +1609,7 @@ requires-dist = [
     { name = "ludus-renderer", editable = "integrations/omnidreams/ludus-renderer" },
     { name = "mediapy", specifier = ">=1.1" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'win32'", specifier = "==9.23.2.1" },
     { name = "nvidia-cudnn-frontend", specifier = "==1.22.1" },
     { name = "opencv-python-headless", specifier = ">=4.5" },
     { name = "pillow", specifier = ">=10.0" },
@@ -3626,6 +3628,13 @@ wheels = [
 name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+]
 dependencies = [
     { name = "nvidia-cublas", marker = "(sys_platform != 'win32' and extra == 'extra-11-flashdreams-dev') or (sys_platform != 'win32' and extra != 'group-11-flashdreams-cuda12') or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
 ]
@@ -3633,6 +3642,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
     { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
     { url = "https://files.pythonhosted.org/packages/78/39/21507455b1bca8b5702a9e9fc6ce73735f216f558dac2c9ede58e4d456b8/nvidia_cudnn_cu13-9.20.0.48-py3-none-win_amd64.whl", hash = "sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24", size = 350712614, upload-time = "2026-03-09T19:31:11.398Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.23.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'win32' or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/0f/0234666bed78ecdc767be01b53710a01df2773194ea856ba143eb3e70490/nvidia_cudnn_cu13-9.23.2.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:d826a14b848a719ff744c19891b6bcbe0a62cc01cd1d426d7cfd759c67d8d7b8", size = 616916016, upload-time = "2026-06-16T03:54:17.416Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/0f/f9434b616c38ffaf50b389f68e9b7b9977e35b964d8b7bded939369905bc/nvidia_cudnn_cu13-9.23.2.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c38408c043d67ea8a3cbe61fe272c3cf5c7f5ec466adfe8ac63e91d4f11cdc7", size = 518553472, upload-time = "2026-06-16T04:43:30.541Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/21/1cd2f2789f624c5c4b1f934ca7872bfc372e95f9f6690fdfda7e2031d4e5/nvidia_cudnn_cu13-9.23.2.1-py3-none-win_amd64.whl", hash = "sha256:03d164905021b64acf429f55e1bbbc26be9151299c2b55e71293c5cf2f1a13e6", size = 403307118, upload-time = "2026-06-16T04:48:03.125Z" },
 ]
 
 [[package]]
@@ -6030,7 +6058,7 @@ dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'win32' and extra == 'extra-11-flashdreams-dev') or (python_full_version < '3.11' and sys_platform != 'win32' and extra != 'group-11-flashdreams-cuda12') or (python_full_version >= '3.11' and extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (sys_platform == 'win32' and extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra != 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'win32' and extra == 'extra-11-flashdreams-dev') or (python_full_version >= '3.11' and sys_platform != 'win32' and extra != 'group-11-flashdreams-cuda12') or (python_full_version < '3.11' and extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (python_full_version < '3.11' and extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13') or (sys_platform == 'win32' and extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra != 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "nvidia-cublas", marker = "(sys_platform != 'win32' and extra == 'extra-11-flashdreams-dev') or (sys_platform != 'win32' and extra != 'group-11-flashdreams-cuda12') or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
-    { name = "nvidia-cudnn-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-11-flashdreams-dev') or (sys_platform == 'linux' and extra != 'group-11-flashdreams-cuda12') or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
+    { name = "nvidia-cudnn-cu13", version = "9.20.0.48", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra == 'extra-11-flashdreams-dev') or (sys_platform == 'linux' and extra != 'group-11-flashdreams-cuda12') or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "nvidia-cusparselt-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-11-flashdreams-dev') or (sys_platform == 'linux' and extra != 'group-11-flashdreams-cuda12') or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "nvidia-nccl-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-11-flashdreams-dev') or (sys_platform == 'linux' and extra != 'group-11-flashdreams-cuda12') or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },
     { name = "nvidia-nvshmem-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-11-flashdreams-dev') or (sys_platform == 'linux' and extra != 'group-11-flashdreams-cuda12') or (extra == 'extra-11-flashdreams-dev' and extra == 'group-11-flashdreams-cuda12') or (extra == 'group-11-flashdreams-cuda12' and extra == 'group-11-flashdreams-cuda13')" },


### PR DESCRIPTION
# Native Windows OmniDreams Interactive Demo Fixes

## Summary

- Materialize `--synthetic-scene` before HUD/MJPEG scene-picker discovery so the
  Windows browser-stream path can start without pre-staged USDZ scenes.
- Register Torch and CUDA runtime DLL directories before importing the Ludus JIT
  extension on Windows, and keep the returned handles alive for the process
  lifetime.
- Add focused CPU tests for synthetic scene materialization and Windows DLL
  directory registration.

## Why

The native Windows `interactive-drive --stream-mjpeg --synthetic-scene` path hit
two blockers before it could complete a lightweight smoke run:

1. HUD/MJPEG startup discovered available scenes before the synthetic scene was
   materialized, so startup failed when the cache had no staged scenes.
2. The Ludus CUDA extension compiled successfully, but importing the generated
   `.pyd` failed because Windows could not find dependent Torch/CUDA DLLs.