### PR TITLE
Fix packaged asset and cache path handling

### DIFF
--- a/integrations/flashvsr/flashvsr/corrector.py
+++ b/integrations/flashvsr/flashvsr/corrector.py
@@ -30,7 +30,7 @@ of the two implementations from the ``implementation`` knob (default
 """
 
 import hashlib
-from pathlib import Path
+from importlib.resources import as_file, files
 from typing import Literal, Optional, Tuple
 
 import torch
@@ -49,6 +49,10 @@ _DISABLE_TORCH_COMPILE = getattr(
 _ADAIN_CUDA_EXTENSION = None
 _ADAIN_CUDA_EXTENSION_LOAD_ERROR: Optional[Exception] = None
 ColorCorrectorImplementation = Literal["torch", "cuda"]
+_ADAIN_CUDA_SOURCE_RESOURCE = files("flashvsr").joinpath(
+    "csrc",
+    "color_corrector_adain_cuda.cu",
+)
 
 
 def _load_adain_cuda_extension():
@@ -58,21 +62,21 @@ def _load_adain_cuda_extension():
     if _ADAIN_CUDA_EXTENSION_LOAD_ERROR is not None:
         return None
 
-    source_path = Path(__file__).parent / "csrc" / "color_corrector_adain_cuda.cu"
-    # Hash the source bytes into the extension name so any edit to
-    # ``color_corrector_adain_cuda.cu`` invalidates the cached ``.so``
-    # under ``~/.cache/torch_extensions``. Without this suffix
-    # ``torch.utils.cpp_extension.load`` would silently reuse a stale build
-    # whenever the source contents change but the file timestamp doesn't
-    # advance enough to trigger its content-only check.
-    csrc_checksum = hashlib.sha256(source_path.read_bytes()).hexdigest()[:8]
     try:
-        _ADAIN_CUDA_EXTENSION = _load_cuda_extension(
-            name=f"flashvsr_adain_cuda_{csrc_checksum}",
-            sources=[str(source_path)],
-            extra_cuda_cflags=["-O3"],
-            verbose=False,
-        )
+        with as_file(_ADAIN_CUDA_SOURCE_RESOURCE) as source_path:
+            # Hash the source bytes into the extension name so any edit to
+            # ``color_corrector_adain_cuda.cu`` invalidates the cached ``.so``
+            # under ``~/.cache/torch_extensions``. Without this suffix
+            # ``torch.utils.cpp_extension.load`` would silently reuse a stale build
+            # whenever the source contents change but the file timestamp doesn't
+            # advance enough to trigger its content-only check.
+            csrc_checksum = hashlib.sha256(source_path.read_bytes()).hexdigest()[:8]
+            _ADAIN_CUDA_EXTENSION = _load_cuda_extension(
+                name=f"flashvsr_adain_cuda_{csrc_checksum}",
+                sources=[str(source_path)],
+                extra_cuda_cflags=["-O3"],
+                verbose=False,
+            )
     except Exception as exc:
         _ADAIN_CUDA_EXTENSION_LOAD_ERROR = exc
         return None

--- a/integrations/flashvsr/flashvsr/corrector.py
+++ b/integrations/flashvsr/flashvsr/corrector.py
@@ -49,9 +49,8 @@ _DISABLE_TORCH_COMPILE = getattr(
 _ADAIN_CUDA_EXTENSION = None
 _ADAIN_CUDA_EXTENSION_LOAD_ERROR: Optional[Exception] = None
 ColorCorrectorImplementation = Literal["torch", "cuda"]
-_ADAIN_CUDA_SOURCE_RESOURCE = files("flashvsr").joinpath(
-    "csrc",
-    "color_corrector_adain_cuda.cu",
+_ADAIN_CUDA_SOURCE_RESOURCE = (
+    files("flashvsr").joinpath("csrc").joinpath("color_corrector_adain_cuda.cu")
 )
 
 

--- a/integrations/hy_worldplay/hy_worldplay/runner.py
+++ b/integrations/hy_worldplay/hy_worldplay/runner.py
@@ -28,6 +28,7 @@ import torch
 from torch import Tensor
 
 from flashdreams.core.io.download import download_to_cache
+from flashdreams.core.io.disk import default_flashdreams_cache_dir
 from flashdreams.infra.runner import Runner, RunnerConfig
 from flashdreams.recipes.wan.pipeline import WanInferencePipeline
 
@@ -54,14 +55,12 @@ frame = 16 latents, matching the default ``num_chunk=4`` rollout. With
 ``--example-data`` this is swapped for the sample pose JSON."""
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[3]
-
 EXAMPLE_DATA_BASE_URL = (
     "https://raw.githubusercontent.com/Tencent-Hunyuan/HY-WorldPlay/main/assets"
 )
 """HTTP base URL where upstream's sample first-frame image / pose JSON live."""
 
-EXAMPLE_DATA_DIR_LOCAL = _REPO_ROOT / "data_local/hy_worldplay"
+EXAMPLE_DATA_DIR_LOCAL = default_flashdreams_cache_dir() / "example_data/hy_worldplay"
 """Local cache root for the downloaded sample inputs (gitignored)."""
 
 _EXAMPLE_IMAGE_FILENAME = "test.png"
@@ -179,7 +178,8 @@ class HyWorldPlayWanI2VRunnerConfig(RunnerConfig):
 
     example_data: bool = False
     """When ``True``, lazy-download the bundled sample first-frame image
-    into ``data_local/hy_worldplay/`` (rank-0 only, gitignored) and fill
+    into ``$FLASHDREAMS_CACHE_DIR/example_data/hy_worldplay/`` (rank-0 only)
+    and fill
     :attr:`image_path` from it when unset."""
 
     pose: str = DEFAULT_POSE

--- a/integrations/hy_worldplay/hy_worldplay/runner.py
+++ b/integrations/hy_worldplay/hy_worldplay/runner.py
@@ -27,8 +27,8 @@ from typing import Any
 import torch
 from torch import Tensor
 
-from flashdreams.core.io.download import download_to_cache
 from flashdreams.core.io.disk import default_flashdreams_cache_dir
+from flashdreams.core.io.download import download_to_cache
 from flashdreams.infra.runner import Runner, RunnerConfig
 from flashdreams.recipes.wan.pipeline import WanInferencePipeline
 

--- a/integrations/lingbot/lingbot/runner.py
+++ b/integrations/lingbot/lingbot/runner.py
@@ -27,6 +27,7 @@ from einops import rearrange
 from loguru import logger
 
 from flashdreams.core.io.download import download_to_cache
+from flashdreams.core.io.disk import default_flashdreams_cache_dir
 from flashdreams.infra.runner import Runner, RunnerConfig
 from lingbot.encoder.camctrl import CamCtrlInput
 from lingbot.encoder.utils import (
@@ -51,16 +52,12 @@ land on the right pixel centers at the runner's actual frame size."""
 _INTRINSICS_REFERENCE_WIDTH = 832
 """Capture-resolution width matching :data:`_INTRINSICS_REFERENCE_HEIGHT`."""
 
-# ``lingbot/runner.py`` -> ``lingbot/`` -> ``integrations/lingbot/`` ->
-# ``integrations/`` -> repo root. Keep this in sync with the file's nesting
-# depth (``parents[3]``).
-_REPO_ROOT = Path(__file__).resolve().parents[3]
 EXAMPLE_DATA_BASE_URL = (
     "https://raw.githubusercontent.com/Robbyant/lingbot-world/main/examples"
 )
 """HTTP base URL where bundled example folders are downloaded from."""
 
-EXAMPLE_DATA_DIR_LOCAL = _REPO_ROOT / "assets/example_data/lingbot_world"
+EXAMPLE_DATA_DIR_LOCAL = default_flashdreams_cache_dir() / "example_data/lingbot_world"
 """Local cache root where downloaded example folders are stored."""
 
 EXAMPLE_DATA_FILENAMES = (
@@ -151,7 +148,7 @@ class LingbotWorldRunnerConfig(RunnerConfig):
 
     example_data: bool = False
     """When ``True``, lazy-download bundled GitHub example assets into
-    ``assets/example_data/lingbot_world/`` and fill ``image_path`` /
+    ``$FLASHDREAMS_CACHE_DIR/example_data/lingbot_world/`` and fill ``image_path`` /
     ``pose_path`` / ``intrinsic_path`` / ``prompt_path`` from the
     bundled defaults. Use for the README demo; pass explicit paths
     for production runs."""

--- a/integrations/lingbot/lingbot/runner.py
+++ b/integrations/lingbot/lingbot/runner.py
@@ -26,8 +26,8 @@ import torch
 from einops import rearrange
 from loguru import logger
 
-from flashdreams.core.io.download import download_to_cache
 from flashdreams.core.io.disk import default_flashdreams_cache_dir
+from flashdreams.core.io.download import download_to_cache
 from flashdreams.infra.runner import Runner, RunnerConfig
 from lingbot.encoder.camctrl import CamCtrlInput
 from lingbot.encoder.utils import (

--- a/integrations/lingbot/lingbot/trajectory_viz.py
+++ b/integrations/lingbot/lingbot/trajectory_viz.py
@@ -67,7 +67,9 @@ from flashdreams.core.io.disk import default_flashdreams_cache_dir
 DEFAULT_EXAMPLE_DATA_ROOT = (
     default_flashdreams_cache_dir() / "example_data/lingbot_world"
 )
-DEFAULT_OUTPUT_PATH = Path("outputs/lingbot_camera_trajectory.mp4")
+DEFAULT_OUTPUT_PATH = (
+    default_flashdreams_cache_dir() / "outputs/lingbot_camera_trajectory.mp4"
+)
 AVAILABLE_EXAMPLE_IDXS = (0, 1, 2, 5)
 DEFAULT_OUTPUT_FPS = 16
 """Default trajectory video FPS, aligned with ``LingbotWorldRunnerConfig.fps``."""

--- a/integrations/lingbot/lingbot/trajectory_viz.py
+++ b/integrations/lingbot/lingbot/trajectory_viz.py
@@ -62,9 +62,12 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_EXAMPLE_DATA_ROOT = REPO_ROOT / "assets/example_data/lingbot_world"
-DEFAULT_OUTPUT_PATH = REPO_ROOT / "outputs/lingbot_camera_trajectory.mp4"
+from flashdreams.core.io.disk import default_flashdreams_cache_dir
+
+DEFAULT_EXAMPLE_DATA_ROOT = (
+    default_flashdreams_cache_dir() / "example_data/lingbot_world"
+)
+DEFAULT_OUTPUT_PATH = Path("outputs/lingbot_camera_trajectory.mp4")
 AVAILABLE_EXAMPLE_IDXS = (0, 1, 2, 5)
 DEFAULT_OUTPUT_FPS = 16
 """Default trajectory video FPS, aligned with ``LingbotWorldRunnerConfig.fps``."""
@@ -85,7 +88,7 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=0,
         choices=AVAILABLE_EXAMPLE_IDXS,
-        help="Example folder index under assets/example_data/lingbot_world.",
+        help="Example folder index under the LingBot example-data cache.",
     )
     parser.add_argument(
         "--example_data_root",

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import argparse
 import os
-from pathlib import Path
+from contextlib import ExitStack
+from importlib.resources import as_file, files
 from typing import Protocol, cast
 
 import torch
@@ -54,7 +55,7 @@ from lingbot.webrtc.session import (
     normalize_prompt_text,
 )
 
-WEB_DIR = Path(__file__).resolve().parent / "web"
+WEB_DIR_RESOURCE = files("lingbot.webrtc").joinpath("web")
 MAX_UPLOAD_IMAGE_BYTES = 15 * 1024 * 1024
 MAX_PROMPT_CHARS = 2_000
 
@@ -119,9 +120,13 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=0,
         choices=EXAMPLE_DATA_AVAILABLE_IDXS,
-        help="Example folder index under assets/example_data/lingbot_world (allowed: 0, 1, 2, 5).",
+        help="Example folder index under the LingBot example-data cache (allowed: 0, 1, 2, 5).",
     )
     return parser.parse_args()
+
+
+async def _close_package_resources(app: web.Application) -> None:
+    app["package_resource_stack"].close()
 
 
 def create_app(
@@ -130,15 +135,25 @@ def create_app(
     session_manager: WebRTCSessionManager | None = None,
 ) -> web.Application:
     manager = session_manager or LingbotWebRTCSessionManager()
-    app = create_webrtc_app(
-        web_dir=WEB_DIR,
-        session_manager=manager,
-        preload_name="Lingbot",
-        request_session_url=request_session_url,
-    )
-    app.router.add_get("/api/session/initial_scene", _initial_scene)
-    app.router.add_get("/api/session/first_frame", _first_frame)
-    app.router.add_post("/api/session/input", _session_input)
+
+    resource_stack = ExitStack()
+    try:
+        web_dir = resource_stack.enter_context(as_file(WEB_DIR_RESOURCE))
+
+        app = create_webrtc_app(
+            web_dir=web_dir,
+            session_manager=manager,
+            preload_name="Lingbot",
+            request_session_url=request_session_url,
+        )
+        app.router.add_get("/api/session/initial_scene", _initial_scene)
+        app.router.add_get("/api/session/first_frame", _first_frame)
+        app.router.add_post("/api/session/input", _session_input)
+        app["package_resource_stack"] = resource_stack
+        app.on_cleanup.append(_close_package_resources)
+    except Exception:
+        resource_stack.close()
+        raise
     return app
 
 

--- a/integrations/lingbot/lingbot/webrtc/session.py
+++ b/integrations/lingbot/lingbot/webrtc/session.py
@@ -20,7 +20,7 @@ import io
 import urllib.error
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +33,7 @@ from flashdreams.core.distributed.rank_orchestration import (
     RankCoordinator,
     distributed_op,
 )
+from flashdreams.core.io.disk import default_flashdreams_cache_dir
 from flashdreams.infra.config import derive_config
 from flashdreams.serving.webrtc.controls import (
     CameraPoseIntegrator,
@@ -48,7 +49,6 @@ from flashdreams.serving.webrtc.manager import (
 from flashdreams.serving.webrtc.server import SessionBusyError
 from lingbot.encoder.utils import preprocess_example_poses
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
 _INTRINSICS_REFERENCE_HEIGHT = 480
 _INTRINSICS_REFERENCE_WIDTH = 832
 _DEFAULT_INTRINSICS = (
@@ -200,7 +200,10 @@ class LingbotRuntimeConfig:
     warmup_chunks: int = 10
     warmup_timeout_s: float = 600.0
 
-    example_data_dir: Path = REPO_ROOT / "assets/example_data/lingbot_world"
+    example_data_dir: Path = field(
+        default_factory=lambda: default_flashdreams_cache_dir()
+        / "example_data/lingbot_world"
+    )
     first_frame_filename: str = "image.jpg"
     intrinsics_filename: str = "intrinsics.npy"
     poses_filename: str = "poses.npy"

--- a/integrations/lingbot/lingbot/webrtc/web/mock_ui_server.py
+++ b/integrations/lingbot/lingbot/webrtc/web/mock_ui_server.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 import argparse
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
+from importlib.resources import as_file, files
 from urllib.parse import urlsplit
 
-WEB_DIR = Path(__file__).resolve().parent
+WEB_DIR_RESOURCE = files("lingbot.webrtc").joinpath("web")
 
 
 class MockUIRequestHandler(SimpleHTTPRequestHandler):
@@ -60,15 +60,16 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    handler = partial(MockUIRequestHandler, directory=str(WEB_DIR))
-    server = ThreadingHTTPServer((args.host, args.port), handler)
-    print(f"Serving mock UI at http://{args.host}:{args.port}/request_session?mock=1")
-    try:
-        server.serve_forever()
-    except KeyboardInterrupt:
-        print("\nStopping mock UI server.")
-    finally:
-        server.server_close()
+    with as_file(WEB_DIR_RESOURCE) as web_dir:
+        handler = partial(MockUIRequestHandler, directory=str(web_dir))
+        server = ThreadingHTTPServer((args.host, args.port), handler)
+        print(f"Serving mock UI at http://{args.host}:{args.port}/request_session?mock=1")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping mock UI server.")
+        finally:
+            server.server_close()
 
 
 if __name__ == "__main__":

--- a/integrations/lingbot/lingbot/webrtc/web/mock_ui_server.py
+++ b/integrations/lingbot/lingbot/webrtc/web/mock_ui_server.py
@@ -63,7 +63,9 @@ def main() -> None:
     with as_file(WEB_DIR_RESOURCE) as web_dir:
         handler = partial(MockUIRequestHandler, directory=str(web_dir))
         server = ThreadingHTTPServer((args.host, args.port), handler)
-        print(f"Serving mock UI at http://{args.host}:{args.port}/request_session?mock=1")
+        print(
+            f"Serving mock UI at http://{args.host}:{args.port}/request_session?mock=1"
+        )
         try:
             server.serve_forever()
         except KeyboardInterrupt:

--- a/integrations/lingbot/tests/test_server_routes.py
+++ b/integrations/lingbot/tests/test_server_routes.py
@@ -16,11 +16,13 @@
 from __future__ import annotations
 
 import base64
+from contextlib import ExitStack
 
 import pytest
 from aiohttp import FormData
 from aiohttp.test_utils import TestClient, TestServer
-from lingbot.webrtc.server import create_app
+from lingbot.webrtc import server as webrtc_server
+from lingbot.webrtc.server import _close_package_resources, create_app
 from lingbot.webrtc.session import (
     LingbotImagePayload,
     LingbotSessionInput,
@@ -100,6 +102,64 @@ async def _build_client(manager: FakeSessionManager) -> TestClient:
     client = TestClient(server)
     await client.start_server()
     return client
+
+
+def test_create_app_keeps_package_web_resource_materialized() -> None:
+    app = create_app(
+        session_manager=FakeSessionManager(),
+        request_session_url="http://127.0.0.1:8080/request_session",
+    )
+    try:
+        assert isinstance(app["package_resource_stack"], ExitStack)
+        assert _close_package_resources in app.on_cleanup
+
+        static_resources = [
+            resource
+            for resource in app.router.resources()
+            if getattr(resource, "canonical", "") == "/static"
+            or resource.get_info().get("prefix") in {"/static", "/static/"}
+        ]
+        assert len(static_resources) == 1
+        web_dir = static_resources[0].get_info()["directory"]
+        assert web_dir.is_dir()
+        assert "Lingbot WebRTC Viewer" in (
+            web_dir / "request_session.html"
+        ).read_text()
+    finally:
+        app["package_resource_stack"].close()
+
+
+def test_create_app_closes_package_resource_when_app_creation_fails(
+    monkeypatch, tmp_path
+) -> None:
+    class TrackedResource:
+        closed = False
+
+        def __enter__(self):
+            return tmp_path
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.closed = True
+
+    tracked_resource = TrackedResource()
+
+    def raise_app_creation_failure(**_kwargs):
+        raise RuntimeError("app creation failed")
+
+    monkeypatch.setattr(webrtc_server, "as_file", lambda _resource: tracked_resource)
+    monkeypatch.setattr(
+        webrtc_server,
+        "create_webrtc_app",
+        raise_app_creation_failure,
+    )
+
+    with pytest.raises(RuntimeError, match="app creation failed"):
+        create_app(
+            session_manager=FakeSessionManager(),
+            request_session_url="http://127.0.0.1:8080/request_session",
+        )
+
+    assert tracked_resource.closed
 
 
 @pytest.mark.asyncio

--- a/integrations/lingbot/tests/test_server_routes.py
+++ b/integrations/lingbot/tests/test_server_routes.py
@@ -122,9 +122,7 @@ def test_create_app_keeps_package_web_resource_materialized() -> None:
         assert len(static_resources) == 1
         web_dir = static_resources[0].get_info()["directory"]
         assert web_dir.is_dir()
-        assert "Lingbot WebRTC Viewer" in (
-            web_dir / "request_session.html"
-        ).read_text()
+        assert "Lingbot WebRTC Viewer" in (web_dir / "request_session.html").read_text()
     finally:
         app["package_resource_stack"].close()
 

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -7,6 +7,7 @@ import argparse
 import os
 from contextlib import ExitStack
 from importlib.resources import as_file, files
+from pathlib import Path
 
 import torch
 import torch.distributed as dist

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -7,7 +7,6 @@ import argparse
 import os
 from contextlib import ExitStack
 from importlib.resources import as_file, files
-from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -31,8 +30,6 @@ from flashdreams.serving.webrtc.bootstrap import (
 from flashdreams.serving.webrtc.server import WebRTCSessionManager, create_webrtc_app
 
 WEB_DIR_RESOURCE = files("omnidreams.webrtc").joinpath("web")
-# Wheel-installed deployments skip this optional mount when the repo root is absent.
-REPO_ASSETS_DIR = Path(__file__).resolve().parents[4] / "assets"
 
 
 def parse_args() -> argparse.Namespace:
@@ -132,8 +129,6 @@ def create_app(
             preload_name="Omnidreams",
             request_session_url=request_session_url,
         )
-        if REPO_ASSETS_DIR.is_dir():
-            app.router.add_static("/assets/", REPO_ASSETS_DIR, show_index=False)
         app["package_resource_stack"] = resource_stack
         app.on_cleanup.append(_close_package_resources)
     except Exception:

--- a/integrations/omnidreams/omnidreams/webrtc/web/assets/horizontal-dark.svg
+++ b/integrations/omnidreams/omnidreams/webrtc/web/assets/horizontal-dark.svg
@@ -1,0 +1,192 @@
+<svg width="2176" height="495" viewBox="0 0 2176 495" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_28_448)">
+<g clip-path="url(#clip1_28_448)">
+<mask id="mask0_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="495" height="495">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 495H495V6.10352e-05H0V495Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_28_448)">
+<mask id="mask1_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask1_28_448)">
+<mask id="mask2_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="61" y="366" width="95" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M64.9593 387.58L62.4372 384.403L61.1377 380.561L61.2138 376.505L62.6566 372.714L65.2961 369.634L68.8214 367.628L72.8174 366.932H155.997V390.57H72.8168L69.9796 390.225L67.3083 389.208L64.9593 387.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask2_28_448)">
+<mask id="mask3_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask3_28_448)">
+<rect x="58.7812" y="365.062" width="99" height="27.8438" fill="url(#pattern0_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask4_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask4_28_448)">
+<mask id="mask5_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="35" y="329" width="121" height="24">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M36.0768 345.069L35.3652 341.369L35.8542 337.633L37.4939 334.241L40.1179 331.537L43.4594 329.797L47.1789 329.196H155.997V352.834L47.1586 352.821L43.6139 352.276L40.3968 350.69L37.8046 348.212L36.0768 345.069Z" fill="white"/>
+</mask>
+<g mask="url(#mask5_28_448)">
+<mask id="mask6_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask6_28_448)">
+<rect x="34.0312" y="327.938" width="123.75" height="27.8438" fill="url(#pattern1_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask7_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask7_28_448)">
+<mask id="mask8_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="29" y="291" width="127" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M29.89 302.558L30.6381 299.083L32.386 295.987L34.9754 293.551L38.1721 291.995L41.6869 291.461H155.997V315.098H41.6943L37.987 314.502L34.6539 312.773L32.0314 310.085L30.3844 306.71L29.8789 302.989L29.89 302.558Z" fill="white"/>
+</mask>
+<g mask="url(#mask8_28_448)">
+<mask id="mask9_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask9_28_448)">
+<rect x="27.8435" y="290.812" width="129.938" height="24.75" fill="url(#pattern2_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask10_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask10_28_448)">
+<mask id="mask11_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="40" y="253" width="116" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M52.2254 277.362L48.2572 276.676L44.7497 274.698L42.1101 271.656L40.6449 267.905L40.5242 263.88L41.7619 260.048L43.6214 257.44L46.1126 255.428L49.0526 254.158L52.2255 253.725H155.997V277.362H52.2254Z" fill="white"/>
+</mask>
+<g mask="url(#mask11_28_448)">
+<mask id="mask12_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask12_28_448)">
+<rect x="40.2188" y="253.688" width="117.562" height="24.75" fill="url(#pattern3_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask13_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask13_28_448)">
+<mask id="mask14_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="76" y="215" width="80" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.6974 239.626L84.89 238.996L81.4886 237.173L78.8558 234.352L77.2722 230.833L76.9067 226.991L77.7983 223.236L79.8519 219.969L82.8486 217.537L85.6722 216.382L88.6974 215.989H155.997V239.626H88.6974Z" fill="white"/>
+</mask>
+<g mask="url(#mask14_28_448)">
+<mask id="mask15_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask15_28_448)">
+<rect x="74.25" y="213.469" width="83.5312" height="27.8438" fill="url(#pattern4_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask16_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask16_28_448)">
+<mask id="mask17_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="120" y="178" width="36" height="24">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M122.218 183.828L124.857 180.853L128.333 178.922L132.253 178.253H139.378H155.997V188.539V201.89H145.431H137.199H132.254L128.717 201.349L125.504 199.774L122.91 197.309L121.172 194.181L120.45 190.677L120.81 187.117L122.218 183.828Z" fill="white"/>
+</mask>
+<g mask="url(#mask17_28_448)">
+<mask id="mask18_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask18_28_448)">
+<rect x="117.562" y="176.344" width="40.2188" height="27.8438" fill="url(#pattern5_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask19_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask19_28_448)">
+<mask id="mask20_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="184" y="114" width="280" height="301">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M184.149 128.816L196.126 123.87L208.481 119.964L221.123 117.125L233.962 115.375L246.903 114.725L260.933 115.398L274.835 117.411L288.48 120.745L301.744 125.369L314.503 131.241L326.643 138.308L338.05 146.505L348.621 155.755L358.257 165.974L366.872 177.069L374.385 188.937L380.728 201.47L382.546 204.34L385.106 206.574L388.196 207.987L399.511 212.014L410.293 217.303L420.402 223.786L429.707 231.379L438.086 239.982L445.431 249.485L451.644 259.762L456.646 270.681L460.372 282.098L462.772 293.865L463.816 305.829L463.49 317.835L461.798 329.724L458.762 341.344L454.423 352.542L448.835 363.173L442.073 373.098L434.223 382.187L425.39 390.323L415.686 397.4L405.24 403.324L394.186 408.02L382.67 411.426L370.84 413.498L358.851 414.208H196.67L230.641 390.57H358.634L369.481 389.846L380.134 387.686L390.407 384.129L400.115 379.239L409.087 373.101L417.164 365.824L424.201 357.539L430.074 348.392L434.68 338.545L437.935 328.173L439.783 317.461L440.191 306.598L439.15 295.777L436.681 285.19L432.825 275.027L427.654 265.465L421.256 256.676L413.747 248.815L405.26 242.023L395.945 236.419L385.968 232.103L375.506 229.151L371.062 227.614L367.135 225.029L363.966 221.554L361.754 217.404L356.261 205.106L349.456 193.482L341.42 182.673L332.25 172.807L322.056 164.003L310.961 156.367L299.097 149.99L286.606 144.95L273.64 141.305L260.352 139.101L246.903 138.363L233.486 139.097L220.229 141.291L207.29 144.919L186.204 130.246L184.149 128.816Z" fill="white"/>
+</mask>
+<g mask="url(#mask20_28_448)">
+<mask id="mask21_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask21_28_448)">
+<rect x="182.531" y="114.469" width="281.531" height="300.094" fill="url(#pattern6_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask22_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask22_28_448)">
+<mask id="mask23_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="155" y="121" width="231" height="310">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M176.365 428.337L172.751 430.094L168.772 430.659L164.811 429.978L161.249 428.117L158.428 425.255L156.62 421.666L155.997 417.696V134.041L156.62 130.07L158.428 126.482L161.249 123.62L164.811 121.759L168.772 121.078L172.751 121.643L176.365 123.399L380.188 265.227L383.167 268.107L385.085 271.779L385.747 275.868L385.085 279.958L383.167 283.63L380.188 286.509L176.365 428.337ZM286.704 265.561L287.174 263.883L286.671 262.215L285.352 261.076L283.629 260.822L244.235 266.235L242.356 265.905L241.02 264.543L240.727 262.658L250.298 201.919L249.909 199.857L248.303 198.508L246.206 198.48L244.565 199.786L182.368 299.902L181.899 301.579L182.402 303.248L183.72 304.386L185.444 304.64L225.039 299.199L226.918 299.53L228.253 300.892L228.546 302.777L219.038 363.119L219.427 365.181L221.033 366.53L223.13 366.558L224.771 365.252L286.704 265.561Z" fill="white"/>
+</mask>
+<g mask="url(#mask23_28_448)">
+<mask id="mask24_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask24_28_448)">
+<rect x="154.688" y="120.656" width="232.031" height="312.469" fill="url(#pattern7_28_448)"/>
+</g>
+</g>
+</g>
+<mask id="mask25_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-92" y="-74" width="1781" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-91.0339 -73.3585H1688.26V586.58H-91.0339V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask25_28_448)">
+<mask id="mask26_28_448" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-123" y="-1046" width="1843" height="2605">
+<path d="M-122.203 1558.91H1719.43V-1045.69H-122.203V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask26_28_448)">
+<path d="M286.704 265.56L224.771 365.252L223.13 366.558L221.033 366.53L219.427 365.18L219.038 363.119L228.547 302.777L228.253 300.892L226.918 299.53L225.039 299.199L185.444 304.64L183.72 304.386L182.402 303.247L181.899 301.579L182.368 299.901L244.565 199.786L246.206 198.48L248.303 198.508L249.909 199.858L250.298 201.919L240.727 262.658L241.02 264.543L242.356 265.905L244.234 266.235L283.629 260.822L285.352 261.076L286.671 262.215L287.174 263.882L286.704 265.56Z" stroke="black" stroke-width="0.0993272" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</g>
+</g>
+</g>
+<path d="M514.18 391V303H481.4V277.7H514.18V268.9C514.18 258.487 517.187 250.127 523.2 243.82C529.213 237.367 538.6 234.14 551.36 234.14H599.32V259.44H559.28C550.48 259.44 546.08 263.913 546.08 272.86V277.7H593.16V303H546.08V391H514.18ZM613.709 391V233.7H645.609V391H613.709ZM699.924 391C688.044 391 678.95 387.993 672.644 381.98C666.337 375.967 663.184 367.387 663.184 356.24C663.184 345.24 666.337 336.733 672.644 330.72C678.95 324.707 688.044 321.7 699.924 321.7H784.404V316.42C784.404 307.473 780.004 303 771.204 303H677.924V277.7H779.564C792.91 277.7 802.37 280.78 807.944 286.94C813.517 292.953 816.304 301.46 816.304 312.46V391H699.924ZM705.644 365.7H784.404V347H705.644C702.857 347 700.657 347.88 699.044 349.64C697.577 351.253 696.844 353.453 696.844 356.24C696.844 359.027 697.577 361.3 699.044 363.06C700.657 364.82 702.857 365.7 705.644 365.7ZM836.844 392.1V366.8H944.644C950.804 366.8 953.884 363.353 953.884 356.46C953.884 349.713 950.804 346.34 944.644 346.34H874.904C861.851 346.34 851.951 343.407 845.204 337.54C838.458 331.527 835.084 322.947 835.084 311.8C835.084 300.507 838.458 291.853 845.204 285.84C852.098 279.68 861.998 276.6 874.904 276.6H975.224V301.9H876.444C870.138 301.9 866.984 304.98 866.984 311.14C866.984 314.22 867.864 316.64 869.624 318.4C871.384 320.16 873.658 321.04 876.444 321.04H950.364C961.804 321.04 970.531 324.047 976.544 330.06C982.704 335.927 985.784 344.507 985.784 355.8C985.784 367.24 982.704 376.187 976.544 382.64C970.384 388.947 961.658 392.1 950.364 392.1H836.844ZM1004.51 391V233.7H1036.41V277.7H1103.29C1116.2 277.7 1125.58 280.927 1131.45 287.38C1137.46 293.687 1140.47 302.047 1140.47 312.46V391H1108.57V316.2C1108.57 307.4 1104.17 303 1095.37 303H1036.41V391H1004.51Z" fill="white"/>
+<path d="M1302.97 391H1271.07V233.7H1302.97V391ZM1297.47 391H1221.57C1201.92 391 1186.59 386.16 1175.59 376.48C1164.59 366.8 1159.09 352.793 1159.09 334.46C1159.09 315.98 1164.59 301.9 1175.59 292.22C1186.59 282.54 1201.92 277.7 1221.57 277.7H1295.27V303H1221.57C1212.04 303 1204.71 305.64 1199.57 310.92C1194.59 316.053 1192.09 323.9 1192.09 334.46C1192.09 344.873 1194.59 352.72 1199.57 358C1204.71 363.133 1212.04 365.7 1221.57 365.7H1297.47V391ZM1327.21 391V277.7H1413.89C1426.65 277.7 1436.03 280.927 1442.05 287.38C1448.06 293.687 1451.07 302.047 1451.07 312.46V336H1418.73V316.42C1418.73 307.62 1414.33 303.22 1405.53 303.22H1359.55V391H1327.21ZM1530.95 392.1C1511.3 392.1 1495.97 387.26 1484.97 377.58C1473.97 367.753 1468.47 353.38 1468.47 334.46C1468.47 315.393 1473.97 301.02 1484.97 291.34C1495.97 281.513 1511.3 276.6 1530.95 276.6H1585.95C1598.86 276.6 1608.68 279.68 1615.43 285.84C1622.32 291.853 1625.77 300.507 1625.77 311.8C1625.77 334.827 1612.5 346.34 1585.95 346.34H1502.79C1505.87 359.98 1515.26 366.8 1530.95 366.8H1620.05V392.1H1530.95ZM1530.95 301.9C1515.84 301.9 1506.53 308.28 1503.01 321.04H1584.41C1587.34 321.04 1589.62 320.16 1591.23 318.4C1592.99 316.64 1593.87 314.22 1593.87 311.14C1593.87 304.98 1590.72 301.9 1584.41 301.9H1530.95ZM1675.74 391C1663.86 391 1654.77 387.993 1648.46 381.98C1642.16 375.967 1639 367.387 1639 356.24C1639 345.24 1642.16 336.733 1648.46 330.72C1654.77 324.707 1663.86 321.7 1675.74 321.7H1760.22V316.42C1760.22 307.473 1755.82 303 1747.02 303H1653.74V277.7H1755.38C1768.73 277.7 1778.19 280.78 1783.76 286.94C1789.34 292.953 1792.12 301.46 1792.12 312.46V391H1675.74ZM1681.46 365.7H1760.22V347H1681.46C1678.68 347 1676.48 347.88 1674.86 349.64C1673.4 351.253 1672.66 353.453 1672.66 356.24C1672.66 359.027 1673.4 361.3 1674.86 363.06C1676.48 364.82 1678.68 365.7 1681.46 365.7ZM1816.4 391V277.7H1963.14C1976.05 277.7 1985.51 280.927 1991.52 287.38C1997.54 293.687 2000.54 302.047 2000.54 312.46V391H1968.64V316.42C1968.64 307.473 1964.1 303 1955 303H1924.42V391H1892.52V303H1848.3V391H1816.4ZM2019.99 392.1V366.8H2127.79C2133.95 366.8 2137.03 363.353 2137.03 356.46C2137.03 349.713 2133.95 346.34 2127.79 346.34H2058.05C2045 346.34 2035.1 343.407 2028.35 337.54C2021.6 331.527 2018.23 322.947 2018.23 311.8C2018.23 300.507 2021.6 291.853 2028.35 285.84C2035.24 279.68 2045.14 276.6 2058.05 276.6H2158.37V301.9H2059.59C2053.28 301.9 2050.13 304.98 2050.13 311.14C2050.13 314.22 2051.01 316.64 2052.77 318.4C2054.53 320.16 2056.8 321.04 2059.59 321.04H2133.51C2144.95 321.04 2153.68 324.047 2159.69 330.06C2165.85 335.927 2168.93 344.507 2168.93 355.8C2168.93 367.24 2165.85 376.187 2159.69 382.64C2153.53 388.947 2144.8 392.1 2133.51 392.1H2019.99Z" fill="#76B900"/>
+<defs>
+<pattern id="pattern0_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_28_448" transform="scale(0.03125 0.111111)"/>
+</pattern>
+<pattern id="pattern1_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image1_28_448" transform="scale(0.025 0.111111)"/>
+</pattern>
+<pattern id="pattern2_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image2_28_448" transform="scale(0.0238095 0.125)"/>
+</pattern>
+<pattern id="pattern3_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image3_28_448" transform="scale(0.0263158 0.125)"/>
+</pattern>
+<pattern id="pattern4_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image4_28_448" transform="scale(0.037037 0.111111)"/>
+</pattern>
+<pattern id="pattern5_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image5_28_448" transform="scale(0.0769231 0.111111)"/>
+</pattern>
+<pattern id="pattern6_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image6_28_448" transform="scale(0.010989 0.0103093)"/>
+</pattern>
+<pattern id="pattern7_28_448" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image7_28_448" transform="scale(0.0133333 0.00990099)"/>
+</pattern>
+<clipPath id="clip0_28_448">
+<rect width="495" height="495" fill="white"/>
+</clipPath>
+<clipPath id="clip1_28_448">
+<rect width="495" height="495" fill="white"/>
+</clipPath>
+<image id="image0_28_448" width="32" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAJCAYAAABT2S4KAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAF0lEQVR4nGP4P8CAYdQBow4YdcCIdwAAqL97vQWQuOoAAAAASUVORK5CYII="/>
+<image id="image1_28_448" width="40" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAJCAYAAABADm7+AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIUlEQVR4nGP4P8gBw0A7gBAYdSClYNSBlIJRB1IKBr0DAVg9mqzZcxHuAAAAAElFTkSuQmCC"/>
+<image id="image2_28_448" width="42" height="8" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACoAAAAICAYAAACPp21mAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAH0lEQVR4nGP4P0QAw0A7gFgw6lBqg1GHUhuMOpTaAAD3aTsMbpJPbwAAAABJRU5ErkJggg=="/>
+<image id="image3_28_448" width="38" height="8" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAAICAYAAACVm43oAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAHklEQVR4nGP4P0gBw0A7ABcYdRipYNRhpIJRh5EKAFN4u33uxRMjAAAAAElFTkSuQmCC"/>
+<image id="image4_28_448" width="27" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAJCAYAAADDylfFAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVR4nGP4T0fAMGrZqGWjltEcAACIKMhiwoS4ngAAAABJRU5ErkJggg=="/>
+<image id="image5_28_448" width="13" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAJCAYAAADpeqZqAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAEklEQVR4nGP4TwZgGNU0JDQBAGlJ0jyyjOxDAAAAAElFTkSuQmCC"/>
+<image id="image6_28_448" width="91" height="97" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFsAAABhCAYAAAC5191SAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAA6UlEQVR4nO3QQREAMAjAMPybHi6yB42CXueFmd8BlzQbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYaaDTUbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYaaDTUbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYaaDTUbajbUbKjZULOhZkPNhpoNNRtqNtRsqNlQs6FmQ82Gmg01G2o21Gyo2VCzoWZDzYYW9FpqHJMJ0QEAAAAASUVORK5CYII="/>
+<image id="image7_28_448" width="75" height="101" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABlCAYAAAAF6B6sAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAA50lEQVR4nO3QQQ0AIAzAwPk3DRbWFyG5U9B0DmvzOuAnZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFZgVmBWYFF5ib7IDH4nxtAAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/integrations/omnidreams/omnidreams/webrtc/web/assets/horizontal-light.svg
+++ b/integrations/omnidreams/omnidreams/webrtc/web/assets/horizontal-light.svg
@@ -1,0 +1,182 @@
+<svg width="2176" height="495" viewBox="0 0 2176 495" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<path d="M514.18 390V302H481.4V276.7H514.18V267.9C514.18 257.487 517.187 249.127 523.2 242.82C529.213 236.367 538.6 233.14 551.36 233.14H599.32V258.44H559.28C550.48 258.44 546.08 262.913 546.08 271.86V276.7H593.16V302H546.08V390H514.18ZM613.709 390V232.7H645.609V390H613.709ZM699.924 390C688.044 390 678.95 386.993 672.644 380.98C666.337 374.967 663.184 366.387 663.184 355.24C663.184 344.24 666.337 335.733 672.644 329.72C678.95 323.707 688.044 320.7 699.924 320.7H784.404V315.42C784.404 306.473 780.004 302 771.204 302H677.924V276.7H779.564C792.91 276.7 802.37 279.78 807.944 285.94C813.517 291.953 816.304 300.46 816.304 311.46V390H699.924ZM705.644 364.7H784.404V346H705.644C702.857 346 700.657 346.88 699.044 348.64C697.577 350.253 696.844 352.453 696.844 355.24C696.844 358.027 697.577 360.3 699.044 362.06C700.657 363.82 702.857 364.7 705.644 364.7ZM836.844 391.1V365.8H944.644C950.804 365.8 953.884 362.353 953.884 355.46C953.884 348.713 950.804 345.34 944.644 345.34H874.904C861.851 345.34 851.951 342.407 845.204 336.54C838.458 330.527 835.084 321.947 835.084 310.8C835.084 299.507 838.458 290.853 845.204 284.84C852.098 278.68 861.998 275.6 874.904 275.6H975.224V300.9H876.444C870.138 300.9 866.984 303.98 866.984 310.14C866.984 313.22 867.864 315.64 869.624 317.4C871.384 319.16 873.658 320.04 876.444 320.04H950.364C961.804 320.04 970.531 323.047 976.544 329.06C982.704 334.927 985.784 343.507 985.784 354.8C985.784 366.24 982.704 375.187 976.544 381.64C970.384 387.947 961.658 391.1 950.364 391.1H836.844ZM1004.51 390V232.7H1036.41V276.7H1103.29C1116.2 276.7 1125.58 279.927 1131.45 286.38C1137.46 292.687 1140.47 301.047 1140.47 311.46V390H1108.57V315.2C1108.57 306.4 1104.17 302 1095.37 302H1036.41V390H1004.51Z" fill="black"/>
+<path d="M1302.97 390H1271.07V232.7H1302.97V390ZM1297.47 390H1221.57C1201.92 390 1186.59 385.16 1175.59 375.48C1164.59 365.8 1159.09 351.793 1159.09 333.46C1159.09 314.98 1164.59 300.9 1175.59 291.22C1186.59 281.54 1201.92 276.7 1221.57 276.7H1295.27V302H1221.57C1212.04 302 1204.71 304.64 1199.57 309.92C1194.59 315.053 1192.09 322.9 1192.09 333.46C1192.09 343.873 1194.59 351.72 1199.57 357C1204.71 362.133 1212.04 364.7 1221.57 364.7H1297.47V390ZM1327.21 390V276.7H1413.89C1426.65 276.7 1436.03 279.927 1442.05 286.38C1448.06 292.687 1451.07 301.047 1451.07 311.46V335H1418.73V315.42C1418.73 306.62 1414.33 302.22 1405.53 302.22H1359.55V390H1327.21ZM1530.95 391.1C1511.3 391.1 1495.97 386.26 1484.97 376.58C1473.97 366.753 1468.47 352.38 1468.47 333.46C1468.47 314.393 1473.97 300.02 1484.97 290.34C1495.97 280.513 1511.3 275.6 1530.95 275.6H1585.95C1598.86 275.6 1608.68 278.68 1615.43 284.84C1622.32 290.853 1625.77 299.507 1625.77 310.8C1625.77 333.827 1612.5 345.34 1585.95 345.34H1502.79C1505.87 358.98 1515.26 365.8 1530.95 365.8H1620.05V391.1H1530.95ZM1530.95 300.9C1515.84 300.9 1506.53 307.28 1503.01 320.04H1584.41C1587.34 320.04 1589.62 319.16 1591.23 317.4C1592.99 315.64 1593.87 313.22 1593.87 310.14C1593.87 303.98 1590.72 300.9 1584.41 300.9H1530.95ZM1675.74 390C1663.86 390 1654.77 386.993 1648.46 380.98C1642.16 374.967 1639 366.387 1639 355.24C1639 344.24 1642.16 335.733 1648.46 329.72C1654.77 323.707 1663.86 320.7 1675.74 320.7H1760.22V315.42C1760.22 306.473 1755.82 302 1747.02 302H1653.74V276.7H1755.38C1768.73 276.7 1778.19 279.78 1783.76 285.94C1789.34 291.953 1792.12 300.46 1792.12 311.46V390H1675.74ZM1681.46 364.7H1760.22V346H1681.46C1678.68 346 1676.48 346.88 1674.86 348.64C1673.4 350.253 1672.66 352.453 1672.66 355.24C1672.66 358.027 1673.4 360.3 1674.86 362.06C1676.48 363.82 1678.68 364.7 1681.46 364.7ZM1816.4 390V276.7H1963.14C1976.05 276.7 1985.51 279.927 1991.52 286.38C1997.54 292.687 2000.54 301.047 2000.54 311.46V390H1968.64V315.42C1968.64 306.473 1964.1 302 1955 302H1924.42V390H1892.52V302H1848.3V390H1816.4ZM2019.99 391.1V365.8H2127.79C2133.95 365.8 2137.03 362.353 2137.03 355.46C2137.03 348.713 2133.95 345.34 2127.79 345.34H2058.05C2045 345.34 2035.1 342.407 2028.35 336.54C2021.6 330.527 2018.23 321.947 2018.23 310.8C2018.23 299.507 2021.6 290.853 2028.35 284.84C2035.24 278.68 2045.14 275.6 2058.05 275.6H2158.37V300.9H2059.59C2053.28 300.9 2050.13 303.98 2050.13 310.14C2050.13 313.22 2051.01 315.64 2052.77 317.4C2054.53 319.16 2056.8 320.04 2059.59 320.04H2133.51C2144.95 320.04 2153.68 323.047 2159.69 329.06C2165.85 334.927 2168.93 343.507 2168.93 354.8C2168.93 366.24 2165.85 375.187 2159.69 381.64C2153.53 387.947 2144.8 391.1 2133.51 391.1H2019.99Z" fill="#76B900"/>
+<g clip-path="url(#clip0_28_299)">
+<mask id="mask0_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="495" height="495">
+<path d="M495 0H0V495H495V0Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_28_299)">
+<mask id="mask1_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="495" height="495">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 495H495V0H0V495Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M224.814 365.252L223.173 366.558L221.076 366.53L219.47 365.181L219.081 363.119L228.589 302.777L228.296 300.892L226.961 299.53L225.082 299.199L185.487 304.64L183.763 304.386L182.444 303.248L181.941 301.579L182.411 299.902L244.607 199.786L246.249 198.48L248.346 198.508L249.952 199.858L250.341 201.919L240.77 262.658L241.063 264.543L242.399 265.905L244.277 266.235L283.671 260.822L285.395 261.076L286.714 262.215L287.217 263.883L286.747 265.561L224.814 365.252Z" fill="black"/>
+</mask>
+<g mask="url(#mask1_28_299)">
+<mask id="mask2_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask2_28_299)">
+<mask id="mask3_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="61" y="366" width="96" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M65.0021 387.58L62.48 384.403L61.1807 380.561L61.2568 376.505L62.6994 372.714L65.339 369.634L68.8643 367.628L72.8602 366.932H156.04V390.57H72.8596L70.0223 390.225L67.3511 389.208L65.0021 387.58Z" fill="white"/>
+</mask>
+<g mask="url(#mask3_28_299)">
+<mask id="mask4_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask4_28_299)">
+<path d="M157.781 365.063H58.781V392.907H157.781V365.063Z" fill="url(#pattern0_28_299)"/>
+</g>
+</g>
+</g>
+<mask id="mask5_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask5_28_299)">
+<mask id="mask6_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="35" y="329" width="122" height="24">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M36.1202 345.069L35.4087 341.369L35.8975 337.633L37.5372 334.241L40.1613 331.537L43.5029 329.797L47.2222 329.196H156.04V352.834L47.2021 352.821L43.6572 352.276L40.44 350.69L37.8478 348.212L36.1202 345.069Z" fill="white"/>
+</mask>
+<g mask="url(#mask6_28_299)">
+<mask id="mask7_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask7_28_299)">
+<path d="M157.782 327.938H34.0317V355.782H157.782V327.938Z" fill="url(#pattern1_28_299)"/>
+</g>
+</g>
+</g>
+<mask id="mask8_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask8_28_299)">
+<mask id="mask9_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="29" y="291" width="128" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M29.933 302.558L30.6811 299.083L32.429 295.987L35.0185 293.551L38.2153 291.995L41.7301 291.461H156.04V315.098H41.7375L38.0299 314.502L34.697 312.773L32.0745 310.085L30.4274 306.71L29.9219 302.989L29.933 302.558Z" fill="white"/>
+</mask>
+<g mask="url(#mask9_28_299)">
+<mask id="mask10_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask10_28_299)">
+<path d="M157.782 290.812H27.844V315.562H157.782V290.812Z" fill="url(#pattern2_28_299)"/>
+</g>
+</g>
+</g>
+<mask id="mask11_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask11_28_299)">
+<mask id="mask12_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="40" y="253" width="117" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M52.2686 277.362L48.3005 276.676L44.7928 274.698L42.1533 271.656L40.688 267.905L40.5674 263.88L41.8052 260.048L43.6645 257.44L46.156 255.428L49.0959 254.158L52.2689 253.725H156.04V277.362H52.2686Z" fill="white"/>
+</mask>
+<g mask="url(#mask12_28_299)">
+<mask id="mask13_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask13_28_299)">
+<path d="M157.781 253.688H40.2192V278.438H157.781V253.688Z" fill="url(#pattern3_28_299)"/>
+</g>
+</g>
+</g>
+<mask id="mask14_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask14_28_299)">
+<mask id="mask15_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="76" y="215" width="81" height="25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.7402 239.626L84.9331 238.996L81.5316 237.173L78.8987 234.352L77.3151 230.833L76.9497 226.991L77.8413 223.236L79.8949 219.969L82.8916 217.537L85.7152 216.382L88.7402 215.989H156.04V239.626H88.7402Z" fill="white"/>
+</mask>
+<g mask="url(#mask15_28_299)">
+<mask id="mask16_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask16_28_299)">
+<path d="M157.781 213.469H74.25V241.313H157.781V213.469Z" fill="url(#pattern4_28_299)"/>
+</g>
+</g>
+</g>
+<mask id="mask17_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask17_28_299)">
+<mask id="mask18_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="120" y="178" width="37" height="24">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M122.262 183.828L124.9 180.853L128.376 178.922L132.296 178.253H139.421H156.04V188.539V201.89H145.474H137.242H132.297L128.76 201.349L125.547 199.774L122.953 197.309L121.215 194.181L120.493 190.677L120.853 187.117L122.262 183.828Z" fill="white"/>
+</mask>
+<g mask="url(#mask18_28_299)">
+<mask id="mask19_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask19_28_299)">
+<path d="M157.781 176.344H117.562V204.188H157.781V176.344Z" fill="url(#pattern5_28_299)"/>
+</g>
+</g>
+</g>
+<mask id="mask20_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask20_28_299)">
+<mask id="mask21_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="184" y="114" width="280" height="301">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M184.193 128.816L196.169 123.87L208.524 119.964L221.166 117.125L234.005 115.375L246.947 114.725L260.977 115.398L274.878 117.411L288.523 120.745L301.787 125.369L314.547 131.241L326.686 138.308L338.093 146.505L348.664 155.755L358.301 165.974L366.915 177.069L374.428 188.937L380.771 201.47L382.589 204.34L385.15 206.574L388.239 207.988L399.554 212.014L410.336 217.303L420.446 223.786L429.751 231.379L438.13 239.982L445.474 249.485L451.688 259.762L456.69 270.681L460.415 282.098L462.815 293.865L463.86 305.829L463.533 317.835L461.842 329.724L458.806 341.344L454.466 352.542L448.878 363.173L442.116 373.098L434.267 382.187L425.433 390.323L415.729 397.4L405.283 403.324L394.229 408.02L382.713 411.426L370.883 413.498L358.895 414.208H196.714L230.684 390.57H358.677L369.524 389.846L380.178 387.686L390.45 384.13L400.159 379.239L409.131 373.101L417.207 365.824L424.244 357.539L430.118 348.392L434.723 338.545L437.979 328.173L439.827 317.461L440.234 306.598L439.193 295.777L436.724 285.19L432.869 275.027L427.697 265.465L421.299 256.676L413.791 248.815L405.304 242.023L395.989 236.419L386.012 232.103L375.549 229.151L371.105 227.614L367.178 225.029L364.01 221.554L361.797 217.404L356.304 205.106L349.499 193.482L341.463 182.673L332.293 172.807L322.1 164.003L311.005 156.367L299.14 149.99L286.65 144.95L273.683 141.305L260.395 139.101L246.947 138.363L233.529 139.097L220.272 141.291L207.334 144.919L186.247 130.246L184.193 128.816Z" fill="white"/>
+</mask>
+<g mask="url(#mask21_28_299)">
+<mask id="mask22_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask22_28_299)">
+<path d="M464.063 114.469H182.532V414.563H464.063V114.469Z" fill="url(#pattern6_28_299)"/>
+</g>
+</g>
+</g>
+<mask id="mask23_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-682" y="-74" width="1780" height="661">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-681.94 -73.3585H1097.36V586.58H-681.94V-73.3585Z" fill="white"/>
+</mask>
+<g mask="url(#mask23_28_299)">
+<mask id="mask24_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="156" y="121" width="230" height="310">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M176.408 428.337L172.794 430.094L168.815 430.659L164.854 429.978L161.293 428.117L158.472 425.255L156.663 421.666L156.04 417.696V134.041L156.663 130.07L158.472 126.482L161.293 123.62L164.854 121.759L168.815 121.078L172.794 121.643L176.408 123.399L380.231 265.227L383.21 268.106L385.128 271.779L385.79 275.868L385.128 279.958L383.21 283.63L380.231 286.509L176.408 428.337Z" fill="white"/>
+</mask>
+<g mask="url(#mask24_28_299)">
+<mask id="mask25_28_299" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="-714" y="-1046" width="1843" height="2605">
+<path d="M-713.109 1558.91H1128.52V-1045.69H-713.109V1558.91Z" fill="white"/>
+</mask>
+<g mask="url(#mask25_28_299)">
+<path d="M386.719 120.656H154.688V433.125H386.719V120.656Z" fill="url(#pattern7_28_299)"/>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+<defs>
+<pattern id="pattern0_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_28_299" transform="scale(0.03125 0.111111)"/>
+</pattern>
+<pattern id="pattern1_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image1_28_299" transform="scale(0.025 0.111111)"/>
+</pattern>
+<pattern id="pattern2_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image2_28_299" transform="scale(0.0238095 0.125)"/>
+</pattern>
+<pattern id="pattern3_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image3_28_299" transform="scale(0.0263158 0.125)"/>
+</pattern>
+<pattern id="pattern4_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image4_28_299" transform="scale(0.037037 0.111111)"/>
+</pattern>
+<pattern id="pattern5_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image5_28_299" transform="scale(0.0769231 0.111111)"/>
+</pattern>
+<pattern id="pattern6_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image6_28_299" transform="scale(0.010989 0.0103093)"/>
+</pattern>
+<pattern id="pattern7_28_299" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image7_28_299" transform="scale(0.0133333 0.00990099)"/>
+</pattern>
+<clipPath id="clip0_28_299">
+<rect width="495" height="495" fill="white"/>
+</clipPath>
+<image id="image0_28_299" width="32" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAJCAYAAABT2S4KAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAGUlEQVR4nGNgYGD4P8B41AGjDhh1wAh3AAD/IR7wp0Kf1QAAAABJRU5ErkJggg=="/>
+<image id="image1_28_299" width="40" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAJCAYAAABADm7+AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAH0lEQVR4nGNgYGD4P8jxgDtg1IGjDhxoB4w6cGQ7EAAATGao7rx6aAAAAABJRU5ErkJggg=="/>
+<image id="image2_28_299" width="42" height="8" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACoAAAAICAYAAACPp21mAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAHUlEQVR4nGNgYGD4P0TwgDtg1KGjDh116KhDsWAAC65OwIaa7YcAAAAASUVORK5CYII="/>
+<image id="image3_28_299" width="38" height="8" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAAICAYAAACVm43oAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAHElEQVR4nGNgYGD4P0jxgDtg1GGjDht12JBwGABSHi7gX0n8fQAAAABJRU5ErkJggg=="/>
+<image id="image4_28_299" width="27" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAJCAYAAADDylfFAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAGElEQVR4nGNgYGD4T0c8atmoZaOW0RgDAHm88g5cxv4KAAAAAElFTkSuQmCC"/>
+<image id="image5_28_299" width="13" height="9" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAJCAYAAADpeqZqAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVR4nGNgYGD4TwYe1TQENAEA7NF0jCgILnAAAAAASUVORK5CYII="/>
+<image id="image6_28_299" width="91" height="97" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFsAAABhCAYAAAC5191SAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABDElEQVR4nO3OMQEAIAAEoe9fWlvIcA7sbNv5nuGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeKOGBEh4o4YESHijhgRIeyLhdCFqEGIn92AAAAABJRU5ErkJggg=="/>
+<image id="image7_28_299" width="75" height="101" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABlCAYAAAAF6B6sAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABGElEQVR4nO3OsQ0AIAAEod9/aV3BjlxiQc+2ne8ZD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBACQ+U8EAJD5TwQAkPlPBAxgVGhnsdaQFnfgAAAABJRU5ErkJggg=="/>
+</defs>
+</svg>

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
       <div class="stageVignette" aria-hidden="true"></div>
 
       <header class="brandOverlay" aria-label="FlashDreams World Model">
-        <img class="brandLogo" src="/assets/logo/horizontal-dark.svg" alt="FlashDreams">
+        <img class="brandLogo" src="/static/assets/horizontal-dark.svg" alt="FlashDreams">
       </header>
 
       <section class="statusCard overlayPanel" aria-live="polite">

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -119,7 +119,7 @@ exclude = ["tests"]
 # workspace editable. Editable installs pick these up from the source
 # tree automatically.
 [tool.setuptools.package-data]
-"omnidreams.webrtc.web" = ["*.html", "*.css", "*.js"]
+"omnidreams.webrtc.web" = ["*.html", "*.css", "*.js", "assets/*.svg"]
 "omnidreams.interactive_drive" = [
     "configs/*.yaml",
     "configs/wheels/*.yaml",

--- a/integrations/omnidreams/tests/test_webrtc_server_routes.py
+++ b/integrations/omnidreams/tests/test_webrtc_server_routes.py
@@ -120,32 +120,6 @@ def test_create_app_closes_package_resource_when_app_creation_fails(
     assert tracked_resource.closed
 
 
-def test_create_app_skips_absent_repo_assets_mount(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr(
-        webrtc_server,
-        "REPO_ASSETS_DIR",
-        tmp_path / "missing-assets",
-    )
-    app = create_app(
-        session_manager=FakeSessionManager(),
-        request_session_url="http://127.0.0.1:8080/request_session",
-    )
-    try:
-        for resource in app.router.resources():
-            info = resource.get_info()
-            candidates = (
-                getattr(resource, "canonical", ""),
-                info.get("prefix", ""),
-                info.get("path", ""),
-            )
-            assert not any(
-                str(candidate) == "/assets" or str(candidate).startswith("/assets/")
-                for candidate in candidates
-            )
-    finally:
-        app["package_resource_stack"].close()
-
-
 @pytest.mark.asyncio
 async def test_request_session_serves_html() -> None:
     manager = FakeSessionManager()
@@ -170,7 +144,7 @@ async def test_request_session_uses_lingbot_aligned_viewer_shell() -> None:
         assert response.status == 200
         assert 'class="brandOverlay"' in body
         assert "FlashDreams" in body
-        assert "/assets/logo/horizontal-dark.svg" in body
+        assert "/static/assets/horizontal-dark.svg" in body
         assert 'class="statusCard overlayPanel"' in body
         assert 'class="controlCard overlayPanel"' in body
         assert 'class="logCard overlayPanel"' in body
@@ -206,7 +180,7 @@ async def test_shared_flashdreams_brand_asset_is_served() -> None:
     manager = FakeSessionManager()
     client = await _build_client(manager)
     try:
-        response = await client.get("/assets/logo/horizontal-dark.svg")
+        response = await client.get("/static/assets/horizontal-dark.svg")
         assert response.status == 200
         assert response.content_type == "image/svg+xml"
     finally:


### PR DESCRIPTION
Address remaining low-risk cases from issue #329 by moving package-local assets away from source-checkout path assumptions. LingBot and OmniDreams WebRTC now resolve packaged web assets through importlib.resources, and OmniDreams serves its logo from bundled static assets instead of the repo root.

Also move downloaded LingBot and HY-WorldPlay example data under FLASHDREAMS_CACHE_DIR, and resolve the FlashVSR CUDA source file through package resources.