### PR TITLE
Add Dockerfile.alpasim with a baked-in virtual environment

### DIFF
--- a/docker/Dockerfile.alpasim
+++ b/docker/Dockerfile.alpasim
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.7
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG FLASHDREAMS_BASE_IMAGE=flashdreams:local
+FROM ${FLASHDREAMS_BASE_IMAGE} AS wheel-builder
+
+WORKDIR /workspace/flashdreams
+
+# Copy only the workspace metadata and package trees. In particular, do not
+# copy checkout-local directories such as .venv or .git into the build.
+COPY pyproject.toml uv.lock ./
+COPY flashdreams ./flashdreams
+COPY integrations ./integrations
+
+# Install the selected workspace packages non-editably while retaining uv's
+# lockfile overrides. Keeping the venv at its final absolute path makes it safe
+# to copy into the runtime stage.
+ENV UV_PROJECT_ENVIRONMENT=/opt/flashdreams
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync \
+    --locked \
+    --package flashdreams-omnidreams \
+    --no-editable
+
+
+FROM ${FLASHDREAMS_BASE_IMAGE}
+
+COPY --from=wheel-builder /opt/flashdreams /opt/flashdreams
+
+ENV VIRTUAL_ENV=/opt/flashdreams
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+WORKDIR /app

--- a/integrations/omnidreams/ludus-renderer/pyproject.toml
+++ b/integrations/omnidreams/ludus-renderer/pyproject.toml
@@ -76,6 +76,7 @@ packages = [
     "_cpp/cudaraster/framework/**/*.hpp",
     "_cpp/cudaraster/framework/**/*.cpp",
     "_cpp/cudaraster/framework/**/*.h",
+    "_cpp/cudaraster/framework/**/*.inl",
     "_cpp/bindings/*.h",
     "_cpp/bindings/*.inl",
     "_cpp/bindings/*.cpp",


### PR DESCRIPTION
As noted in [this alpasim issue](https://github.com/NVlabs/alpasim/issues/119), our omnidreams-alpasim integration release was missing the `Dockerfile.alpasim` file needed for building the alpasim-compatible image.

This MR:
* Adds the missing file, which generates python wheels in a temporary container and copies them into a minimal runtime image.
* Fixes a missing declaration in `integrations/omnidreams/ludus-renderer/pyproject.toml`, which caused built wheels to not work out-of-tree.
* Is *not* a full resolution to the user-reported issue as there is a minor adjustment + a dataset fixup left on Alpasim side.