### PR TITLE
Make WebRTC serving reusable across demos

### DIFF
--- a/docs/source/api/serving.rst
+++ b/docs/source/api/serving.rst
@@ -16,8 +16,8 @@
 Serving
 ===================================
 
-Serving in FlashDreams is currently integration-driven: model-specific serving
-stacks wrap the same runner/pipeline abstractions used for offline inference.
+Serving in FlashDreams is integration-driven at the model/runtime layer, while
+WebRTC provides the shared browser-facing transport for realtime demos.
 
 Serving building blocks
 -----------------------
@@ -25,18 +25,19 @@ Serving building blocks
 - **Runner config** defines serving-relevant I/O fields (prompts, control
   tensors, image paths, output transport).
 - **Pipeline** manages model lifecycle and cached state across steps.
-- **Integration transport** (for example WebRTC in
-  :doc:`LingBot-World </models/lingbot_world>`) handles
-  session I/O, request routing, and media responses.
+- **Shared WebRTC transport** handles browser session I/O, request routing,
+  data-channel controls, and media responses for realtime demos.
+- **Integration runtime** owns model-specific checkpoint setup, conditioning,
+  prompt/scene semantics, and chunk generation.
 
 Reference integration
 ---------------------
 
-:doc:`LingBot-World </models/lingbot_world>` provides the canonical serving
-integration:
+The public WebRTC demos provide concrete examples of the shared serving stack:
 
-- runner and pipeline wiring under ``integrations/lingbot/lingbot/``,
-- interactive transport under ``integrations/lingbot/lingbot/webrtc/``.
+- shared transport code under ``flashdreams/flashdreams/serving/webrtc/``,
+- LingBot runner and runtime wiring under ``integrations/lingbot/lingbot/``,
+- OmniDreams WebRTC runtime wiring under ``integrations/omnidreams/omnidreams/webrtc/``.
 
 Launch patterns
 ---------------

--- a/docs/source/developer_guides/interactive_serving.rst
+++ b/docs/source/developer_guides/interactive_serving.rst
@@ -60,4 +60,33 @@ Serving implementation references
 - :doc:`/api/serving` for serving API concepts and component mapping.
 - :doc:`/developer_guides/inference_pipeline_overview` for runner/pipeline
   execution flow.
-- ``integrations/lingbot/lingbot/webrtc`` for the WebRTC serving stack.
+- ``flashdreams.serving.webrtc`` for the shared WebRTC server, session manager,
+  runtime protocol, data-channel messages, packaged UI app factory, and
+  distributed serve-loop helpers.
+- ``integrations/lingbot/lingbot/webrtc`` and
+  ``integrations/omnidreams/omnidreams/webrtc`` for concrete WebRTC demos built
+  on the shared serving stack.
+
+WebRTC demo shape
+-----------------
+
+New realtime demos should use WebRTC as the primary browser transport. The
+shared package owns the reusable serving shell:
+
+- ``runtime.WebRTCGenerationRuntime`` describes the lifecycle a model runtime
+  must provide: initialize, reset a rollout, generate one chunk, and close.
+- ``manager.BaseWebRTCSessionManager`` owns one active peer connection, control
+  data-channel parsing, liveness, keyboard resampling, loopback warmup, and
+  chunk scheduling.
+- ``server.create_packaged_webrtc_app`` builds the aiohttp app from packaged
+  browser assets and keeps those resources alive until cleanup.
+- ``bootstrap.initialize_cuda_distributed`` and ``bootstrap.run_webrtc_server``
+  provide the common CUDA/distributed launch and teardown path.
+- ``messages`` defines the common action, event, heartbeat, disconnect,
+  ``chunk_done``, ``event_ack``, and error payload contracts.
+
+Model integrations should keep model-specific runtime code local: checkpoint
+setup, scene or prompt semantics, conditioning/rendering, cache math, and any
+custom HTTP routes that configure a session. The shared WebRTC layer should be
+enough for a new demo to provide a runtime, package its UI assets, add optional
+routes, and start serving without copying another demo's bootstrap code.

