### PR TITLE
Use `Robbyant/lingbot-world-v2` as the canonical example source

### DIFF
--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -75,7 +75,7 @@ example:
        --total-blocks 21
 
 Sample data is downloaded from the
-`LingBot-World repository <https://github.com/Robbyant/lingbot-world/tree/main/examples>`_.
+`LingBot-World v2 repository <https://github.com/Robbyant/lingbot-world-v2/tree/main/examples>`_.
 Valid ``--example-idx`` values are ``0, 1, 2, 5``. Note the single GPU command might run
 out of memory for large ``--total-blocks`` values.
 
@@ -120,7 +120,7 @@ What to expect
 
 - **Example data**: ``--example-data True`` downloads ``image.jpg``,
   ``intrinsics.npy``, ``poses.npy``, ``prompt.txt`` from the
-  `upstream examples folder <https://github.com/Robbyant/lingbot-world/tree/main/examples>`_
+  `canonical examples folder <https://github.com/Robbyant/lingbot-world-v2/tree/main/examples>`_
   into ``assets/example_data/lingbot_world/<NN>/`` (``<NN>`` matches
   ``--example-idx``). Cached after first run; no credentials needed.
 - **Model checkpoint**: ~70 GB pulled from

--- a/docs/source/models/lingbot_world.rst
+++ b/docs/source/models/lingbot_world.rst
@@ -29,7 +29,9 @@ LingBot-World
       Official code
 
 Introduced by `Robbyant <https://technology.robbyant.com/>`_, LingBot-World is a camera-controllable image-to-video
-(I2V) world model with streaming inference and context-parallel runtime support.
+(I2V) world model with streaming inference and context-parallel runtime support. This page covers both the original
+`LingBot-World v1 <https://github.com/robbyant/lingbot-world>`_ and the newer 14B causal-fast
+`LingBot-World v2 <https://github.com/Robbyant/lingbot-world-v2>`_ checkpoints.
 
 .. raw:: html
 
@@ -105,6 +107,12 @@ We provide the following variants:
    * - ``lingbot-world-fast-taehv-window15-sink3``
      - Efficient streaming configuration: TAEHV decoder, ``window_size_t=15``
        + ``sink_size_t=3`` streaming KV-cache.
+   * - ``lingbot-world-v2-14b-causal-fast``
+     - LingBot-World V2 14B causal-fast on the shared LingBot pipeline
+       (Wan VAE decoder, 4-step). See `LingBot-World V2`_.
+   * - ``lingbot-world-v2-14b-causal-fast-taehv-window15-sink3``
+     - LingBot-World V2 14B causal-fast with the TAEHV decoder,
+       ``window_size_t=15`` + ``sink_size_t=3`` streaming KV-cache.
 
 To inspect all supported CLI arguments and their default values, run:
 
@@ -114,6 +122,46 @@ To inspect all supported CLI arguments and their default values, run:
        flashdreams-run \
        lingbot-world-fast \
        --help
+
+LingBot-World V2
+----------------
+
+LingBot-World V2 is the newer 14B causal-fast checkpoint from Robbyant. It
+uses the same architecture, pipeline, and serving code as v1 — only the
+checkpoint config slug changes — so every command on this page works by
+swapping in a V2 runner slug. See the canonical repository at
+`Robbyant/lingbot-world-v2 <https://github.com/Robbyant/lingbot-world-v2>`_.
+
+Two V2 runner slugs are registered:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Method
+     - Description
+   * - ``lingbot-world-v2-14b-causal-fast``
+     - LingBot-World V2 14B causal-fast on the shared LingBot pipeline
+       (Wan VAE decoder, full KV-cache).
+   * - ``lingbot-world-v2-14b-causal-fast-taehv-window15-sink3``
+     - V2 checkpoint with the efficient streaming preset: TAEHV decoder,
+       ``window_size_t=15`` + ``sink_size_t=3`` streaming KV-cache.
+
+For example, to run the V2 model on a single GPU:
+
+.. code-block:: bash
+
+   uv run --project integrations/lingbot \
+       flashdreams-run \
+       lingbot-world-v2-14b-causal-fast \
+       --example-data True \
+       --example-idx 0 \
+       --pixel-height 464 --pixel-width 832 \
+       --total-blocks 21
+
+The V2 checkpoint (~70 GB) is pulled from
+``huggingface.co/robbyant/lingbot-world-v2-14b-causal-fast`` on first run.
+Export ``HF_TOKEN`` first.
 
 What to expect
 --------------

