### PR TITLE
Refactor model output tensor handling and flashdreams-run output selection

### DIFF
--- a/flashdreams/flashdreams/infra/postprocess/stream.py
+++ b/flashdreams/flashdreams/infra/postprocess/stream.py
@@ -75,7 +75,7 @@ class VideoPostprocessStepStats:
 
 
 class VideoPostprocessStream:
-    """Process and collect decoded video chunks through one configured chain.
+    """Process decoded video chunks through one configured chain.
 
     This object belongs to the runner or serving output layer. It deliberately
     sits outside :class:`StreamInferencePipeline`, whose contract remains
@@ -91,9 +91,6 @@ class VideoPostprocessStream:
         per_view: bool = False,
         world_size: int = 1,
         profile: bool = False,
-        collect_output: bool = True,
-        move_to_cpu: bool = True,
-        empty_message: str = "post-processing emitted no video frames",
     ) -> None:
         postprocess.validate_execution(world_size=world_size)
         self.postprocess = postprocess
@@ -102,18 +99,14 @@ class VideoPostprocessStream:
         self.per_view = per_view
         self.world_size = world_size
         self.profile = profile
-        self.collect_output = collect_output
-        self.move_to_cpu = move_to_cpu
-        self.empty_message = empty_message
         self.state = _VideoPostprocessStreamState()
         self._time_dim = _video_layout_time_dim(output_layout)
-        self._chunks: list[Tensor] = []
         self._closed = False
         self._prepared = False
         self.last_process_stats: VideoPostprocessStepStats | None = None
 
     def process(self, output: Tensor, *, autoregressive_index: int) -> Tensor:
-        """Process and collect one decoded chunk."""
+        """Process one decoded chunk and return emitted frames."""
         if self._closed:
             raise RuntimeError("cannot process video after finish()")
         self.last_process_stats = None
@@ -128,7 +121,6 @@ class VideoPostprocessStream:
                 autoregressive_index=autoregressive_index,
                 output=output,
             )
-            self._append_if_nonempty(result)
             return result
 
         profiler = self._create_event_profiler()
@@ -156,7 +148,6 @@ class VideoPostprocessStream:
             f"input {tuple(output.shape)} output {tuple(result.shape)} | "
             f"buffering {self.last_process_stats.buffering}"
         )
-        self._append_if_nonempty(result)
         return result
 
     def add_process_stats(self, stats: dict[str, float]) -> dict[str, object]:
@@ -167,20 +158,17 @@ class VideoPostprocessStream:
         return combined
 
     def finish(self) -> Tensor | None:
-        """Flush buffered output and return the collected rank-zero video."""
+        """Close the stream and return any post-processing tail frames."""
         if self._closed:
             return None
         self._closed = True
         if not self.profile:
