### PR TITLE
feat(wan-vae): default Wan 2.2 TI2V-5B VAE to the native .pth (no remap)

### DIFF
--- a/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
+++ b/flashdreams/flashdreams/recipes/wan/autoencoder/vae.py
@@ -52,23 +52,18 @@ from flashdreams.infra.encoder import (
     StreamingVideoEncoder,
 )
 
-# Wan 2.2 TI2V 5B's VAE ships in the diffusers Wan-AI repo. The
-# loader pulls the diffusers safetensors shard and remaps keys via
-# :func:`wan22_ti2v_5b_vae_state_dict_transform` (``encoder.conv_in``
-# / ``quant_conv`` / ``post_quant_conv`` etc. -> our internal layout).
-WAN22_TI2V_5B_VAE_DIFFUSERS_PATH = "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers/resolve/main/vae/diffusion_pytorch_model.safetensors"
-
-# Alternative upstream single-file checkpoint. Top-level key prefixes
-# (``encoder.*`` / ``decoder.*`` / ``conv1`` / ``conv2``) line up with
-# our internal :mod:`_residual_vae` model shape, BUT the ``.pth`` does
-# not cover every parameter our ``WanVAE`` wrapper builds (some encoder
-# / decoder slots stay on meta and ``model.to(device)`` raises
-# ``NotImplementedError: Cannot copy out of meta tensor``). Kept as a
-# constant for callers who want to invest in a tighter audit + a
-# tailored loader; the diffusers path above is still the default.
+# Upstream's native single-file checkpoint. Its key names match the
+# ``WanVAE`` module tree one-to-one, so it loads with no key remap and is
+# the production default for the Wan 2.2 TI2V 5B configs below.
 WAN22_TI2V_5B_VAE_PATH = (
     "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B/resolve/main/Wan2.2_VAE.pth"
 )
+
+# The same VAE re-exported in the diffusers ``AutoencoderKLWan`` layout.
+# Loadable via :func:`wan22_ti2v_5b_vae_state_dict_transform`, which
+# renames the diffusers keys onto the ``WanVAE`` tree; kept as an opt-in
+# fallback for callers who prefer the diffusers safetensors shard.
+WAN22_TI2V_5B_VAE_DIFFUSERS_PATH = "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers/resolve/main/vae/diffusion_pytorch_model.safetensors"
 
 AVAILABLE_WAN_VAE_CHECKPOINT_PATHS = {
     "lightvae": "https://huggingface.co/lightx2v/Autoencoders/resolve/main/lightvaew2_1.pth",
@@ -596,24 +591,24 @@ class ResidualDownBlock(nn.Module):
             factor_t=2 if temperal_downsample else 1,
             factor_s=2 if down_flag else 1,
         )
-        resnets: list[nn.Module] = []
+        # One flat ``Sequential`` holding the residual blocks followed by
+        # the optional downsampling ``Resample``, matching upstream's
+        # native ``downsamples.{j}`` layout so ``Wan2.2_VAE.pth`` loads
+        # with no key remap.
+        layers: list[nn.Module] = []
         for _ in range(num_res_blocks):
-            resnets.append(ResidualBlock(in_dim, out_dim, dropout))
+            layers.append(ResidualBlock(in_dim, out_dim, dropout))
             in_dim = out_dim
-        self.resnets = nn.ModuleList(resnets)
         if down_flag:
             mode = "downsample3d" if temperal_downsample else "downsample2d"
-            self.downsampler: Resample | None = Resample(out_dim, mode=mode)
-        else:
-            self.downsampler = None
+            layers.append(Resample(out_dim, mode=mode))
+        self.downsamples = nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor, state: Dict[int, torch.Tensor]) -> torch.Tensor:
         # Snapshot input for the avg shortcut before mutating ``x``.
         x_shortcut = x
-        for resnet in self.resnets:
-            x = resnet(x, state)
-        if self.downsampler is not None:
-            x = self.downsampler(x, state)
+        for layer in self.downsamples:
+            x = layer(x, state)
         return x + self.avg_shortcut(x_shortcut)
 
 
