### PR TITLE
Adds manifest-driven Omnidreams WebRTC and stabilizes the interactive browser playback path

### DIFF
--- a/flashdreams/flashdreams/serving/webrtc/media.py
+++ b/flashdreams/flashdreams/serving/webrtc/media.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
@@ -145,8 +145,9 @@ class NVENCVideoTrack(MediaStreamTrack):
     ``RTCRtpSender`` routes through ``H264Encoder.pack()`` for RTP
     fragmentation only. The encoder sets ``pts`` and ``time_base`` on
     each packet before enqueueing; this track only paces delivery to
-    ``fps`` and applies a drop-oldest overflow policy so a slow
-    consumer cannot stall the encode worker.
+    ``fps``. The async enqueue path applies backpressure so the browser
+    receives every frame in timestamp order instead of seeing silent
+    server-side drops.
     """
 
     kind = "video"
@@ -182,14 +183,28 @@ class NVENCVideoTrack(MediaStreamTrack):
     def qsize(self) -> int:
         return self._packets.qsize()
 
+    async def enqueue_encoded_packet(self, packet: Packet) -> bool:
+        """Enqueue one encoded packet, waiting for sender-side queue space."""
+        if self._closed:
+            return False
+        await self._packets.put(packet)
+        return True
+
+    async def enqueue_encoded_packets(self, packets: Sequence[Packet]) -> int:
+        """Enqueue encoded packets in order, applying backpressure if full."""
+        for i, packet in enumerate(packets):
+            if not await self.enqueue_encoded_packet(packet):
+                return i
+        return len(packets)
+
     def enqueue_encoded_packet_nowait(self, packet: Packet) -> bool:
         """Synchronously enqueue one packet on the loop thread.
 
-        Called from the encode worker via ``loop.call_soon_threadsafe`` so
-        packets become visible to :meth:`recv` as soon as they are
-        produced, without waiting for the whole chunk to finish encoding.
-        Drops the oldest queued packet on overflow so real-time streaming
-        does not stall behind a slow consumer.
+        This compatibility helper is intentionally lossy on overflow.
+        The production NVENC path uses :meth:`enqueue_encoded_packets`
+        so playback preserves every frame; tests and diagnostic probes
+        can still use this helper when they explicitly want nonblocking
+        enqueue semantics.
         """
         if self._closed:
             return False

--- a/flashdreams/flashdreams/serving/webrtc/nvenc.py
+++ b/flashdreams/flashdreams/serving/webrtc/nvenc.py
@@ -272,32 +272,25 @@ class PyNvHardwareEncoder:
                 "PyNvHardwareEncoder requires an NVENCVideoTrack; got "
                 f"{type(track).__name__}. Create it via encoder.create_track()."
             )
-        loop = asyncio.get_running_loop()
+        packets: list[Packet] = []
 
-        def _stream(pkt: Packet) -> None:
-            # Marshal each packet back onto the asyncio loop as soon as
-            # NVENC produces it, rather than waiting for the whole chunk
-            # to finish encoding — otherwise the first packet's latency is
-            # bounded below by ``T / fps``.
-            try:
-                loop.call_soon_threadsafe(
-                    track.enqueue_encoded_packet_nowait,
-                    pkt,
-                )
-            except RuntimeError:
-                # Loop has been closed; drop the packet silently rather
-                # than raising from the encode worker thread.
-                return
-
-        num_frames, num_keyframes, encode_ms = await asyncio.to_thread(
+        _num_frames, num_keyframes, encode_ms = await asyncio.to_thread(
             self.encode_chunk_sync,
             chunk,
             force_keyframe=force_keyframe,
-            on_packet=_stream,
+            on_packet=packets.append,
         )
+        enqueued = await track.enqueue_encoded_packets(packets)
+        if enqueued < len(packets):
+            logger.debug(
+                "NVENC track closed while enqueueing encoded chunk; "
+                "enqueued {} of {} packet(s).",
+                enqueued,
+                len(packets),
+            )
         return ChunkDeliveryResult(
             backend=self.backend,
-            num_frames=num_frames,
+            num_frames=enqueued,
             num_keyframes=num_keyframes,
             encode_ms=encode_ms,
         )

--- a/flashdreams/flashdreams/serving/webrtc/nvenc.py
+++ b/flashdreams/flashdreams/serving/webrtc/nvenc.py
@@ -272,21 +272,41 @@ class PyNvHardwareEncoder:
                 "PyNvHardwareEncoder requires an NVENCVideoTrack; got "
                 f"{type(track).__name__}. Create it via encoder.create_track()."
             )
-        packets: list[Packet] = []
+        loop = asyncio.get_running_loop()
+        emitted = 0
+        enqueued = 0
+
+        def _stream(packet: Packet) -> None:
+            nonlocal emitted, enqueued
+            emitted += 1
+            enqueue = track.enqueue_encoded_packet(packet)
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    enqueue,
+                    loop,
+                )
+            except RuntimeError:
+                enqueue.close()
+                return
+            try:
+                accepted = future.result()
+            except Exception:
+                return
+            if accepted:
+                enqueued += 1
 
         _num_frames, num_keyframes, encode_ms = await asyncio.to_thread(
             self.encode_chunk_sync,
             chunk,
             force_keyframe=force_keyframe,
-            on_packet=packets.append,
+            on_packet=_stream,
         )
-        enqueued = await track.enqueue_encoded_packets(packets)
-        if enqueued < len(packets):
+        if enqueued < emitted:
             logger.debug(
                 "NVENC track closed while enqueueing encoded chunk; "
                 "enqueued {} of {} packet(s).",
                 enqueued,
-                len(packets),
+                emitted,
             )
         return ChunkDeliveryResult(
             backend=self.backend,

--- a/flashdreams/tests/test_encoders.py
+++ b/flashdreams/tests/test_encoders.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
+from collections.abc import Callable
 from fractions import Fraction
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -439,9 +440,9 @@ class _OrderingFakeEncoder:
     marshaling contract without needing CUDA or PyNvVideoCodec.
 
     Encoding runs on an ``asyncio.to_thread`` worker and each emitted
-    packet is delivered to the track via ``loop.call_soon_threadsafe``,
-    exactly as the real hardware encoder does. This lets us assert the
-    end-to-end ordering property without any GPU dependency.
+    packet is delivered to the track via ``run_coroutine_threadsafe``.
+    That mirrors the real hardware encoder's backpressured per-packet
+    handoff without needing any GPU dependency.
 
     The pts counter is guarded by a lock because the fire-and-forget
     test dispatches multiple ``deliver_chunk`` calls concurrently, and
@@ -474,8 +475,8 @@ class _OrderingFakeEncoder:
 
         def _encode_worker() -> None:
             # One packet per frame, monotonically-increasing pts. The
-            # per-iteration call_soon_threadsafe hand-off mirrors what
-            # PyNvHardwareEncoder does with its on_packet callback.
+            # The per-iteration run_coroutine_threadsafe hand-off mirrors
+            # what PyNvHardwareEncoder does with its on_packet callback.
             for _ in range(frames):
                 packet = Packet(b"\x00\x00\x00\x01\x67")
                 with self._pts_counter_lock:
@@ -483,10 +484,11 @@ class _OrderingFakeEncoder:
                     self._pts_counter += 1
                 packet.pts = (pts_frame_index * 90_000) // self.fps
                 packet.time_base = self._time_base
-                loop.call_soon_threadsafe(
-                    track.enqueue_encoded_packet_nowait,
-                    packet,
+                future = asyncio.run_coroutine_threadsafe(
+                    track.enqueue_encoded_packet(packet),
+                    loop,
                 )
+                future.result()
 
         await asyncio.to_thread(_encode_worker)
         return ChunkDeliveryResult(
@@ -529,6 +531,72 @@ class TestDeliverChunkOrdering:
     marshaling. They pass under the current ``await``-based design and
     would fail under a fire-and-forget rewrite.
     """
