### PR TITLE
Stabilize Omnidreams WebRTC Presentation

### DIFF
--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -9,6 +9,7 @@ import asyncio
 import contextlib
 import inspect
 import json
+import math
 from collections import deque
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
@@ -21,6 +22,7 @@ from aiortc import (
     RTCRtpSender,
     RTCSessionDescription,
 )
+from aiortc.sdp import SessionDescription
 from loguru import logger
 
 from flashdreams.serving.realtime.input import KeyboardResampler
@@ -81,6 +83,45 @@ def _stat_ms(stats: dict[str, float], name: str, default_ms: float = 0.0) -> flo
 
 def _stat_int(stats: dict[str, float], name: str) -> int:
     return int(round(_stat_float(stats, name)))
+
+
+def _performance_stats_payload(stats: dict[str, float] | None) -> dict[str, float]:
+    if not stats:
+        return {}
+    payload: dict[str, float] = {}
+    for key, value in stats.items():
+        if not isinstance(key, str):
+            continue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(number):
+            payload[key] = round(number, 1)
+    return payload
+
+
+def _format_performance_stats(stats: dict[str, float]) -> str:
+    return " ".join(f"{key}={value:.1f}" for key, value in sorted(stats.items()))
+
+
+def _sdp_video_codecs(sdp: str) -> tuple[str, ...] | None:
+    """Return offered video codec MIME types, or ``None`` if parsing fails."""
+    try:
+        description = SessionDescription.parse(sdp)
+    except Exception:
+        logger.debug("Could not parse remote SDP while checking video codecs.")
+        return None
+
+    codecs: list[str] = []
+    for media in description.media:
+        if getattr(media, "kind", None) != "video":
+            continue
+        for codec in media.rtp.codecs:
+            mime_type = str(getattr(codec, "mimeType", "")).strip()
+            if mime_type:
+                codecs.append(mime_type)
+    return tuple(dict.fromkeys(codecs))
 
 
 class WebRTCControlSignal(IntEnum):
@@ -288,6 +329,37 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
             return
         transceiver.setCodecPreferences(h264_codecs)
 
+    def _prepare_video_encoder_for_offer(
+        self,
+        *,
+        video_encoder: VideoEncoder,
+        offer_sdp: str,
+    ) -> VideoEncoder:
+        """Select a session encoder compatible with the browser offer."""
+        if video_encoder.prefers_codec != "h264":
+            return video_encoder
+
+        offered_video_codecs = _sdp_video_codecs(offer_sdp)
+        if offered_video_codecs is None:
+            return video_encoder
+        if any(codec.lower() == "video/h264" for codec in offered_video_codecs):
+            return video_encoder
+
+        offered = ", ".join(offered_video_codecs) or "<none>"
+        if getattr(self.runtime_config, "encoder_backend", None) == "nvenc":
+            raise RuntimeError(
+                "encoder_backend='nvenc' requested but the browser offer does "
+                f"not advertise H.264; offered video codecs: {offered}."
+            )
+
+        logger.warning(
+            "Hardware encoder emits H.264, but the browser offer does not "
+            "advertise H.264 (offered: {}). Using aiortc software encoder "
+            "for this session.",
+            offered,
+        )
+        return DefaultRTCEncoder(fps=self.fps)
+
     async def _enforce_h264_or_fallback(
         self,
         *,
@@ -300,8 +372,8 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
         aiortc exposes the negotiated codec set on
         ``RTCRtpTransceiver._codecs`` after ``setLocalDescription``. We
         read it via that attribute (aiortc-internal, but stable in the
-        pinned version) and, if H.264 did not land, close the hardware
-        encoder and install a :class:`DefaultRTCEncoder` with a
+        pinned version) and, if H.264 did not land, close the pre-encoded
+        track and install a :class:`DefaultRTCEncoder` with a
         :class:`BufferedVideoTrack` on the same sender before the first
         RTP packet flies. ``replaceTrack`` does not renegotiate; aiortc's
         RTP loop will encode raw ``av.VideoFrame`` output with whatever
@@ -316,6 +388,11 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
             return
 
         chosen = negotiated[0].mimeType if negotiated else "<none>"
