### PR TITLE
Extract shared realtime acceleration helpers

### DIFF
--- a/flashdreams/flashdreams/infra/acceleration/__init__.py
+++ b/flashdreams/flashdreams/infra/acceleration/__init__.py
@@ -7,8 +7,26 @@ from flashdreams.infra.acceleration.cuda_graph_dispatch import (
     CUDAGraphDispatch,
     cuda_graph_capture_ar_index,
 )
+from flashdreams.infra.acceleration.prewarm import (
+    PrewarmDeadline,
+    PrewarmSequenceTiming,
+    PrewarmTimeoutError,
+    PrewarmTiming,
+    cuda_graph_prewarm_steps,
+    is_warmup_index,
+    run_prewarm_sequence,
+    run_timed_prewarm,
+)
 
 __all__ = [
     "CUDAGraphDispatch",
+    "PrewarmDeadline",
+    "PrewarmSequenceTiming",
+    "PrewarmTimeoutError",
+    "PrewarmTiming",
     "cuda_graph_capture_ar_index",
+    "cuda_graph_prewarm_steps",
+    "is_warmup_index",
+    "run_prewarm_sequence",
+    "run_timed_prewarm",
 ]

--- a/flashdreams/flashdreams/infra/acceleration/__init__.py
+++ b/flashdreams/flashdreams/infra/acceleration/__init__.py
@@ -2,3 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Optional acceleration policy helpers."""
+
+from flashdreams.infra.acceleration.cuda_graph_dispatch import (
+    CUDAGraphDispatch,
+    cuda_graph_capture_ar_index,
+)
+
+__all__ = [
+    "CUDAGraphDispatch",
+    "cuda_graph_capture_ar_index",
+]

--- a/flashdreams/flashdreams/infra/acceleration/__init__.py
+++ b/flashdreams/flashdreams/infra/acceleration/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional acceleration policy helpers."""

--- a/flashdreams/flashdreams/infra/acceleration/__init__.py
+++ b/flashdreams/flashdreams/infra/acceleration/__init__.py
@@ -7,6 +7,11 @@ from flashdreams.infra.acceleration.cuda_graph_dispatch import (
     CUDAGraphDispatch,
     cuda_graph_capture_ar_index,
 )