+
+    @pytest.mark.asyncio
+    async def test_hardware_deliver_streams_before_chunk_encode_returns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """First packet should reach the track while later frames encode.
+
+        This catches whole-chunk buffering regressions where the NVENC
+        callback merely appends packets to a local list and ``deliver_chunk``
+        does not enqueue anything until ``encode_chunk_sync`` has returned.
+        """
+        nvenc_mod = _install_fake_nvc(monkeypatch, MagicMock())
+        encoder = nvenc_mod.PyNvHardwareEncoder.__new__(nvenc_mod.PyNvHardwareEncoder)
+        loop = asyncio.get_running_loop()
+        first_packet_enqueued = asyncio.Event()
+        finish_encode = threading.Event()
+        encode_returned = threading.Event()
+
+        def _packet(pts: int) -> Packet:
+            packet = Packet(b"\x00\x00\x00\x01\x67")
+            packet.pts = pts
+            packet.time_base = Fraction(1, 90_000)
+            return packet
+
+        def _fake_encode_chunk_sync(
+            chunk: object,
+            *,
+            force_keyframe: bool = False,
+            on_packet: Callable[[Packet], None] | None = None,
+        ) -> tuple[int, int, float]:
+            del chunk, force_keyframe
+            assert on_packet is not None
+            on_packet(_packet(0))
+            loop.call_soon_threadsafe(first_packet_enqueued.set)
+            assert finish_encode.wait(timeout=1.0)
+            on_packet(_packet(1))
+            encode_returned.set()
+            return (2, 0, 12.5)
+
+        setattr(encoder, "encode_chunk_sync", _fake_encode_chunk_sync)
+        track = NVENCVideoTrack(fps=_ORDERING_FPS, maxsize=4)
+        deliver_task = asyncio.create_task(
+            encoder.deliver_chunk(
+                object(),
+                track,
+            )
+        )
+
+        try:
+            await asyncio.wait_for(first_packet_enqueued.wait(), timeout=1.0)
+            assert not encode_returned.is_set()
+            assert track.qsize() == 1
+            first = await asyncio.wait_for(track.recv(), timeout=1.0)
+            assert first.pts == 0
+        finally:
+            finish_encode.set()
+
+        result = await asyncio.wait_for(deliver_task, timeout=1.0)
+        assert result.backend == "pynvvideocodec"
+        assert result.num_frames == 2
+        assert result.num_keyframes == 0
+        assert result.encode_ms == 12.5
+        second = await asyncio.wait_for(track.recv(), timeout=1.0)
+        assert second.pts == 1
+        await track.close()
 
     @pytest.mark.asyncio
     async def test_sequential_await_produces_monotonic_pts(self) -> None:

--- a/flashdreams/tests/test_nvenc_track.py
+++ b/flashdreams/tests/test_nvenc_track.py
@@ -9,8 +9,11 @@ matters is that:
 - ``recv()`` returns exactly the enqueued :class:`av.Packet` (aiortc's
   ``H264Encoder.pack()`` reads ``payload``, ``pts`` and ``time_base``
   directly), and
-- overflow drops the *oldest* packet — a stale I-frame is more useful than
-  falling behind wall-clock on an interactive stream.
+- the async enqueue path applies backpressure instead of dropping packets,
+  preserving the 30 fps media timeline the browser receives.
+
+The legacy nonblocking helper is still tested separately because it is useful
+for tests and diagnostics that deliberately choose lossy enqueue semantics.
 """
 
 from __future__ import annotations
@@ -58,6 +61,47 @@ class TestEnqueue:
         assert track.qsize() == 1
 
     @pytest.mark.asyncio
+    async def test_async_enqueue_waits_for_queue_space(self) -> None:
+        track = NVENCVideoTrack(fps=90_000, maxsize=1)
+        assert await track.enqueue_encoded_packet(_mk_packet(0)) is True
+
+        enqueue_task = asyncio.create_task(track.enqueue_encoded_packet(_mk_packet(1)))
+        await asyncio.sleep(0)
+        assert not enqueue_task.done()
+        assert track.qsize() == 1
+        assert track.dropped_packets == 0
+
+        first = await asyncio.wait_for(track.recv(), timeout=1.0)
+        assert first.pts == 0
+        assert await asyncio.wait_for(enqueue_task, timeout=1.0) is True
+        assert track.qsize() == 1
+        assert track.dropped_packets == 0
+
+        second = await asyncio.wait_for(track.recv(), timeout=1.0)
+        assert second.pts == 1
+
+    @pytest.mark.asyncio
+    async def test_async_batch_enqueue_preserves_order_without_drops(self) -> None:
+        track = NVENCVideoTrack(fps=90_000, maxsize=2)
+        packets = [_mk_packet(pts=i) for i in range(4)]
+
+        enqueue_task = asyncio.create_task(track.enqueue_encoded_packets(packets))
+        await asyncio.sleep(0)
+        assert not enqueue_task.done()
+        assert track.qsize() == 2
+
+        seen_pts = []
+        for _ in packets:
+            packet = await asyncio.wait_for(track.recv(), timeout=1.0)
+            assert packet.pts is not None
+            seen_pts.append(int(packet.pts))
+            await asyncio.sleep(0)
+
+        assert await asyncio.wait_for(enqueue_task, timeout=1.0) == len(packets)
+        assert seen_pts == [0, 1, 2, 3]
+        assert track.dropped_packets == 0
+
+    @pytest.mark.asyncio
     async def test_enqueue_returns_false_on_closed_track(self) -> None:
         track = NVENCVideoTrack(fps=30, maxsize=8)
         await track.close()
@@ -86,11 +130,10 @@ class TestRecv:
 
 
 class TestOverflow:
-    """When the queue fills up, drop the oldest packet, not the newest.
+    """The explicit nowait helper drops the oldest packet on overflow.
 
-    Real-time streams tolerate a stale I-frame worse than they tolerate
-    stale motion, and aiortc will re-request a keyframe via PLI/FIR if
-    the oldest dropped packet was a keyframe.
+    The production async enqueue path above backpressures instead. This
+    branch exists for callers that deliberately choose nonblocking enqueue.
     """
 
     def test_full_queue_drops_oldest(self) -> None:

--- a/integrations/omnidreams/omnidreams/conditioning/conditioning_wrapper.py
+++ b/integrations/omnidreams/omnidreams/conditioning/conditioning_wrapper.py
@@ -24,6 +24,7 @@ This module combines:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 import torch
@@ -93,6 +94,7 @@ class OmnidreamsConditioningWrapper(nn.Module):
         self,
         *,
         pipeline_config_name: str,
+        pipeline_config: Any | None = None,
         resolution_wh: tuple[int, int],
         seed_for_every_rollout: int | None = None,
         device: torch.device = torch.device("cuda:0"),
@@ -103,6 +105,9 @@ class OmnidreamsConditioningWrapper(nn.Module):
             pipeline_config_name: Key into
                 :data:`omnidreams.config.OMNIDREAMS_CONFIGS`
                 identifying the pipeline literal to instantiate.
