### PR TITLE
Gate Omnidreams postprocess controls by launch preset

### DIFF
--- a/flashdreams/flashdreams/infra/postprocess/rtx.py
+++ b/flashdreams/flashdreams/infra/postprocess/rtx.py
@@ -313,7 +313,7 @@ def _empty_output_like(canonical: Tensor, *, spec: VideoSpec) -> Tensor:
 
 def _load_video_super_res_class() -> Any:
     try:
-        from nvvfx import (  # ty: ignore[unresolved-import]  # noqa: PLC0415
+        from nvvfx import (  # noqa: PLC0415
             VideoSuperRes,
         )
     except ImportError as exc:

--- a/flashdreams/flashdreams/infra/postprocess/rtx.py
+++ b/flashdreams/flashdreams/infra/postprocess/rtx.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from importlib import import_module
 from typing import Any, Literal, get_args
 
 import torch
@@ -313,17 +314,15 @@ def _empty_output_like(canonical: Tensor, *, spec: VideoSpec) -> Tensor:
 
 def _load_video_super_res_class() -> Any:
     try:
-        from nvvfx import (  # noqa: PLC0415
-            VideoSuperRes,
-        )
-    except ImportError as exc:
+        nvvfx = import_module("nvvfx")
+        return getattr(nvvfx, "VideoSuperRes")
+    except (AttributeError, ImportError) as exc:
         raise RuntimeError(
             "RTX Video Super Resolution post-processing requires the optional "
             "`nvidia-vfx` package, which provides `nvvfx.VideoSuperRes`. "
             "Install it in the active environment before selecting the "
             "`rtx-super-resolution` postprocess preset."
         ) from exc
-    return VideoSuperRes
 
 
 def _resolve_quality(video_super_res: Any, quality: str) -> Any:

--- a/flashdreams/tests/test_rtx_super_resolution_postprocess.py
+++ b/flashdreams/tests/test_rtx_super_resolution_postprocess.py
@@ -289,6 +289,33 @@ def test_rtx_super_resolution_empty_chunk_does_not_load_backend(
     assert outputs[0].tensor.shape == (1, 1, 0, 3, 4, 6)
 
 
+def test_rtx_super_resolution_loader_uses_optional_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeVfx:
+        VideoSuperRes = object()
+
+    imported: list[str] = []
+
+    def _fake_import_module(name: str) -> object:
+        imported.append(name)
+        return _FakeVfx
+
+    monkeypatch.setattr(rtx_module, "import_module", _fake_import_module)
+
+    assert rtx_module._load_video_super_res_class() is _FakeVfx.VideoSuperRes
+    assert imported == ["nvvfx"]
+
+
+def test_rtx_super_resolution_loader_missing_vfx_symbol_is_actionable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rtx_module, "import_module", lambda name: object())
+
+    with pytest.raises(RuntimeError, match="nvvfx.VideoSuperRes"):
+        rtx_module._load_video_super_res_class()
+
+
 def test_rtx_super_resolution_missing_backend_error_is_actionable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/integrations/omnidreams/README.md
+++ b/integrations/omnidreams/README.md
@@ -180,9 +180,16 @@ the weather-matched `clipgt/prompt<N>.txt` (falling back to `clipgt/prompt.txt`)
 Pass `--scene_dir <path>` to use a pre-staged local scene instead.
 
 To enable video post-processing by default, pass a registered preset such as
-`--postprocess-preset rtx-super-resolution`. The request-session page also
-offers a **Post-process** selector; its choice applies to the next connection
-and can override the command-line default, including turning processing off.
+`--postprocess-preset rtx-super-resolution`. RTX postprocess presets require the
+optional NVIDIA VFX runtime:
+
+```bash
+uv sync --package flashdreams-omnidreams --extra rtx-postprocess
+```
+
+The request-session page only offers a **Post-process** selector when the server
+was launched with `--postprocess-preset`; the selector can toggle that launched
+preset off for the next connection.
 
 ## Run gRPC server
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py
@@ -1405,6 +1405,7 @@ class SlangPyHudPresenter:
         header_w = panel_size[0] - margin * 2
         header_y = py + 8
         variant_y = header_y + bar_h + 4
+        postprocess_available = bool(self._postprocess_preset)
         postprocess_y = variant_y + bar_h + 4
         self._scene_header_rect = (
             header_x,
@@ -1418,21 +1419,22 @@ class SlangPyHudPresenter:
             header_x + header_w,
             variant_y + bar_h,
         )
-        self._postprocess_rect = (
-            header_x,
-            postprocess_y,
-            header_x + header_w,
-            postprocess_y + bar_h,
-        )
+        if postprocess_available:
+            self._postprocess_rect = (
+                header_x,
+                postprocess_y,
+                header_x + header_w,
+                postprocess_y + bar_h,
+            )
+            speed_y = postprocess_y + bar_h + 12
+        else:
+            self._postprocess_rect = None
+            speed_y = variant_y + bar_h + 12
 
         center_x = px + panel_size[0] // 2
         # ``speed_y`` is the top of the speed-digit chip. PIL renders
         # text into a tight glyph-bbox image (no leading above the
-        # glyph), so positioning the chip-top right after the variant
-        # bar would still land the visible glyph inside the bar. Add a
-        # ~12 px clearance below ``variant_y + bar_h`` so the digit
-        # never overlaps the headers.
-        speed_y = postprocess_y + bar_h + 12
+        # glyph), so keep a ~12 px clearance below the last visible header.
         self._draw_speed(canvas, draw, center_x, speed_y, int(self._speed_mph))
 
         # Light the reverse indicator red when reverse is engaged; the cached
@@ -1577,55 +1579,50 @@ class SlangPyHudPresenter:
                 font=self._font_small,
             )
 
