### PR TITLE
ci: validate locked Python 3.12 environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
     env:
       UV_PROJECT_ENVIRONMENT: /tmp/flashdreams-venv
       UV_LINK_MODE: copy
-      UV_PYTHON: "3.10"
+      # Exercise the dependency branch used by current Python releases.
+      # GPU CI below remains on 3.10, the minimum supported version.
+      UV_PYTHON: "3.12"
     steps:
       - name: Get PR info
         if: startsWith(github.ref_name, 'pull-request/')
@@ -55,7 +57,7 @@ jobs:
           # that cannot be installed on CPU-only runners:
           # - transformer-engine-torch: source-only, requires GPU arch to compile
           uv venv --clear
-          uv sync --extra dev --group lint \
+          uv sync --locked --extra dev --group lint \
             --no-install-package transformer-engine-torch
 
       - name: Run linter checks
@@ -150,7 +152,7 @@ jobs:
           NVTE_CUDA_ARCHS: ${{ steps.gpu-arch.outputs.arch }}
         run: |
           uv venv --clear
-          uv sync --extra dev
+          uv sync --locked --extra dev
 
       - name: Verify GPU availability
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,9 +250,6 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Sync versions
-        run: uv run .github/scripts/sync_version.py || true
-
       - name: Build wheel
         run: uv build --wheel --package flashdreams
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,7 +38,7 @@ jobs:
           UV_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
           UV_INDEX_STRATEGY: unsafe-best-match
         run: |
-          uv sync --only-group docs --only-group docs-ci --python 3.12
+          uv sync --locked --only-group docs --only-group docs-ci --python 3.12
           uv pip install --no-deps ./flashdreams
 
       # Read version from `flashdreams/flashdreams/_version.py` (the single

--- a/.github/workflows/omnidreams-worldlens-canary.yml
+++ b/.github/workflows/omnidreams-worldlens-canary.yml
@@ -84,7 +84,7 @@ jobs:
           NVTE_CUDA_ARCHS: ${{ steps.gpu-arch.outputs.arch }}
         run: |
           uv venv --clear
-          uv sync --extra dev
+          uv sync --locked --extra dev
 
       - name: Run OmniDreams WorldLens canary
         env:

--- a/.github/workflows/omnidreams-worldlens-canary.yml
+++ b/.github/workflows/omnidreams-worldlens-canary.yml
@@ -146,7 +146,7 @@ jobs:
             --write-config \
             --force
 
-          uv run \
+          uv run --locked \
             --package flashdreams-omnidreams \
             --with hydra-core \
             --with omegaconf \

--- a/.github/workflows/video-quality-regression.yml
+++ b/.github/workflows/video-quality-regression.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install CPU dependencies
         run: |
           uv venv --clear
-          uv sync --extra dev --no-install-package transformer-engine-torch
+          uv sync --locked --extra dev --no-install-package transformer-engine-torch
 
       - name: Run video-quality regression
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         pass_filenames: false
       - id: ty
         name: ty type check
-        entry: uv run --group lint ty check
+        entry: uv run --locked --group lint ty check
         language: system
         types: [python]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
       - id: ruff-format
   - repo: local
     hooks:
+      - id: uv-lock-check
+        name: validate uv lockfile
+        entry: uv lock --check
+        language: system
+        files: '(^|/)pyproject\.toml$|^uv\.lock$'
+        pass_filenames: false
       - id: sync-version
         name: sync package versions
         entry: uv run --no-sync .github/scripts/sync_version.py


### PR DESCRIPTION
https://github.com/NVIDIA/flashdreams/pull/360 fixes a py312 crash due to a recent `numpy` version breaking compatibility, however it doesn't provide a means to detect such breakages in CI. This MR attempts that by

* Running CPU CI on Python 3.12 (previously: 3.10)
* Retaining Python 3.10 for GPU coverage
* Requiring all workflow syncs to use the committed `uv.lock` (no silent `uv.lock` upgrades in CI)
* Adding a `pre-commit` lockfile freshness check to alert developers of what would come up as CI breakage

By running CPU jobs with `py312` and GPU with `py310` we keep testing the lowest supported Python version but also have a way to catch simple regressions in a more modern version without increasing CI burden. This is a judgement call, we could choose to e.g. run GPU@310 and multiple CPU jobs @310,311,312,313.

Overall, this MR should make it much harder to have a similar breakage reappear on `main` in the future.