+            pipeline_config: Optional already-derived pipeline config. When
+                provided, it is instantiated instead of looking up
+                ``pipeline_config_name``.
             resolution_wh: Decoded video ``(width, height)``. Not encoded in
                 the pipeline config; supplied per server deployment.
             seed_for_every_rollout: Optional per-rollout RNG seed override. When
@@ -110,20 +115,21 @@ class OmnidreamsConditioningWrapper(nn.Module):
             device: CUDA device the pipeline is moved to.
 
         Raises:
-            KeyError: ``pipeline_config_name`` is not a registered Omnidreams
-                integration.
+            KeyError: ``pipeline_config`` is omitted and ``pipeline_config_name``
+                is not a registered Omnidreams integration.
             TypeError: The selected pipeline does not use
                 :class:`CosmosTransformerConfig` (the wrapper relies on its
                 ``num_views`` / ``len_t`` fields to size session state).
         """
         super().__init__()
 
-        if pipeline_config_name not in OMNIDREAMS_CONFIGS:
-            raise KeyError(
-                f"Unknown Omnidreams pipeline config {pipeline_config_name!r}. "
-                f"Available: {sorted(OMNIDREAMS_CONFIGS)}"
-            )
-        pipeline_config = OMNIDREAMS_CONFIGS[pipeline_config_name]
+        if pipeline_config is None:
+            if pipeline_config_name not in OMNIDREAMS_CONFIGS:
+                raise KeyError(
+                    f"Unknown Omnidreams pipeline config {pipeline_config_name!r}. "
+                    f"Available: {sorted(OMNIDREAMS_CONFIGS)}"
+                )
+            pipeline_config = OMNIDREAMS_CONFIGS[pipeline_config_name]
 
         transformer_cfg = pipeline_config.diffusion_model.transformer
         if not isinstance(transformer_cfg, CosmosTransformerConfig):

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -20,9 +20,13 @@ from omnidreams.interactive_drive.config import (
     RasterConfig,
     WorldModelProfileConfig,
 )
+from omnidreams.interactive_drive.cli_args import ExplicitArgTrackingArgumentParser
 from omnidreams.interactive_drive.log import configure_logging
 from omnidreams.interactive_drive.synthetic_scene import build_synthetic_scene_to_temp
-from omnidreams.interactive_drive.world_model.manifest import load_world_model_manifest
+from omnidreams.interactive_drive.world_model.manifest import (
+    load_world_model_manifest,
+    resolve_world_model_manifest_path,
+)
 from omnidreams.scenes import local_scene_archive_path
 
 from flashdreams.infra.postprocess import VideoPostprocessChainConfig
@@ -53,28 +57,11 @@ def resolve_manifest_path(path: str | Path) -> Path:
     config directory, so ``--manifest example_world_model_perf.yaml`` works
     from a workspace root.
     """