@@ -651,12 +646,15 @@ class ResidualUpBlock(nn.Module):
         else:
             self.avg_shortcut = None
 
-        resnets: list[nn.Module] = []
+        # One flat ``Sequential`` holding the residual blocks followed by
+        # the optional upsampling ``Resample``, matching upstream's native
+        # ``upsamples.{j}`` layout so ``Wan2.2_VAE.pth`` loads with no key
+        # remap.
+        layers: list[nn.Module] = []
         current_dim = in_dim
         for _ in range(num_res_blocks + 1):
-            resnets.append(ResidualBlock(current_dim, out_dim, dropout))
+            layers.append(ResidualBlock(current_dim, out_dim, dropout))
             current_dim = out_dim
-        self.resnets = nn.ModuleList(resnets)
 
         if up_flag:
             mode = "upsample3d" if temperal_upsample else "upsample2d"
@@ -670,9 +668,8 @@ class ResidualUpBlock(nn.Module):
                 "blindly rewire ResidualUpBlock's keep-channel upsampler."
             )
             up.resample[1] = nn.Conv2d(out_dim, out_dim, 3, padding=1)
-            self.upsampler: Resample | None = up
-        else:
-            self.upsampler = None
+            layers.append(up)
+        self.upsamples = nn.Sequential(*layers)
 
     def forward(
         self,
@@ -681,10 +678,8 @@ class ResidualUpBlock(nn.Module):
         first_chunk: bool = False,
     ) -> torch.Tensor:
         x_shortcut = x
-        for resnet in self.resnets:
-            x = resnet(x, state)
-        if self.upsampler is not None:
-            x = self.upsampler(x, state)
+        for layer in self.upsamples:
+            x = layer(x, state)
         if self.avg_shortcut is not None:
             x = x + self.avg_shortcut(x_shortcut, first_chunk=first_chunk)
         return x
