### PR TITLE
Extract realtime input and media primitives

### DIFF
--- a/flashdreams/flashdreams/serving/realtime/__init__.py
+++ b/flashdreams/flashdreams/serving/realtime/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transport-neutral realtime serving primitives."""

--- a/flashdreams/flashdreams/serving/realtime/frame_bus.py
+++ b/flashdreams/flashdreams/serving/realtime/frame_bus.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-slot latest-frame publishing for realtime transports."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from threading import Condition
+from typing import Generic, TypeVar
+
+FrameT = TypeVar("FrameT")
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedFrame(Generic[FrameT]):
+    """Frame payload plus its monotonically increasing publication count."""
+
+    payload: FrameT
+    count: int
+
+
+class LatestFrameBus(Generic[FrameT]):
+    """Thread-safe single-slot bus for latest-frame transports.
+
+    The bus stores only the newest frame. Waiters can block until a frame
+    newer than ``last_seen_count`` is published, or until ``close`` wakes them.
+    """
+
+    def __init__(self) -> None:
+        self._condition = Condition()
+        self._latest: FrameT | None = None
+        self._frame_count = 0
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        with self._condition:
+            return self._closed
+
+    @property
+    def frame_count(self) -> int:
+        with self._condition:
+            return self._frame_count
+
+    def publish(self, frame: FrameT) -> int:
+        """Publish ``frame`` and return its publication count."""
+        with self._condition:
+            if self._closed:
+                raise RuntimeError("Cannot publish to a closed LatestFrameBus.")
+            self._latest = frame
+            self._frame_count += 1
+            self._condition.notify_all()
+            return self._frame_count
+
+    def latest(self) -> PublishedFrame[FrameT] | None:
+        """Return the latest frame without blocking, if one has been published."""
+        with self._condition:
+            if self._latest is None:
+                return None
+            return PublishedFrame(payload=self._latest, count=self._frame_count)
+
+    def wait_for_frame(
+        self,
+        *,
+        last_seen_count: int = 0,
+        timeout_s: float | None = None,
+    ) -> PublishedFrame[FrameT] | None:
+        """Block until a newer frame is available or the bus closes.
+
+        Returns ``None`` on timeout or when closed before a newer frame is
+        published.
+        """
+        if last_seen_count < 0:
+            raise ValueError("last_seen_count must be >= 0")
+        if timeout_s is not None and timeout_s < 0:
+            raise ValueError("timeout_s must be >= 0")
+
+        deadline = None if timeout_s is None else time.monotonic() + timeout_s
+        with self._condition:
+            while self._latest is None or self._frame_count <= last_seen_count:
+                if self._closed:
+                    return None
+                if deadline is None:
+                    self._condition.wait()
+                    continue
+                remaining_s = deadline - time.monotonic()
+                if remaining_s <= 0:
+                    return None
+                self._condition.wait(timeout=remaining_s)
+            return PublishedFrame(payload=self._latest, count=self._frame_count)
+
+    def close(self) -> None:
+        """Wake all waiters and reject future publications."""
+        with self._condition:
+            self._closed = True
+            self._condition.notify_all()

--- a/flashdreams/flashdreams/serving/realtime/input.py
+++ b/flashdreams/flashdreams/serving/realtime/input.py
@@ -12,6 +12,9 @@ from typing import Literal
 import numpy as np
 
 DEFAULT_SUPPORTED_KEYS = frozenset({"w", "a", "s", "d", "q", "e", "i", "k", "j", "l"})
+DRIVING_SUPPORTED_KEYS = frozenset(
+    {"w", "a", "s", "d", "up", "down", "left", "right", "space"}
+)
 WSAD_SUPPORTED_KEYS = frozenset({"w", "a", "s", "d"})
 KEY_ALIASES = {
     "arrowup": "w",

--- a/flashdreams/flashdreams/serving/realtime/input.py
+++ b/flashdreams/flashdreams/serving/realtime/input.py
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Input state and sparse-control helpers for realtime serving."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Literal
+
+import numpy as np
+
+DEFAULT_SUPPORTED_KEYS = frozenset({"w", "a", "s", "d", "q", "e", "i", "k", "j", "l"})
+WSAD_SUPPORTED_KEYS = frozenset({"w", "a", "s", "d"})
+KEY_ALIASES = {
+    "arrowup": "w",
+    "arrowleft": "a",
+    "arrowdown": "s",
+    "arrowright": "d",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ResetRequest:
+    """Transport-neutral request to reset the realtime rollout."""
+
+    reason: str | None = None
+    request_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PromptRequest:
+    """Transport-neutral prompt update request."""
+
+    prompt: str
+    negative_prompt: str | None = None
+    request_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ImageRequest:
+    """Transport-neutral image update request."""
+
+    data: bytes
+    content_type: str
+    request_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SparseInputSnapshot:
+    """Sparse input state sampled at a realtime loop boundary."""
+
+    timestamp_s: float
+    pressed_keys: frozenset[str] = field(default_factory=frozenset)
+    effective_keys: frozenset[str] = field(default_factory=frozenset)
+    reset: ResetRequest | None = None
+    prompt: PromptRequest | None = None
+    image: ImageRequest | None = None
+
+
+def normalize_key(key: str) -> str:
+    normalized = key.strip().lower()
+    return KEY_ALIASES.get(normalized, normalized)
+
+
+@dataclass(slots=True)
+class KeyboardState:
+    pressed_keys: set[str] = field(default_factory=set)
+    supported_keys: frozenset[str] = DEFAULT_SUPPORTED_KEYS
+    _press_order: dict[str, int] = field(default_factory=dict)
+    _press_counter: int = 0
+
+    def apply_event(self, *, event: str, key: str) -> bool:
+        normalized_key = normalize_key(key)
+        if normalized_key not in self.supported_keys:
+            return False
+
+        normalized_event = event.strip().lower()
+        if normalized_event == "keydown":
+            self.pressed_keys.add(normalized_key)
+            self._press_counter += 1
+            self._press_order[normalized_key] = self._press_counter
+            return True
+        if normalized_event == "keyup":
+            self.pressed_keys.discard(normalized_key)
+            self._press_order.pop(normalized_key, None)
+            return True
+        return False
+
+    def snapshot(self) -> frozenset[str]:
+        return frozenset(self.pressed_keys)
+
+    def sparse_snapshot(self, *, timestamp_s: float) -> SparseInputSnapshot:
+        return SparseInputSnapshot(
+            timestamp_s=timestamp_s,
+            pressed_keys=self.snapshot(),
+            effective_keys=self.resolved_effective_keys(),
+        )
+
+    def _latest_pressed(self, keys: tuple[str, ...]) -> str | None:
+        latest_key: str | None = None
+        latest_idx = -1
+        for key in keys:
+            if key not in self.pressed_keys:
+                continue
+            idx = self._press_order.get(key, -1)
+            if idx >= latest_idx:
+                latest_idx = idx
+                latest_key = key
+        return latest_key
+
+    def resolved_effective_keys(self) -> frozenset[str]:
+        effective: set[str] = set()
+        for key in (
+            self._latest_pressed(("w", "s")),
+            self._latest_pressed(("a", "d", "j", "l")),
+            self._latest_pressed(("q", "e")),
+            self._latest_pressed(("i", "k")),
+        ):
+            if key is not None:
+                effective.add(key)
+        return frozenset(key for key in effective if key in self.supported_keys)
+
+
+PoseSegment = tuple[float, float, frozenset[str]]
+
+
+class KeyboardResampler:
+    """Resample sparse keydown/keyup edges into a chunk timeline."""
+
+    def __init__(
+        self,
+        *,
+        fps: int,
+        start_v: float = 0.0,
+        supported_keys: frozenset[str] = DEFAULT_SUPPORTED_KEYS,
+    ) -> None:
+        if fps <= 0:
+            raise ValueError("fps must be > 0")
+        self._fps = fps
+        self._dt = 1.0 / fps
+        self._supported_keys = supported_keys
+        self.next_chunk_start_v = start_v
+        self._event_log: deque[tuple[float, dict[str, str]]] = deque()
+        self._carried_state = KeyboardState(supported_keys=supported_keys)
+
+    @property
+    def fps(self) -> int:
+        return self._fps
+
+    @property
+    def dt(self) -> float:
+        return self._dt
+
+    def on_edge(self, *, arrival_t: float, event: str, key: str) -> None:
+        self._event_log.append((arrival_t, {"event": event, "key": key}))
+
+    def sample_chunk(self, num_frames: int) -> tuple[list[PoseSegment], list[float]]:
+        if num_frames < 1:
+            raise ValueError("num_frames must be >= 1")
+
+        chunk_start_v = self.next_chunk_start_v
+        chunk_end_v = chunk_start_v + num_frames * self._dt
+
+        while self._event_log and self._event_log[0][0] < chunk_start_v:
+            _, payload = self._event_log.popleft()
+            self._carried_state.apply_event(**payload)
+
+        segments: list[PoseSegment] = []
+        prev_t = chunk_start_v
+        prev_state = self._carried_state.resolved_effective_keys()
+        while self._event_log and self._event_log[0][0] <= chunk_end_v:
+            event_t, payload = self._event_log.popleft()
+            if event_t > prev_t:
+                segments.append((prev_t, event_t, prev_state))
+            self._carried_state.apply_event(**payload)
+            prev_state = self._carried_state.resolved_effective_keys()
+            prev_t = event_t
+        if prev_t < chunk_end_v:
+            segments.append((prev_t, chunk_end_v, prev_state))
+        elif not segments:
+            segments.append((chunk_start_v, chunk_end_v, prev_state))
+
+        frame_times = [chunk_start_v + (i + 1) * self._dt for i in range(num_frames)]
+        self.next_chunk_start_v = chunk_end_v
+        return segments, frame_times
+
+    def reset(self, *, start_v: float) -> None:
+        self._event_log.clear()
+        self._carried_state = KeyboardState(supported_keys=self._supported_keys)
+        self.next_chunk_start_v = start_v
+
+    def event_log_size(self) -> int:
+        return len(self._event_log)
+
+
+def _rotation_matrix(axis: str, angle_rad: float) -> np.ndarray:
+    cos_t = np.float32(np.cos(angle_rad))
+    sin_t = np.float32(np.sin(angle_rad))
+    if axis == "x":
+        return np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, cos_t, -sin_t],
+                [0.0, sin_t, cos_t],
+            ],
+            dtype=np.float32,
+        )
+    if axis == "y":
+        return np.array(
+            [
+                [cos_t, 0.0, sin_t],
+                [0.0, 1.0, 0.0],
+                [-sin_t, 0.0, cos_t],
+            ],
+            dtype=np.float32,
+        )
+    if axis == "z":
+        return np.array(
+            [
+                [cos_t, -sin_t, 0.0],
+                [sin_t, cos_t, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+    return np.eye(3, dtype=np.float32)
+
+
+@dataclass(slots=True)
+class CameraPoseIntegrator:
+    """Integrate a piecewise-constant keyboard timeline into a camera trajectory."""
+
+    move_speed_per_s: float = 0.8
+    rotate_speed_rad_per_s: float = float(np.deg2rad(32.0))
+    pitch_limit_rad: float = float(np.deg2rad(85.0))
+    coordinate_system: Literal["RDF", "FLU"] = "RDF"
+    _current_pose: np.ndarray = field(
+        default_factory=lambda: np.eye(4, dtype=np.float32),
+    )
+    _current_pitch: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.coordinate_system not in {"RDF", "FLU"}:
+            raise ValueError(
+                "coordinate_system must be 'RDF' (right-down-forward) "
+                "or 'FLU' (forward-left-up)"
+            )
+
+    def reset(self, pose: np.ndarray | None = None) -> None:
+        if pose is None:
+            self._current_pose = np.eye(4, dtype=np.float32)
+            self._current_pitch = 0.0
+            return
+        if pose.shape != (4, 4):
+            raise ValueError(f"Expected pose shape (4, 4), got {pose.shape}")
+        self._current_pose = pose.astype(np.float32, copy=True)
+        if self.coordinate_system == "FLU":
+            self._current_pitch = float(np.arcsin(np.clip(pose[2, 0], -1.0, 1.0)))
+        else:
+            self._current_pitch = float(np.arctan2(pose[2, 1], pose[1, 1]))
+
+    def current_pose(self) -> np.ndarray:
+        return self._current_pose.copy()
+
+    def _advance(self, *, state: frozenset[str], duration: float) -> None:
+        if duration <= 0:
+            return
+
+        yaw_rate = 0.0
+        if self.coordinate_system == "FLU":
+            if "a" in state or "j" in state:
+                yaw_rate += self.rotate_speed_rad_per_s
+            if "d" in state or "l" in state:
+                yaw_rate -= self.rotate_speed_rad_per_s
+        else:
+            if "a" in state or "j" in state:
+                yaw_rate -= self.rotate_speed_rad_per_s
+            if "d" in state or "l" in state:
+                yaw_rate += self.rotate_speed_rad_per_s
+        pitch_rate = 0.0
+        if "i" in state:
+            pitch_rate += self.rotate_speed_rad_per_s
+        if "k" in state:
+            pitch_rate -= self.rotate_speed_rad_per_s
+
+        yaw_delta = yaw_rate * duration
+        pitch_delta = pitch_rate * duration
+
+        new_pitch = self._current_pitch + pitch_delta
+        if -self.pitch_limit_rad <= new_pitch <= self.pitch_limit_rad:
+            self._current_pitch = new_pitch
+        else:
+            pitch_delta = 0.0
+
+        rot = self._current_pose[:3, :3]
+        trans = self._current_pose[:3, 3]
+        if self.coordinate_system == "FLU":
+            rot_pitch = _rotation_matrix("y", -pitch_delta)
+            rot_yaw = _rotation_matrix("z", yaw_delta)
+        else:
+            rot_pitch = _rotation_matrix("x", pitch_delta)
+            rot_yaw = _rotation_matrix("y", yaw_delta)
+        rot_new = rot_yaw @ rot @ rot_pitch
+
+        forward_rate = 0.0
+        if "w" in state:
+            forward_rate += self.move_speed_per_s
+        if "s" in state:
+            forward_rate -= self.move_speed_per_s
+        right_rate = 0.0
+        if "e" in state:
+            right_rate += self.move_speed_per_s
+        if "q" in state:
+            right_rate -= self.move_speed_per_s
+
+        if self.coordinate_system == "FLU":
+            vec_forward = rot_new[:, 0]
+            vec_right = -rot_new[:, 1]
+            forward_flat = np.array(
+                [vec_forward[0], vec_forward[1], 0.0], dtype=np.float32
+            )
+            right_flat = np.array([vec_right[0], vec_right[1], 0.0], dtype=np.float32)
+        else:
+            vec_right = rot_new[:, 0]
+            vec_forward = rot_new[:, 2]
+            forward_flat = np.array(
+                [vec_forward[0], 0.0, vec_forward[2]], dtype=np.float32
+            )
+            right_flat = np.array([vec_right[0], 0.0, vec_right[2]], dtype=np.float32)
+        forward_norm = np.linalg.norm(forward_flat)
+        right_norm = np.linalg.norm(right_flat)
+        if forward_norm > 0:
+            forward_flat /= forward_norm
+        if right_norm > 0:
+            right_flat /= right_norm
+
+        move_vec = forward_flat * (forward_rate * duration) + right_flat * (
+            right_rate * duration
+        )
+        self._current_pose = np.eye(4, dtype=np.float32)
+        self._current_pose[:3, :3] = rot_new
+        self._current_pose[:3, 3] = trans + move_vec
+
+    def integrate_chunk(
+        self,
+        *,
+        segments: list[PoseSegment],
+        frame_times: list[float],
+    ) -> np.ndarray:
+        if not segments:
+            raise ValueError("segments must be non-empty")
+        if not frame_times:
+            raise ValueError("frame_times must be non-empty")
+        chunk_start = segments[0][0]
+        chunk_end = segments[-1][1]
+        if any(
+            frame_times[i] >= frame_times[i + 1] for i in range(len(frame_times) - 1)
+        ):
+            raise ValueError("frame_times must be strictly increasing")
+        if frame_times[0] < chunk_start - 1e-9 or frame_times[-1] > chunk_end + 1e-9:
+            raise ValueError(
+                "frame_times must lie within the chunk window "
+                f"[{chunk_start}, {chunk_end}]"
+            )
+
+        poses: list[np.ndarray] = []
+        cur_t = chunk_start
+        ft_idx = 0
+        for _, seg_end, seg_state in segments:
+            while ft_idx < len(frame_times) and frame_times[ft_idx] <= seg_end:
+                target_t = frame_times[ft_idx]
+                self._advance(state=seg_state, duration=target_t - cur_t)
+                cur_t = target_t
+                poses.append(self._current_pose.copy())
+                ft_idx += 1
+            if seg_end > cur_t:
+                self._advance(state=seg_state, duration=seg_end - cur_t)
+                cur_t = seg_end
+
+        return np.stack(poses, axis=0).astype(np.float32)

--- a/flashdreams/flashdreams/serving/realtime/media.py
+++ b/flashdreams/flashdreams/serving/realtime/media.py
@@ -38,6 +38,8 @@ def _as_numpy(value: object, *, sync_device: bool) -> np.ndarray:
                 "host/device synchronization is explicit at the call site."
             )
         tensor = tensor.cpu()
+    if tensor.is_floating_point():
+        tensor = tensor.float()
     return tensor.numpy()
 
 
@@ -135,10 +137,10 @@ def tensor_chunk_to_rgb_frames(
     sync_device: bool = True,
 ) -> list[np.ndarray]:
     """Convert common model output tensor layouts to RGB uint8 frames."""
+    value_range: ValueRange = (
+        "minus_one_one" if video_chunk.is_floating_point() else "uint8"
+    )
     if video_chunk.ndim == 4:
-        value_range: ValueRange = (
-            "minus_one_one" if video_chunk.is_floating_point() else "uint8"
-        )
         return rgb_array_to_uint8_frames(
             video_chunk,
             layout="tchw",
@@ -146,9 +148,6 @@ def tensor_chunk_to_rgb_frames(
             sync_device=sync_device,
         )
     if video_chunk.ndim == 6:
-        value_range: ValueRange = (
-            "minus_one_one" if video_chunk.is_floating_point() else "uint8"
-        )
         return rgb_array_to_uint8_frames(
             video_chunk,
             layout="bvtchw",

--- a/flashdreams/flashdreams/serving/realtime/media.py
+++ b/flashdreams/flashdreams/serving/realtime/media.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transport-neutral realtime media conversion helpers."""
+
+from __future__ import annotations
+
+import importlib
+import io
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import torch
+
+FrameLayout = Literal["hwc", "chw", "thwc", "tchw", "bvtchw"]
+ValueRange = Literal["minus_one_one", "zero_one", "uint8"]
+
+
+def _as_numpy(value: object, *, sync_device: bool) -> np.ndarray:
+    if isinstance(value, np.ndarray):
+        return value
+
+    try:
+        import torch
+    except ModuleNotFoundError as exc:
+        raise TypeError("Expected a numpy array or torch tensor.") from exc
+
+    if not isinstance(value, torch.Tensor):
+        raise TypeError("Expected a numpy array or torch tensor.")
+
+    tensor = value.detach()
+    if tensor.device.type != "cpu":
+        if not sync_device:
+            raise ValueError(
+                "Converting a non-CPU tensor requires sync_device=True so the "
+                "host/device synchronization is explicit at the call site."
+            )
+        tensor = tensor.cpu()
+    return tensor.numpy()
+
+
+def _scale_rgb(array: np.ndarray, *, value_range: ValueRange) -> np.ndarray:
+    if array.dtype == np.uint8:
+        return np.ascontiguousarray(array)
+
+    values = array.astype(np.float32, copy=False)
+    if value_range == "minus_one_one":
+        values = (values + 1.0) / 2.0 * 255.0
+    elif value_range == "zero_one":
+        values = values * 255.0
+    elif value_range != "uint8":
+        raise ValueError(f"Unsupported value_range={value_range!r}.")
+    return np.ascontiguousarray(values.clip(0, 255).astype(np.uint8))
+
+
+def rgb_frame_to_uint8(
+    frame: object,
+    *,
+    layout: Literal["hwc", "chw"] = "hwc",
+    value_range: ValueRange = "uint8",
+    sync_device: bool = True,
+) -> np.ndarray:
+    """Convert one RGB frame to contiguous ``HWC`` uint8 host memory."""
+    array = _as_numpy(frame, sync_device=sync_device)
+    if layout == "hwc":
+        if array.ndim != 3 or array.shape[-1] != 3:
+            raise ValueError(
+                f"Expected HWC RGB frame with shape [H, W, 3], got {array.shape}"
+            )
+        return _scale_rgb(array, value_range=value_range)
+    if layout == "chw":
+        if array.ndim != 3 or array.shape[0] != 3:
+            raise ValueError(
+                f"Expected CHW RGB frame with shape [3, H, W], got {array.shape}"
+            )
+        return _scale_rgb(np.transpose(array, (1, 2, 0)), value_range=value_range)
+    raise ValueError(f"Unsupported layout={layout!r}.")
+
+
+def rgb_array_to_uint8_frames(
+    data: object,
+    *,
+    layout: FrameLayout,
+    value_range: ValueRange = "minus_one_one",
+    sync_device: bool = True,
+) -> list[np.ndarray]:
+    """Convert a tensor/array video chunk to ``HWC`` uint8 RGB frames."""
+    array = _as_numpy(data, sync_device=sync_device)
+    if layout == "hwc" or layout == "chw":
+        return [
+            rgb_frame_to_uint8(
+                array,
+                layout=layout,
+                value_range=value_range,
+                sync_device=sync_device,
+            )
+        ]
+    if layout == "thwc":
+        if array.ndim != 4 or array.shape[-1] != 3:
+            raise ValueError(
+                f"Expected THWC RGB chunk with shape [T, H, W, 3], got {array.shape}"
+            )
+        frames = array
+    elif layout == "tchw":
+        if array.ndim != 4 or array.shape[1] != 3:
+            raise ValueError(
+                f"Expected TCHW RGB chunk with shape [T, 3, H, W], got {array.shape}"
+            )
+        frames = np.transpose(array, (0, 2, 3, 1))
+    elif layout == "bvtchw":
+        if array.ndim != 6 or array.shape[0] != 1 or array.shape[1] != 1:
+            raise ValueError(
+                "Expected single-batch single-view video chunk "
+                f"[1, 1, T, 3, H, W], got {array.shape}"
+            )
+        frames = np.transpose(array[0, 0], (0, 2, 3, 1))
+    else:
+        raise ValueError(f"Unsupported layout={layout!r}.")
+
+    return [_scale_rgb(frame, value_range=value_range) for frame in frames]
+
+
+def tensor_chunk_to_rgb_frames(
+    video_chunk: torch.Tensor,
+    *,
+    sync_device: bool = True,
+) -> list[np.ndarray]:
+    """Convert common model output tensor layouts to RGB uint8 frames."""
+    if video_chunk.ndim == 4:
+        return rgb_array_to_uint8_frames(
+            video_chunk,
+            layout="tchw",
+            value_range="minus_one_one",
+            sync_device=sync_device,
+        )
+    if video_chunk.ndim == 6:
+        value_range: ValueRange = (
+            "minus_one_one" if video_chunk.is_floating_point() else "uint8"
+        )
+        return rgb_array_to_uint8_frames(
+            video_chunk,
+            layout="bvtchw",
+            value_range=value_range,
+            sync_device=sync_device,
+        )
+    raise ValueError(
+        "Expected video chunk [T, C, H, W] or [1, 1, T, 3, H, W], "
+        f"got {tuple(video_chunk.shape)}"
+    )
+
+
+def encode_rgb_frame_to_jpeg(
+    frame: object,
+    *,
+    quality: int = 85,
+    layout: Literal["hwc", "chw"] = "hwc",
+    value_range: ValueRange = "uint8",
+    sync_device: bool = True,
+) -> bytes:
+    """JPEG-encode one RGB frame.
+
+    Pillow is imported lazily so importing realtime serving modules does not
+    force image-codec dependencies into non-JPEG transports.
+    """
+    if not 1 <= quality <= 100:
+        raise ValueError("quality must be between 1 and 100")
+
+    image_module = importlib.import_module("PIL.Image")
+    image_from_array = getattr(image_module, "fromarray")
+    rgb_uint8 = rgb_frame_to_uint8(
+        frame,
+        layout=layout,
+        value_range=value_range,
+        sync_device=sync_device,
+    )
+    output = io.BytesIO()
+    image_from_array(rgb_uint8).save(output, format="JPEG", quality=quality)
+    return output.getvalue()