-        # Post-processing is selected by CLI and can be switched live for the
-        # local window. An empty preset remains visible but disabled so users
-        # know which launch option unlocks the control.
-        postprocess_y = variant_y + bar_h + 4
-        postprocess_rect = (
-            margin,
-            postprocess_y,
-            margin + header_w,
-            postprocess_y + bar_h,
-        )
         postprocess_available = bool(self._postprocess_preset)
-        postprocess_clickable = postprocess_available and not (
-            self._scene_dropdown_open or self._variant_dropdown_open
-        )
-        d.rounded_rectangle(postprocess_rect, radius=6, fill=HEADER_BG + (255,))
-        d.text(
-            (margin + 10, postprocess_y + 6),
-            "Upsample 2x",
-            fill=TEXT_COLOR if postprocess_clickable else LABEL_COLOR,
-            font=self._font_small,
-        )
-        state_label = (
-            ("ON" if self._postprocess_enabled else "OFF")
-            if postprocess_available
-            else "N/A"
-        )
-        state_bbox = _measure_text(self._font_small, state_label)
-        state_w = state_bbox[2] - state_bbox[0]
-        state_fill = (
-            NVIDIA_GREEN
-            if self._postprocess_enabled and postprocess_clickable
-            else LABEL_COLOR
-        )
-        d.text(
-            (
-                margin + header_w - state_w - 10 - state_bbox[0],
-                postprocess_y + 6,
-            ),
-            state_label,
-            fill=state_fill,
-            font=self._font_small,
-        )
+        speed_y = variant_y + bar_h + 12
+        if postprocess_available:
+            postprocess_y = variant_y + bar_h + 4
+            postprocess_rect = (
+                margin,
+                postprocess_y,
+                margin + header_w,
+                postprocess_y + bar_h,
+            )
+            postprocess_clickable = not (
+                self._scene_dropdown_open or self._variant_dropdown_open
+            )
+            d.rounded_rectangle(postprocess_rect, radius=6, fill=HEADER_BG + (255,))
+            d.text(
+                (margin + 10, postprocess_y + 6),
+                "Upsample 2x",
+                fill=TEXT_COLOR if postprocess_clickable else LABEL_COLOR,
+                font=self._font_small,
+            )
+            state_label = "ON" if self._postprocess_enabled else "OFF"
+            state_bbox = _measure_text(self._font_small, state_label)
+            state_w = state_bbox[2] - state_bbox[0]
+            state_fill = (
+                NVIDIA_GREEN
+                if self._postprocess_enabled and postprocess_clickable
+                else LABEL_COLOR
+            )
+            d.text(
+                (
+                    margin + header_w - state_w - 10 - state_bbox[0],
+                    postprocess_y + 6,
+                ),
+                state_label,
+                fill=state_fill,
+                font=self._font_small,
+            )
+            speed_y = postprocess_y + bar_h + 12
 
         # ``mph`` label baseline + reverse-indicator box. Speed-y must
         # match the live ``_draw_panel`` calculation; both place the