+        if getattr(self.runtime_config, "encoder_backend", None) == "nvenc":
+            raise RuntimeError(
+                "encoder_backend='nvenc' requested but SDP negotiation landed on "
+                f"{chosen!r}; cannot stream pre-encoded H.264 packets."
+            )
         logger.warning(
             "H.264 preferred by hardware encoder but SDP negotiation "
             "landed on {!r}; swapping to the software encoder before "
@@ -458,7 +535,10 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
         # frames than steady state; sizing to it would force a per-chunk
         # stall, so we size to the steady-state count.
         num_frames = self._runtime_steady_output_num_frames(self._runtime)
-        video_encoder = self._resolve_video_encoder()
+        video_encoder = self._prepare_video_encoder_for_offer(
+            video_encoder=self._resolve_video_encoder(),
+            offer_sdp=offer_sdp,
+        )
         video_track = video_encoder.create_track(maxsize=num_frames)
         # Use ``addTransceiver`` (not ``addTrack``) so we can constrain the
         # SDP m-line's codec list via ``setCodecPreferences`` when the
@@ -790,6 +870,7 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                     consumed_action_arrivals.append(
                         managed_session.pending_action_arrivals.popleft()
                     )
+                t_after_sample = loop.time()
                 try:
                     result = await runtime.generate_chunk(
                         segments=segments, frame_times=frame_times
@@ -813,7 +894,15 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                 t_after_enqueue = loop.time()
 
                 gen_ms = (t_after_gen - t_before_gen) * 1e3
+                sample_ms = (t_after_sample - t_before_gen) * 1e3
+                runtime_call_ms = (t_after_gen - t_after_sample) * 1e3
                 enqueue_ms = (t_after_enqueue - t_after_gen) * 1e3
+                chunk_total_ms = (t_after_enqueue - t_before_gen) * 1e3
+                chunk_fps = (
+                    result.num_frames * 1000.0 / chunk_total_ms
+                    if chunk_total_ms > 0
+                    else 0.0
+                )
                 play_ms = result.num_frames * 1000.0 / video_track.fps
                 lag_ms = (t_after_enqueue - resampler.next_chunk_start_v) * 1e3
                 control_latency_ms = (
@@ -821,6 +910,19 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                     if consumed_action_arrivals
                     else None
                 )
+                track_dropped_packets = getattr(
+                    video_track,
+                    "dropped_packets",
+                    None,
+                )
+                runtime_stats = _performance_stats_payload(result.stats)
+                log_stats = {
+                    **runtime_stats,
+                    "delivery_encode_ms": round(delivery.encode_ms, 1),
+                }
+                if isinstance(track_dropped_packets, int):
+                    log_stats["track_dropped_packets"] = float(track_dropped_packets)
+                extra_stats = _format_performance_stats(log_stats)
                 perf_window_chunks += 1
                 perf_window_frames += result.num_frames
                 if result.chunk_index == 0 or (
@@ -836,7 +938,9 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                     logger.info(
                         "WebRTC perf chunk={} interval_chunks={} frames={} "
                         "gen_fps={:.1f} interval_fps={:.1f} playback_fps={} "
-                        "gen_ms={:.0f} enqueue_ms={:.0f} model_ms={:.0f} "
+                        "gen_ms={:.0f} sample_ms={:.0f} runtime_call_ms={:.0f} "
+                        "delivery_ms={:.0f} delivery_encode_ms={:.0f} "
+                        "enqueue_ms={:.0f} model_ms={:.0f} "
                         "denoise_ms={:.0f} decode_ms={:.0f} pixel_post_ms={:.0f} "
                         "copy_ms={:.0f} cache_ms={:.0f} "
                         "cache_wait_ms={:.0f} cache_submit_ms={:.0f} "
@@ -850,6 +954,10 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                         interval_fps,
                         video_track.fps,
                         gen_ms,
+                        sample_ms,
+                        runtime_call_ms,
+                        enqueue_ms,
+                        delivery.encode_ms,
                         enqueue_ms,
                         _stat_ms(stats, "model_step_s", gen_ms),
                         _stat_ms(stats, "denoise_s"),
@@ -873,25 +981,48 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                     perf_window_start = t_after_enqueue
                     perf_window_chunks = 0
                     perf_window_frames = 0
-                logger.debug(
-                    "Chunk done chunk={} input_frames={} output_frames={} "
-                    "segments={} enqueued={} "
-                    "gen_ms={:.1f} enqueue_ms={:.1f} play_ms={:.1f} queue_depth={} "
-                    "lag_ms={:.1f}",
+                log_level = (
+                    logger.info
+                    if (
+                        result.chunk_index <= 2
+                        or result.chunk_index % 10 == 0
+                        or chunk_total_ms > play_ms
+                        or lag_ms > play_ms
+                    )
+                    else logger.debug
+                )
+                log_level(
+                    "WebRTC chunk done chunk={} input_frames={} output_frames={} "
+                    "segments={} "
+                    "enqueued={} encoder={} gen_ms={:.1f} sample_ms={:.1f} "
+                    "runtime_call_ms={:.1f} delivery_ms={:.1f} "
+                    "delivery_encode_ms={:.1f} "
+                    "play_ms={:.1f} chunk_fps={:.1f} queue_depth={} "
+                    "lag_ms={:.1f} {}",
                     result.chunk_index,
                     input_num_frames,
                     result.num_frames,
                     len(segments),
                     enqueued,
+                    delivery.backend,
                     gen_ms,
+                    sample_ms,
+                    runtime_call_ms,
                     enqueue_ms,
+                    delivery.encode_ms,
                     play_ms,
+                    chunk_fps,
                     video_track.qsize(),
                     lag_ms,
+                    extra_stats,
                 )
 
                 channel = managed_session.control_channel
                 if channel is not None:
+                    extra_payload = dict(runtime_stats)
+                    if isinstance(track_dropped_packets, int):
+                        extra_payload["track_dropped_packets"] = track_dropped_packets
+                    extra_payload.update(self._chunk_done_extra())
                     self._send_json(
                         channel,
                         make_chunk_done_payload(
@@ -903,13 +1034,21 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                             height=self.runtime_config.video_height,
                             model=self._model_name(),
                             gen_ms=gen_ms,
+                            sample_ms=sample_ms,
+                            runtime_call_ms=runtime_call_ms,
                             enqueue_ms=enqueue_ms,
+                            delivery_ms=enqueue_ms,
+                            delivery_encode_ms=delivery.encode_ms,
+                            encoder_backend=delivery.backend,
+                            keyframes=delivery.num_keyframes,
+                            chunk_total_ms=chunk_total_ms,
+                            chunk_fps=chunk_fps,
                             play_ms=play_ms,
                             queue_depth=video_track.qsize(),
                             lag_ms=lag_ms,
                             control_latency_ms=control_latency_ms,
                             consumed_actions=len(consumed_action_arrivals),
-                            extra=self._chunk_done_extra(),
+                            extra=extra_payload,
                         ),
                     )
         except asyncio.CancelledError:

--- a/flashdreams/flashdreams/serving/webrtc/media.py
+++ b/flashdreams/flashdreams/serving/webrtc/media.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
@@ -145,8 +145,9 @@ class NVENCVideoTrack(MediaStreamTrack):
     ``RTCRtpSender`` routes through ``H264Encoder.pack()`` for RTP
     fragmentation only. The encoder sets ``pts`` and ``time_base`` on
     each packet before enqueueing; this track only paces delivery to
-    ``fps`` and applies a drop-oldest overflow policy so a slow
-    consumer cannot stall the encode worker.
+    ``fps``. The async enqueue path applies backpressure so the browser
+    receives every frame in timestamp order instead of seeing silent
+    server-side drops.
     """
 
     kind = "video"
@@ -182,14 +183,28 @@ class NVENCVideoTrack(MediaStreamTrack):
     def qsize(self) -> int:
         return self._packets.qsize()
 
+    async def enqueue_encoded_packet(self, packet: Packet) -> bool:
+        """Enqueue one encoded packet, waiting for sender-side queue space."""
+        if self._closed:
+            return False
+        await self._packets.put(packet)
+        return True
+
+    async def enqueue_encoded_packets(self, packets: Sequence[Packet]) -> int:
+        """Enqueue encoded packets in order, applying backpressure if full."""
+        for i, packet in enumerate(packets):
+            if not await self.enqueue_encoded_packet(packet):
+                return i
+        return len(packets)
+
     def enqueue_encoded_packet_nowait(self, packet: Packet) -> bool:
         """Synchronously enqueue one packet on the loop thread.
 
-        Called from the encode worker via ``loop.call_soon_threadsafe`` so
-        packets become visible to :meth:`recv` as soon as they are
-        produced, without waiting for the whole chunk to finish encoding.
-        Drops the oldest queued packet on overflow so real-time streaming
-        does not stall behind a slow consumer.
+        This compatibility helper is intentionally lossy on overflow.
+        The production NVENC path uses :meth:`enqueue_encoded_packets`
+        so playback preserves every frame; tests and diagnostic probes
+        can still use this helper when they explicitly want nonblocking
+        enqueue semantics.
         """
         if self._closed:
             return False

--- a/flashdreams/flashdreams/serving/webrtc/messages.py
+++ b/flashdreams/flashdreams/serving/webrtc/messages.py
@@ -53,6 +53,14 @@ def make_chunk_done_payload(
     play_ms: float,
     queue_depth: int,
     lag_ms: float,
+    sample_ms: float | None = None,
+    runtime_call_ms: float | None = None,
+    delivery_ms: float | None = None,
+    delivery_encode_ms: float | None = None,
+    encoder_backend: str | None = None,
+    keyframes: int | None = None,
+    chunk_total_ms: float | None = None,
+    chunk_fps: float | None = None,
     control_latency_ms: float | None = None,
     consumed_actions: int | None = None,
     extra: Mapping[str, Any] | None = None,
@@ -71,6 +79,21 @@ def make_chunk_done_payload(
         "queue_depth": queue_depth,
         "lag_ms": round(lag_ms, 1),
     }
+    optional_numbers = {
+        "sample_ms": sample_ms,
+        "runtime_call_ms": runtime_call_ms,
+        "delivery_ms": delivery_ms,
+        "delivery_encode_ms": delivery_encode_ms,
+        "chunk_total_ms": chunk_total_ms,
+        "chunk_fps": chunk_fps,
+    }
+    for key, value in optional_numbers.items():
+        if value is not None:
+            payload[key] = round(value, 1)
+    if encoder_backend is not None:
+        payload["encoder_backend"] = encoder_backend
+    if keyframes is not None:
+        payload["keyframes"] = keyframes
     if extra is not None:
         payload.update(extra)
     if control_latency_ms is not None:

--- a/flashdreams/flashdreams/serving/webrtc/nvenc.py
+++ b/flashdreams/flashdreams/serving/webrtc/nvenc.py
@@ -272,32 +272,25 @@ class PyNvHardwareEncoder:
                 "PyNvHardwareEncoder requires an NVENCVideoTrack; got "
                 f"{type(track).__name__}. Create it via encoder.create_track()."
             )
-        loop = asyncio.get_running_loop()
+        packets: list[Packet] = []
 
-        def _stream(pkt: Packet) -> None:
-            # Marshal each packet back onto the asyncio loop as soon as
-            # NVENC produces it, rather than waiting for the whole chunk
-            # to finish encoding — otherwise the first packet's latency is
-            # bounded below by ``T / fps``.
-            try:
-                loop.call_soon_threadsafe(
-                    track.enqueue_encoded_packet_nowait,
-                    pkt,
-                )
-            except RuntimeError:
-                # Loop has been closed; drop the packet silently rather
-                # than raising from the encode worker thread.
-                return
-
-        num_frames, num_keyframes, encode_ms = await asyncio.to_thread(
+        _num_frames, num_keyframes, encode_ms = await asyncio.to_thread(
             self.encode_chunk_sync,
             chunk,
             force_keyframe=force_keyframe,
-            on_packet=_stream,
+            on_packet=packets.append,
         )
+        enqueued = await track.enqueue_encoded_packets(packets)
+        if enqueued < len(packets):
+            logger.debug(
+                "NVENC track closed while enqueueing encoded chunk; "
+                "enqueued {} of {} packet(s).",
+                enqueued,
+                len(packets),
+            )
         return ChunkDeliveryResult(
             backend=self.backend,
-            num_frames=num_frames,
+            num_frames=enqueued,
             num_keyframes=num_keyframes,
             encode_ms=encode_ms,
         )

--- a/flashdreams/tests/test_encoders.py
+++ b/flashdreams/tests/test_encoders.py
@@ -37,8 +37,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from av.packet import Packet
 
-pytestmark = pytest.mark.ci_cpu
-
 from flashdreams.serving.webrtc import encoders as enc_mod
 from flashdreams.serving.webrtc.encoders import (
     ChunkDeliveryResult,
@@ -48,6 +46,8 @@ from flashdreams.serving.webrtc.encoders import (
     select_encoder,
 )
 from flashdreams.serving.webrtc.media import NVENCVideoTrack
+
+pytestmark = pytest.mark.ci_cpu
 
 _SELECT_KW = dict(
     width=1280,
@@ -436,12 +436,12 @@ class TestCompatGuards:
 
 class _OrderingFakeEncoder:
     """Minimal encoder that mimics :class:`PyNvHardwareEncoder`'s async
-    marshaling contract without needing CUDA or PyNvVideoCodec.
+    encode-then-enqueue contract without needing CUDA or PyNvVideoCodec.
 
-    Encoding runs on an ``asyncio.to_thread`` worker and each emitted
-    packet is delivered to the track via ``loop.call_soon_threadsafe``,
-    exactly as the real hardware encoder does. This lets us assert the
-    end-to-end ordering property without any GPU dependency.
+    Encoding runs on an ``asyncio.to_thread`` worker, then the encoded
+    packets are enqueued through the track's backpressured async API.
+    This lets us assert the end-to-end ordering property without any GPU
+    dependency.
 
     The pts counter is guarded by a lock because the fire-and-forget
     test dispatches multiple ``deliver_chunk`` calls concurrently, and
@@ -469,13 +469,13 @@ class _OrderingFakeEncoder:
         force_keyframe: bool = False,
     ) -> ChunkDeliveryResult:
         del chunk, force_keyframe
-        loop = asyncio.get_running_loop()
         frames = self._frames_per_chunk
 
-        def _encode_worker() -> None:
+        def _encode_worker() -> list[Packet]:
             # One packet per frame, monotonically-increasing pts. The
-            # per-iteration call_soon_threadsafe hand-off mirrors what
-            # PyNvHardwareEncoder does with its on_packet callback.
+            # caller enqueues the collected packets after the worker
+            # returns, mirroring PyNvHardwareEncoder.deliver_chunk.
+            packets: list[Packet] = []
             for _ in range(frames):
                 packet = Packet(b"\x00\x00\x00\x01\x67")
                 with self._pts_counter_lock:
@@ -483,15 +483,14 @@ class _OrderingFakeEncoder:
                     self._pts_counter += 1
                 packet.pts = (pts_frame_index * 90_000) // self.fps
                 packet.time_base = self._time_base
-                loop.call_soon_threadsafe(
-                    track.enqueue_encoded_packet_nowait,
-                    packet,
-                )
+                packets.append(packet)
+            return packets
 
-        await asyncio.to_thread(_encode_worker)
+        packets = await asyncio.to_thread(_encode_worker)
+        enqueued = await track.enqueue_encoded_packets(packets)
         return ChunkDeliveryResult(
             backend=self.backend,
-            num_frames=frames,
+            num_frames=enqueued,
             num_keyframes=0,
             encode_ms=0.0,
         )

--- a/flashdreams/tests/test_nvenc_track.py
+++ b/flashdreams/tests/test_nvenc_track.py
@@ -9,8 +9,11 @@ matters is that:
 - ``recv()`` returns exactly the enqueued :class:`av.Packet` (aiortc's
   ``H264Encoder.pack()`` reads ``payload``, ``pts`` and ``time_base``
   directly), and
-- overflow drops the *oldest* packet — a stale I-frame is more useful than
-  falling behind wall-clock on an interactive stream.
+- the async enqueue path applies backpressure instead of dropping packets,
+  preserving the 30 fps media timeline the browser receives.
+
+The legacy nonblocking helper is still tested separately because it is useful
+for diagnostics, but the production NVENC encoder path does not use it.
 """
 
 from __future__ import annotations
@@ -22,9 +25,9 @@ import pytest
 from aiortc.mediastreams import MediaStreamError
 from av.packet import Packet
 
-pytestmark = pytest.mark.ci_cpu
-
 from flashdreams.serving.webrtc.media import NVENCVideoTrack
+
+pytestmark = pytest.mark.ci_cpu
 
 
 def _mk_packet(pts: int, payload: bytes = b"\x00\x00\x00\x01\x67") -> Packet:
@@ -58,9 +61,44 @@ class TestEnqueue:
         assert track.qsize() == 1
 
     @pytest.mark.asyncio
+    async def test_async_enqueue_waits_for_queue_space(self) -> None:
+        track = NVENCVideoTrack(fps=30, maxsize=1)
+        assert await track.enqueue_encoded_packet(_mk_packet(0)) is True
+
+        enqueue_task = asyncio.create_task(track.enqueue_encoded_packet(_mk_packet(1)))
+        await asyncio.sleep(0)
+        assert not enqueue_task.done()
+
+        first = await asyncio.wait_for(track.recv(), timeout=1.0)
+        assert first.pts == 0
+        assert await asyncio.wait_for(enqueue_task, timeout=1.0) is True
+        assert track.qsize() == 1
+        assert track.dropped_packets == 0
+
+        second = await asyncio.wait_for(track.recv(), timeout=1.0)
+        assert second.pts == 1
+
+    @pytest.mark.asyncio
+    async def test_async_enqueue_many_preserves_order(self) -> None:
+        track = NVENCVideoTrack(fps=30, maxsize=2)
+        packets = [_mk_packet(pts=i) for i in range(4)]
+
+        enqueue_task = asyncio.create_task(track.enqueue_encoded_packets(packets))
+        seen_pts: list[int] = []
+        for _ in packets:
+            packet = await asyncio.wait_for(track.recv(), timeout=1.0)
+            assert packet.pts is not None
+            seen_pts.append(packet.pts)
+
+        assert await asyncio.wait_for(enqueue_task, timeout=1.0) == len(packets)
+        assert seen_pts == [0, 1, 2, 3]
+        assert track.dropped_packets == 0
+
+    @pytest.mark.asyncio
     async def test_enqueue_returns_false_on_closed_track(self) -> None:
         track = NVENCVideoTrack(fps=30, maxsize=8)
         await track.close()
+        assert await track.enqueue_encoded_packet(_mk_packet(0)) is False
         assert track.enqueue_encoded_packet_nowait(_mk_packet(0)) is False
 
 
@@ -86,11 +124,10 @@ class TestRecv:
 
 
 class TestOverflow:
-    """When the queue fills up, drop the oldest packet, not the newest.
+    """The explicit nowait helper drops the oldest packet on overflow.
 
-    Real-time streams tolerate a stale I-frame worse than they tolerate
-    stale motion, and aiortc will re-request a keyframe via PLI/FIR if
-    the oldest dropped packet was a keyframe.
+    The production async enqueue path above backpressures instead. This
+    branch exists for callers that deliberately choose nonblocking enqueue.
     """
 
     def test_full_queue_drops_oldest(self) -> None:

--- a/flashdreams/tests/test_webrtc_manager.py
+++ b/flashdreams/tests/test_webrtc_manager.py
@@ -279,7 +279,10 @@ async def test_chunk_done_payload_includes_model_and_extra() -> None:
                 chunk_index=0,
                 num_frames=1,
                 video_chunk=torch.zeros((1, 1, 1, 3, 2, 2), dtype=torch.uint8),
-                stats=None,
+                stats={
+                    "runtime_input_ms": 1.25,
+                    "wrapper_generate_ms": 2.5,
+                },
             )
 
     class _ExtraManager(_BaseTestManager):
@@ -306,6 +309,12 @@ async def test_chunk_done_payload_includes_model_and_extra() -> None:
     assert payload["model"] == "fake-model"
     assert payload["stream"] == "rgb"
     assert payload["resolution"] == {"width": 8, "height": 4}
+    assert payload["encoder_backend"] == "fake"
+    assert payload["delivery_encode_ms"] == 0.1
+    assert payload["runtime_input_ms"] == 1.2
+    assert payload["wrapper_generate_ms"] == 2.5
+    assert payload["chunk_total_ms"] >= 0.0
+    assert payload["chunk_fps"] >= 0.0
 
 
 @pytest.mark.asyncio

--- a/integrations/omnidreams/omnidreams/conditioning/conditioning_wrapper.py
+++ b/integrations/omnidreams/omnidreams/conditioning/conditioning_wrapper.py
@@ -24,6 +24,7 @@ This module combines:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 import torch
@@ -93,6 +94,7 @@ class OmnidreamsConditioningWrapper(nn.Module):
         self,
         *,
         pipeline_config_name: str,
+        pipeline_config: Any | None = None,
         resolution_wh: tuple[int, int],
         seed_for_every_rollout: int | None = None,
         device: torch.device = torch.device("cuda:0"),
@@ -103,6 +105,9 @@ class OmnidreamsConditioningWrapper(nn.Module):
             pipeline_config_name: Key into
                 :data:`omnidreams.config.OMNIDREAMS_CONFIGS`
                 identifying the pipeline literal to instantiate.
+            pipeline_config: Optional already-derived pipeline config. When
+                provided, it is instantiated instead of looking up
+                ``pipeline_config_name``.
             resolution_wh: Decoded video ``(width, height)``. Not encoded in
                 the pipeline config; supplied per server deployment.
             seed_for_every_rollout: Optional per-rollout RNG seed override. When
@@ -110,20 +115,21 @@ class OmnidreamsConditioningWrapper(nn.Module):
             device: CUDA device the pipeline is moved to.
 
         Raises:
-            KeyError: ``pipeline_config_name`` is not a registered Omnidreams
-                integration.
+            KeyError: ``pipeline_config`` is omitted and ``pipeline_config_name``
+                is not a registered Omnidreams integration.
             TypeError: The selected pipeline does not use
                 :class:`CosmosTransformerConfig` (the wrapper relies on its
                 ``num_views`` / ``len_t`` fields to size session state).
         """
         super().__init__()
 
-        if pipeline_config_name not in OMNIDREAMS_CONFIGS:
-            raise KeyError(
-                f"Unknown Omnidreams pipeline config {pipeline_config_name!r}. "
-                f"Available: {sorted(OMNIDREAMS_CONFIGS)}"
-            )
-        pipeline_config = OMNIDREAMS_CONFIGS[pipeline_config_name]
+        if pipeline_config is None:
+            if pipeline_config_name not in OMNIDREAMS_CONFIGS:
+                raise KeyError(
+                    f"Unknown Omnidreams pipeline config {pipeline_config_name!r}. "
+                    f"Available: {sorted(OMNIDREAMS_CONFIGS)}"
+                )
+            pipeline_config = OMNIDREAMS_CONFIGS[pipeline_config_name]
 
         transformer_cfg = pipeline_config.diffusion_model.transformer
         if not isinstance(transformer_cfg, CosmosTransformerConfig):

--- a/integrations/omnidreams/omnidreams/conditioning/conditioning_wrapper.py
+++ b/integrations/omnidreams/omnidreams/conditioning/conditioning_wrapper.py
@@ -23,6 +23,7 @@ This module combines:
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -80,6 +81,7 @@ class GenerationOutput:
         None  # Generated video frames [B, V, T, 3, H, W] (None if skip_video_generation)
     )
     finalization_state: dict | None = None  # Finalization state from the video model
+    stats: dict[str, float] | None = None
 
 
 class OmnidreamsConditioningWrapper(nn.Module):
@@ -402,6 +404,7 @@ class OmnidreamsConditioningWrapper(nn.Module):
             GenerationOutput with ``condition_frames`` ``[B, V, T, 3, H, W]``
             and ``rgb_frames`` ``[B, V, T, 3, H, W]`` (or None).
         """
+        t_start = time.perf_counter()
 
         assert len(text_prompts) == 1, (
             "Only one text prompt (batch size == 1) is supported for now"
@@ -413,6 +416,7 @@ class OmnidreamsConditioningWrapper(nn.Module):
             frame_timestamps_us=frame_timestamps_us,
             expected_length=self.initial_frame_chunk_size,
         )
+        t_validated = time.perf_counter()
 
         # condition_frames: [B, V, T, 3, H, W]
         condition_frames = self._render_condition_frames(
@@ -422,13 +426,21 @@ class OmnidreamsConditioningWrapper(nn.Module):
             frame_timestamps_us,
             dynamic_actor_pool,
         )
+        t_rendered = time.perf_counter()
 
         if skip_video_generation:
             state = OmnidreamsConditioningState(
                 renderer=renderer,
             )
             return GenerationOutput(
-                state=state, condition_frames=condition_frames, rgb_frames=None
+                state=state,
+                condition_frames=condition_frames,
+                rgb_frames=None,
+                stats={
+                    "wrapper_validate_ms": (t_validated - t_start) * 1000.0,
+                    "wrapper_render_ms": (t_rendered - t_validated) * 1000.0,
+                    "wrapper_total_ms": (time.perf_counter() - t_start) * 1000.0,
+                },
             )
 
         initial_rgb_frames, condition_frames = self._normalize_start_inputs(
@@ -439,16 +451,20 @@ class OmnidreamsConditioningWrapper(nn.Module):
 
         first_frame = self._to_model_range(initial_rgb_frames).unsqueeze(2)
         condition = self._to_model_range(condition_frames)
+        t_prepared = time.perf_counter()
 
         pipeline_cache = self.pipeline.initialize_cache(
             text=text, image=first_frame, view_names=camera_names
         )
+        t_cache_ready = time.perf_counter()
         rgb_frames = self.pipeline.generate(
             autoregressive_index=0,
             hdmap=condition,
             cache=pipeline_cache,
         )
+        t_generated = time.perf_counter()
         rgb_frames = self._to_uint8(rgb_frames).contiguous()
+        t_uint8_ready = time.perf_counter()
 
         state = OmnidreamsConditioningState(
             renderer=renderer,
@@ -459,6 +475,15 @@ class OmnidreamsConditioningWrapper(nn.Module):
             condition_frames=condition_frames,
             rgb_frames=rgb_frames,
             finalization_state={"autoregressive_index": 0},
+            stats={
+                "wrapper_validate_ms": (t_validated - t_start) * 1000.0,
+                "wrapper_render_ms": (t_rendered - t_validated) * 1000.0,
+                "wrapper_prepare_ms": (t_prepared - t_rendered) * 1000.0,
+                "wrapper_cache_ms": (t_cache_ready - t_prepared) * 1000.0,
+                "wrapper_generate_ms": (t_generated - t_cache_ready) * 1000.0,
+                "wrapper_to_uint8_ms": (t_uint8_ready - t_generated) * 1000.0,
+                "wrapper_total_ms": (t_uint8_ready - t_start) * 1000.0,
+            },
         )
 
     def continue_generation(
@@ -486,12 +511,14 @@ class OmnidreamsConditioningWrapper(nn.Module):
             GenerationOutput with ``condition_frames`` ``[B, V, T, 3, H, W]``
             and ``rgb_frames`` ``[B, V, T, 3, H, W]`` (or None).
         """
+        t_start = time.perf_counter()
         self._validate_camera_inputs(
             camera_names=camera_names,
             camera_poses_per_view=camera_poses_per_view,
             frame_timestamps_us=frame_timestamps_us,
             expected_length=self.frame_chunk_size,
         )
+        t_validated = time.perf_counter()
         renderer = state.renderer
 
         profiler = get_profiler()
@@ -508,10 +535,18 @@ class OmnidreamsConditioningWrapper(nn.Module):
                 frame_timestamps_us,
                 dynamic_actor_pool,
             )
+        t_rendered = time.perf_counter()
 
         if skip_video_generation:
             return GenerationOutput(
-                state=state, condition_frames=condition_frames, rgb_frames=None
+                state=state,
+                condition_frames=condition_frames,
+                rgb_frames=None,
+                stats={
+                    "wrapper_validate_ms": (t_validated - t_start) * 1000.0,
+                    "wrapper_render_ms": (t_rendered - t_validated) * 1000.0,
+                    "wrapper_total_ms": (time.perf_counter() - t_start) * 1000.0,
+                },
             )
 
         if state.pipeline_cache is None:
@@ -524,6 +559,7 @@ class OmnidreamsConditioningWrapper(nn.Module):
         condition = self._to_model_range(model_cond)
         prev_block_idx = state.pipeline_cache.autoregressive_index
         block_idx = 0 if prev_block_idx is None else prev_block_idx + 1
+        t_prepared = time.perf_counter()
 
         with profiler.measure(
             "pipeline.continue_generation",
@@ -536,7 +572,9 @@ class OmnidreamsConditioningWrapper(nn.Module):
                 hdmap=condition,
                 cache=state.pipeline_cache,
             )
+            t_generated = time.perf_counter()
             rgb_frames = self._to_uint8(rgb_frames).contiguous()
+            t_uint8_ready = time.perf_counter()
 
         new_state = OmnidreamsConditioningState(
             renderer=renderer,
@@ -547,6 +585,14 @@ class OmnidreamsConditioningWrapper(nn.Module):
             condition_frames=condition_frames,
             rgb_frames=rgb_frames,
             finalization_state={"autoregressive_index": block_idx},
+            stats={
+                "wrapper_validate_ms": (t_validated - t_start) * 1000.0,
+                "wrapper_render_ms": (t_rendered - t_validated) * 1000.0,
+                "wrapper_prepare_ms": (t_prepared - t_rendered) * 1000.0,
+                "wrapper_generate_ms": (t_generated - t_prepared) * 1000.0,
+                "wrapper_to_uint8_ms": (t_uint8_ready - t_generated) * 1000.0,
+                "wrapper_total_ms": (t_uint8_ready - t_start) * 1000.0,
+            },
         )
 
     def cleanup(self, state: OmnidreamsConditioningState) -> None:

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -20,9 +20,13 @@ from omnidreams.interactive_drive.config import (
     RasterConfig,
     WorldModelProfileConfig,
 )
+from omnidreams.interactive_drive.cli_args import ExplicitArgTrackingArgumentParser
 from omnidreams.interactive_drive.log import configure_logging
 from omnidreams.interactive_drive.synthetic_scene import build_synthetic_scene_to_temp
-from omnidreams.interactive_drive.world_model.manifest import load_world_model_manifest
+from omnidreams.interactive_drive.world_model.manifest import (
+    load_world_model_manifest,
+    resolve_world_model_manifest_path,
+)
 from omnidreams.scenes import local_scene_archive_path
 
 from flashdreams.infra.postprocess import VideoPostprocessChainConfig
@@ -53,28 +57,11 @@ def resolve_manifest_path(path: str | Path) -> Path:
     config directory, so ``--manifest example_world_model_perf.yaml`` works
     from a workspace root.
     """
-    raw_path = Path(path).expanduser()
-    if raw_path.is_absolute():
-        return raw_path
-
-    cwd_path = raw_path.resolve()
-    if cwd_path.exists():
-        return cwd_path
-
-    package_path = (_PACKAGE_ROOT / raw_path).resolve()
-    if package_path.exists():
-        return package_path
-
-    if len(raw_path.parts) == 1:
-        configs_path = (_CONFIGS_ROOT / raw_path).resolve()
-        if configs_path.exists():
-            return configs_path
-
-    return cwd_path
+    return resolve_world_model_manifest_path(path)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = ExplicitArgTrackingArgumentParser(
         description="Single-process flashdreams driving demo"
     )
     parser.add_argument(

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli_args.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli_args.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+_EXPLICIT_ARG_DESTS_ATTR = "_explicit_arg_dests"
+
+
+def explicit_arg_dests(
+    parser: argparse.ArgumentParser, argv: Sequence[str]
+) -> frozenset[str]:
+    """Return parser destination names whose option strings appear in ``argv``."""
+    option_dests = {
+        option: action.dest
+        for action in parser._actions
+        for option in action.option_strings
+    }
+    explicit = set()
+    for token in argv:
+        option = token.split("=", 1)[0]
+        dest = option_dests.get(option)
+        if dest is not None:
+            explicit.add(dest)
+    return frozenset(explicit)
+
+
+def arg_was_explicit(args: argparse.Namespace, dest: str) -> bool:
+    """Return whether a parsed namespace field came from an explicit CLI flag."""
+    return dest in getattr(args, _EXPLICIT_ARG_DESTS_ATTR, frozenset())
+
+
+class ExplicitArgTrackingArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that records which optional arguments users supplied."""
+
+    def parse_args(
+        self,
+        args: Sequence[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> argparse.Namespace:
+        raw_args = sys.argv[1:] if args is None else list(args)
+        parsed = super().parse_args(raw_args, namespace)
+        setattr(parsed, _EXPLICIT_ARG_DESTS_ATTR, explicit_arg_dests(self, raw_args))
+        return parsed

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli_args.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli_args.py
@@ -10,21 +10,45 @@ from collections.abc import Sequence
 _EXPLICIT_ARG_DESTS_ATTR = "_explicit_arg_dests"
 
 
+def _resolve_option_action(
+    parser: argparse.ArgumentParser, token: str
+) -> argparse.Action | None:
+    """Resolve a raw argv token to the argparse action that consumes it."""
+    option = token.split("=", 1)[0]
+    action = parser._option_string_actions.get(option)
+    if action is not None:
+        return action
+
+    if not getattr(parser, "allow_abbrev", True):
+        return None
+    if len(option) < 2 or option[0] not in parser.prefix_chars:
+        return None
+
+    matches = []
+    if option[1] in parser.prefix_chars:
+        for option_string, candidate in parser._option_string_actions.items():
+            if option_string.startswith(option):
+                matches.append(candidate)
+    else:
+        short_option = option[:2]
+        for option_string, candidate in parser._option_string_actions.items():
+            if option_string == short_option or option_string.startswith(option):
+                matches.append(candidate)
+
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
 def explicit_arg_dests(
     parser: argparse.ArgumentParser, argv: Sequence[str]
 ) -> frozenset[str]:
-    """Return parser destination names whose option strings appear in ``argv``."""
-    option_dests = {
-        option: action.dest
-        for action in parser._actions
-        for option in action.option_strings
-    }
+    """Return parser destination names whose options appear in ``argv``."""
     explicit = set()
     for token in argv:
-        option = token.split("=", 1)[0]
-        dest = option_dests.get(option)
-        if dest is not None:
-            explicit.add(dest)
+        action = _resolve_option_action(parser, token)
+        if action is not None:
+            explicit.add(action.dest)
     return frozenset(explicit)
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
@@ -26,6 +26,8 @@ _RESOLUTION_ALIGNMENT_PX = 16
 _NATIVE_DIT_ACCELERATION_MODES = ("auto", "disabled", "required")
 _NATIVE_DIT_BACKENDS = ("fp8_kvcache_cudnn", "bf16")
 _NATIVE_VAE_ENCODERS = ("disabled", "fp8")
+_INTERACTIVE_DRIVE_ROOT = Path(__file__).resolve().parents[1]
+_CONFIGS_ROOT = _INTERACTIVE_DRIVE_ROOT / "configs"
 
 
 def _is_hf_url(raw: str) -> bool:
@@ -97,6 +99,28 @@ def _resolve_manifest_path(raw_path: str | None, *, manifest_dir: Path) -> Path 
     if not path.is_absolute():
         path = (manifest_dir / path).resolve()
     return path
+
+
+def resolve_world_model_manifest_path(path: str | Path) -> Path:
+    """Resolve a CLI manifest value against cwd and bundled configs."""
+    raw_path = Path(path).expanduser()
+    if raw_path.is_absolute():
+        return raw_path
+
+    cwd_path = raw_path.resolve()
+    if cwd_path.exists():
+        return cwd_path
+
+    package_path = (_INTERACTIVE_DRIVE_ROOT / raw_path).resolve()
+    if package_path.exists():
+        return package_path
+
+    if len(raw_path.parts) == 1:
+        configs_path = (_CONFIGS_ROOT / raw_path).resolve()
+        if configs_path.exists():
+            return configs_path
+
+    return cwd_path
 
 
 def _parse_resolution_wh(raw: object) -> tuple[int, int]:

--- a/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
+++ b/integrations/omnidreams/omnidreams/native/omnidreams_singleview.py
@@ -26,10 +26,12 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Iterator
 
+from loguru import logger
 from omnidreams.native.acceleration import (
     NativeAccelerationConfig,
     NativeAvailabilityCheck,
@@ -528,6 +530,7 @@ def load_extension(
         if _extension is not None:
             return _extension
         _extension_load_error = None
+        build_started_s: float | None = None
 
         try:
             _ensure_windows_cuda13_toolkit()
@@ -554,6 +557,19 @@ def load_extension(
             _add_windows_cuda_dll_directories(cudnn_package_dir)
 
             with _scoped_torch_max_jobs(max_jobs), _scoped_cuda_arch_list():
+                build_started_s = time.perf_counter()
+                logger.info(
+                    "Building/loading OmniDreams single-view native extension "
+                    "{}. First-time builds can take several minutes; seeing "
+                    "compiler processes such as cc1plus/nvcc is expected. "
+                    "build_directory={} MAX_JOBS={} TORCH_CUDA_ARCH_LIST={} "
+                    "verbose={}",
+                    extension_name,
+                    extension_build_dir,
+                    os.environ.get(_PYTORCH_MAX_JOBS_ENV, "<unset>"),
+                    os.environ.get(_PYTORCH_CUDA_ARCH_LIST_ENV, "<unset>"),
+                    verbose,
+                )
                 _extension = load_torch_extension(
                     name=extension_name,
                     sources=[str(source) for source in _extension_sources()],
@@ -657,8 +673,20 @@ def load_extension(
                     with_cuda=True,
                     verbose=verbose,
                 )
+                logger.info(
+                    "OmniDreams single-view native extension {} ready in {:.1f}s.",
+                    extension_name,
+                    time.perf_counter() - build_started_s,
+                )
         except Exception as exc:  # pragma: no cover - environment-specific build path
             _extension_load_error = exc
+            if build_started_s is not None:
+                logger.warning(
+                    "OmniDreams single-view native extension build/load failed "
+                    "after {:.1f}s: {}",
+                    time.perf_counter() - build_started_s,
+                    exc,
+                )
             return None
         return _extension
 

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -4,15 +4,28 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 from importlib.resources import as_file, files
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import torch
 import torch.distributed as dist
 from aiohttp import web
 from loguru import logger
 from omnidreams.config import OMNIDREAMS_CONFIGS
+from omnidreams.interactive_drive.cli_args import (
+    ExplicitArgTrackingArgumentParser,
+    arg_was_explicit,
+)
+from omnidreams.interactive_drive.config import WorldModelProfileConfig
+from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
+    _build_pipeline_config,
+)
+from omnidreams.interactive_drive.world_model.manifest import (
+    load_world_model_manifest,
+    resolve_world_model_manifest_path,
+)
 from omnidreams.transformer import CosmosTransformerConfig
 from omnidreams.webrtc.session import (
     OmnidreamsRuntimeConfig,
@@ -53,8 +66,8 @@ class _OmnidreamsSessionManager(WebRTCSessionManager, Protocol):
     ) -> None: ...
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = ExplicitArgTrackingArgumentParser(
         description=(
             "Omnidreams WebRTC server: serves /request_session and streams "
             "single-view WSAD-controlled video chunks over one peer connection."
@@ -76,6 +89,17 @@ def parse_args() -> argparse.Namespace:
             "Local WebRTC scene directory containing clipgt/first_image.* "
             "and clipgt/prompt.txt. If omitted, the server downloads and "
             "stages the selected Hugging Face scene."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help=(
+            "Omnidreams world-model manifest (YAML). Accepts a path or a "
+            "bundled config filename such as example_world_model_perf.yaml. "
+            "When set, WebRTC uses the same pipeline perf toggles as the "
+            "interactive-drive world-model path."
         ),
     )
     parser.add_argument(
@@ -150,7 +174,7 @@ def parse_args() -> argparse.Namespace:
             "software encoder otherwise."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def _get_omnidreams_manager(app: web.Application) -> _OmnidreamsSessionManager:
@@ -221,16 +245,58 @@ def build_runtime_config(
     *,
     device_override: str | None = None,
 ) -> OmnidreamsRuntimeConfig:
+    manifest_path = None
+    manifest = None
+    pipeline_config = None
+    pipeline_config_name = args.pipeline_config_name
+    device = args.device
+    seed = args.seed
+    fps = args.fps
+    video_width = args.video_width
+    video_height = args.video_height
+
+    manifest_arg = getattr(args, "manifest", None)
+    if manifest_arg is not None:
+        manifest_path = resolve_world_model_manifest_path(manifest_arg)
+        manifest = load_world_model_manifest(manifest_path)
+        pipeline_config = _build_pipeline_config(
+            manifest,
+            profile=WorldModelProfileConfig(),
+        )
+        pipeline_config_name = str(pipeline_config.name)
+        if (
+            arg_was_explicit(args, "pipeline_config_name")
+            and args.pipeline_config_name != pipeline_config_name
+        ):
+            raise ValueError(
+                "--manifest selects pipeline config "
+                f"{pipeline_config_name!r}, but --pipeline_config_name was "
+                f"also set to {args.pipeline_config_name!r}."
+            )
+
+        if not arg_was_explicit(args, "device"):
+            device = manifest.device
+        if not arg_was_explicit(args, "seed"):
+            seed = manifest.seed_for_every_rollout
+        if not arg_was_explicit(args, "fps"):
+            fps = manifest.fps
+        if not arg_was_explicit(args, "video_width"):
+            video_width = manifest.resolution_wh[0]
+        if not arg_was_explicit(args, "video_height"):
+            video_height = manifest.resolution_wh[1]
+
     return OmnidreamsRuntimeConfig(
-        pipeline_config_name=args.pipeline_config_name,
+        pipeline_config_name=pipeline_config_name,
+        pipeline_config=pipeline_config,
+        manifest_path=manifest_path,
         scene_dir=args.scene_dir,
         scene_uuid=args.scene_uuid,
         scene_variant=args.scene_variant,
-        seed=args.seed,
-        device=device_override or args.device,
-        video_height=args.video_height,
-        video_width=args.video_width,
-        fps=args.fps,
+        seed=seed,
+        device=device_override or device,
+        video_height=video_height,
+        video_width=video_width,
+        fps=fps,
         camera_name=args.camera_name,
         warmup_chunks=args.warmup_chunks,
         warmup_timeout_s=args.warmup_timeout_s,
@@ -259,8 +325,10 @@ def initialize_distributed(
     return context.device, context.world_rank, context.world_size
 
 
-def _validate_single_view_config(config_name: str) -> None:
-    pipeline_cfg = OMNIDREAMS_CONFIGS[config_name]
+def _validate_single_view_config(
+    config_name: str, pipeline_config: Any | None = None
+) -> None:
+    pipeline_cfg = pipeline_config or OMNIDREAMS_CONFIGS[config_name]
     transformer_cfg = pipeline_cfg.diffusion_model.transformer
     if not isinstance(transformer_cfg, CosmosTransformerConfig):
         raise TypeError("Omnidreams WebRTC requires a CosmosTransformerConfig.")
@@ -274,10 +342,16 @@ def _validate_single_view_config(config_name: str) -> None:
 def main() -> None:
     configure_logging()
     args = parse_args()
-    _validate_single_view_config(args.pipeline_config_name)
+    runtime_config = build_runtime_config(args)
+    _validate_single_view_config(
+        runtime_config.pipeline_config_name,
+        runtime_config.pipeline_config,
+    )
 
-    runtime_device, world_rank, _ = initialize_distributed(default_device=args.device)
-    runtime_config = build_runtime_config(args, device_override=str(runtime_device))
+    runtime_device, world_rank, _ = initialize_distributed(
+        default_device=runtime_config.device
+    )
+    runtime_config = replace(runtime_config, device=str(runtime_device))
     session_manager = OmnidreamsWebRTCSessionManager(runtime_config=runtime_config)
     app = None
     if world_rank == 0:

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -161,7 +161,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "can override this selection before connecting."
         ),
     )
-    parser.add_argument(
+    encoder_group = parser.add_mutually_exclusive_group()
+    encoder_group.add_argument(
         "--prefer_sw_encoder",
         action="store_true",
         help=(
@@ -172,6 +173,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "the encoder is auto-selected at startup: NVENC when the "
             "driver reports support at the target resolution, aiortc's "
             "software encoder otherwise."
+        ),
+    )
+    encoder_group.add_argument(
+        "--require_nvenc",
+        action="store_true",
+        help=(
+            "Require the PyNvVideoCodec/NVENC H.264 path. Startup fails "
+            "instead of falling back to aiortc if the library, driver, "
+            "codec negotiation, or target resolution cannot use NVENC."
         ),
     )
     return parser.parse_args(argv)
@@ -302,7 +312,13 @@ def build_runtime_config(
         warmup_timeout_s=args.warmup_timeout_s,
         debug_serve_hdmaps=args.debug_serve_hdmaps,
         postprocess=VideoPostprocessChainConfig(preset=args.postprocess_preset),
-        encoder_backend="default" if args.prefer_sw_encoder else "auto",
+        encoder_backend=(
+            "nvenc"
+            if getattr(args, "require_nvenc", False)
+            else "default"
+            if getattr(args, "prefer_sw_encoder", False)
+            else "auto"
+        ),
     )
 
 

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -497,6 +497,7 @@ class OmnidreamsInferenceRuntime:
         self._text_prompts: list[TextPrompt] | None = None
         self._camera_to_rig: torch.Tensor | None = None
         self._initial_ego_pose: np.ndarray | None = None
+        self._pending_finalization_state: dict | None = None
         self._next_timestamp_us: int = 0
         self._postprocess_stream: VideoPostprocessStream | None = None
         self._postprocess_preset = self.config.postprocess.preset
@@ -888,6 +889,7 @@ class OmnidreamsInferenceRuntime:
         if self._initial_ego_pose is None or self._scene_data is None:
             raise OmnidreamsRuntimeError("Scene state is not initialized.")
 
+        self._finalize_pending_generation_sync()
         self._reset_postprocess_stream(session_input)
         if self._state is not None and self._state.pipeline_cache is not None:
             del self._state.pipeline_cache
@@ -903,6 +905,7 @@ class OmnidreamsInferenceRuntime:
         self._wrapper.set_rollout_seed(self.config.seed)
 
     def _close_sync(self) -> None:
+        self._finalize_pending_generation_sync()
         state = self._state
         wrapper = self._wrapper
         self._state = None
@@ -976,12 +979,32 @@ class OmnidreamsInferenceRuntime:
         self._postprocess_stream.finish()
         self._postprocess_stream = None
 
+    def _finalize_pending_generation_sync(self) -> float:
+        finalization_state = self._pending_finalization_state
+        if finalization_state is None:
+            return 0.0
+        self._pending_finalization_state = None
+        if (
+            self._wrapper is None
+            or self._state is None
+            or self._state.pipeline_cache is None
+        ):
+            return 0.0
+
+        t_start = time.perf_counter()
+        self._wrapper.finalize_block_generation(
+            self._state.pipeline_cache,
+            finalization_state,
+        )
+        return (time.perf_counter() - t_start) * 1000.0
+
     def _generate_one_chunk_sync(
         self,
         *,
         segments: list[PoseSegment],
         frame_times: list[float],
     ) -> WebRTCStepResult:
+        t_start = time.perf_counter()
         if (
             self._wrapper is None
             or self._renderer is None
@@ -992,6 +1015,9 @@ class OmnidreamsInferenceRuntime:
             raise OmnidreamsRuntimeError("Runtime is not initialized.")
         if self._device is None:
             raise OmnidreamsRuntimeError("Runtime device is not initialized.")
+
+        prior_finalize_ms = self._finalize_pending_generation_sync()
+        t_after_prior_finalize = time.perf_counter()
 
         num_frames = self.peek_next_chunk_num_frames()
         if len(frame_times) != num_frames:
@@ -1012,10 +1038,12 @@ class OmnidreamsInferenceRuntime:
         )
         camera_poses = torch.einsum("nij,jk->nik", ego_poses_t, self._camera_to_rig)
         frame_timestamps_us = self._consume_timestamps(num_frames)
+        t_inputs_ready = time.perf_counter()
 
         camera_names = [self.config.camera_name]
         camera_poses_per_view = {self.config.camera_name: camera_poses}
         serve_hdmaps = self.config.debug_serve_hdmaps
+        t_wrapper_start = time.perf_counter()
         if self._state is None:
             output = self._wrapper.start_generation(
                 text_prompts=self._text_prompts,
@@ -1036,12 +1064,8 @@ class OmnidreamsInferenceRuntime:
                 skip_video_generation=serve_hdmaps,
             )
             self._state = output.state
-
-        if self._state.pipeline_cache is not None:
-            self._wrapper.finalize_block_generation(
-                self._state.pipeline_cache,
-                output.finalization_state,
-            )
+        t_wrapper_done = time.perf_counter()
+        self._pending_finalization_state = output.finalization_state
 
         if serve_hdmaps:
             video_chunk = output.condition_frames
@@ -1049,6 +1073,7 @@ class OmnidreamsInferenceRuntime:
             raise OmnidreamsRuntimeError("Omnidreams WebRTC received no RGB frames.")
         else:
             video_chunk = output.rgb_frames
+        t_video_selected = time.perf_counter()
 
         if not serve_hdmaps and self._postprocess_stream is not None:
             video_chunk = self._postprocess_stream.process(
@@ -1062,14 +1087,30 @@ class OmnidreamsInferenceRuntime:
         # software encoder path performs its own D2H copy inside
         # ``BufferedVideoTrack``'s worker thread. Either way, the model's
         # writes must be visible before those readers run.
+        t_sync_start = time.perf_counter()
         if self._device is not None and self._device.type == "cuda":
             torch.cuda.current_stream(self._device).synchronize()
+        t_synced = time.perf_counter()
+
+        stats: dict[str, float] = dict(getattr(output, "stats", None) or {})
+        stats.update(
+            {
+                "runtime_input_ms": (t_inputs_ready - t_after_prior_finalize)
+                * 1000.0,
+                "runtime_wrapper_ms": (t_wrapper_done - t_wrapper_start) * 1000.0,
+                "runtime_finalize_ms": prior_finalize_ms,
+                "runtime_prior_finalize_ms": prior_finalize_ms,
+                "runtime_select_ms": (t_video_selected - t_wrapper_done) * 1000.0,
+                "runtime_sync_ms": (t_synced - t_sync_start) * 1000.0,
+                "runtime_total_ms": (t_synced - t_start) * 1000.0,
+            }
+        )
 
         result = WebRTCStepResult(
             chunk_index=self.autoregressive_index,
             num_frames=int(video_chunk.shape[2]),
             video_chunk=video_chunk.detach(),
-            stats=None,
+            stats=stats,
         )
         self.autoregressive_index += 1
         return result

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -431,6 +431,8 @@ class OmnidreamsRuntimeConfig:
     pipeline_config_name: str = (
         "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
     )
+    pipeline_config: Any | None = None
+    manifest_path: Path | None = None
     scene_dir: Path | None = None
     scene_uuid: str | None = None
     # Weather variant slug (default/rain/snow): picks the sibling USDZ + prompt.
@@ -680,14 +682,19 @@ class OmnidreamsInferenceRuntime:
             camera_name=cfg.camera_name,
             variant=cfg.scene_variant,
         )
-        if cfg.pipeline_config_name not in OMNIDREAMS_CONFIGS:
+        if (
+            cfg.pipeline_config is None
+            and cfg.pipeline_config_name not in OMNIDREAMS_CONFIGS
+        ):
             supported = ", ".join(sorted(OMNIDREAMS_CONFIGS))
             raise ValueError(
                 f"Unknown pipeline_config_name={cfg.pipeline_config_name!r}. "
                 f"Supported: {supported}"
             )
 
-        pipeline_cfg = OMNIDREAMS_CONFIGS[cfg.pipeline_config_name]
+        pipeline_cfg = cfg.pipeline_config or OMNIDREAMS_CONFIGS[
+            cfg.pipeline_config_name
+        ]
         transformer_cfg = pipeline_cfg.diffusion_model.transformer
         if not isinstance(transformer_cfg, CosmosTransformerConfig):
             raise TypeError(
@@ -769,6 +776,7 @@ class OmnidreamsInferenceRuntime:
         pipeline_t0 = time.perf_counter()
         self._wrapper = OmnidreamsConditioningWrapper(
             pipeline_config_name=cfg.pipeline_config_name,
+            pipeline_config=cfg.pipeline_config,
             resolution_wh=(cfg.video_width, cfg.video_height),
             seed_for_every_rollout=cfg.seed,
             device=self._device,

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.css
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.css
@@ -34,6 +34,10 @@ body {
   color: var(--text);
 }
 
+body.has-video {
+  overflow: hidden;
+}
+
 button {
   font: inherit;
 }
@@ -85,16 +89,23 @@ select {
   object-fit: cover;
   opacity: 0;
   background: #050607;
+  transform: translateZ(0);
   transition: opacity 220ms ease;
+  will-change: opacity;
 }
 
 body.has-video .stageVideo {
   opacity: 1;
 }
 
+body.has-video .stage {
+  min-height: 100vh;
+  min-height: 100svh;
+}
+
 body.has-video .idleCanvas,
 body.has-video .stageBackdrop {
-  opacity: 0;
+  display: none;
 }
 
 .stageVignette {
@@ -122,6 +133,7 @@ body.has-video .stageBackdrop {
   background: var(--panel-bg);
   box-shadow: var(--panel-shadow);
   backdrop-filter: blur(18px) saturate(1.15);
+  contain: layout paint;
 }
 
 .brandOverlay {
@@ -416,31 +428,135 @@ body[data-status="generating"] .connectButton {
   left: 50%;
   bottom: clamp(20px, 4vh, 40px);
   display: grid;
-  grid-template-columns:
-    minmax(max-content, 0.7fr)
-    minmax(max-content, 1fr)
-    minmax(max-content, 1.15fr)
-    minmax(max-content, 0.7fr)
-    minmax(max-content, 1.45fr);
-  width: min(960px, calc(100vw - 36px));
+  grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+  width: min(1180px, calc(100vw - 36px));
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 8px;
   background: rgba(18, 20, 22, 0.74);
   box-shadow: 0 12px 38px rgba(0, 0, 0, 0.32);
   backdrop-filter: blur(16px) saturate(1.12);
+  contain: layout paint;
   transform: translateX(-50%);
+}
+
+body.has-video .overlayPanel,
+body.has-video .metricsBar {
+  background: rgba(5, 6, 7, 0.82);
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+body.has-video .brandOverlay,
+body.has-video .logCard {
+  display: none;
+}
+
+body.has-video .statusCard {
+  top: 14px;
+  right: 14px;
+  width: auto;
+  min-width: 0;
+  padding: 7px 10px;
+  gap: 0;
+  border-color: rgba(255, 255, 255, 0.10);
+}
+
+body.has-video .statusCard .panelLabel,
+body.has-video .statusCard .flowLine {
+  display: none;
+}
+
+body.has-video .statusLine {
+  min-height: 20px;
+  gap: 7px;
+  font-size: 0.82rem;
+}
+
+body.has-video .statusDot {
+  width: 7px;
+  height: 7px;
+  box-shadow: none;
+}
+
+body.has-video .controlCard {
+  left: 14px;
+  bottom: 70px;
+  width: auto;
+  padding: 8px;
+  border-color: rgba(255, 255, 255, 0.10);
+}
+
+body.has-video .controlCard h2,
+body.has-video .controlRow > span {
+  display: none;
+}
+
+body.has-video .controlRow {
+  grid-template-columns: auto;
+  gap: 0;
+  min-height: 0;
+}
+
+body.has-video .keyCluster {
+  grid-auto-columns: 32px;
+  gap: 6px;
+}
+
+body.has-video .controlKey {
+  width: 32px;
+  height: 32px;
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(5, 6, 7, 0.82);
+  box-shadow: none;
+  font-size: 0.78rem;
+}
+
+body.has-video .controlKey.is-active {
+  border-color: rgba(142, 240, 28, 0.68);
+  background: rgba(85, 156, 18, 0.42);
+  box-shadow: none;
+}
+
+body.has-video .metricsBar {
+  bottom: 14px;
+  width: min(560px, calc(100vw - 28px));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-color: rgba(255, 255, 255, 0.10);
+}
+
+body.has-video .metricDetail {
+  display: none;
+}
+
+body.has-video .metric {
+  min-height: 34px;
+  padding: 4px 8px;
+  border-bottom: 0;
+  font-size: 0.74rem;
+}
+
+body.has-video .metricLiveEnd {
+  border-right: 0;
+}
+
+body.has-video .metric strong {
+  font-size: 0.82rem;
+}
+
+body.has-video[data-status="generating"] .statusLine strong {
+  animation: none;
 }
 
 .metric {
   display: grid;
-  grid-template-columns: max-content max-content;
+  grid-template-columns: 1fr;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  min-width: max-content;
-  min-height: 42px;
-  padding: 0 16px;
+  gap: 3px;
+  min-width: 0;
+  min-height: 48px;
+  padding: 7px 12px;
   border-right: 1px solid rgba(255, 255, 255, 0.11);
   font-size: 0.88rem;
   text-align: center;
@@ -452,11 +568,16 @@ body[data-status="generating"] .connectButton {
 
 .metric span {
   color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .metric strong {
-  text-align: left;
+  min-width: 0;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 760;
 }
@@ -481,7 +602,7 @@ body[data-status="generating"] .statusLine strong {
   }
 
   .stage {
-    min-height: max(100svh, 980px);
+    min-height: max(100svh, 1080px);
   }
 
   .brandOverlay {
@@ -504,11 +625,11 @@ body[data-status="generating"] .statusLine strong {
   }
 
   .controlCard {
-    bottom: 440px;
+    bottom: 520px;
   }
 
   .logCard {
-    bottom: 164px;
+    bottom: 230px;
   }
 
   .metricsBar {
@@ -529,7 +650,7 @@ body[data-status="generating"] .statusLine strong {
   }
 
   .metric:last-child {
-    grid-column: 1 / -1;
+    grid-column: auto;
   }
 }
 
@@ -552,18 +673,20 @@ body[data-status="generating"] .statusLine strong {
     max-height: 150px;
   }
 
-  .metricsBar {
-    grid-template-columns: 1fr;
-  }
-
   .metric {
-    min-height: 36px;
+    min-height: 38px;
+    padding: 6px 8px;
     border-right: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.11);
+  }
+
+  .metric:nth-child(2n - 1) {
+    border-right: 1px solid rgba(255, 255, 255, 0.11);
   }
 
   .metric:last-child {
     grid-column: auto;
     border-bottom: 0;
+    border-right: 0;
   }
 }

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
@@ -69,24 +69,44 @@ SPDX-License-Identifier: Apache-2.0
 
       <section class="metricsBar" aria-label="Session telemetry">
         <div class="metric">
-          <span>FPS</span>
-          <strong id="fpsValue">--</strong>
+          <span>Media FPS</span>
+          <strong id="browserFpsValue">--</strong>
         </div>
         <div class="metric">
+          <span>Presented</span>
+          <strong id="presentedFpsValue">--</strong>
+        </div>
+        <div class="metric">
+          <span>Server FPS</span>
+          <strong id="serverFpsValue">--</strong>
+        </div>
+        <div class="metric">
+          <span>Dropped</span>
+          <strong id="dropValue">--</strong>
+        </div>
+        <div class="metric metricDetail">
+          <span>Jitter</span>
+          <strong id="jitterValue">--</strong>
+        </div>
+        <div class="metric metricDetail">
+          <span>Decode</span>
+          <strong id="decodeValue">--</strong>
+        </div>
+        <div class="metric metricDetail">
+          <span>Bitrate</span>
+          <strong id="bitrateValue">--</strong>
+        </div>
+        <div class="metric metricLiveEnd">
           <span>Latency</span>
           <strong id="latencyValue">--</strong>
         </div>
-        <div class="metric">
+        <div class="metric metricDetail">
           <span>Resolution</span>
           <strong id="resolutionValue">--</strong>
         </div>
-        <div class="metric">
+        <div class="metric metricDetail">
           <span>Step</span>
           <strong id="stepValue">--</strong>
-        </div>
-        <div class="metric">
-          <span>World Model</span>
-          <strong id="modelValue">Omnidreams</strong>
         </div>
       </section>
     </section>

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.js
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.js
@@ -8,7 +8,13 @@ const eventLog = document.getElementById("eventLog")
 const logState = document.getElementById("logState")
 const remoteVideo = document.getElementById("remoteVideo")
 const idleCanvas = document.getElementById("idleCanvas")
-const fpsValue = document.getElementById("fpsValue")
+const browserFpsValue = document.getElementById("browserFpsValue")
+const presentedFpsValue = document.getElementById("presentedFpsValue")
+const serverFpsValue = document.getElementById("serverFpsValue")
+const dropValue = document.getElementById("dropValue")
+const jitterValue = document.getElementById("jitterValue")
+const decodeValue = document.getElementById("decodeValue")
+const bitrateValue = document.getElementById("bitrateValue")
 const latencyValue = document.getElementById("latencyValue")
 const resolutionValue = document.getElementById("resolutionValue")
 const stepValue = document.getElementById("stepValue")
@@ -26,26 +32,59 @@ const keyAliases = new Map([
 const keySources = new Map()
 const heldKeyOrder = new Map()
 const activeKeys = new Set()
-const frameTimes = []
+const videoFrameCallbackTimes = []
+const presentedFrameSamples = []
 const pendingActions = []
 const maxPendingActions = 32
 const heartbeatIntervalMs = 2000
+const browserProfileLogIntervalMs = 5000
+const metricsRenderIntervalMs = 500
 
 let peerConnection = null
 let controlChannel = null
 let statsTimer = null
 let videoMetricsTimer = null
 let heartbeatTimer = null
+let metricsRenderTimer = null
+let idleAnimationFrame = null
+let previousInboundVideoStats = null
+let previousBrowserProfileLogAt = 0
+let previousMetricsRenderAt = 0
 let inferenceInFlight = false
 let connected = false
 let disconnecting = false
 let heldKeySequence = 0
 
 const metrics = {
-  fps: null,
+  browserFps: null,
+  browserRtpFps: null,
+  receivedFps: null,
+  decodedFps: null,
+  presentedFps: null,
+  videoCallbackFps: null,
+  serverFps: null,
   targetFps: null,
   latencyMs: null,
   rttMs: null,
+  droppedFrames: null,
+  droppedFps: null,
+  dropPercent: null,
+  jitterMs: null,
+  jitterBufferMs: null,
+  decodeMs: null,
+  processingMs: null,
+  bitrateMbps: null,
+  packetsLost: null,
+  packetsLostPerSec: null,
+  freezeCount: null,
+  nackCount: null,
+  decoder: null,
+  presentationDelayMs: null,
+  serverQueueDepth: null,
+  serverLagMs: null,
+  serverDeliveryMs: null,
+  serverEncodeMs: null,
+  serverTrackDroppedPackets: null,
   resolution: null,
   step: null,
   model: "Omnidreams",
@@ -62,12 +101,24 @@ function formatTime() {
 
 function firstFinite(...values) {
   for (const value of values) {
+    if (value === null || value === undefined || value === "") {
+      continue
+    }
     const number = Number(value)
     if (Number.isFinite(number)) {
       return number
     }
   }
   return null
+}
+
+function toFiniteNumber(value) {
+  return firstFinite(value)
+}
+
+function formatFps(value) {
+  const number = toFiniteNumber(value)
+  return number === null ? "--" : number.toFixed(1)
 }
 
 function formatMs(value) {
@@ -80,12 +131,49 @@ function formatMs(value) {
   return `${Math.round(value)} ms`
 }
 
-function logEvent(message, { source = "server", level = "info" } = {}) {
-  const consoleMessage = `[Omnidreams WebRTC][${source}] ${message}`
-  if (level === "error") {
-    console.error(consoleMessage)
-  } else {
-    console.info(consoleMessage)
+function formatMbps(value) {
+  const number = toFiniteNumber(value)
+  if (number === null) {
+    return "--"
+  }
+  if (number >= 10) {
+    return `${number.toFixed(1)} Mb/s`
+  }
+  return `${number.toFixed(2)} Mb/s`
+}
+
+function formatDropValue() {
+  const total = toFiniteNumber(metrics.droppedFrames)
+  if (total === null) {
+    return "--"
+  }
+  const droppedFps = toFiniteNumber(metrics.droppedFps)
+  if (droppedFps !== null && droppedFps > 0.05) {
+    return `${Math.round(total)} (${droppedFps.toFixed(1)}/s)`
+  }
+  return String(Math.round(total))
+}
+
+function setTextIfChanged(element, text) {
+  if (element.textContent !== text) {
+    element.textContent = text
+  }
+}
+
+function logEvent(
+  message,
+  { source = "server", level = "info", dom = true, consoleOutput = true } = {}
+) {
+  if (consoleOutput) {
+    const consoleMessage = `[Omnidreams WebRTC][${source}] ${message}`
+    if (level === "error") {
+      console.error(consoleMessage)
+    } else {
+      console.info(consoleMessage)
+    }
+  }
+  if (!dom) {
+    return
   }
 
   const entry = document.createElement("div")
@@ -107,17 +195,24 @@ function logEvent(message, { source = "server", level = "info" } = {}) {
 }
 
 function setStatus(message, state = message.toLowerCase()) {
-  statusText.textContent = message
-  document.body.dataset.status = state
-  logState.textContent = state === "idle" ? "Waiting" : message
+  setTextIfChanged(statusText, message)
+  if (document.body.dataset.status !== state) {
+    document.body.dataset.status = state
+  }
+  setTextIfChanged(logState, state === "idle" ? "Waiting" : message)
 }
 
 function setFlow(message) {
-  flowText.textContent = message
+  setTextIfChanged(flowText, message)
 }
 
 function setVideoVisible(visible) {
   document.body.classList.toggle("has-video", visible)
+  if (visible) {
+    stopIdleAnimation()
+  } else {
+    startIdleAnimation()
+  }
 }
 
 async function loadPostprocessOptions() {
@@ -165,14 +260,45 @@ async function configureSessionInput() {
   )
 }
 
-function renderMetrics() {
-  const fps = firstFinite(metrics.fps, metrics.targetFps)
+function renderMetrics({ force = false } = {}) {
+  const now = performance.now()
+  if (!force && previousMetricsRenderAt > 0) {
+    const elapsed = now - previousMetricsRenderAt
+    if (elapsed < metricsRenderIntervalMs) {
+      if (metricsRenderTimer === null) {
+        metricsRenderTimer = window.setTimeout(() => {
+          metricsRenderTimer = null
+          renderMetrics({ force: true })
+        }, metricsRenderIntervalMs - elapsed)
+      }
+      return
+    }
+  }
+
+  previousMetricsRenderAt = now
+  const browserFps = firstFinite(
+    metrics.browserRtpFps,
+    metrics.decodedFps,
+    metrics.receivedFps,
+    metrics.presentedFps
+  )
+  const presentedFps = firstFinite(metrics.presentedFps)
+  const serverFps = firstFinite(metrics.serverFps, metrics.targetFps)
   const latency = firstFinite(metrics.latencyMs, metrics.rttMs)
-  fpsValue.textContent = Number.isFinite(fps) ? String(Math.round(fps)) : "--"
-  latencyValue.textContent = formatMs(latency)
-  resolutionValue.textContent = metrics.resolution || "--"
-  stepValue.textContent = metrics.step === null ? "--" : String(metrics.step)
-  modelValue.textContent = metrics.model || "Omnidreams"
+  metrics.browserFps = browserFps
+  setTextIfChanged(browserFpsValue, formatFps(browserFps))
+  setTextIfChanged(presentedFpsValue, formatFps(presentedFps))
+  setTextIfChanged(serverFpsValue, formatFps(serverFps))
+  setTextIfChanged(dropValue, formatDropValue())
+  setTextIfChanged(
+    jitterValue,
+    formatMs(firstFinite(metrics.jitterBufferMs, metrics.jitterMs))
+  )
+  setTextIfChanged(decodeValue, formatMs(firstFinite(metrics.decodeMs, metrics.processingMs)))
+  setTextIfChanged(bitrateValue, formatMbps(metrics.bitrateMbps))
+  setTextIfChanged(latencyValue, formatMs(latency))
+  setTextIfChanged(resolutionValue, metrics.resolution || "--")
+  setTextIfChanged(stepValue, metrics.step === null ? "--" : String(metrics.step))
 }
 
 function recordActionSent(action) {
@@ -197,6 +323,15 @@ function takeObservedActionLatency(now = performance.now()) {
 function updateMetricsFromChunk(payload) {
   const observedLatencyMs = takeObservedActionLatency()
   metrics.targetFps = firstFinite(payload.fps, payload.target_fps, metrics.targetFps)
+  metrics.serverFps = firstFinite(payload.chunk_fps, metrics.serverFps)
+  metrics.serverQueueDepth = firstFinite(payload.queue_depth, metrics.serverQueueDepth)
+  metrics.serverLagMs = firstFinite(payload.lag_ms, metrics.serverLagMs)
+  metrics.serverDeliveryMs = firstFinite(payload.delivery_ms, payload.enqueue_ms, metrics.serverDeliveryMs)
+  metrics.serverEncodeMs = firstFinite(payload.delivery_encode_ms, metrics.serverEncodeMs)
+  metrics.serverTrackDroppedPackets = firstFinite(
+    payload.track_dropped_packets,
+    metrics.serverTrackDroppedPackets
+  )
   metrics.latencyMs = firstFinite(
     payload.latency_ms,
     payload.control_latency_ms,
@@ -224,8 +359,11 @@ function updateMetricsFromChunk(payload) {
 
 function updateMetricsFromVideo() {
   if (remoteVideo.videoWidth > 0 && remoteVideo.videoHeight > 0) {
-    metrics.resolution = `${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`
-    renderMetrics()
+    const resolution = `${remoteVideo.videoWidth}x${remoteVideo.videoHeight}`
+    if (metrics.resolution !== resolution) {
+      metrics.resolution = resolution
+      renderMetrics({ force: true })
+    }
   }
 }
 
@@ -272,6 +410,11 @@ function drawRouteRibbon(ctx, width, height, t) {
 }
 
 function drawIdleScene(now) {
+  idleAnimationFrame = null
+  if (document.body.classList.contains("has-video")) {
+    return
+  }
+
   const ctx = idleCanvas.getContext("2d")
   if (!ctx) {
     return
@@ -365,23 +508,78 @@ function drawIdleScene(now) {
   ctx.fillStyle = `rgba(255, 255, 255, ${0.06 + Math.sin(t * 1.4) * 0.018})`
   ctx.fillRect(0, 0, width, height)
 
-  if (!document.body.classList.contains("has-video")) {
-    recordFrame(now)
-  }
-  window.requestAnimationFrame(drawIdleScene)
+  idleAnimationFrame = window.requestAnimationFrame(drawIdleScene)
 }
 
-function recordFrame(timestamp) {
+function startIdleAnimation() {
+  if (
+    idleAnimationFrame !== null ||
+    document.body.classList.contains("has-video")
+  ) {
+    return
+  }
+  idleAnimationFrame = window.requestAnimationFrame(drawIdleScene)
+}
+
+function stopIdleAnimation() {
+  if (idleAnimationFrame !== null) {
+    window.cancelAnimationFrame(idleAnimationFrame)
+    idleAnimationFrame = null
+  }
+}
+
+function recordPresentedFrame(timestamp, metadata = {}) {
   const now = Number.isFinite(timestamp) ? timestamp : performance.now()
-  frameTimes.push(now)
-  while (frameTimes.length > 0 && now - frameTimes[0] > 1200) {
-    frameTimes.shift()
+  videoFrameCallbackTimes.push(now)
+  while (
+    videoFrameCallbackTimes.length > 0 &&
+    now - videoFrameCallbackTimes[0] > 1200
+  ) {
+    videoFrameCallbackTimes.shift()
   }
-  if (frameTimes.length >= 2) {
-    const elapsed = frameTimes[frameTimes.length - 1] - frameTimes[0]
-    metrics.fps = elapsed > 0 ? ((frameTimes.length - 1) * 1000) / elapsed : metrics.fps
-    renderMetrics()
+  if (videoFrameCallbackTimes.length >= 2) {
+    const elapsed =
+      videoFrameCallbackTimes[videoFrameCallbackTimes.length - 1] -
+      videoFrameCallbackTimes[0]
+    metrics.videoCallbackFps =
+      elapsed > 0
+        ? ((videoFrameCallbackTimes.length - 1) * 1000) / elapsed
+        : metrics.videoCallbackFps
   }
+
+  const presentedFrames = toFiniteNumber(metadata.presentedFrames)
+  if (presentedFrames !== null) {
+    presentedFrameSamples.push({ count: presentedFrames, timestamp: now })
+    while (
+      presentedFrameSamples.length > 0 &&
+      now - presentedFrameSamples[0].timestamp > 1200
+    ) {
+      presentedFrameSamples.shift()
+    }
+    if (presentedFrameSamples.length >= 2) {
+      const firstSample = presentedFrameSamples[0]
+      const lastSample = presentedFrameSamples[presentedFrameSamples.length - 1]
+      const elapsed = lastSample.timestamp - firstSample.timestamp
+      const frameDelta = lastSample.count - firstSample.count
+      if (elapsed > 0 && frameDelta >= 0) {
+        metrics.presentedFps = (frameDelta * 1000) / elapsed
+      }
+    }
+  } else {
+    metrics.presentedFps = metrics.videoCallbackFps
+  }
+
+  const presentationTime = toFiniteNumber(metadata.presentationTime)
+  if (presentationTime !== null) {
+    metrics.presentationDelayMs = Math.max(0, now - presentationTime)
+  }
+
+  const processingDuration = toFiniteNumber(metadata.processingDuration)
+  if (processingDuration !== null) {
+    metrics.processingMs = processingDuration * 1000
+  }
+
+  renderMetrics()
 }
 
 function updateControlHighlights() {
@@ -402,7 +600,7 @@ function actionLabel(action) {
   return `${action.event}${action.key ? `:${action.key}` : ""}`
 }
 
-function sendControlAction(action) {
+function sendControlAction(action, { log = true } = {}) {
   if (!connected || !controlChannel || controlChannel.readyState !== "open") {
     return false
   }
@@ -417,12 +615,17 @@ function sendControlAction(action) {
   recordActionSent(action)
   setStatus("Generating", "generating")
   setFlow(`sent ${actionLabel(action)}, waiting=${inferenceInFlight}`)
-  logEvent(`control ${actionLabel(action)}`, { source: "client" })
+  if (log) {
+    logEvent(`control ${actionLabel(action)}`, {
+      source: "client",
+      dom: !document.body.classList.contains("has-video"),
+    })
+  }
   return true
 }
 
-function enqueueAction(action) {
-  const sent = sendControlAction(action)
+function enqueueAction(action, options = {}) {
+  const sent = sendControlAction(action, options)
   if (!sent) {
     setFlow(connected ? `not_sent ${actionLabel(action)}` : "connect session first")
   }
@@ -433,7 +636,7 @@ function enqueueHeldKeyRepeats() {
     return (heldKeyOrder.get(a) || 0) - (heldKeyOrder.get(b) || 0)
   })
   for (const key of heldKeys) {
-    enqueueAction({ event: "keydown", key })
+    enqueueAction({ event: "keydown", key }, { log: false })
   }
 }
 
@@ -494,17 +697,49 @@ function handleControlMessage(rawMessage) {
     inferenceInFlight = false
     updateMetricsFromChunk(payload)
     const genMs = firstFinite(payload.gen_ms)
+    const runtimeCallMs = firstFinite(payload.runtime_call_ms)
+    const renderMs = firstFinite(payload.wrapper_render_ms)
+    const modelMs = firstFinite(payload.wrapper_generate_ms)
+    const syncMs = firstFinite(payload.runtime_sync_ms)
+    const deliveryMs = firstFinite(payload.delivery_ms, payload.enqueue_ms)
+    const encodeMs = firstFinite(payload.delivery_encode_ms)
+    const chunkFps = firstFinite(payload.chunk_fps)
     const lagMs = firstFinite(payload.lag_ms)
     const queueDepth = firstFinite(payload.queue_depth)
+    const trackDroppedPackets = firstFinite(payload.track_dropped_packets)
     const parts = [
       `chunk_done index=${payload.chunk_index}`,
       `frames=${payload.num_frames}`,
     ]
+    if (typeof payload.encoder_backend === "string" && payload.encoder_backend) {
+      parts.push(`encoder=${payload.encoder_backend}`)
+    }
     if (Number.isFinite(Number(payload.enqueued_frames))) {
       parts.push(`enqueued=${payload.enqueued_frames}`)
     }
+    if (chunkFps !== null) {
+      parts.push(`chunk_fps=${Math.round(chunkFps)}`)
+    }
     if (genMs !== null) {
       parts.push(`gen=${Math.round(genMs)}ms`)
+    }
+    if (runtimeCallMs !== null) {
+      parts.push(`runtime=${Math.round(runtimeCallMs)}ms`)
+    }
+    if (renderMs !== null) {
+      parts.push(`render=${Math.round(renderMs)}ms`)
+    }
+    if (modelMs !== null) {
+      parts.push(`model=${Math.round(modelMs)}ms`)
+    }
+    if (syncMs !== null) {
+      parts.push(`sync=${Math.round(syncMs)}ms`)
+    }
+    if (deliveryMs !== null) {
+      parts.push(`delivery=${Math.round(deliveryMs)}ms`)
+    }
+    if (encodeMs !== null) {
+      parts.push(`encode=${Math.round(encodeMs)}ms`)
     }
     if (lagMs !== null) {
       parts.push(`lag=${Math.round(lagMs)}ms`)
@@ -515,9 +750,26 @@ function handleControlMessage(rawMessage) {
     if (queueDepth !== null) {
       parts.push(`queue=${queueDepth}`)
     }
-    logEvent(parts.join(", "))
+    if (trackDroppedPackets !== null && trackDroppedPackets > 0) {
+      parts.push(`track_dropped=${trackDroppedPackets}`)
+    }
+    const chunkIndex = Number(payload.chunk_index)
+    const hasVideo = document.body.classList.contains("has-video")
+    const importantChunk =
+      !Number.isFinite(chunkIndex) ||
+      chunkIndex <= 2 ||
+      chunkIndex % 10 === 0 ||
+      (trackDroppedPackets !== null && trackDroppedPackets > 0)
+    const showInPanel = !hasVideo && importantChunk
+    const showInConsole = importantChunk
+    logEvent(parts.join(", "), {
+      dom: showInPanel,
+      consoleOutput: showInConsole,
+    })
     setStatus(activeKeys.size > 0 ? "Generating" : "Waiting", activeKeys.size > 0 ? "generating" : "waiting")
-    setFlow(`chunk ${payload.chunk_index} complete`)
+    if (showInPanel || !hasVideo) {
+      setFlow(`chunk ${payload.chunk_index} complete`)
+    }
     if (activeKeys.size > 0) {
       enqueueHeldKeyRepeats()
     }
@@ -561,6 +813,273 @@ async function waitForIceGatheringComplete(pc) {
   })
 }
 
+function setLowLatencyReceiverHint(receiver) {
+  if (!receiver || !("playoutDelayHint" in receiver)) {
+    return
+  }
+  try {
+    receiver.playoutDelayHint = 0
+  } catch (error) {
+    logEvent(`could not set low-latency playout hint: ${error.message}`, {
+      source: "client",
+    })
+  }
+}
+
+function applyLowLatencyReceiverHints(pc) {
+  for (const receiver of pc.getReceivers()) {
+    if (receiver.track && receiver.track.kind === "video") {
+      setLowLatencyReceiverHint(receiver)
+    }
+  }
+}
+
+function preferH264VideoCodec(transceiver) {
+  if (
+    !transceiver ||
+    typeof transceiver.setCodecPreferences !== "function" ||
+    !window.RTCRtpReceiver ||
+    typeof RTCRtpReceiver.getCapabilities !== "function"
+  ) {
+    return
+  }
+  const capabilities = RTCRtpReceiver.getCapabilities("video")
+  const codecs = capabilities && Array.isArray(capabilities.codecs)
+    ? capabilities.codecs
+    : []
+  const h264Codecs = codecs.filter((codec) => {
+    return String(codec.mimeType || "").toLowerCase() === "video/h264"
+  })
+  if (h264Codecs.length === 0) {
+    return
+  }
+  try {
+    transceiver.setCodecPreferences(h264Codecs)
+    logEvent("preferred H.264 receive codec for NVENC compatibility", {
+      source: "client",
+    })
+  } catch (error) {
+    logEvent(`could not prefer H.264 codec: ${error.message}`, {
+      source: "client",
+    })
+  }
+}
+
+function snapshotInboundVideoStats(report) {
+  const timestamp = toFiniteNumber(report.timestamp)
+  return {
+    timestamp: timestamp === null ? performance.now() : timestamp,
+    framesPerSecond: toFiniteNumber(report.framesPerSecond),
+    framesReceived: toFiniteNumber(report.framesReceived),
+    framesDecoded: toFiniteNumber(report.framesDecoded),
+    framesDropped: toFiniteNumber(report.framesDropped),
+    jitter: toFiniteNumber(report.jitter),
+    jitterBufferDelay: toFiniteNumber(report.jitterBufferDelay),
+    jitterBufferEmittedCount: toFiniteNumber(report.jitterBufferEmittedCount),
+    totalDecodeTime: toFiniteNumber(report.totalDecodeTime),
+    totalProcessingDelay: toFiniteNumber(report.totalProcessingDelay),
+    bytesReceived: toFiniteNumber(report.bytesReceived),
+    packetsLost: toFiniteNumber(report.packetsLost),
+    nackCount: toFiniteNumber(report.nackCount),
+    freezeCount: toFiniteNumber(report.freezeCount),
+    decoderImplementation:
+      typeof report.decoderImplementation === "string" ? report.decoderImplementation : null,
+  }
+}
+
+function deltaValue(current, previous, key) {
+  if (!previous) {
+    return null
+  }
+  const currentValue = toFiniteNumber(current[key])
+  const previousValue = toFiniteNumber(previous[key])
+  if (currentValue === null || previousValue === null) {
+    return null
+  }
+  const delta = currentValue - previousValue
+  return delta >= 0 ? delta : null
+}
+
+function deltaRate(current, previous, key, elapsedSeconds) {
+  const delta = deltaValue(current, previous, key)
+  if (delta === null || elapsedSeconds <= 0) {
+    return null
+  }
+  return delta / elapsedSeconds
+}
+
+function deltaAverageMs(current, previous, totalKey, countKey) {
+  const totalDelta = deltaValue(current, previous, totalKey)
+  const countDelta = deltaValue(current, previous, countKey)
+  if (totalDelta === null || countDelta === null || countDelta <= 0) {
+    return null
+  }
+  return (totalDelta * 1000) / countDelta
+}
+
+function updateInboundVideoMetrics(report) {
+  const current = snapshotInboundVideoStats(report)
+  const previous = previousInboundVideoStats
+  const elapsedMs = previous ? current.timestamp - previous.timestamp : null
+  const elapsedSeconds = elapsedMs !== null && elapsedMs > 0 ? elapsedMs / 1000 : null
+
+  metrics.browserRtpFps = firstFinite(current.framesPerSecond, metrics.browserRtpFps)
+  metrics.jitterMs = current.jitter === null ? metrics.jitterMs : current.jitter * 1000
+  metrics.droppedFrames = firstFinite(current.framesDropped, metrics.droppedFrames)
+  metrics.packetsLost = firstFinite(current.packetsLost, metrics.packetsLost)
+  metrics.freezeCount = firstFinite(current.freezeCount, metrics.freezeCount)
+  metrics.nackCount = firstFinite(current.nackCount, metrics.nackCount)
+  metrics.decoder = current.decoderImplementation || metrics.decoder
+
+  if (elapsedSeconds !== null) {
+    const receivedFps = deltaRate(current, previous, "framesReceived", elapsedSeconds)
+    const decodedFps = deltaRate(current, previous, "framesDecoded", elapsedSeconds)
+    const droppedFps = deltaRate(current, previous, "framesDropped", elapsedSeconds)
+    const bytesPerSecond = deltaRate(current, previous, "bytesReceived", elapsedSeconds)
+    const packetsLostPerSecond = deltaRate(current, previous, "packetsLost", elapsedSeconds)
+    const jitterBufferMs = deltaAverageMs(
+      current,
+      previous,
+      "jitterBufferDelay",
+      "jitterBufferEmittedCount"
+    )
+    const decodeMs = deltaAverageMs(current, previous, "totalDecodeTime", "framesDecoded")
+    const processingMs = deltaAverageMs(
+      current,
+      previous,
+      "totalProcessingDelay",
+      "framesDecoded"
+    )
+
+    metrics.receivedFps = firstFinite(receivedFps, metrics.receivedFps)
+    metrics.decodedFps = firstFinite(decodedFps, metrics.decodedFps)
+    metrics.droppedFps = firstFinite(droppedFps, metrics.droppedFps)
+    metrics.packetsLostPerSec = firstFinite(packetsLostPerSecond, metrics.packetsLostPerSec)
+    metrics.jitterBufferMs = firstFinite(jitterBufferMs, metrics.jitterBufferMs)
+    metrics.decodeMs = firstFinite(decodeMs, metrics.decodeMs)
+    metrics.processingMs = firstFinite(processingMs, metrics.processingMs)
+    if (bytesPerSecond !== null) {
+      metrics.bitrateMbps = (bytesPerSecond * 8) / 1_000_000
+    }
+
+    const dropped = deltaValue(current, previous, "framesDropped")
+    const decoded = deltaValue(current, previous, "framesDecoded")
+    if (dropped !== null && decoded !== null && dropped + decoded > 0) {
+      metrics.dropPercent = (dropped * 100) / (dropped + decoded)
+    }
+  }
+
+  previousInboundVideoStats = current
+  renderMetrics()
+}
+
+function diagnoseBrowserProfile() {
+  const serverFps = firstFinite(metrics.serverFps, metrics.targetFps)
+  const mediaFps = firstFinite(
+    metrics.browserFps,
+    metrics.browserRtpFps,
+    metrics.decodedFps,
+    metrics.receivedFps
+  )
+  const presentedFps = firstFinite(metrics.presentedFps)
+  if (serverFps === null || mediaFps === null) {
+    return "collecting"
+  }
+  const frameBudgetMs = 1000 / Math.max(firstFinite(metrics.targetFps, 30), 1)
+  if (firstFinite(metrics.droppedFps, 0) > 1 || firstFinite(metrics.dropPercent, 0) > 5) {
+    return "browser_dropping_frames"
+  }
+  if (
+    firstFinite(metrics.jitterBufferMs, 0) > frameBudgetMs * 2 ||
+    firstFinite(metrics.jitterMs, 0) > 20
+  ) {
+    return "network_or_jitter_buffer"
+  }
+  if (firstFinite(metrics.decodeMs, 0) > frameBudgetMs) {
+    return "decode_bound"
+  }
+  if (presentedFps !== null && mediaFps - presentedFps > 3) {
+    return "presentation_throttled"
+  }
+  if (serverFps - mediaFps <= 3) {
+    return "server_browser_matched"
+  }
+  if (
+    metrics.receivedFps !== null &&
+    metrics.decodedFps !== null &&
+    metrics.receivedFps - metrics.decodedFps > 3
+  ) {
+    return "decode_backlog"
+  }
+  if (
+    firstFinite(metrics.serverQueueDepth, 0) > 2 ||
+    firstFinite(metrics.serverLagMs, 0) > frameBudgetMs * 2
+  ) {
+    return "server_queue_lag"
+  }
+  return "receiver_or_display_pacing"
+}
+
+function maybeLogBrowserProfile(now = performance.now()) {
+  if (!connected || now - previousBrowserProfileLogAt < browserProfileLogIntervalMs) {
+    return
+  }
+  previousBrowserProfileLogAt = now
+
+  const browserFps = firstFinite(metrics.browserFps, metrics.browserRtpFps)
+  const serverFps = firstFinite(metrics.serverFps, metrics.targetFps)
+  const parts = [`diagnosis=${diagnoseBrowserProfile()}`]
+  if (browserFps !== null) {
+    parts.push(`browser_fps=${browserFps.toFixed(1)}`)
+  }
+  if (serverFps !== null) {
+    parts.push(`server_fps=${serverFps.toFixed(1)}`)
+  }
+  if (metrics.receivedFps !== null) {
+    parts.push(`recv_fps=${metrics.receivedFps.toFixed(1)}`)
+  }
+  if (metrics.decodedFps !== null) {
+    parts.push(`decoded_fps=${metrics.decodedFps.toFixed(1)}`)
+  }
+  if (metrics.presentedFps !== null) {
+    parts.push(`presented_fps=${metrics.presentedFps.toFixed(1)}`)
+  }
+  if (metrics.videoCallbackFps !== null) {
+    parts.push(`callback_fps=${metrics.videoCallbackFps.toFixed(1)}`)
+  }
+  if (metrics.droppedFps !== null) {
+    parts.push(`dropped_fps=${metrics.droppedFps.toFixed(1)}`)
+  }
+  if (metrics.jitterBufferMs !== null) {
+    parts.push(`jitter_buffer=${Math.round(metrics.jitterBufferMs)}ms`)
+  }
+  if (metrics.decodeMs !== null) {
+    parts.push(`decode=${metrics.decodeMs.toFixed(1)}ms`)
+  }
+  if (metrics.bitrateMbps !== null) {
+    parts.push(`bitrate=${metrics.bitrateMbps.toFixed(2)}Mb/s`)
+  }
+  if (metrics.serverQueueDepth !== null) {
+    parts.push(`server_queue=${metrics.serverQueueDepth}`)
+  }
+  if (metrics.serverLagMs !== null) {
+    parts.push(`server_lag=${Math.round(metrics.serverLagMs)}ms`)
+  }
+  if (
+    metrics.serverTrackDroppedPackets !== null &&
+    metrics.serverTrackDroppedPackets > 0
+  ) {
+    parts.push(`server_track_dropped=${metrics.serverTrackDroppedPackets}`)
+  }
+  if (metrics.decoder) {
+    parts.push(`decoder=${metrics.decoder}`)
+  }
+  logEvent(`browser_profile ${parts.join(", ")}`, {
+    source: "client",
+    dom: !document.body.classList.contains("has-video"),
+  })
+}
+
 async function pollWebRtcStats() {
   if (!peerConnection) {
     return
@@ -577,13 +1096,13 @@ async function pollWebRtcStats() {
       }
       if (
         report.type === "inbound-rtp" &&
-        (report.kind === "video" || report.mediaType === "video") &&
-        Number.isFinite(report.framesPerSecond)
+        (report.kind === "video" || report.mediaType === "video")
       ) {
-        metrics.fps = report.framesPerSecond
+        updateInboundVideoMetrics(report)
       }
     }
     renderMetrics()
+    maybeLogBrowserProfile()
   } catch (error) {
     logEvent(`stats unavailable: ${error.message}`, { source: "client" })
   }
@@ -603,6 +1122,52 @@ function stopStatsPolling() {
     window.clearInterval(statsTimer)
     statsTimer = null
   }
+}
+
+function resetBrowserProfileMetrics() {
+  videoFrameCallbackTimes.length = 0
+  presentedFrameSamples.length = 0
+  previousInboundVideoStats = null
+  previousBrowserProfileLogAt = 0
+  previousMetricsRenderAt = 0
+  if (metricsRenderTimer !== null) {
+    window.clearTimeout(metricsRenderTimer)
+    metricsRenderTimer = null
+  }
+  Object.assign(metrics, {
+    browserFps: null,
+    browserRtpFps: null,
+    receivedFps: null,
+    decodedFps: null,
+    presentedFps: null,
+    videoCallbackFps: null,
+    serverFps: null,
+    targetFps: null,
+    latencyMs: null,
+    rttMs: null,
+    droppedFrames: null,
+    droppedFps: null,
+    dropPercent: null,
+    jitterMs: null,
+    jitterBufferMs: null,
+    decodeMs: null,
+    processingMs: null,
+    bitrateMbps: null,
+    packetsLost: null,
+    packetsLostPerSec: null,
+    freezeCount: null,
+    nackCount: null,
+    decoder: null,
+    presentationDelayMs: null,
+    serverQueueDepth: null,
+    serverLagMs: null,
+    serverDeliveryMs: null,
+    serverEncodeMs: null,
+    serverTrackDroppedPackets: null,
+    resolution: null,
+    step: null,
+  })
+  renderMetrics({ force: true })
 }
 
 function resetPeerHandles(pc = peerConnection, channel = controlChannel) {
@@ -713,6 +1278,7 @@ async function connectSession() {
   setStatus("Connecting", "connecting")
   setFlow("creating peer connection")
   logEvent("connecting to server...", { source: "client" })
+  resetBrowserProfileMetrics()
   disconnecting = false
 
   try {
@@ -721,7 +1287,9 @@ async function connectSession() {
     const channel = pc.createDataChannel("controls")
     peerConnection = pc
     controlChannel = channel
-    pc.addTransceiver("video", { direction: "recvonly" })
+    const videoTransceiver = pc.addTransceiver("video", { direction: "recvonly" })
+    preferH264VideoCodec(videoTransceiver)
+    setLowLatencyReceiverHint(videoTransceiver.receiver)
 
     channel.onopen = () => {
       connected = true
@@ -754,6 +1322,8 @@ async function connectSession() {
         remoteVideo.srcObject = stream
         updateMetricsFromVideo()
       }
+      setLowLatencyReceiverHint(event.receiver)
+      applyLowLatencyReceiverHints(pc)
       setFlow("video track attached")
       logEvent("video track attached", { source: "client" })
     }
@@ -765,6 +1335,7 @@ async function connectSession() {
         connected = true
         setStatus("Waiting", "waiting")
         setFlow("connected; waiting for input")
+        applyLowLatencyReceiverHints(pc)
         startStatsPolling()
         return
       }
@@ -887,9 +1458,9 @@ function startVideoFrameMonitor() {
     }
     return
   }
-  const onFrame = (now) => {
+  const onFrame = (now, metadata) => {
     if (document.body.classList.contains("has-video")) {
-      recordFrame(now)
+      recordPresentedFrame(now, metadata)
       updateMetricsFromVideo()
     }
     remoteVideo.requestVideoFrameCallback(onFrame)
@@ -897,13 +1468,46 @@ function startVideoFrameMonitor() {
   remoteVideo.requestVideoFrameCallback(onFrame)
 }
 
+function getBrowserProfileSnapshot() {
+  return {
+    ...metrics,
+    connected,
+    inferenceInFlight,
+    activeKeys: Array.from(activeKeys),
+    diagnosis: diagnoseBrowserProfile(),
+  }
+}
+
+async function getPeerStatsSnapshot() {
+  if (!peerConnection) {
+    return []
+  }
+  const stats = await peerConnection.getStats()
+  return Array.from(stats.values()).map((report) => ({ ...report }))
+}
+
+function getRecentLogMessages(limit = 20) {
+  return Array.from(eventLog.querySelectorAll(".logEntry span"))
+    .slice(0, limit)
+    .map((entry) => entry.textContent)
+}
+
+function exposeBrowserProfile() {
+  window.omnidreamsWebRTCProfile = {
+    snapshot: getBrowserProfileSnapshot,
+    peerStats: getPeerStatsSnapshot,
+    logs: getRecentLogMessages,
+  }
+}
+
 function initialize() {
   document.body.dataset.status = "idle"
+  exposeBrowserProfile()
   logEvent("viewer ready", { source: "client" })
   setFlow("waiting")
   renderMetrics()
   attachPointerControls()
-  window.requestAnimationFrame(drawIdleScene)
+  startIdleAnimation()
   startVideoFrameMonitor()
   void loadPostprocessOptions().catch((error) => {
     logEvent(`post-process options unavailable: ${error.message}`, {

--- a/integrations/omnidreams/tests/interactive_drive/test_cli.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_cli.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import pytest
+
 from omnidreams.interactive_drive.cli import build_parser
+from omnidreams.interactive_drive.cli_args import arg_was_explicit
+
+pytestmark = pytest.mark.ci_cpu
 
 
 def test_offload_text_encoder_flag_defaults_disabled() -> None:
@@ -26,3 +31,19 @@ def test_postprocess_preset_accepts_rtx_super_resolution() -> None:
     args = build_parser().parse_args(["--postprocess-preset", "rtx-super-resolution"])
 
     assert args.postprocess_preset == "rtx-super-resolution"
+
+
+def test_parser_records_explicit_arg_destinations() -> None:
+    args = build_parser().parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--offload-text-encoder",
+            "--no-bev",
+        ]
+    )
+
+    assert arg_was_explicit(args, "manifest")
+    assert arg_was_explicit(args, "offload_text_encoder")
+    assert arg_was_explicit(args, "bev")
+    assert not arg_was_explicit(args, "camera")

--- a/integrations/omnidreams/tests/interactive_drive/test_cli.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_cli.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import argparse
+
 import pytest
 
 from omnidreams.interactive_drive.cli import build_parser
-from omnidreams.interactive_drive.cli_args import arg_was_explicit
+from omnidreams.interactive_drive.cli_args import (
+    ExplicitArgTrackingArgumentParser,
+    arg_was_explicit,
+)
 
 pytestmark = pytest.mark.ci_cpu
 
@@ -47,3 +52,35 @@ def test_parser_records_explicit_arg_destinations() -> None:
     assert arg_was_explicit(args, "offload_text_encoder")
     assert arg_was_explicit(args, "bev")
     assert not arg_was_explicit(args, "camera")
+
+
+def test_parser_records_abbreviated_arg_destinations() -> None:
+    parser = ExplicitArgTrackingArgumentParser()
+    parser.add_argument("--manifest")
+    parser.add_argument("--device")
+    parser.add_argument("--seed", type=int)
+    parser.add_argument(
+        "--feature-flag",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+    )
+
+    args = parser.parse_args(
+        [
+            "--man",
+            "example_world_model_perf.yaml",
+            "--dev=cuda:5",
+            "--see",
+            "123",
+            "--no-feat",
+        ]
+    )
+
+    assert args.manifest == "example_world_model_perf.yaml"
+    assert args.device == "cuda:5"
+    assert args.seed == 123
+    assert args.feature_flag is False
+    assert arg_was_explicit(args, "manifest")
+    assert arg_was_explicit(args, "device")
+    assert arg_was_explicit(args, "seed")
+    assert arg_was_explicit(args, "feature_flag")

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -652,12 +652,53 @@ def test_build_runtime_config_manifest_allows_explicit_runtime_overrides() -> No
     assert cfg.pipeline_config is not OMNIDREAMS_CONFIGS[cfg.pipeline_config_name]
 
 
+def test_build_runtime_config_manifest_allows_abbreviated_runtime_overrides() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manif",
+            "example_world_model_perf.yaml",
+            "--dev",
+            "cuda:5",
+            "--see",
+            "123",
+            "--fp",
+            "24",
+            "--video_w",
+            "640",
+            "--video_h",
+            "352",
+        ]
+    )
+
+    cfg = webrtc_server.build_runtime_config(args)
+
+    assert cfg.device == "cuda:5"
+    assert cfg.seed == 123
+    assert cfg.fps == 24
+    assert cfg.video_width == 640
+    assert cfg.video_height == 352
+
+
 def test_build_runtime_config_rejects_manifest_config_name_conflict() -> None:
     args = webrtc_server.parse_args(
         [
             "--manifest",
             "example_world_model_perf.yaml",
             "--pipeline_config_name",
+            "omnidreams-sv-2steps-chunk3-loc6-vae-vae",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="--manifest selects pipeline config"):
+        webrtc_server.build_runtime_config(args)
+
+
+def test_build_runtime_config_rejects_manifest_abbreviated_config_name_conflict() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manif",
+            "example_world_model_perf.yaml",
+            "--pipeline",
             "omnidreams-sv-2steps-chunk3-loc6-vae-vae",
         ]
     )

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -35,7 +35,7 @@ from flashdreams.serving.webrtc.encoders import (
     ChunkDeliveryResult,
     DefaultRTCEncoder,
 )
-from flashdreams.serving.webrtc.manager import WebRTCStepResult
+from flashdreams.serving.webrtc.manager import WebRTCStepResult, _sdp_video_codecs
 from flashdreams.serving.webrtc.media import BufferedVideoTrack
 
 pytestmark = pytest.mark.ci_cpu
@@ -217,7 +217,7 @@ def test_generate_chunk_dispatches_start_then_continue() -> None:
     assert wrapper.calls[0][2] == [1000, 34333]
     assert wrapper.calls[1][0] == "continue"
     assert wrapper.calls[1][1] == (3, 4, 4)
-    assert len(wrapper.finalized) == 2
+    assert wrapper.finalized == [{"autoregressive_index": 0}]
     assert wrapper.skip_video_generation_flags == [False, False]
 
 
@@ -538,6 +538,7 @@ def test_build_runtime_config_threads_hf_scene_args(tmp_path: Path) -> None:
         debug_serve_hdmaps=True,
         postprocess_preset="rtx-super-resolution",
         prefer_sw_encoder=False,
+        require_nvenc=False,
     )
 
     cfg = webrtc_server.build_runtime_config(args, device_override="cuda:7")
@@ -557,18 +558,16 @@ def test_build_runtime_config_threads_hf_scene_args(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "prefer_sw_encoder, expected_backend",
-    [(False, "auto"), (True, "default")],
+    "prefer_sw_encoder, require_nvenc, expected_backend",
+    [(False, False, "auto"), (True, False, "default"), (False, True, "nvenc")],
 )
 def test_build_runtime_config_maps_prefer_sw_encoder_to_backend(
     tmp_path: Path,
     prefer_sw_encoder: bool,
+    require_nvenc: bool,
     expected_backend: str,
 ) -> None:
-    """--prefer_sw_encoder is the single CLI switch that toggles between
-    the auto-probe path and the forced-software path. Any regression in
-    this mapping would silently disable the hardware encoder (or worse,
-    fail to disable it when explicitly asked)."""
+    """Encoder CLI switches map to the requested backend mode."""
     args = argparse.Namespace(
         pipeline_config_name="omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf",
         scene_dir=tmp_path / "local-scene",
@@ -585,9 +584,15 @@ def test_build_runtime_config_maps_prefer_sw_encoder_to_backend(
         debug_serve_hdmaps=False,
         postprocess_preset="",
         prefer_sw_encoder=prefer_sw_encoder,
+        require_nvenc=require_nvenc,
     )
     cfg = webrtc_server.build_runtime_config(args)
     assert cfg.encoder_backend == expected_backend
+
+
+def test_parse_args_rejects_conflicting_encoder_modes() -> None:
+    with pytest.raises(SystemExit):
+        webrtc_server.parse_args(["--prefer_sw_encoder", "--require_nvenc"])
 
 
 def test_build_runtime_config_uses_manifest_perf_toggles() -> None:
@@ -1283,6 +1288,87 @@ def _sdp_fallback_managed_session(
     )
 
 
+def _video_offer_sdp(*codecs: str) -> str:
+    payload_types = list(range(96, 96 + len(codecs)))
+    lines = [
+        "v=0",
+        "o=- 1 2 IN IP4 127.0.0.1",
+        "s=-",
+        "t=0 0",
+        "m=video 9 UDP/TLS/RTP/SAVPF "
+        + " ".join(str(payload_type) for payload_type in payload_types),
+        "c=IN IP4 0.0.0.0",
+        "a=recvonly",
+    ]
+    for payload_type, codec in zip(payload_types, codecs, strict=True):
+        lines.append(f"a=rtpmap:{payload_type} {codec}/90000")
+    lines.extend(
+        [
+            "m=application 9 UDP/DTLS/SCTP webrtc-datachannel",
+            "c=IN IP4 0.0.0.0",
+            "a=sctp-port:5000",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def test_sdp_video_codecs_extracts_video_mime_types() -> None:
+    assert _sdp_video_codecs(_video_offer_sdp("VP8", "H264")) == (
+        "video/VP8",
+        "video/H264",
+    )
+
+
+def test_prepare_video_encoder_for_offer_keeps_hardware_when_h264_offered() -> None:
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(device="cpu", warmup_chunks=0),
+    )
+    hw_encoder = _HardwareEncoderStub(fps=30)
+
+    selected = manager._prepare_video_encoder_for_offer(
+        video_encoder=hw_encoder,
+        offer_sdp=_video_offer_sdp("VP8", "H264"),
+    )
+
+    assert selected is hw_encoder
+    assert not hw_encoder.closed
+
+
+def test_prepare_video_encoder_for_offer_falls_back_without_h264() -> None:
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(device="cpu", warmup_chunks=0),
+    )
+    hw_encoder = _HardwareEncoderStub(fps=30)
+
+    selected = manager._prepare_video_encoder_for_offer(
+        video_encoder=hw_encoder,
+        offer_sdp=_video_offer_sdp("VP8", "VP9"),
+    )
+
+    assert not hw_encoder.closed
+    assert isinstance(selected, DefaultRTCEncoder)
+
+
+def test_prepare_video_encoder_raises_without_h264_when_nvenc_required() -> None:
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(
+            device="cpu",
+            warmup_chunks=0,
+            encoder_backend="nvenc",
+        ),
+    )
+    hw_encoder = _HardwareEncoderStub(fps=30)
+
+    with pytest.raises(RuntimeError, match="browser offer does not advertise H.264"):
+        manager._prepare_video_encoder_for_offer(
+            video_encoder=hw_encoder,
+            offer_sdp=_video_offer_sdp("VP8", "VP9"),
+        )
+
+    assert not hw_encoder.closed
+
+
 @pytest.mark.asyncio
 async def test_enforce_h264_or_fallback_swaps_when_negotiation_lands_on_non_h264() -> (
     None
@@ -1309,6 +1395,31 @@ async def test_enforce_h264_or_fallback_swaps_when_negotiation_lands_on_non_h264
     assert isinstance(managed_session.video_encoder, DefaultRTCEncoder)
     assert isinstance(managed_session.video_track, BufferedVideoTrack)
     assert transceiver.sender.replaced_with is managed_session.video_track
+
+
+@pytest.mark.asyncio
+async def test_enforce_h264_or_fallback_raises_when_nvenc_required() -> None:
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(
+            device="cpu",
+            warmup_chunks=0,
+            encoder_backend="nvenc",
+        ),
+    )
+    hw_encoder = _HardwareEncoderStub(fps=30)
+    managed_session = _sdp_fallback_managed_session(hw_encoder)
+    transceiver = _FakeTransceiver([_FakeSdpCodec(mimeType="video/VP8")])
+
+    with pytest.raises(RuntimeError, match="encoder_backend='nvenc' requested"):
+        await manager._enforce_h264_or_fallback(
+            transceiver=transceiver,
+            managed_session=managed_session,
+            num_frames=4,
+        )
+
+    assert not hw_encoder.closed
+    assert managed_session.video_encoder is hw_encoder
+    assert transceiver.sender.replaced_with is None
 
 
 @pytest.mark.asyncio

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 import torch
 from omnidreams import scenes
+from omnidreams.config import OMNIDREAMS_CONFIGS
 from omnidreams.webrtc import server as webrtc_server
 from omnidreams.webrtc import session
 from omnidreams.webrtc.session import (
@@ -589,6 +590,82 @@ def test_build_runtime_config_maps_prefer_sw_encoder_to_backend(
     assert cfg.encoder_backend == expected_backend
 
 
+def test_build_runtime_config_uses_manifest_perf_toggles() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--warmup_chunks",
+            "0",
+        ]
+    )
+
+    cfg = webrtc_server.build_runtime_config(args)
+
+    assert cfg.manifest_path is not None
+    assert cfg.manifest_path.name == "example_world_model_perf.yaml"
+    assert cfg.pipeline_config is not None
+    assert (
+        cfg.pipeline_config_name
+        == "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
+    )
+    assert cfg.video_width == 1168
+    assert cfg.video_height == 640
+    assert cfg.fps == 30
+    assert cfg.seed is None
+
+    transformer_cfg = cfg.pipeline_config.diffusion_model.transformer
+    scheduler_cfg = cfg.pipeline_config.diffusion_model.scheduler
+    assert transformer_cfg.skip_finalize_kv_cache is True
+    assert transformer_cfg.native_dit_acceleration == "required"
+    assert transformer_cfg.native_dit_backend == "fp8_kvcache_cudnn"
+    assert transformer_cfg.native_dit_attention_backend == "cudnn"
+    assert list(scheduler_cfg.denoising_timesteps) == [1000, 100]
+    assert scheduler_cfg.num_inference_steps == 2
+
+
+def test_build_runtime_config_manifest_allows_explicit_runtime_overrides() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--device",
+            "cuda:5",
+            "--seed",
+            "123",
+            "--fps",
+            "24",
+            "--video_width",
+            "640",
+            "--video_height",
+            "352",
+        ]
+    )
+
+    cfg = webrtc_server.build_runtime_config(args)
+
+    assert cfg.device == "cuda:5"
+    assert cfg.seed == 123
+    assert cfg.fps == 24
+    assert cfg.video_width == 640
+    assert cfg.video_height == 352
+    assert cfg.pipeline_config is not OMNIDREAMS_CONFIGS[cfg.pipeline_config_name]
+
+
+def test_build_runtime_config_rejects_manifest_config_name_conflict() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--pipeline_config_name",
+            "omnidreams-sv-2steps-chunk3-loc6-vae-vae",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="--manifest selects pipeline config"):
+        webrtc_server.build_runtime_config(args)
+
+
 def test_parse_args_omits_scene_dir_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -607,6 +684,83 @@ def test_parse_args_omits_scene_dir_by_default(
     assert args.scene_uuid is None
     assert args.debug_serve_hdmaps is True
     assert args.postprocess_preset == ""
+
+
+def test_runtime_initialization_passes_manifest_pipeline_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest_args = webrtc_server.parse_args(
+        ["--manifest", "example_world_model_perf.yaml"]
+    )
+    cfg = webrtc_server.build_runtime_config(manifest_args)
+    cfg.scene_dir = tmp_path / "scene"
+    clipgt_dir = cfg.scene_dir / "clipgt"
+    clipgt_dir.mkdir(parents=True)
+    first_frame_path = clipgt_dir / "first_image.png"
+    prompt_path = clipgt_dir / "prompt.txt"
+    first_frame_path.write_text("fake image", encoding="utf-8")
+    prompt_path.write_text("test prompt", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    class _FakePose:
+        transformation_matrix = torch.eye(4).numpy()
+        timestamp = 123
+
+    class _FakeSceneData:
+        ego_poses = [_FakePose()]
+        camera_models = {cfg.camera_name: object()}
+        camera_extrinsics = {cfg.camera_name: torch.eye(4).numpy()}
+
+    class _FakeConditioningWrapper:
+        initial_frame_chunk_size = 5
+        frame_chunk_size = 8
+
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def create_renderer(self, *_args: object) -> object:
+            return object()
+
+        def set_rollout_seed(self, seed: int | None) -> None:
+            captured["rollout_seed"] = seed
+
+    monkeypatch.setattr(
+        session,
+        "_extract_local_webrtc_scene_if_needed",
+        lambda scene_dir, **_kwargs: scene_dir,
+    )
+    monkeypatch.setattr(
+        session,
+        "_resolve_webrtc_scene_assets",
+        lambda scene_dir, **_kwargs: (clipgt_dir, first_frame_path, prompt_path),
+    )
+    monkeypatch.setattr(
+        session.cv2,
+        "imread",
+        lambda *_args, **_kwargs: torch.zeros((2, 2, 3), dtype=torch.uint8).numpy(),
+    )
+    monkeypatch.setattr(
+        session, "load_scene", lambda *_args, **_kwargs: _FakeSceneData()
+    )
+    monkeypatch.setattr(
+        session,
+        "load_and_attach_ludus_scene",
+        lambda _path, scene_data, **_kwargs: scene_data,
+    )
+    monkeypatch.setattr(
+        session,
+        "OmnidreamsConditioningWrapper",
+        _FakeConditioningWrapper,
+    )
+    runtime = OmnidreamsInferenceRuntime(config=cfg)
+
+    runtime._initialize_sync()
+
+    assert captured["pipeline_config_name"] == cfg.pipeline_config_name
+    assert captured["pipeline_config"] is cfg.pipeline_config
+    assert captured["resolution_wh"] == (cfg.video_width, cfg.video_height)
+    assert captured["seed_for_every_rollout"] is None
+    assert captured["rollout_seed"] is None
 
 
 def test_runtime_uses_default_scene_uuid_when_scene_is_unspecified(


### PR DESCRIPTION
# Stabilize Omnidreams WebRTC Presentation

## Summary

This PR keeps the NVENC feature already merged on `main` and adds the follow-up fixes and usability enhancements from PR 393 on top of it. It improves the Omnidreams WebRTC path by adding manifest-based startup, preserving explicit CLI argument handling, and stabilizing browser presentation with richer server/client profiling.

The key runtime fix is that the NVENC delivery path now applies async backpressure when handing encoded packets to the WebRTC track, avoiding packet drops/races in the presentation path while keeping the hardware H.264 encoder active.

## Changes

- Add Omnidreams WebRTC manifest startup support, including manifest-derived runner/config values and scene defaults.
- Track abbreviated explicit CLI arguments so manifest values and command-line overrides compose predictably.
- Preserve existing post-process preset wiring while adding the PR 393 WebRTC session/runtime timing fields.
- Add NVENC/WebRTC delivery backpressure by awaiting encoded-packet enqueue instead of scheduling best-effort packet insertion.
- Add H.264 offer/negotiation checks for the hardware encoder path, with clear failure when `--require_nvenc` is used.
- Add server-side timing payload fields for generation, runtime call, delivery, encode, queue, lag, and dropped packet counters.
- Add browser-side WebRTC profiling for media, received, decoded, presented, callback FPS, jitter buffer, decode time, bitrate, and diagnosis.
- Update focused WebRTC, encoder, NVENC track, CLI, and Omnidreams runtime tests for the new behavior.

## Notes

- The NVENC feature commits themselves are intentionally not included here because PR 359 is already merged into `main`.
- Omitting `--require_nvenc` uses encoder auto-selection. Use `--require_nvenc` when validation should fail instead of falling back to software encoding.
- The local Ubuntu `chromium` binary did not advertise H.264; GPU WebRTC validation used `google-chrome-stable`, which did advertise H.264.

## Tests

Local syntax check:

```bash
python -m py_compile \
  flashdreams/flashdreams/serving/webrtc/manager.py \
  flashdreams/flashdreams/serving/webrtc/messages.py \
  flashdreams/flashdreams/serving/webrtc/nvenc.py \
  integrations/omnidreams/omnidreams/webrtc/server.py \
  integrations/omnidreams/omnidreams/webrtc/session.py \
  integrations/omnidreams/tests/test_webrtc_runtime.py
```

Result:

```text
passed
```

Focused CPU tests:

```bash
UV_PROJECT_ENVIRONMENT=/home/horde/github/main_flashdreams/.venv \
uv run --package flashdreams-omnidreams pytest \
  flashdreams/tests/test_webrtc_manager.py \
  flashdreams/tests/test_webrtc_serving.py \
  flashdreams/tests/test_encoders.py \
  flashdreams/tests/test_nvenc_track.py \
  integrations/omnidreams/tests/interactive_drive/test_cli.py \
  integrations/omnidreams/tests/test_webrtc_runtime.py \
  -m ci_cpu
```

Result:

```text
108 passed in 7.88s
```

Whitespace check:

```bash
git diff --check origin/main..HEAD
```

Result:

```text
passed
```

GPU WebRTC profile server:

```bash
UV_PROJECT_ENVIRONMENT=/home/horde/github/main_flashdreams/.venv \
LOGURU_LEVEL=DEBUG PYTHONUNBUFFERED=1 \
uv run --package flashdreams-omnidreams torchrun --standalone --nproc_per_node 1 \
  -m omnidreams.webrtc.server \
  --host 127.0.0.1 \
  --port 8094 \
  --manifest example_world_model_perf.yaml \
  --scene-uuid 0d404ff7-2b66-498c-b047-1ed8cded60d4 \
  --device cuda:0 \
  --warmup_chunks 5 \
  --warmup_timeout_s 1200 \
  --require_nvenc
```

Result:

```text
Video encoder ready: backend=pynvvideocodec codec=h264 1168x640@30fps bitrate=6000000bps gop=30 gpu=0
Video codec negotiated: video/H264 (hardware encoder path active).
Omnidreams WebRTC loopback warmup complete.
```

Headless browser WebRTC profile:

```text
Connected google-chrome-stable to http://127.0.0.1:8094/request_session through CDP,
held the W control path, and collected browser_profile console samples.
```

Result:

```text
browser_profile_result=pass
browser_profile diagnosis=server_browser_matched, browser_fps=30.0, server_fps=30.1, recv_fps=30.0, decoded_fps=30.0, presented_fps=30.0, callback_fps=30.0, dropped_fps=0.0, jitter_buffer=9ms, decode=15.0ms, bitrate=6.14Mb/s, server_queue=8, server_lag=337ms
track_dropped_packets=0.0
```