--- a/flashdreams/flashdreams/serving/realtime/media.py
+++ b/flashdreams/flashdreams/serving/realtime/media.py
@@ -42,7 +42,11 @@ def _as_numpy(value: object, *, sync_device: bool) -> np.ndarray:
 
 
 def _scale_rgb(array: np.ndarray, *, value_range: ValueRange) -> np.ndarray:
+    if value_range not in ("minus_one_one", "zero_one", "uint8"):
+        raise ValueError(f"Unsupported value_range={value_range!r}.")
     if array.dtype == np.uint8:
+        if value_range != "uint8":
+            raise ValueError("uint8 inputs require value_range='uint8'.")
         return np.ascontiguousarray(array)
 
     values = array.astype(np.float32, copy=False)
@@ -50,8 +54,6 @@ def _scale_rgb(array: np.ndarray, *, value_range: ValueRange) -> np.ndarray:
         values = (values + 1.0) / 2.0 * 255.0
     elif value_range == "zero_one":
         values = values * 255.0
-    elif value_range != "uint8":
-        raise ValueError(f"Unsupported value_range={value_range!r}.")
     return np.ascontiguousarray(values.clip(0, 255).astype(np.uint8))
 
 
@@ -110,7 +112,12 @@ def rgb_array_to_uint8_frames(
             )
         frames = np.transpose(array, (0, 2, 3, 1))
     elif layout == "bvtchw":
