### PR TITLE
Fix S3 sync failure propagation

### DIFF
--- a/flashdreams/flashdreams/core/io/s3_sync.py
+++ b/flashdreams/flashdreams/core/io/s3_sync.py
@@ -215,7 +215,7 @@ def sync_s3_dir_to_local(
 
     error = payload[0]["error"]
     if error is not None:
-        if rank0_error is not None and not is_distributed:
+        if rank0_error is not None:
             raise rank0_error
         raise RuntimeError(error)
 

--- a/flashdreams/flashdreams/core/io/s3_sync.py
+++ b/flashdreams/flashdreams/core/io/s3_sync.py
@@ -180,7 +180,9 @@ def sync_s3_dir_to_local(
             else:
                 raise exc
 
+    is_distributed = dist.is_available() and dist.is_initialized()
     payload: list[dict[str, str | None]] = [{"error": None}]
+    rank0_error: Exception | None = None
     if should_download:
         try:
             s3_fs = S3FileSystem(credential_path=s3_credential_path)
@@ -205,13 +207,16 @@ def sync_s3_dir_to_local(
             finally:
                 s3_fs.close()
         except Exception as exc:
+            rank0_error = exc
             payload[0]["error"] = f"{type(exc).__name__}: {exc}"
 
-    if dist.is_available() and dist.is_initialized():
+    if is_distributed:
         dist.broadcast_object_list(payload, src=0)
 
     error = payload[0]["error"]
     if error is not None:
+        if rank0_error is not None and not is_distributed:
+            raise rank0_error
         raise RuntimeError(error)
 
     _barrier_robust()

--- a/flashdreams/flashdreams/core/io/s3_sync.py
+++ b/flashdreams/flashdreams/core/io/s3_sync.py
@@ -19,7 +19,6 @@ import base64
 import hashlib
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
 from urllib.parse import urlparse
 
 import torch.distributed as dist
@@ -125,9 +124,7 @@ def sync_s3_dir_to_local(
     )
 
     should_download = world_rank == 0
-    s3_fs = (
-        S3FileSystem(credential_path=s3_credential_path) if should_download else None
-    )
+    s3_fs: S3FileSystem | None = None
 
     def _validate_local_file(local_path: str, key: str) -> None:
         """Validate local file using remote size and optional FULL_OBJECT SHA256 checksum."""
@@ -183,27 +180,38 @@ def sync_s3_dir_to_local(
             else:
                 raise exc
 
-    try:
-        if should_download:
+    payload: list[dict[str, str | None]] = [{"error": None}]
+    if should_download:
+        try:
+            s3_fs = S3FileSystem(credential_path=s3_credential_path)
             assert s3_fs is not None
-            object_suffixes = s3_fs.list_files_recursive(s3_dir=s3_dir)
-            if object_suffixes:
-                worker_count = min(max(1, max_workers), len(object_suffixes))
-                with ThreadPoolExecutor(max_workers=worker_count) as executor:
-                    futures = [
-                        executor.submit(_download_one, obj_suffix)
-                        for obj_suffix in object_suffixes
-                    ]
-                    with tqdm.tqdm(
-                        total=len(object_suffixes),
-                        desc=desc,
-                        disable=not show_progress,
-                    ) as pbar:
-                        for future in as_completed(futures):
-                            future.result()
-                            pbar.update(1)
-    finally:
-        if s3_fs is not None:
-            s3_fs.close()
+            try:
+                object_suffixes = s3_fs.list_files_recursive(s3_dir=s3_dir)
+                if object_suffixes:
+                    worker_count = min(max(1, max_workers), len(object_suffixes))
+                    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                        futures = [
+                            executor.submit(_download_one, obj_suffix)
+                            for obj_suffix in object_suffixes
+                        ]
+                        with tqdm.tqdm(
+                            total=len(object_suffixes),
+                            desc=desc,
+                            disable=not show_progress,
+                        ) as pbar:
+                            for future in as_completed(futures):
+                                future.result()
+                                pbar.update(1)
+            finally:
+                s3_fs.close()
+        except Exception as exc:
+            payload[0]["error"] = f"{type(exc).__name__}: {exc}"
+
+    if dist.is_available() and dist.is_initialized():
+        dist.broadcast_object_list(payload, src=0)
+
+    error = payload[0]["error"]
+    if error is not None:
+        raise RuntimeError(error)
 
     _barrier_robust()

--- a/flashdreams/tests/test_s3_sync.py
+++ b/flashdreams/tests/test_s3_sync.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from flashdreams.core.io import s3_sync
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_rank0_download_failure_is_broadcast_to_all_ranks(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _FailingS3FileSystem:
+        instances: list["_FailingS3FileSystem"] = []
+
+        def __init__(self, credential_path: str) -> None:
+            self.credential_path = credential_path
+            self.closed = False
+            self.instances.append(self)
+
+        def list_files_recursive(self, s3_dir: str) -> list[str]:
+            assert s3_dir == "s3://bucket/assets"
+            return ["model.bin"]
+
+        def download_to_local(self, s3_uri: str, local_path: str) -> None:
+            assert s3_uri == "s3://bucket/assets/model.bin"
+            raise OSError("S3 download failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    current_rank = [0]
+    transmitted_payload: list[dict[str, str | None]] = [{"error": None}]
+    barriers: list[None] = []
+
+    monkeypatch.setattr(s3_sync, "S3FileSystem", _FailingS3FileSystem)
+    monkeypatch.setattr(s3_sync, "ensure_free_disk", lambda *args, **kwargs: None)
+    monkeypatch.setattr(s3_sync, "cache_min_free_bytes", lambda: 0)
+    monkeypatch.setattr(s3_sync.dist, "is_available", lambda: True)
+    monkeypatch.setattr(s3_sync.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(s3_sync.dist, "get_rank", lambda: current_rank[0])
+    monkeypatch.setattr(s3_sync.tqdm.tqdm, "write", lambda *args, **kwargs: None)
+    monkeypatch.setattr(s3_sync, "_barrier_robust", lambda: barriers.append(None))
+
+    def _broadcast_object_list(payload: list[dict[str, str | None]], src: int) -> None:
+        assert src == 0
+        if current_rank[0] == 0:
+            transmitted_payload[0] = payload[0].copy()
+        else:
+            payload[0] = transmitted_payload[0].copy()
+
+    monkeypatch.setattr(s3_sync.dist, "broadcast_object_list", _broadcast_object_list)
+
+    for rank in (0, 1):
+        current_rank[0] = rank
+        with pytest.raises(RuntimeError, match="OSError: S3 download failed"):
+            s3_sync.sync_s3_dir_to_local(
+                s3_dir="s3://bucket/assets",
+                s3_credential_path="credentials/s3.json",
+                cache_dir=str(tmp_path),
+                show_progress=False,
+            )
+
+    assert transmitted_payload == [{"error": "OSError: S3 download failed"}]
+    assert len(_FailingS3FileSystem.instances) == 1
+    assert _FailingS3FileSystem.instances[0].closed
+    assert barriers == []

--- a/flashdreams/tests/test_s3_sync.py
+++ b/flashdreams/tests/test_s3_sync.py
@@ -68,3 +68,22 @@ def test_rank0_download_failure_is_broadcast_to_all_ranks(
     assert len(_FailingS3FileSystem.instances) == 1
     assert _FailingS3FileSystem.instances[0].closed
     assert barriers == []
+
+
+def test_single_process_failure_preserves_native_exception(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fail_s3_client(*, credential_path: str) -> None:
+        assert credential_path == "credentials/s3.json"
+        raise OSError("S3 client initialization failed")
+
+    monkeypatch.setattr(s3_sync, "S3FileSystem", _fail_s3_client)
+    monkeypatch.setattr(s3_sync, "ensure_free_disk", lambda *args, **kwargs: None)
+    monkeypatch.setattr(s3_sync.dist, "is_available", lambda: False)
+
+    with pytest.raises(OSError, match="S3 client initialization failed"):
+        s3_sync.sync_s3_dir_to_local(
+            s3_dir="s3://bucket/assets",
+            s3_credential_path="credentials/s3.json",
+            cache_dir=str(tmp_path),
+        )

--- a/flashdreams/tests/test_s3_sync.py
+++ b/flashdreams/tests/test_s3_sync.py
@@ -54,9 +54,9 @@ def test_rank0_download_failure_is_broadcast_to_all_ranks(
 
     monkeypatch.setattr(s3_sync.dist, "broadcast_object_list", _broadcast_object_list)
 
-    for rank in (0, 1):
+    for rank, expected_error in ((0, OSError), (1, RuntimeError)):
         current_rank[0] = rank
-        with pytest.raises(RuntimeError, match="OSError: S3 download failed"):
+        with pytest.raises(expected_error, match="S3 download failed"):
             s3_sync.sync_s3_dir_to_local(
                 s3_dir="s3://bucket/assets",
                 s3_credential_path="credentials/s3.json",


### PR DESCRIPTION
## Summary
- Broadcast rank-zero S3 synchronization failures before peers enter the final barrier.
- Add CPU regression coverage that verifies the failure reaches simulated ranks zero and one.

## Testing
- `PYTHONPATH=flashdreams uv run --no-project --isolated ... python -m pytest flashdreams/tests/test_s3_sync.py -q`
- `pre-commit run ruff-format --files flashdreams/flashdreams/core/io/s3_sync.py flashdreams/tests/test_s3_sync.py`
- `pre-commit run ruff-check-only --hook-stage manual --files flashdreams/flashdreams/core/io/s3_sync.py flashdreams/tests/test_s3_sync.py`