-    raw_path = Path(path).expanduser()
-    if raw_path.is_absolute():
-        return raw_path
-
-    cwd_path = raw_path.resolve()
-    if cwd_path.exists():
-        return cwd_path
-
-    package_path = (_PACKAGE_ROOT / raw_path).resolve()
-    if package_path.exists():
-        return package_path
-
-    if len(raw_path.parts) == 1:
-        configs_path = (_CONFIGS_ROOT / raw_path).resolve()
-        if configs_path.exists():
-            return configs_path
-
-    return cwd_path
+    return resolve_world_model_manifest_path(path)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = ExplicitArgTrackingArgumentParser(
         description="Single-process flashdreams driving demo"
     )
     parser.add_argument(

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli.py
@@ -14,13 +14,13 @@ from omnidreams.interactive_drive.app import InteractiveDriveApp
 from omnidreams.interactive_drive.backends.base import RenderBackend
 from omnidreams.interactive_drive.backends.raster import RasterRenderBackend
 from omnidreams.interactive_drive.backends.world_model import WorldModelRenderBackend
+from omnidreams.interactive_drive.cli_args import ExplicitArgTrackingArgumentParser
 from omnidreams.interactive_drive.config import (
     AppConfig,
     BevConfig,
     RasterConfig,
     WorldModelProfileConfig,
 )
-from omnidreams.interactive_drive.cli_args import ExplicitArgTrackingArgumentParser
 from omnidreams.interactive_drive.log import configure_logging
 from omnidreams.interactive_drive.synthetic_scene import build_synthetic_scene_to_temp
 from omnidreams.interactive_drive.world_model.manifest import (

--- a/integrations/omnidreams/omnidreams/interactive_drive/cli_args.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/cli_args.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+_EXPLICIT_ARG_DESTS_ATTR = "_explicit_arg_dests"
+
+
+def explicit_arg_dests(
+    parser: argparse.ArgumentParser, argv: Sequence[str]
+) -> frozenset[str]:
+    """Return parser destination names whose option strings appear in ``argv``."""
+    option_dests = {
+        option: action.dest
+        for action in parser._actions
+        for option in action.option_strings
+    }
+    explicit = set()
+    for token in argv:
+        option = token.split("=", 1)[0]
+        dest = option_dests.get(option)
+        if dest is not None:
+            explicit.add(dest)
+    return frozenset(explicit)
+
+
+def arg_was_explicit(args: argparse.Namespace, dest: str) -> bool:
+    """Return whether a parsed namespace field came from an explicit CLI flag."""
+    return dest in getattr(args, _EXPLICIT_ARG_DESTS_ATTR, frozenset())
+
+
+class ExplicitArgTrackingArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that records which optional arguments users supplied."""
+
+    def parse_args(
+        self,
+        args: Sequence[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> argparse.Namespace:
+        raw_args = sys.argv[1:] if args is None else list(args)
+        parsed = super().parse_args(raw_args, namespace)
+        setattr(parsed, _EXPLICIT_ARG_DESTS_ATTR, explicit_arg_dests(self, raw_args))
+        return parsed

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/manifest.py
@@ -26,6 +26,8 @@ _RESOLUTION_ALIGNMENT_PX = 16
 _NATIVE_DIT_ACCELERATION_MODES = ("auto", "disabled", "required")
 _NATIVE_DIT_BACKENDS = ("fp8_kvcache_cudnn", "bf16")
 _NATIVE_VAE_ENCODERS = ("disabled", "fp8")
+_INTERACTIVE_DRIVE_ROOT = Path(__file__).resolve().parents[1]
+_CONFIGS_ROOT = _INTERACTIVE_DRIVE_ROOT / "configs"
 
 
 def _is_hf_url(raw: str) -> bool:
@@ -97,6 +99,28 @@ def _resolve_manifest_path(raw_path: str | None, *, manifest_dir: Path) -> Path 
     if not path.is_absolute():
         path = (manifest_dir / path).resolve()
     return path
+
+
+def resolve_world_model_manifest_path(path: str | Path) -> Path:
+    """Resolve a CLI manifest value against cwd and bundled configs."""
+    raw_path = Path(path).expanduser()
+    if raw_path.is_absolute():
+        return raw_path
+
+    cwd_path = raw_path.resolve()
+    if cwd_path.exists():
+        return cwd_path
+
+    package_path = (_INTERACTIVE_DRIVE_ROOT / raw_path).resolve()
+    if package_path.exists():
+        return package_path
+
+    if len(raw_path.parts) == 1:
+        configs_path = (_CONFIGS_ROOT / raw_path).resolve()
+        if configs_path.exists():
+            return configs_path
+
+    return cwd_path
 
 
 def _parse_resolution_wh(raw: object) -> tuple[int, int]:

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -4,15 +4,28 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 from importlib.resources import as_file, files
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import torch
 import torch.distributed as dist
 from aiohttp import web
 from loguru import logger
 from omnidreams.config import OMNIDREAMS_CONFIGS
+from omnidreams.interactive_drive.cli_args import (
+    ExplicitArgTrackingArgumentParser,
+    arg_was_explicit,
+)
+from omnidreams.interactive_drive.config import WorldModelProfileConfig
+from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
+    _build_pipeline_config,
+)
+from omnidreams.interactive_drive.world_model.manifest import (
+    load_world_model_manifest,
+    resolve_world_model_manifest_path,
+)
 from omnidreams.transformer import CosmosTransformerConfig
 from omnidreams.webrtc.session import (
     OmnidreamsRuntimeConfig,
@@ -53,8 +66,8 @@ class _OmnidreamsSessionManager(WebRTCSessionManager, Protocol):
     ) -> None: ...
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = ExplicitArgTrackingArgumentParser(
         description=(
             "Omnidreams WebRTC server: serves /request_session and streams "
             "single-view WSAD-controlled video chunks over one peer connection."
@@ -76,6 +89,17 @@ def parse_args() -> argparse.Namespace:
             "Local WebRTC scene directory containing clipgt/first_image.* "
             "and clipgt/prompt.txt. If omitted, the server downloads and "
             "stages the selected Hugging Face scene."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help=(
+            "Omnidreams world-model manifest (YAML). Accepts a path or a "
+            "bundled config filename such as example_world_model_perf.yaml. "
+            "When set, WebRTC uses the same pipeline perf toggles as the "
+            "interactive-drive world-model path."
         ),
     )
     parser.add_argument(
@@ -150,7 +174,7 @@ def parse_args() -> argparse.Namespace:
             "software encoder otherwise."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def _get_omnidreams_manager(app: web.Application) -> _OmnidreamsSessionManager:
@@ -221,16 +245,58 @@ def build_runtime_config(
     *,
     device_override: str | None = None,
 ) -> OmnidreamsRuntimeConfig:
+    manifest_path = None
+    manifest = None
+    pipeline_config = None
+    pipeline_config_name = args.pipeline_config_name
+    device = args.device
+    seed = args.seed
+    fps = args.fps
+    video_width = args.video_width
+    video_height = args.video_height
+
+    manifest_arg = getattr(args, "manifest", None)
+    if manifest_arg is not None:
+        manifest_path = resolve_world_model_manifest_path(manifest_arg)
+        manifest = load_world_model_manifest(manifest_path)
+        pipeline_config = _build_pipeline_config(
+            manifest,
+            profile=WorldModelProfileConfig(),
+        )
+        pipeline_config_name = str(pipeline_config.name)
+        if (
+            arg_was_explicit(args, "pipeline_config_name")
+            and args.pipeline_config_name != pipeline_config_name
+        ):
+            raise ValueError(
+                "--manifest selects pipeline config "
+                f"{pipeline_config_name!r}, but --pipeline_config_name was "
+                f"also set to {args.pipeline_config_name!r}."
+            )
+
+        if not arg_was_explicit(args, "device"):
+            device = manifest.device
+        if not arg_was_explicit(args, "seed"):
+            seed = manifest.seed_for_every_rollout
+        if not arg_was_explicit(args, "fps"):
+            fps = manifest.fps
+        if not arg_was_explicit(args, "video_width"):
+            video_width = manifest.resolution_wh[0]
+        if not arg_was_explicit(args, "video_height"):
+            video_height = manifest.resolution_wh[1]
+
     return OmnidreamsRuntimeConfig(
-        pipeline_config_name=args.pipeline_config_name,
+        pipeline_config_name=pipeline_config_name,
+        pipeline_config=pipeline_config,
+        manifest_path=manifest_path,
         scene_dir=args.scene_dir,
         scene_uuid=args.scene_uuid,
         scene_variant=args.scene_variant,
-        seed=args.seed,
-        device=device_override or args.device,
-        video_height=args.video_height,
-        video_width=args.video_width,
-        fps=args.fps,
+        seed=seed,
+        device=device_override or device,
+        video_height=video_height,
+        video_width=video_width,
+        fps=fps,
         camera_name=args.camera_name,
         warmup_chunks=args.warmup_chunks,
         warmup_timeout_s=args.warmup_timeout_s,
@@ -259,8 +325,10 @@ def initialize_distributed(
     return context.device, context.world_rank, context.world_size
 
 
-def _validate_single_view_config(config_name: str) -> None:
-    pipeline_cfg = OMNIDREAMS_CONFIGS[config_name]
+def _validate_single_view_config(
+    config_name: str, pipeline_config: Any | None = None
+) -> None:
+    pipeline_cfg = pipeline_config or OMNIDREAMS_CONFIGS[config_name]
     transformer_cfg = pipeline_cfg.diffusion_model.transformer
     if not isinstance(transformer_cfg, CosmosTransformerConfig):
         raise TypeError("Omnidreams WebRTC requires a CosmosTransformerConfig.")
@@ -274,10 +342,16 @@ def _validate_single_view_config(config_name: str) -> None:
 def main() -> None:
     configure_logging()
     args = parse_args()
-    _validate_single_view_config(args.pipeline_config_name)
+    runtime_config = build_runtime_config(args)
+    _validate_single_view_config(
+        runtime_config.pipeline_config_name,
+        runtime_config.pipeline_config,
+    )
 
-    runtime_device, world_rank, _ = initialize_distributed(default_device=args.device)
-    runtime_config = build_runtime_config(args, device_override=str(runtime_device))
+    runtime_device, world_rank, _ = initialize_distributed(
+        default_device=runtime_config.device
+    )
+    runtime_config = replace(runtime_config, device=str(runtime_device))
     session_manager = OmnidreamsWebRTCSessionManager(runtime_config=runtime_config)
     app = None
     if world_rank == 0:

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -692,9 +692,9 @@ class OmnidreamsInferenceRuntime:
                 f"Supported: {supported}"
             )
 
-        pipeline_cfg = cfg.pipeline_config or OMNIDREAMS_CONFIGS[
-            cfg.pipeline_config_name
-        ]
+        pipeline_cfg = (
+            cfg.pipeline_config or OMNIDREAMS_CONFIGS[cfg.pipeline_config_name]
+        )
         transformer_cfg = pipeline_cfg.diffusion_model.transformer
         if not isinstance(transformer_cfg, CosmosTransformerConfig):
             raise TypeError(

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -431,6 +431,8 @@ class OmnidreamsRuntimeConfig:
     pipeline_config_name: str = (
         "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
     )
+    pipeline_config: Any | None = None
+    manifest_path: Path | None = None
     scene_dir: Path | None = None
     scene_uuid: str | None = None
     # Weather variant slug (default/rain/snow): picks the sibling USDZ + prompt.
@@ -680,14 +682,19 @@ class OmnidreamsInferenceRuntime:
             camera_name=cfg.camera_name,
             variant=cfg.scene_variant,
         )
-        if cfg.pipeline_config_name not in OMNIDREAMS_CONFIGS:
+        if (
+            cfg.pipeline_config is None
+            and cfg.pipeline_config_name not in OMNIDREAMS_CONFIGS
+        ):
             supported = ", ".join(sorted(OMNIDREAMS_CONFIGS))
             raise ValueError(
                 f"Unknown pipeline_config_name={cfg.pipeline_config_name!r}. "
                 f"Supported: {supported}"
             )
 
-        pipeline_cfg = OMNIDREAMS_CONFIGS[cfg.pipeline_config_name]
+        pipeline_cfg = cfg.pipeline_config or OMNIDREAMS_CONFIGS[
+            cfg.pipeline_config_name
+        ]
         transformer_cfg = pipeline_cfg.diffusion_model.transformer
         if not isinstance(transformer_cfg, CosmosTransformerConfig):
             raise TypeError(
@@ -769,6 +776,7 @@ class OmnidreamsInferenceRuntime:
         pipeline_t0 = time.perf_counter()
         self._wrapper = OmnidreamsConditioningWrapper(
             pipeline_config_name=cfg.pipeline_config_name,
+            pipeline_config=cfg.pipeline_config,
             resolution_wh=(cfg.video_width, cfg.video_height),
             seed_for_every_rollout=cfg.seed,
             device=self._device,

--- a/integrations/omnidreams/tests/interactive_drive/test_cli.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_cli.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import pytest
-
 from omnidreams.interactive_drive.cli import build_parser
 from omnidreams.interactive_drive.cli_args import arg_was_explicit
 

--- a/integrations/omnidreams/tests/interactive_drive/test_cli.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_cli.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import pytest
+
 from omnidreams.interactive_drive.cli import build_parser
+from omnidreams.interactive_drive.cli_args import arg_was_explicit
+
+pytestmark = pytest.mark.ci_cpu
 
 
 def test_offload_text_encoder_flag_defaults_disabled() -> None:
@@ -26,3 +31,19 @@ def test_postprocess_preset_accepts_rtx_super_resolution() -> None:
     args = build_parser().parse_args(["--postprocess-preset", "rtx-super-resolution"])
 
     assert args.postprocess_preset == "rtx-super-resolution"
+
+
+def test_parser_records_explicit_arg_destinations() -> None:
+    args = build_parser().parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--offload-text-encoder",
+            "--no-bev",
+        ]
+    )
+
+    assert arg_was_explicit(args, "manifest")
+    assert arg_was_explicit(args, "offload_text_encoder")
+    assert arg_was_explicit(args, "bev")
+    assert not arg_was_explicit(args, "camera")

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -690,9 +690,13 @@ def test_runtime_initialization_passes_manifest_pipeline_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manifest_args = webrtc_server.parse_args(
-        ["--manifest", "example_world_model_perf.yaml"]
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--prefer_sw_encoder",
+        ]
     )
-    cfg = webrtc_server.build_runtime_config(manifest_args)
+    cfg = webrtc_server.build_runtime_config(manifest_args, device_override="cpu")
     cfg.scene_dir = tmp_path / "scene"
     clipgt_dir = cfg.scene_dir / "clipgt"
     clipgt_dir.mkdir(parents=True)
@@ -990,7 +994,9 @@ async def test_loopback_warmup_drives_session_generation(
     assert fake_runtime is not None
     assert fake_runtime.initialize_calls == 1
     assert fake_runtime.reset_calls == 1
-    assert len(fake_runtime.generated_segments) == 2
+    # The close signal can race with the generation worker starting the next
+    # chunk; the warmup contract is that at least the requested chunks complete.
+    assert len(fake_runtime.generated_segments) >= 2
     assert not manager.has_active_session()
 
 

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 import torch
 from omnidreams import scenes
+from omnidreams.config import OMNIDREAMS_CONFIGS
 from omnidreams.webrtc import server as webrtc_server
 from omnidreams.webrtc import session
 from omnidreams.webrtc.session import (
@@ -589,6 +590,82 @@ def test_build_runtime_config_maps_prefer_sw_encoder_to_backend(
     assert cfg.encoder_backend == expected_backend
 
 
+def test_build_runtime_config_uses_manifest_perf_toggles() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--warmup_chunks",
+            "0",
+        ]
+    )
+
+    cfg = webrtc_server.build_runtime_config(args)
+
+    assert cfg.manifest_path is not None
+    assert cfg.manifest_path.name == "example_world_model_perf.yaml"
+    assert cfg.pipeline_config is not None
+    assert (
+        cfg.pipeline_config_name
+        == "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
+    )
+    assert cfg.video_width == 1168
+    assert cfg.video_height == 640
+    assert cfg.fps == 30
+    assert cfg.seed is None
+
+    transformer_cfg = cfg.pipeline_config.diffusion_model.transformer
+    scheduler_cfg = cfg.pipeline_config.diffusion_model.scheduler
+    assert transformer_cfg.skip_finalize_kv_cache is True
+    assert transformer_cfg.native_dit_acceleration == "required"
+    assert transformer_cfg.native_dit_backend == "fp8_kvcache_cudnn"
+    assert transformer_cfg.native_dit_attention_backend == "cudnn"
+    assert list(scheduler_cfg.denoising_timesteps) == [1000, 100]
+    assert scheduler_cfg.num_inference_steps == 2
+
+
+def test_build_runtime_config_manifest_allows_explicit_runtime_overrides() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--device",
+            "cuda:5",
+            "--seed",
+            "123",
+            "--fps",
+            "24",
+            "--video_width",
+            "640",
+            "--video_height",
+            "352",
+        ]
+    )
+
+    cfg = webrtc_server.build_runtime_config(args)
+
+    assert cfg.device == "cuda:5"
+    assert cfg.seed == 123
+    assert cfg.fps == 24
+    assert cfg.video_width == 640
+    assert cfg.video_height == 352
+    assert cfg.pipeline_config is not OMNIDREAMS_CONFIGS[cfg.pipeline_config_name]
+
+
+def test_build_runtime_config_rejects_manifest_config_name_conflict() -> None:
+    args = webrtc_server.parse_args(
+        [
+            "--manifest",
+            "example_world_model_perf.yaml",
+            "--pipeline_config_name",
+            "omnidreams-sv-2steps-chunk3-loc6-vae-vae",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="--manifest selects pipeline config"):
+        webrtc_server.build_runtime_config(args)
+
+
 def test_parse_args_omits_scene_dir_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -607,6 +684,83 @@ def test_parse_args_omits_scene_dir_by_default(
     assert args.scene_uuid is None
     assert args.debug_serve_hdmaps is True
     assert args.postprocess_preset == ""
+
+
+def test_runtime_initialization_passes_manifest_pipeline_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest_args = webrtc_server.parse_args(
+        ["--manifest", "example_world_model_perf.yaml"]
+    )
+    cfg = webrtc_server.build_runtime_config(manifest_args)
+    cfg.scene_dir = tmp_path / "scene"
+    clipgt_dir = cfg.scene_dir / "clipgt"
+    clipgt_dir.mkdir(parents=True)
+    first_frame_path = clipgt_dir / "first_image.png"
+    prompt_path = clipgt_dir / "prompt.txt"
+    first_frame_path.write_text("fake image", encoding="utf-8")
+    prompt_path.write_text("test prompt", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    class _FakePose:
+        transformation_matrix = torch.eye(4).numpy()
+        timestamp = 123
+
+    class _FakeSceneData:
+        ego_poses = [_FakePose()]
+        camera_models = {cfg.camera_name: object()}
+        camera_extrinsics = {cfg.camera_name: torch.eye(4).numpy()}
+
+    class _FakeConditioningWrapper:
+        initial_frame_chunk_size = 5
+        frame_chunk_size = 8
+
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def create_renderer(self, *_args: object) -> object:
+            return object()
+
+        def set_rollout_seed(self, seed: int | None) -> None:
+            captured["rollout_seed"] = seed
+
+    monkeypatch.setattr(
+        session,
+        "_extract_local_webrtc_scene_if_needed",
+        lambda scene_dir, **_kwargs: scene_dir,
+    )
+    monkeypatch.setattr(
+        session,
+        "_resolve_webrtc_scene_assets",
+        lambda scene_dir, **_kwargs: (clipgt_dir, first_frame_path, prompt_path),
+    )
+    monkeypatch.setattr(
+        session.cv2,
+        "imread",
+        lambda *_args, **_kwargs: torch.zeros((2, 2, 3), dtype=torch.uint8).numpy(),
+    )
+    monkeypatch.setattr(
+        session, "load_scene", lambda *_args, **_kwargs: _FakeSceneData()
+    )
+    monkeypatch.setattr(
+        session,
+        "load_and_attach_ludus_scene",
+        lambda _path, scene_data, **_kwargs: scene_data,
+    )
+    monkeypatch.setattr(
+        session,
+        "OmnidreamsConditioningWrapper",
+        _FakeConditioningWrapper,
+    )
+    runtime = OmnidreamsInferenceRuntime(config=cfg)
+
+    runtime._initialize_sync()
+
+    assert captured["pipeline_config_name"] == cfg.pipeline_config_name
+    assert captured["pipeline_config"] is cfg.pipeline_config
+    assert captured["resolution_wh"] == (cfg.video_width, cfg.video_height)
+    assert captured["seed_for_every_rollout"] is None
+    assert captured["rollout_seed"] is None
 
 
 def test_runtime_uses_default_scene_uuid_when_scene_is_unspecified(


### PR DESCRIPTION
This PR adds 2 changes

1. Adds manifest parsing to the Omnidreams WebRTC, to be consistent with the local window mode. So now it takes `--manifest example_world_model_perf.yaml` to use the native kernel path.
2. The WebRTC demo can now prefer hardware H.264 encode when the browser negotiates it. This PR also preserve encoded packet order with backpressured NVENC queue delivery instead of silently dropping packets in the production path.

This combined can deliver 30 FPS when omnidream demo is running in a RTX6000 server, and viewed from the browser with H.264 decoding capability.

Test with 
```
uv run --package flashdreams-omnidreams torchrun --standalone --nproc_per_node 1 \
  -m omnidreams.webrtc.server \
  --host 0.0.0.0 \
  --port 8080 \
  --manifest example_world_model_perf.yaml \
  --scene-uuid 0d404ff7-2b66-498c-b047-1ed8cded60d4 \
  --warmup_chunks 5 \
  --warmup_timeout_s 1200
```