@@ -1588,48 +1583,52 @@ _WAN22_TI2V_5B_VAE_KEY_REMAP: dict[str, str] = {
     #   0 norm1, 2 conv1, 3 norm2, 6 conv2 (1/4 SiLU, 5 Dropout).
     # diffusers ``conv_shortcut`` -> our ``shortcut``.
     r"^encoder\.down_blocks\.(\d+)\.resnets\.(\d+)\.norm1\.(.*)$": (
-        r"encoder.downsamples.\1.resnets.\2.residual.0.\3"
+        r"encoder.downsamples.\1.downsamples.\2.residual.0.\3"
     ),
     r"^encoder\.down_blocks\.(\d+)\.resnets\.(\d+)\.conv1\.(.*)$": (
-        r"encoder.downsamples.\1.resnets.\2.residual.2.\3"
+        r"encoder.downsamples.\1.downsamples.\2.residual.2.\3"
     ),
     r"^encoder\.down_blocks\.(\d+)\.resnets\.(\d+)\.norm2\.(.*)$": (
-        r"encoder.downsamples.\1.resnets.\2.residual.3.\3"
+        r"encoder.downsamples.\1.downsamples.\2.residual.3.\3"
     ),
     r"^encoder\.down_blocks\.(\d+)\.resnets\.(\d+)\.conv2\.(.*)$": (
-        r"encoder.downsamples.\1.resnets.\2.residual.6.\3"
+        r"encoder.downsamples.\1.downsamples.\2.residual.6.\3"
     ),
     r"^encoder\.down_blocks\.(\d+)\.resnets\.(\d+)\.conv_shortcut\.(.*)$": (
-        r"encoder.downsamples.\1.resnets.\2.shortcut.\3"
+        r"encoder.downsamples.\1.downsamples.\2.shortcut.\3"
     ),
-    # Encoder down-block extras: residual stage shortcut + downsampler.
+    # Encoder down-block extras: the per-stage average-pool shortcut and
+    # the downsampling resample, which sits at index 2 of the flat
+    # ``downsamples`` sequential (after the two residual blocks).
     r"^encoder\.down_blocks\.(\d+)\.avg_shortcut\.(.*)$": (
         r"encoder.downsamples.\1.avg_shortcut.\2"
     ),
     r"^encoder\.down_blocks\.(\d+)\.downsampler\.(.*)$": (
-        r"encoder.downsamples.\1.downsampler.\2"
+        r"encoder.downsamples.\1.downsamples.2.\2"
     ),
     # Decoder up-block residual-conv remap (same Sequential layout).
     r"^decoder\.up_blocks\.(\d+)\.resnets\.(\d+)\.norm1\.(.*)$": (
-        r"decoder.upsamples.\1.resnets.\2.residual.0.\3"
+        r"decoder.upsamples.\1.upsamples.\2.residual.0.\3"
     ),
     r"^decoder\.up_blocks\.(\d+)\.resnets\.(\d+)\.conv1\.(.*)$": (
-        r"decoder.upsamples.\1.resnets.\2.residual.2.\3"
+        r"decoder.upsamples.\1.upsamples.\2.residual.2.\3"
     ),
     r"^decoder\.up_blocks\.(\d+)\.resnets\.(\d+)\.norm2\.(.*)$": (
-        r"decoder.upsamples.\1.resnets.\2.residual.3.\3"
+        r"decoder.upsamples.\1.upsamples.\2.residual.3.\3"
     ),
     r"^decoder\.up_blocks\.(\d+)\.resnets\.(\d+)\.conv2\.(.*)$": (
-        r"decoder.upsamples.\1.resnets.\2.residual.6.\3"
+        r"decoder.upsamples.\1.upsamples.\2.residual.6.\3"
     ),
     r"^decoder\.up_blocks\.(\d+)\.resnets\.(\d+)\.conv_shortcut\.(.*)$": (
-        r"decoder.upsamples.\1.resnets.\2.shortcut.\3"
+        r"decoder.upsamples.\1.upsamples.\2.shortcut.\3"
     ),
     r"^decoder\.up_blocks\.(\d+)\.avg_shortcut\.(.*)$": (
         r"decoder.upsamples.\1.avg_shortcut.\2"
     ),
+    # The upsampling resample sits at index 3 of the flat ``upsamples``
+    # sequential (after the three residual blocks).
     r"^decoder\.up_blocks\.(\d+)\.upsampler\.(.*)$": (
-        r"decoder.upsamples.\1.upsampler.\2"
+        r"decoder.upsamples.\1.upsamples.3.\2"
     ),
 }
 
@@ -1639,10 +1638,12 @@ def wan22_ti2v_5b_vae_state_dict_transform(
 ) -> Dict[str, Tensor]:
     """Remap a diffusers ``AutoencoderKLWan`` state-dict to ``WanVAE`` keys.
 
-    Applied automatically when :class:`Wan22TI2V5BVAEEncoderConfig` /
-    :class:`Wan22TI2V5BVAEDecoderConfig` load the diffusers VAE checkpoint.
-    Renames keys only -- no tensors are copied or reshaped. Unmatched keys
-    pass through and surface as ``unexpected_keys`` on load.
+    Opt-in for callers who point :class:`Wan22TI2V5BVAEEncoderConfig` /
+    :class:`Wan22TI2V5BVAEDecoderConfig` at the diffusers safetensors shard
+    (:data:`WAN22_TI2V_5B_VAE_DIFFUSERS_PATH`) instead of the native
+    ``.pth`` default. Renames keys only -- no tensors are copied or
+    reshaped. Unmatched keys pass through and surface as ``unexpected_keys``
+    on load.
     """
     from flashdreams.core.checkpoint.remap import remap_checkpoint_keys
 