-            flushed = flush_video_postprocess(
+            return flush_video_postprocess(
                 postprocess=self.postprocess,
                 output_layout=self.output_layout,
                 per_view=self.per_view,
                 state=self.state,
             )
-            if flushed is not None:
-                self._append_if_nonempty(flushed)
-            return self._collected_output()
 
         profiler = self._create_event_profiler()
         result = flush_video_postprocess(
@@ -193,9 +181,7 @@ class VideoPostprocessStream:
         elapsed_ms = profiler.sync_and_summarize()["postprocess_flush"]
         output_shape = None if result is None else tuple(result.shape)
         logger.info(f"postprocess flush {elapsed_ms:.3f} ms | output {output_shape}")
-        if result is not None:
-            self._append_if_nonempty(result)
-        return self._collected_output()
+        return result
 
     def _create_event_profiler(self) -> EventProfiler:
         # The stream owns its one explicit readiness barrier in ``_prepare``.
@@ -224,20 +210,6 @@ class VideoPostprocessStream:
             # rank can enter it, and the process-group timeout bounds failures.
             torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
         self._prepared = True
-
-    def _append_if_nonempty(self, output: Tensor) -> None:
-        if not self.collect_output or output.shape[self._time_dim] == 0:
-            return
-        self._chunks.append(output.cpu() if self.move_to_cpu else output)
-
-    def _collected_output(self) -> Tensor | None:
-        if not self.collect_output:
-            return None
-        if not self._chunks:
-            raise ValueError(self.empty_message)
-        output = torch.cat(self._chunks, dim=self._time_dim)
-        self._chunks.clear()
-        return output
 
 
 def create_runner_postprocess_stream(
@@ -276,7 +248,6 @@ def create_runner_postprocess_stream(
         fps=configured_fps,
         per_view=getattr(config, "postprocess_per_view"),
         world_size=world_size,
-        collect_output=is_rank_zero,
         profile=bool(
             getattr(getattr(config, "pipeline", None), "enable_sync_and_profile", False)
         ),
@@ -519,8 +490,8 @@ def _postprocess_chunks_to_tensor(
         )
     # A streaming post-processor may consume this AR chunk without emitting
     # frames yet. Keep ``process()`` tensor-only by returning an empty tensor
-    # in the caller's layout instead of ``None``; ``_append_if_nonempty`` skips
-    # collection later by checking that the time dimension is zero.
+    # in the caller's layout instead of ``None``; output sinks can skip it by
+    # checking that the time dimension is zero.
     canonical = to_bvtchw(reference, layout=layout)[:, :, :0]
     return from_bvtchw(canonical, layout=layout)
 

--- a/flashdreams/flashdreams/infra/runner.py
+++ b/flashdreams/flashdreams/infra/runner.py
@@ -39,6 +39,7 @@ from flashdreams.infra.postprocess import (
     VideoTensorLayout,
     create_runner_postprocess_stream,
 )
+from flashdreams.infra.video_output import RunnerVideoOutputStream
 
 
 def _is_torchrun_env() -> bool:
@@ -169,27 +170,30 @@ class Runner(ABC, Generic[RunnerConfigT, PipelineT]):
         self,
         *,
         fps: float | None = None,
-        move_to_cpu: bool = True,
-    ) -> VideoPostprocessStream:
+    ) -> VideoPostprocessStream | None:
         """Create one stateful post-processing stream for a rollout."""
-        stream = create_runner_postprocess_stream(
+        return create_runner_postprocess_stream(
             self.config,
             world_size=self.world_size,
             is_rank_zero=self.is_rank_zero,
             fps=fps,
         )
-        if stream is not None:
-            stream.collect_output = self.is_rank_zero
-            stream.move_to_cpu = move_to_cpu
-            return stream
 
+    def create_video_output_stream(
+        self,
+        *,
+        fps: float | None = None,
+        move_to_cpu: bool = True,
+    ) -> RunnerVideoOutputStream:
+        """Create the standard runner video output stream for one rollout."""
         layout = self.config.postprocess_output_layout
         if layout is None:
-            raise ValueError("Runner output collection requires an output layout.")
-        return VideoPostprocessStream(
-            postprocess=VideoPostprocessChainConfig(),
+            raise ValueError(
+                "Runner video output collection requires an output layout."
+            )
+        return RunnerVideoOutputStream(
+            postprocess_stream=self.create_postprocess_stream(fps=fps),
             output_layout=layout,
-            fps=fps,
             collect_output=self.is_rank_zero,
             move_to_cpu=move_to_cpu,
         )

--- a/flashdreams/flashdreams/infra/runner_io.py
+++ b/flashdreams/flashdreams/infra/runner_io.py
@@ -41,7 +41,7 @@ ResizeInterpolation: TypeAlias = Literal[
 ]
 """OpenCV resize interpolation names accepted by runner image/video helpers."""
 
-VideoTensorLayout: TypeAlias = Literal["thwc", "tchw", "bcthw"]
+VideoTensorLayout: TypeAlias = Literal["thwc", "tchw", "btchw", "bcthw"]
 """Tensor layouts accepted by ``write_video_tensor``."""
 
 InputAssetValidator: TypeAlias = Callable[[Path], object]
@@ -295,6 +295,13 @@ def video_tensor_to_uint8(
         canvas = video
     elif layout == "tchw":
         canvas = video.permute(0, 2, 3, 1)
+    elif layout == "btchw":
+        if video.shape[0] != 1:
+            raise ValueError(
+                "layout='btchw' expects a single batch element; "
+                f"got {tuple(video.shape)}"
+            )
+        canvas = video[0].permute(0, 2, 3, 1)
     elif layout == "bcthw":
         if video.shape[0] != 1:
             raise ValueError(

--- a/flashdreams/flashdreams/infra/video_output.py
+++ b/flashdreams/flashdreams/infra/video_output.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared video output contracts for runners and serving transports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from flashdreams.infra.postprocess import VideoPostprocessStream, VideoTensorLayout
+
+
+def video_layout_time_dim(layout: VideoTensorLayout) -> int:
+    """Return the time-axis index for a supported RGB video tensor layout."""
+    if layout == "tchw":
+        return 0
+    if layout == "btchw":
+        return 1
+    if layout in ("bcthw", "bvtchw"):
+        return 2
+    raise ValueError(f"unsupported video layout: {layout}")
+
+
+def infer_video_num_frames(tensor: Tensor, *, layout: VideoTensorLayout) -> int:
+    """Infer a video chunk's frame count from its declared layout."""
+    return int(tensor.shape[video_layout_time_dim(layout)])
+
+
+@dataclass(slots=True)
+class VideoStepResult:
+    """One generated video chunk plus per-step metadata.
+
+    The field names intentionally match the pre-existing WebRTC result shape
+    so serving runtimes and output helpers share layout-aware chunk metadata.
+    """
+
+    chunk_index: int
+    num_frames: int
+    video_chunk: Tensor
+    stats: dict[str, float] | None = None
+    layout: VideoTensorLayout | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_video_chunk(
+        cls,
+        *,
+        chunk_index: int,
+        video_chunk: Tensor,
+        layout: VideoTensorLayout,
+        stats: dict[str, float] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "VideoStepResult":
+        """Build a result and infer ``num_frames`` from ``layout``."""
+        return cls(
+            chunk_index=chunk_index,
+            num_frames=infer_video_num_frames(video_chunk, layout=layout),
+            video_chunk=video_chunk,
+            stats=stats,
+            layout=layout,
+            metadata=dict(metadata or {}),
+        )
+
+
+class RunnerVideoOutputStream:
+    """Post-process, collect, and summarize runner video chunks."""
+
+    def __init__(
+        self,
+        *,
+        postprocess_stream: VideoPostprocessStream | None,
+        output_layout: VideoTensorLayout,
+        collect_output: bool = True,
+        move_to_cpu: bool = True,
+        empty_message: str = "runner emitted no video frames",
+    ) -> None:
+        self.postprocess_stream = postprocess_stream
+        self.output_layout = output_layout
+        self._time_dim = video_layout_time_dim(output_layout)
+        self._collect_output = collect_output
+        self.move_to_cpu = move_to_cpu
+        self.empty_message = empty_message
+        self._chunks: list[Tensor] = []
+        self._closed = False
+        self.stats_history: list[dict[str, object]] = []
+
+    @property
+    def collect_output(self) -> bool:
+        """Return whether this stream collects chunks for rank-zero writing."""
+        return self._collect_output
+
+    def process(
+        self,
+        video_chunk: Tensor,
+        *,
+        autoregressive_index: int,
+        stats: dict[str, float] | None = None,
+        stats_extra: Mapping[str, object] | None = None,
+    ) -> None:
+        """Process one generated chunk and collect it when this rank writes output."""
+        if self._closed:
+            raise RuntimeError("cannot process video after finish()")
+        processed = video_chunk
+        if self.postprocess_stream is not None:
+            processed = self.postprocess_stream.process(
+                video_chunk,
+                autoregressive_index=autoregressive_index,
+            )
+        self._append_if_nonempty(processed)
+        if self.collect_output and stats is not None:
+            if self.postprocess_stream is None:
+                combined_stats: dict[str, object] = dict(stats)
+            else:
+                combined_stats = self.postprocess_stream.add_process_stats(stats)
+            entry: dict[str, object] = {
+                "autoregressive_index": autoregressive_index,
+                **combined_stats,
+            }
+            if stats_extra is not None:
+                entry.update(stats_extra)
+            self.stats_history.append(entry)
+
+    def finish(self) -> Tensor | None:
+        """Flush post-processing and return the collected rank-zero video."""
+        if self._closed:
+            return None
+        self._closed = True
+        if self.postprocess_stream is not None:
+            flushed = self.postprocess_stream.finish()
+            if flushed is not None:
+                self._append_if_nonempty(flushed)
+        return self._collected_output()
+
+    def _append_if_nonempty(self, output: Tensor) -> None:
+        if not self.collect_output or output.shape[self._time_dim] == 0:
+            return
+        self._chunks.append(output.cpu() if self.move_to_cpu else output)
+
+    def _collected_output(self) -> Tensor | None:
+        if not self.collect_output:
+            return None
+        if not self._chunks:
+            raise ValueError(self.empty_message)
+        if len(self._chunks) == 1:
+            return self._chunks.pop()
+        output = torch.cat(self._chunks, dim=self._time_dim)
+        self._chunks.clear()
+        return output
+
+
+__all__ = [
+    "RunnerVideoOutputStream",
+    "VideoStepResult",
+    "infer_video_num_frames",
+    "video_layout_time_dim",
+]

--- a/flashdreams/flashdreams/infra/video_output.py
+++ b/flashdreams/flashdreams/infra/video_output.py
@@ -24,6 +24,7 @@ from typing import Any
 import torch
 from torch import Tensor
 
+from flashdreams.infra.acceleration.frame_prefetch import LazyCudaFrame
 from flashdreams.infra.postprocess import VideoPostprocessStream, VideoTensorLayout
 
 
@@ -41,6 +42,94 @@ def video_layout_time_dim(layout: VideoTensorLayout) -> int:
 def infer_video_num_frames(tensor: Tensor, *, layout: VideoTensorLayout) -> int:
     """Infer a video chunk's frame count from its declared layout."""
     return int(tensor.shape[video_layout_time_dim(layout)])
+
+
+class LazyRGBFrame(LazyCudaFrame):
+    """Defer RGB frame host materialization until a host-only consumer needs it."""
+
+    def __init__(
+        self,
+        frames_hwc_uint8: Any,
+        frame_index: int,
+        *,
+        source_event: object | None = None,
+    ) -> None:
+        super().__init__(
+            frames_hwc_uint8,
+            frame_index,
+            source_event=source_event,
+            lost_source_message=(
+                "Lazy RGB frame lost its source tensor before materialization."
+            ),
+            already_materialized_message=(
+                "Lazy RGB frame was already materialized on the host."
+            ),
+        )
+
+
+def video_tensor_to_hwc_uint8(
+    video: Tensor,
+    *,
+    layout: VideoTensorLayout,
+    batch_index: int = 0,
+    view_index: int = 0,
+) -> Tensor:
+    """Convert a GPU/CPU RGB video chunk to uint8 ``[T, H, W, C]`` tensor.
+
+    The conversion preserves the source device. Callers that need host frames
+    can materialize the returned tensor later; GPU-aware consumers can keep it
+    resident for interop or hardware encoding.
+    """
+    if layout == "tchw":
+        frames = video
+    elif layout == "btchw":
+        frames = video[batch_index]
+    elif layout == "bcthw":
+        frames = video[batch_index].permute(1, 0, 2, 3)
+    elif layout == "bvtchw":
+        frames = video[batch_index, view_index]
+    else:
+        raise ValueError(f"unsupported video layout: {layout!r}")
+
+    if frames.ndim != 4:
+        raise ValueError(
+            f"expected a 4D [T,C,H,W] frame tensor, got {tuple(frames.shape)}"
+        )
+    if frames.shape[1] != 3:
+        raise ValueError(
+            "expected RGB video frames with C=3 in [T,C,H,W], "
+            f"got {tuple(frames.shape)}"
+        )
+
+    if frames.dtype != torch.uint8:
+        frames = frames.clamp(-1.0, 1.0)
+        frames = ((frames + 1.0) * 127.5).round().to(torch.uint8)
+    return frames.detach().permute(0, 2, 3, 1).contiguous()
+
+
+def lazy_rgb_frames_from_video_tensor(
+    video: Tensor,
+    *,
+    layout: VideoTensorLayout,
+    batch_index: int = 0,
+    view_index: int = 0,
+    record_cuda_event: bool = True,
+) -> list[LazyRGBFrame]:
+    """Return lazy per-frame RGB handles backed by one video tensor chunk."""
+    frames = video_tensor_to_hwc_uint8(
+        video,
+        layout=layout,
+        batch_index=batch_index,
+        view_index=view_index,
+    )
+    source_event = None
+    if record_cuda_event and frames.is_cuda:
+        source_event = torch.cuda.Event()
+        source_event.record(torch.cuda.current_stream(frames.device))
+    return [
+        LazyRGBFrame(frames, frame_index, source_event=source_event)
+        for frame_index in range(frames.shape[0])
+    ]
 
 
 @dataclass(slots=True)
@@ -67,7 +156,7 @@ class VideoStepResult:
         layout: VideoTensorLayout,
         stats: dict[str, float] | None = None,
         metadata: Mapping[str, Any] | None = None,
-    ) -> "VideoStepResult":
+    ) -> VideoStepResult:
         """Build a result and infer ``num_frames`` from ``layout``."""
         return cls(
             chunk_index=chunk_index,
@@ -76,6 +165,40 @@ class VideoStepResult:
             stats=stats,
             layout=layout,
             metadata=dict(metadata or {}),
+        )
+
+    def lazy_rgb_frames(
+        self,
+        *,
+        batch_index: int = 0,
+        view_index: int = 0,
+        record_cuda_event: bool = True,
+    ) -> list[LazyRGBFrame]:
+        """Expose this chunk as lazy per-frame RGB handles."""
+        if self.layout is None:
+            raise ValueError("VideoStepResult.layout is required for frame extraction")
+        return lazy_rgb_frames_from_video_tensor(
+            self.video_chunk,
+            layout=self.layout,
+            batch_index=batch_index,
+            view_index=view_index,
+            record_cuda_event=record_cuda_event,
+        )
+
+    def video_hwc_uint8(
+        self,
+        *,
+        batch_index: int = 0,
+        view_index: int = 0,
+    ) -> Tensor:
+        """Return this chunk as a uint8 ``[T,H,W,C]`` tensor on its source device."""
+        if self.layout is None:
+            raise ValueError("VideoStepResult.layout is required for frame extraction")
+        return video_tensor_to_hwc_uint8(
+            self.video_chunk,
+            layout=self.layout,
+            batch_index=batch_index,
+            view_index=view_index,
         )
 
 
@@ -166,8 +289,11 @@ class RunnerVideoOutputStream:
 
 
 __all__ = [
+    "LazyRGBFrame",
     "RunnerVideoOutputStream",
     "VideoStepResult",
     "infer_video_num_frames",
+    "lazy_rgb_frames_from_video_tensor",
     "video_layout_time_dim",
+    "video_tensor_to_hwc_uint8",
 ]

--- a/flashdreams/flashdreams/scripts/cli.py
+++ b/flashdreams/flashdreams/scripts/cli.py
@@ -28,6 +28,8 @@ Usage::
     flashdreams-run wan21-i2v-14b-480p --prompt "..." --image-path frame.png
     flashdreams-run --no-instantiate template-offline # resolve config only
     flashdreams-run wan21-t2v-1.3b-480p --postprocess.preset flashvsr-v1.1-sparse-2.0
+    flashdreams-run --output webrtc lingbot-world-fast
+    flashdreams-run --output local-window omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae
 
     # Multi-GPU via context-parallelism (integration transformers auto-detect
     # CP size from the launcher's WORLD group). ``--no-python`` tells
@@ -42,7 +44,8 @@ import dataclasses
 import os
 import sys
 from collections.abc import Callable
-from typing import Annotated
+from pathlib import Path
+from typing import Annotated, Any, cast
 
 import tyro
 
@@ -50,21 +53,59 @@ from flashdreams.configs.runner_configs import _annotated_base_runner_union
 from flashdreams.core.distributed import shutdown as shutdown_distributed
 from flashdreams.core.io.disk import disk_space_error_from_exception
 from flashdreams.infra.runner import RunnerConfig
+from flashdreams.serving.output_targets import (
+    OutputLaunchOptions,
+    OutputMode,
+    available_output_modes,
+    launch_output_target,
+    resolve_output_target,
+)
 
 
 def main(
     config: RunnerConfig,
     no_instantiate: bool = False,
+    *,
+    output: OutputMode = "cli",
+    output_host: str | None = None,
+    output_port: int | None = None,
+    output_manifest: Path | None = None,
+    prefer_sw_encoder: bool = False,
 ) -> None:
     """Print the resolved config and (by default) run the runner.
 
     Under ``torchrun`` only local-rank 0 prints; every rank holds the
     same resolved config.
     """
+    output_spec = None
+    output_options = OutputLaunchOptions(
+        host=output_host,
+        port=output_port,
+        prefer_sw_encoder=prefer_sw_encoder,
+        local_window_manifest=output_manifest,
+    )
+    if output != "cli":
+        output_spec = resolve_output_target(
+            config,
+            mode=output,
+            options=output_options,
+        )
+
     if int(os.environ.get("LOCAL_RANK", "0")) == 0:
         print(f"Resolved config for {config.runner_name!r}:")
         print(config)
+        print(
+            f"Available outputs: {', '.join(available_output_modes(config, output_options))}"
+        )
+        if output_spec is not None:
+            print(f"Selected output: {output_spec.label}")
+            print(f"Launch command: {output_spec.command}")
+            for note in output_spec.notes:
+                print(f"Note: {note}")
     if no_instantiate:
+        return
+    if output_spec is not None:
+        launch_output_target(output_spec)
         return
     runner = config.setup()
     completed = False
@@ -119,6 +160,31 @@ def entrypoint() -> None:
                 bool,
                 dataclasses.field(default=False),
             ),
+            (
+                "output",
+                OutputMode,
+                dataclasses.field(default="cli"),
+            ),
+            (
+                "output_host",
+                str | None,
+                dataclasses.field(default=None),
+            ),
+            (
+                "output_port",
+                int | None,
+                dataclasses.field(default=None),
+            ),
+            (
+                "output_manifest",
+                Path | None,
+                dataclasses.field(default=None),
+            ),
+            (
+                "prefer_sw_encoder",
+                bool,
+                dataclasses.field(default=False),
+            ),
         ],
     )
     args_cls.__doc__ = __doc__
@@ -133,11 +199,26 @@ def entrypoint() -> None:
         description=__doc__,
         console_outputs=_is_rank_zero(),
     )
-    # ``args_cls`` is built dynamically so the static checker only
-    # sees ``object``; ``getattr`` keeps the type narrowing local.
-    runner_cfg: RunnerConfig = getattr(args, "runner")
-    no_instantiate: bool = getattr(args, "no_instantiate")
-    _run_with_disk_error_handling(lambda: main(runner_cfg, no_instantiate))
+    # ``args_cls`` is built dynamically; keep the untyped boundary explicit.
+    parsed_args = cast(Any, args)
+    runner_cfg: RunnerConfig = parsed_args.runner
+    no_instantiate: bool = parsed_args.no_instantiate
+    output: OutputMode = parsed_args.output
+    output_host: str | None = parsed_args.output_host
+    output_port: int | None = parsed_args.output_port
+    output_manifest: Path | None = parsed_args.output_manifest
+    prefer_sw_encoder: bool = parsed_args.prefer_sw_encoder
+    _run_with_disk_error_handling(
+        lambda: main(
+            runner_cfg,
+            no_instantiate,
+            output=output,
+            output_host=output_host,
+            output_port=output_port,
+            output_manifest=output_manifest,
+            prefer_sw_encoder=prefer_sw_encoder,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/flashdreams/flashdreams/serving/output_targets.py
+++ b/flashdreams/flashdreams/serving/output_targets.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Output target selection for ``flashdreams-run``."""
+
+from __future__ import annotations
+
+import runpy
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, TypeAlias
+
+from flashdreams.infra.runner import RunnerConfig
+
+OutputMode: TypeAlias = Literal["cli", "webrtc", "local-window"]
+
+_OMNIDREAMS_LOCAL_WINDOW_MANIFESTS = {
+    "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae": ("example_world_model.yaml"),
+    "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf": (
+        "example_world_model_perf.yaml"
+    ),
+    "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-native-perf": (
+        "example_world_model_perf.yaml"
+    ),
+}
+
+
+class OutputTargetUnavailableError(ValueError):
+    """Raised when a runner cannot be launched through a requested output."""
+
+
+@dataclass(frozen=True, slots=True)
+class OutputLaunchOptions:
+    """Common launch options shared by non-CLI output targets."""
+
+    host: str | None = None
+    port: int | None = None
+    prefer_sw_encoder: bool = False
+    local_window_manifest: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OutputTargetSpec:
+    """A concrete output target module plus argv translated from a runner config."""
+
+    mode: OutputMode
+    label: str
+    module: str
+    argv: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    @property
+    def command(self) -> str:
+        """Return a copy-pasteable module command for diagnostics."""
+        return shlex.join(("python", "-m", self.module, *self.argv))
+
+
+def available_output_modes(
+    config: RunnerConfig,
+    options: OutputLaunchOptions | None = None,
+) -> tuple[OutputMode, ...]:
+    """Return output modes known to support ``config``."""
+    options = options or OutputLaunchOptions()
+    modes: list[OutputMode] = ["cli"]
+    if _webrtc_spec(config, options) is not None:
+        modes.append("webrtc")
+    if _local_window_spec(config, options) is not None:
+        modes.append("local-window")
+    return tuple(modes)
+
+
+def resolve_output_target(
+    config: RunnerConfig,
+    *,
+    mode: OutputMode,
+    options: OutputLaunchOptions | None = None,
+) -> OutputTargetSpec:
+    """Resolve a non-CLI output target for a runner config."""
+    if mode == "cli":
+        raise ValueError("CLI mode is run directly by the selected Runner.")
+    options = options or OutputLaunchOptions()
+    spec = (
+        _webrtc_spec(config, options)
+        if mode == "webrtc"
+        else _local_window_spec(config, options)
+    )
+    if spec is None:
+        supported = ", ".join(available_output_modes(config, options))
+        raise OutputTargetUnavailableError(
+            f"Output mode {mode!r} is not available for runner "
+            f"{config.runner_name!r}. Supported modes: {supported}."
+        )
+    return spec
+
+
+def launch_output_target(spec: OutputTargetSpec) -> None:
+    """Execute an output target module as if launched with ``python -m``."""
+    original_argv = sys.argv
+    sys.argv = [spec.module, *spec.argv]
+    try:
+        runpy.run_module(spec.module, run_name="__main__")
+    finally:
+        sys.argv = original_argv
+
+
+def _webrtc_spec(
+    config: RunnerConfig,
+    options: OutputLaunchOptions,
+) -> OutputTargetSpec | None:
+    name = _runner_name(config)
+    if _is_lingbot_runner(name):
+        return _lingbot_webrtc_spec(config, options)
+    if _is_omnidreams_runner(name) and _is_omnidreams_single_view(config):
+        return _omnidreams_webrtc_spec(config, options)
+    return None
+
+
+def _local_window_spec(
+    config: RunnerConfig,
+    options: OutputLaunchOptions,
+) -> OutputTargetSpec | None:
+    name = _runner_name(config)
+    if not _is_omnidreams_runner(name):
+        return None
+    manifest = options.local_window_manifest
+    if manifest is None:
+        manifest_name = _OMNIDREAMS_LOCAL_WINDOW_MANIFESTS.get(name)
+        if manifest_name is None:
+            return None
+        manifest_arg = manifest_name
+    else:
+        manifest_arg = str(manifest)
+
+    argv = ["--manifest", manifest_arg]
+    _append_postprocess_preset(argv, config)
+    return OutputTargetSpec(
+        mode="local-window",
+        label="Omnidreams local interactive window",
+        module="omnidreams.interactive_drive",
+        argv=tuple(argv),
+        notes=(
+            (
+                "Local-window uses the Omnidreams interactive-drive manifest for "
+                "scene, resolution, and runtime-specific controls."
+            ),
+        ),
+    )
+
+
+def _lingbot_webrtc_spec(
+    config: RunnerConfig,
+    options: OutputLaunchOptions,
+) -> OutputTargetSpec:
+    argv = [
+        "--config_name",
+        _pipeline_name(config),
+        "--device",
+        _device(config),
+        "--fps",
+        str(getattr(config, "fps", 16)),
+        "--video-height",
+        str(getattr(config, "pixel_height", 464)),
+        "--video-width",
+        str(getattr(config, "pixel_width", 832)),
+    ]
+    if _compile_network(config) is False:
+        argv.append("--no_compile")
+    example_idx = getattr(config, "example_idx", None)
+    if example_idx is not None:
+        argv.extend(("--example-idx", str(example_idx)))
+    _append_webrtc_bind_args(argv, options)
+    return OutputTargetSpec(
+        mode="webrtc",
+        label="LingBot WebRTC server",
+        module="lingbot.webrtc.server",
+        argv=tuple(argv),
+    )
+
+
+def _omnidreams_webrtc_spec(
+    config: RunnerConfig,
+    options: OutputLaunchOptions,
+) -> OutputTargetSpec:
+    argv = [
+        "--pipeline_config_name",
+        _pipeline_name(config),
+        "--device",
+        _device(config),
+        "--fps",
+        str(getattr(config, "output_fps", 30)),
+        "--video_height",
+        str(getattr(config, "pixel_height", 704)),
+        "--video_width",
+        str(getattr(config, "pixel_width", 1280)),
+    ]
+    seed = _diffusion_seed(config)
+    if seed is not None:
+        argv.extend(("--seed", str(seed)))
+    _append_postprocess_preset(argv, config)
+    _append_webrtc_bind_args(argv, options)
+    return OutputTargetSpec(
+        mode="webrtc",
+        label="Omnidreams WebRTC server",
+        module="omnidreams.webrtc.server",
+        argv=tuple(argv),
+    )
+
+
+def _append_webrtc_bind_args(
+    argv: list[str],
+    options: OutputLaunchOptions,
+) -> None:
+    if options.host:
+        argv.extend(("--host", options.host))
+    if options.port is not None:
+        argv.extend(("--port", str(options.port)))
+    if options.prefer_sw_encoder:
+        argv.append("--prefer_sw_encoder")
+
+
+def _append_postprocess_preset(argv: list[str], config: RunnerConfig) -> None:
+    preset = getattr(getattr(config, "postprocess", None), "preset", "")
+    if preset:
+        argv.extend(("--postprocess-preset", str(preset)))
+
+
+def _runner_name(config: RunnerConfig) -> str:
+    return str(getattr(config, "runner_name", ""))
+
+
+def _pipeline_name(config: RunnerConfig) -> str:
+    pipeline = getattr(config, "pipeline", None)
+    name = getattr(pipeline, "name", None)
+    return str(name or config.runner_name)
+
+
+def _device(config: RunnerConfig) -> str:
+    return str(getattr(config, "device", "cuda"))
+
+
+def _compile_network(config: RunnerConfig) -> bool | None:
+    transformer = _transformer_config(config)
+    value = getattr(transformer, "compile_network", None)
+    return None if value is None else bool(value)
+
+
+def _diffusion_seed(config: RunnerConfig) -> int | None:
+    diffusion_model = getattr(
+        getattr(config, "pipeline", None), "diffusion_model", None
+    )
+    seed = getattr(diffusion_model, "seed", None)
+    return None if seed is None else int(seed)
+
+
+def _transformer_config(config: RunnerConfig) -> Any:
+    diffusion_model = getattr(
+        getattr(config, "pipeline", None), "diffusion_model", None
+    )
+    return getattr(diffusion_model, "transformer", None)
+
+
+def _is_lingbot_runner(name: str) -> bool:
+    return name.startswith("lingbot-world")
+
+
+def _is_omnidreams_runner(name: str) -> bool:
+    return name.startswith("omnidreams-")
+
+
+def _is_omnidreams_single_view(config: RunnerConfig) -> bool:
+    num_views = getattr(_transformer_config(config), "num_views", 1)
+    return int(num_views) == 1
+
+
+__all__ = [
+    "OutputLaunchOptions",
+    "OutputMode",
+    "OutputTargetSpec",
+    "OutputTargetUnavailableError",
+    "available_output_modes",
+    "launch_output_target",
+    "resolve_output_target",
+]

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -42,6 +42,7 @@ from flashdreams.serving.webrtc.runtime import (
     WebRTCRuntimeConfig,
     WebRTCSessionRuntime,
     WebRTCStepResult,
+    make_webrtc_step_result,
 )
 from flashdreams.serving.webrtc.server import SessionBusyError
 from flashdreams.serving.webrtc.warmup import (
@@ -54,6 +55,7 @@ __all__ = [
     "ManagedWebRTCSession",
     "WebRTCControlSignal",
     "WebRTCStepResult",
+    "make_webrtc_step_result",
 ]
 
 # Close the active session if no client heartbeat/control message arrives

--- a/flashdreams/flashdreams/serving/webrtc/runtime.py
+++ b/flashdreams/flashdreams/serving/webrtc/runtime.py
@@ -5,24 +5,43 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
-from dataclasses import dataclass
+from collections.abc import Awaitable, Mapping
 from typing import Any, Protocol
 
 import torch
 
+from flashdreams.infra.postprocess import VideoTensorLayout
+from flashdreams.infra.video_output import VideoStepResult, infer_video_num_frames
 from flashdreams.serving.realtime.input import PoseSegment
 
 
-@dataclass(slots=True)
-class WebRTCStepResult:
+class WebRTCStepResult(VideoStepResult):
     """One generated chunk handed back by a WebRTC model runtime."""
 
-    chunk_index: int
-    # Number of output video frames in ``video_chunk``.
-    num_frames: int
-    video_chunk: torch.Tensor
-    stats: dict[str, float] | None
+
+def make_webrtc_step_result(
+    *,
+    chunk_index: int,
+    video_chunk: torch.Tensor,
+    layout: VideoTensorLayout,
+    stats: dict[str, float] | None = None,
+    sync_device: torch.device | str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> WebRTCStepResult:
+    """Package a generated chunk for WebRTC without forcing a host copy."""
+    if sync_device is not None:
+        device = torch.device(sync_device)
+        if device.type == "cuda":
+            torch.cuda.current_stream(device).synchronize()
+
+    return WebRTCStepResult(
+        chunk_index=chunk_index,
+        num_frames=infer_video_num_frames(video_chunk, layout=layout),
+        video_chunk=video_chunk.detach(),
+        stats=stats,
+        layout=layout,
+        metadata=dict(metadata or {}),
+    )
 
 
 class WebRTCRuntimeConfig(Protocol):

--- a/flashdreams/tests/test_output_targets.py
+++ b/flashdreams/tests/test_output_targets.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
+from flashdreams.infra.runner import RunnerConfig
 from flashdreams.serving import output_targets as output_targets_module
 from flashdreams.serving.output_targets import (
     OutputLaunchOptions,
@@ -28,7 +30,7 @@ def _runner_config(
     pipeline_name: str | None = None,
     num_views: int = 1,
     compile_network: bool = True,
-) -> SimpleNamespace:
+) -> RunnerConfig:
     transformer = SimpleNamespace(
         num_views=num_views,
         compile_network=compile_network,
@@ -37,16 +39,19 @@ def _runner_config(
         name=pipeline_name or runner_name,
         diffusion_model=SimpleNamespace(seed=42, transformer=transformer),
     )
-    return SimpleNamespace(
-        runner_name=runner_name,
-        pipeline=pipeline,
-        device="cuda:1",
-        pixel_height=480,
-        pixel_width=832,
-        fps=20,
-        output_fps=24,
-        example_idx=3,
-        postprocess=SimpleNamespace(preset=""),
+    return cast(
+        RunnerConfig,
+        SimpleNamespace(
+            runner_name=runner_name,
+            pipeline=pipeline,
+            device="cuda:1",
+            pixel_height=480,
+            pixel_width=832,
+            fps=20,
+            output_fps=24,
+            example_idx=3,
+            postprocess=SimpleNamespace(preset=""),
+        ),
     )
 
 
@@ -57,7 +62,7 @@ def test_lingbot_webrtc_target_translates_runner_config() -> None:
     )
 
     spec = resolve_output_target(
-        config,  # ty:ignore[invalid-argument-type]
+        config,
         mode="webrtc",
         options=OutputLaunchOptions(
             host="127.0.0.1",
@@ -95,10 +100,10 @@ def test_omnidreams_webrtc_target_rejects_multi_view() -> None:
         num_views=4,
     )
 
-    assert available_output_modes(config) == ("cli",)  # ty:ignore[invalid-argument-type]
+    assert available_output_modes(config) == ("cli",)
     with pytest.raises(OutputTargetUnavailableError, match="Supported modes: cli"):
         resolve_output_target(
-            config,  # ty:ignore[invalid-argument-type]
+            config,
             mode="webrtc",
         )
 
@@ -110,7 +115,7 @@ def test_omnidreams_local_window_target_uses_manifest_override() -> None:
     config.postprocess.preset = "flashvsr-v1.1-sparse-2.0"
 
     spec = resolve_output_target(
-        config,  # ty:ignore[invalid-argument-type]
+        config,
         mode="local-window",
         options=OutputLaunchOptions(local_window_manifest=Path("custom.yaml")),
     )
@@ -129,7 +134,7 @@ def test_output_manifest_extends_local_window_availability() -> None:
     config = _runner_config(runner_name="omnidreams-sv-2steps-chunk3-loc6-vae-vae")
     options = OutputLaunchOptions(local_window_manifest=Path("custom.yaml"))
 
-    assert available_output_modes(  # ty:ignore[invalid-argument-type]
+    assert available_output_modes(
         config,
         options,
     ) == ("cli", "webrtc", "local-window")

--- a/flashdreams/tests/test_output_targets.py
+++ b/flashdreams/tests/test_output_targets.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from flashdreams.serving import output_targets as output_targets_module
+from flashdreams.serving.output_targets import (
+    OutputLaunchOptions,
+    OutputTargetSpec,
+    OutputTargetUnavailableError,
+    available_output_modes,
+    launch_output_target,
+    resolve_output_target,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def _runner_config(
+    *,
+    runner_name: str,
+    pipeline_name: str | None = None,
+    num_views: int = 1,
+    compile_network: bool = True,
+) -> SimpleNamespace:
+    transformer = SimpleNamespace(
+        num_views=num_views,
+        compile_network=compile_network,
+    )
+    pipeline = SimpleNamespace(
+        name=pipeline_name or runner_name,
+        diffusion_model=SimpleNamespace(seed=42, transformer=transformer),
+    )
+    return SimpleNamespace(
+        runner_name=runner_name,
+        pipeline=pipeline,
+        device="cuda:1",
+        pixel_height=480,
+        pixel_width=832,
+        fps=20,
+        output_fps=24,
+        example_idx=3,
+        postprocess=SimpleNamespace(preset=""),
+    )
+
+
+def test_lingbot_webrtc_target_translates_runner_config() -> None:
+    config = _runner_config(
+        runner_name="lingbot-world-fast",
+        compile_network=False,
+    )
+
+    spec = resolve_output_target(
+        config,  # ty:ignore[invalid-argument-type]
+        mode="webrtc",
+        options=OutputLaunchOptions(
+            host="127.0.0.1",
+            port=9010,
+            prefer_sw_encoder=True,
+        ),
+    )
+
+    assert spec.module == "lingbot.webrtc.server"
+    assert spec.argv == (
+        "--config_name",
+        "lingbot-world-fast",
+        "--device",
+        "cuda:1",
+        "--fps",
+        "20",
+        "--video-height",
+        "480",
+        "--video-width",
+        "832",
+        "--no_compile",
+        "--example-idx",
+        "3",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9010",
+        "--prefer_sw_encoder",
+    )
+
+
+def test_omnidreams_webrtc_target_rejects_multi_view() -> None:
+    config = _runner_config(
+        runner_name="omnidreams-mv-2steps-chunk4-loc8-pshuffle-lighttae",
+        num_views=4,
+    )
+
+    assert available_output_modes(config) == ("cli",)  # ty:ignore[invalid-argument-type]
+    with pytest.raises(OutputTargetUnavailableError, match="Supported modes: cli"):
+        resolve_output_target(
+            config,  # ty:ignore[invalid-argument-type]
+            mode="webrtc",
+        )
+
+
+def test_omnidreams_local_window_target_uses_manifest_override() -> None:
+    config = _runner_config(
+        runner_name="omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
+    )
+    config.postprocess.preset = "flashvsr-v1.1-sparse-2.0"
+
+    spec = resolve_output_target(
+        config,  # ty:ignore[invalid-argument-type]
+        mode="local-window",
+        options=OutputLaunchOptions(local_window_manifest=Path("custom.yaml")),
+    )
+
+    assert spec.module == "omnidreams.interactive_drive"
+    assert spec.argv == (
+        "--manifest",
+        "custom.yaml",
+        "--postprocess-preset",
+        "flashvsr-v1.1-sparse-2.0",
+    )
+    assert spec.notes
+
+
+def test_output_manifest_extends_local_window_availability() -> None:
+    config = _runner_config(runner_name="omnidreams-sv-2steps-chunk3-loc6-vae-vae")
+    options = OutputLaunchOptions(local_window_manifest=Path("custom.yaml"))
+
+    assert available_output_modes(  # ty:ignore[invalid-argument-type]
+        config,
+        options,
+    ) == ("cli", "webrtc", "local-window")
+
+
+def test_launch_output_target_runs_module_with_translated_argv(monkeypatch) -> None:
+    calls: list[tuple[str, str, tuple[str, ...]]] = []
+    original_argv = list(sys.argv)
+
+    def fake_run_module(module: str, *, run_name: str) -> None:
+        calls.append((module, run_name, tuple(sys.argv)))
+
+    monkeypatch.setattr(output_targets_module.runpy, "run_module", fake_run_module)
+
+    launch_output_target(
+        OutputTargetSpec(
+            mode="webrtc",
+            label="test",
+            module="demo.server",
+            argv=("--port", "9000"),
+        )
+    )
+
+    assert calls == [("demo.server", "__main__", ("demo.server", "--port", "9000"))]
+    assert sys.argv == original_argv

--- a/flashdreams/tests/test_postprocess_stream.py
+++ b/flashdreams/tests/test_postprocess_stream.py
@@ -142,7 +142,7 @@ def test_stream_profiles_buffering_as_a_separate_ar_stat(
     }
 
 
-def test_stream_collects_generated_chunks_without_postprocess() -> None:
+def test_noop_stream_returns_chunks_without_collecting() -> None:
     stream = VideoPostprocessStream(
         postprocess=VideoPostprocessChainConfig(),
         output_layout="bcthw",
@@ -153,13 +153,9 @@ def test_stream_collects_generated_chunks_without_postprocess() -> None:
 
     assert stream.process(first, autoregressive_index=0) is first
     stream.process(empty, autoregressive_index=1)
-    stream.process(second, autoregressive_index=2)
-    output = stream.finish()
+    assert stream.process(second, autoregressive_index=2) is second
 
-    assert output is not None
-    assert output.shape == (1, 3, 3, 4, 5)
-    assert torch.equal(output[:, :, :2], first)
-    assert torch.equal(output[:, :, 2:], second)
+    assert stream.finish() is None
 
 
 def test_chain_propagates_output_spec_to_downstream_session() -> None:

--- a/flashdreams/tests/test_runner_io.py
+++ b/flashdreams/tests/test_runner_io.py
@@ -193,11 +193,28 @@ def test_video_tensor_to_uint8_converts_bcthw_layout() -> None:
     assert frames.max() == 0
 
 
+def test_video_tensor_to_uint8_converts_btchw_layout() -> None:
+    video = torch.full((1, 2, 3, 4, 5), 1.0, dtype=torch.float32)
+
+    frames = video_tensor_to_uint8(video, layout="btchw")
+
+    assert frames.shape == (2, 4, 5, 3)
+    assert frames.dtype == np.uint8
+    assert frames.min() == 255
+
+
 def test_video_tensor_to_uint8_rejects_multi_batch_bcthw() -> None:
     video = torch.zeros((2, 3, 1, 4, 5), dtype=torch.float32)
 
     with pytest.raises(ValueError, match="expects a single batch element"):
         video_tensor_to_uint8(video, layout="bcthw")
+
+
+def test_video_tensor_to_uint8_rejects_multi_batch_btchw() -> None:
+    video = torch.zeros((2, 1, 3, 4, 5), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="expects a single batch element"):
+        video_tensor_to_uint8(video, layout="btchw")
 
 
 def test_read_first_frame_rgb_rejects_empty_video(

--- a/flashdreams/tests/test_runner_postprocess.py
+++ b/flashdreams/tests/test_runner_postprocess.py
@@ -104,7 +104,7 @@ def test_rank_zero_processor_is_skipped_on_nonzero_rank() -> None:
     assert stream is None
 
 
-def test_all_rank_processor_stream_does_not_collect_on_nonzero_rank() -> None:
+def test_all_rank_processor_stream_is_created_on_nonzero_rank() -> None:
     config = _config(
         VideoPostprocessChainConfig(
             processors=(_DistributedProcessorConfig(attention_mode="full"),)
@@ -118,4 +118,5 @@ def test_all_rank_processor_stream_does_not_collect_on_nonzero_rank() -> None:
     )
 
     assert stream is not None
-    assert not stream.collect_output
+    assert stream.world_size == 2
+    assert stream.postprocess is config.postprocess

--- a/flashdreams/tests/test_video_output.py
+++ b/flashdreams/tests/test_video_output.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for shared video output contracts."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashdreams.infra.video_output import (
+    RunnerVideoOutputStream,
+    VideoStepResult,
+    infer_video_num_frames,
+)
+from flashdreams.serving.webrtc.manager import WebRTCStepResult, make_webrtc_step_result
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_video_step_result_infers_num_frames_from_layout() -> None:
+    video = torch.zeros((1, 2, 4, 3, 5, 6), dtype=torch.float32)
+
+    result = VideoStepResult.from_video_chunk(
+        chunk_index=7,
+        video_chunk=video,
+        layout="bvtchw",
+        stats={"total_ms": 12.5},
+        metadata={"stream": "rgb"},
+    )
+
+    assert result.chunk_index == 7
+    assert result.num_frames == 4
+    assert result.video_chunk is video
+    assert result.stats == {"total_ms": 12.5}
+    assert result.layout == "bvtchw"
+    assert result.metadata == {"stream": "rgb"}
+    assert infer_video_num_frames(video, layout="bvtchw") == 4
+
+
+def test_webrtc_step_result_uses_shared_video_result_contract() -> None:
+    result = WebRTCStepResult(
+        chunk_index=1,
+        num_frames=2,
+        video_chunk=torch.zeros((2, 3, 4, 5)),
+        stats=None,
+    )
+
+    assert isinstance(result, VideoStepResult)
+    assert result.num_frames == 2
+
+
+def test_make_webrtc_step_result_preserves_tensor_and_infers_frames() -> None:
+    video = torch.zeros((3, 3, 4, 5), dtype=torch.float32, requires_grad=True)
+
+    result = make_webrtc_step_result(
+        chunk_index=4,
+        video_chunk=video,
+        layout="tchw",
+        stats={"decode_ms": 1.5},
+    )
+
+    assert isinstance(result, WebRTCStepResult)
+    assert result.chunk_index == 4
+    assert result.num_frames == 3
+    assert result.video_chunk.device == video.device
+    assert result.video_chunk.data_ptr() == video.data_ptr()
+    assert result.video_chunk.requires_grad is False
+    assert result.layout == "tchw"
+    assert result.stats == {"decode_ms": 1.5}
+
+
+def test_runner_video_output_stream_collects_chunks_and_stats() -> None:
+    output_stream = RunnerVideoOutputStream(
+        postprocess_stream=None,
+        output_layout="tchw",
+        move_to_cpu=False,
+    )
+    chunk = torch.zeros((2, 3, 4, 5), dtype=torch.float32)
+
+    output_stream.process(
+        chunk,
+        autoregressive_index=3,
+        stats={"total_ms": 8.0},
+        stats_extra={"frames": 2, "fps": 250.0},
+    )
+    collected = output_stream.finish()
+
+    assert collected is not None
+    assert collected.shape == chunk.shape
+    assert collected.data_ptr() == chunk.data_ptr()
+    assert output_stream.stats_history == [
+        {
+            "autoregressive_index": 3,
+            "total_ms": 8.0,
+            "frames": 2,
+            "fps": 250.0,
+        }
+    ]
+
+
+def test_runner_video_output_stream_collects_noop_chunks_without_postprocess() -> None:
+    output_stream = RunnerVideoOutputStream(
+        postprocess_stream=None,
+        output_layout="bcthw",
+        move_to_cpu=False,
+    )
+    first = torch.ones((1, 3, 2, 4, 5))
+    empty = torch.empty((1, 3, 0, 4, 5))
+    second = torch.full((1, 3, 1, 4, 5), 2.0)
+
+    output_stream.process(first, autoregressive_index=0)
+    output_stream.process(empty, autoregressive_index=1)
+    output_stream.process(second, autoregressive_index=2)
+    output = output_stream.finish()
+
+    assert output is not None
+    assert output.shape == (1, 3, 3, 4, 5)
+    assert torch.equal(output[:, :, :2], first)
+    assert torch.equal(output[:, :, 2:], second)

--- a/flashdreams/tests/test_video_output.py
+++ b/flashdreams/tests/test_video_output.py
@@ -9,9 +9,12 @@ import pytest
 import torch
 
 from flashdreams.infra.video_output import (
+    LazyRGBFrame,
     RunnerVideoOutputStream,
     VideoStepResult,
     infer_video_num_frames,
+    lazy_rgb_frames_from_video_tensor,
+    video_tensor_to_hwc_uint8,
 )
 from flashdreams.serving.webrtc.manager import WebRTCStepResult, make_webrtc_step_result
 
@@ -68,6 +71,44 @@ def test_make_webrtc_step_result_preserves_tensor_and_infers_frames() -> None:
     assert result.video_chunk.requires_grad is False
     assert result.layout == "tchw"
     assert result.stats == {"decode_ms": 1.5}
+
+
+def test_video_tensor_to_hwc_uint8_preserves_device_layout_conversion() -> None:
+    video = torch.empty((1, 3, 1, 2, 2), dtype=torch.float32)
+    video[:, 0] = -1.0
+    video[:, 1] = 0.5
+    video[:, 2] = 1.0
+
+    frames = video_tensor_to_hwc_uint8(video, layout="bcthw")
+
+    assert frames.device == video.device
+    assert frames.dtype == torch.uint8
+    assert frames.shape == (1, 2, 2, 3)
+    assert frames[0, 0, 0].tolist() == [0, 191, 255]
+
+
+def test_lazy_rgb_frames_from_video_tensor_materializes_on_demand() -> None:
+    video = torch.zeros((2, 3, 4, 5), dtype=torch.float32)
+    video[1, :, 2, 3] = 1.0
+
+    frames = lazy_rgb_frames_from_video_tensor(video, layout="tchw")
+
+    assert len(frames) == 2
+    assert isinstance(frames[0], LazyRGBFrame)
+    assert frames[1].to_numpy()[2, 3].tolist() == [255, 255, 255]
+
+
+def test_video_step_result_exposes_lazy_rgb_frames() -> None:
+    result = VideoStepResult.from_video_chunk(
+        chunk_index=0,
+        video_chunk=torch.zeros((1, 2, 1, 3, 4, 5), dtype=torch.float32),
+        layout="bvtchw",
+    )
+
+    frames = result.lazy_rgb_frames()
+
+    assert len(frames) == 1
+    assert frames[0].to_numpy().shape == (4, 5, 3)
 
 
 def test_runner_video_output_stream_collects_chunks_and_stats() -> None:

--- a/integrations/causal_forcing/causal_forcing/runner.py
+++ b/integrations/causal_forcing/causal_forcing/runner.py
@@ -167,23 +167,13 @@ class CausalForcingT2VRunner(
         cache = self._initialize_cache()
 
         # Generate the autoregressive chunks.
-        postprocess_stream = self.create_postprocess_stream(fps=config.fps)
-        stats_history: list[dict[str, object]] = []
+        output_stream = self.create_video_output_stream(fps=config.fps)
         for i in range(config.total_blocks):
             video_chunk = self.pipeline.generate(autoregressive_index=i, cache=cache)
             stats = self.pipeline.finalize(autoregressive_index=i, cache=cache)
-            video_chunk = postprocess_stream.process(
-                video_chunk, autoregressive_index=i
-            )
-            if postprocess_stream.collect_output and stats is not None:
-                stats_history.append(
-                    {
-                        "autoregressive_index": i,
-                        **postprocess_stream.add_process_stats(stats),
-                    }
-                )
+            output_stream.process(video_chunk, autoregressive_index=i, stats=stats)
 
-        generated = postprocess_stream.finish()
+        generated = output_stream.finish()
         if generated is None:
             return
 
@@ -198,9 +188,9 @@ class CausalForcingT2VRunner(
         )
 
         # Write the perf stats.
-        if stats_history:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
-                config.output_dir, config.runner_name, stats_history
+                config.output_dir, config.runner_name, output_stream.stats_history
             )
             logger.info(
                 f"[{config.runner_name}] wrote per-AR-step stats -> {stats_path.resolve()}"

--- a/integrations/cosmos_predict2/cosmos_predict2/runner.py
+++ b/integrations/cosmos_predict2/cosmos_predict2/runner.py
@@ -137,11 +137,11 @@ class Cosmos2T2VRunner(Runner[Cosmos2T2VRunnerConfig, CosmosInferencePipeline]):
 
         cache = self._initialize_cache()
 
-        postprocess_stream = self.create_postprocess_stream(fps=config.fps)
+        output_stream = self.create_video_output_stream(fps=config.fps)
         generated = self.pipeline.generate(autoregressive_index=0, cache=cache)
         stats = self.pipeline.finalize(autoregressive_index=0, cache=cache)
-        postprocess_stream.process(generated, autoregressive_index=0)
-        generated = postprocess_stream.finish()
+        output_stream.process(generated, autoregressive_index=0, stats=stats)
+        generated = output_stream.finish()
         if generated is None:
             return
 
@@ -154,11 +154,11 @@ class Cosmos2T2VRunner(Runner[Cosmos2T2VRunnerConfig, CosmosInferencePipeline]):
             f"-> {video_path.resolve()}"
         )
 
-        if stats is not None:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
                 config.output_dir,
                 config.runner_name,
-                [{"autoregressive_index": 0, **stats}],
+                output_stream.stats_history,
             )
             logger.info(
                 f"[{config.runner_name}] wrote per-AR-step stats "

--- a/integrations/fastvideo_causal_wan22/fastvideo_causal_wan22/runner.py
+++ b/integrations/fastvideo_causal_wan22/fastvideo_causal_wan22/runner.py
@@ -127,24 +127,14 @@ class FastvideoCausalWan22T2VRunner(
         # Initialize the autoregressive cache.
         cache = self._initialize_cache()
 
-        postprocess_stream = self.create_postprocess_stream(fps=config.fps)
-        stats_history: list[dict[str, object]] = []
+        output_stream = self.create_video_output_stream(fps=config.fps)
         for i in range(config.total_blocks):
             # Generate the autoregressive chunks.
             video_chunk = self.pipeline.generate(autoregressive_index=i, cache=cache)
             stats = self.pipeline.finalize(autoregressive_index=i, cache=cache)
-            video_chunk = postprocess_stream.process(
-                video_chunk, autoregressive_index=i
-            )
-            if postprocess_stream.collect_output and stats is not None:
-                stats_history.append(
-                    {
-                        "autoregressive_index": i,
-                        **postprocess_stream.add_process_stats(stats),
-                    }
-                )
+            output_stream.process(video_chunk, autoregressive_index=i, stats=stats)
 
-        generated = postprocess_stream.finish()
+        generated = output_stream.finish()
         if generated is None:
             return
 
@@ -159,9 +149,9 @@ class FastvideoCausalWan22T2VRunner(
         )
 
         # Write the perf stats.
-        if stats_history:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
-                config.output_dir, config.runner_name, stats_history
+                config.output_dir, config.runner_name, output_stream.stats_history
             )
             logger.info(
                 f"[{config.runner_name}] wrote per-AR-step stats -> {stats_path.resolve()}"

--- a/integrations/flashvsr/flashvsr/runner.py
+++ b/integrations/flashvsr/flashvsr/runner.py
@@ -424,8 +424,7 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
 
         cache = self._initialize_cache()
 
-        postprocess_stream = self.create_postprocess_stream(fps=fps)
-        stats_history: list[dict[str, object]] = []
+        output_stream = self.create_video_output_stream(fps=fps)
         for chunk_idx, (start, size) in enumerate(chunks):
             clip = video_t[:, :, start : start + size]
             video_chunk = self.pipeline.generate(
@@ -435,11 +434,8 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
             )
             pipeline_frames = int(video_chunk.shape[2])
             stats = self.pipeline.finalize(autoregressive_index=chunk_idx, cache=cache)
-            postprocess_stream.process(
-                video_chunk,
-                autoregressive_index=chunk_idx,
-            )
-            if postprocess_stream.collect_output and stats is not None:
+            stats_extra: dict[str, float | int] | None = None
+            if stats is not None:
                 # Pipeline throughput is based on this AR step's direct output.
                 # Postprocess emission/buffering is reported separately.
                 chunk_total_ms = stats["total_ms"]
@@ -448,16 +444,15 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
                     if chunk_total_ms > 0
                     else 0.0
                 )
-                stats_history.append(
-                    {
-                        "autoregressive_index": chunk_idx,
-                        **postprocess_stream.add_process_stats(stats),
-                        "frames": pipeline_frames,
-                        "fps": chunk_fps,
-                    }
-                )
+                stats_extra = {"frames": pipeline_frames, "fps": chunk_fps}
+            output_stream.process(
+                video_chunk,
+                autoregressive_index=chunk_idx,
+                stats=stats,
+                stats_extra=stats_extra,
+            )
 
-        generated = postprocess_stream.finish()
+        generated = output_stream.finish()
         if generated is None:
             return
 
@@ -470,9 +465,9 @@ class FlashVSRRunner(Runner[FlashVSRRunnerConfig, FlashVSRPipeline]):
             f"-> {video_path.resolve()}"
         )
 
-        if stats_history:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
-                config.output_dir, config.runner_name, stats_history
+                config.output_dir, config.runner_name, output_stream.stats_history
             )
             logger.info(
                 f"[{config.runner_name}] wrote per-AR-step stats -> "

--- a/integrations/hy_worldplay/hy_worldplay/runner.py
+++ b/integrations/hy_worldplay/hy_worldplay/runner.py
@@ -35,6 +35,7 @@ from flashdreams.infra.runner_io import (
     resolve_prompt_value,
     runner_artifact_path,
     write_runner_stats,
+    write_video_tensor,
 )
 from flashdreams.recipes.wan.pipeline import WanInferencePipeline
 
@@ -124,37 +125,6 @@ def _pil_to_numpy(img: object) -> object:
     import numpy as np
 
     return np.asarray(img)
-
-
-def _write_mp4(video: Tensor, out_path: Path, *, fps: int) -> None:
-    """Persist a decoded video tensor as mp4.
-
-    Expects ``video`` shape ``[*batch, T, C, H, W]`` in ``[-1, 1]``.
-    Drops the leading batch axis (size 1), converts to ``[T, H, W, C]``
-    float32 in ``[0, 1]``, and hands the frame list to
-    ``diffusers.utils.export_to_video``.
-
-    Note:
-        Frames must be float in ``[0, 1]``: ``export_to_video``
-        multiplies ndarray frames by 255 before ``.astype(np.uint8)``,
-        so uint8 ``[0, 255]`` input overflows.
-    """
-    import numpy as np
-    from diffusers.utils import export_to_video
-
-    if video.dim() > 4:
-        # Squeeze leading batch axes one at a time, asserting size 1.
-        while video.dim() > 4:
-            assert video.shape[0] == 1, (
-                f"_write_mp4 expects batch_size=1; got leading shape {video.shape[0]}."
-            )
-            video = video.squeeze(0)
-    # video is now [T, C, H, W] in [-1, 1]; map to [0, 1] float32 for
-    # diffusers' export_to_video contract on ndarray frames.
-    arr = ((video.clamp(-1.0, 1.0) + 1.0) * 0.5).to(torch.float32)
-    arr_thwc = arr.permute(0, 2, 3, 1).cpu().numpy()  # [T, H, W, C]
-    frames: list[np.ndarray] = list(arr_thwc)
-    export_to_video(frames, str(out_path), fps=fps)
 
 
 @dataclass(kw_only=True)
@@ -371,12 +341,7 @@ class HyWorldPlayWanI2VRunner(
             device=device, dtype=first_param.dtype
         )
 
-        postprocess_stream = self.create_postprocess_stream(
-            fps=cfg.fps, move_to_cpu=False
-        )
-        # Each ``finalize`` returns the per-stage ms dict for that AR
-        # step; collect into ``stats_history`` and dump as JSON.
-        stats_history: list[dict[str, object]] = []
+        output_stream = self.create_video_output_stream(fps=cfg.fps, move_to_cpu=False)
         if torch.cuda.is_available():
             torch.cuda.reset_peak_memory_stats()
         start_time = time.time()
@@ -387,15 +352,8 @@ class HyWorldPlayWanI2VRunner(
                 # advances the KV cache; called on every chunk
                 # (including the last) for consistent stats.
                 stats = self.pipeline.finalize(ar_idx, cache)
-                postprocess_stream.process(chunk, autoregressive_index=ar_idx)
-                if postprocess_stream.collect_output and stats is not None:
-                    stats_history.append(
-                        {
-                            "autoregressive_index": ar_idx,
-                            **postprocess_stream.add_process_stats(stats),
-                        }
-                    )
-            video = postprocess_stream.finish()
+                output_stream.process(chunk, autoregressive_index=ar_idx, stats=stats)
+            video = output_stream.finish()
         elapsed = time.time() - start_time
 
         if video is None:
@@ -403,15 +361,15 @@ class HyWorldPlayWanI2VRunner(
 
         ensure_output_dir(cfg.output_dir)
         out_path = runner_artifact_path(cfg.output_dir, cfg.runner_name, "mp4")
-        _write_mp4(video, out_path, fps=cfg.fps)
+        write_video_tensor(video, out_path, fps=cfg.fps, layout="btchw")
         logger.info(
             f"[{cfg.runner_name}] wrote video "
             f"({tuple(video.shape)}) -> {out_path.resolve()} in {elapsed:.2f}s"
         )
 
-        if stats_history:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
-                cfg.output_dir, cfg.runner_name, stats_history
+                cfg.output_dir, cfg.runner_name, output_stream.stats_history
             )
             logger.info(
                 f"[{cfg.runner_name}] wrote per-AR-step stats -> {stats_path.resolve()}"

--- a/integrations/lingbot/lingbot/runner.py
+++ b/integrations/lingbot/lingbot/runner.py
@@ -286,8 +286,7 @@ class LingbotWorldRunner(
         if torch.distributed.is_initialized():
             torch.distributed.barrier()
 
-        postprocess_stream = self.create_postprocess_stream(fps=cfg.fps)
-        stats_history: list[dict[str, object]] = []
+        output_stream = self.create_video_output_stream(fps=cfg.fps)
         start = 0
         for i in range(cfg.total_blocks):
             num_frames = self.pipeline.get_num_output_frames(i)
@@ -310,19 +309,10 @@ class LingbotWorldRunner(
                 input=camctrl_input,
             )
             stats = self.pipeline.finalize(autoregressive_index=i, cache=cache)
-            video_chunk = postprocess_stream.process(
-                video_chunk, autoregressive_index=i
-            )
-            if postprocess_stream.collect_output and stats is not None:
-                stats_history.append(
-                    {
-                        "autoregressive_index": i,
-                        **postprocess_stream.add_process_stats(stats),
-                    }
-                )
+            output_stream.process(video_chunk, autoregressive_index=i, stats=stats)
             start = end
 
-        video = postprocess_stream.finish()
+        video = output_stream.finish()
         if video is None:
             return
 
@@ -340,9 +330,9 @@ class LingbotWorldRunner(
             f"-> {video_path.resolve()}"
         )
 
-        if stats_history:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
-                cfg.output_dir, cfg.runner_name, stats_history
+                cfg.output_dir, cfg.runner_name, output_stream.stats_history
             )
             logger.info(
                 f"[{cfg.runner_name}] wrote per-AR-step stats -> {stats_path.resolve()}"

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -138,6 +138,16 @@ def parse_args() -> argparse.Namespace:
         help="Output video pixel width. Must be divisible by 16.",
     )
     parser.add_argument(
+        "--prefer_sw_encoder",
+        action="store_true",
+        help=(
+            "Force aiortc's default software encoder instead of probing NVENC. "
+            "Without this flag, LingBot uses NVENC when the driver reports "
+            "support at the target resolution and falls back to software "
+            "otherwise."
+        ),
+    )
+    parser.add_argument(
         "--example-idx",
         "--example_idx",
         type=int,
@@ -343,6 +353,10 @@ def build_runtime_config(
         warmup_timeout_s=args.warmup_timeout_s,
         video_height=args.video_height,
         video_width=args.video_width,
+        fps=args.fps,
+        encoder_backend=(
+            "default" if getattr(args, "prefer_sw_encoder", False) else "auto"
+        ),
         example_data_dir=example_dir,
         default_image_url=f"{EXAMPLE_DATA_BASE_URL}/{example_dirname}/image.jpg",
         default_intrinsics_url=(

--- a/integrations/lingbot/lingbot/webrtc/session.py
+++ b/integrations/lingbot/lingbot/webrtc/session.py
@@ -45,12 +45,18 @@ from flashdreams.serving.webrtc.controls import (
     CameraPoseIntegrator,
     PoseSegment,
 )
+from flashdreams.serving.webrtc.encoders import (
+    EncoderBackend,
+    VideoEncoder,
+    select_encoder,
+)
 from flashdreams.serving.webrtc.manager import (
     DEFAULT_CLIENT_LIVENESS_TIMEOUT_S,
     BaseWebRTCSessionManager,
     ManagedWebRTCSession,
     WebRTCControlSignal,
     WebRTCStepResult,
+    make_webrtc_step_result,
 )
 from flashdreams.serving.webrtc.server import SessionBusyError
 from lingbot.encoder.utils import preprocess_example_poses
@@ -445,6 +451,7 @@ class LingbotRuntimeConfig:
     device: str = "cuda:0"
     video_height: int = 464
     video_width: int = 832
+    fps: int = 16
     world_scale: float | None = None
     default_intrinsics: tuple[float, float, float, float] | None = None
     default_prompt: str = ""
@@ -454,6 +461,9 @@ class LingbotRuntimeConfig:
     default_poses_url: str | None = _DEFAULT_POSES_URL
     warmup_chunks: int = 10
     warmup_timeout_s: float = 600.0
+    encoder_backend: EncoderBackend = "auto"
+    encoder_bitrate_bps: int = 6_000_000
+    encoder_gop: int = 30
 
     example_data_dir: Path = field(
         default_factory=lambda: default_flashdreams_cache_dir()
@@ -588,6 +598,7 @@ class LingbotInferenceRuntime:
         self._event_embeddings: dict[str, torch.Tensor] = {}
         self._active_event_id: str | None = None
         self._world_scale = 1.0
+        self._video_encoder: VideoEncoder | None = None
         self._closed = False
 
         self._step_lock = asyncio.Lock()
@@ -602,6 +613,15 @@ class LingbotInferenceRuntime:
     @property
     def is_master(self) -> bool:
         return self.rank == self.MASTER_RANK
+
+    @property
+    def video_encoder(self) -> VideoEncoder:
+        """Return the encoder selected at :meth:`initialize` time."""
+        if self._video_encoder is None:
+            raise LingbotRuntimeError(
+                "Video encoder is not initialized; call runtime.initialize() first."
+            )
+        return self._video_encoder
 
     def wait_for_termination(self) -> None:
         self.rank_coordinator.worker_loop(exit_signal=WebRTCControlSignal.EXIT)
@@ -785,6 +805,37 @@ class LingbotInferenceRuntime:
         )
         self._pipeline = pipeline_config.setup().to(device=self._device)
         self._reset_rollout_sync()
+        self._initialize_video_encoder_sync()
+
+    def _initialize_video_encoder_sync(self) -> None:
+        """Select the video encoder for this runtime."""
+        if not self.is_master:
+            return
+        if self._video_encoder is not None:
+            self._video_encoder.close()
+            self._video_encoder = None
+        device = (
+            self._device
+            if self._device is not None
+            else torch.device(self.config.device)
+        )
+        backend: EncoderBackend = self.config.encoder_backend
+        if device.type != "cuda" and backend == "auto":
+            backend = "default"
+        if device.type != "cuda" and backend == "nvenc":
+            raise LingbotRuntimeError(
+                "encoder_backend='nvenc' requires a CUDA runtime device."
+            )
+        gpu_id = device.index if device.index is not None else 0
+        self._video_encoder = select_encoder(
+            backend=backend,
+            width=self.config.video_width,
+            height=self.config.video_height,
+            fps=self.config.fps,
+            bitrate=self.config.encoder_bitrate_bps,
+            gpu_id=gpu_id,
+            gop=self.config.encoder_gop,
+        )
 
     def _encode_text_embeddings_sync(self, texts: list[str]) -> torch.Tensor:
         if self._pipeline is None:
@@ -1061,6 +1112,9 @@ class LingbotInferenceRuntime:
         self._base_text_embeddings = None
         self._event_embeddings = {}
         self._active_event_id = None
+        if self._video_encoder is not None:
+            self._video_encoder.close()
+            self._video_encoder = None
 
         if cache is not None:
             del cache
@@ -1119,12 +1173,18 @@ class LingbotInferenceRuntime:
         )
         stats = self._pipeline.finalize(self.autoregressive_index, self._cache)
 
-        result = WebRTCStepResult(
+        result = make_webrtc_step_result(
             chunk_index=self.autoregressive_index,
-            num_frames=num_frames,
-            video_chunk=video_chunk.detach().cpu(),
+            video_chunk=video_chunk,
+            layout="tchw",
             stats=stats,
+            sync_device=self._device,
         )
+        if result.num_frames != num_frames:
+            raise LingbotRuntimeError(
+                f"Expected generated chunk to contain {num_frames} frames, "
+                f"got {result.num_frames}."
+            )
         self.autoregressive_index += 1
         return result
 
@@ -1145,12 +1205,13 @@ class LingbotWebRTCSessionManager(
         self,
         *,
         runtime_config: LingbotRuntimeConfig | None = None,
-        fps: int = 16,
+        fps: int | None = None,
         client_liveness_timeout_s: float = DEFAULT_CLIENT_LIVENESS_TIMEOUT_S,
     ) -> None:
+        runtime_config = runtime_config or LingbotRuntimeConfig()
+        fps = runtime_config.fps if fps is None else fps
         if fps <= 0:
             raise ValueError("fps must be > 0")
-        runtime_config = runtime_config or LingbotRuntimeConfig()
         super().__init__(
             runtime=LingbotInferenceRuntime(config=runtime_config),
             runtime_config=runtime_config,

--- a/integrations/lingbot/tests/test_distributed_server_main.py
+++ b/integrations/lingbot/tests/test_distributed_server_main.py
@@ -48,6 +48,7 @@ def _args(device: str = "cuda:0") -> Namespace:
         fps=16,
         video_height=352,
         video_width=640,
+        prefer_sw_encoder=False,
         example_idx=0,
     )
 
@@ -182,6 +183,8 @@ def test_main_rank0_sends_exit_signal(monkeypatch: pytest.MonkeyPatch) -> None:
     assert runtime_configs[0].context_parallel_size == 1
     assert runtime_configs[0].video_height == 352
     assert runtime_configs[0].video_width == 640
+    assert runtime_configs[0].fps == 16
+    assert runtime_configs[0].encoder_backend == "auto"
     assert manager_fps == [16]
     assert request_session_urls == ["http://203.0.113.10:8080/request_session"]
 
@@ -220,7 +223,25 @@ def test_main_worker_rank_waits_for_termination(
     assert runtime_configs[0].context_parallel_size == 2
     assert runtime_configs[0].video_height == 352
     assert runtime_configs[0].video_width == 640
+    assert runtime_configs[0].fps == 16
+    assert runtime_configs[0].encoder_backend == "auto"
     assert manager_fps == [16]
+
+
+@pytest.mark.parametrize(
+    "prefer_sw_encoder, expected_backend",
+    [(False, "auto"), (True, "default")],
+)
+def test_build_runtime_config_maps_prefer_sw_encoder_to_backend(
+    prefer_sw_encoder: bool,
+    expected_backend: str,
+) -> None:
+    args = _args()
+    args.prefer_sw_encoder = prefer_sw_encoder
+
+    config = server.build_runtime_config(args)
+
+    assert config.encoder_backend == expected_backend
 
 
 def test_build_runtime_config_rejects_non_patch_aligned_resolution() -> None:

--- a/integrations/lingbot/tests/test_webrtc_runtime.py
+++ b/integrations/lingbot/tests/test_webrtc_runtime.py
@@ -29,6 +29,7 @@ from lingbot.webrtc.session import (
     LingbotWebRTCSessionManager,
 )
 
+from flashdreams.infra.postprocess import VideoTensorLayout
 from flashdreams.serving.webrtc.manager import WebRTCStepResult
 
 pytestmark = pytest.mark.ci_cpu
@@ -96,6 +97,151 @@ def test_runtime_defaults_use_canonical_v2_examples() -> None:
     assert config.default_image_url == f"{expected_base_url}/image.jpg"
     assert config.default_intrinsics_url == f"{expected_base_url}/intrinsics.npy"
     assert config.default_poses_url == f"{expected_base_url}/poses.npy"
+    assert config.fps == 16
+    assert config.encoder_backend == "auto"
+
+
+def test_session_manager_uses_runtime_config_fps_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(session, "LingbotInferenceRuntime", _fake_runtime_factory)
+
+    manager = LingbotWebRTCSessionManager(
+        runtime_config=LingbotRuntimeConfig(device="cpu", warmup_chunks=0, fps=12)
+    )
+
+    assert manager.fps == 12
+
+
+def test_initialize_video_encoder_sync_skips_on_non_master(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _select_encoder_should_not_be_called(**_kw: object) -> object:
+        raise AssertionError("worker ranks must not initialize WebRTC encoders")
+
+    monkeypatch.setattr(session, "select_encoder", _select_encoder_should_not_be_called)
+    runtime = session.LingbotInferenceRuntime(
+        config=LingbotRuntimeConfig(device="cpu", warmup_chunks=0)
+    )
+    runtime.rank = 1
+    runtime._device = torch.device("cpu")
+
+    runtime._initialize_video_encoder_sync()
+
+    assert runtime._video_encoder is None
+
+
+def test_initialize_video_encoder_sync_selects_runtime_encoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _FakeVideoEncoder()
+    calls: list[dict[str, object]] = []
+
+    def _fake_select_encoder(**kwargs: object) -> _FakeVideoEncoder:
+        calls.append(kwargs)
+        return stub
+
+    monkeypatch.setattr(session, "select_encoder", _fake_select_encoder)
+    runtime = session.LingbotInferenceRuntime(
+        config=LingbotRuntimeConfig(
+            device="cuda:2",
+            warmup_chunks=0,
+            video_height=360,
+            video_width=640,
+            fps=12,
+            encoder_backend="auto",
+            encoder_bitrate_bps=4_000_000,
+            encoder_gop=24,
+        )
+    )
+    runtime.rank = 0
+    runtime._device = torch.device("cuda:2")
+
+    runtime._initialize_video_encoder_sync()
+
+    assert runtime._video_encoder is stub
+    assert calls == [
+        {
+            "backend": "auto",
+            "width": 640,
+            "height": 360,
+            "fps": 12,
+            "bitrate": 4_000_000,
+            "gpu_id": 2,
+            "gop": 24,
+        }
+    ]
+
+
+def test_generate_one_chunk_sync_hands_gpu_resident_output_to_webrtc_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _NoCpuChunk:
+        detach_calls = 0
+
+        def detach(self) -> "_NoCpuChunk":
+            self.detach_calls += 1
+            return self
+
+        def cpu(self) -> object:
+            raise AssertionError("LingBot WebRTC must not eagerly call .cpu()")
+
+    class _FakePipeline:
+        def __init__(self) -> None:
+            self.output = _NoCpuChunk()
+
+        @staticmethod
+        def get_num_output_frames(autoregressive_index: int) -> int:
+            assert autoregressive_index == 0
+            return 2
+
+        def generate(self, **_kwargs: object) -> _NoCpuChunk:
+            return self.output
+
+        @staticmethod
+        def finalize(autoregressive_index: int, cache: object) -> dict[str, float]:
+            assert autoregressive_index == 0
+            return {"total_ms": 3.0}
+
+    captured: dict[str, object] = {}
+
+    def _fake_make_webrtc_step_result(**kwargs: object) -> WebRTCStepResult:
+        captured.update(kwargs)
+        stats = cast(dict[str, float] | None, kwargs["stats"])
+        layout = cast(VideoTensorLayout | None, kwargs["layout"])
+        return WebRTCStepResult(
+            chunk_index=0,
+            num_frames=2,
+            video_chunk=torch.zeros((2, 3, 4, 5)),
+            stats=stats,
+            layout=layout,
+        )
+
+    runtime = session.LingbotInferenceRuntime(
+        config=LingbotRuntimeConfig(device="cpu", warmup_chunks=0)
+    )
+    pipeline = _FakePipeline()
+    runtime._device = torch.device("cpu")
+    runtime._pipeline = pipeline
+    runtime._cache = object()
+    runtime._base_intrinsics = torch.ones(4)
+    monkeypatch.setattr(
+        session,
+        "make_webrtc_step_result",
+        _fake_make_webrtc_step_result,
+    )
+
+    result = runtime._generate_one_chunk_sync(
+        segments=[(0.0, 1.0, frozenset())],
+        frame_times=[0.25, 0.5],
+    )
+
+    assert captured["video_chunk"] is pipeline.output
+    assert captured["layout"] == "tchw"
+    assert captured["sync_device"] == torch.device("cpu")
+    assert pipeline.output.detach_calls == 0
+    assert result.stats == {"total_ms": 3.0}
+    assert runtime.autoregressive_index == 1
 
 
 def test_validate_remote_url_normalizes_github_blob_image_url(

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -26,12 +26,12 @@ from flashdreams.infra.acceleration.encoder_lifecycle import (
     run_one_shot_encoder_stage,
     setup_one_shot_encoder,
 )
-from flashdreams.infra.acceleration.frame_prefetch import LazyCudaFrame
 from flashdreams.infra.acceleration.prewarm import run_timed_prewarm
 from flashdreams.infra.postprocess import (
     VideoPostprocessChainConfig,
     VideoPostprocessStream,
 )
+from flashdreams.infra.video_output import lazy_rgb_frames_from_video_tensor
 
 PipelineFactory = Callable[[WorldModelManifest, WorldModelProfileConfig], Any]
 _VIEW_NAMES = ["camera_front_wide_120fov"]
@@ -849,37 +849,13 @@ class FlashdreamsWorldModelSession:
             raise ValueError(
                 f"Expected [B,V,T,3,H,W] video tensor, got shape {tuple(video.shape)}"
             )
-        frames = video[0, 0]
-        if frames.dtype != torch.uint8:
-            frames = frames.clamp(-1.0, 1.0)
-            frames = ((frames + 1.0) * 127.5).round().to(torch.uint8)
-        frames = frames.permute(0, 2, 3, 1).contiguous()
-        source_event = None
-        if frames.is_cuda:
-            source_event = torch.cuda.Event()
-            source_event.record(torch.cuda.current_stream(frames.device))
-        return [
-            _LazyRGBFrame(frames, frame_index, source_event=source_event)
-            for frame_index in range(frames.shape[0])
-        ]
-
-
-class _LazyRGBFrame(LazyCudaFrame):
-    """Defer GPU-to-host copies until the presenter consumes each frame."""
-
-    def __init__(
-        self,
-        frames_hwc_uint8: torch.Tensor,
-        frame_index: int,
-        *,
-        source_event: object | None = None,
-    ) -> None:
-        super().__init__(
-            frames_hwc_uint8,
-            frame_index,
-            source_event=source_event,
-            lost_source_message="Lazy RGB frame lost its source tensor before materialization.",
-            already_materialized_message="Lazy RGB frame was already materialized on the host.",
+        return list(
+            lazy_rgb_frames_from_video_tensor(
+                video,
+                layout="bvtchw",
+                batch_index=0,
+                view_index=0,
+            )
         )
 
 

--- a/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
+++ b/integrations/omnidreams/omnidreams/interactive_drive/world_model/flashdreams_adapter.py
@@ -729,8 +729,6 @@ class FlashdreamsWorldModelSession:
                 fps=self.manifest.fps,
                 per_view=False,
                 world_size=1,
-                collect_output=False,
-                move_to_cpu=False,
             )
         processed = self._postprocess_stream.process(
             video, autoregressive_index=autoregressive_index

--- a/integrations/omnidreams/omnidreams/runner.py
+++ b/integrations/omnidreams/omnidreams/runner.py
@@ -391,8 +391,7 @@ class OmnidreamsRunner(Runner[OmnidreamsRunnerConfig, OmnidreamsPipeline]):
         if torch.distributed.is_initialized():
             torch.distributed.barrier()
 
-        postprocess_stream = self.create_postprocess_stream(fps=cfg.output_fps)
-        stats_history: list[dict[str, object]] = []
+        output_stream = self.create_video_output_stream(fps=cfg.output_fps)
         start = 0
         for i in range(cfg.total_blocks):
             num_frames = self.pipeline.get_num_frames(i)
@@ -410,19 +409,10 @@ class OmnidreamsRunner(Runner[OmnidreamsRunnerConfig, OmnidreamsPipeline]):
                 hdmap=hdmap_videos_t[:, :, start:end],
             )
             stats = self.pipeline.finalize(autoregressive_index=i, cache=cache)
-            video_chunk = postprocess_stream.process(
-                video_chunk, autoregressive_index=i
-            )
-            if postprocess_stream.collect_output and stats is not None:
-                stats_history.append(
-                    {
-                        "autoregressive_index": i,
-                        **postprocess_stream.add_process_stats(stats),
-                    }
-                )
+            output_stream.process(video_chunk, autoregressive_index=i, stats=stats)
             start = end
 
-        video = postprocess_stream.finish()
+        video = output_stream.finish()
         if video is None:
             return
         generated_num_frames = video.shape[2]
@@ -452,9 +442,9 @@ class OmnidreamsRunner(Runner[OmnidreamsRunnerConfig, OmnidreamsPipeline]):
             f"-> {video_path.resolve()}"
         )
 
-        if stats_history:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
-                cfg.output_dir, cfg.runner_name, stats_history
+                cfg.output_dir, cfg.runner_name, output_stream.stats_history
             )
             logger.info(
                 f"[{cfg.runner_name}] wrote per-AR-step stats -> {stats_path.resolve()}"

--- a/integrations/omnidreams/omnidreams/webrtc/session.py
+++ b/integrations/omnidreams/omnidreams/webrtc/session.py
@@ -70,6 +70,7 @@ from flashdreams.serving.webrtc.manager import (
     ManagedWebRTCSession,
     WebRTCControlSignal,
     WebRTCStepResult,
+    make_webrtc_step_result,
 )
 from flashdreams.serving.webrtc.server import SessionBusyError
 
@@ -954,8 +955,6 @@ class OmnidreamsInferenceRuntime:
             fps=self.config.fps,
             per_view=False,
             world_size=world_size,
-            collect_output=False,
-            move_to_cpu=False,
         )
         logger.info(
             "Omnidreams WebRTC post-processing enabled with preset {!r}.",
@@ -1048,20 +1047,12 @@ class OmnidreamsInferenceRuntime:
                 autoregressive_index=self.autoregressive_index,
             )
 
-        # Preserve the compute-stream sync barrier that the previous
-        # ``.cpu()`` provided implicitly. The tensor stays on-device — the
-        # hardware encoder reads it via DLPack (zero-copy) while the
-        # software encoder path performs its own D2H copy inside
-        # ``BufferedVideoTrack``'s worker thread. Either way, the model's
-        # writes must be visible before those readers run.
-        if self._device is not None and self._device.type == "cuda":
-            torch.cuda.current_stream(self._device).synchronize()
-
-        result = WebRTCStepResult(
+        result = make_webrtc_step_result(
             chunk_index=self.autoregressive_index,
-            num_frames=int(video_chunk.shape[2]),
-            video_chunk=video_chunk.detach(),
+            video_chunk=video_chunk,
+            layout="bvtchw",
             stats=None,
+            sync_device=self._device,
         )
         self.autoregressive_index += 1
         return result

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -15,7 +15,6 @@ from omnidreams.interactive_drive.config import WorldModelProfileConfig
 from omnidreams.interactive_drive.world_model.flashdreams_adapter import (
     FlashdreamsWorldModelSession,
     _build_pipeline_config,
-    _LazyRGBFrame,
     _select_config_name,
 )
 from omnidreams.interactive_drive.world_model.manifest import WorldModelManifest
@@ -24,6 +23,7 @@ from omnidreams.interactive_drive.world_model.synthetic_fixture import (
 )
 
 from flashdreams.infra.postprocess import VideoPostprocessChainConfig
+from flashdreams.infra.video_output import LazyRGBFrame
 
 
 class _FakePipeline:
@@ -384,7 +384,7 @@ def test_session_synchronizes_generated_frame_events_before_return(monkeypatch) 
 
 def test_lazy_rgb_frame_exposes_tensor_before_host_materialization() -> None:
     frames = torch.arange(2 * 2 * 3 * 3, dtype=torch.uint8).reshape(2, 2, 3, 3)
-    lazy = _LazyRGBFrame(frames, frame_index=1)
+    lazy = LazyRGBFrame(frames, frame_index=1)
 
     tensor = lazy.to_cuda_tensor()
 

--- a/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
+++ b/integrations/omnidreams/tests/interactive_drive/test_world_model_adapter.py
@@ -317,7 +317,9 @@ def test_session_postprocesses_local_frames_and_supports_live_toggle(
     first_stream = streams[0]
     assert first_stream.calls == [0]
     assert first_stream.kwargs["output_layout"] == "bvtchw"
-    assert first_stream.kwargs["collect_output"] is False
+    assert first_stream.kwargs["fps"] == session.manifest.fps
+    assert "collect_output" not in first_stream.kwargs
+    assert "move_to_cpu" not in first_stream.kwargs
 
     session.set_postprocess_enabled(False)
     assert first_stream.finished is True

--- a/integrations/self_forcing/self_forcing/runner.py
+++ b/integrations/self_forcing/self_forcing/runner.py
@@ -126,23 +126,13 @@ class SelfForcingT2VRunner(Runner[SelfForcingT2VRunnerConfig, WanInferencePipeli
         cache = self._initialize_cache()
 
         # Generate the autoregressive chunks.
-        postprocess_stream = self.create_postprocess_stream(fps=config.fps)
-        stats_history: list[dict[str, object]] = []
+        output_stream = self.create_video_output_stream(fps=config.fps)
         for i in range(config.total_blocks):
             video_chunk = self.pipeline.generate(autoregressive_index=i, cache=cache)
             stats = self.pipeline.finalize(autoregressive_index=i, cache=cache)
-            video_chunk = postprocess_stream.process(
-                video_chunk, autoregressive_index=i
-            )
-            if postprocess_stream.collect_output and stats is not None:
-                stats_history.append(
-                    {
-                        "autoregressive_index": i,
-                        **postprocess_stream.add_process_stats(stats),
-                    }
-                )
+            output_stream.process(video_chunk, autoregressive_index=i, stats=stats)
 
-        generated = postprocess_stream.finish()
+        generated = output_stream.finish()
         if generated is None:
             return
 
@@ -157,9 +147,9 @@ class SelfForcingT2VRunner(Runner[SelfForcingT2VRunnerConfig, WanInferencePipeli
         )
 
         # Write the perf stats.
-        if stats_history:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
-                config.output_dir, config.runner_name, stats_history
+                config.output_dir, config.runner_name, output_stream.stats_history
             )
             logger.info(
                 f"[{config.runner_name}] wrote per-AR-step stats -> {stats_path.resolve()}"

--- a/integrations/wan21/wan21/runner.py
+++ b/integrations/wan21/wan21/runner.py
@@ -172,11 +172,11 @@ class Wan21T2VRunner(Runner[Wan21T2VRunnerConfig, WanInferencePipeline]):
         cache = self._initialize_cache()
 
         # Generate the output in one AR step.
-        postprocess_stream = self.create_postprocess_stream(fps=config.fps)
+        output_stream = self.create_video_output_stream(fps=config.fps)
         generated = self.pipeline.generate(autoregressive_index=0, cache=cache)
         stats = self.pipeline.finalize(autoregressive_index=0, cache=cache)
-        postprocess_stream.process(generated, autoregressive_index=0)
-        generated = postprocess_stream.finish()
+        output_stream.process(generated, autoregressive_index=0, stats=stats)
+        generated = output_stream.finish()
         if generated is None:
             return
 
@@ -191,11 +191,11 @@ class Wan21T2VRunner(Runner[Wan21T2VRunnerConfig, WanInferencePipeline]):
         )
 
         # Write the perf stats.
-        if stats is not None:
+        if output_stream.stats_history:
             stats_path = write_runner_stats(
                 config.output_dir,
                 config.runner_name,
-                [{"autoregressive_index": 0, **stats}],
+                output_stream.stats_history,
             )
             logger.info(
                 f"[{config.runner_name}] wrote per-AR-step stats -> {stats_path.resolve()}"


### PR DESCRIPTION
- Introduces shared video output handling via VideoStepResult and RunnerVideoOutputStream, so CLI runners and WebRTC runtimes use a common RGB chunk contract.
- Separates post-processing from output collection: VideoPostprocessStream now only processes/flushed frames, while RunnerVideoOutputStream owns buffering, stats, and final video assembly.
- Updates model runners to use the shared output stream, reducing duplicated chunk collection/write logic across integrations.
- Keeps WebRTC model outputs GPU-resident by avoiding eager .cpu() calls in LingBot and Omnidreams, allowing hardware encoders such as NVENC to consume tensors when available.
- Moves local-window RGB frame materialization toward shared infrastructure with a common lazy RGB frame path.
- Adds flashdreams-run --output selection for cli, webrtc, and local-window launch modes where supported.
- Adds focused CPU tests covering shared output contracts, postprocess behavior, runner I/O layouts, and WebRTC tensor handling.

Before:
```mermaid
flowchart TB
  G["Integration runner calls pipeline.generate()"] --> T["Decoded RGB tensor"]

  T --> R1["Each CLI runner"]
  R1 --> P1["VideoPostprocessStream"]
  P1 --> C1["Postprocess stream also owns chunk collection"]
  C1 --> F1["finish() returns full collected video"]
  F1 --> W1["write_video_tensor / MP4"]

  T --> O1["Omnidreams WebRTC runtime"]
  O1 --> CPU1["WebRTCStepResult(video_chunk.detach().cpu())"]
  CPU1 --> M1["WebRTC manager / media queue"]

  T --> L1["LingBot WebRTC runtime"]
  L1 --> CPU2["WebRTCStepResult(video_chunk.detach().cpu())"]
  CPU2 --> M1

  T --> LW1["Omnidreams local-window demo"]
  LW1 --> LP1["Private lazy frame / presenter path"]
```

After:
```mermaid
flowchart TB
  G["Integration runner calls pipeline.generate()"] --> T["Decoded RGB tensor + declared layout"]

  T --> R2["Shared RunnerVideoOutputStream"]
  R2 --> Q{"Postprocess configured?"}

  Q -->|yes| P2["VideoPostprocessStream"]
  P2 --> P3["Processes chunks only"]
  P3 --> C2["RunnerVideoOutputStream collects emitted chunks"]

  Q -->|no| N2["No-op direct chunk path"]
  N2 --> C2

  C2 --> F2["finish() flushes postprocess tail + concatenates collected chunks"]
  F2 --> W2["write_video_tensor / MP4"]

  T --> V2["VideoStepResult shared chunk contract"]
  V2 --> MW["make_webrtc_step_result(layout=..., sync_device=...)"]
  MW --> GPU["video_chunk.detach(), stays on original device"]

  GPU --> O2["Omnidreams WebRTC"]
  GPU --> L2["LingBot WebRTC"]
  O2 --> E2["WebRTC encode/transport can consume GPU tensor when supported"]
  L2 --> E2

  T --> LW2["Omnidreams local-window demo"]
  LW2 --> LP2["Still separate presenter path"]
```


Sample output target selection:
# Default CLI runner path, writes normal runner artifacts
```
uv run flashdreams-run lingbot-world-fast --example-data True
```
# Same thing, explicit CLI output target
```
uv run flashdreams-run --output cli lingbot-world-fast --example-data True
```
# Launch LingBot WebRTC server
```
uv run flashdreams-run \
  --output webrtc \
  --output-host 0.0.0.0 \
  --output-port 8080 \
  lingbot-world-fast
```

# Launch Omnidreams WebRTC server
```
uv run flashdreams-run \
  --output webrtc \
  --output-host 0.0.0.0 \
  --output-port 8082 \
  omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf
```

```
Useful knobs:
--output cli|webrtc|local-window
--output-host 0.0.0.0
--output-port 8080
--prefer-sw-encoder
--output-manifest path/to/manifest.yaml for local-window Omnidreams.
```