-        if array.ndim != 6 or array.shape[0] != 1 or array.shape[1] != 1:
+        if (
+            array.ndim != 6
+            or array.shape[0] != 1
+            or array.shape[1] != 1
+            or array.shape[3] != 3
+        ):
             raise ValueError(
                 "Expected single-batch single-view video chunk "
                 f"[1, 1, T, 3, H, W], got {array.shape}"
@@ -129,10 +136,13 @@ def tensor_chunk_to_rgb_frames(
 ) -> list[np.ndarray]:
     """Convert common model output tensor layouts to RGB uint8 frames."""
     if video_chunk.ndim == 4:
+        value_range: ValueRange = (
+            "minus_one_one" if video_chunk.is_floating_point() else "uint8"
+        )
         return rgb_array_to_uint8_frames(
             video_chunk,
             layout="tchw",
-            value_range="minus_one_one",
+            value_range=value_range,
             sync_device=sync_device,
         )
     if video_chunk.ndim == 6:

--- a/flashdreams/flashdreams/serving/webrtc/controls.py
+++ b/flashdreams/flashdreams/serving/webrtc/controls.py
@@ -1,337 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Keyboard state, sparse-edge event resampling, and camera pose integration."""
+"""WebRTC adapters for shared realtime input helpers."""
 
 from __future__ import annotations
 
-from collections import deque
-from dataclasses import dataclass, field
-from typing import Literal
+from flashdreams.serving.realtime.input import (
+    DEFAULT_SUPPORTED_KEYS,
+    KEY_ALIASES,
+    WSAD_SUPPORTED_KEYS,
+    CameraPoseIntegrator,
+    ImageRequest,
+    KeyboardResampler,
+    KeyboardState,
+    PoseSegment,
+    PromptRequest,
+    ResetRequest,
+    SparseInputSnapshot,
+    normalize_key,
+)
 
-import numpy as np
-
-DEFAULT_SUPPORTED_KEYS = frozenset({"w", "a", "s", "d", "q", "e", "i", "k", "j", "l"})
-WSAD_SUPPORTED_KEYS = frozenset({"w", "a", "s", "d"})
-KEY_ALIASES = {
-    "arrowup": "w",
-    "arrowleft": "a",
-    "arrowdown": "s",
-    "arrowright": "d",
-}
-
-
-def normalize_key(key: str) -> str:
-    normalized = key.strip().lower()
-    return KEY_ALIASES.get(normalized, normalized)
-
-
-@dataclass(slots=True)
-class KeyboardState:
-    pressed_keys: set[str] = field(default_factory=set)
-    supported_keys: frozenset[str] = DEFAULT_SUPPORTED_KEYS
-    _press_order: dict[str, int] = field(default_factory=dict)
-    _press_counter: int = 0
-
-    def apply_event(self, *, event: str, key: str) -> bool:
-        normalized_key = normalize_key(key)
-        if normalized_key not in self.supported_keys:
-            return False
-
-        normalized_event = event.strip().lower()
-        if normalized_event == "keydown":
-            self.pressed_keys.add(normalized_key)
-            self._press_counter += 1
-            self._press_order[normalized_key] = self._press_counter
-            return True
-        if normalized_event == "keyup":
-            self.pressed_keys.discard(normalized_key)
-            self._press_order.pop(normalized_key, None)
-            return True
-        return False
-
-    def snapshot(self) -> frozenset[str]:
-        return frozenset(self.pressed_keys)
-
-    def _latest_pressed(self, keys: tuple[str, ...]) -> str | None:
-        latest_key: str | None = None
-        latest_idx = -1
-        for key in keys:
-            if key not in self.pressed_keys:
-                continue
-            idx = self._press_order.get(key, -1)
-            if idx >= latest_idx:
-                latest_idx = idx
-                latest_key = key
-        return latest_key
-
-    def resolved_effective_keys(self) -> frozenset[str]:
-        effective: set[str] = set()
-        for key in (
-            self._latest_pressed(("w", "s")),
-            self._latest_pressed(("a", "d", "j", "l")),
-            self._latest_pressed(("q", "e")),
-            self._latest_pressed(("i", "k")),
-        ):
-            if key is not None:
-                effective.add(key)
-        return frozenset(key for key in effective if key in self.supported_keys)
-
-
-PoseSegment = tuple[float, float, frozenset[str]]
-
-
-class KeyboardResampler:
-    """Resample sparse keydown/keyup edges into a chunk timeline."""
-
-    def __init__(
-        self,
-        *,
-        fps: int,
-        start_v: float = 0.0,
-        supported_keys: frozenset[str] = DEFAULT_SUPPORTED_KEYS,
-    ) -> None:
-        if fps <= 0:
-            raise ValueError("fps must be > 0")
-        self._fps = fps
-        self._dt = 1.0 / fps
-        self._supported_keys = supported_keys
-        self.next_chunk_start_v = start_v
-        self._event_log: deque[tuple[float, dict[str, str]]] = deque()
-        self._carried_state = KeyboardState(supported_keys=supported_keys)
-
-    @property
-    def fps(self) -> int:
-        return self._fps
-
-    @property
-    def dt(self) -> float:
-        return self._dt
-
-    def on_edge(self, *, arrival_t: float, event: str, key: str) -> None:
-        self._event_log.append((arrival_t, {"event": event, "key": key}))
-
-    def sample_chunk(self, num_frames: int) -> tuple[list[PoseSegment], list[float]]:
-        if num_frames < 1:
-            raise ValueError("num_frames must be >= 1")
-
-        chunk_start_v = self.next_chunk_start_v
-        chunk_end_v = chunk_start_v + num_frames * self._dt
-
-        while self._event_log and self._event_log[0][0] < chunk_start_v:
-            _, payload = self._event_log.popleft()
-            self._carried_state.apply_event(**payload)
-
-        segments: list[PoseSegment] = []
-        prev_t = chunk_start_v
-        prev_state = self._carried_state.resolved_effective_keys()
-        while self._event_log and self._event_log[0][0] <= chunk_end_v:
-            event_t, payload = self._event_log.popleft()
-            if event_t > prev_t:
-                segments.append((prev_t, event_t, prev_state))
-            self._carried_state.apply_event(**payload)
-            prev_state = self._carried_state.resolved_effective_keys()
-            prev_t = event_t
-        if prev_t < chunk_end_v:
-            segments.append((prev_t, chunk_end_v, prev_state))
-        elif not segments:
-            segments.append((chunk_start_v, chunk_end_v, prev_state))
-
-        frame_times = [chunk_start_v + (i + 1) * self._dt for i in range(num_frames)]
-        self.next_chunk_start_v = chunk_end_v
-        return segments, frame_times
-
-    def reset(self, *, start_v: float) -> None:
-        self._event_log.clear()
-        self._carried_state = KeyboardState(supported_keys=self._supported_keys)
-        self.next_chunk_start_v = start_v
-
-    def event_log_size(self) -> int:
-        return len(self._event_log)
-
-
-def _rotation_matrix(axis: str, angle_rad: float) -> np.ndarray:
-    cos_t = np.float32(np.cos(angle_rad))
-    sin_t = np.float32(np.sin(angle_rad))
-    if axis == "x":
-        return np.array(
-            [
-                [1.0, 0.0, 0.0],
-                [0.0, cos_t, -sin_t],
-                [0.0, sin_t, cos_t],
-            ],
-            dtype=np.float32,
-        )
-    if axis == "y":
-        return np.array(
-            [
-                [cos_t, 0.0, sin_t],
-                [0.0, 1.0, 0.0],
-                [-sin_t, 0.0, cos_t],
-            ],
-            dtype=np.float32,
-        )
-    if axis == "z":
-        return np.array(
-            [
-                [cos_t, -sin_t, 0.0],
-                [sin_t, cos_t, 0.0],
-                [0.0, 0.0, 1.0],
-            ],
-            dtype=np.float32,
-        )
-    return np.eye(3, dtype=np.float32)
-
-
-@dataclass(slots=True)
-class CameraPoseIntegrator:
-    """Integrate a piecewise-constant keyboard timeline into a camera trajectory."""
-
-    move_speed_per_s: float = 0.8
-    rotate_speed_rad_per_s: float = float(np.deg2rad(32.0))
-    pitch_limit_rad: float = float(np.deg2rad(85.0))
-    coordinate_system: Literal["RDF", "FLU"] = "RDF"
-    _current_pose: np.ndarray = field(
-        default_factory=lambda: np.eye(4, dtype=np.float32),
-    )
-    _current_pitch: float = 0.0
-
-    def __post_init__(self) -> None:
-        if self.coordinate_system not in {"RDF", "FLU"}:
-            raise ValueError(
-                "coordinate_system must be 'RDF' (right-down-forward) "
-                "or 'FLU' (forward-left-up)"
-            )
-
-    def reset(self, pose: np.ndarray | None = None) -> None:
-        if pose is None:
-            self._current_pose = np.eye(4, dtype=np.float32)
-            self._current_pitch = 0.0
-            return
-        if pose.shape != (4, 4):
-            raise ValueError(f"Expected pose shape (4, 4), got {pose.shape}")
-        self._current_pose = pose.astype(np.float32, copy=True)
-        if self.coordinate_system == "FLU":
-            self._current_pitch = float(np.arcsin(np.clip(pose[2, 0], -1.0, 1.0)))
-        else:
-            self._current_pitch = float(np.arctan2(pose[2, 1], pose[1, 1]))
-
-    def current_pose(self) -> np.ndarray:
-        return self._current_pose.copy()
-
-    def _advance(self, *, state: frozenset[str], duration: float) -> None:
-        if duration <= 0:
-            return
-
-        yaw_rate = 0.0
-        if self.coordinate_system == "FLU":
-            if "a" in state or "j" in state:
-                yaw_rate += self.rotate_speed_rad_per_s
-            if "d" in state or "l" in state:
-                yaw_rate -= self.rotate_speed_rad_per_s
-        else:
-            if "a" in state or "j" in state:
-                yaw_rate -= self.rotate_speed_rad_per_s
-            if "d" in state or "l" in state:
-                yaw_rate += self.rotate_speed_rad_per_s
-        pitch_rate = 0.0
-        if "i" in state:
-            pitch_rate += self.rotate_speed_rad_per_s
-        if "k" in state:
-            pitch_rate -= self.rotate_speed_rad_per_s
-
-        yaw_delta = yaw_rate * duration
-        pitch_delta = pitch_rate * duration
-
-        new_pitch = self._current_pitch + pitch_delta
-        if -self.pitch_limit_rad <= new_pitch <= self.pitch_limit_rad:
-            self._current_pitch = new_pitch
-        else:
-            pitch_delta = 0.0
-
-        rot = self._current_pose[:3, :3]
-        trans = self._current_pose[:3, 3]
-        if self.coordinate_system == "FLU":
-            rot_pitch = _rotation_matrix("y", -pitch_delta)
-            rot_yaw = _rotation_matrix("z", yaw_delta)
-        else:
-            rot_pitch = _rotation_matrix("x", pitch_delta)
-            rot_yaw = _rotation_matrix("y", yaw_delta)
-        rot_new = rot_yaw @ rot @ rot_pitch
-
-        forward_rate = 0.0
-        if "w" in state:
-            forward_rate += self.move_speed_per_s
-        if "s" in state:
-            forward_rate -= self.move_speed_per_s
-        right_rate = 0.0
-        if "e" in state:
-            right_rate += self.move_speed_per_s
-        if "q" in state:
-            right_rate -= self.move_speed_per_s
-
-        if self.coordinate_system == "FLU":
-            vec_forward = rot_new[:, 0]
-            vec_right = -rot_new[:, 1]
-            forward_flat = np.array(
-                [vec_forward[0], vec_forward[1], 0.0], dtype=np.float32
-            )
-            right_flat = np.array([vec_right[0], vec_right[1], 0.0], dtype=np.float32)
-        else:
-            vec_right = rot_new[:, 0]
-            vec_forward = rot_new[:, 2]
-            forward_flat = np.array(
-                [vec_forward[0], 0.0, vec_forward[2]], dtype=np.float32
-            )
-            right_flat = np.array([vec_right[0], 0.0, vec_right[2]], dtype=np.float32)
-        forward_norm = np.linalg.norm(forward_flat)
-        right_norm = np.linalg.norm(right_flat)
-        if forward_norm > 0:
-            forward_flat /= forward_norm
-        if right_norm > 0:
-            right_flat /= right_norm
-
-        move_vec = forward_flat * (forward_rate * duration) + right_flat * (
-            right_rate * duration
-        )
-        self._current_pose = np.eye(4, dtype=np.float32)
-        self._current_pose[:3, :3] = rot_new
-        self._current_pose[:3, 3] = trans + move_vec
-
-    def integrate_chunk(
-        self,
-        *,
-        segments: list[PoseSegment],
-        frame_times: list[float],
-    ) -> np.ndarray:
-        if not segments:
-            raise ValueError("segments must be non-empty")
-        if not frame_times:
-            raise ValueError("frame_times must be non-empty")
-        chunk_start = segments[0][0]
-        chunk_end = segments[-1][1]
-        if any(
-            frame_times[i] >= frame_times[i + 1] for i in range(len(frame_times) - 1)
-        ):
-            raise ValueError("frame_times must be strictly increasing")
-        if frame_times[0] < chunk_start - 1e-9 or frame_times[-1] > chunk_end + 1e-9:
-            raise ValueError(
-                "frame_times must lie within the chunk window "
-                f"[{chunk_start}, {chunk_end}]"
-            )
-
-        poses: list[np.ndarray] = []
-        cur_t = chunk_start
-        ft_idx = 0
-        for _, seg_end, seg_state in segments:
-            while ft_idx < len(frame_times) and frame_times[ft_idx] <= seg_end:
-                target_t = frame_times[ft_idx]
-                self._advance(state=seg_state, duration=target_t - cur_t)
-                cur_t = target_t
-                poses.append(self._current_pose.copy())
-                ft_idx += 1
-            if seg_end > cur_t:
-                self._advance(state=seg_state, duration=seg_end - cur_t)
-                cur_t = seg_end
-
-        return np.stack(poses, axis=0).astype(np.float32)
+__all__ = [
+    "DEFAULT_SUPPORTED_KEYS",
+    "KEY_ALIASES",
+    "WSAD_SUPPORTED_KEYS",
+    "CameraPoseIntegrator",
+    "ImageRequest",
+    "KeyboardResampler",
+    "KeyboardState",
+    "PoseSegment",
+    "PromptRequest",
+    "ResetRequest",
+    "SparseInputSnapshot",
+    "normalize_key",
+]

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -19,7 +19,7 @@ import torch
 from aiortc import RTCConfiguration, RTCPeerConnection, RTCSessionDescription
 from loguru import logger
 
-from flashdreams.serving.webrtc.controls import KeyboardResampler
+from flashdreams.serving.realtime.input import KeyboardResampler
 from flashdreams.serving.webrtc.media import BufferedVideoTrack
 from flashdreams.serving.webrtc.server import SessionBusyError
 from flashdreams.serving.webrtc.warmup import (

--- a/flashdreams/flashdreams/serving/webrtc/media.py
+++ b/flashdreams/flashdreams/serving/webrtc/media.py
@@ -6,41 +6,25 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from fractions import Fraction
+from typing import TYPE_CHECKING
 
 import numpy as np
-import torch
 from aiortc import MediaStreamTrack
 from aiortc.mediastreams import MediaStreamError
 from av import VideoFrame
 from loguru import logger
 
+from flashdreams.serving.realtime.media import tensor_chunk_to_rgb_frames
+
+if TYPE_CHECKING:
+    import torch
+
 _STALL_THRESHOLD_MS = 1.0
 _PACING_LAG_LOG_MS = 5.0
 
 
-def tensor_chunk_to_rgb_frames(video_chunk: torch.Tensor) -> list[np.ndarray]:
-    """Convert common model output tensor layouts to RGB uint8 frames."""
-    if video_chunk.ndim == 4:
-        frames = video_chunk.float().permute(0, 2, 3, 1).numpy()
-        frames = ((frames + 1.0) / 2.0 * 255.0).clip(0, 255).astype(np.uint8)
-        return [np.ascontiguousarray(frame) for frame in frames]
-    if video_chunk.ndim == 6:
-        if video_chunk.shape[0] != 1 or video_chunk.shape[1] != 1:
-            raise ValueError(
-                "Expected single-batch single-view video chunk [1, 1, T, 3, H, W], "
-                f"got {tuple(video_chunk.shape)}"
-            )
-        chunk = video_chunk[0, 0]
-        if chunk.dtype == torch.uint8:
-            frames = chunk.permute(0, 2, 3, 1).cpu().numpy()
-        else:
-            frames = chunk.float().permute(0, 2, 3, 1).cpu().numpy()
-            frames = ((frames + 1.0) / 2.0 * 255.0).clip(0, 255).astype(np.uint8)
-        return [np.ascontiguousarray(frame) for frame in frames]
-    raise ValueError(
-        "Expected video chunk [T, C, H, W] or [1, 1, T, 3, H, W], "
-        f"got {tuple(video_chunk.shape)}"
-    )
+def _default_frame_converter(video_chunk: torch.Tensor) -> list[np.ndarray]:
+    return tensor_chunk_to_rgb_frames(video_chunk, sync_device=True)
 
 
 class BufferedVideoTrack(MediaStreamTrack):
@@ -66,7 +50,7 @@ class BufferedVideoTrack(MediaStreamTrack):
         self._next_deadline_s: float | None = None
         self._pts = 0
         self._maxsize = maxsize
-        self._frame_converter = frame_converter or tensor_chunk_to_rgb_frames
+        self._frame_converter = frame_converter or _default_frame_converter
         self._frames: asyncio.Queue[np.ndarray | None] = asyncio.Queue(maxsize=maxsize)
         self._closed = False
 

--- a/flashdreams/tests/test_realtime_serving.py
+++ b/flashdreams/tests/test_realtime_serving.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pytest
+import torch
+
+from flashdreams.serving.realtime.frame_bus import LatestFrameBus
+from flashdreams.serving.realtime.input import (
+    ImageRequest,
+    KeyboardState,
+    PromptRequest,
+    ResetRequest,
+    SparseInputSnapshot,
+)
+from flashdreams.serving.realtime.media import (
+    encode_rgb_frame_to_jpeg,
+    rgb_array_to_uint8_frames,
+    tensor_chunk_to_rgb_frames,
+)
+from flashdreams.serving.webrtc.media import (
+    tensor_chunk_to_rgb_frames as webrtc_tensor_chunk_to_rgb_frames,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_keyboard_state_builds_sparse_snapshot_with_effective_keys() -> None:
+    state = KeyboardState()
+
+    assert state.apply_event(event="keydown", key="ArrowLeft")
+    assert state.apply_event(event="keydown", key="d")
+
+    snapshot = state.sparse_snapshot(timestamp_s=12.5)
+
+    assert snapshot == SparseInputSnapshot(
+        timestamp_s=12.5,
+        pressed_keys=frozenset({"a", "d"}),
+        effective_keys=frozenset({"d"}),
+    )
+
+
+def test_input_request_containers_are_transport_neutral() -> None:
+    snapshot = SparseInputSnapshot(
+        timestamp_s=1.0,
+        reset=ResetRequest(reason="new_session", request_id="reset-1"),
+        prompt=PromptRequest(prompt="drive forward", request_id="prompt-1"),
+        image=ImageRequest(
+            data=b"image-bytes",
+            content_type="image/jpeg",
+            request_id="image-1",
+        ),
+    )
+
+    assert snapshot.reset is not None
+    assert snapshot.reset.reason == "new_session"
+    assert snapshot.prompt is not None
+    assert snapshot.prompt.prompt == "drive forward"
+    assert snapshot.image is not None
+    assert snapshot.image.content_type == "image/jpeg"
+
+
+def test_latest_frame_bus_publishes_single_slot_frames() -> None:
+    bus = LatestFrameBus[bytes]()
+
+    assert bus.latest() is None
+    first_count = bus.publish(b"first")
+    second_count = bus.publish(b"second")
+
+    assert first_count == 1
+    assert second_count == 2
+    latest = bus.latest()
+    assert latest is not None
+    assert latest.payload == b"second"
+    assert latest.count == 2
+    waited = bus.wait_for_frame(last_seen_count=1, timeout_s=0.01)
+    assert waited is not None
+    assert waited.payload == b"second"
+    assert waited.count == 2
+
+
+def test_latest_frame_bus_close_wakes_waiters() -> None:
+    bus = LatestFrameBus[bytes]()
+    waiter_ready = threading.Event()
+    results: list[object] = []
+
+    def wait_for_frame() -> None:
+        waiter_ready.set()
+        results.append(bus.wait_for_frame(last_seen_count=0, timeout_s=1.0))
+
+    thread = threading.Thread(target=wait_for_frame)
+    thread.start()
+    assert waiter_ready.wait(timeout=1.0)
+
+    bus.close()
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert results == [None]
+    with pytest.raises(RuntimeError, match="closed LatestFrameBus"):
+        bus.publish(b"late")
+
+
+def test_realtime_media_matches_webrtc_tensor_chunk_conversion() -> None:
+    chunk = torch.tensor(
+        [
+            [
+                [[-1.0, 0.0], [1.0, 2.0]],
+                [[-2.0, 0.5], [0.0, 1.0]],
+                [[1.0, -1.0], [0.0, 0.0]],
+            ],
+        ],
+        dtype=torch.float32,
+    )
+
+    shared_frames = tensor_chunk_to_rgb_frames(chunk)
+    webrtc_frames = webrtc_tensor_chunk_to_rgb_frames(chunk)
+
+    assert len(shared_frames) == 1
+    np.testing.assert_array_equal(shared_frames[0], webrtc_frames[0])
+    np.testing.assert_array_equal(
+        shared_frames[0],
+        np.array(
+            [[[0, 0, 255], [127, 191, 0]], [[255, 127, 127], [255, 255, 127]]],
+            dtype=np.uint8,
+        ),
+    )
+
+
+def test_realtime_media_supports_omnidreams_uint8_layout() -> None:
+    chunk = torch.zeros((1, 1, 2, 3, 4, 5), dtype=torch.uint8)
+    chunk[0, 0, 1, 0] = 255
+
+    frames = tensor_chunk_to_rgb_frames(chunk)
+
+    assert len(frames) == 2
+    assert frames[0].shape == (4, 5, 3)
+    assert frames[0].dtype == np.uint8
+    assert frames[1][0, 0, 0] == 255
+
+
+def test_realtime_media_converts_array_chunks() -> None:
+    chunk = np.array(
+        [
+            [[[0.0, 0.5, 1.0], [1.0, 0.0, 0.5]]],
+            [[[0.25, 0.75, 1.0], [0.0, 0.0, 0.0]]],
+        ],
+        dtype=np.float32,
+    )
+
+    frames = rgb_array_to_uint8_frames(
+        chunk,
+        layout="thwc",
+        value_range="zero_one",
+    )
+
+    assert len(frames) == 2
+    np.testing.assert_array_equal(
+        frames[0],
+        np.array([[[0, 127, 255], [255, 0, 127]]], dtype=np.uint8),
+    )
+
+
+def test_realtime_media_encodes_jpeg_bytes() -> None:
+    pytest.importorskip("PIL.Image")
+    frame = np.full((4, 5, 3), 127, dtype=np.uint8)
+
+    jpeg = encode_rgb_frame_to_jpeg(frame, quality=80)
+
+    assert jpeg.startswith(b"\xff\xd8")
+    assert jpeg.endswith(b"\xff\xd9")

--- a/flashdreams/tests/test_realtime_serving.py
+++ b/flashdreams/tests/test_realtime_serving.py
@@ -22,9 +22,6 @@ from flashdreams.serving.realtime.media import (
     rgb_array_to_uint8_frames,
     tensor_chunk_to_rgb_frames,
 )
-from flashdreams.serving.webrtc.media import (
-    tensor_chunk_to_rgb_frames as webrtc_tensor_chunk_to_rgb_frames,
-)
 
 pytestmark = pytest.mark.ci_cpu
 
@@ -85,16 +82,22 @@ def test_latest_frame_bus_publishes_single_slot_frames() -> None:
 
 def test_latest_frame_bus_close_wakes_waiters() -> None:
     bus = LatestFrameBus[bytes]()
-    waiter_ready = threading.Event()
+    waiter_blocking = threading.Event()
     results: list[object] = []
+    original_wait = bus._condition.wait
+
+    def wait_after_ready(timeout: float | None = None) -> bool:
+        waiter_blocking.set()
+        return original_wait(timeout=timeout)
+
+    setattr(bus._condition, "wait", wait_after_ready)
 
     def wait_for_frame() -> None:
-        waiter_ready.set()
-        results.append(bus.wait_for_frame(last_seen_count=0, timeout_s=1.0))
+        results.append(bus.wait_for_frame(last_seen_count=0, timeout_s=5.0))
 
     thread = threading.Thread(target=wait_for_frame)
     thread.start()
-    assert waiter_ready.wait(timeout=1.0)
+    assert waiter_blocking.wait(timeout=1.0)
 
     bus.close()
     thread.join(timeout=1.0)
@@ -105,7 +108,7 @@ def test_latest_frame_bus_close_wakes_waiters() -> None:
         bus.publish(b"late")
 
 
-def test_realtime_media_matches_webrtc_tensor_chunk_conversion() -> None:
+def test_realtime_media_matches_legacy_tensor_chunk_pixels() -> None:
     chunk = torch.tensor(
         [
             [
@@ -118,10 +121,8 @@ def test_realtime_media_matches_webrtc_tensor_chunk_conversion() -> None:
     )
 
     shared_frames = tensor_chunk_to_rgb_frames(chunk)
-    webrtc_frames = webrtc_tensor_chunk_to_rgb_frames(chunk)
 
     assert len(shared_frames) == 1
-    np.testing.assert_array_equal(shared_frames[0], webrtc_frames[0])
     np.testing.assert_array_equal(
         shared_frames[0],
         np.array(
@@ -141,6 +142,24 @@ def test_realtime_media_supports_omnidreams_uint8_layout() -> None:
     assert frames[0].shape == (4, 5, 3)
     assert frames[0].dtype == np.uint8
     assert frames[1][0, 0, 0] == 255
+
+
+def test_realtime_media_rejects_non_rgb_bvtchw_layout() -> None:
+    chunk = torch.zeros((1, 1, 2, 4, 5, 6), dtype=torch.uint8)
+
+    with pytest.raises(ValueError, match=r"\[1, 1, T, 3, H, W\]"):
+        tensor_chunk_to_rgb_frames(chunk)
+
+
+def test_realtime_media_rejects_scaled_value_range_for_uint8() -> None:
+    chunk = np.zeros((1, 2, 2, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="uint8 inputs require value_range='uint8'"):
+        rgb_array_to_uint8_frames(
+            chunk,
+            layout="thwc",
+            value_range="minus_one_one",
+        )
 
 
 def test_realtime_media_converts_array_chunks() -> None:

--- a/flashdreams/tests/test_realtime_serving.py
+++ b/flashdreams/tests/test_realtime_serving.py
@@ -144,6 +144,24 @@ def test_realtime_media_supports_omnidreams_uint8_layout() -> None:
     assert frames[1][0, 0, 0] == 255
 
 
+@pytest.mark.parametrize(
+    "chunk",
+    [
+        torch.full((1, 3, 2, 2), -1.0, dtype=torch.bfloat16),
+        torch.full((1, 1, 1, 3, 2, 2), -1.0, dtype=torch.bfloat16),
+    ],
+)
+def test_realtime_media_promotes_bfloat16_tensor_chunks(
+    chunk: torch.Tensor,
+) -> None:
+    frames = tensor_chunk_to_rgb_frames(chunk)
+
+    assert len(frames) == 1
+    assert frames[0].shape == (2, 2, 3)
+    assert frames[0].dtype == np.uint8
+    assert frames[0].max() == 0
+
+
 def test_realtime_media_rejects_non_rgb_bvtchw_layout() -> None:
     chunk = torch.zeros((1, 1, 2, 4, 5, 6), dtype=torch.uint8)
 

--- a/integrations/flashvsr/flashvsr/grpc/streaming_view.py
+++ b/integrations/flashvsr/flashvsr/grpc/streaming_view.py
@@ -27,6 +27,8 @@ import numpy as np
 import torch
 from loguru import logger
 
+from flashdreams.serving.realtime.media import encode_rgb_frame_to_jpeg
+
 DEFAULT_VIEWER_CHUNK_QUEUE_DEPTH = 8
 DEFAULT_VIEWER_JPEG_QUALITY = 90
 DEFAULT_VIEWER_JPEG_BACKEND = "auto"
@@ -58,10 +60,15 @@ def _load_pillow_image():
 
 def _encode_jpeg_rgb(frame: np.ndarray, quality: int) -> bytes:
     """Encode one uint8 RGB frame to JPEG bytes."""
-    image = _load_pillow_image().fromarray(np.ascontiguousarray(frame))
-    buf = io.BytesIO()
-    image.save(buf, format="JPEG", quality=quality)
-    return buf.getvalue()
+    try:
+        return encode_rgb_frame_to_jpeg(frame, quality=quality, value_range="uint8")
+    except ModuleNotFoundError as exc:
+        if exc.name not in ("PIL", "PIL.Image"):
+            raise
+        raise RuntimeError(
+            "JPEG support requires Pillow. Install the flashvsr integration "
+            "dependencies before using JPEG input or the browser viewer."
+        ) from exc
 
 
 def _load_torchvision_encode_jpeg():

--- a/integrations/flashvsr/flashvsr/grpc/uplift_client.py
+++ b/integrations/flashvsr/flashvsr/grpc/uplift_client.py
@@ -33,7 +33,6 @@ Usage (from repo root):
 """
 
 import argparse
-import io
 import sys
 import time
 import uuid
@@ -44,6 +43,7 @@ import grpc
 import mediapy as media
 import numpy as np
 
+from flashdreams.serving.realtime.media import encode_rgb_frame_to_jpeg
 from flashvsr.grpc.protos import flashvsr_pb2 as pb2
 from flashvsr.grpc.protos import flashvsr_pb2_grpc as pb2_grpc
 
@@ -106,20 +106,16 @@ def video_to_rgb_bytes(frames_np: np.ndarray) -> bytes:
 def encode_jpeg_frames(frames_np: np.ndarray, quality: int) -> list[bytes]:
     """uint8 [T,H,W,3] → one JPEG byte string per frame."""
     try:
-        from PIL import Image
-    except ImportError as exc:
+        return [
+            encode_rgb_frame_to_jpeg(frame, quality=quality, value_range="uint8")
+            for frame in frames_np
+        ]
+    except ModuleNotFoundError as exc:
+        if exc.name not in ("PIL", "PIL.Image"):
+            raise
         raise RuntimeError(
             "JPEG input requires Pillow in the client environment"
         ) from exc
-
-    encoded = []
-    for frame in frames_np:
-        buf = io.BytesIO()
-        Image.fromarray(np.ascontiguousarray(frame)).save(
-            buf, format="JPEG", quality=quality
-        )
-        encoded.append(buf.getvalue())
-    return encoded
 
 
 def build_chunk_request(

--- a/integrations/flashvsr/tests/test_grpc_client.py
+++ b/integrations/flashvsr/tests/test_grpc_client.py
@@ -17,9 +17,13 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from flashvsr.grpc import uplift_server as grpc_server
 from flashvsr.grpc.protos import flashvsr_pb2 as pb2
-from flashvsr.grpc.uplift_client import build_chunk_request, build_chunks
+from flashvsr.grpc.streaming_view import _encode_jpeg_rgb
+from flashvsr.grpc.uplift_client import (
+    build_chunk_request,
+    build_chunks,
+    encode_jpeg_frames,
+)
 
 pytestmark = pytest.mark.ci_cpu
 
@@ -55,7 +59,30 @@ def test_build_chunk_request_raw_display_only() -> None:
     assert request.display_only
 
 
+def test_encode_jpeg_frames_returns_jpeg_payloads() -> None:
+    pytest.importorskip("PIL.Image")
+    frames = np.zeros((2, 4, 6, 3), dtype=np.uint8)
+
+    encoded = encode_jpeg_frames(frames, quality=90)
+
+    assert len(encoded) == 2
+    assert all(frame.startswith(b"\xff\xd8") for frame in encoded)
+    assert all(frame.endswith(b"\xff\xd9") for frame in encoded)
+
+
+def test_streaming_view_cpu_jpeg_encoder_returns_jpeg_payload() -> None:
+    pytest.importorskip("PIL.Image")
+    frame = np.zeros((4, 6, 3), dtype=np.uint8)
+
+    encoded = _encode_jpeg_rgb(frame, quality=90)
+
+    assert encoded.startswith(b"\xff\xd8")
+    assert encoded.endswith(b"\xff\xd9")
+
+
 def test_attention_mode_auto_uses_sparse(monkeypatch: pytest.MonkeyPatch) -> None:
+    from flashvsr.grpc import uplift_server as grpc_server
+
     monkeypatch.setattr(grpc_server, "_sparse_attention_available", lambda: True)
 
     assert grpc_server._resolve_attention_mode("auto") == "sparse"
@@ -66,6 +93,8 @@ def test_attention_mode_auto_uses_sparse(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_attention_mode_auto_falls_back_to_full_when_sparse_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from flashvsr.grpc import uplift_server as grpc_server
+
     monkeypatch.setattr(
         grpc_server,
         "_sparse_attention_available",

--- a/integrations/omnidreams/omnidreams/grpc/utils.py
+++ b/integrations/omnidreams/omnidreams/grpc/utils.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from flashdreams.serving.realtime.media import encode_rgb_frame_to_jpeg
 from google.protobuf.json_format import MessageToDict
 from loguru import logger
 from ludus_renderer import CUBE_FLAG_WIREFRAME, PRIM_OBSTACLE, CubePool
@@ -99,12 +100,12 @@ def encode_image(
     Returns:
         Encoded image bytes.
     """
+    if format.upper() == "JPEG":
+        return encode_rgb_frame_to_jpeg(image_np, quality=quality, value_range="uint8")
+
     img = Image.fromarray(image_np)
     buf = io.BytesIO()
-    if format.upper() == "JPEG":
-        img.save(buf, format="JPEG", quality=quality)
-    else:
-        img.save(buf, format=format)
+    img.save(buf, format=format)
     return buf.getvalue()
 
 

--- a/integrations/omnidreams/omnidreams/grpc/utils.py
+++ b/integrations/omnidreams/omnidreams/grpc/utils.py
@@ -35,7 +35,6 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from flashdreams.serving.realtime.media import encode_rgb_frame_to_jpeg
 from google.protobuf.json_format import MessageToDict
 from loguru import logger
 from ludus_renderer import CUBE_FLAG_WIREFRAME, PRIM_OBSTACLE, CubePool
@@ -48,6 +47,8 @@ from omnidreams.conditioning.world_scenario.settings import SETTINGS
 from PIL import Image
 from scipy.spatial.transform import Rotation, Slerp
 from torch import Tensor
+
+from flashdreams.serving.realtime.media import encode_rgb_frame_to_jpeg
 
 
 def decode_image(

--- a/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
@@ -4,16 +4,19 @@
 import threading
 import time
 
-from flashdreams.serving.realtime.input import (
-    DRIVING_SUPPORTED_KEYS,
-    KeyboardState as RealtimeKeyboardState,
-    normalize_key,
-)
 from omnidreams.interactive_drive.input.backend import InputBackend, SampledInput
 from omnidreams.interactive_drive.types import (
     ControlSnapshot,
     DriverCommand,
     VehicleState,
+)
+
+from flashdreams.serving.realtime.input import (
+    DRIVING_SUPPORTED_KEYS,
+    normalize_key,
+)
+from flashdreams.serving.realtime.input import (
+    KeyboardState as RealtimeKeyboardState,
 )
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/input/keyboard.py
@@ -4,6 +4,11 @@
 import threading
 import time
 
+from flashdreams.serving.realtime.input import (
+    DRIVING_SUPPORTED_KEYS,
+    KeyboardState as RealtimeKeyboardState,
+    normalize_key,
+)
 from omnidreams.interactive_drive.input.backend import InputBackend, SampledInput
 from omnidreams.interactive_drive.types import (
     ControlSnapshot,
@@ -26,7 +31,7 @@ class KeyboardState:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._pressed: set[str] = set()
+        self._keyboard = RealtimeKeyboardState(supported_keys=DRIVING_SUPPORTED_KEYS)
         self._view_mode = "rgb"
         self._drive_command: DriverCommand | None = None
         self._reset_pending = False
@@ -44,10 +49,10 @@ class KeyboardState:
 
     def set_key(self, name: str, down: bool) -> None:
         with self._lock:
-            if down:
-                self._pressed.add(name)
-            else:
-                self._pressed.discard(name)
+            self._keyboard.apply_event(
+                event="keydown" if down else "keyup",
+                key=name,
+            )
 
     def set_view_mode(self, mode: str) -> None:
         with self._lock:
@@ -113,7 +118,7 @@ class KeyboardState:
     def command(self) -> DriverCommand:
         with self._lock:
             drive_command = self._drive_command
-            pressed = set(self._pressed)
+            pressed = set(self._keyboard.snapshot())
         if drive_command is not None:
             if "space" in pressed:
                 return DriverCommand(
@@ -130,18 +135,19 @@ class KeyboardState:
 
 
 def command_from_snapshot(snapshot: ControlSnapshot) -> DriverCommand:
-    throttle = 1.0 if {"w", "up"} & snapshot.pressed else 0.0
-    brake = 1.0 if {"s", "down"} & snapshot.pressed else 0.0
+    pressed = {normalize_key(key) for key in snapshot.pressed}
+    throttle = 1.0 if {"w", "up"} & pressed else 0.0
+    brake = 1.0 if {"s", "down"} & pressed else 0.0
     steer = 0.0
-    if {"a", "left"} & snapshot.pressed:
+    if {"a", "left"} & pressed:
         steer += 1.0
-    if {"d", "right"} & snapshot.pressed:
+    if {"d", "right"} & pressed:
         steer -= 1.0
     return DriverCommand(
         throttle=throttle,
         brake=brake,
         steer=steer,
-        stop="space" in snapshot.pressed,
+        stop="space" in pressed,
     )
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -22,16 +22,17 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
-from flashdreams.serving.realtime.frame_bus import LatestFrameBus
-from flashdreams.serving.realtime.media import (
-    encode_rgb_frame_to_jpeg,
-    rgb_frame_to_uint8,
-)
 from loguru import logger
 from omnidreams.interactive_drive.config import RasterConfig
 from omnidreams.interactive_drive.input.keyboard import KeyboardState
 from omnidreams.interactive_drive.loading_overlay import render_loading_overlay
 from omnidreams.interactive_drive.types import DriverCommand, PresentedFrame
+
+from flashdreams.serving.realtime.frame_bus import LatestFrameBus
+from flashdreams.serving.realtime.media import (
+    encode_rgb_frame_to_jpeg,
+    rgb_frame_to_uint8,
+)
 
 # Boundary marker embedded in the multipart response. The exact string
 # doesn't matter as long as it never appears inside a JPEG payload (they

--- a/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/streaming_presenter.py
@@ -10,7 +10,6 @@ graphics GPU; prefer ``omnidreams.webrtc.server`` for a richer viewer.
 
 from __future__ import annotations
 
-import io
 import json
 import shutil
 import subprocess
@@ -23,12 +22,16 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
+from flashdreams.serving.realtime.frame_bus import LatestFrameBus
+from flashdreams.serving.realtime.media import (
+    encode_rgb_frame_to_jpeg,
+    rgb_frame_to_uint8,
+)
 from loguru import logger
 from omnidreams.interactive_drive.config import RasterConfig
 from omnidreams.interactive_drive.input.keyboard import KeyboardState
 from omnidreams.interactive_drive.loading_overlay import render_loading_overlay
 from omnidreams.interactive_drive.types import DriverCommand, PresentedFrame
-from PIL import Image
 
 # Boundary marker embedded in the multipart response. The exact string
 # doesn't matter as long as it never appears inside a JPEG payload (they
@@ -540,19 +543,11 @@ class MJPEGStreamingPresenter:
         self._keyboard = keyboard
         self._jpeg_quality = int(jpeg_quality)
         self._stop_event = threading.Event()
-        # Guarded by ``_frame_cond`` so a sending thread can ``wait()``
-        # for the next frame rather than spinning.
-        self._latest_jpeg: bytes | None = None
-        self._frame_count = 0
-        self._frame_cond = threading.Condition()
+        self._frame_bus = LatestFrameBus[bytes]()
         # BEV minimap stream lives on its own JPEG buffer so connected
         # clients of /bev_stream can paginate at a different rate than
-        # /stream (e.g. if the HUD process throttles). We reuse the same
-        # condition variable as the main stream because frames are only
-        # published when ``present_frame`` runs anyway, so notifications
-        # to either waiter are always safe.
-        self._latest_bev_jpeg: bytes | None = None
-        self._bev_frame_count = 0
+        # /stream (e.g. if the HUD process throttles).
+        self._bev_frame_bus = LatestFrameBus[bytes]()
         # Scene options surfaced to the browser dropdown via /scenes.
         # Each entry is a dict with ``label``, ``path``, ``variants``;
         # the demo wrapper builds these from its scene-discovery layer
@@ -736,10 +731,8 @@ class MJPEGStreamingPresenter:
 
     def close(self) -> None:
         self._stop_event.set()
-        # Wake any /stream handlers blocked in ``_frame_cond.wait`` so
-        # they observe ``should_close`` and exit their per-connection loop.
-        with self._frame_cond:
-            self._frame_cond.notify_all()
+        self._frame_bus.close()
+        self._bev_frame_bus.close()
         self._server.shutdown()
         self._server.server_close()
         if self._server_thread.is_alive():
@@ -748,15 +741,12 @@ class MJPEGStreamingPresenter:
     # -- Internals --------------------------------------------------
 
     def _publish(self, rgb_host_uint8: object) -> None:
-        buf = io.BytesIO()
-        Image.fromarray(_as_rgb_host_uint8(rgb_host_uint8)).save(
-            buf, format="JPEG", quality=self._jpeg_quality
+        jpeg = encode_rgb_frame_to_jpeg(
+            _as_rgb_host_uint8(rgb_host_uint8),
+            quality=self._jpeg_quality,
+            value_range="uint8",
         )
-        jpeg = buf.getvalue()
-        with self._frame_cond:
-            self._latest_jpeg = jpeg
-            self._frame_count += 1
-            self._frame_cond.notify_all()
+        _publish_if_open(self._frame_bus, jpeg, stop_event=self._stop_event)
 
     def _publish_bev(self, bev_rgb_host_uint8: object) -> None:
         """Encode the BEV minimap (quality 95, not 85) and stash it for ``/bev_stream``.
@@ -764,44 +754,34 @@ class MJPEGStreamingPresenter:
         Higher quality avoids JPEG ringing the HUD's Google-Maps filter would
         otherwise surface as grey halos around lane / vehicle edges.
         """
-        buf = io.BytesIO()
-        Image.fromarray(_as_rgb_host_uint8(bev_rgb_host_uint8)).save(
-            buf, format="JPEG", quality=95
+        jpeg = encode_rgb_frame_to_jpeg(
+            _as_rgb_host_uint8(bev_rgb_host_uint8),
+            quality=95,
+            value_range="uint8",
         )
-        jpeg = buf.getvalue()
-        with self._frame_cond:
-            self._latest_bev_jpeg = jpeg
-            self._bev_frame_count += 1
-            self._frame_cond.notify_all()
+        _publish_if_open(self._bev_frame_bus, jpeg, stop_event=self._stop_event)
 
     def _wait_for_new_frame(self, last_seen_count: int) -> tuple[bytes, int] | None:
         """Block until a frame newer than ``last_seen_count`` is ready or
         the server is shutting down. Returns ``(jpeg_bytes, frame_count)``
         on success, ``None`` when closing.
         """
-        with self._frame_cond:
-            while self._latest_jpeg is None or self._frame_count <= last_seen_count:
-                if self._stop_event.is_set():
-                    return None
-                self._frame_cond.wait(timeout=1.0)
-            return self._latest_jpeg, self._frame_count
+        return _wait_for_bus_frame(
+            self._frame_bus,
+            last_seen_count=last_seen_count,
+            stop_event=self._stop_event,
+        )
 
     def _wait_for_new_bev_frame(self, last_seen_count: int) -> tuple[bytes, int] | None:
         """Same as :meth:`_wait_for_new_frame` but for the BEV stream.
 
-        Returns ``None`` when the server is closing. Sharing the condition
-        variable means the waiter wakes immediately on every published
-        frame; the loop body then re-checks the BEV-specific counter.
+        Returns ``None`` when the server is closing.
         """
-        with self._frame_cond:
-            while (
-                self._latest_bev_jpeg is None
-                or self._bev_frame_count <= last_seen_count
-            ):
-                if self._stop_event.is_set():
-                    return None
-                self._frame_cond.wait(timeout=1.0)
-            return self._latest_bev_jpeg, self._bev_frame_count
+        return _wait_for_bus_frame(
+            self._bev_frame_bus,
+            last_seen_count=last_seen_count,
+            stop_event=self._stop_event,
+        )
 
     def _apply_control(self, key: str, down: bool) -> None:
         # Direction keys (W/A/S/D + arrows + Space) flow through the
@@ -867,15 +847,7 @@ class MJPEGStreamingPresenter:
                 resolved_variant = (
                     variant if variant in entry_variants else entry_variants[0]
                 )
-                # Wake any handlers waiting on the frame condition so
-                # they observe ``should_close`` flipping and exit their
-                # per-connection loop promptly. Not strictly required
-                # for correctness (the existing 1 s timeout would
-                # eventually retry) but it makes the scene transition
-                # feel snappier.
                 self._pending_scene_change = (Path(entry_path), str(resolved_variant))
-                with self._frame_cond:
-                    self._frame_cond.notify_all()
                 return True
         return False
 
@@ -1070,13 +1042,43 @@ def _as_rgb_host_uint8(frame: object) -> np.ndarray:
     """Materialize a frame to ``(H, W, 3)`` uint8.
 
     World-model frames are lazy GPU handles (``_LazyRGBFrame``) with
-    ``to_numpy()`` but no ``__array_interface__``, so ``Image.fromarray`` can't
-    take them directly. Mirrors the slangpy presenter.
+    ``to_numpy()`` but no ``__array_interface__``, so shared media helpers
+    need an explicit materialization step. Mirrors the slangpy presenter.
     """
     to_numpy = getattr(frame, "to_numpy", None)
     if callable(to_numpy):
         frame = to_numpy()
-    return np.ascontiguousarray(np.asarray(frame, dtype=np.uint8)[..., :3])
+    array = np.asarray(frame)
+    if array.ndim == 3 and array.shape[-1] > 3:
+        array = array[..., :3]
+    return rgb_frame_to_uint8(array, value_range="uint8")
+
+
+def _publish_if_open(
+    bus: LatestFrameBus[bytes], jpeg: bytes, *, stop_event: threading.Event
+) -> None:
+    if stop_event.is_set():
+        return
+    try:
+        bus.publish(jpeg)
+    except RuntimeError:
+        if not stop_event.is_set():
+            raise
+
+
+def _wait_for_bus_frame(
+    bus: LatestFrameBus[bytes],
+    *,
+    last_seen_count: int,
+    stop_event: threading.Event,
+) -> tuple[bytes, int] | None:
+    while not stop_event.is_set():
+        frame = bus.wait_for_frame(last_seen_count=last_seen_count, timeout_s=1.0)
+        if frame is not None:
+            return frame.payload, frame.count
+        if bus.closed:
+            return None
+    return None
 
 
 def _with_status_overlay(rgb_host_uint8: object, message: str | None) -> np.ndarray:

--- a/integrations/omnidreams/tests/interactive_drive/test_keyboard_state.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_keyboard_state.py
@@ -46,6 +46,17 @@ def test_view_mode_reflects_set_view_mode() -> None:
     assert keyboard.view_mode == "hdmap"
 
 
+def test_keyboard_state_uses_shared_key_normalization() -> None:
+    keyboard = KeyboardState()
+    keyboard.set_key("ArrowUp", True)
+    keyboard.set_key("ArrowLeft", True)
+
+    command = keyboard.command()
+
+    assert command.throttle == 1.0
+    assert command.steer == 1.0
+
+
 def test_consume_exit_scene_request_returns_false_when_none_pending() -> None:
     keyboard = KeyboardState()
     assert keyboard.consume_exit_scene_request() is False

--- a/integrations/omnidreams/tests/interactive_drive/test_streaming_presenter_realtime.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_streaming_presenter_realtime.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+from flashdreams.serving.realtime.frame_bus import LatestFrameBus
+from omnidreams.interactive_drive.streaming_presenter import (
+    _as_rgb_host_uint8,
+    _publish_if_open,
+    _wait_for_bus_frame,
+)
+
+
+def test_streaming_presenter_materializes_lazy_rgba_frames() -> None:
+    class LazyFrame:
+        def to_numpy(self) -> np.ndarray:
+            return np.array(
+                [[[1, 2, 3, 255], [4, 5, 6, 255]]],
+                dtype=np.uint8,
+            )
+
+    frame = _as_rgb_host_uint8(LazyFrame())
+
+    assert frame.flags.c_contiguous
+    np.testing.assert_array_equal(
+        frame,
+        np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8),
+    )
+
+
+def test_streaming_presenter_publishes_jpeg_on_latest_frame_bus() -> None:
+    bus = LatestFrameBus[bytes]()
+
+    _publish_if_open(bus, b"jpeg", stop_event=threading.Event())
+
+    latest = bus.latest()
+    assert latest is not None
+    assert latest.payload == b"jpeg"
+    assert latest.count == 1
+
+
+def test_streaming_presenter_frame_wait_returns_none_after_bus_close() -> None:
+    bus = LatestFrameBus[bytes]()
+    bus.publish(b"old")
+    bus.close()
+
+    frame = _wait_for_bus_frame(
+        bus,
+        last_seen_count=1,
+        stop_event=threading.Event(),
+    )
+
+    assert frame is None

--- a/integrations/omnidreams/tests/interactive_drive/test_streaming_presenter_realtime.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_streaming_presenter_realtime.py
@@ -1,18 +1,18 @@
-# SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
 import threading
 
 import numpy as np
-
-from flashdreams.serving.realtime.frame_bus import LatestFrameBus
 from omnidreams.interactive_drive.streaming_presenter import (
     _as_rgb_host_uint8,
     _publish_if_open,
     _wait_for_bus_frame,
 )
+
+from flashdreams.serving.realtime.frame_bus import LatestFrameBus
 
 
 def test_streaming_presenter_materializes_lazy_rgba_frames() -> None:


### PR DESCRIPTION
Add a transport-neutral serving.realtime package for keyboard/input state, latest-frame publishing, tensor/array RGB conversion, and lazy JPEG encoding. Refactor WebRTC controls and media to consume the shared primitives while preserving existing import compatibility and BufferedVideoTrack behavior.

Add CPU tests covering input snapshots, frame-bus shutdown semantics, media conversion parity, and JPEG encoding.