--- a/flashdreams/flashdreams/serving/webrtc/bootstrap.py
+++ b/flashdreams/flashdreams/serving/webrtc/bootstrap.py
@@ -46,7 +46,7 @@ def _distributed_init() -> None:
 def initialize_cuda_distributed(
     *,
     default_device: str | torch.device = "cuda:0",
-    distributed_init_fn: Callable[[], None] | None = None,
+    distributed_init_fn: Callable[[], object] | None = None,
     configure_logging_fn: Callable[..., None] = configure_logging,
     torch_module: Any = torch,
     dist_module: Any = dist,

--- a/flashdreams/flashdreams/serving/webrtc/bootstrap.py
+++ b/flashdreams/flashdreams/serving/webrtc/bootstrap.py
@@ -7,27 +7,93 @@ from __future__ import annotations
 
 import gc
 import logging
-from typing import Protocol
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
 import torch
 import torch.distributed as dist
 from aiohttp import web
 from loguru import logger
 
-from flashdreams.core.distributed import configure_loguru_for_distributed
+from flashdreams.serving.webrtc.runtime import WebRTCServerLifecycle
 
 
-class WebRTCServerLifecycle(Protocol):
-    """Rank-coordination surface the serve loop needs from a session manager."""
+@dataclass(frozen=True, slots=True)
+class WebRTCDistributedContext:
+    """CUDA/distributed launch context for a WebRTC demo server."""
 
-    def send_exit_signal(self) -> None: ...
-    def wait_for_termination(self) -> None: ...
+    device: torch.device
+    world_rank: int
+    world_size: int
 
 
 def configure_logging(*, world_rank: int | None = None) -> None:
+    from flashdreams.core.distributed import configure_loguru_for_distributed
+
     configure_loguru_for_distributed(world_rank=world_rank)
     for logger_name in ("aioice", "aioice.ice", "aiortc"):
         logging.getLogger(logger_name).setLevel(logging.WARNING)
+
+
+def _distributed_init() -> None:
+    from flashdreams.core.distributed import init as distributed_init
+
+    distributed_init()
+
+
+def initialize_cuda_distributed(
+    *,
+    default_device: str | torch.device = "cuda:0",
+    distributed_init_fn: Callable[[], None] | None = None,
+    configure_logging_fn: Callable[..., None] = configure_logging,
+    torch_module: Any = torch,
+    dist_module: Any = dist,
+) -> WebRTCDistributedContext:
+    """Initialize CUDA and optional torch.distributed for WebRTC serving."""
+    if not torch_module.cuda.is_available():
+        raise RuntimeError("CUDA is required for inference in the WebRTC server.")
+
+    has_rank = "RANK" in os.environ
+    has_world_size = "WORLD_SIZE" in os.environ
+    if has_rank != has_world_size:
+        raise RuntimeError(
+            "Distributed launch expects both RANK and WORLD_SIZE to be set."
+        )
+
+    distributed_launch = has_rank and has_world_size
+    if distributed_launch:
+        if distributed_init_fn is None:
+            distributed_init_fn = _distributed_init
+        distributed_init_fn()
+        world_rank = dist_module.get_rank()
+        world_size = dist_module.get_world_size()
+    else:
+        world_rank = 0
+        world_size = 1
+
+    device_count = torch_module.cuda.device_count()
+    if device_count < 1:
+        raise RuntimeError("CUDA device count must be >= 1 for inference.")
+    if distributed_launch:
+        local_rank = world_rank % device_count
+        torch_device = torch_module.device(f"cuda:{local_rank}")
+    else:
+        torch_device = torch_module.device(default_device)
+        if torch_device.type != "cuda":
+            raise RuntimeError(
+                f"CUDA device is required for inference, got {torch_device}."
+            )
+        if torch_device.index is None:
+            torch_device = torch_module.device("cuda:0")
+    torch_module.cuda.set_device(torch_device)
+    configure_logging_fn(world_rank=world_rank)
+    return WebRTCDistributedContext(
+        device=torch_device,
+        world_rank=world_rank,
+        world_size=world_size,
+    )
 
 
 def run_webrtc_server(

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -30,8 +30,8 @@ from flashdreams.serving.webrtc.messages import (
     make_event_ack_payload,
 )
 from flashdreams.serving.webrtc.runtime import (
-    WebRTCSessionRuntime,
     WebRTCRuntimeConfig,
+    WebRTCSessionRuntime,
     WebRTCStepResult,
 )
 from flashdreams.serving.webrtc.server import SessionBusyError

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -13,7 +13,7 @@ from collections import deque
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from aiortc import RTCConfiguration, RTCPeerConnection, RTCSessionDescription
 from loguru import logger
@@ -30,7 +30,7 @@ from flashdreams.serving.webrtc.messages import (
     make_event_ack_payload,
 )
 from flashdreams.serving.webrtc.runtime import (
-    WebRTCGenerationRuntime,
+    WebRTCSessionRuntime,
     WebRTCRuntimeConfig,
     WebRTCStepResult,
 )
@@ -53,6 +53,9 @@ DEFAULT_CLIENT_LIVENESS_TIMEOUT_S = 10.0
 
 # How often the liveness watchdog wakes to re-check the elapsed-since-last-message.
 _CLIENT_LIVENESS_CHECK_INTERVAL_S = 1.0
+
+_RuntimeT = TypeVar("_RuntimeT", bound=WebRTCSessionRuntime)
+_RuntimeConfigT = TypeVar("_RuntimeConfigT", bound=WebRTCRuntimeConfig)
 
 
 class WebRTCControlSignal(IntEnum):
@@ -112,7 +115,7 @@ class ManagedWebRTCSession:
         await self.peer_connection.close()
 
 
-class BaseWebRTCSessionManager:
+class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
     """Owns one active WebRTC session and forwards actions into a model runtime."""
 
     _busy_message: str = "A WebRTC session is already active."
@@ -124,8 +127,8 @@ class BaseWebRTCSessionManager:
     def __init__(
         self,
         *,
-        runtime: WebRTCGenerationRuntime,
-        runtime_config: WebRTCRuntimeConfig,
+        runtime: _RuntimeT,
+        runtime_config: _RuntimeConfigT,
         fps: int,
         client_liveness_timeout_s: float = DEFAULT_CLIENT_LIVENESS_TIMEOUT_S,
     ) -> None:

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -15,17 +15,37 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Any
 
-import torch
 from aiortc import RTCConfiguration, RTCPeerConnection, RTCSessionDescription
 from loguru import logger
 
 from flashdreams.serving.realtime.input import KeyboardResampler
 from flashdreams.serving.webrtc.media import BufferedVideoTrack
+from flashdreams.serving.webrtc.messages import (
+    MESSAGE_TYPE_ACTION,
+    MESSAGE_TYPE_DISCONNECT,
+    MESSAGE_TYPE_EVENT,
+    MESSAGE_TYPE_HEARTBEAT,
+    make_chunk_done_payload,
+    make_error_payload,
+    make_event_ack_payload,
+)
+from flashdreams.serving.webrtc.runtime import (
+    WebRTCGenerationRuntime,
+    WebRTCRuntimeConfig,
+    WebRTCStepResult,
+)
 from flashdreams.serving.webrtc.server import SessionBusyError
 from flashdreams.serving.webrtc.warmup import (
     run_loopback_warmup_session,
     wait_for_ice_gathering_complete,
 )
+
+__all__ = [
+    "BaseWebRTCSessionManager",
+    "ManagedWebRTCSession",
+    "WebRTCControlSignal",
+    "WebRTCStepResult",
+]
 
 # Close the active session if no client heartbeat/control message arrives
 # within this many seconds. Browsers sends periodic heartbeats.
@@ -44,16 +64,6 @@ class WebRTCControlSignal(IntEnum):
     CLOSE = 3
     EVENT = 4
     EXIT = 99
-
-
-@dataclass(slots=True)
-class WebRTCStepResult:
-    """One generated chunk handed back by a model runtime's ``generate_chunk``."""
-
-    chunk_index: int
-    num_frames: int
-    video_chunk: torch.Tensor
-    stats: dict[str, float] | None
 
 
 @dataclass(slots=True)
@@ -114,8 +124,8 @@ class BaseWebRTCSessionManager:
     def __init__(
         self,
         *,
-        runtime: Any,
-        runtime_config: Any,
+        runtime: WebRTCGenerationRuntime,
+        runtime_config: WebRTCRuntimeConfig,
         fps: int,
         client_liveness_timeout_s: float = DEFAULT_CLIENT_LIVENESS_TIMEOUT_S,
     ) -> None:
@@ -183,13 +193,12 @@ class BaseWebRTCSessionManager:
             if channel is not None:
                 self._send_json(
                     channel,
-                    {
-                        "type": "error",
-                        "message": (
+                    make_error_payload(
+                        (
                             "Event payload must include non-empty 'event_id' "
                             "unless state clears the active event."
                         ),
-                    },
+                    ),
                 )
             return False
 
@@ -198,10 +207,7 @@ class BaseWebRTCSessionManager:
             if channel is not None:
                 self._send_json(
                     channel,
-                    {
-                        "type": "error",
-                        "message": "This runtime does not support event messages.",
-                    },
+                    make_error_payload("This runtime does not support event messages."),
                 )
             return False
 
@@ -211,20 +217,18 @@ class BaseWebRTCSessionManager:
                 result = await result
         except Exception as exc:
             if channel is not None:
-                self._send_json(channel, {"type": "error", "message": str(exc)})
+                self._send_json(channel, make_error_payload(str(exc)))
             return False
 
         if channel is not None:
-            ack: dict[str, Any] = {
-                "type": "event_ack",
-                "event_id": event_id or None,
-                "state": state,
-            }
-            if isinstance(result, dict):
-                for key, value in result.items():
-                    if key not in ack:
-                        ack[key] = value
-            self._send_json(channel, ack)
+            self._send_json(
+                channel,
+                make_event_ack_payload(
+                    event_id=event_id or None,
+                    state=state,
+                    result=result if isinstance(result, dict) else None,
+                ),
+            )
         return True
 
     def has_active_session(self) -> bool:
@@ -440,32 +444,28 @@ class BaseWebRTCSessionManager:
         managed_session.last_client_message_at = asyncio.get_running_loop().time()
 
         if not isinstance(raw_message, str):
-            self._send_json(
-                channel, {"type": "error", "message": "Expected text payload."}
-            )
+            self._send_json(channel, make_error_payload("Expected text payload."))
             return
 
         try:
             payload = json.loads(raw_message)
         except json.JSONDecodeError:
-            self._send_json(
-                channel, {"type": "error", "message": "Invalid JSON payload."}
-            )
+            self._send_json(channel, make_error_payload("Invalid JSON payload."))
             return
 
         if not isinstance(payload, dict):
             self._send_json(
-                channel, {"type": "error", "message": "Payload must be a JSON object."}
+                channel, make_error_payload("Payload must be a JSON object.")
             )
             return
         message_type = str(payload.get("type", "")).strip().lower()
-        if message_type == "heartbeat":
+        if message_type == MESSAGE_TYPE_HEARTBEAT:
             return
-        if message_type == "disconnect":
+        if message_type == MESSAGE_TYPE_DISCONNECT:
             logger.info("Client requested disconnect; closing active session.")
             await self.close_active_session()
             return
-        if message_type == "event":
+        if message_type == MESSAGE_TYPE_EVENT:
             handled = await self._handle_event_message(
                 managed_session=managed_session,
                 payload=payload,
@@ -475,22 +475,19 @@ class BaseWebRTCSessionManager:
                 # want the model to generate an idle-camera chunk with updated text.
                 managed_session.first_action_received.set()
             return
-        if message_type != "action":
+        if message_type != MESSAGE_TYPE_ACTION:
             self._send_json(
                 channel,
-                {
-                    "type": "error",
-                    "message": "Unsupported message type, expected "
+                make_error_payload(
+                    "Unsupported message type, expected "
                     "'action', 'event', 'heartbeat', or 'disconnect'.",
-                },
+                ),
             )
             return
 
         action_payload = payload.get("action", payload)
         if not isinstance(action_payload, dict):
-            self._send_json(
-                channel, {"type": "error", "message": "'action' must be an object."}
-            )
+            self._send_json(channel, make_error_payload("'action' must be an object."))
             return
 
         event = str(action_payload.get("event", "")).strip().lower()
@@ -503,21 +500,16 @@ class BaseWebRTCSessionManager:
         if event not in ("keydown", "keyup"):
             self._send_json(
                 channel,
-                {
-                    "type": "error",
-                    "message": f"Unsupported event={event!r}; "
-                    "expected 'keydown' or 'keyup'.",
-                },
+                make_error_payload(
+                    f"Unsupported event={event!r}; expected 'keydown' or 'keyup'.",
+                ),
             )
             return
         key = str(action_payload.get("key", "")).strip()
         if not key:
             self._send_json(
                 channel,
-                {
-                    "type": "error",
-                    "message": "Action payload must include non-empty 'key'.",
-                },
+                make_error_payload("Action payload must include non-empty 'key'."),
             )
             return
 
@@ -611,7 +603,7 @@ class BaseWebRTCSessionManager:
                     logger.exception("Chunk generation failed.")
                     channel = managed_session.control_channel
                     if channel is not None:
-                        self._send_json(channel, {"type": "error", "message": str(exc)})
+                        self._send_json(channel, make_error_payload(str(exc)))
                     if self._close_session_on_generation_error:
                         await self.close_active_session()
                         return
@@ -646,29 +638,26 @@ class BaseWebRTCSessionManager:
 
                 channel = managed_session.control_channel
                 if channel is not None:
-                    payload: dict[str, Any] = {
-                        "type": "chunk_done",
-                        "chunk_index": result.chunk_index,
-                        "num_frames": result.num_frames,
-                        "enqueued_frames": enqueued,
-                        "fps": video_track.fps,
-                        "resolution": {
-                            "width": self.runtime_config.video_width,
-                            "height": self.runtime_config.video_height,
-                        },
-                        "model": self._model_name(),
-                        "gen_ms": round(gen_ms, 1),
-                        "enqueue_ms": round(enqueue_ms, 1),
-                        "play_ms": round(play_ms, 1),
-                        "queue_depth": video_track.qsize(),
-                        "lag_ms": round(lag_ms, 1),
-                    }
-                    payload.update(self._chunk_done_extra())
-                    if control_latency_ms is not None:
-                        payload["latency_ms"] = round(control_latency_ms, 1)
-                        payload["control_latency_ms"] = round(control_latency_ms, 1)
-                        payload["consumed_actions"] = len(consumed_action_arrivals)
-                    self._send_json(channel, payload)
+                    self._send_json(
+                        channel,
+                        make_chunk_done_payload(
+                            chunk_index=result.chunk_index,
+                            num_frames=result.num_frames,
+                            enqueued_frames=enqueued,
+                            fps=video_track.fps,
+                            width=self.runtime_config.video_width,
+                            height=self.runtime_config.video_height,
+                            model=self._model_name(),
+                            gen_ms=gen_ms,
+                            enqueue_ms=enqueue_ms,
+                            play_ms=play_ms,
+                            queue_depth=video_track.qsize(),
+                            lag_ms=lag_ms,
+                            control_latency_ms=control_latency_ms,
+                            consumed_actions=len(consumed_action_arrivals),
+                            extra=self._chunk_done_extra(),
+                        ),
+                    )
         except asyncio.CancelledError:
             logger.info("Generation worker cancelled.")
             raise

--- a/flashdreams/flashdreams/serving/webrtc/messages.py
+++ b/flashdreams/flashdreams/serving/webrtc/messages.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared WebRTC data-channel message helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+MESSAGE_TYPE_ACTION = "action"
+MESSAGE_TYPE_CHUNK_DONE = "chunk_done"
+MESSAGE_TYPE_DISCONNECT = "disconnect"
+MESSAGE_TYPE_ERROR = "error"
+MESSAGE_TYPE_EVENT = "event"
+MESSAGE_TYPE_EVENT_ACK = "event_ack"
+MESSAGE_TYPE_HEARTBEAT = "heartbeat"
+
+
+def make_error_payload(message: str) -> dict[str, str]:
+    return {"type": MESSAGE_TYPE_ERROR, "message": message}
+
+
+def make_event_ack_payload(
+    *,
+    event_id: str | None,
+    state: str,
+    result: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": MESSAGE_TYPE_EVENT_ACK,
+        "event_id": event_id,
+        "state": state,
+    }
+    if result is not None:
+        for key, value in result.items():
+            if key not in payload:
+                payload[key] = value
+    return payload
+
+
+def make_chunk_done_payload(
+    *,
+    chunk_index: int,
+    num_frames: int,
+    enqueued_frames: int,
+    fps: int,
+    width: int,
+    height: int,
+    model: str,
+    gen_ms: float,
+    enqueue_ms: float,
+    play_ms: float,
+    queue_depth: int,
+    lag_ms: float,
+    control_latency_ms: float | None = None,
+    consumed_actions: int | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": MESSAGE_TYPE_CHUNK_DONE,
+        "chunk_index": chunk_index,
+        "num_frames": num_frames,
+        "enqueued_frames": enqueued_frames,
+        "fps": fps,
+        "resolution": {"width": width, "height": height},
+        "model": model,
+        "gen_ms": round(gen_ms, 1),
+        "enqueue_ms": round(enqueue_ms, 1),
+        "play_ms": round(play_ms, 1),
+        "queue_depth": queue_depth,
+        "lag_ms": round(lag_ms, 1),
+    }
+    if extra is not None:
+        payload.update(extra)
+    if control_latency_ms is not None:
+        rounded_latency_ms = round(control_latency_ms, 1)
+        payload["latency_ms"] = rounded_latency_ms
+        payload["control_latency_ms"] = rounded_latency_ms
+        payload["consumed_actions"] = (
+            0 if consumed_actions is None else consumed_actions
+        )
+    return payload

--- a/flashdreams/flashdreams/serving/webrtc/runtime.py
+++ b/flashdreams/flashdreams/serving/webrtc/runtime.py
@@ -34,7 +34,7 @@ class WebRTCRuntimeConfig(Protocol):
 
 
 class WebRTCGenerationRuntime(Protocol):
-    """Lifecycle required by :class:`BaseWebRTCSessionManager`.
+    """Generation lifecycle for one shared WebRTC session.
 
     Integrations keep their model-specific state, checkpoints, conditioning,
     and cache logic inside their concrete runtime. The shared manager only
@@ -73,3 +73,7 @@ class WebRTCServerLifecycle(Protocol):
     def send_exit_signal(self) -> None: ...
 
     def wait_for_termination(self) -> None: ...
+
+
+class WebRTCSessionRuntime(WebRTCGenerationRuntime, WebRTCServerLifecycle, Protocol):
+    """Complete runtime contract consumed by the shared session manager."""

--- a/flashdreams/flashdreams/serving/webrtc/runtime.py
+++ b/flashdreams/flashdreams/serving/webrtc/runtime.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime contracts for shared WebRTC demo serving."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import torch
+
+from flashdreams.serving.realtime.input import PoseSegment
+
+
+@dataclass(slots=True)
+class WebRTCStepResult:
+    """One generated chunk handed back by a WebRTC model runtime."""
+
+    chunk_index: int
+    num_frames: int
+    video_chunk: torch.Tensor
+    stats: dict[str, float] | None
+
+
+class WebRTCRuntimeConfig(Protocol):
+    """Config fields consumed by the shared WebRTC session manager."""
+
+    video_width: int
+    video_height: int
+    warmup_chunks: int
+    warmup_timeout_s: float
+
+
+class WebRTCGenerationRuntime(Protocol):
+    """Lifecycle required by :class:`BaseWebRTCSessionManager`.
+
+    Integrations keep their model-specific state, checkpoints, conditioning,
+    and cache logic inside their concrete runtime. The shared manager only
+    needs this lifecycle and chunk-generation surface.
+    """
+
+    async def initialize(self) -> None: ...
+
+    async def reset_for_new_session(self) -> None: ...
+
+    def peek_steady_chunk_num_frames(self) -> int: ...
+
+    def peek_next_chunk_num_frames(self) -> int: ...
+
+    async def generate_chunk(
+        self,
+        *,
+        segments: list[PoseSegment],
+        frame_times: list[float],
+    ) -> WebRTCStepResult: ...
+
+    async def close(self) -> None: ...
+
+
+class WebRTCEventRuntime(Protocol):
+    """Optional runtime capability for model-specific data-channel events."""
+
+    def trigger_event(
+        self, *, event_id: str, state: str = "trigger"
+    ) -> dict[str, Any] | Awaitable[dict[str, Any]]: ...
+
+
+class WebRTCServerLifecycle(Protocol):
+    """Distributed worker lifecycle used by the shared WebRTC serve loop."""
+
+    def send_exit_signal(self) -> None: ...
+
+    def wait_for_termination(self) -> None: ...

--- a/flashdreams/flashdreams/serving/webrtc/server.py
+++ b/flashdreams/flashdreams/serving/webrtc/server.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextlib import AbstractContextManager, ExitStack
+from importlib.resources import as_file
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -25,6 +28,7 @@ class WebRTCSessionManager(Protocol):
 
 
 SESSION_MANAGER_KEY = web.AppKey("session_manager", WebRTCSessionManager)
+PACKAGE_RESOURCE_STACK_KEY = web.AppKey("package_resource_stack", ExitStack)
 
 
 def create_webrtc_app(
@@ -103,4 +107,47 @@ def create_webrtc_app(
     app.router.add_static("/static/", web_dir, show_index=False)
     app.on_startup.append(on_startup)
     app.on_shutdown.append(on_shutdown)
+    return app
+
+
+async def close_package_resources(app: web.Application) -> None:
+    app[PACKAGE_RESOURCE_STACK_KEY].close()
+
+
+def create_packaged_webrtc_app(
+    *,
+    web_resource: Any,
+    session_manager: WebRTCSessionManager,
+    request_session_url: str,
+    preload_name: str,
+    configure_app: Callable[[web.Application], None] | None = None,
+    index_filename: str = "request_session.html",
+    as_file_fn: Callable[[Any], AbstractContextManager[Path]] = as_file,
+    create_app_fn: Callable[..., web.Application] = create_webrtc_app,
+    cleanup_callback: Callable[[web.Application], Any] = close_package_resources,
+) -> web.Application:
+    """Create a WebRTC app from packaged static assets.
+
+    ``importlib.resources.as_file`` can materialize package resources into a
+    temporary directory. The returned app owns that context until aiohttp
+    cleanup, so demos can serve static browser assets from packages and tests
+    can still inspect the materialized directory.
+    """
+    resource_stack = ExitStack()
+    try:
+        web_dir = resource_stack.enter_context(as_file_fn(web_resource))
+        app = create_app_fn(
+            web_dir=web_dir,
+            session_manager=session_manager,
+            preload_name=preload_name,
+            request_session_url=request_session_url,
+            index_filename=index_filename,
+        )
+        if configure_app is not None:
+            configure_app(app)
+        app[PACKAGE_RESOURCE_STACK_KEY] = resource_stack
+        app.on_cleanup.append(cleanup_callback)
+    except Exception:
+        resource_stack.close()
+        raise
     return app

--- a/flashdreams/tests/test_webrtc_bootstrap.py
+++ b/flashdreams/tests/test_webrtc_bootstrap.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashdreams.serving.webrtc import bootstrap
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_initialize_cuda_distributed_single_process_uses_default_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+
+    set_device_calls: list[torch.device] = []
+    logging_ranks: list[int | None] = []
+    monkeypatch.setattr(bootstrap.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(bootstrap.torch.cuda, "device_count", lambda: 4)
+    monkeypatch.setattr(
+        bootstrap.torch.cuda,
+        "set_device",
+        lambda device: set_device_calls.append(device),
+    )
+
+    context = bootstrap.initialize_cuda_distributed(
+        default_device="cuda:2",
+        configure_logging_fn=lambda *, world_rank: logging_ranks.append(world_rank),
+    )
+
+    assert context.device == torch.device("cuda:2")
+    assert context.world_rank == 0
+    assert context.world_size == 1
+    assert set_device_calls == [torch.device("cuda:2")]
+    assert logging_ranks == [0]
+
+
+def test_initialize_cuda_distributed_defaults_unspecified_cuda_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    set_device_calls: list[torch.device] = []
+    monkeypatch.setattr(bootstrap.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(bootstrap.torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(
+        bootstrap.torch.cuda,
+        "set_device",
+        lambda device: set_device_calls.append(device),
+    )
+
+    context = bootstrap.initialize_cuda_distributed(
+        default_device="cuda",
+        configure_logging_fn=lambda *, world_rank: None,
+    )
+
+    assert context.device == torch.device("cuda:0")
+    assert set_device_calls == [torch.device("cuda:0")]
+
+
+def test_initialize_cuda_distributed_uses_local_rank_for_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("WORLD_SIZE", "8")
+
+    init_calls = 0
+
+    def _fake_distributed_init() -> None:
+        nonlocal init_calls
+        init_calls += 1
+
+    set_device_calls: list[torch.device] = []
+    monkeypatch.setattr(bootstrap.dist, "get_rank", lambda: 3)
+    monkeypatch.setattr(bootstrap.dist, "get_world_size", lambda: 8)
+    monkeypatch.setattr(bootstrap.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(bootstrap.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(
+        bootstrap.torch.cuda,
+        "set_device",
+        lambda device: set_device_calls.append(device),
+    )
+
+    context = bootstrap.initialize_cuda_distributed(
+        distributed_init_fn=_fake_distributed_init,
+        configure_logging_fn=lambda *, world_rank: None,
+    )
+
+    assert init_calls == 1
+    assert context.device == torch.device("cuda:1")
+    assert context.world_rank == 3
+    assert context.world_size == 8
+    assert set_device_calls == [torch.device("cuda:1")]
+
+
+def test_initialize_cuda_distributed_requires_rank_world_size_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.setattr(bootstrap.torch.cuda, "is_available", lambda: True)
+
+    with pytest.raises(RuntimeError, match="both RANK and WORLD_SIZE"):
+        bootstrap.initialize_cuda_distributed()
+
+
+def test_initialize_cuda_distributed_rejects_cpu_default_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.setattr(bootstrap.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(bootstrap.torch.cuda, "device_count", lambda: 1)
+
+    with pytest.raises(RuntimeError, match="CUDA device is required"):
+        bootstrap.initialize_cuda_distributed(default_device="cpu")

--- a/flashdreams/tests/test_webrtc_serving.py
+++ b/flashdreams/tests/test_webrtc_serving.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
 import torch
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
 from flashdreams.serving.webrtc.controls import (
     WSAD_SUPPORTED_KEYS,
@@ -14,6 +18,16 @@ from flashdreams.serving.webrtc.controls import (
     KeyboardState,
 )
 from flashdreams.serving.webrtc.media import tensor_chunk_to_rgb_frames
+from flashdreams.serving.webrtc.messages import (
+    make_chunk_done_payload,
+    make_error_payload,
+    make_event_ack_payload,
+)
+from flashdreams.serving.webrtc.server import (
+    PACKAGE_RESOURCE_STACK_KEY,
+    close_package_resources,
+    create_packaged_webrtc_app,
+)
 
 pytestmark = pytest.mark.ci_cpu
 
@@ -80,3 +94,156 @@ def test_tensor_chunk_to_rgb_frames_supports_omnidreams_layout() -> None:
     assert frames[0].shape == (4, 5, 3)
     assert frames[0].dtype == np.uint8
     assert frames[1][0, 0, 0] == 255
+
+
+class _FakeSessionManager:
+    def __init__(self) -> None:
+        self.preload_calls = 0
+        self.shutdown_calls = 0
+
+    def has_active_session(self) -> bool:
+        return False
+
+    def is_runtime_ready(self) -> bool:
+        return self.preload_calls > 0
+
+    async def preload_runtime(self) -> None:
+        self.preload_calls += 1
+
+    async def create_answer(self, *, offer_sdp: str, offer_type: str) -> dict[str, str]:
+        del offer_sdp, offer_type
+        return {"sdp": "answer-sdp", "type": "answer"}
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+def test_packaged_webrtc_app_keeps_resource_materialized(tmp_path) -> None:
+    (tmp_path / "request_session.html").write_text(
+        "<html>session</html>", encoding="utf-8"
+    )
+    (tmp_path / "client.js").write_text("", encoding="utf-8")
+
+    app = create_packaged_webrtc_app(
+        web_resource=tmp_path,
+        session_manager=_FakeSessionManager(),
+        request_session_url="http://127.0.0.1:8080/request_session",
+        preload_name="Test",
+        as_file_fn=lambda resource: nullcontext(resource),
+    )
+    try:
+        assert PACKAGE_RESOURCE_STACK_KEY in app
+        assert close_package_resources in app.on_cleanup
+
+        static_resources = [
+            resource
+            for resource in app.router.resources()
+            if resource.get_info().get("prefix") in {"/static", "/static/"}
+        ]
+        assert len(static_resources) == 1
+        assert static_resources[0].get_info()["directory"] == tmp_path
+    finally:
+        app[PACKAGE_RESOURCE_STACK_KEY].close()
+
+
+def test_packaged_webrtc_app_closes_resource_when_setup_fails(tmp_path) -> None:
+    closed = False
+
+    class _TrackedContext:
+        def __enter__(self):
+            return tmp_path
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            nonlocal closed
+            closed = True
+
+    def _raise_creation_failure(**_kwargs) -> web.Application:
+        raise RuntimeError("app creation failed")
+
+    with pytest.raises(RuntimeError, match="app creation failed"):
+        create_packaged_webrtc_app(
+            web_resource=tmp_path,
+            session_manager=_FakeSessionManager(),
+            request_session_url="http://127.0.0.1:8080/request_session",
+            preload_name="Test",
+            as_file_fn=lambda _resource: _TrackedContext(),
+            create_app_fn=_raise_creation_failure,
+        )
+
+    assert closed
+
+
+@pytest.mark.asyncio
+async def test_packaged_webrtc_app_serves_common_routes(tmp_path) -> None:
+    (tmp_path / "request_session.html").write_text(
+        "<html>session</html>", encoding="utf-8"
+    )
+    manager = _FakeSessionManager()
+    app = create_packaged_webrtc_app(
+        web_resource=tmp_path,
+        session_manager=manager,
+        request_session_url="http://127.0.0.1:8080/request_session",
+        preload_name="Test",
+        as_file_fn=lambda resource: nullcontext(resource),
+    )
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        response = await client.get("/request_session")
+        body = await response.text()
+
+        assert response.status == 200
+        assert body == "<html>session</html>"
+        assert manager.preload_calls == 1
+    finally:
+        await client.close()
+
+
+def test_webrtc_message_helpers_preserve_public_payload_shape() -> None:
+    assert make_error_payload("boom") == {"type": "error", "message": "boom"}
+    assert make_event_ack_payload(
+        event_id="rain",
+        state="trigger",
+        result={"state": "ignored", "active_event_id": "rain"},
+    ) == {
+        "type": "event_ack",
+        "event_id": "rain",
+        "state": "trigger",
+        "active_event_id": "rain",
+    }
+
+    assert make_chunk_done_payload(
+        chunk_index=2,
+        num_frames=3,
+        enqueued_frames=3,
+        fps=30,
+        width=1280,
+        height=704,
+        model="demo",
+        gen_ms=12.34,
+        enqueue_ms=0.56,
+        play_ms=100.0,
+        queue_depth=1,
+        lag_ms=4.44,
+        control_latency_ms=20.04,
+        consumed_actions=2,
+        extra={"stream": "rgb"},
+    ) == {
+        "type": "chunk_done",
+        "chunk_index": 2,
+        "num_frames": 3,
+        "enqueued_frames": 3,
+        "fps": 30,
+        "resolution": {"width": 1280, "height": 704},
+        "model": "demo",
+        "gen_ms": 12.3,
+        "enqueue_ms": 0.6,
+        "play_ms": 100.0,
+        "queue_depth": 1,
+        "lag_ms": 4.4,
+        "stream": "rgb",
+        "latency_ms": 20.0,
+        "control_latency_ms": 20.0,
+        "consumed_actions": 2,
+    }

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
-from contextlib import ExitStack
 from importlib.resources import as_file, files
 from typing import Protocol, cast
 
@@ -37,9 +35,12 @@ from flashdreams.core.distributed import (
 from flashdreams.serving.network import get_external_ip
 from flashdreams.serving.webrtc.bootstrap import (
     configure_logging,
+    initialize_cuda_distributed,
     run_webrtc_server,
 )
 from flashdreams.serving.webrtc.server import (
+    close_package_resources as _close_package_resources,
+    create_packaged_webrtc_app,
     SESSION_MANAGER_KEY,
     SessionBusyError,
     WebRTCSessionManager,
@@ -145,34 +146,28 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-async def _close_package_resources(app: web.Application) -> None:
-    app["package_resource_stack"].close()
-
-
 def create_app(
     *,
     request_session_url: str,
     session_manager: WebRTCSessionManager | None = None,
 ) -> web.Application:
     manager = session_manager or LingbotWebRTCSessionManager()
-    resource_stack = ExitStack()
-    try:
-        web_dir = resource_stack.enter_context(as_file(WEB_DIR_RESOURCE))
-        app = create_webrtc_app(
-            web_dir=web_dir,
-            session_manager=manager,
-            preload_name="Lingbot",
-            request_session_url=request_session_url,
-        )
+
+    def _configure_app(app: web.Application) -> None:
         app.router.add_get("/api/session/initial_scene", _initial_scene)
         app.router.add_get("/api/session/first_frame", _first_frame)
         app.router.add_post("/api/session/input", _session_input)
-        app["package_resource_stack"] = resource_stack
-        app.on_cleanup.append(_close_package_resources)
-    except Exception:
-        resource_stack.close()
-        raise
-    return app
+
+    return create_packaged_webrtc_app(
+        web_resource=WEB_DIR_RESOURCE,
+        session_manager=manager,
+        preload_name="Lingbot",
+        request_session_url=request_session_url,
+        configure_app=_configure_app,
+        as_file_fn=as_file,
+        create_app_fn=create_webrtc_app,
+        cleanup_callback=_close_package_resources,
+    )
 
 
 async def _initial_scene(request: web.Request) -> web.StreamResponse:
@@ -358,50 +353,19 @@ def build_runtime_config(
 def initialize_distributed(
     *, default_device: str | torch.device = "cuda:0"
 ) -> tuple[torch.device, int, int]:
-    if not torch.cuda.is_available():
-        raise RuntimeError(
-            "CUDA is required for inference in the Lingbot WebRTC server."
-        )
-
-    has_rank = "RANK" in os.environ
-    has_world_size = "WORLD_SIZE" in os.environ
-    if has_rank != has_world_size:
-        raise RuntimeError(
-            "Distributed launch expects both RANK and WORLD_SIZE to be set."
-        )
-
-    distributed_launch = has_rank and has_world_size
-    if distributed_launch:
-        distributed_init()
-        world_rank = dist.get_rank()
-        world_size = dist.get_world_size()
-    else:
-        world_rank = 0
-        world_size = 1
-
-    device_count = torch.cuda.device_count()
-    if device_count < 1:
-        raise RuntimeError("CUDA device count must be >= 1 for inference.")
-    if distributed_launch:
-        local_rank = world_rank % device_count
-        torch_device = torch.device(f"cuda:{local_rank}")
-    else:
-        torch_device = torch.device(default_device)
-        if torch_device.type != "cuda":
-            raise RuntimeError(
-                f"CUDA device is required for inference, got {torch_device}."
-            )
-        if torch_device.index is None:
-            torch_device = torch.device("cuda:0")
-    torch.cuda.set_device(torch_device)
-
-    configure_logging(world_rank=world_rank)
+    context = initialize_cuda_distributed(
+        default_device=default_device,
+        distributed_init_fn=distributed_init,
+        configure_logging_fn=configure_logging,
+        torch_module=torch,
+        dist_module=dist,
+    )
     logger.info(
         "Rank {} initialized Lingbot runtime with context_parallel_size {}",
-        world_rank,
-        world_size,
+        context.world_rank,
+        context.world_size,
     )
-    return torch_device, world_rank, world_size
+    return context.device, context.world_rank, context.world_size
 
 
 def main() -> None:

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -39,12 +39,14 @@ from flashdreams.serving.webrtc.bootstrap import (
     run_webrtc_server,
 )
 from flashdreams.serving.webrtc.server import (
-    close_package_resources as _close_package_resources,
-    create_packaged_webrtc_app,
     SESSION_MANAGER_KEY,
     SessionBusyError,
     WebRTCSessionManager,
+    create_packaged_webrtc_app,
     create_webrtc_app,
+)
+from flashdreams.serving.webrtc.server import (
+    close_package_resources as _close_package_resources,
 )
 from lingbot.runner import (
     EXAMPLE_DATA_AVAILABLE_IDXS,

--- a/integrations/lingbot/lingbot/webrtc/session.py
+++ b/integrations/lingbot/lingbot/webrtc/session.py
@@ -1132,7 +1132,9 @@ class LingbotInferenceRuntime:
 _ManagedLingbotSession = ManagedWebRTCSession
 
 
-class LingbotWebRTCSessionManager(BaseWebRTCSessionManager):
+class LingbotWebRTCSessionManager(
+    BaseWebRTCSessionManager[LingbotInferenceRuntime, LingbotRuntimeConfig]
+):
     """Owns one active WebRTC session and forwards actions into Lingbot runtime."""
 
     _busy_message = "A Lingbot session is already active."

--- a/integrations/lingbot/tests/test_server_routes.py
+++ b/integrations/lingbot/tests/test_server_routes.py
@@ -32,6 +32,8 @@ from lingbot.webrtc.session import (
     SessionBusyError,
 )
 
+from flashdreams.serving.webrtc.server import PACKAGE_RESOURCE_STACK_KEY
+
 pytestmark = pytest.mark.ci_gpu
 
 
@@ -119,7 +121,7 @@ def test_create_app_keeps_package_web_resource_materialized() -> None:
         request_session_url="http://127.0.0.1:8080/request_session",
     )
     try:
-        assert isinstance(app["package_resource_stack"], ExitStack)
+        assert isinstance(app[PACKAGE_RESOURCE_STACK_KEY], ExitStack)
         assert _close_package_resources in app.on_cleanup
 
         static_resources = [
@@ -133,7 +135,7 @@ def test_create_app_keeps_package_web_resource_materialized() -> None:
         assert web_dir.is_dir()
         assert "Lingbot WebRTC Viewer" in (web_dir / "request_session.html").read_text()
     finally:
-        app["package_resource_stack"].close()
+        app[PACKAGE_RESOURCE_STACK_KEY].close()
 
 
 def test_create_app_closes_package_resource_when_app_creation_fails(

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -29,9 +29,11 @@ from flashdreams.serving.webrtc.bootstrap import (
 )
 from flashdreams.serving.webrtc.server import (
     WebRTCSessionManager,
-    close_package_resources as _close_package_resources,
     create_packaged_webrtc_app,
     create_webrtc_app,
+)
+from flashdreams.serving.webrtc.server import (
+    close_package_resources as _close_package_resources,
 )
 
 WEB_DIR_RESOURCE = files("omnidreams.webrtc").joinpath("web")

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import os
-from contextlib import ExitStack
 from importlib.resources import as_file, files
 from pathlib import Path
 
@@ -26,9 +24,15 @@ from flashdreams.core.distributed import (
 from flashdreams.serving.network import get_external_ip
 from flashdreams.serving.webrtc.bootstrap import (
     configure_logging,
+    initialize_cuda_distributed,
     run_webrtc_server,
 )
-from flashdreams.serving.webrtc.server import WebRTCSessionManager, create_webrtc_app
+from flashdreams.serving.webrtc.server import (
+    WebRTCSessionManager,
+    close_package_resources as _close_package_resources,
+    create_packaged_webrtc_app,
+    create_webrtc_app,
+)
 
 WEB_DIR_RESOURCE = files("omnidreams.webrtc").joinpath("web")
 
@@ -109,33 +113,21 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-async def _close_package_resources(app: web.Application) -> None:
-    app["package_resource_stack"].close()
-
-
 def create_app(
     *,
     request_session_url: str,
     session_manager: WebRTCSessionManager | None = None,
 ) -> web.Application:
     manager = session_manager or OmnidreamsWebRTCSessionManager()
-
-    resource_stack = ExitStack()
-    try:
-        web_dir = resource_stack.enter_context(as_file(WEB_DIR_RESOURCE))
-
-        app = create_webrtc_app(
-            web_dir=web_dir,
-            session_manager=manager,
-            preload_name="Omnidreams",
-            request_session_url=request_session_url,
-        )
-        app["package_resource_stack"] = resource_stack
-        app.on_cleanup.append(_close_package_resources)
-    except Exception:
-        resource_stack.close()
-        raise
-    return app
+    return create_packaged_webrtc_app(
+        web_resource=WEB_DIR_RESOURCE,
+        session_manager=manager,
+        preload_name="Omnidreams",
+        request_session_url=request_session_url,
+        as_file_fn=as_file,
+        create_app_fn=create_webrtc_app,
+        cleanup_callback=_close_package_resources,
+    )
 
 
 def build_runtime_config(
@@ -164,50 +156,19 @@ def initialize_distributed(
     *,
     default_device: str | torch.device = "cuda:0",
 ) -> tuple[torch.device, int, int]:
-    if not torch.cuda.is_available():
-        raise RuntimeError(
-            "CUDA is required for inference in the Omnidreams WebRTC server."
-        )
-
-    has_rank = "RANK" in os.environ
-    has_world_size = "WORLD_SIZE" in os.environ
-    if has_rank != has_world_size:
-        raise RuntimeError(
-            "Distributed launch expects both RANK and WORLD_SIZE to be set."
-        )
-
-    distributed_launch = has_rank and has_world_size
-    if distributed_launch:
-        distributed_init()
-        world_rank = dist.get_rank()
-        world_size = dist.get_world_size()
-    else:
-        world_rank = 0
-        world_size = 1
-
-    device_count = torch.cuda.device_count()
-    if device_count < 1:
-        raise RuntimeError("CUDA device count must be >= 1 for inference.")
-    if distributed_launch:
-        local_rank = world_rank % device_count
-        torch_device = torch.device(f"cuda:{local_rank}")
-    else:
-        torch_device = torch.device(default_device)
-        if torch_device.type != "cuda":
-            raise RuntimeError(
-                f"CUDA device is required for inference, got {torch_device}."
-            )
-        if torch_device.index is None:
-            torch_device = torch.device("cuda:0")
-    torch.cuda.set_device(torch_device)
-
-    configure_logging(world_rank=world_rank)
+    context = initialize_cuda_distributed(
+        default_device=default_device,
+        distributed_init_fn=distributed_init,
+        configure_logging_fn=configure_logging,
+        torch_module=torch,
+        dist_module=dist,
+    )
     logger.info(
         "Rank {} initialized Omnidreams runtime with context_parallel_size {}",
-        world_rank,
-        world_size,
+        context.world_rank,
+        context.world_size,
     )
-    return torch_device, world_rank, world_size
+    return context.device, context.world_rank, context.world_size
 
 
 def _validate_single_view_config(config_name: str) -> None:

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -898,7 +898,9 @@ class OmnidreamsInferenceRuntime:
 _ManagedOmnidreamsSession = ManagedWebRTCSession
 
 
-class OmnidreamsWebRTCSessionManager(BaseWebRTCSessionManager):
+class OmnidreamsWebRTCSessionManager(
+    BaseWebRTCSessionManager[OmnidreamsInferenceRuntime, OmnidreamsRuntimeConfig]
+):
     """Owns one active WebRTC session and forwards WSAD actions."""
 
     _busy_message = "An Omnidreams session is already active."

--- a/integrations/omnidreams/tests/test_webrtc_server_routes.py
+++ b/integrations/omnidreams/tests/test_webrtc_server_routes.py
@@ -15,7 +15,10 @@ from omnidreams.webrtc.server import (
     create_app,
 )
 
-from flashdreams.serving.webrtc.server import SessionBusyError
+from flashdreams.serving.webrtc.server import (
+    PACKAGE_RESOURCE_STACK_KEY,
+    SessionBusyError,
+)
 
 pytestmark = pytest.mark.ci_gpu
 
@@ -68,7 +71,7 @@ def test_create_app_keeps_package_web_resource_materialized() -> None:
         request_session_url="http://127.0.0.1:8080/request_session",
     )
     try:
-        assert isinstance(app["package_resource_stack"], ExitStack)
+        assert isinstance(app[PACKAGE_RESOURCE_STACK_KEY], ExitStack)
         assert _close_package_resources in app.on_cleanup
 
         static_resources = [
@@ -84,7 +87,7 @@ def test_create_app_keeps_package_web_resource_materialized() -> None:
             "Omnidreams WebRTC Drive" in (web_dir / "request_session.html").read_text()
         )
     finally:
-        app["package_resource_stack"].close()
+        app[PACKAGE_RESOURCE_STACK_KEY].close()
 
 
 def test_create_app_closes_package_resource_when_app_creation_fails(


### PR DESCRIPTION
Add shared WebRTC runtime and data-channel message contracts, plus common packaged-app and CUDA/distributed bootstrap helpers. Migrate the LingBot and OmniDreams WebRTC servers onto the shared helpers while keeping their model-specific routes, runtime config, and preflight logic local.