-        # speed-digit chip-top ~12 px below the variant bar so PIL's
-        # tight-bbox glyph chip clears the headers.
+        # speed-digit chip-top ~12 px below the last visible header so PIL's
+        # tight-bbox glyph chip clears the controls.
         center_x = panel_w // 2
-        speed_y = postprocess_y + bar_h + 12
         mbox = _measure_text(self._font_tiny, "mph")
         mw = mbox[2] - mbox[0]
         d.text(

--- a/integrations/omnidreams/omnidreams/webrtc/server.py
+++ b/integrations/omnidreams/omnidreams/webrtc/server.py
@@ -133,8 +133,8 @@ def parse_args() -> argparse.Namespace:
         default="",
         choices=sorted(discover_postprocess_presets()),
         help=(
-            "Default video post-process preset for WebRTC sessions. The browser "
-            "can override this selection before connecting."
+            "Video post-process preset for WebRTC sessions. The browser can "
+            "only toggle this launched preset before connecting."
         ),
     )
     parser.add_argument(
@@ -159,10 +159,11 @@ def _get_omnidreams_manager(app: web.Application) -> _OmnidreamsSessionManager:
 
 async def _postprocess_options(request: web.Request) -> web.StreamResponse:
     manager = _get_omnidreams_manager(request.app)
-    presets = sorted(discover_postprocess_presets())
+    configured_preset = manager.runtime_config.postprocess.preset
+    presets = [configured_preset] if configured_preset else []
     return web.json_response(
         {
-            "default_preset": manager.runtime_config.postprocess.preset,
+            "default_preset": configured_preset,
             "presets": presets,
         }
     )

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -466,7 +466,23 @@ class OmnidreamsSessionInput:
     """Browser-selectable settings applied to the next WebRTC rollout."""
 
     postprocess_preset: str | None = None
-    """Preset override; ``None`` keeps the CLI default and ``""`` disables it."""
+    """Launched preset selection; ``None`` keeps the CLI default and ``""`` disables it."""
+
+
+def _validate_requested_postprocess_preset(
+    *, requested_preset: str, configured_preset: str
+) -> None:
+    if not configured_preset:
+        raise ValueError(
+            "Post-processing is not enabled for this server; restart with "
+            "--postprocess-preset to make a preset available."
+        )
+    if requested_preset != configured_preset:
+        raise ValueError(
+            "Post-processing preset must match the launched preset "
+            f"{configured_preset!r}; got {requested_preset!r}."
+        )
+    resolve_postprocess_preset(requested_preset)
 
 
 class OmnidreamsInferenceRuntime:
@@ -934,7 +950,10 @@ class OmnidreamsInferenceRuntime:
             else configured.preset
         )
         if preset:
-            resolve_postprocess_preset(preset)
+            _validate_requested_postprocess_preset(
+                requested_preset=preset,
+                configured_preset=configured.preset,
+            )
         postprocess = VideoPostprocessChainConfig(
             processors=configured.processors,
             preset=preset,
@@ -1129,7 +1148,10 @@ class OmnidreamsWebRTCSessionManager(
             raise SessionBusyError(self._busy_message)
         preset = session_input.postprocess_preset
         if preset:
-            resolve_postprocess_preset(preset)
+            _validate_requested_postprocess_preset(
+                requested_preset=preset,
+                configured_preset=self.runtime_config.postprocess.preset,
+            )
         self._pending_session_input = session_input
 
     def _register_extra_peer_handlers(self, peer_connection: Any) -> None:

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.css
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.css
@@ -230,6 +230,10 @@ body[data-status="error"] .statusDot {
   text-transform: uppercase;
 }
 
+.postprocessField[hidden] {
+  display: none;
+}
+
 .postprocessField select {
   width: 100%;
   min-height: 34px;

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.html
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
           <strong id="statusText">Idle</strong>
         </div>
         <button id="connectButton" class="connectButton" type="button">Connect Session</button>
-        <label class="postprocessField" for="postprocessSelect">
+        <label id="postprocessField" class="postprocessField" for="postprocessSelect" hidden>
           <span>Post-process</span>
           <select id="postprocessSelect">
             <option value="">Off</option>

--- a/integrations/omnidreams/omnidreams/webrtc/web/request_session.js
+++ b/integrations/omnidreams/omnidreams/webrtc/web/request_session.js
@@ -13,6 +13,7 @@ const latencyValue = document.getElementById("latencyValue")
 const resolutionValue = document.getElementById("resolutionValue")
 const stepValue = document.getElementById("stepValue")
 const modelValue = document.getElementById("modelValue")
+const postprocessField = document.getElementById("postprocessField")
 const postprocessSelect = document.getElementById("postprocessSelect")
 const controlButtons = Array.from(document.querySelectorAll("[data-control-key]"))
 
@@ -40,6 +41,7 @@ let inferenceInFlight = false
 let connected = false
 let disconnecting = false
 let heldKeySequence = 0
+let postprocessControlAvailable = false
 
 const metrics = {
   fps: null,
@@ -120,6 +122,10 @@ function setVideoVisible(visible) {
   document.body.classList.toggle("has-video", visible)
 }
 
+function setPostprocessDisabled(disabled) {
+  postprocessSelect.disabled = disabled || !postprocessControlAvailable
+}
+
 async function loadPostprocessOptions() {
   const response = await fetch("/api/postprocess/options")
   if (!response.ok) {
@@ -127,6 +133,11 @@ async function loadPostprocessOptions() {
   }
   const payload = await response.json()
   const presets = Array.isArray(payload.presets) ? payload.presets : []
+  const defaultPreset = typeof payload.default_preset === "string"
+    ? payload.default_preset
+    : ""
+  postprocessControlAvailable = Boolean(defaultPreset && presets.includes(defaultPreset))
+  postprocessField.hidden = !postprocessControlAvailable
   postprocessSelect.replaceChildren()
 
   const offOption = document.createElement("option")
@@ -142,10 +153,8 @@ async function loadPostprocessOptions() {
     option.textContent = preset
     postprocessSelect.append(option)
   }
-  const defaultPreset = typeof payload.default_preset === "string"
-    ? payload.default_preset
-    : ""
-  postprocessSelect.value = presets.includes(defaultPreset) ? defaultPreset : ""
+  postprocessSelect.value = postprocessControlAvailable ? defaultPreset : ""
+  setPostprocessDisabled(false)
 }
 
 async function configureSessionInput() {
@@ -686,7 +695,7 @@ function disconnectSession({ notify = true } = {}) {
   stopStatsPolling()
   connected = false
   connectButton.disabled = false
-  postprocessSelect.disabled = false
+  setPostprocessDisabled(false)
   if (notify && controlChannel && controlChannel.readyState === "open") {
     try {
       controlChannel.send(JSON.stringify({ type: "disconnect" }))
@@ -709,7 +718,7 @@ async function connectSession() {
   }
 
   connectButton.disabled = true
-  postprocessSelect.disabled = true
+  setPostprocessDisabled(true)
   setStatus("Connecting", "connecting")
   setFlow("creating peer connection")
   logEvent("connecting to server...", { source: "client" })
@@ -775,7 +784,7 @@ async function connectSession() {
       if (["failed", "closed", "disconnected"].includes(state)) {
         connected = false
         connectButton.disabled = false
-        postprocessSelect.disabled = false
+        setPostprocessDisabled(false)
         stopHeartbeat()
         stopStatsPolling()
         setStatus(state === "failed" ? "Error" : "Idle", state === "failed" ? "error" : "idle")
@@ -830,7 +839,7 @@ async function connectSession() {
     setFlow("failed")
     logEvent(`connect failed: ${error.message}`, { source: "client", level: "error" })
     connectButton.disabled = false
-    postprocessSelect.disabled = false
+    setPostprocessDisabled(false)
   }
 }
 

--- a/integrations/omnidreams/pyproject.toml
+++ b/integrations/omnidreams/pyproject.toml
@@ -77,6 +77,11 @@ ludus-renderer = { workspace = true }
 interactive-drive = [
     "slangpy==0.42.0",
 ]
+# Optional NVIDIA VFX runtime for selecting RTX postprocess presets such as
+# ``--postprocess-preset rtx-super-resolution`` in the WebRTC or local demo.
+rtx-postprocess = [
+    "flashdreams[rtx-postprocess]",
+]
 dev = [
     "pytest>=8.0",
     "pytest-manual-marker>=2.0",

--- a/integrations/omnidreams/tests/interactive_drive/test_presenter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_presenter.py
@@ -681,6 +681,23 @@ def test_hud_postprocess_control_toggles_configured_preset() -> None:
     assert presenter._postprocess_enabled is True
 
 
+@pytest.mark.ci_cpu
+def test_hud_postprocess_control_ignores_click_without_configured_preset() -> None:
+    presenter = _hud_presenter_without_window()
+    calls: list[bool] = []
+    presenter._postprocess_rect = (10, 20, 110, 52)
+    presenter._postprocess_preset = ""
+    presenter._postprocess_enabled = False
+    presenter._postprocess_callback = calls.append
+    presenter._scene_dropdown_open = False
+    presenter._variant_dropdown_open = False
+
+    presenter._handle_click((20, 30))
+
+    assert calls == []
+    assert presenter._postprocess_enabled is False
+
+
 def test_hud_scene_dropdown_blocks_underlying_upsample_toggle() -> None:
     presenter = _hud_presenter_without_window()
     calls: list[bool] = []

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import sys
 import zipfile
 from dataclasses import dataclass
@@ -15,6 +16,8 @@ from typing import Any
 
 import pytest
 import torch
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 from omnidreams import scenes
 from omnidreams.webrtc import server as webrtc_server
 from omnidreams.webrtc import session
@@ -25,7 +28,10 @@ from omnidreams.webrtc.session import (
 )
 
 import flashdreams.plugins.registry as plugin_registry
-from flashdreams.infra.postprocess import VideoPostProcessorConfig
+from flashdreams.infra.postprocess import (
+    VideoPostProcessorConfig,
+    VideoPostprocessChainConfig,
+)
 from flashdreams.serving.webrtc.controls import (
     WSAD_SUPPORTED_KEYS,
     CameraPoseIntegrator,
@@ -36,6 +42,7 @@ from flashdreams.serving.webrtc.encoders import (
 )
 from flashdreams.serving.webrtc.manager import WebRTCStepResult
 from flashdreams.serving.webrtc.media import BufferedVideoTrack
+from flashdreams.serving.webrtc.server import SESSION_MANAGER_KEY
 
 pytestmark = pytest.mark.ci_cpu
 
@@ -265,7 +272,11 @@ def test_session_postprocess_override_replaces_the_rollout_stream(
         lambda name: preset_config,
     )
     runtime = OmnidreamsInferenceRuntime(
-        config=OmnidreamsRuntimeConfig(device="cpu", fps=30)
+        config=OmnidreamsRuntimeConfig(
+            device="cpu",
+            fps=30,
+            postprocess=VideoPostprocessChainConfig(preset="fake-preset"),
+        )
     )
 
     runtime._reset_postprocess_stream(
@@ -703,14 +714,87 @@ def test_session_manager_stores_postprocess_override_for_next_rollout() -> None:
     assert manager._peek_pending_session_input() is None
 
 
+def test_session_manager_rejects_unlaunched_postprocess_preset() -> None:
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(device="cpu")
+    )
+
+    with pytest.raises(ValueError, match="not enabled for this server"):
+        manager.set_pending_session_input(
+            session.OmnidreamsSessionInput(postprocess_preset="fake-preset")
+        )
+
+
+def test_session_manager_rejects_non_launched_postprocess_preset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preset_config = VideoPostProcessorConfig()
+    monkeypatch.setattr(
+        session,
+        "resolve_postprocess_preset",
+        lambda name: preset_config,
+    )
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(
+            device="cpu",
+            postprocess=VideoPostprocessChainConfig(preset="launched-preset"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="must match the launched preset"):
+        manager.set_pending_session_input(
+            session.OmnidreamsSessionInput(postprocess_preset="other-preset")
+        )
+
+
+@pytest.mark.asyncio
+async def test_postprocess_options_hide_unlaunched_presets() -> None:
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(device="cpu")
+    )
+    app = web.Application()
+    app[SESSION_MANAGER_KEY] = manager
+    request = make_mocked_request("GET", "/api/postprocess/options", app=app)
+
+    response = await webrtc_server._postprocess_options(request)
+    payload = json.loads(response.text)
+
+    assert payload == {"default_preset": "", "presets": []}
+
+
+@pytest.mark.asyncio
+async def test_postprocess_options_exposes_only_launch_preset() -> None:
+    manager = OmnidreamsWebRTCSessionManager(
+        runtime_config=OmnidreamsRuntimeConfig(
+            device="cpu",
+            postprocess=VideoPostprocessChainConfig(preset="launched-preset"),
+        )
+    )
+    app = web.Application()
+    app[SESSION_MANAGER_KEY] = manager
+    request = make_mocked_request("GET", "/api/postprocess/options", app=app)
+
+    response = await webrtc_server._postprocess_options(request)
+    payload = json.loads(response.text)
+
+    assert payload == {
+        "default_preset": "launched-preset",
+        "presets": ["launched-preset"],
+    }
+
+
 def test_webrtc_ui_posts_selected_postprocess_preset() -> None:
     web_dir = files("omnidreams.webrtc").joinpath("web")
     html = web_dir.joinpath("request_session.html").read_text(encoding="utf-8")
     javascript = web_dir.joinpath("request_session.js").read_text(encoding="utf-8")
 
+    assert 'id="postprocessField"' in html
+    assert "hidden" in html
     assert 'id="postprocessSelect"' in html
     assert 'fetch("/api/postprocess/options")' in javascript
     assert 'fetch("/api/session/input"' in javascript
+    assert "postprocessControlAvailable" in javascript
+    assert "postprocessField.hidden = !postprocessControlAvailable" in javascript
     assert "postprocess_preset: postprocessPreset" in javascript
 
 

--- a/integrations/omnidreams/tests/test_webrtc_runtime.py
+++ b/integrations/omnidreams/tests/test_webrtc_runtime.py
@@ -29,8 +29,8 @@ from omnidreams.webrtc.session import (
 
 import flashdreams.plugins.registry as plugin_registry
 from flashdreams.infra.postprocess import (
-    VideoPostProcessorConfig,
     VideoPostprocessChainConfig,
+    VideoPostProcessorConfig,
 )
 from flashdreams.serving.webrtc.controls import (
     WSAD_SUPPORTED_KEYS,
@@ -98,6 +98,15 @@ class _FakeVideoEncoder:
 
     def close(self) -> None:
         self.closed = True
+
+
+def _json_response_payload(response: web.StreamResponse) -> dict[str, Any]:
+    assert isinstance(response, web.Response)
+    text = response.text
+    assert text is not None
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    return payload
 
 
 def _fake_runtime_factory(config: OmnidreamsRuntimeConfig) -> object:
@@ -757,7 +766,7 @@ async def test_postprocess_options_hide_unlaunched_presets() -> None:
     request = make_mocked_request("GET", "/api/postprocess/options", app=app)
 
     response = await webrtc_server._postprocess_options(request)
-    payload = json.loads(response.text)
+    payload = _json_response_payload(response)
 
     assert payload == {"default_preset": "", "presets": []}
 
@@ -775,7 +784,7 @@ async def test_postprocess_options_exposes_only_launch_preset() -> None:
     request = make_mocked_request("GET", "/api/postprocess/options", app=app)
 
     response = await webrtc_server._postprocess_options(request)
-    payload = json.loads(response.text)
+    payload = _json_response_payload(response)
 
     assert payload == {
         "default_preset": "launched-preset",

--- a/uv.lock
+++ b/uv.lock
@@ -1404,10 +1404,14 @@ dev = [
 interactive-drive = [
     { name = "slangpy" },
 ]
+rtx-postprocess = [
+    { name = "flashdreams", extra = ["rtx-postprocess"] },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "einops", specifier = ">=0.8" },
+    { name = "flashdreams", extras = ["rtx-postprocess"], marker = "extra == 'rtx-postprocess'", editable = "flashdreams" },
     { name = "flashdreams", extras = ["serving"], editable = "flashdreams" },
     { name = "flip-evaluator", marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "grpcio", specifier = ">=1.50" },
@@ -1435,7 +1439,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67" },
     { name = "transformers", specifier = ">=5.0,<6" },
 ]
-provides-extras = ["interactive-drive", "dev"]
+provides-extras = ["interactive-drive", "rtx-postprocess", "dev"]
 
 [[package]]
 name = "flashdreams-sana-wm"


### PR DESCRIPTION
# Gate Omnidreams Postprocess Controls By Launch Preset

## Summary

This PR makes Omnidreams post-processing explicitly launch-gated for both the
WebRTC browser path and the local interactive window path. It also adds an
Omnidreams `rtx-postprocess` optional extra so demo operators can install the
RTX Video Super Resolution runtime without making it a default dependency.

Some post-processors can require heavy first-time initialization, model load, or
GPU warmup. Exposing every installed preset in the WebRTC UI made it possible to
enable that work from the browser even when the server was not launched with a
postprocess preset. That is surprising during interactive demos, adds runtime
warmup pressure, and suggests that switching presets is cheap even though some
postprocess chains are not designed for easy live switching.

The RTX presets specifically depend on the optional proprietary `nvidia-vfx`
runtime. Keeping that package out of the default Omnidreams install avoids
forcing every serving or local-demo environment to install RTX-only postprocess
support, while still giving users a one-command opt-in path when they do want to
launch with `--postprocess-preset rtx-super-resolution`.

## Why This Is Needed

- The launch command should be the source of truth for whether post-processing is
  available.
- The browser should not be able to discover and enable installed presets that
  were not selected at server startup.
- The local HUD should not show a disabled or unavailable postprocess affordance
  when the demo was launched without postprocess support.
- Reviewers and demo operators should be able to tell from the command line
  whether postprocess warmup or runtime overhead can occur.
- RTX postprocess dependencies should remain optional, but easy to install from
  the Omnidreams package when needed.

## Changes

- Commit `4356dc90`: gate Omnidreams postprocess controls by launch preset.
- WebRTC `/api/postprocess/options` now returns only the launched preset, or an
  empty preset list when `--postprocess-preset` was not provided.
- WebRTC session input now rejects any requested preset unless it matches the
  launched preset.
- WebRTC HTML/JS hides the Post-process selector by default and only reveals it
  when the server reports a launched preset.
- Local interactive HUD no longer draws the postprocess row or hit-test region
  unless `--postprocess-preset` was provided.
- Added CPU tests for launch-gated WebRTC preset exposure, server-side rejection
  of unlaunched presets, and local HUD click behavior without a configured
  preset.
- Commit `250ee589`: add an Omnidreams `rtx-postprocess` extra that forwards to
  `flashdreams[rtx-postprocess]`, update `uv.lock`, and document how to install
  the optional RTX postprocess runtime.

## Notes

- Passing an empty postprocess preset from the browser still disables the
  launched preset for the next session.
- Runtime switching remains limited to toggling the launched preset on/off; this
  PR intentionally does not add browser-side selection among all installed
  presets.
- The default Omnidreams install still does not include `nvidia-vfx`. Install
  RTX postprocess support explicitly when selecting RTX presets:

```bash
UV_PROJECT_ENVIRONMENT=/home/horde/github/main_flashdreams/.venv \
uv sync --package flashdreams-omnidreams --extra rtx-postprocess
```

- For the local interactive window with the SlangPy HUD and RTX postprocess
  support:

```bash
UV_PROJECT_ENVIRONMENT=/home/horde/github/main_flashdreams/.venv \
uv sync --package flashdreams-omnidreams \
  --extra interactive-drive \
  --extra rtx-postprocess
```

## Tests

Local verification:

```bash
python -m py_compile \
  integrations/omnidreams/omnidreams/webrtc/server.py \
  integrations/omnidreams/omnidreams/webrtc/session.py \
  integrations/omnidreams/omnidreams/interactive_drive/slangpy_hud_presenter.py \
  integrations/omnidreams/tests/test_webrtc_runtime.py \
  integrations/omnidreams/tests/interactive_drive/test_presenter.py
```

Result:

```text
passed
```

Local verification:

```bash
UV_PROJECT_ENVIRONMENT=/home/horde/github/main_flashdreams/.venv \
uv run --package flashdreams-omnidreams pytest \
  integrations/omnidreams/tests/test_webrtc_runtime.py::test_session_postprocess_override_replaces_the_rollout_stream \
  integrations/omnidreams/tests/test_webrtc_runtime.py::test_session_manager_stores_postprocess_override_for_next_rollout \
  integrations/omnidreams/tests/test_webrtc_runtime.py::test_session_manager_rejects_unlaunched_postprocess_preset \
  integrations/omnidreams/tests/test_webrtc_runtime.py::test_session_manager_rejects_non_launched_postprocess_preset \
  integrations/omnidreams/tests/test_webrtc_runtime.py::test_postprocess_options_hide_unlaunched_presets \
  integrations/omnidreams/tests/test_webrtc_runtime.py::test_postprocess_options_exposes_only_launch_preset \
  integrations/omnidreams/tests/test_webrtc_runtime.py::test_webrtc_ui_posts_selected_postprocess_preset \
  integrations/omnidreams/tests/interactive_drive/test_presenter.py::test_hud_postprocess_control_toggles_configured_preset \
  integrations/omnidreams/tests/interactive_drive/test_presenter.py::test_hud_postprocess_control_ignores_click_without_configured_preset \
  integrations/omnidreams/tests/interactive_drive/test_presenter.py::test_hud_scene_dropdown_blocks_underlying_upsample_toggle
```

Result:

```text
10 passed in 7.36s
```

Local verification:

```bash
git diff --check
```

Result:

```text
passed
```

Local verification:

```bash
uv lock
uv lock --check
```

Result:

```text
passed; resolved 254 packages
```

Local verification:

```bash
UV_PROJECT_ENVIRONMENT=/home/horde/github/main_flashdreams/.venv \
uv run --package flashdreams-omnidreams pytest \
  tests/test_dependency_policy.py \
  integrations/omnidreams/tests/test_recipe_configs.py \
  -m ci_cpu
```

Result:

```text
6 passed in 6.00s
```

Not run:

```text
ruff check; ruff is not installed in the current uv environment.
```