+from flashdreams.infra.acceleration.overlap import (
+    CudaStreamOverlap,
+    HostThreadOverlap,
+    SynchronousOverlap,
+)
 from flashdreams.infra.acceleration.prewarm import (
     PrewarmDeadline,
     PrewarmSequenceTiming,
@@ -20,10 +25,13 @@ from flashdreams.infra.acceleration.prewarm import (
 
 __all__ = [
     "CUDAGraphDispatch",
+    "CudaStreamOverlap",
+    "HostThreadOverlap",
     "PrewarmDeadline",
     "PrewarmSequenceTiming",
     "PrewarmTimeoutError",
     "PrewarmTiming",
+    "SynchronousOverlap",
     "cuda_graph_capture_ar_index",
     "cuda_graph_prewarm_steps",
     "is_warmup_index",

--- a/flashdreams/flashdreams/infra/acceleration/__init__.py
+++ b/flashdreams/flashdreams/infra/acceleration/__init__.py
@@ -7,6 +7,14 @@ from flashdreams.infra.acceleration.cuda_graph_dispatch import (
     CUDAGraphDispatch,
     cuda_graph_capture_ar_index,
 )
+from flashdreams.infra.acceleration.encoder_lifecycle import (
+    collect_and_release_cuda_memory,
+    ensure_one_shot_encoder,
+    move_tensors_to_cpu,
+    release_one_shot_encoder_references,
+    run_one_shot_encoder_stage,
+    setup_one_shot_encoder,
+)
 from flashdreams.infra.acceleration.overlap import (
     CudaStreamOverlap,
     HostThreadOverlap,
@@ -32,9 +40,15 @@ __all__ = [
     "PrewarmTimeoutError",
     "PrewarmTiming",
     "SynchronousOverlap",
+    "collect_and_release_cuda_memory",
     "cuda_graph_capture_ar_index",
     "cuda_graph_prewarm_steps",
+    "ensure_one_shot_encoder",
     "is_warmup_index",
+    "move_tensors_to_cpu",
+    "release_one_shot_encoder_references",
     "run_prewarm_sequence",
+    "run_one_shot_encoder_stage",
     "run_timed_prewarm",
+    "setup_one_shot_encoder",
 ]

--- a/flashdreams/flashdreams/infra/acceleration/__init__.py
+++ b/flashdreams/flashdreams/infra/acceleration/__init__.py
@@ -15,6 +15,11 @@ from flashdreams.infra.acceleration.encoder_lifecycle import (
     run_one_shot_encoder_stage,
     setup_one_shot_encoder,
 )
+from flashdreams.infra.acceleration.frame_prefetch import (
+    CudaHostPrefetch,
+    LazyCudaFrame,
+    prefetch_to_numpy,
+)
 from flashdreams.infra.acceleration.overlap import (
     CudaStreamOverlap,
     HostThreadOverlap,
@@ -33,8 +38,10 @@ from flashdreams.infra.acceleration.prewarm import (
 
 __all__ = [
     "CUDAGraphDispatch",
+    "CudaHostPrefetch",
     "CudaStreamOverlap",
     "HostThreadOverlap",
+    "LazyCudaFrame",
     "PrewarmDeadline",
     "PrewarmSequenceTiming",
     "PrewarmTimeoutError",
@@ -46,6 +53,7 @@ __all__ = [
     "ensure_one_shot_encoder",
     "is_warmup_index",
     "move_tensors_to_cpu",
+    "prefetch_to_numpy",
     "release_one_shot_encoder_references",
     "run_prewarm_sequence",
     "run_one_shot_encoder_stage",

--- a/flashdreams/flashdreams/infra/acceleration/cuda_graph_dispatch.py
+++ b/flashdreams/flashdreams/infra/acceleration/cuda_graph_dispatch.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA-graph dispatch policy helpers for autoregressive inference."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+CUDAGraphWrapper: Any | None = None
+
+
+def _cuda_graph_wrapper_cls() -> Any:
+    global CUDAGraphWrapper
+    if CUDAGraphWrapper is None:
+        from flashdreams.infra.cuda_graph import CUDAGraphWrapper as wrapper_cls
+
+        CUDAGraphWrapper = wrapper_cls
+    return CUDAGraphWrapper
+
+
+def cuda_graph_capture_ar_index(
+    *,
+    sink_size_t: int,
+    window_size_t: int,
+    len_t: int,
+    size_name: str = "sink_size_t + window_size_t",
+    len_name: str = "len_t",
+) -> int:
+    """Return the first AR index whose KV cache is in steady state."""
+    chunks_total = sink_size_t + window_size_t
+    assert len_t > 0, f"{len_name} ({len_t}) must be positive."
+    assert chunks_total % len_t == 0, (
+        f"{size_name} ({chunks_total}) must be divisible by {len_name} "
+        f"({len_t}) so the KV cache can fit a whole number of AR chunks."
+    )
+    return chunks_total // len_t
+
+
+class CUDAGraphDispatch:
+    """Dispatch filling AR steps eagerly and steady AR steps through CUDA graphs.
+
+    The dispatch owns one wrapper for the conditional branch and one for the
+    CFG-unconditional branch. Both wrappers call the same underlying function,
+    but they must not share static buffers because the branch caches diverge.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        *,
+        enabled: bool,
+        capture_ar_idx: int,
+        warmup_iters: int,
+        build: bool = True,
+    ) -> None:
+        self.fn = fn
+        self.enabled = enabled
+        self.capture_ar_idx = capture_ar_idx
+        self.warmup_iters = warmup_iters
+        self._cond_call: Any | None = None
+        self._uncond_call: Any | None = None
+        if enabled and build:
+            self.rebuild()
+
+    @property
+    def cond_call(self) -> Any | None:
+        return self._cond_call
+
+    @property
+    def uncond_call(self) -> Any | None:
+        return self._uncond_call
+
+    def rebuild(self, *, capture_ar_idx: int | None = None) -> None:
+        """Build fresh wrappers, optionally updating the steady-state threshold."""
+        if capture_ar_idx is not None:
+            self.capture_ar_idx = capture_ar_idx
+        if not self.enabled:
+            self._cond_call = None
+            self._uncond_call = None
+            return
+        wrapper_cls = _cuda_graph_wrapper_cls()
+        self._cond_call = wrapper_cls(self.fn, warmup_iters=self.warmup_iters)
+        self._uncond_call = wrapper_cls(self.fn, warmup_iters=self.warmup_iters)
+
+    def disable(self, *, fn: Callable[..., Any] | None = None) -> None:
+        """Disable graph dispatch and drop wrapper references."""
+        if fn is not None:
+            self.fn = fn
+        self.enabled = False
+        self._cond_call = None
+        self._uncond_call = None
+
+    def reset(self) -> None:
+        """Reset captured graphs and staged buffers for a fresh cache."""
+        if not self.enabled:
+            return
+        if self._cond_call is None or self._uncond_call is None:
+            self.rebuild()
+            return
+        self._cond_call.reset()
+        self._uncond_call.reset()
+
+    def select(
+        self,
+        autoregressive_index: int,
+        *,
+        uncond: bool,
+    ) -> Callable[..., Any]:
+        """Return eager ``fn``, wrapper ``drain``, or wrapper replay callable."""
+        if not self.enabled:
+            return self.fn
+        wrapper = self._uncond_call if uncond else self._cond_call
+        if wrapper is None:
+            raise RuntimeError(
+                "CUDA graph dispatch was selected before wrappers were built."
+            )
+        if autoregressive_index < self.capture_ar_idx:
+            return wrapper.drain
+        return wrapper

--- a/flashdreams/flashdreams/infra/acceleration/encoder_lifecycle.py
+++ b/flashdreams/flashdreams/infra/acceleration/encoder_lifecycle.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle helpers for one-shot encoders used during cache initialization."""
+
+from __future__ import annotations
+
+import gc
+import importlib
+from collections.abc import Callable
+from contextlib import nullcontext
+from typing import Any
+
+
+def setup_one_shot_encoder(
+    config: Any,
+    *,
+    device: Any | Callable[[], Any] | None = None,
+    torch_module: Any | None = None,
+) -> Any:
+    """Instantiate an encoder config and move torch modules to ``device``."""
+    encoder = config.setup()
+    if device is None:
+        return encoder
+
+    torch = torch_module if torch_module is not None else _maybe_import_torch()
+    module_cls = getattr(getattr(torch, "nn", None), "Module", None)
+    if module_cls is not None and isinstance(encoder, module_cls):
+        resolved_device = device() if callable(device) else device
+        encoder = encoder.to(device=resolved_device)
+    return encoder
+
+
+def ensure_one_shot_encoder(
+    encoder: Any | None,
+    config: Any | None,
+    *,
+    device: Any | Callable[[], Any] | None = None,
+    name: str = "encoder",
+    required: bool = True,
+    torch_module: Any | None = None,
+) -> Any | None:
+    """Return ``encoder`` if loaded, otherwise instantiate it from ``config``."""
+    if encoder is not None:
+        return encoder
+    if config is None:
+        if required:
+            raise RuntimeError(
+                f"{name} is not loaded and no config is available to reload it."
+            )
+        return None
+    return setup_one_shot_encoder(
+        config,
+        device=device,
+        torch_module=torch_module,
+    )
+
+
+def release_one_shot_encoder_references(
+    owner: Any,
+    *attrs: str,
+    device: Any | None = None,
+    synchronize_cuda: bool = False,
+    empty_cuda_cache: bool = True,
+    torch_module: Any | None = None,
+) -> tuple[str, ...]:
+    """Set encoder attributes to ``None`` and release reclaimed CUDA memory.
+
+    Returns the names that previously held non-``None`` values. Attributes are
+    set to ``None`` even when they were already empty so later access sees a
+    useful unloaded state instead of a missing attribute.
+    """
+    released: list[str] = []
+    for attr in attrs:
+        if getattr(owner, attr, None) is not None:
+            released.append(attr)
+        setattr(owner, attr, None)
+
+    collect_and_release_cuda_memory(
+        device=device,
+        synchronize_cuda=synchronize_cuda,
+        empty_cuda_cache=empty_cuda_cache,
+        torch_module=torch_module,
+    )
+    return tuple(released)
+
+
+def collect_and_release_cuda_memory(
+    *,
+    device: Any | None = None,
+    synchronize_cuda: bool = False,
+    empty_cuda_cache: bool = True,
+    torch_module: Any | None = None,
+) -> None:
+    """Run GC and optionally return freed CUDA blocks to the caching allocator."""
+    gc.collect()
+    if not empty_cuda_cache and not synchronize_cuda:
+        return
+
+    torch = torch_module if torch_module is not None else _maybe_import_torch()
+    cuda = getattr(torch, "cuda", None)
+    is_available = getattr(cuda, "is_available", None)
+    if cuda is None or not callable(is_available) or not is_available():
+        return
+
+    if synchronize_cuda:
+        synchronize = getattr(cuda, "synchronize", None)
+        if callable(synchronize):
+            if device is None:
+                synchronize()
+            else:
+                synchronize(device=device)
+    if empty_cuda_cache:
+        empty_cache = getattr(cuda, "empty_cache", None)
+        if callable(empty_cache):
+            empty_cache()
+
+
+def move_tensors_to_cpu(value: Any, *, torch_module: Any | None = None) -> Any:
+    """Recursively move torch tensors in ``value`` to CPU."""
+    torch = torch_module if torch_module is not None else _maybe_import_torch()
+    is_tensor = getattr(torch, "is_tensor", None)
+    if callable(is_tensor) and is_tensor(value):
+        return value.cpu()
+    if isinstance(value, dict):
+        return {
+            key: move_tensors_to_cpu(item, torch_module=torch)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [move_tensors_to_cpu(item, torch_module=torch) for item in value]
+    if isinstance(value, tuple):
+        return tuple(move_tensors_to_cpu(item, torch_module=torch) for item in value)
+    return value
+
+
+def run_one_shot_encoder_stage(
+    stage: Callable[[], Any],
+    *,
+    release: Callable[[], Any] | None = None,
+    cpu_result: bool = True,
+    torch_module: Any | None = None,
+) -> Any:
+    """Run an encoder-only stage under ``no_grad`` and release encoders after it."""
+    torch = torch_module if torch_module is not None else _maybe_import_torch()
+    no_grad = getattr(torch, "no_grad", None)
+    context = no_grad() if callable(no_grad) else nullcontext()
+    try:
+        with context:
+            result = stage()
+        if cpu_result:
+            result = move_tensors_to_cpu(result, torch_module=torch)
+        return result
+    finally:
+        if release is not None:
+            release_result = release()
+            del release_result
+
+
+def _maybe_import_torch() -> Any | None:
+    try:
+        return importlib.import_module("torch")
+    except ImportError:
+        return None

--- a/flashdreams/flashdreams/infra/acceleration/frame_prefetch.py
+++ b/flashdreams/flashdreams/infra/acceleration/frame_prefetch.py
@@ -113,8 +113,9 @@ class LazyCudaFrame:
     def to_numpy(self) -> np.ndarray:
         if self._host is None:
             if self._prefetch is not None:
-                self._host = self._prefetch.to_numpy()
+                prefetch = self._prefetch
                 self._prefetch = None
+                self._host = prefetch.to_numpy()
                 self._frames_hwc_uint8 = None
                 return self._host
             if self._frames_hwc_uint8 is None:
@@ -145,8 +146,13 @@ class LazyCudaFrame:
     ) -> np.ndarray:
         array = self.to_numpy()
         if dtype is not None:
+            target_dtype = np.dtype(dtype)
+            if copy is False and target_dtype != array.dtype:
+                raise ValueError(
+                    "Unable to avoid copy while creating an array as requested."
+                )
             array = array.astype(dtype, copy=False)
-        if copy:
+        if copy is True:
             return np.array(array, copy=True)
         return array
 

--- a/flashdreams/flashdreams/infra/acceleration/frame_prefetch.py
+++ b/flashdreams/flashdreams/infra/acceleration/frame_prefetch.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA-to-host frame prefetch helpers for realtime presentation paths."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+_STREAMS_LOCK = threading.Lock()
+_HOST_COPY_STREAMS: dict[int, Any] = {}
+
+
+class CudaHostPrefetch:
+    """Asynchronously stage one CUDA uint8 RGB frame into pinned host memory."""
+
+    def __init__(self, tensor: Any, *, source_event: Any | None = None) -> None:
+        self._tensor = tensor
+        self._source_event = source_event
+        self._host_tensor: Any | None = None
+        self._done_event: Any | None = None
+        self._started = False
+
+    def start(self) -> bool:
+        if self._started:
+            return self._host_tensor is not None
+        self._started = True
+
+        try:
+            import torch
+        except ImportError:
+            return False
+
+        tensor = self._tensor
+        if not torch.is_tensor(tensor) or not tensor.is_cuda:
+            return False
+
+        try:
+            host_tensor = torch.empty(
+                tuple(tensor.shape),
+                dtype=tensor.dtype,
+                device="cpu",
+                pin_memory=True,
+            )
+            copy_stream = _host_copy_stream(torch, tensor.device)
+            with torch.cuda.device(tensor.device):
+                if self._source_event is not None:
+                    copy_stream.wait_event(self._source_event)
+                with torch.cuda.stream(copy_stream):
+                    host_tensor.copy_(tensor, non_blocking=True)
+                    tensor.record_stream(copy_stream)
+                    done_event = torch.cuda.Event()
+                    done_event.record(copy_stream)
+        except Exception:
+            self._host_tensor = None
+            self._done_event = None
+            return False
+
+        self._host_tensor = host_tensor
+        self._done_event = done_event
+        return True
+
+    def to_numpy(self) -> np.ndarray:
+        host_tensor = self._host_tensor
+        if host_tensor is None:
+            raise RuntimeError("CUDA host prefetch was not started.")
+        done_event = self._done_event
+        if done_event is not None:
+            done_event.synchronize()
+        return np.ascontiguousarray(host_tensor.numpy(), dtype=np.uint8)
+
+
+class LazyCudaFrame:
+    """Expose one frame as CUDA first, with optional async host prefetch."""
+
+    def __init__(
+        self,
+        frames_hwc_uint8: Any,
+        frame_index: int,
+        *,
+        source_event: object | None = None,
+        lost_source_message: str = "Lazy CUDA frame lost its source tensor before materialization.",
+        already_materialized_message: str = "Lazy CUDA frame was already materialized on the host.",
+        synchronize_source_event_on_host_copy: bool = False,
+    ) -> None:
+        self._frames_hwc_uint8: Any | None = frames_hwc_uint8
+        self._frame_index = int(frame_index)
+        self._source_event = source_event
+        self._host: np.ndarray | None = None
+        self._prefetch: CudaHostPrefetch | None = None
+        self._lost_source_message = lost_source_message
+        self._already_materialized_message = already_materialized_message
+        self._synchronize_source_event_on_host_copy = (
+            synchronize_source_event_on_host_copy
+        )
+
+    def prefetch_to_numpy(self) -> None:
+        if (
+            self._host is not None
+            or self._prefetch is not None
+            or self._frames_hwc_uint8 is None
+        ):
+            return
+        frame = self._frames_hwc_uint8[self._frame_index].detach()
+        prefetch = CudaHostPrefetch(frame, source_event=self._source_event)
+        if prefetch.start():
+            self._prefetch = prefetch
+
+    def to_numpy(self) -> np.ndarray:
+        if self._host is None:
+            if self._prefetch is not None:
+                self._host = self._prefetch.to_numpy()
+                self._prefetch = None
+                self._frames_hwc_uint8 = None
+                return self._host
+            if self._frames_hwc_uint8 is None:
+                raise RuntimeError(self._lost_source_message)
+            if self._synchronize_source_event_on_host_copy:
+                synchronize = getattr(self._source_event, "synchronize", None)
+                if callable(synchronize):
+                    synchronize()
+            frame = self._frames_hwc_uint8[self._frame_index].detach().cpu().numpy()
+            self._host = np.ascontiguousarray(frame, dtype=np.uint8)
+            self._frames_hwc_uint8 = None
+        return self._host
+
+    def to_cuda_tensor(self) -> Any:
+        if self._frames_hwc_uint8 is None:
+            raise RuntimeError(self._already_materialized_message)
+        return self._frames_hwc_uint8[self._frame_index]
+
+    def to_cuda_event(self) -> object | None:
+        if self._frames_hwc_uint8 is None:
+            return None
+        return self._source_event
+
+    def __array__(
+        self,
+        dtype: npt.DTypeLike | None = None,
+        copy: bool | None = None,
+    ) -> np.ndarray:
+        array = self.to_numpy()
+        if dtype is not None:
+            array = array.astype(dtype, copy=False)
+        if copy:
+            return np.array(array, copy=True)
+        return array
+
+
+def prefetch_to_numpy(frame: object) -> None:
+    """Start host materialization for frame-like objects that support it."""
+    prefetch = getattr(frame, "prefetch_to_numpy", None)
+    if callable(prefetch):
+        prefetch()
+
+
+def _host_copy_stream(torch: Any, device: Any) -> Any:
+    key = _device_index(device)
+    with _STREAMS_LOCK:
+        stream = _HOST_COPY_STREAMS.get(key)
+        if stream is None:
+            with torch.cuda.device(device):
+                stream = torch.cuda.Stream(device=device)
+            _HOST_COPY_STREAMS[key] = stream
+        return stream
+
+
+def _device_index(device: Any) -> int:
+    index = getattr(device, "index", None)
+    return 0 if index is None else int(index)

--- a/flashdreams/flashdreams/infra/acceleration/overlap.py
+++ b/flashdreams/flashdreams/infra/acceleration/overlap.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small overlap runners for deferring realtime post-work."""
+
+from __future__ import annotations
+
+import importlib
+import threading
+import time
+from collections.abc import Callable
+from contextlib import nullcontext
+from typing import Any
+
+
+class SynchronousOverlap:
+    """Run submitted work immediately while exposing the overlap-runner API."""
+
+    def __init__(self, *, name: str = "sync-overlap") -> None:
+        self.name = name
+        self._error: BaseException | None = None
+
+    @property
+    def pending(self) -> bool:
+        return False
+
+    @property
+    def last_error(self) -> BaseException | None:
+        return self._error
+
+    def wait(
+        self, *, timeout_s: float | None = None, raise_error: bool = False
+    ) -> bool:
+        del timeout_s
+        if raise_error:
+            self._raise_if_failed()
+        return True
+
+    def submit(self, work: Callable[[], Any], *, name: str | None = None) -> None:
+        del name
+        self._error = None
+        try:
+            result = work()
+            del result
+        except BaseException as exc:
+            self._error = exc
+            raise
+
+    def close(self, *, wait: bool = True) -> None:
+        del wait
+
+    def _raise_if_failed(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+
+class HostThreadOverlap:
+    """Run one overlapped task at a time on a daemon host thread."""
+
+    def __init__(
+        self,
+        *,
+        name: str = "host-overlap",
+        daemon: bool = True,
+        reraise_worker_errors: bool = True,
+    ) -> None:
+        self.name = name
+        self._daemon = daemon
+        self._reraise_worker_errors = reraise_worker_errors
+        self._done = threading.Event()
+        self._done.set()
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._error: BaseException | None = None
+
+    @property
+    def pending(self) -> bool:
+        return not self._done.is_set()
+
+    @property
+    def last_error(self) -> BaseException | None:
+        return self._error
+
+    def wait(
+        self, *, timeout_s: float | None = None, raise_error: bool = False
+    ) -> bool:
+        completed = self._done.wait(timeout=timeout_s)
+        if completed and raise_error:
+            self._raise_if_failed()
+        return completed
+
+    def submit(self, work: Callable[[], Any], *, name: str | None = None) -> None:
+        with self._lock:
+            if not self._done.is_set():
+                raise RuntimeError(f"{self.name} already has pending overlap work.")
+            self._error = None
+            self._done.clear()
+            thread = threading.Thread(
+                target=self._run,
+                args=(work,),
+                name=name or self.name,
+                daemon=self._daemon,
+            )
+            self._thread = thread
+            thread.start()
+
+    def close(self, *, wait: bool = True) -> None:
+        thread = self._thread
+        if wait and thread is not None:
+            thread.join()
+
+    def _run(self, work: Callable[[], Any]) -> None:
+        try:
+            result = work()
+            del result
+        except BaseException as exc:
+            self._error = exc
+            if self._reraise_worker_errors:
+                raise
+        finally:
+            self._done.set()
+
+    def _raise_if_failed(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+
+class CudaStreamOverlap:
+    """Run CUDA-enqueued work on a side stream and wait on its completion event."""
+
+    def __init__(
+        self,
+        *,
+        name: str = "cuda-stream-overlap",
+        device: Any | None = None,
+        torch_module: Any | None = None,
+    ) -> None:
+        self.name = name
+        self._torch = torch_module if torch_module is not None else _import_torch()
+        if not self._torch.cuda.is_available():
+            raise RuntimeError("CUDA stream overlap requires torch.cuda availability.")
+        self._device = self._torch.device(device) if device is not None else None
+        self._stream = self._torch.cuda.Stream(device=self._device)
+        self._event: Any | None = None
+        self._error: BaseException | None = None
+
+    @property
+    def pending(self) -> bool:
+        return self._event is not None and not self._event.query()
+
+    @property
+    def last_error(self) -> BaseException | None:
+        return self._error
+
+    def wait(
+        self, *, timeout_s: float | None = None, raise_error: bool = False
+    ) -> bool:
+        event = self._event
+        if event is None:
+            if raise_error:
+                self._raise_if_failed()
+            return True
+
+        if timeout_s is None:
+            event.synchronize()
+            completed = True
+        else:
+            completed = _wait_for_cuda_event(event, timeout_s=timeout_s)
+
+        if completed and raise_error:
+            self._raise_if_failed()
+        return completed
+
+    def submit(self, work: Callable[[], Any], *, name: str | None = None) -> None:
+        del name
+        if not self.wait(timeout_s=0.0):
+            raise RuntimeError(f"{self.name} already has pending overlap work.")
+        self._error = None
+        try:
+            with _cuda_device_context(self._torch, self._device):
+                with self._torch.cuda.stream(self._stream):
+                    result = work()
+                    del result
+                    event = self._torch.cuda.Event()
+                    event.record(self._stream)
+        except BaseException as exc:
+            self._error = exc
+            raise
+        self._event = event
+
+    def close(self, *, wait: bool = True) -> None:
+        if wait:
+            self.wait()
+
+    def _raise_if_failed(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+
+def _import_torch() -> Any:
+    return importlib.import_module("torch")
+
+
+def _cuda_device_context(torch_module: Any, device: Any | None) -> Any:
+    if device is None:
+        return nullcontext()
+    return torch_module.cuda.device(device)
+
+
+def _wait_for_cuda_event(event: Any, *, timeout_s: float) -> bool:
+    if timeout_s < 0.0:
+        raise ValueError(f"timeout_s must be non-negative, got {timeout_s}.")
+    deadline = time.monotonic() + timeout_s
+    while not event.query():
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.001)
+    return True

--- a/flashdreams/flashdreams/infra/acceleration/prewarm.py
+++ b/flashdreams/flashdreams/infra/acceleration/prewarm.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model/compile prewarm helpers for realtime inference paths."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+class PrewarmTimeoutError(TimeoutError):
+    """Raised when a synchronous prewarm step exceeds its configured deadline."""
+
+    def __init__(self, label: str, *, timeout_s: float, elapsed_s: float) -> None:
+        self.label = label
+        self.timeout_s = timeout_s
+        self.elapsed_s = elapsed_s
+        super().__init__(
+            f"Prewarm step '{label}' exceeded timeout_s={timeout_s:.3f} "
+            f"(elapsed_s={elapsed_s:.3f})."
+        )
+
+
+@dataclass(frozen=True)
+class PrewarmTiming:
+    """Wall-clock timing for one prewarm step."""
+
+    label: str
+    start_time: float
+    end_time: float
+
+    @property
+    def elapsed_s(self) -> float:
+        return self.end_time - self.start_time
+
+    @property
+    def elapsed_ms(self) -> float:
+        return self.elapsed_s * 1000.0
+
+
+@dataclass(frozen=True)
+class PrewarmSequenceTiming:
+    """Wall-clock timings for a cold-start step followed by steady steps."""
+
+    label: str
+    cold_start: PrewarmTiming | None
+    steady_state: tuple[PrewarmTiming, ...]
+
+    @property
+    def steps(self) -> tuple[PrewarmTiming, ...]:
+        if self.cold_start is None:
+            return self.steady_state
+        return (self.cold_start, *self.steady_state)
+
+    @property
+    def elapsed_s(self) -> float:
+        steps = self.steps
+        if not steps:
+            return 0.0
+        return steps[-1].end_time - steps[0].start_time
+
+    @property
+    def elapsed_ms(self) -> float:
+        return self.elapsed_s * 1000.0
+
+
+@dataclass(frozen=True)
+class PrewarmDeadline:
+    """Shared deadline for a multi-step prewarm sequence.
+
+    Synchronous prewarm callbacks cannot be interrupted safely, so deadlines are
+    checked before and after each callback.
+    """
+
+    label: str
+    start_time: float
+    timeout_s: float | None = None
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        label: str = "prewarm",
+        timeout_s: float | None = None,
+        time_fn: Callable[[], float] = time.perf_counter,
+    ) -> "PrewarmDeadline":
+        _validate_timeout(timeout_s)
+        return cls(label=label, start_time=time_fn(), timeout_s=timeout_s)
+
+    def elapsed_s(
+        self,
+        *,
+        now: float | None = None,
+        time_fn: Callable[[], float] = time.perf_counter,
+    ) -> float:
+        if now is None:
+            now = time_fn()
+        return now - self.start_time
+
+    def remaining_s(
+        self,
+        *,
+        now: float | None = None,
+        time_fn: Callable[[], float] = time.perf_counter,
+    ) -> float | None:
+        if self.timeout_s is None:
+            return None
+        return max(0.0, self.timeout_s - self.elapsed_s(now=now, time_fn=time_fn))
+
+    def raise_if_expired(
+        self,
+        *,
+        now: float | None = None,
+        time_fn: Callable[[], float] = time.perf_counter,
+    ) -> None:
+        if self.timeout_s is None:
+            return
+        elapsed_s = self.elapsed_s(now=now, time_fn=time_fn)
+        if elapsed_s > self.timeout_s:
+            raise PrewarmTimeoutError(
+                self.label,
+                timeout_s=self.timeout_s,
+                elapsed_s=elapsed_s,
+            )
+
+
+def run_timed_prewarm(
+    step: Callable[[], Any],
+    *,
+    label: str = "prewarm",
+    timeout_s: float | None = None,
+    time_fn: Callable[[], float] = time.perf_counter,
+) -> PrewarmTiming:
+    """Run one synchronous prewarm step and return its wall-clock timing."""
+    _validate_timeout(timeout_s)
+    start_time = time_fn()
+    result = step()
+    del result
+    end_time = time_fn()
+    timing = PrewarmTiming(label=label, start_time=start_time, end_time=end_time)
+    _raise_if_timeout_expired(label, timeout_s, timing.elapsed_s)
+    return timing
+
+
+def run_prewarm_sequence(
+    *,
+    steady_state: Callable[[], Any],
+    steady_steps: int,
+    cold_start: Callable[[], Any] | None = None,
+    label: str = "prewarm",
+    timeout_s: float | None = None,
+    time_fn: Callable[[], float] = time.perf_counter,
+) -> PrewarmSequenceTiming:
+    """Run cold-start and steady-state prewarm callbacks under one deadline."""
+    if steady_steps < 0:
+        raise ValueError(f"steady_steps must be non-negative, got {steady_steps}.")
+
+    deadline = PrewarmDeadline.start(
+        label=label,
+        timeout_s=timeout_s,
+        time_fn=time_fn,
+    )
+    cold_timing = None
+    if cold_start is not None:
+        cold_timing = _run_deadlined_step(
+            cold_start,
+            label=f"{label}.cold_start",
+            deadline=deadline,
+            time_fn=time_fn,
+        )
+
+    steady_timings = tuple(
+        _run_deadlined_step(
+            steady_state,
+            label=f"{label}.steady_state.{step_index}",
+            deadline=deadline,
+            time_fn=time_fn,
+        )
+        for step_index in range(steady_steps)
+    )
+    return PrewarmSequenceTiming(
+        label=label,
+        cold_start=cold_timing,
+        steady_state=steady_timings,
+    )
+
+
+def cuda_graph_prewarm_steps(
+    *,
+    warmup_iters: int,
+    capture_steps: int = 1,
+    replay_steps: int = 1,
+) -> int:
+    """Return steady-state calls needed after cache saturation for graph replay."""
+    _validate_non_negative("warmup_iters", warmup_iters)
+    _validate_non_negative("capture_steps", capture_steps)
+    _validate_non_negative("replay_steps", replay_steps)
+    return warmup_iters + capture_steps + replay_steps
+
+
+def is_warmup_index(index: int, *, warmup_count: int = 1) -> bool:
+    """Return whether ``index`` belongs to an excluded warmup prefix."""
+    _validate_non_negative("index", index)
+    _validate_non_negative("warmup_count", warmup_count)
+    return index < warmup_count
+
+
+def _run_deadlined_step(
+    step: Callable[[], Any],
+    *,
+    label: str,
+    deadline: PrewarmDeadline,
+    time_fn: Callable[[], float],
+) -> PrewarmTiming:
+    deadline.raise_if_expired(time_fn=time_fn)
+    start_time = time_fn()
+    result = step()
+    del result
+    end_time = time_fn()
+    deadline.raise_if_expired(now=end_time, time_fn=time_fn)
+    return PrewarmTiming(label=label, start_time=start_time, end_time=end_time)
+
+
+def _raise_if_timeout_expired(
+    label: str,
+    timeout_s: float | None,
+    elapsed_s: float,
+) -> None:
+    if timeout_s is not None and elapsed_s > timeout_s:
+        raise PrewarmTimeoutError(label, timeout_s=timeout_s, elapsed_s=elapsed_s)
+
+
+def _validate_timeout(timeout_s: float | None) -> None:
+    if timeout_s is None:
+        return
+    if timeout_s < 0.0:
+        raise ValueError(f"timeout_s must be non-negative, got {timeout_s}.")
+
+
+def _validate_non_negative(name: str, value: int) -> None:
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative, got {value}.")

--- a/flashdreams/flashdreams/recipes/cosmos/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/cosmos/transformer/__init__.py
@@ -29,8 +29,11 @@ from flashdreams.core.attention.rope import (
     RotaryPositionEmbedding3D,
 )
 from flashdreams.core.checkpoint.load import load_checkpoint
+from flashdreams.infra.acceleration.cuda_graph_dispatch import (
+    CUDAGraphDispatch,
+    cuda_graph_capture_ar_index,
+)
 from flashdreams.infra.compile import compile_module
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
@@ -214,31 +217,25 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         if config.compile_network:
             self.network = compile_module(self.network)
 
-        # Per-rollout dispatch when use_cuda_graph=True:
-        # filling phase -> wrapper.drain (eager, drains Inductor autotune);
-        # steady-state -> wrapper.__call__ (warmup + capture + replay).
-        # First AR step that runs on the KV cache's steady-state code
-        # path. The cache fills at AR step ``chunks_total // len_t - 1``;
-        # the *next* step is the first one whose ``before_update`` sees
-        # ``is_steady_state() == True`` and whose forward takes the steady
-        # branches.
+        # Cond and CFG-uncond branches each get their own CUDA-graph wrapper
+        # since each mutates an independent rolling KV cache.
         self._use_cuda_graph = config.use_cuda_graph
-        chunks_total = config.sink_size_t + config.window_size_t
-        assert chunks_total % config.len_t == 0, (
-            f"sink_size_t + window_size_t ({chunks_total}) must be "
-            f"divisible by len_t ({config.len_t}) so the BlockKVCache can "
-            f"fit a whole number of AR chunks."
+        self._cuda_graph_capture_ar_idx = cuda_graph_capture_ar_index(
+            sink_size_t=config.sink_size_t,
+            window_size_t=config.window_size_t,
+            len_t=config.len_t,
         )
-        self._cuda_graph_capture_ar_idx: int = chunks_total // config.len_t
-        self._network_call: CUDAGraphWrapper | CosmosDiTNetwork = (
-            CUDAGraphWrapper(self.network, warmup_iters=config.cuda_graph_warmup_iters)
-            if config.use_cuda_graph
-            else self.network
+        self._cuda_graph_dispatch = CUDAGraphDispatch(
+            self.network,
+            enabled=config.use_cuda_graph,
+            capture_ar_idx=self._cuda_graph_capture_ar_idx,
+            warmup_iters=config.cuda_graph_warmup_iters,
         )
-        self._network_call_uncond: CUDAGraphWrapper | CosmosDiTNetwork = (
-            CUDAGraphWrapper(self.network, warmup_iters=config.cuda_graph_warmup_iters)
-            if config.use_cuda_graph
-            else self.network
+        # Compatibility aliases for diagnostic hooks that predate the shared
+        # dispatch helper.
+        self._network_call = self._cuda_graph_dispatch.cond_call or self.network
+        self._network_call_uncond = (
+            self._cuda_graph_dispatch.uncond_call or self.network
         )
 
     @property
@@ -389,13 +386,8 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         mask_first_patched = self.patchify_and_maybe_split_cp(mask_first_block)
         mask_other_patched = self.patchify_and_maybe_split_cp(mask_other_blocks)
 
-        # Reset any prior CUDA graph: it refers to slot pointers from the
-        # previous cache, which the new cache invalidates.
         if self._use_cuda_graph:
-            assert isinstance(self._network_call, CUDAGraphWrapper)
-            self._network_call.reset()
-            assert isinstance(self._network_call_uncond, CUDAGraphWrapper)
-            self._network_call_uncond.reset()
+            self._cuda_graph_dispatch.reset()
 
         return CosmosTransformerCache(
             network_cache=network_cache,
@@ -423,19 +415,11 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         return cache.mask_first_block
 
     def _select_network(self, autoregressive_index: int, *, uncond: bool) -> Any:
-        # Filling phase: eager ``.drain`` (drains Inductor autotune and
-        # exercises the KV cache's slice-returning filling path).
-        # Steady phase: ``wrapper.__call__`` (warmup + capture + replay).
-        # Cond and CFG-uncond branches both mutate their rolling KV cache,
-        # so neither branch can be graph-captured until the cache is steady.
         if not self._use_cuda_graph:
             return self.network
-        network_call = self._network_call_uncond if uncond else self._network_call
-        assert isinstance(network_call, CUDAGraphWrapper)
-        return (
-            network_call.drain
-            if autoregressive_index < self._cuda_graph_capture_ar_idx
-            else network_call
+        return self._cuda_graph_dispatch.select(
+            autoregressive_index,
+            uncond=uncond,
         )
 
     def _build_per_token_timesteps(

--- a/flashdreams/flashdreams/recipes/template/transformer/__init__.py
+++ b/flashdreams/flashdreams/recipes/template/transformer/__init__.py
@@ -30,8 +30,11 @@ from flashdreams.core.distributed.context_parallel import (
     cat_outputs_cp,
     split_inputs_cp,
 )
+from flashdreams.infra.acceleration.cuda_graph_dispatch import (
+    CUDAGraphDispatch,
+    cuda_graph_capture_ar_index,
+)
 from flashdreams.infra.compile import compile_module
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
@@ -213,9 +216,16 @@ class TemplateTransformer(Transformer[TemplateTransformerCache]):
         self._output_width: int | None = None
 
         self._use_cuda_graph = config.use_cuda_graph
-        self._network_call: CUDAGraphWrapper | None = None
-        self._network_call_uncond: CUDAGraphWrapper | None = None
         self._cuda_graph_capture_ar_idx: int = 0
+        self._cuda_graph_dispatch = CUDAGraphDispatch(
+            self.network,
+            enabled=config.use_cuda_graph,
+            capture_ar_idx=self._cuda_graph_capture_ar_idx,
+            warmup_iters=config.cuda_graph_warmup_iters,
+            build=False,
+        )
+        self._network_call = None
+        self._network_call_uncond = None
 
     @property
     def latent_shape(self) -> tuple[int, ...]:
@@ -406,20 +416,19 @@ class TemplateTransformer(Transformer[TemplateTransformerCache]):
         self._output_height = height
         self._output_width = width
 
-        # One wrapper per rollout: static buffers and the captured
-        # graph are bound to this cache's KV pointers. The dispatch
-        # threshold matches the KV cache's filling → steady transition
-        # so the captured region only sees steady-state paths.
+        # One wrapper pair per rollout: static buffers and the captured graph
+        # are bound to this cache's KV pointers.
         if self._use_cuda_graph:
-            self._cuda_graph_capture_ar_idx = (
-                cfg.sink_size_t + cfg.window_size_t
-            ) // cfg.len_t
-            self._network_call = CUDAGraphWrapper(
-                self.network, warmup_iters=cfg.cuda_graph_warmup_iters
+            self._cuda_graph_capture_ar_idx = cuda_graph_capture_ar_index(
+                sink_size_t=cfg.sink_size_t,
+                window_size_t=cfg.window_size_t,
+                len_t=cfg.len_t,
             )
-            self._network_call_uncond = CUDAGraphWrapper(
-                self.network, warmup_iters=cfg.cuda_graph_warmup_iters
+            self._cuda_graph_dispatch.rebuild(
+                capture_ar_idx=self._cuda_graph_capture_ar_idx
             )
+            self._network_call = self._cuda_graph_dispatch.cond_call
+            self._network_call_uncond = self._cuda_graph_dispatch.uncond_call
 
         return TemplateTransformerCache(
             network_cache=network_cache,
@@ -428,22 +437,11 @@ class TemplateTransformer(Transformer[TemplateTransformerCache]):
         )
 
     def _select_network(self, autoregressive_index: int, *, uncond: bool) -> Any:
-        # Filling phase: eager ``.drain`` (drains Inductor autotune and
-        # exercises the KV cache's slice-returning filling path).
-        # Steady phase: ``wrapper.__call__`` (warmup + capture + replay).
-        # Capturing in the filling phase would bake slice pointers into
-        # the graph and read stale storage after the cache rolls.
         if not self._use_cuda_graph:
             return self.network
-        network_call = self._network_call_uncond if uncond else self._network_call
-        assert isinstance(network_call, CUDAGraphWrapper), (
-            "predict_flow called before initialize_autoregressive_cache "
-            "while use_cuda_graph=True."
-        )
-        return (
-            network_call.drain
-            if autoregressive_index < self._cuda_graph_capture_ar_idx
-            else network_call
+        return self._cuda_graph_dispatch.select(
+            autoregressive_index,
+            uncond=uncond,
         )
 
     def _predict_flow(

--- a/flashdreams/flashdreams/recipes/wan/pipeline.py
+++ b/flashdreams/flashdreams/recipes/wan/pipeline.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import gc
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -25,6 +24,11 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 
+from flashdreams.infra.acceleration.encoder_lifecycle import (
+    ensure_one_shot_encoder,
+    release_one_shot_encoder_references,
+    setup_one_shot_encoder,
+)
 from flashdreams.infra.decoder import StreamingVideoDecoder
 from flashdreams.infra.encoder import StreamingVideoEncoder
 from flashdreams.infra.encoder.image.clip import (
@@ -141,22 +145,30 @@ class WanInferencePipeline(
         )
 
     def _setup_oneshot_encoder(self, config: Any) -> Any:
-        encoder = config.setup()
-        if isinstance(encoder, torch.nn.Module):
-            encoder = encoder.to(device=self.device)
-        return encoder
+        return setup_one_shot_encoder(
+            config,
+            device=lambda: self.device,
+            torch_module=torch,
+        )
 
     def _ensure_oneshot_encoders_loaded(self) -> None:
         """Reload one-shot encoders released after an earlier rollout."""
         if self.text_encoder is None:
-            assert self.config.text_encoder is not None, (
-                "text_encoder is not set and config.text_encoder is None; "
-                "cannot encode raw prompts."
+            self.text_encoder = ensure_one_shot_encoder(
+                self.text_encoder,
+                self.config.text_encoder,
+                device=lambda: self.device,
+                name="text_encoder",
+                torch_module=torch,
             )
-            self.text_encoder = self._setup_oneshot_encoder(self.config.text_encoder)
-
         if self.image_encoder is None and self.config.image_encoder is not None:
-            self.image_encoder = self._setup_oneshot_encoder(self.config.image_encoder)
+            self.image_encoder = ensure_one_shot_encoder(
+                self.image_encoder,
+                self.config.image_encoder,
+                device=lambda: self.device,
+                name="image_encoder",
+                torch_module=torch,
+            )
 
     @property
     def _transformer_config(self) -> Wan21TransformerConfig | Wan22TransformerConfig:
@@ -322,15 +334,12 @@ class WanInferencePipeline(
         Idempotent. A later :meth:`initialize_cache` call can reload the
         encoders from ``self.config`` before encoding raw prompts/images.
         """
-        # None instead of delattr so initialize_cache's `is not None` guard
-        # fires with a useful message rather than an AttributeError.
-        self.text_encoder = None
-        self.image_encoder = None
-        # nn.Module reference cycles (parent <-> child, hooks) often outlive
-        # the local refcount drop, so force a GC pass before releasing the
-        # freed CUDA blocks.
-        gc.collect()
-        torch.cuda.empty_cache()
+        release_one_shot_encoder_references(
+            self,
+            "text_encoder",
+            "image_encoder",
+            torch_module=torch,
+        )
 
     @torch.no_grad()
     def generate(

--- a/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/wan21.py
@@ -29,8 +29,11 @@ from flashdreams.core.attention.rope import (
     RotaryPositionEmbedding3D,
 )
 from flashdreams.core.checkpoint.load import load_checkpoint
+from flashdreams.infra.acceleration.cuda_graph_dispatch import (
+    CUDAGraphDispatch,
+    cuda_graph_capture_ar_index,
+)
 from flashdreams.infra.compile import compile_module
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
@@ -261,10 +264,11 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         len_t = config.len_t // kt
         window_size_t = config.window_size_t // kt
         sink_size_t = config.sink_size_t // kt
-        assert (sink_size_t + window_size_t) % len_t == 0, (
-            f"sink_size_t + window_size_t ({sink_size_t + window_size_t}) must be "
-            f"divisible by post-patch len_t ({len_t}) so the BlockKVCache can "
-            f"fit a whole number of AR chunks."
+        cuda_graph_capture_ar_idx = cuda_graph_capture_ar_index(
+            sink_size_t=sink_size_t,
+            window_size_t=window_size_t,
+            len_t=len_t,
+            len_name="post-patch len_t",
         )
         self._output_height: int | None = None
         self._output_width: int | None = None
@@ -287,25 +291,21 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         if config.compile_network:
             self.network = compile_module(self.network)
 
-        # Per-rollout dispatch when use_cuda_graph=True:
-        # filling phase -> wrapper.drain (eager, drains Inductor autotune);
-        # steady-state -> wrapper.__call__ (warmup + capture + replay).
-        # Cond and CFG-uncond branches each get their own wrapper since each
-        # mutates an independent rolling KV cache. The dispatch threshold
-        # matches the KV cache's filling -> steady transition so the captured
-        # region only sees steady-state paths.
+        # Cond and CFG-uncond branches each get their own CUDA-graph wrapper
+        # since each mutates an independent rolling KV cache.
         self._use_cuda_graph = config.use_cuda_graph
-        chunks_total = sink_size_t + window_size_t
-        self._cuda_graph_capture_ar_idx: int = chunks_total // len_t
-        self._network_call: CUDAGraphWrapper | WanDiTNetwork = (
-            CUDAGraphWrapper(self.network, warmup_iters=config.cuda_graph_warmup_iters)
-            if config.use_cuda_graph
-            else self.network
+        self._cuda_graph_capture_ar_idx = cuda_graph_capture_ar_idx
+        self._cuda_graph_dispatch = CUDAGraphDispatch(
+            self.network,
+            enabled=config.use_cuda_graph,
+            capture_ar_idx=self._cuda_graph_capture_ar_idx,
+            warmup_iters=config.cuda_graph_warmup_iters,
         )
-        self._network_call_uncond: CUDAGraphWrapper | WanDiTNetwork = (
-            CUDAGraphWrapper(self.network, warmup_iters=config.cuda_graph_warmup_iters)
-            if config.use_cuda_graph
-            else self.network
+        # Compatibility aliases for diagnostic hooks that predate the shared
+        # dispatch helper.
+        self._network_call = self._cuda_graph_dispatch.cond_call or self.network
+        self._network_call_uncond = (
+            self._cuda_graph_dispatch.uncond_call or self.network
         )
 
     @property
@@ -460,13 +460,8 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
             rope_adapter = KVCacheRelativeRotaryPositionEmbedding3D(**rope_kwargs)
         rope_adapter.set_context_parallel_group(cp_group=self._cp_group)
 
-        # Reset any prior CUDA graph: it refers to slot pointers from the
-        # previous cache, which the new cache invalidates.
         if self._use_cuda_graph:
-            assert isinstance(self._network_call, CUDAGraphWrapper)
-            self._network_call.reset()
-            assert isinstance(self._network_call_uncond, CUDAGraphWrapper)
-            self._network_call_uncond.reset()
+            self._cuda_graph_dispatch.reset()
 
         return Wan21TransformerCache(
             network_cache=network_cache,
@@ -532,19 +527,11 @@ class Wan21Transformer(Transformer[Wan21TransformerCache]):
         return latent * (1.0 - control.mask) + control.latent * control.mask
 
     def _select_network(self, autoregressive_index: int, *, uncond: bool) -> Any:
-        # Filling phase: eager ``.drain`` (drains Inductor autotune and
-        # exercises the KV cache's slice-returning filling path).
-        # Steady phase: ``wrapper.__call__`` (warmup + capture + replay).
-        # Cond and CFG-uncond branches both mutate their rolling KV cache,
-        # so neither branch can be graph-captured until the cache is steady.
         if not self._use_cuda_graph:
             return self.network
-        network_call = self._network_call_uncond if uncond else self._network_call
-        assert isinstance(network_call, CUDAGraphWrapper)
-        return (
-            network_call.drain
-            if autoregressive_index < self._cuda_graph_capture_ar_idx
-            else network_call
+        return self._cuda_graph_dispatch.select(
+            autoregressive_index,
+            uncond=uncond,
         )
 
     def _build_network_input(

--- a/flashdreams/tests/test_cuda_graph_dispatch.py
+++ b/flashdreams/tests/test_cuda_graph_dispatch.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from flashdreams.infra.acceleration import cuda_graph_dispatch
+
+pytestmark = pytest.mark.ci_cpu
+
+
+class FakeCUDAGraphWrapper:
+    instances: list["FakeCUDAGraphWrapper"] = []
+
+    def __init__(self, fn: Any, warmup_iters: int) -> None:
+        self.fn = fn
+        self.warmup_iters = warmup_iters
+        self.calls: list[str] = []
+        self.resets = 0
+        self.instances.append(self)
+
+    def drain(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append("drain")
+        return ("drain", self.fn(*args, **kwargs))
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append("graph")
+        return ("graph", self.fn(*args, **kwargs))
+
+    def reset(self) -> None:
+        self.resets += 1
+
+
+def test_cuda_graph_capture_ar_index_checks_chunk_alignment() -> None:
+    assert (
+        cuda_graph_dispatch.cuda_graph_capture_ar_index(
+            sink_size_t=2,
+            window_size_t=6,
+            len_t=2,
+        )
+        == 4
+    )
+
+    with pytest.raises(AssertionError, match="whole number of AR chunks"):
+        cuda_graph_dispatch.cuda_graph_capture_ar_index(
+            sink_size_t=1,
+            window_size_t=6,
+            len_t=4,
+        )
+
+
+def test_dispatch_selects_drain_before_capture_and_wrapper_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeCUDAGraphWrapper.instances = []
+    monkeypatch.setattr(
+        cuda_graph_dispatch,
+        "CUDAGraphWrapper",
+        FakeCUDAGraphWrapper,
+    )
+
+    def fn(value: int, *, scale: int = 1) -> int:
+        return value * scale
+
+    dispatch = cuda_graph_dispatch.CUDAGraphDispatch(
+        fn,
+        enabled=True,
+        capture_ar_idx=3,
+        warmup_iters=5,
+    )
+
+    assert len(FakeCUDAGraphWrapper.instances) == 2
+    cond_wrapper, uncond_wrapper = FakeCUDAGraphWrapper.instances
+    assert cond_wrapper.warmup_iters == 5
+    assert uncond_wrapper.warmup_iters == 5
+
+    assert dispatch.select(2, uncond=False)(2, scale=10) == ("drain", 20)
+    assert dispatch.select(3, uncond=False)(3, scale=10) == ("graph", 30)
+    assert dispatch.select(4, uncond=True)(4, scale=10) == ("graph", 40)
+
+    assert cond_wrapper.calls == ["drain", "graph"]
+    assert uncond_wrapper.calls == ["graph"]
+
+
+def test_dispatch_reset_and_rebuild_manage_wrapper_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeCUDAGraphWrapper.instances = []
+    monkeypatch.setattr(
+        cuda_graph_dispatch,
+        "CUDAGraphWrapper",
+        FakeCUDAGraphWrapper,
+    )
+
+    dispatch = cuda_graph_dispatch.CUDAGraphDispatch(
+        lambda value: value,
+        enabled=True,
+        capture_ar_idx=1,
+        warmup_iters=2,
+    )
+    first_cond, first_uncond = FakeCUDAGraphWrapper.instances
+
+    dispatch.reset()
+
+    assert first_cond.resets == 1
+    assert first_uncond.resets == 1
+
+    dispatch.rebuild(capture_ar_idx=7)
+
+    assert dispatch.capture_ar_idx == 7
+    assert len(FakeCUDAGraphWrapper.instances) == 4
+    assert dispatch.cond_call is FakeCUDAGraphWrapper.instances[2]
+    assert dispatch.uncond_call is FakeCUDAGraphWrapper.instances[3]
+
+
+def test_disabled_dispatch_uses_eager_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeCUDAGraphWrapper.instances = []
+    monkeypatch.setattr(
+        cuda_graph_dispatch,
+        "CUDAGraphWrapper",
+        FakeCUDAGraphWrapper,
+    )
+
+    def fn(value: int) -> int:
+        return value + 1
+
+    dispatch = cuda_graph_dispatch.CUDAGraphDispatch(
+        fn,
+        enabled=False,
+        capture_ar_idx=1,
+        warmup_iters=2,
+    )
+
+    assert FakeCUDAGraphWrapper.instances == []
+    assert dispatch.select(100, uncond=True)(4) == 5
+
+    dispatch.reset()
+    dispatch.rebuild(capture_ar_idx=3)
+
+    assert dispatch.capture_ar_idx == 3
+    assert dispatch.cond_call is None
+    assert dispatch.uncond_call is None
+    assert FakeCUDAGraphWrapper.instances == []
+
+
+def test_disable_drops_wrappers_and_rebinds_eager_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeCUDAGraphWrapper.instances = []
+    monkeypatch.setattr(
+        cuda_graph_dispatch,
+        "CUDAGraphWrapper",
+        FakeCUDAGraphWrapper,
+    )
+
+    dispatch = cuda_graph_dispatch.CUDAGraphDispatch(
+        lambda value: value + 1,
+        enabled=True,
+        capture_ar_idx=1,
+        warmup_iters=2,
+    )
+
+    dispatch.disable(fn=lambda value: value + 10)
+
+    assert dispatch.enabled is False
+    assert dispatch.cond_call is None
+    assert dispatch.uncond_call is None
+    assert dispatch.select(100, uncond=False)(1) == 11

--- a/flashdreams/tests/test_encoder_lifecycle.py
+++ b/flashdreams/tests/test_encoder_lifecycle.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from flashdreams.infra.acceleration.encoder_lifecycle import (
+    ensure_one_shot_encoder,
+    move_tensors_to_cpu,
+    release_one_shot_encoder_references,
+    run_one_shot_encoder_stage,
+    setup_one_shot_encoder,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_setup_one_shot_encoder_moves_torch_module_to_device() -> None:
+    config = _EncoderConfig(_FakeModule())
+
+    encoder = setup_one_shot_encoder(config, device=torch.device("cpu"))
+
+    assert isinstance(encoder, _FakeModule)
+    assert encoder.to_calls == [{"device": torch.device("cpu")}]
+
+
+def test_ensure_one_shot_encoder_reuses_loaded_encoder() -> None:
+    existing = object()
+    config = _EncoderConfig(object())
+
+    encoder = ensure_one_shot_encoder(
+        existing,
+        config,
+        device=torch.device("cpu"),
+    )
+
+    assert encoder is existing
+    assert config.setup_calls == 0
+
+
+def test_ensure_one_shot_encoder_handles_missing_optional_config() -> None:
+    assert (
+        ensure_one_shot_encoder(
+            None,
+            None,
+            name="image_encoder",
+            required=False,
+        )
+        is None
+    )
+    with pytest.raises(RuntimeError, match="text_encoder"):
+        ensure_one_shot_encoder(None, None, name="text_encoder")
+
+
+def test_release_one_shot_encoder_references_clears_attrs_and_cuda_cache() -> None:
+    owner = SimpleNamespace(text_encoder=object(), image_encoder=None)
+    fake_torch = SimpleNamespace(cuda=_FakeCuda())
+
+    released = release_one_shot_encoder_references(
+        owner,
+        "text_encoder",
+        "image_encoder",
+        device="cuda:0",
+        synchronize_cuda=True,
+        torch_module=fake_torch,
+    )
+
+    assert released == ("text_encoder",)
+    assert owner.text_encoder is None
+    assert owner.image_encoder is None
+    assert fake_torch.cuda.synchronize_calls == ["cuda:0"]
+    assert fake_torch.cuda.empty_cache_calls == 1
+
+
+def test_move_tensors_to_cpu_recurses_through_containers() -> None:
+    tensor = torch.ones(2)
+    result = move_tensors_to_cpu(
+        {
+            "tensor": tensor,
+            "nested": [tensor],
+            "tuple": (tensor,),
+            "plain": "value",
+        }
+    )
+
+    assert result["tensor"].device.type == "cpu"
+    assert result["nested"][0].device.type == "cpu"
+    assert result["tuple"][0].device.type == "cpu"
+    assert result["plain"] == "value"
+
+
+def test_run_one_shot_encoder_stage_moves_result_and_releases() -> None:
+    released: list[str] = []
+
+    result = run_one_shot_encoder_stage(
+        lambda: {"tensor": torch.ones(1)},
+        release=lambda: released.append("released"),
+    )
+
+    assert result["tensor"].device.type == "cpu"
+    assert released == ["released"]
+
+
+class _FakeModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.to_calls: list[dict[str, Any]] = []
+
+    def to(self, *args: Any, **kwargs: Any) -> "_FakeModule":
+        del args
+        self.to_calls.append(kwargs)
+        return self
+
+
+class _EncoderConfig:
+    def __init__(self, encoder: object) -> None:
+        self.encoder = encoder
+        self.setup_calls = 0
+
+    def setup(self) -> object:
+        self.setup_calls += 1
+        return self.encoder
+
+
+class _FakeCuda:
+    def __init__(self) -> None:
+        self.synchronize_calls: list[object] = []
+        self.empty_cache_calls = 0
+
+    def is_available(self) -> bool:
+        return True
+
+    def synchronize(self, device: object | None = None) -> None:
+        self.synchronize_calls.append(device)
+
+    def empty_cache(self) -> None:
+        self.empty_cache_calls += 1

--- a/flashdreams/tests/test_frame_prefetch.py
+++ b/flashdreams/tests/test_frame_prefetch.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from flashdreams.infra.acceleration.frame_prefetch import (
+    CudaHostPrefetch,
+    LazyCudaFrame,
+    prefetch_to_numpy,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+class _Event:
+    def __init__(self) -> None:
+        self.synchronize_calls = 0
+
+    def synchronize(self) -> None:
+        self.synchronize_calls += 1
+
+
+class _Prefetchable:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def prefetch_to_numpy(self) -> None:
+        self.calls += 1
+
+
+def test_cuda_host_prefetch_returns_false_for_cpu_tensor() -> None:
+    prefetch = CudaHostPrefetch(torch.zeros((1, 2, 3), dtype=torch.uint8))
+
+    assert not prefetch.start()
+    assert not prefetch.start()
+    with pytest.raises(RuntimeError, match="not started"):
+        prefetch.to_numpy()
+
+
+def test_lazy_cuda_frame_materializes_cpu_tensor_on_fallback_path() -> None:
+    frames = torch.arange(18, dtype=torch.uint8).reshape(2, 1, 3, 3)
+    frame = LazyCudaFrame(frames, 1)
+
+    frame.prefetch_to_numpy()
+    host = frame.to_numpy()
+
+    assert host.flags.c_contiguous
+    np.testing.assert_array_equal(host, frames[1].numpy())
+    assert frame.to_cuda_event() is None
+    with pytest.raises(RuntimeError, match="already materialized"):
+        frame.to_cuda_tensor()
+
+
+def test_lazy_cuda_frame_synchronizes_source_event_on_configured_host_copy() -> None:
+    frames = torch.zeros((1, 2, 2, 3), dtype=torch.uint8)
+    event = _Event()
+    frame = LazyCudaFrame(
+        frames,
+        0,
+        source_event=event,
+        synchronize_source_event_on_host_copy=True,
+    )
+
+    frame.to_numpy()
+
+    assert event.synchronize_calls == 1
+
+
+def test_lazy_cuda_frame_keeps_source_event_until_materialized() -> None:
+    frames = torch.zeros((1, 2, 2, 3), dtype=torch.uint8)
+    event = object()
+    frame = LazyCudaFrame(frames, 0, source_event=event)
+
+    assert frame.to_cuda_event() is event
+    assert torch.equal(frame.to_cuda_tensor(), frames[0])
+
+    frame.to_numpy()
+
+    assert frame.to_cuda_event() is None
+
+
+def test_lazy_cuda_frame_array_protocol_supports_dtype_and_copy() -> None:
+    frames = torch.ones((1, 1, 1, 3), dtype=torch.uint8)
+    frame = LazyCudaFrame(frames, 0)
+
+    array = np.array(frame, dtype=np.float32, copy=True)
+
+    assert array.dtype == np.float32
+    assert array.flags.owndata
+    np.testing.assert_array_equal(array, np.ones((1, 1, 3), dtype=np.float32))
+
+
+def test_prefetch_to_numpy_dispatches_only_when_supported() -> None:
+    prefetchable = _Prefetchable()
+
+    prefetch_to_numpy(prefetchable)
+    prefetch_to_numpy(object())
+
+    assert prefetchable.calls == 1

--- a/flashdreams/tests/test_frame_prefetch.py
+++ b/flashdreams/tests/test_frame_prefetch.py
@@ -94,6 +94,29 @@ def test_lazy_cuda_frame_array_protocol_supports_dtype_and_copy() -> None:
     np.testing.assert_array_equal(array, np.ones((1, 1, 3), dtype=np.float32))
 
 
+def test_lazy_cuda_frame_array_protocol_rejects_unavoidable_copy() -> None:
+    frames = torch.ones((1, 1, 1, 3), dtype=torch.uint8)
+    frame = LazyCudaFrame(frames, 0)
+
+    with pytest.raises(ValueError, match="Unable to avoid copy"):
+        np.asarray(frame, dtype=np.float32, copy=False)
+
+
+def test_lazy_cuda_frame_recovers_from_failed_prefetch() -> None:
+    frames = torch.arange(3, dtype=torch.uint8).reshape(1, 1, 1, 3)
+    frame = LazyCudaFrame(frames, 0)
+    failed_prefetch = _FailedPrefetch()
+    frame._prefetch = failed_prefetch  # ty:ignore[invalid-assignment]
+
+    with pytest.raises(RuntimeError, match="copy failed"):
+        frame.to_numpy()
+
+    assert failed_prefetch.calls == 1
+    host = frame.to_numpy()
+
+    np.testing.assert_array_equal(host, frames[0].numpy())
+
+
 def test_prefetch_to_numpy_dispatches_only_when_supported() -> None:
     prefetchable = _Prefetchable()
 
@@ -101,3 +124,12 @@ def test_prefetch_to_numpy_dispatches_only_when_supported() -> None:
     prefetch_to_numpy(object())
 
     assert prefetchable.calls == 1
+
+
+class _FailedPrefetch:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def to_numpy(self) -> np.ndarray:
+        self.calls += 1
+        raise RuntimeError("copy failed")

--- a/flashdreams/tests/test_overlap.py
+++ b/flashdreams/tests/test_overlap.py
@@ -91,17 +91,21 @@ def test_cuda_stream_overlap_enqueues_work_and_waits_on_event() -> None:
     assert fake_torch.cuda.device_contexts == ["cuda:0"]
     assert overlap.pending
 
-    overlap._event.complete()
+    event = overlap._event
+    assert event is not None
+    event.complete()
 
     assert overlap.wait(timeout_s=1.0)
     assert not overlap.pending
-    assert overlap._event.synchronize_calls == 0
+    assert event.synchronize_calls == 0
 
     overlap.submit(lambda: calls.append("again"))
     assert calls == ["work", "again"]
-    overlap._event.complete()
+    event = overlap._event
+    assert event is not None
+    event.complete()
     overlap.close()
-    assert overlap._event.synchronize_calls == 1
+    assert event.synchronize_calls == 1
 
 
 class _FakeTorch:

--- a/flashdreams/tests/test_overlap.py
+++ b/flashdreams/tests/test_overlap.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+from flashdreams.infra.acceleration.overlap import (
+    CudaStreamOverlap,
+    HostThreadOverlap,
+    SynchronousOverlap,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_synchronous_overlap_runs_work_before_return() -> None:
+    calls: list[str] = []
+    overlap = SynchronousOverlap(name="sync")
+
+    overlap.submit(lambda: calls.append("work"))
+
+    assert calls == ["work"]
+    assert not overlap.pending
+    assert overlap.wait()
+
+
+def test_host_thread_overlap_runs_work_until_wait() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    calls: list[str] = []
+    overlap = HostThreadOverlap(name="host-test")
+
+    def work() -> None:
+        started.set()
+        release.wait(timeout=1.0)
+        calls.append("done")
+
+    overlap.submit(work)
+
+    assert started.wait(timeout=1.0)
+    assert overlap.pending
+    assert not overlap.wait(timeout_s=0.001)
+
+    release.set()
+
+    assert overlap.wait(timeout_s=1.0)
+    assert calls == ["done"]
+    assert not overlap.pending
+
+
+def test_host_thread_overlap_rejects_second_pending_task() -> None:
+    release = threading.Event()
+    overlap = HostThreadOverlap(name="host-test")
+
+    overlap.submit(lambda: release.wait(timeout=1.0))
+
+    with pytest.raises(RuntimeError, match="pending"):
+        overlap.submit(lambda: None)
+
+    release.set()
+    assert overlap.wait(timeout_s=1.0)
+
+
+def test_host_thread_overlap_can_report_worker_error_on_wait() -> None:
+    overlap = HostThreadOverlap(name="host-test", reraise_worker_errors=False)
+
+    def work() -> None:
+        raise ValueError("boom")
+
+    overlap.submit(work)
+
+    assert overlap.wait(timeout_s=1.0)
+    assert isinstance(overlap.last_error, ValueError)
+    with pytest.raises(ValueError, match="boom"):
+        overlap.wait(raise_error=True)
+
+
+def test_cuda_stream_overlap_enqueues_work_and_waits_on_event() -> None:
+    fake_torch = _FakeTorch()
+    calls: list[str] = []
+    overlap = CudaStreamOverlap(torch_module=fake_torch, device="cuda:0")
+
+    overlap.submit(lambda: calls.append("work"))
+
+    assert calls == ["work"]
+    assert fake_torch.cuda.stream_contexts == [overlap._stream]
+    assert fake_torch.cuda.device_contexts == ["cuda:0"]
+    assert overlap.pending
+
+    overlap._event.complete()
+
+    assert overlap.wait(timeout_s=1.0)
+    assert not overlap.pending
+    assert overlap._event.synchronize_calls == 0
+
+    overlap.submit(lambda: calls.append("again"))
+    assert calls == ["work", "again"]
+    overlap._event.complete()
+    overlap.close()
+    assert overlap._event.synchronize_calls == 1
+
+
+class _FakeTorch:
+    def __init__(self) -> None:
+        self.cuda = _FakeCuda()
+
+    def device(self, value: str) -> str:
+        return value
+
+
+class _FakeCuda:
+    def __init__(self) -> None:
+        self.device_contexts: list[str] = []
+        self.stream_contexts: list[object] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def Stream(self, *, device: str | None = None) -> object:
+        return _FakeStream(device)
+
+    def Event(self) -> "_FakeEvent":
+        return _FakeEvent()
+
+    @contextmanager
+    def device(self, device: str):
+        self.device_contexts.append(device)
+        yield
+
+    @contextmanager
+    def stream(self, stream: object):
+        self.stream_contexts.append(stream)
+        yield
+
+
+class _FakeStream:
+    def __init__(self, device: str | None) -> None:
+        self.device = device
+
+
+class _FakeEvent:
+    def __init__(self) -> None:
+        self._complete = False
+        self.recorded_stream: object | None = None
+        self.synchronize_calls = 0
+
+    def record(self, stream: object) -> None:
+        self.recorded_stream = stream
+
+    def query(self) -> bool:
+        return self._complete
+
+    def synchronize(self) -> None:
+        self.synchronize_calls += 1
+        self._complete = True
+
+    def complete(self) -> None:
+        self._complete = True

--- a/flashdreams/tests/test_prewarm.py
+++ b/flashdreams/tests/test_prewarm.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from flashdreams.infra.acceleration.prewarm import (
+    PrewarmDeadline,
+    PrewarmTimeoutError,
+    cuda_graph_prewarm_steps,
+    is_warmup_index,
+    run_prewarm_sequence,
+    run_timed_prewarm,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def _clock(*times: float) -> Callable[[], float]:
+    values = iter(times)
+    return lambda: next(values)
+
+
+def test_run_timed_prewarm_records_elapsed_without_retaining_result() -> None:
+    calls: list[str] = []
+
+    def step() -> object:
+        calls.append("step")
+        return object()
+
+    timing = run_timed_prewarm(
+        step,
+        label="model",
+        time_fn=_clock(10.0, 10.25),
+    )
+
+    assert calls == ["step"]
+    assert timing.label == "model"
+    assert timing.start_time == 10.0
+    assert timing.end_time == 10.25
+    assert timing.elapsed_ms == pytest.approx(250.0)
+
+
+def test_run_timed_prewarm_reports_timeout_after_sync_step() -> None:
+    with pytest.raises(PrewarmTimeoutError, match="slow"):
+        run_timed_prewarm(
+            lambda: None,
+            label="slow",
+            timeout_s=0.1,
+            time_fn=_clock(0.0, 0.2),
+        )
+
+
+def test_prewarm_sequence_runs_cold_start_then_steady_steps() -> None:
+    calls: list[str] = []
+
+    timing = run_prewarm_sequence(
+        cold_start=lambda: calls.append("cold"),
+        steady_state=lambda: calls.append("steady"),
+        steady_steps=3,
+        label="compile",
+        time_fn=_clock(0.0, 0.1, 0.2, 0.2, 0.3, 0.3, 0.4, 0.4, 0.5),
+    )
+
+    assert calls == ["cold", "steady", "steady", "steady"]
+    assert timing.label == "compile"
+    assert [step.label for step in timing.steps] == [
+        "compile.cold_start",
+        "compile.steady_state.0",
+        "compile.steady_state.1",
+        "compile.steady_state.2",
+    ]
+    assert timing.elapsed_ms == pytest.approx(400.0)
+
+
+def test_prewarm_sequence_checks_shared_deadline_between_steps() -> None:
+    calls: list[str] = []
+
+    with pytest.raises(PrewarmTimeoutError, match="compile"):
+        run_prewarm_sequence(
+            steady_state=lambda: calls.append("steady"),
+            steady_steps=2,
+            label="compile",
+            timeout_s=0.25,
+            time_fn=_clock(0.0, 0.05, 0.1, 0.2, 0.21, 0.22, 0.4),
+        )
+
+    assert calls == ["steady", "steady"]
+
+
+def test_prewarm_deadline_reports_remaining_time() -> None:
+    deadline = PrewarmDeadline.start(
+        label="startup",
+        timeout_s=1.0,
+        time_fn=_clock(5.0),
+    )
+
+    assert deadline.elapsed_s(now=5.25) == pytest.approx(0.25)
+    assert deadline.remaining_s(now=5.25) == pytest.approx(0.75)
+    deadline.raise_if_expired(now=5.99)
+    with pytest.raises(PrewarmTimeoutError, match="startup"):
+        deadline.raise_if_expired(now=6.01)
+
+
+def test_cuda_graph_prewarm_steps_counts_warmup_capture_and_replay() -> None:
+    assert cuda_graph_prewarm_steps(warmup_iters=2) == 4
+    assert (
+        cuda_graph_prewarm_steps(
+            warmup_iters=3,
+            capture_steps=2,
+            replay_steps=0,
+        )
+        == 5
+    )
+
+    with pytest.raises(ValueError, match="warmup_iters"):
+        cuda_graph_prewarm_steps(warmup_iters=-1)
+
+
+def test_is_warmup_index_matches_excluded_prefix() -> None:
+    assert is_warmup_index(0)
+    assert not is_warmup_index(1)
+    assert is_warmup_index(2, warmup_count=3)
+    assert not is_warmup_index(3, warmup_count=3)
+
+    with pytest.raises(ValueError, match="index"):
+        is_warmup_index(-1)

--- a/integrations/flashvsr/flashvsr/postprocess.py
+++ b/integrations/flashvsr/flashvsr/postprocess.py
@@ -19,11 +19,16 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any, Literal
 
 import torch
 from torch import Tensor
 
+from flashdreams.infra.acceleration.prewarm import (
+    cuda_graph_prewarm_steps,
+    run_prewarm_sequence,
+)
 from flashdreams.infra.postprocess import (
     VideoChunk,
     VideoPostProcessor,
@@ -38,7 +43,7 @@ from flashvsr.encoder import FlashVSREncoder
 _DTypeName = Literal["bfloat16", "float16", "float32"]
 _TailPolicy = Literal["replicate_pad", "drop"]
 
-_DISTRIBUTED_PREPARE_STEADY_CHUNKS = 4
+_DISTRIBUTED_PREPARE_STEADY_CHUNKS = cuda_graph_prewarm_steps(warmup_iters=2)
 """Steady chunks needed to warm, capture, and replay every CUDA-graph stage."""
 
 
@@ -169,16 +174,19 @@ class _FlashVSRPostProcessorSession(VideoPostProcessorSession):
             device=device,
             dtype=dtype,
         )
-        self._run_flashvsr_chunk(first)
-        # The steady-state path can have different iteration and graph shapes
-        # from the cold-start chunk, so compile/capture it as well.
         steady = torch.zeros(
             (1, 3, self._subseq_size, self._spec.height, self._spec.width),
             device=device,
             dtype=dtype,
         )
-        for _ in range(_DISTRIBUTED_PREPARE_STEADY_CHUNKS):
-            self._run_flashvsr_chunk(steady)
+        # The steady-state path can have different iteration and graph shapes
+        # from the cold-start chunk, so compile/capture it as well.
+        run_prewarm_sequence(
+            cold_start=partial(self._run_flashvsr_chunk, first),
+            steady_state=partial(self._run_flashvsr_chunk, steady),
+            steady_steps=_DISTRIBUTED_PREPARE_STEADY_CHUNKS,
+            label="flashvsr.distributed_prepare",
+        )
         del first, steady
 
         # Warmup must not consume rollout state. Keep the transformer cache

--- a/integrations/lingbot/lingbot/transformer/__init__.py
+++ b/integrations/lingbot/lingbot/transformer/__init__.py
@@ -23,7 +23,6 @@ from typing import overload
 import torch
 from torch import Tensor
 
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.recipes.wan.transformer.wan21 import (
     Wan21Transformer,
     Wan21TransformerCache,
@@ -98,11 +97,7 @@ class LingbotWorldTransformer(Wan21Transformer):
         assert isinstance(network, LingbotWorldDiTNetwork)
         network.replace_text_embeddings(cache.network_cache, text_embeddings)
         if self._use_cuda_graph:
-            assert isinstance(self._network_call, CUDAGraphWrapper)
-            self._network_call.reset()
-            if self._network_call_uncond is not None:
-                assert isinstance(self._network_call_uncond, CUDAGraphWrapper)
-                self._network_call_uncond.reset()
+            self._cuda_graph_dispatch.reset()
 
     def predict_flow(
         self,

--- a/integrations/omnidreams/omnidreams/grpc/server.py
+++ b/integrations/omnidreams/omnidreams/grpc/server.py
@@ -29,7 +29,6 @@ import gc
 import importlib.metadata
 import os
 import re
-import threading
 import time
 import traceback
 import uuid
@@ -87,6 +86,7 @@ from flashdreams.core.distributed.rank_orchestration import (
     RankCoordinator,
     distributed_op,
 )
+from flashdreams.infra.acceleration.overlap import HostThreadOverlap
 from flashdreams.serving.network import get_external_ip
 
 VERBOSE = False
@@ -754,10 +754,11 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
             logger.info("Session recording disabled")
         self.recorders: dict[str, SessionRecorder] = {}  # session_id -> SessionRecorder
 
-        # Finalization synchronization: ensures KV cache update completes before next request
-        # The event is set when no finalization is pending, cleared when finalization starts
-        self._finalization_done = threading.Event()
-        self._finalization_done.set()  # Initially done (no pending finalization)
+        # Finalization synchronization: ensures KV cache update completes before
+        # the next request while still allowing post-response overlap.
+        self._finalization_overlap = HostThreadOverlap(
+            name="omnidreams-kv-finalization"
+        )
 
         logger.info("WorldModelService initialized successfully")
 
@@ -1011,7 +1012,7 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
 
         # Wait for previous finalization to complete before processing new request
         # This ensures KV cache is ready for the new generation
-        self._finalization_done.wait()
+        self._finalization_overlap.wait()
 
         # 1. Get session ID
         session_id = request.session_id.session_id
@@ -1096,20 +1097,14 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
         )
         response = self.render_video_chunk_all_ranks(render_video_chunk_payload)
 
-        # Schedule KV cache finalization in background thread
-        # This allows the gRPC response to be sent immediately while KV cache update
+        # Schedule KV cache finalization in a background host thread. This
+        # allows the gRPC response to be sent immediately while KV cache update
         # happens in parallel, utilizing the network transfer time.
         if session_state.pending_finalization_state is not None:
-            self._finalization_done.clear()  # Mark finalization as pending
-
-            def do_finalization():
-                try:
-                    self.finalize_kv_cache_all_ranks(session_id=session_id)
-                finally:
-                    self._finalization_done.set()  # Mark finalization as complete
-
-            finalization_thread = threading.Thread(target=do_finalization, daemon=True)
-            finalization_thread.start()
+            self._finalization_overlap.submit(
+                lambda: self.finalize_kv_cache_all_ranks(session_id=session_id),
+                name=f"omnidreams-kv-finalization-{session_id}",
+            )
 
         profiler.increment_chunk_idx(session_id)
 
@@ -1147,7 +1142,7 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
         start_time_ns = time.time_ns()
 
         # Wait for any pending finalization to complete before closing
-        self._finalization_done.wait()
+        self._finalization_overlap.wait()
 
         # Get session ID
         session_id = request.session_id

--- a/integrations/omnidreams/omnidreams/grpc/server.py
+++ b/integrations/omnidreams/omnidreams/grpc/server.py
@@ -29,6 +29,7 @@ import gc
 import importlib.metadata
 import os
 import re
+import threading
 import time
 import traceback
 import uuid
@@ -36,6 +37,7 @@ import warnings
 from concurrent import futures
 from dataclasses import dataclass
 from enum import IntEnum
+from functools import wraps
 from pathlib import Path
 from typing import Any, Callable
 
@@ -167,7 +169,8 @@ class RenderVideoChunkPayload:
         )
 
 
-def capture_exceptions(func: Callable) -> Callable:
+def capture_exceptions(func: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
@@ -177,6 +180,20 @@ def capture_exceptions(func: Callable) -> Callable:
             raise
 
     return wrapper
+
+
+def _synchronized_method(
+    lock_attr: str,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+            with getattr(self, lock_attr):
+                return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def _omnidreams_version_id() -> str:
@@ -759,6 +776,7 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
         self._finalization_overlap = HostThreadOverlap(
             name="omnidreams-kv-finalization"
         )
+        self._finalization_lock = threading.Lock()
 
         logger.info("WorldModelService initialized successfully")
 
@@ -985,6 +1003,7 @@ class WorldModelService(video_model_pb2_grpc.WorldModelServiceServicer):
         return response
 
     @capture_exceptions
+    @_synchronized_method("_finalization_lock")
     def render_video_chunk(
         self,
         request: video_model_pb2.VideoChunkRequest,

--- a/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/backends/world_model.py
@@ -31,6 +31,8 @@ from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
 from PIL import Image
 
+from flashdreams.infra.acceleration.prewarm import run_timed_prewarm
+
 _FIRST_STEADY_STATE_WARMUP_MESSAGE = "Optimizing world model..."
 
 
@@ -85,10 +87,12 @@ class WorldModelRenderBackend(RenderBackend):
             raise ValueError(
                 "The flashdreams world-model path is locked to a 5-frame first chunk."
             )
-        start = time.perf_counter()
-        self._session.warmup_model()
+        warmup_timing = run_timed_prewarm(
+            self._session.warmup_model,
+            label="world-model.session",
+        )
         logger.info(
-            f"[world-model] model warmup session_ms={(time.perf_counter() - start) * 1000.0:.1f}",
+            f"[world-model] model warmup session_ms={warmup_timing.elapsed_ms:.1f}",
         )
 
     def load_scene(self, scene: SceneBundle) -> None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/cuda_host_prefetch.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cuda_host_prefetch.py
@@ -1,87 +1,10 @@
-# SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility imports for the shared CUDA host frame-prefetch helper."""
 
 from __future__ import annotations
 
-import threading
-from typing import Any
+from flashdreams.infra.acceleration.frame_prefetch import CudaHostPrefetch
 
-import numpy as np
-
-_STREAMS_LOCK = threading.Lock()
-_HOST_COPY_STREAMS: dict[int, Any] = {}
-
-
-class CudaHostPrefetch:
-    """Asynchronously stage one CUDA uint8 RGB frame into pinned host memory."""
-
-    def __init__(self, tensor: Any, *, source_event: Any | None = None) -> None:
-        self._tensor = tensor
-        self._source_event = source_event
-        self._host_tensor: Any | None = None
-        self._done_event: Any | None = None
-        self._started = False
-
-    def start(self) -> bool:
-        if self._started:
-            return self._host_tensor is not None
-        self._started = True
-
-        try:
-            import torch
-        except ImportError:
-            return False
-
-        tensor = self._tensor
-        if not torch.is_tensor(tensor) or not tensor.is_cuda:
-            return False
-
-        try:
-            host_tensor = torch.empty(
-                tuple(tensor.shape),
-                dtype=tensor.dtype,
-                device="cpu",
-                pin_memory=True,
-            )
-            copy_stream = _host_copy_stream(torch, tensor.device)
-            with torch.cuda.device(tensor.device):
-                if self._source_event is not None:
-                    copy_stream.wait_event(self._source_event)
-                with torch.cuda.stream(copy_stream):
-                    host_tensor.copy_(tensor, non_blocking=True)
-                    tensor.record_stream(copy_stream)
-                    done_event = torch.cuda.Event()
-                    done_event.record(copy_stream)
-        except Exception:
-            self._host_tensor = None
-            self._done_event = None
-            return False
-
-        self._host_tensor = host_tensor
-        self._done_event = done_event
-        return True
-
-    def to_numpy(self) -> np.ndarray:
-        host_tensor = self._host_tensor
-        if host_tensor is None:
-            raise RuntimeError("CUDA host prefetch was not started.")
-        done_event = self._done_event
-        if done_event is not None:
-            done_event.synchronize()
-        return np.ascontiguousarray(host_tensor.numpy(), dtype=np.uint8)
-
-
-def _host_copy_stream(torch: Any, device: Any) -> Any:
-    key = _device_index(device)
-    with _STREAMS_LOCK:
-        stream = _HOST_COPY_STREAMS.get(key)
-        if stream is None:
-            with torch.cuda.device(device):
-                stream = torch.cuda.Stream(device=device)
-            _HOST_COPY_STREAMS[key] = stream
-        return stream
-
-
-def _device_index(device: Any) -> int:
-    index = getattr(device, "index", None)
-    return 0 if index is None else int(index)
+__all__ = ["CudaHostPrefetch"]

--- a/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/presenter.py
@@ -15,6 +15,8 @@ from omnidreams.interactive_drive.input.keyboard import KeyboardState
 from omnidreams.interactive_drive.loading_overlay import render_loading_overlay
 from omnidreams.interactive_drive.types import PresentedFrame
 
+from flashdreams.infra.acceleration.frame_prefetch import prefetch_to_numpy
+
 
 class SlangPyPresenter:
     def __init__(self, raster: RasterConfig, keyboard: KeyboardState) -> None:
@@ -707,9 +709,7 @@ _env_truthy = env_truthy
 
 
 def _prefetch_to_numpy(frame: object) -> None:
-    prefetch = getattr(frame, "prefetch_to_numpy", None)
-    if callable(prefetch):
-        prefetch()
+    prefetch_to_numpy(frame)
 
 
 def _with_status_overlay(rgb_host_uint8: object, message: str | None) -> np.ndarray:

--- a/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/rasterizer.py
@@ -31,9 +31,10 @@ from ludus_renderer.torch import LudusCudaTimestampedContext
 from ludus_renderer.torch.ops import CAMERA_TYPE_BEV, CAMERA_TYPE_REGULAR
 from omnidreams.interactive_drive.config import BevConfig, RasterConfig
 from omnidreams.interactive_drive.cuda_env import DISABLE_CUDA_INTEROP_ENV, env_truthy
-from omnidreams.interactive_drive.cuda_host_prefetch import CudaHostPrefetch
 from omnidreams.interactive_drive.types import PresentedFrame, RasterChunk, SceneBundle
 from torch import Tensor
+
+from flashdreams.infra.acceleration.frame_prefetch import LazyCudaFrame
 
 _BEV_CAMERA_NAME = "interactive_drive_bev"
 
@@ -52,7 +53,7 @@ class _RenderedCameraFrames:
     ready_event: object | None
 
 
-class _LazyRasterFrame:
+class _LazyRasterFrame(LazyCudaFrame):
     """Expose a rendered HDMap frame as CUDA first, NumPy only on fallback."""
 
     def __init__(
@@ -62,66 +63,14 @@ class _LazyRasterFrame:
         *,
         source_event: object | None = None,
     ) -> None:
-        self._frames_hwc_uint8: Tensor | None = frames_hwc_uint8
-        self._frame_index = int(frame_index)
-        self._source_event = source_event
-        self._host: np.ndarray | None = None
-        self._prefetch: CudaHostPrefetch | None = None
-
-    def prefetch_to_numpy(self) -> None:
-        if (
-            self._host is not None
-            or self._prefetch is not None
-            or self._frames_hwc_uint8 is None
-        ):
-            return
-        frame = self._frames_hwc_uint8[self._frame_index].detach()
-        prefetch = CudaHostPrefetch(frame, source_event=self._source_event)
-        if prefetch.start():
-            self._prefetch = prefetch
-
-    def to_numpy(self) -> np.ndarray:
-        if self._host is None:
-            if self._prefetch is not None:
-                self._host = self._prefetch.to_numpy()
-                self._prefetch = None
-                self._frames_hwc_uint8 = None
-                return self._host
-            if self._frames_hwc_uint8 is None:
-                raise RuntimeError(
-                    "Lazy raster frame lost its source tensor before materialization."
-                )
-            synchronize = getattr(self._source_event, "synchronize", None)
-            if callable(synchronize):
-                synchronize()
-            frame = self._frames_hwc_uint8[self._frame_index].detach().cpu().numpy()
-            self._host = np.ascontiguousarray(frame, dtype=np.uint8)
-            self._frames_hwc_uint8 = None
-        return self._host
-
-    def to_cuda_tensor(self) -> Tensor:
-        if self._frames_hwc_uint8 is None:
-            raise RuntimeError(
-                "Lazy raster frame was already materialized on the host."
-            )
-        return self._frames_hwc_uint8[self._frame_index]
-
-    def to_cuda_event(self) -> object | None:
-        if self._frames_hwc_uint8 is None:
-            return None
-        return self._source_event
-
-    def __array__(
-        self,
-        dtype: object | None = None,
-        copy: bool | None = None,
-    ) -> np.ndarray:
-        array = self.to_numpy()
-        if dtype is not None:
-            array = array.astype(dtype, copy=False)
-        if copy:
-            return np.array(array, copy=True)
-        return array
+        super().__init__(
+            frames_hwc_uint8,
+            frame_index,
+            source_event=source_event,
+            lost_source_message="Lazy raster frame lost its source tensor before materialization.",
+            already_materialized_message="Lazy raster frame was already materialized on the host.",
+            synchronize_source_event_on_host_copy=True,
+        )
 
 
 class _LudusConditionRasterizerImpl:

--- a/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/runtime/loop.py
@@ -18,6 +18,7 @@ from omnidreams.interactive_drive.video_model.chunk_pipeline import (
     QueuedFrame,
 )
 
+from flashdreams.infra.acceleration.prewarm import is_warmup_index
 from flashdreams.serving.realtime.presenter import (
     PresentationQueue,
     wait_until_present_time,
@@ -520,7 +521,9 @@ def run_main_loop(
                 state.last_consumed_chunk_index = queued_frame.chunk_times.chunk_index
                 state.chunks_outstanding = max(0, state.chunks_outstanding - 1)
             present_trace = (
-                trace_context if queued_frame.chunk_times.chunk_index >= 1 else None
+                None
+                if is_warmup_index(queued_frame.chunk_times.chunk_index)
+                else trace_context
             )
             present_queued_frame(
                 queued_frame,

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -31,6 +31,8 @@ from omnidreams.interactive_drive.presenter import (
 from omnidreams.interactive_drive.types import DriverCommand, PresentedFrame
 from PIL import Image, ImageDraw, ImageFont
 
+from flashdreams.infra.acceleration.frame_prefetch import prefetch_to_numpy
+
 # Colour palette mirrors :mod:`omnidreams.interactive_drive.demo` for a
 # consistent visual identity.
 NVIDIA_GREEN: tuple[int, int, int] = (118, 185, 0)
@@ -2467,9 +2469,7 @@ def _rect_contains(rect: tuple[int, int, int, int], pos: tuple[int, int]) -> boo
 
 
 def _prefetch_to_numpy(frame: object) -> None:
-    prefetch = getattr(frame, "prefetch_to_numpy", None)
-    if callable(prefetch):
-        prefetch()
+    prefetch_to_numpy(frame)
 
 
 def _has_cuda_tensor(frame: object) -> bool:

--- a/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/video_model/chunk_pipeline.py
@@ -16,6 +16,7 @@ from omnidreams.interactive_drive.types import (
     TrajectoryChunk,
 )
 
+from flashdreams.infra.acceleration.prewarm import run_timed_prewarm
 from flashdreams.serving.realtime.timing import (
     ChunkTimes,
     TraceContext,
@@ -302,20 +303,20 @@ class ChunkPipeline:
 
     def _worker(self) -> None:
         try:
-            warmup_start = time.perf_counter()
             logger.info("[chunk-pipeline] warmup start")
-            self._backend.warmup_model()
-            warmup_end = time.perf_counter()
+            warmup_timing = run_timed_prewarm(
+                self._backend.warmup_model,
+                label="chunk-pipeline.worker_warmup",
+            )
             if self._trace_context is not None:
                 self._trace_context.add_range(
                     "worker_warmup",
                     thread=self._trace_context.worker_thread,
-                    begin_ns=trace_time_ns(warmup_start),
-                    end_ns=trace_time_ns(warmup_end),
+                    begin_ns=trace_time_ns(warmup_timing.start_time),
+                    end_ns=trace_time_ns(warmup_timing.end_time),
                 )
-            warmup_elapsed_ms = (warmup_end - warmup_start) * 1000.0
             logger.info(
-                f"[chunk-pipeline] warmup done elapsed_ms={warmup_elapsed_ms:.1f}",
+                f"[chunk-pipeline] warmup done elapsed_ms={warmup_timing.elapsed_ms:.1f}",
             )
             self._model_ready.set()
             while True:

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -502,7 +502,11 @@ class FlashdreamsWorldModelSession:
         embeddings are computed and the one-shot encoders freed before the
         AR pipeline is allocated.
         """
-        if self._offload_text_encoder and not self.manifest.synthetic_model:
+        if (
+            self._pipeline_factory is None
+            and self._offload_text_encoder
+            and not self.manifest.synthetic_model
+        ):
             return
 
         def build_and_validate_pipeline() -> None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -20,6 +20,7 @@ from omnidreams.interactive_drive.world_model.synthetic_fixture import (
 )
 
 from flashdreams.infra.acceleration.frame_prefetch import LazyCudaFrame
+from flashdreams.infra.acceleration.prewarm import run_timed_prewarm
 
 PipelineFactory = Callable[[WorldModelManifest, WorldModelProfileConfig], Any]
 _VIEW_NAMES = ["camera_front_wide_120fov"]
@@ -501,18 +502,25 @@ class FlashdreamsWorldModelSession:
         embeddings are computed and the one-shot encoders freed before the
         AR pipeline is allocated.
         """
-        start = time.perf_counter()
-        if self._pipeline_factory is not None:
-            self._pipeline = self._pipeline_factory(self.manifest, self._profile_config)
-        elif self._offload_text_encoder and not self.manifest.synthetic_model:
+        if self._offload_text_encoder and not self.manifest.synthetic_model:
             return
-        else:
-            config = _build_pipeline_config(self.manifest, self._profile_config)
-            self._pipeline = _setup_pipeline_from_config(config, self.manifest)
-        self._validate_chunk_sizes()
-        elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+        def build_and_validate_pipeline() -> None:
+            if self._pipeline_factory is not None:
+                self._pipeline = self._pipeline_factory(
+                    self.manifest, self._profile_config
+                )
+            else:
+                config = _build_pipeline_config(self.manifest, self._profile_config)
+                self._pipeline = _setup_pipeline_from_config(config, self.manifest)
+            self._validate_chunk_sizes()
+
+        warmup_timing = run_timed_prewarm(
+            build_and_validate_pipeline,
+            label="flashdreams-session.model",
+        )
         logger.info(
-            f"[flashdreams-session] model warmup runtime_ms={elapsed_ms:.1f}",
+            f"[flashdreams-session] model warmup runtime_ms={warmup_timing.elapsed_ms:.1f}",
         )
 
     def prepare_for_scene(

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -13,12 +13,13 @@ import numpy as np
 import torch
 from loguru import logger
 from omnidreams.interactive_drive.config import WorldModelProfileConfig
-from omnidreams.interactive_drive.cuda_host_prefetch import CudaHostPrefetch
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
 from omnidreams.interactive_drive.world_model.synthetic_fixture import (
     build_synthetic_world_model_assets,
     default_synthetic_asset_dir,
 )
+
+from flashdreams.infra.acceleration.frame_prefetch import LazyCudaFrame
 
 PipelineFactory = Callable[[WorldModelManifest, WorldModelProfileConfig], Any]
 _VIEW_NAMES = ["camera_front_wide_120fov"]
@@ -767,7 +768,7 @@ class FlashdreamsWorldModelSession:
         ]
 
 
-class _LazyRGBFrame:
+class _LazyRGBFrame(LazyCudaFrame):
     """Defer GPU-to-host copies until the presenter consumes each frame."""
 
     def __init__(
@@ -777,61 +778,13 @@ class _LazyRGBFrame:
         *,
         source_event: object | None = None,
     ) -> None:
-        self._frames_hwc_uint8: torch.Tensor | None = frames_hwc_uint8
-        self._frame_index = int(frame_index)
-        self._source_event = source_event
-        self._host: np.ndarray | None = None
-        self._prefetch: CudaHostPrefetch | None = None
-
-    def prefetch_to_numpy(self) -> None:
-        if (
-            self._host is not None
-            or self._prefetch is not None
-            or self._frames_hwc_uint8 is None
-        ):
-            return
-        frame = self._frames_hwc_uint8[self._frame_index].detach()
-        prefetch = CudaHostPrefetch(frame, source_event=self._source_event)
-        if prefetch.start():
-            self._prefetch = prefetch
-
-    def to_numpy(self) -> np.ndarray:
-        if self._host is None:
-            if self._prefetch is not None:
-                self._host = self._prefetch.to_numpy()
-                self._prefetch = None
-                self._frames_hwc_uint8 = None
-                return self._host
-            if self._frames_hwc_uint8 is None:
-                raise RuntimeError(
-                    "Lazy RGB frame lost its source tensor before materialization."
-                )
-            frame = self._frames_hwc_uint8[self._frame_index].detach().cpu().numpy()
-            self._host = np.ascontiguousarray(frame, dtype=np.uint8)
-            self._frames_hwc_uint8 = None
-        return self._host
-
-    def to_cuda_tensor(self) -> torch.Tensor:
-        if self._frames_hwc_uint8 is None:
-            raise RuntimeError("Lazy RGB frame was already materialized on the host.")
-        return self._frames_hwc_uint8[self._frame_index]
-
-    def to_cuda_event(self) -> object | None:
-        if self._frames_hwc_uint8 is None:
-            return None
-        return self._source_event
-
-    def __array__(
-        self,
-        dtype: object | None = None,
-        copy: bool | None = None,
-    ) -> np.ndarray:
-        array = self.to_numpy()
-        if dtype is not None:
-            array = array.astype(dtype, copy=False)
-        if copy:
-            return np.array(array, copy=True)
-        return array
+        super().__init__(
+            frames_hwc_uint8,
+            frame_index,
+            source_event=source_event,
+            lost_source_message="Lazy RGB frame lost its source tensor before materialization.",
+            already_materialized_message="Lazy RGB frame was already materialized on the host.",
+        )
 
 
 def _rgb_hwc_uint8(frame: object) -> np.ndarray:

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
-import gc
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -19,6 +19,13 @@ from omnidreams.interactive_drive.world_model.synthetic_fixture import (
     default_synthetic_asset_dir,
 )
 
+from flashdreams.infra.acceleration.encoder_lifecycle import (
+    collect_and_release_cuda_memory,
+    move_tensors_to_cpu,
+    release_one_shot_encoder_references,
+    run_one_shot_encoder_stage,
+    setup_one_shot_encoder,
+)
 from flashdreams.infra.acceleration.frame_prefetch import LazyCudaFrame
 from flashdreams.infra.acceleration.prewarm import run_timed_prewarm
 
@@ -325,17 +332,28 @@ def _precompute_embeddings_from_config(
     )
 
     start = time.perf_counter()
-    text_encoder = text_encoder_config.setup().to(device=device)
-    image_encoder = image_encoder_config.setup().to(device=device)
-    with torch.no_grad():
+    encoders = SimpleNamespace(
+        text_encoder=setup_one_shot_encoder(
+            text_encoder_config,
+            device=device,
+            torch_module=torch,
+        ),
+        image_encoder=setup_one_shot_encoder(
+            image_encoder_config,
+            device=device,
+            torch_module=torch,
+        ),
+    )
+
+    def compute_embeddings() -> dict[str, torch.Tensor | None]:
         text_embeddings = torch.stack(
-            [text_encoder(prompt_row) for prompt_row in text], dim=0
+            [encoders.text_encoder(prompt_row) for prompt_row in text], dim=0
         )
-        image_embeddings = image_encoder(image)
+        image_embeddings = encoders.image_encoder(image)
         negative_text_embeddings = (
             torch.stack(
                 [
-                    text_encoder([NEGATIVE_PROMPT for _ in prompt_row])
+                    encoders.text_encoder([NEGATIVE_PROMPT for _ in prompt_row])
                     for prompt_row in text
                 ],
                 dim=0,
@@ -343,33 +361,34 @@ def _precompute_embeddings_from_config(
             if needs_negative_text
             else None
         )
+        return {
+            "text_embeddings": text_embeddings,
+            "image_embeddings": image_embeddings,
+            "negative_text_embeddings": negative_text_embeddings,
+        }
 
-    embeddings = {
-        "text_embeddings": text_embeddings.cpu(),
-        "image_embeddings": image_embeddings.cpu(),
-        "negative_text_embeddings": (
-            negative_text_embeddings.cpu()
-            if negative_text_embeddings is not None
-            else None
+    embeddings = run_one_shot_encoder_stage(
+        compute_embeddings,
+        release=lambda: release_one_shot_encoder_references(
+            encoders,
+            "text_encoder",
+            "image_encoder",
+            device=device,
+            synchronize_cuda=device.type == "cuda",
+            torch_module=torch,
         ),
-    }
-    del (
-        text_encoder,
-        image_encoder,
-        text_embeddings,
-        image_embeddings,
-        negative_text_embeddings,
+        torch_module=torch,
     )
-    gc.collect()
-    if device.type == "cuda" and torch.cuda.is_available():
-        torch.cuda.synchronize(device)
-        torch.cuda.empty_cache()
+    text_embeddings = embeddings["text_embeddings"]
+    image_embeddings = embeddings["image_embeddings"]
+    assert text_embeddings is not None
+    assert image_embeddings is not None
     elapsed_ms = (time.perf_counter() - start) * 1000.0
     logger.info(
         "[flashdreams-session] offloaded one-shot encoders "
         f"precompute_ms={elapsed_ms:.1f} "
-        f"text_shape={tuple(embeddings['text_embeddings'].shape)} "
-        f"image_shape={tuple(embeddings['image_embeddings'].shape)}",
+        f"text_shape={tuple(text_embeddings.shape)} "
+        f"image_shape={tuple(image_embeddings.shape)}",
     )
     return embeddings
 
@@ -581,11 +600,12 @@ class FlashdreamsWorldModelSession:
         if self._pipeline is None:
             return
         self._pipeline = None
-        gc.collect()
         device = torch.device(self.manifest.device)
-        if device.type == "cuda" and torch.cuda.is_available():
-            torch.cuda.synchronize(device)
-            torch.cuda.empty_cache()
+        collect_and_release_cuda_memory(
+            device=device,
+            synchronize_cuda=device.type == "cuda",
+            torch_module=torch,
+        )
 
     def start(
         self,
@@ -722,15 +742,18 @@ class FlashdreamsWorldModelSession:
                 "offload_text_encoder requires flashdreams precompute_embeddings()."
             )
 
-        embeddings = precompute_embeddings(
-            text=[[prompt]],
-            image=self._initial_rgb_tensor(initial_rgb),
+        embeddings = move_tensors_to_cpu(
+            precompute_embeddings(
+                text=[[prompt]],
+                image=self._initial_rgb_tensor(initial_rgb),
+            ),
+            torch_module=torch,
         )
         self._precomputed_embeddings = {
-            "text_embeddings": embeddings["text_embeddings"].cpu(),
-            "image_embeddings": embeddings["image_embeddings"].cpu(),
+            "text_embeddings": embeddings["text_embeddings"],
+            "image_embeddings": embeddings["image_embeddings"],
             "negative_text_embeddings": (
-                embeddings["negative_text_embeddings"].cpu()
+                embeddings["negative_text_embeddings"]
                 if embeddings.get("negative_text_embeddings") is not None
                 else None
             ),

--- a/integrations/omnidreams/omnidreams/pipeline.py
+++ b/integrations/omnidreams/omnidreams/pipeline.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import gc
 from dataclasses import dataclass, field
 from typing import TypeAlias
 
@@ -35,6 +34,10 @@ from flashdreams.core.distributed.context_parallel import (
     cat_outputs_cp,
     split_inputs_cp,
     split_inputs_cp_object_list,
+)
+from flashdreams.infra.acceleration.encoder_lifecycle import (
+    move_tensors_to_cpu,
+    release_one_shot_encoder_references,
 )
 from flashdreams.infra.decoder import StreamingDecoderCache
 from flashdreams.infra.encoder import StreamingEncoderCache
@@ -347,15 +350,18 @@ class OmnidreamsPipeline(
                     for prompt_row in text
                 ],
                 dim=0,
-            ).cpu()
+            )
         else:
             negative_text_embeddings = None
 
-        return {
-            "text_embeddings": text_embeddings.cpu(),
-            "image_embeddings": image_embeddings.cpu(),
-            "negative_text_embeddings": negative_text_embeddings,
-        }
+        return move_tensors_to_cpu(
+            {
+                "text_embeddings": text_embeddings,
+                "image_embeddings": image_embeddings,
+                "negative_text_embeddings": negative_text_embeddings,
+            },
+            torch_module=torch,
+        )
 
     def _validate_image_resolution(self, image: Tensor) -> None:
         transformer = self.diffusion_model.transformer
@@ -383,13 +389,12 @@ class OmnidreamsPipeline(
         Idempotent. Only safe for one-shot pipeline lifetimes (demos);
         long-lived hosts that reuse the pipeline must not call this.
         """
-        # None (not delattr) so initialize_cache's `is not None` guard gives a useful error.
-        self.text_encoder = None
-        self.image_encoder = None
-        # nn.Module ref cycles (parent<->child, hooks) outlive the refcount drop;
-        # force GC before releasing the freed CUDA blocks.
-        gc.collect()
-        torch.cuda.empty_cache()
+        release_one_shot_encoder_references(
+            self,
+            "text_encoder",
+            "image_encoder",
+            torch_module=torch,
+        )
 
     @torch.no_grad()
     def generate(

--- a/integrations/omnidreams/omnidreams/transformer/__init__.py
+++ b/integrations/omnidreams/omnidreams/transformer/__init__.py
@@ -36,8 +36,11 @@ from flashdreams.core.attention.rope import (
 )
 from flashdreams.core.checkpoint.load import load_checkpoint
 from flashdreams.core.distributed.context_parallel import split_inputs_cp
+from flashdreams.infra.acceleration.cuda_graph_dispatch import (
+    CUDAGraphDispatch,
+    cuda_graph_capture_ar_index,
+)
 from flashdreams.infra.compile import compile_module
-from flashdreams.infra.cuda_graph import CUDAGraphWrapper
 from flashdreams.infra.diffusion.transformer import (
     Transformer,
     TransformerAutoregressiveCache,
@@ -318,28 +321,25 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         if config.compile_network and self._optimized_dit_executor is None:
             self.network = compile_module(self.network)
 
-        # CUDA-graph dispatch (use_cuda_graph=True): filling phase uses
-        # wrapper.drain (eager, drains Inductor autotune); steady-state uses
-        # wrapper.__call__ (warmup + capture + replay). The cache fills at AR
-        # step chunks_total // len_t - 1, so the next step is the first to see a
-        # steady-state KV cache and take the capturable steady branches.
+        # Cond and CFG-uncond branches each get their own CUDA-graph wrapper
+        # since each mutates an independent rolling KV cache.
         self._use_cuda_graph = config.use_cuda_graph
-        chunks_total = config.sink_size_t + config.window_size_t
-        assert chunks_total % config.len_t == 0, (
-            f"sink_size_t + window_size_t ({chunks_total}) must be "
-            f"divisible by len_t ({config.len_t}) so the BlockKVCache can "
-            f"fit a whole number of AR chunks."
+        self._cuda_graph_capture_ar_idx = cuda_graph_capture_ar_index(
+            sink_size_t=config.sink_size_t,
+            window_size_t=config.window_size_t,
+            len_t=config.len_t,
         )
-        self._cuda_graph_capture_ar_idx: int = chunks_total // config.len_t
-        self._network_call: CUDAGraphWrapper | CosmosDiTNetwork = (
-            CUDAGraphWrapper(self.network, warmup_iters=config.cuda_graph_warmup_iters)
-            if config.use_cuda_graph
-            else self.network
+        self._cuda_graph_dispatch = CUDAGraphDispatch(
+            self.network,
+            enabled=config.use_cuda_graph,
+            capture_ar_idx=self._cuda_graph_capture_ar_idx,
+            warmup_iters=config.cuda_graph_warmup_iters,
         )
-        self._network_call_uncond: CUDAGraphWrapper | CosmosDiTNetwork = (
-            CUDAGraphWrapper(self.network, warmup_iters=config.cuda_graph_warmup_iters)
-            if config.use_cuda_graph
-            else self.network
+        # Compatibility aliases for native acceleration hooks that predate the
+        # shared dispatch helper.
+        self._network_call = self._cuda_graph_dispatch.cond_call or self.network
+        self._network_call_uncond = (
+            self._cuda_graph_dispatch.uncond_call or self.network
         )
 
         # Single view: flatten latent to 4D [B, V, L, D] so CP applies on L
@@ -600,13 +600,8 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         mask_first_patched = self.patchify_and_maybe_split_cp(mask_first_block)
         mask_other_patched = self.patchify_and_maybe_split_cp(mask_other_blocks)
 
-        # Reset any prior CUDA graph: it refers to slot pointers from the
-        # previous cache, which the new cache invalidates.
         if self._use_cuda_graph:
-            assert isinstance(self._network_call, CUDAGraphWrapper)
-            self._network_call.reset()
-            assert isinstance(self._network_call_uncond, CUDAGraphWrapper)
-            self._network_call_uncond.reset()
+            self._cuda_graph_dispatch.reset()
 
         cache = CosmosTransformerCache(
             network_cache=network_cache,
@@ -647,14 +642,9 @@ class CosmosTransformer(Transformer[CosmosTransformerCache]):
         if not self._use_cuda_graph:
             return self.network
 
-        network_call = self._network_call_uncond if uncond else self._network_call
-        assert isinstance(network_call, CUDAGraphWrapper)
-        # Cond and CFG-uncond branches both mutate the rolling KV cache, so
-        # neither branch can be graph-captured until the cache is steady.
-        return (
-            network_call.drain
-            if autoregressive_index < self._cuda_graph_capture_ar_idx
-            else network_call
+        return self._cuda_graph_dispatch.select(
+            autoregressive_index,
+            uncond=uncond,
         )
 
     def _predict_branch(

--- a/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
+++ b/integrations/omnidreams/omnidreams_singleview/python/optimized_dit.py
@@ -1134,6 +1134,9 @@ class OptimizedDiTExecutor:
         # The parent graph wrappers point at the freed PyTorch network and
         # must stay disabled when a reset initializes a fresh cache.
         self.transformer._use_cuda_graph = False
+        cuda_graph_dispatch = getattr(self.transformer, "_cuda_graph_dispatch", None)
+        if cuda_graph_dispatch is not None:
+            cuda_graph_dispatch.disable(fn=shape_ops)
         cast(Any, self.transformer)._network_call = None
         cast(Any, self.transformer)._network_call_uncond = None
         self.network = shape_ops


### PR DESCRIPTION
Extract shared realtime acceleration helpers

## Summary

This PR extracts reusable realtime acceleration helpers from demo-specific code
and migrates the existing demos/integrations to use the shared implementations.

It builds on the shared realtime serving, timing, and presentation work by
adding common infrastructure for frame prefetching, CUDA graph dispatch policy,
prewarm execution, overlapped work, and one-shot encoder lifecycle management.

## Changes

- Add shared frame prefetch helpers for CUDA host prefetch, lazy CUDA-frame
  materialization, and generic prefetch dispatch.
- Keep the previous `cuda_host_prefetch` import path as a compatibility shim.
- Add shared CUDA graph dispatch policy helpers.
- Add shared prewarm helpers and migrate existing warmup/prewarm paths.
- Add shared overlap runners for synchronous, host-thread, and CUDA-stream
  execution.
- Add shared one-shot encoder lifecycle helpers for setup, reuse, CPU result
  materialization, release, and CUDA memory cleanup.
- Migrate the relevant OmniDreams, Wan, and FlashVSR paths onto the shared
  acceleration utilities.
- Add focused CPU tests for the new shared helper modules.

## Validation

- Existing CPU CI is expected to cover the new helper-level tests.
- Manual GPU smoke testing covered LingBot, OmniDreams WebRTC, and
  interactive-drive flows.
- Observed demo behavior and steady-state timings are comparable to the
  pre-refactor phase 5 baseline.