--- a/integrations/lingbot/README.md
+++ b/integrations/lingbot/README.md
@@ -185,8 +185,8 @@ Then open:
   HuggingFace on first run and cached under `$HF_HOME`.
 - ~200 GB free disk for the model + HF cache.
 - Example assets (`image.jpg`, `intrinsics.npy`, `poses.npy`, and a prompt when
-  available) auto-download from the upstream
-  [`Robbyant/lingbot-world`](https://github.com/Robbyant/lingbot-world/tree/main/examples)
+  available) for both v1 and v2 models auto-download from the canonical
+  [`Robbyant/lingbot-world-v2`](https://github.com/Robbyant/lingbot-world-v2/tree/main/examples)
   examples folder into `assets/example_data/lingbot_world/<NN>/` on
   first launch (`<NN>` is the `--example-idx`: `00` through `05`). Examples
   `03` and `04` use an empty prompt because they do not provide their own

--- a/integrations/lingbot/README.md
+++ b/integrations/lingbot/README.md
@@ -185,16 +185,12 @@ Then open:
   HuggingFace on first run and cached under `$HF_HOME`.
 - ~200 GB free disk for the model + HF cache.
 - Example assets (`image.jpg`, `intrinsics.npy`, `poses.npy`, and a prompt when
-  available) for v1 presets auto-download from the upstream
+  available) auto-download from the upstream
   [`Robbyant/lingbot-world`](https://github.com/Robbyant/lingbot-world/tree/main/examples)
-  examples folder into
-  `$FLASHDREAMS_CACHE_DIR/example_data/lingbot_world/<NN>/`. A v2 preset instead
-  downloads from
-  [`Robbyant/lingbot-world-v2`](https://github.com/Robbyant/lingbot-world-v2/tree/main/examples)
-  into `$FLASHDREAMS_CACHE_DIR/example_data/lingbot_world_v2/<NN>/`, which keeps
-  the versions from sharing stale cached assets. `<NN>` is the `--example-idx`:
-  `00` through `05`. Examples `03` and `04` use an empty prompt because they do
-  not provide their own upstream `prompt.txt`.
+  examples folder into `assets/example_data/lingbot_world/<NN>/` on
+  first launch (`<NN>` is the `--example-idx`: `00` through `05`). Examples
+  `03` and `04` use an empty prompt because they do not provide their own
+  upstream `prompt.txt`.
 
 ### DataChannel message format
 

--- a/integrations/lingbot/README.md
+++ b/integrations/lingbot/README.md
@@ -187,7 +187,7 @@ Then open:
 - Example assets (`image.jpg`, `intrinsics.npy`, `poses.npy`, and a prompt when
   available) for both v1 and v2 models auto-download from the canonical
   [`Robbyant/lingbot-world-v2`](https://github.com/Robbyant/lingbot-world-v2/tree/main/examples)
-  examples folder into `assets/example_data/lingbot_world/<NN>/` on
+  examples folder into `$FLASHDREAMS_CACHE_DIR/example_data/lingbot_world/<NN>/` on
   first launch (`<NN>` is the `--example-idx`: `00` through `05`). Examples
   `03` and `04` use an empty prompt because they do not provide their own
   upstream `prompt.txt`.

--- a/integrations/lingbot/lingbot/config.py
+++ b/integrations/lingbot/lingbot/config.py
@@ -33,10 +33,7 @@ from lingbot.encoder.camctrl import (
     LingbotI2VCtrlEncoderConfig,
 )
 from lingbot.pipeline import LingbotWorldInferencePipelineConfig
-from lingbot.runner import (
-    EXAMPLE_DATA_REPOSITORY_V2,
-    LingbotWorldRunnerConfig,
-)
+from lingbot.runner import LingbotWorldRunnerConfig
 from lingbot.transformer import LingbotWorldTransformerConfig
 from lingbot.transformer.impl.network import LingbotWorldDiTNetwork14BConfig
 
@@ -154,7 +151,6 @@ RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST = LingbotWorldRunnerConfig(
         "(Wan VAE decoder, 4-step)."
     ),
     pipeline=PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST,
-    example_data_repository=EXAMPLE_DATA_REPOSITORY_V2,
 )
 
 PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3 = derive_config(
@@ -175,7 +171,6 @@ RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3 = LingbotWorldRunne
         "(LightTAE decoder, window=15 + sink=3 streaming KV cache)."
     ),
     pipeline=PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3,
-    example_data_repository=EXAMPLE_DATA_REPOSITORY_V2,
 )
 
 PIPELINE_CONFIGS: dict[str, LingbotWorldInferencePipelineConfig] = {

--- a/integrations/lingbot/lingbot/runner.py
+++ b/integrations/lingbot/lingbot/runner.py
@@ -54,9 +54,9 @@ _INTRINSICS_REFERENCE_WIDTH = 832
 """Capture-resolution width matching :data:`_INTRINSICS_REFERENCE_HEIGHT`."""
 
 EXAMPLE_DATA_BASE_URL = (
-    "https://raw.githubusercontent.com/Robbyant/lingbot-world/main/examples"
+    "https://raw.githubusercontent.com/Robbyant/lingbot-world-v2/main/examples"
 )
-"""HTTP base URL where bundled example folders are downloaded from."""
+"""HTTP base URL for the canonical examples shared by all LingBot versions."""
 
 EXAMPLE_DATA_DIR_LOCAL = default_flashdreams_cache_dir() / "example_data/lingbot_world"
 """Local cache root where downloaded example folders are stored."""

--- a/integrations/lingbot/lingbot/runner.py
+++ b/integrations/lingbot/lingbot/runner.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
 
 import numpy as np
 import torch
@@ -41,14 +40,8 @@ from lingbot.pipeline import (
 )
 
 __all__ = [
-    "EXAMPLE_DATA_REPOSITORY_V1",
-    "EXAMPLE_DATA_REPOSITORY_V2",
-    "ExampleDataRepository",
     "LingbotWorldRunnerConfig",
     "LingbotWorldRunner",
-    "ensure_example_data_downloaded",
-    "example_data_base_url",
-    "example_data_cache_dir",
 ]
 
 
@@ -63,29 +56,10 @@ _INTRINSICS_REFERENCE_WIDTH = 832
 EXAMPLE_DATA_BASE_URL = (
     "https://raw.githubusercontent.com/Robbyant/lingbot-world/main/examples"
 )
-"""HTTP base URL where LingBot-World v1 example folders are downloaded from."""
-
-EXAMPLE_DATA_BASE_URL_V2 = (
-    "https://raw.githubusercontent.com/Robbyant/lingbot-world-v2/main/examples"
-)
-"""HTTP base URL where LingBot-World v2 example folders are downloaded from."""
+"""HTTP base URL where bundled example folders are downloaded from."""
 
 EXAMPLE_DATA_DIR_LOCAL = default_flashdreams_cache_dir() / "example_data/lingbot_world"
-"""Local cache root where downloaded LingBot-World v1 examples are stored."""
-
-EXAMPLE_DATA_DIR_LOCAL_V2 = (
-    default_flashdreams_cache_dir() / "example_data/lingbot_world_v2"
-)
-"""Local cache root where downloaded LingBot-World v2 examples are stored."""
-
-ExampleDataRepository = Literal["lingbot-world", "lingbot-world-v2"]
-"""Supported upstream repositories for bundled LingBot example data."""
-
-EXAMPLE_DATA_REPOSITORY_V1: ExampleDataRepository = "lingbot-world"
-"""Upstream example-data repository used by LingBot-World v1 presets."""
-
-EXAMPLE_DATA_REPOSITORY_V2: ExampleDataRepository = "lingbot-world-v2"
-"""Upstream example-data repository used by LingBot-World v2 presets."""
+"""Local cache root where downloaded example folders are stored."""
 
 EXAMPLE_DATA_FILENAMES = (
     "image.jpg",
@@ -110,55 +84,7 @@ def example_data_dirname(example_idx: int) -> str:
     return f"{example_idx:02d}"
 
 
-def example_data_base_url(repository: ExampleDataRepository) -> str:
-    """Return the raw GitHub examples URL for ``repository``.
-
-    Args:
-        repository: Upstream repository selected by the runner preset.
-
-    Returns:
-        Raw GitHub URL containing the numbered example folders.
-
-    Raises:
-        ValueError: ``repository`` is not a supported LingBot example source.
-    """
-    if repository == EXAMPLE_DATA_REPOSITORY_V1:
-        return EXAMPLE_DATA_BASE_URL
-    if repository == EXAMPLE_DATA_REPOSITORY_V2:
-        return EXAMPLE_DATA_BASE_URL_V2
-    raise ValueError(f"Unsupported LingBot example-data repository: {repository!r}")
-
-
-def example_data_cache_dir(
-    *, repository: ExampleDataRepository, example_idx: int
-) -> Path:
-    """Return the version-specific local cache directory for an example.
-
-    Args:
-        repository: Upstream repository selected by the runner preset.
-        example_idx: Numbered upstream example folder.
-
-    Returns:
-        Cache directory reserved for the selected repository and example.
-
-    Raises:
-        ValueError: ``repository`` is not a supported LingBot example source.
-    """
-    if repository == EXAMPLE_DATA_REPOSITORY_V1:
-        cache_root = EXAMPLE_DATA_DIR_LOCAL
-    elif repository == EXAMPLE_DATA_REPOSITORY_V2:
-        cache_root = EXAMPLE_DATA_DIR_LOCAL_V2
-    else:
-        raise ValueError(f"Unsupported LingBot example-data repository: {repository!r}")
-    return cache_root / example_data_dirname(example_idx)
-
-
-def ensure_example_data_downloaded(
-    *,
-    is_rank_zero: bool,
-    example_idx: int,
-    repository: ExampleDataRepository = EXAMPLE_DATA_REPOSITORY_V1,
-) -> Path:
+def ensure_example_data_downloaded(*, is_rank_zero: bool, example_idx: int) -> Path:
     """Download bundled GitHub example files on rank 0; barrier other ranks.
 
     The runner calls this from :meth:`LingbotWorldRunner._fill_example_data_defaults`;
@@ -167,23 +93,11 @@ def ensure_example_data_downloaded(
     ``LingbotWebRTCSessionManager._initialize_sync`` checks for them. The
     download itself is small (image + intrinsics + poses, plus a prompt
     when available), uses the public LingBot-World GitHub raw URLs, and
-    is cached in a repository-specific directory so v1 and v2 assets
-    cannot be silently mixed.
-
-    Args:
-        is_rank_zero: Whether this process owns filesystem downloads.
-        example_idx: Numbered upstream example folder.
-        repository: Upstream repository selected by the runner preset.
-
-    Returns:
-        Version-specific directory containing the downloaded files.
+    is cached at :data:`EXAMPLE_DATA_DIR_LOCAL` so repeat calls are
+    no-ops.
     """
     example_dirname = example_data_dirname(example_idx)
-    cache_dir = example_data_cache_dir(
-        repository=repository,
-        example_idx=example_idx,
-    )
-    base_url = example_data_base_url(repository)
+    cache_dir = EXAMPLE_DATA_DIR_LOCAL / example_dirname
     if is_rank_zero:
         for filename in EXAMPLE_DATA_FILENAMES:
             if (
@@ -192,7 +106,7 @@ def ensure_example_data_downloaded(
             ):
                 continue
             download_to_cache(
-                f"{base_url}/{example_dirname}/{filename}",
+                f"{EXAMPLE_DATA_BASE_URL}/{example_dirname}/{filename}",
                 cache_dir=cache_dir,
                 filename=filename,
             )
@@ -246,15 +160,13 @@ class LingbotWorldRunnerConfig(RunnerConfig):
 
     example_data: bool = False
     """When ``True``, lazy-download bundled GitHub example assets into
-    a version-specific cache and fill ``image_path`` / ``pose_path`` /
-    ``intrinsic_path`` / ``prompt_path`` from the bundled defaults. Use
-    for the README demo; pass explicit paths for production runs."""
+    ``$FLASHDREAMS_CACHE_DIR/example_data/lingbot_world/`` and fill ``image_path`` /
+    ``pose_path`` / ``intrinsic_path`` / ``prompt_path`` from the
+    bundled defaults. Use for the README demo; pass explicit paths
+    for production runs."""
 
     example_idx: int = 0
     """Example folder index under ``.../examples/``; allowed: ``0`` through ``5``."""
-
-    example_data_repository: ExampleDataRepository = EXAMPLE_DATA_REPOSITORY_V1
-    """Upstream GitHub repository used for bundled example data."""
 
 
 class LingbotWorldRunner(
@@ -290,7 +202,6 @@ class LingbotWorldRunner(
         example_dir = ensure_example_data_downloaded(
             is_rank_zero=self.is_rank_zero,
             example_idx=cfg.example_idx,
-            repository=cfg.example_data_repository,
         )
         if cfg.image_path is None:
             cfg.image_path = example_dir / "image.jpg"

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -47,6 +47,7 @@ from flashdreams.serving.webrtc.server import (
 )
 from lingbot.runner import (
     EXAMPLE_DATA_AVAILABLE_IDXS,
+    EXAMPLE_DATA_BASE_URL,
     EXAMPLE_DATA_DIR_LOCAL,
     ensure_example_data_downloaded,
     example_data_dirname,
@@ -328,7 +329,8 @@ def build_runtime_config(
     if args.video_height % 16 != 0 or args.video_width % 16 != 0:
         raise ValueError("--video-height and --video-width must be divisible by 16")
     example_idx = getattr(args, "example_idx", 0)
-    example_dir = EXAMPLE_DATA_DIR_LOCAL / example_data_dirname(example_idx)
+    example_dirname = example_data_dirname(example_idx)
+    example_dir = EXAMPLE_DATA_DIR_LOCAL / example_dirname
     if (
         example_idx == 0
         and not example_dir.exists()
@@ -345,6 +347,11 @@ def build_runtime_config(
         video_height=args.video_height,
         video_width=args.video_width,
         example_data_dir=example_dir,
+        default_image_url=f"{EXAMPLE_DATA_BASE_URL}/{example_dirname}/image.jpg",
+        default_intrinsics_url=(
+            f"{EXAMPLE_DATA_BASE_URL}/{example_dirname}/intrinsics.npy"
+        ),
+        default_poses_url=f"{EXAMPLE_DATA_BASE_URL}/{example_dirname}/poses.npy",
     )
 
 

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -45,16 +45,10 @@ from flashdreams.serving.webrtc.server import (
     WebRTCSessionManager,
     create_webrtc_app,
 )
-from lingbot.config import RUNNER_CONFIGS
 from lingbot.runner import (
     EXAMPLE_DATA_AVAILABLE_IDXS,
     EXAMPLE_DATA_DIR_LOCAL,
-    EXAMPLE_DATA_REPOSITORY_V1,
-    ExampleDataRepository,
-    LingbotWorldRunnerConfig,
     ensure_example_data_downloaded,
-    example_data_base_url,
-    example_data_cache_dir,
     example_data_dirname,
 )
 from lingbot.webrtc.session import (
@@ -334,20 +328,13 @@ def build_runtime_config(
     if args.video_height % 16 != 0 or args.video_width % 16 != 0:
         raise ValueError("--video-height and --video-width must be divisible by 16")
     example_idx = getattr(args, "example_idx", 0)
-    repository = _example_data_repository(args.config_name)
-    example_dir = example_data_cache_dir(
-        repository=repository,
-        example_idx=example_idx,
-    )
+    example_dir = EXAMPLE_DATA_DIR_LOCAL / example_data_dirname(example_idx)
     if (
-        repository == EXAMPLE_DATA_REPOSITORY_V1
-        and example_idx == 0
+        example_idx == 0
         and not example_dir.exists()
         and (EXAMPLE_DATA_DIR_LOCAL / "image.jpg").exists()
     ):
         example_dir = EXAMPLE_DATA_DIR_LOCAL
-    example_dirname = example_data_dirname(example_idx)
-    base_url = example_data_base_url(repository)
     return LingbotRuntimeConfig(
         config_name=args.config_name,
         compile_network=not args.no_compile,
@@ -358,17 +345,7 @@ def build_runtime_config(
         video_height=args.video_height,
         video_width=args.video_width,
         example_data_dir=example_dir,
-        default_image_url=f"{base_url}/{example_dirname}/image.jpg",
-        default_intrinsics_url=f"{base_url}/{example_dirname}/intrinsics.npy",
-        default_poses_url=f"{base_url}/{example_dirname}/poses.npy",
     )
-
-
-def _example_data_repository(config_name: str) -> ExampleDataRepository:
-    runner_config = RUNNER_CONFIGS.get(config_name)
-    if not isinstance(runner_config, LingbotWorldRunnerConfig):
-        raise ValueError(f"Unknown LingBot runner config: {config_name!r}")
-    return runner_config.example_data_repository
 
 
 def initialize_distributed(
@@ -440,7 +417,6 @@ def main() -> None:
     ensure_example_data_downloaded(
         is_rank_zero=(world_rank == 0),
         example_idx=args.example_idx,
-        repository=_example_data_repository(args.config_name),
     )
 
     runtime_config = build_runtime_config(

--- a/integrations/lingbot/lingbot/webrtc/session.py
+++ b/integrations/lingbot/lingbot/webrtc/session.py
@@ -66,7 +66,7 @@ _DEFAULT_INTRINSICS = (
 # Aligned with the world scale computed from the first LingBot-World demo scene.
 _DEFAULT_WORLD_SCALE = 1.271182656288147
 _DEFAULT_DEMO_BASE_URL = (
-    "https://raw.githubusercontent.com/robbyant/lingbot-world/main/examples/00"
+    "https://raw.githubusercontent.com/Robbyant/lingbot-world-v2/main/examples/00"
 )
 _DEFAULT_IMAGE_URL = f"{_DEFAULT_DEMO_BASE_URL}/image.jpg"
 _DEFAULT_INTRINSICS_URL = f"{_DEFAULT_DEMO_BASE_URL}/intrinsics.npy"

--- a/integrations/lingbot/tests/baseline_lightx2v/run.sh
+++ b/integrations/lingbot/tests/baseline_lightx2v/run.sh
@@ -20,7 +20,7 @@ RESULT_PATH_4GPU="${REPO_DIR}/save_results/output_lightx2v_lingbot_fast_i2v_4gpu
 RUN_CONFIG_JSON_4GPU="${SCRIPT_DIR}/lingbot_fast_i2v_4gpu.runtime.json"
 LOG_DIR="${SCRIPT_DIR}/logs"
 EXAMPLES_DIR="${SCRIPT_DIR}/lingbot-world-examples/00"
-EXAMPLES_BASE_URL="https://raw.githubusercontent.com/Robbyant/lingbot-world/main/examples/00"
+EXAMPLES_BASE_URL="https://raw.githubusercontent.com/Robbyant/lingbot-world-v2/main/examples/00"
 PROMPT_PATH="${EXAMPLES_DIR}/prompt.txt"
 
 if [[ ! -d "${REPO_DIR}/.git" ]]; then

--- a/integrations/lingbot/tests/test_distributed_server_main.py
+++ b/integrations/lingbot/tests/test_distributed_server_main.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from pathlib import Path
 
 import pytest
 import torch
@@ -143,7 +142,6 @@ def test_main_rank0_sends_exit_signal(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_manager = _FakeSessionManager()
     runtime_configs = []
     request_session_urls = []
-    example_downloads: list[dict[str, object]] = []
 
     monkeypatch.delenv("RANK", raising=False)
     monkeypatch.delenv("WORLD_SIZE", raising=False)
@@ -154,11 +152,7 @@ def test_main_rank0_sends_exit_signal(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda default_device: (torch.device("cuda:2"), 0, 1),
     )
     # Don't hit the network for the bundled example assets in a unit test.
-    monkeypatch.setattr(
-        server,
-        "ensure_example_data_downloaded",
-        lambda **kwargs: example_downloads.append(kwargs),
-    )
+    monkeypatch.setattr(server, "ensure_example_data_downloaded", lambda **kwargs: None)
 
     manager_fps: list[int] = []
 
@@ -190,13 +184,6 @@ def test_main_rank0_sends_exit_signal(monkeypatch: pytest.MonkeyPatch) -> None:
     assert runtime_configs[0].video_width == 640
     assert manager_fps == [16]
     assert request_session_urls == ["http://203.0.113.10:8080/request_session"]
-    assert example_downloads == [
-        {
-            "is_rank_zero": True,
-            "example_idx": 0,
-            "repository": "lingbot-world-v2",
-        }
-    ]
 
 
 def test_main_worker_rank_waits_for_termination(
@@ -242,51 +229,3 @@ def test_build_runtime_config_rejects_non_patch_aligned_resolution() -> None:
 
     with pytest.raises(ValueError, match="divisible by 16"):
         server.build_runtime_config(args)
-
-
-@pytest.mark.parametrize(
-    ("config_name", "repository", "cache_name"),
-    [
-        ("lingbot-world-fast", "lingbot-world", "lingbot_world"),
-        (
-            "lingbot-world-v2-14b-causal-fast",
-            "lingbot-world-v2",
-            "lingbot_world_v2",
-        ),
-    ],
-)
-def test_build_runtime_config_uses_versioned_example_source(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    config_name: str,
-    repository: str,
-    cache_name: str,
-) -> None:
-    """Route WebRTC defaults through the selected model version's examples."""
-    monkeypatch.setattr(
-        server,
-        "EXAMPLE_DATA_DIR_LOCAL",
-        tmp_path / "lingbot_world",
-    )
-    monkeypatch.setattr(
-        server,
-        "example_data_cache_dir",
-        lambda *, repository, example_idx: tmp_path
-        / ("lingbot_world_v2" if repository.endswith("-v2") else "lingbot_world")
-        / f"{example_idx:02d}",
-    )
-    args = _args()
-    args.config_name = config_name
-    args.example_idx = 2
-
-    runtime_config = server.build_runtime_config(args)
-
-    assert runtime_config.example_data_dir == tmp_path / cache_name / "02"
-    expected_base_url = (
-        f"https://raw.githubusercontent.com/Robbyant/{repository}/main/examples/02"
-    )
-    assert runtime_config.default_image_url == f"{expected_base_url}/image.jpg"
-    assert (
-        runtime_config.default_intrinsics_url == f"{expected_base_url}/intrinsics.npy"
-    )
-    assert runtime_config.default_poses_url == f"{expected_base_url}/poses.npy"

--- a/integrations/lingbot/tests/test_smoke.py
+++ b/integrations/lingbot/tests/test_smoke.py
@@ -66,6 +66,33 @@ def test_all_upstream_example_indices_are_available() -> None:
     ]
 
 
+def test_examples_download_from_canonical_v2_repository(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Download shared examples from the canonical LingBot-World v2 repository."""
+    urls: list[str] = []
+
+    def _record_download(url: str, *, cache_dir: Path, filename: str) -> None:
+        del cache_dir, filename
+        urls.append(url)
+
+    monkeypatch.setattr(runner_mod, "EXAMPLE_DATA_DIR_LOCAL", tmp_path)
+    monkeypatch.setattr(runner_mod, "download_to_cache", _record_download)
+
+    runner_mod.ensure_example_data_downloaded(is_rank_zero=True, example_idx=0)
+
+    expected_base_url = (
+        "https://raw.githubusercontent.com/Robbyant/lingbot-world-v2/main/examples/00"
+    )
+    assert urls == [
+        f"{expected_base_url}/image.jpg",
+        f"{expected_base_url}/poses.npy",
+        f"{expected_base_url}/intrinsics.npy",
+        f"{expected_base_url}/prompt.txt",
+    ]
+
+
 @pytest.mark.parametrize("example_idx", [3, 4])
 def test_promptless_examples_skip_the_prompt_download(
     monkeypatch: pytest.MonkeyPatch,

--- a/integrations/lingbot/tests/test_smoke.py
+++ b/integrations/lingbot/tests/test_smoke.py
@@ -35,8 +35,6 @@ from lingbot.config import (
 from lingbot.pipeline import LingbotWorldInferencePipelineConfig
 from lingbot.runner import (
     EXAMPLE_DATA_AVAILABLE_IDXS,
-    EXAMPLE_DATA_REPOSITORY_V1,
-    EXAMPLE_DATA_REPOSITORY_V2,
     LingbotWorldRunner,
     LingbotWorldRunnerConfig,
     example_data_dirname,
@@ -98,54 +96,6 @@ def test_promptless_examples_skip_the_prompt_download(
     assert all(f"/{example_idx:02d}/" in url for url, _, _ in downloads)
 
 
-@pytest.mark.parametrize(
-    ("repository", "cache_name"),
-    [
-        (EXAMPLE_DATA_REPOSITORY_V1, "lingbot_world"),
-        (EXAMPLE_DATA_REPOSITORY_V2, "lingbot_world_v2"),
-    ],
-)
-def test_example_download_uses_versioned_repository_and_cache(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    repository: runner_mod.ExampleDataRepository,
-    cache_name: str,
-) -> None:
-    """Route each model version to its matching repository and cache."""
-    downloads: list[tuple[str, Path, str]] = []
-
-    def _record_download(url: str, *, cache_dir: Path, filename: str) -> None:
-        downloads.append((url, cache_dir, filename))
-
-    monkeypatch.setattr(
-        runner_mod,
-        "EXAMPLE_DATA_DIR_LOCAL",
-        tmp_path / "lingbot_world",
-    )
-    monkeypatch.setattr(
-        runner_mod,
-        "EXAMPLE_DATA_DIR_LOCAL_V2",
-        tmp_path / "lingbot_world_v2",
-    )
-    monkeypatch.setattr(runner_mod, "download_to_cache", _record_download)
-
-    cache_dir = runner_mod.ensure_example_data_downloaded(
-        is_rank_zero=True,
-        example_idx=0,
-        repository=repository,
-    )
-
-    assert cache_dir == tmp_path / cache_name / "00"
-    assert len(downloads) == 4
-    assert all(
-        url.startswith(
-            f"https://raw.githubusercontent.com/Robbyant/{repository}/main/examples/00/"
-        )
-        for url, _, _ in downloads
-    )
-    assert all(download_cache == cache_dir for _, download_cache, _ in downloads)
-
-
 def test_promptless_example_resolves_to_empty_string(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -164,17 +114,10 @@ def test_promptless_example_resolves_to_empty_string(
     )
     runner.config = runner_config
     runner.is_rank_zero = True
-
-    download_kwargs: dict[str, object] = {}
-
-    def _record_example_download(**kwargs: object) -> Path:
-        download_kwargs.update(kwargs)
-        return tmp_path
-
     monkeypatch.setattr(
         runner_mod,
         "ensure_example_data_downloaded",
-        _record_example_download,
+        lambda **_kwargs: tmp_path,
     )
     warnings: list[str] = []
     monkeypatch.setattr(
@@ -185,7 +128,6 @@ def test_promptless_example_resolves_to_empty_string(
 
     runner._fill_example_data_defaults()
 
-    assert download_kwargs["repository"] == EXAMPLE_DATA_REPOSITORY_V2
     assert runner_config.prompt_path is None
     assert runner._resolve_prompt() == ""
     assert warnings == [
@@ -214,22 +156,6 @@ def test_runners_have_descriptions() -> None:
         slug for slug, cfg in RUNNER_CONFIGS.items() if not cfg.description.strip()
     ]
     assert not empty, f"runners missing description: {empty}"
-
-
-def test_runner_versions_select_matching_example_repository() -> None:
-    """Keep every runner preset on its matching example-data repository."""
-    repositories = {
-        slug: cast(LingbotWorldRunnerConfig, cfg).example_data_repository
-        for slug, cfg in RUNNER_CONFIGS.items()
-    }
-    assert repositories == {
-        "lingbot-world-fast": EXAMPLE_DATA_REPOSITORY_V1,
-        "lingbot-world-fast-taehv-window15-sink3": EXAMPLE_DATA_REPOSITORY_V1,
-        "lingbot-world-v2-14b-causal-fast": EXAMPLE_DATA_REPOSITORY_V2,
-        "lingbot-world-v2-14b-causal-fast-taehv-window15-sink3": (
-            EXAMPLE_DATA_REPOSITORY_V2
-        ),
-    }
 
 
 def test_lingbot_configs_carry_documented_checkpoint_disk_requirement() -> None:

--- a/integrations/lingbot/tests/test_webrtc_runtime.py
+++ b/integrations/lingbot/tests/test_webrtc_runtime.py
@@ -73,6 +73,18 @@ def test_session_manager_hooks_are_wired() -> None:
     assert LingbotWebRTCSessionManager._close_session_on_generation_error is False
 
 
+def test_runtime_defaults_use_canonical_v2_examples() -> None:
+    """Use LingBot-World v2 assets for the shared WebRTC defaults."""
+    config = LingbotRuntimeConfig()
+    expected_base_url = (
+        "https://raw.githubusercontent.com/Robbyant/lingbot-world-v2/main/examples/00"
+    )
+
+    assert config.default_image_url == f"{expected_base_url}/image.jpg"
+    assert config.default_intrinsics_url == f"{expected_base_url}/intrinsics.npy"
+    assert config.default_poses_url == f"{expected_base_url}/poses.npy"
+
+
 def test_validate_remote_url_normalizes_github_blob_image_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Revert the per-version example repository and cache split.
- Use `Robbyant/lingbot-world-v2` as the canonical example source for both
  LingBot v1 and v2.
- Update offline, WebRTC, test, and documentation URLs.

## Testing

- `53 passed`
- Pre-commit and type checks passed.