@@ -1653,22 +1654,22 @@ def wan22_ti2v_5b_vae_state_dict_transform(
 class Wan22TI2V5BVAEEncoderConfig(WanVAEEncoderConfig):
     """Pre-rolled config for the Wan 2.2 TI2V 5B encoder.
 
-    Pins the diffusers upstream checkpoint, the 16x-spatial / 48ch /
-    residual / patchify architecture knobs, and the matching diffusers
-    -> flashdreams key remap. Equivalent to the Wan 2.1 encoder config
-    plus the 5B-specific knobs flipped on.
+    Pins upstream's native ``Wan2.2_VAE.pth`` (loaded with no key remap),
+    the 16x-spatial / 48ch / residual / patchify architecture knobs.
+    Equivalent to the Wan 2.1 encoder config plus the 5B-specific knobs
+    flipped on. To load the diffusers shard instead, override
+    ``checkpoint_path=WAN22_TI2V_5B_VAE_DIFFUSERS_PATH`` and
+    ``state_dict_transform=wan22_ti2v_5b_vae_state_dict_transform``.
     """
 
-    checkpoint_path: str = WAN22_TI2V_5B_VAE_DIFFUSERS_PATH
+    checkpoint_path: str = WAN22_TI2V_5B_VAE_PATH
     base_dim: int = 160
     z_dim: int = 48
     patch_size: int = 2
     is_residual: bool = True
     latent_mean: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_MEAN
     latent_std: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_STD
-    state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = (
-        wan22_ti2v_5b_vae_state_dict_transform
-    )
+    state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None
 
 
 @dataclass(kw_only=True)
@@ -1679,7 +1680,7 @@ class Wan22TI2V5BVAEDecoderConfig(WanVAEDecoderConfig):
     ``decoder_base_dim=256``.
     """
 
-    checkpoint_path: str = WAN22_TI2V_5B_VAE_DIFFUSERS_PATH
+    checkpoint_path: str = WAN22_TI2V_5B_VAE_PATH
     base_dim: int = 160
     decoder_base_dim: int | None = 256
     z_dim: int = 48
@@ -1687,6 +1688,4 @@ class Wan22TI2V5BVAEDecoderConfig(WanVAEDecoderConfig):
     is_residual: bool = True
     latent_mean: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_MEAN
     latent_std: tuple[float, ...] = _WAN22_TI2V_5B_LATENT_STD
-    state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = (
-        wan22_ti2v_5b_vae_state_dict_transform
-    )
+    state_dict_transform: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None

--- a/flashdreams/tests/test_vae.py
+++ b/flashdreams/tests/test_vae.py
@@ -122,6 +122,174 @@ def test_tokenizer(
     )
 
 
+def _build_wan22_ti2v_5b_vae_modules() -> dict[str, tuple[int, ...]]:
+    """Build the Wan 2.2 TI2V-5B ``WanVAE`` module tree on ``meta``.
+
+    Mirrors the knobs in :class:`Wan22TI2V5BVAEEncoderConfig` /
+    :class:`Wan22TI2V5BVAEDecoderConfig`. Returns ``{key: shape}`` for the
+    full encoder + decoder + top-level convs, with no checkpoint download.
+    """
+    from flashdreams.recipes.wan.autoencoder.vae import (
+        CausalConv3d,
+        Decoder3d,
+        Encoder3d,
+    )
+
+    td = (False, True, True)
+    with torch.device("meta"):
+        enc = Encoder3d(
+            dim=160,
+            z_dim=96,
+            temperal_downsample=td,
+            in_channels=12,
+            dim_mult=(1, 2, 4, 4),
+            num_res_blocks=2,
+            attn_scales=(),
+            dropout=0.0,
+            pruning_rate=0.0,
+            is_residual=True,
+        )
+        conv1 = CausalConv3d(96, 96, 1)
+        dec = Decoder3d(
+            dim=256,
+            z_dim=48,
+            temperal_upsample=tuple(reversed(td)),
+            out_channels=12,
+            dim_mult=(1, 2, 4, 4),
+            num_res_blocks=2,
+            attn_scales=(),
+            dropout=0.0,
+            pruning_rate=0.0,
+            is_residual=True,
+        )
+        conv2 = CausalConv3d(48, 48, 1)
+
+    model: dict[str, tuple[int, ...]] = {}
+    for name, mod in (
+        ("encoder", enc),
+        ("conv1", conv1),
+        ("decoder", dec),
+        ("conv2", conv2),
+    ):
+        for k, v in mod.state_dict().items():
+            model[f"{name}.{k}"] = tuple(v.shape)
+    return model
+
+
+@pytest.mark.ci_cpu
+def test_wan22_vae_native_pth_loads_without_remap() -> None:
+    """The native ``Wan2.2_VAE.pth`` layout matches the module tree 1:1.
+
+    The production configs pin :data:`WAN22_TI2V_5B_VAE_PATH` with
+    ``state_dict_transform=None``: the native keys must land on the
+    ``WanVAE`` modules directly, with nothing left on ``meta``. This builds
+    the module tree on ``meta`` (no download) and checks real
+    ``Wan2.2_VAE.pth`` key strings (from a ``torch.load`` key dump) are
+    present verbatim, and that the renamed flat ``downsamples`` /
+    ``upsamples`` layout carries no residue of the old grouped names.
+    """
+    model = _build_wan22_ti2v_5b_vae_modules()
+
+    # Real upstream ``Wan2.2_VAE.pth`` keys spanning every down/up leaf kind
+    # (residual conv, residual shortcut, spatial resample, temporal conv)
+    # plus pass-through mid/head/top-level params.
+    real_native_keys = [
+        "encoder.downsamples.0.downsamples.0.residual.2.weight",
+        "encoder.downsamples.1.downsamples.0.shortcut.weight",
+        "encoder.downsamples.0.downsamples.2.resample.1.weight",
+        "encoder.downsamples.1.downsamples.2.time_conv.weight",
+        "decoder.upsamples.0.upsamples.0.residual.2.weight",
+        "decoder.upsamples.0.upsamples.3.resample.1.weight",
+        "decoder.upsamples.0.upsamples.3.time_conv.weight",
+        "encoder.middle.1.to_qkv.weight",
+        "decoder.head.2.weight",
+        "conv1.weight",
+    ]
+    missing = [k for k in real_native_keys if k not in model]
+    assert not missing, f"native .pth keys absent from the module tree: {missing}"
+
+    stale = [
+        k
+        for k in model
+        if ".resnets." in k or ".downsampler." in k or ".upsampler." in k
+    ]
+    assert not stale, f"grouped names survived the native-layout rename: {stale[:5]}"
+
+
+@pytest.mark.ci_cpu
+def test_wan22_vae_diffusers_remap_still_targets_real_params() -> None:
+    """The opt-in diffusers remap lands on real module keys after the rename.
+
+    Guards the down/up-block rules (whose targets moved from the grouped
+    ``resnets`` / ``downsampler`` / ``upsampler`` names to the flat
+    ``downsamples.{j}`` / ``upsamples.{j}`` layout) against representative
+    diffusers ``AutoencoderKLWan`` key strings.
+    """
+    from flashdreams.recipes.wan.autoencoder.vae import (
+        wan22_ti2v_5b_vae_state_dict_transform,
+    )
+
+    model = _build_wan22_ti2v_5b_vae_modules()
+    # RMS norms carry ``.gamma`` (not ``.weight``); convs carry ``.weight``.
+    cases = {
+        "encoder.down_blocks.0.resnets.0.norm1.gamma": "encoder.downsamples.0.downsamples.0.residual.0.gamma",
+        "encoder.down_blocks.0.resnets.1.conv2.weight": "encoder.downsamples.0.downsamples.1.residual.6.weight",
+        "encoder.down_blocks.1.resnets.0.conv_shortcut.weight": "encoder.downsamples.1.downsamples.0.shortcut.weight",
+        "encoder.down_blocks.0.downsampler.resample.1.weight": "encoder.downsamples.0.downsamples.2.resample.1.weight",
+        "decoder.up_blocks.0.resnets.2.norm2.gamma": "decoder.upsamples.0.upsamples.2.residual.3.gamma",
+        "decoder.up_blocks.0.upsampler.time_conv.weight": "decoder.upsamples.0.upsamples.3.time_conv.weight",
+    }
+    out = wan22_ti2v_5b_vae_state_dict_transform({k: torch.empty(1) for k in cases})
+    for src, want in cases.items():
+        assert want in out, (
+            f"{src!r} should remap to {want!r}; got {sorted(out)[:3]}..."
+        )
+        assert want in model, f"remap target {want!r} is not a real module param"
+
+
+@torch.no_grad()
+@pytest.mark.manual
+def test_wan22_vae_native_pth_and_diffusers_weights_identical() -> None:
+    """Native ``.pth`` (no remap) and the diffusers remap yield identical weights.
+
+    The verification behind defaulting to ``Wan2.2_VAE.pth``: loading the
+    native checkpoint directly and loading the diffusers shard through
+    :func:`wan22_ti2v_5b_vae_state_dict_transform` must produce the same
+    state dict, so the switch is a pure checkpoint-source change.
+
+    Marked ``manual``: downloads both checkpoints (~few GB) from
+    HuggingFace. Set ``WAN22_VAE_PTH`` to a local ``Wan2.2_VAE.pth`` to skip
+    that download.
+    """
+    import os
+
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    from flashdreams.recipes.wan.autoencoder.vae import (
+        wan22_ti2v_5b_vae_state_dict_transform,
+    )
+
+    diff_path = hf_hub_download(
+        "Wan-AI/Wan2.2-TI2V-5B-Diffusers", "vae/diffusion_pytorch_model.safetensors"
+    )
+    pth_path = os.environ.get("WAN22_VAE_PTH") or hf_hub_download(
+        "Wan-AI/Wan2.2-TI2V-5B", "Wan2.2_VAE.pth"
+    )
+
+    from_diffusers = wan22_ti2v_5b_vae_state_dict_transform(load_file(diff_path))
+    native = torch.load(pth_path, map_location="cpu", weights_only=True)
+    while isinstance(native, dict) and "state_dict" in native and len(native) <= 4:
+        native = native["state_dict"]
+
+    assert set(from_diffusers) == set(native), "remapped key sets differ"
+    worst = max(
+        (from_diffusers[k].float() - native[k].float()).abs().max().item()
+        for k in from_diffusers
+    )
+    assert worst == 0.0, f"weights differ between checkpoints (max |delta| = {worst})"
+
+
 # python tests/test_vae.py
 if __name__ == "__main__":
     tokenizer_choices: list[Literal["lightvae", "vae"]] = ["lightvae", "vae"]


### PR DESCRIPTION
Supersedes #223 

Addresses review on #223 (name the component the same way it is named in the pth).

## What changed
- Renames the Wan 2.2 residual down/up blocks' grouped `resnets` ModuleList + separate `downsampler` / `upsampler` into a single flat `downsamples` / `upsamples` `Sequential` (residual blocks followed by the optional resample). This matches upstream's native `Wan2.2_VAE.pth` key layout **one-to-one**.
- **Removes** `_WAN22_TI2V_5B_VAE_PTH_KEY_REMAP` and `wan22_ti2v_5b_vae_pth_state_dict_transform` entirely — they're no longer needed. The Wan 2.2 VAE configs now load the native `.pth` with `state_dict_transform=None` (genuinely no remap runs).
- The diffusers `AutoencoderKLWan` remap is retargeted onto the new flat layout and kept as an opt-in fallback.

## Tests
- `test_wan22_vae_native_pth_loads_without_remap` (ci_cpu): the native layout matches the module tree 1:1 with no leftover grouped names.
- `test_wan22_vae_diffusers_remap_still_targets_real_params` (ci_cpu): the diffusers fallback still targets real module params after the rename.
- `test_wan22_vae_native_pth_and_diffusers_weights_identical` (manual): both load paths yield bit-identical weights.

Verified on CPU: 196-param module tree matches the native keys 1:1, forward smoke passes, `ruff check` + `format` clean (pinned v0.12.7).
