### PR TITLE
Share demo WebRTC plumbing across models (#424)

### DIFF
--- a/flashdreams/flashdreams/runtime/__init__.py
+++ b/flashdreams/flashdreams/runtime/__init__.py
@@ -4,7 +4,8 @@
 """Experimental inference runtime API envelope.
 
 This package defines the small v0 boundary above ``flashdreams.infra``. It is
-intentionally additive while integrations migrate onto it.
+intentionally additive while integrations migrate onto it, and re-exports the
+runtime/session/input/output pieces model adapters and demo launchers consume.
 """
 
 from flashdreams.runtime.canonical import (

--- a/flashdreams/flashdreams/runtime/_utils.py
+++ b/flashdreams/flashdreams/runtime/_utils.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Small helpers shared by the experimental runtime API."""
+"""Small helpers shared by the experimental runtime API.
+
+Keep this module limited to tiny dependency-light utilities that support the
+runtime data shapes without becoming another abstraction layer.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/config.py
+++ b/flashdreams/flashdreams/runtime/config.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Runtime-facing configuration envelope."""
+"""Runtime-facing configuration envelope.
+
+This file defines execution settings that affect model construction and
+optimization. User inputs, demo scenarios, output paths, and transport choices
+live outside this config so runtimes stay reusable across apps.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/demo/__init__.py
+++ b/flashdreams/flashdreams/runtime/demo/__init__.py
@@ -15,6 +15,7 @@ from flashdreams.runtime.demo.spec import (
     PreparedScenario,
     WebRTCOutputSpec,
 )
+from flashdreams.runtime.demo.webrtc import WebRTCAppExtension, WebRTCManagerOptions
 
 __all__ = [
     "DemoAdapter",
@@ -23,6 +24,8 @@ __all__ = [
     "NullOutputSpec",
     "OutputSpec",
     "PreparedScenario",
+    "WebRTCAppExtension",
+    "WebRTCManagerOptions",
     "WebRTCOutputSpec",
     "build_output_target",
     "run_flashdreams_demo",

--- a/flashdreams/flashdreams/runtime/demo/__init__.py
+++ b/flashdreams/flashdreams/runtime/demo/__init__.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Experimental shared demo API above the inference runtime API."""
+"""Experimental shared demo API above the inference runtime API.
+
+This package owns demo-level specs and launchers so integrations can provide
+small adapters instead of writing replay loops, output-target setup, or WebRTC
+server/session plumbing.
+"""
 
 from flashdreams.runtime.demo.app import run_flashdreams_demo, serve_flashdreams_demo
 from flashdreams.runtime.demo.outputs import build_output_target

--- a/flashdreams/flashdreams/runtime/demo/__init__.py
+++ b/flashdreams/flashdreams/runtime/demo/__init__.py
@@ -15,7 +15,14 @@ from flashdreams.runtime.demo.spec import (
     PreparedScenario,
     WebRTCOutputSpec,
 )
-from flashdreams.runtime.demo.webrtc import WebRTCAppExtension, WebRTCManagerOptions
+from flashdreams.runtime.demo.webrtc import (
+    PendingSessionInputState,
+    WebRTCAppExtension,
+    WebRTCManagerOptions,
+    WebRTCRoute,
+    json_get_route,
+    session_input_route,
+)
 
 __all__ = [
     "DemoAdapter",
@@ -23,12 +30,16 @@ __all__ = [
     "Mp4OutputSpec",
     "NullOutputSpec",
     "OutputSpec",
+    "PendingSessionInputState",
     "PreparedScenario",
     "WebRTCAppExtension",
     "WebRTCManagerOptions",
+    "WebRTCRoute",
     "WebRTCOutputSpec",
     "build_output_target",
+    "json_get_route",
     "run_flashdreams_demo",
     "run_replay_demo",
+    "session_input_route",
     "serve_flashdreams_demo",
 ]

--- a/flashdreams/flashdreams/runtime/demo/app.py
+++ b/flashdreams/flashdreams/runtime/demo/app.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Experimental shared demo entrypoints."""
+"""Experimental shared demo entrypoints.
+
+This file chooses the shared replay or WebRTC launcher from ``DemoSpec`` output
+mode. Model demos should enter here instead of directly owning mode-specific
+run loops.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/demo/outputs.py
+++ b/flashdreams/flashdreams/runtime/demo/outputs.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared demo output-target construction."""
+"""Shared demo output-target construction.
+
+This file converts demo output specs into runtime ``OutputTarget`` objects for
+replay-style demos. Realtime WebRTC serving is selected here but constructed by
+the shared WebRTC launcher.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/demo/replay.py
+++ b/flashdreams/flashdreams/runtime/demo/replay.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared replay demo runner."""
+"""Shared replay demo runner.
+
+This file validates a demo spec, asks the adapter for a prepared scenario, then
+delegates execution to ``run_inference_session`` with a selected output target.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/demo/spec.py
+++ b/flashdreams/flashdreams/runtime/demo/spec.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Experimental shared demo API data shapes."""
+"""Experimental shared demo API data shapes.
+
+This file defines the high-level demo contract: what model to run, which
+scenario/input mode to use, and which output mode to build. Model adapters fill
+in model-specific preparation behind these generic shapes.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/demo/webrtc.py
+++ b/flashdreams/flashdreams/runtime/demo/webrtc.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared WebRTC demo construction."""
+"""Shared WebRTC demo construction.
+
+This file owns demo-level WebRTC app/session-manager construction, shared route
+registration, pending session input lifecycle, and server startup wiring. Model
+demos provide runtimes, static assets, and semantic hooks through options.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/demo/webrtc.py
+++ b/flashdreams/flashdreams/runtime/demo/webrtc.py
@@ -16,6 +16,8 @@ from aiohttp import web
 from flashdreams.serving.webrtc.bootstrap import run_webrtc_server
 from flashdreams.serving.webrtc.manager import BaseWebRTCSessionManager
 from flashdreams.serving.webrtc.server import (
+    SESSION_MANAGER_KEY,
+    SessionBusyError,
     create_packaged_webrtc_app,
     create_webrtc_app,
 )
@@ -42,6 +44,134 @@ ChunkDoneExtraHook = Callable[[Any, Any], Mapping[str, Any]]
 PeerConnectionHook = Callable[[Any], None]
 SdpHook = Callable[[str], None]
 ConfigureWebRTCApp = Callable[[web.Application], None]
+WebRTCRouteHandler = Callable[
+    [web.Request, Any], Awaitable[web.StreamResponse] | web.StreamResponse
+]
+JsonRoutePayload = Mapping[str, Any]
+RouteResponse = web.StreamResponse | JsonRoutePayload
+JsonRouteBuilder = Callable[[Any], Awaitable[JsonRoutePayload] | JsonRoutePayload]
+SessionInputParser = Callable[[web.Request, Any], Awaitable[Any] | Any]
+SessionInputResponseBuilder = Callable[
+    [Any, Any],
+    Awaitable[RouteResponse] | RouteResponse,
+]
+SessionInputValidator = Callable[[Any], None]
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class WebRTCRoute:
+    """Model-provided route registered on a shared demo WebRTC app."""
+
+    method: str
+    path: str
+    handler: WebRTCRouteHandler
+
+    def __post_init__(self) -> None:
+        method = self.method.strip().upper()
+        path = self.path.strip()
+        if not method:
+            raise ValueError("WebRTCRoute.method must be non-empty.")
+        if not path.startswith("/"):
+            raise ValueError("WebRTCRoute.path must start with '/'.")
+        object.__setattr__(self, "method", method)
+        object.__setattr__(self, "path", path)
+
+
+@dataclass(slots=True)
+class PendingSessionInputState:
+    """Shared storage and busy handling for next-session WebRTC input."""
+
+    busy_message: str
+    input_type: type[Any] | tuple[type[Any], ...] | None = None
+    validate_input: SessionInputValidator | None = None
+    pending_session_input: Any = None
+
+    def __post_init__(self) -> None:
+        if not self.busy_message.strip():
+            raise ValueError("PendingSessionInputState.busy_message must be non-empty.")
+
+    def peek(self) -> Any:
+        return self.pending_session_input
+
+    def clear(self) -> None:
+        self.pending_session_input = None
+
+    def set(self, manager: Any, session_input: Any) -> None:
+        if self.input_type is not None and not isinstance(
+            session_input, self.input_type
+        ):
+            expected = _type_name(self.input_type)
+            raise TypeError(f"Expected {expected}.")
+        if manager.has_active_session():
+            raise SessionBusyError(self.busy_message)
+        if self.validate_input is not None:
+            self.validate_input(session_input)
+        self.pending_session_input = session_input
+
+
+def json_get_route(path: str, build_payload: JsonRouteBuilder) -> WebRTCRoute:
+    """Create a shared JSON GET route backed by a model payload hook."""
+
+    async def handler(request: web.Request, manager: Any) -> web.StreamResponse:
+        del request
+        return await _as_route_response(build_payload(manager))
+
+    return WebRTCRoute(method="GET", path=path, handler=handler)
+
+
+def session_input_route(
+    path: str,
+    *,
+    parse_input: SessionInputParser,
+    build_response: SessionInputResponseBuilder | None = None,
+) -> WebRTCRoute:
+    """Create a shared session-input POST route around model hooks."""
+
+    async def handler(request: web.Request, manager: Any) -> web.StreamResponse:
+        try:
+            session_input = await _maybe_await(parse_input(request, manager))
+        except web.HTTPException:
+            raise
+        except ValueError as exc:
+            raise web.HTTPBadRequest(reason=str(exc)) from exc
+
+        try:
+            result = manager.set_pending_session_input(session_input)
+            if inspect.isawaitable(result):
+                await result
+        except web.HTTPException:
+            raise
+        except (TypeError, ValueError) as exc:
+            raise web.HTTPBadRequest(reason=str(exc)) from exc
+        except SessionBusyError as exc:
+            raise web.HTTPConflict(reason=str(exc)) from exc
+
+        if build_response is None:
+            return web.json_response({})
+        return await _as_route_response(build_response(session_input, manager))
+
+    return WebRTCRoute(method="POST", path=path, handler=handler)
+
+
+async def _maybe_await(value: Awaitable[Any] | Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _as_route_response(
+    value: Awaitable[RouteResponse] | RouteResponse,
+) -> web.StreamResponse:
+    resolved = await _maybe_await(value)
+    if isinstance(resolved, web.StreamResponse):
+        return resolved
+    return web.json_response(resolved)
+
+
+def _type_name(input_type: type[Any] | tuple[type[Any], ...]) -> str:
+    if isinstance(input_type, tuple):
+        return " or ".join(sorted(t.__name__ for t in input_type))
+    return input_type.__name__
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -92,6 +222,7 @@ class WebRTCAppExtension:
     web_dir: str | Path | None = None
     preload_name: str | None = None
     index_filename: str = "request_session.html"
+    routes: tuple[WebRTCRoute, ...] = ()
     configure_app: ConfigureWebRTCApp | None = None
 
     def __post_init__(self) -> None:
@@ -105,6 +236,7 @@ class WebRTCAppExtension:
             raise ValueError("WebRTCAppExtension.index_filename must be non-empty.")
         if self.preload_name is not None and not self.preload_name.strip():
             raise ValueError("WebRTCAppExtension.preload_name must be non-empty.")
+        object.__setattr__(self, "routes", tuple(self.routes))
 
 
 class SharedDemoWebRTCSessionManager(BaseWebRTCSessionManager[Any, Any]):
@@ -450,13 +582,14 @@ def _build_webrtc_app_from_extension(
     fallback_preload_name: str,
 ) -> web.Application:
     preload_name = extension.preload_name or fallback_preload_name
+    configure_app = _configure_app_from_extension(extension)
     if extension.web_resource is not None:
         return create_packaged_webrtc_app(
             web_resource=extension.web_resource,
             session_manager=session_manager,
             request_session_url=request_session_url,
             preload_name=preload_name,
-            configure_app=extension.configure_app,
+            configure_app=configure_app,
             index_filename=extension.index_filename,
             create_app_fn=create_app_fn,
         )
@@ -471,9 +604,32 @@ def _build_webrtc_app_from_extension(
         preload_name=preload_name,
         index_filename=extension.index_filename,
     )
-    if extension.configure_app is not None:
-        extension.configure_app(app)
+    if configure_app is not None:
+        configure_app(app)
     return app
+
+
+def _configure_app_from_extension(
+    extension: WebRTCAppExtension,
+) -> ConfigureWebRTCApp | None:
+    if not extension.routes and extension.configure_app is None:
+        return None
+
+    def configure(app: web.Application) -> None:
+        for route in extension.routes:
+            _register_webrtc_route(app, route)
+        if extension.configure_app is not None:
+            extension.configure_app(app)
+
+    return configure
+
+
+def _register_webrtc_route(app: web.Application, route: WebRTCRoute) -> None:
+    async def handler(request: web.Request) -> web.StreamResponse:
+        manager = request.app[SESSION_MANAGER_KEY]
+        return await _maybe_await(route.handler(request, manager))
+
+    app.router.add_route(route.method, route.path, handler)
 
 
 def _build_webrtc_app(
@@ -500,12 +656,16 @@ def _request_session_url(output: WebRTCOutputSpec) -> str:
 
 __all__ = [
     "CreateWebRTCApp",
+    "PendingSessionInputState",
     "RunWebRTCServer",
     "SharedDemoWebRTCSessionManager",
     "WebRTCAppExtension",
     "WebRTCDemo",
     "WebRTCManagerOptions",
+    "WebRTCRoute",
     "WebRTCDemoRuntimeConfig",
     "build_webrtc_demo",
+    "json_get_route",
+    "session_input_route",
     "serve_webrtc_demo",
 ]

--- a/flashdreams/flashdreams/runtime/demo/webrtc.py
+++ b/flashdreams/flashdreams/runtime/demo/webrtc.py
@@ -37,6 +37,7 @@ class WebRTCDemoRuntimeConfig:
 ManagerResetHook = Callable[[Any, Any], Awaitable[None] | None]
 PendingInputHook = Callable[[], Any]
 ClearPendingInputHook = Callable[[], None]
+SetPendingInputHook = Callable[[Any, Any], None]
 ChunkDoneExtraHook = Callable[[Any, Any], Mapping[str, Any]]
 PeerConnectionHook = Callable[[Any], None]
 SdpHook = Callable[[str], None]
@@ -55,6 +56,7 @@ class WebRTCManagerOptions:
     supported_keys: AbstractSet[str] | None = None
     peek_pending_session_input: PendingInputHook | None = None
     clear_pending_session_input: ClearPendingInputHook | None = None
+    set_pending_session_input: SetPendingInputHook | None = None
     reset_runtime_for_session: ManagerResetHook | None = None
     chunk_done_extra: ChunkDoneExtraHook | None = None
     register_extra_peer_handlers: PeerConnectionHook | None = None
@@ -148,6 +150,14 @@ class SharedDemoWebRTCSessionManager(BaseWebRTCSessionManager[Any, Any]):
         hook = self._demo_manager_options.clear_pending_session_input
         if hook is not None:
             hook()
+
+    def set_pending_session_input(self, session_input: Any) -> None:
+        hook = self._demo_manager_options.set_pending_session_input
+        if hook is None:
+            raise NotImplementedError(
+                "This WebRTC demo does not accept pending session input."
+            )
+        hook(self, session_input)
 
     async def _reset_runtime_for_session(self, session_input: Any) -> None:
         hook = self._demo_manager_options.reset_runtime_for_session

--- a/flashdreams/flashdreams/runtime/demo/webrtc.py
+++ b/flashdreams/flashdreams/runtime/demo/webrtc.py
@@ -5,16 +5,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import AbstractSet, Any
 
 from aiohttp import web
 
 from flashdreams.serving.webrtc.bootstrap import run_webrtc_server
 from flashdreams.serving.webrtc.manager import BaseWebRTCSessionManager
-from flashdreams.serving.webrtc.server import create_webrtc_app
+from flashdreams.serving.webrtc.server import (
+    create_packaged_webrtc_app,
+    create_webrtc_app,
+)
 
 from .replay import _require_supported_mode
 from .spec import DemoAdapter, DemoSpec, WebRTCOutputSpec
@@ -30,6 +34,77 @@ class WebRTCDemoRuntimeConfig:
     warmup_timeout_s: float
 
 
+ManagerResetHook = Callable[[Any, Any], Awaitable[None] | None]
+PendingInputHook = Callable[[], Any]
+ClearPendingInputHook = Callable[[], None]
+ChunkDoneExtraHook = Callable[[Any, Any], Mapping[str, Any]]
+PeerConnectionHook = Callable[[Any], None]
+SdpHook = Callable[[str], None]
+ConfigureWebRTCApp = Callable[[web.Application], None]
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class WebRTCManagerOptions:
+    """Declarative options for the shared demo WebRTC session manager."""
+
+    model_name: str | None = None
+    busy_message: str | None = None
+    warmup_label: str | None = None
+    runtime_error_types: tuple[type[Exception], ...] = (RuntimeError,)
+    close_session_on_generation_error: bool = False
+    supported_keys: AbstractSet[str] | None = None
+    peek_pending_session_input: PendingInputHook | None = None
+    clear_pending_session_input: ClearPendingInputHook | None = None
+    reset_runtime_for_session: ManagerResetHook | None = None
+    chunk_done_extra: ChunkDoneExtraHook | None = None
+    register_extra_peer_handlers: PeerConnectionHook | None = None
+    on_offer_received: SdpHook | None = None
+    on_answer_created: SdpHook | None = None
+
+    def __post_init__(self) -> None:
+        if self.model_name is not None and not self.model_name.strip():
+            raise ValueError("WebRTCManagerOptions.model_name must be non-empty.")
+        if self.busy_message is not None and not self.busy_message.strip():
+            raise ValueError("WebRTCManagerOptions.busy_message must be non-empty.")
+        if self.warmup_label is not None and not self.warmup_label.strip():
+            raise ValueError("WebRTCManagerOptions.warmup_label must be non-empty.")
+        if not self.runtime_error_types:
+            raise ValueError(
+                "WebRTCManagerOptions.runtime_error_types cannot be empty."
+            )
+        for error_type in self.runtime_error_types:
+            if not issubclass(error_type, Exception):
+                raise TypeError(
+                    "WebRTCManagerOptions.runtime_error_types must contain "
+                    "Exception subclasses."
+                )
+        if self.supported_keys is not None:
+            object.__setattr__(self, "supported_keys", frozenset(self.supported_keys))
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class WebRTCAppExtension:
+    """Model-owned additions to a shared demo WebRTC app."""
+
+    web_resource: Any | None = None
+    web_dir: str | Path | None = None
+    preload_name: str | None = None
+    index_filename: str = "request_session.html"
+    configure_app: ConfigureWebRTCApp | None = None
+
+    def __post_init__(self) -> None:
+        if self.web_resource is not None and self.web_dir is not None:
+            raise ValueError(
+                "WebRTCAppExtension accepts either web_resource or web_dir, not both."
+            )
+        if self.web_dir is not None:
+            object.__setattr__(self, "web_dir", Path(self.web_dir))
+        if not self.index_filename.strip():
+            raise ValueError("WebRTCAppExtension.index_filename must be non-empty.")
+        if self.preload_name is not None and not self.preload_name.strip():
+            raise ValueError("WebRTCAppExtension.preload_name must be non-empty.")
+
+
 class SharedDemoWebRTCSessionManager(BaseWebRTCSessionManager[Any, Any]):
     """Generic session manager wrapper for demo adapters."""
 
@@ -41,8 +116,20 @@ class SharedDemoWebRTCSessionManager(BaseWebRTCSessionManager[Any, Any]):
         runtime_config: Any,
         fps: int,
         client_liveness_timeout_s: float,
+        manager_options: WebRTCManagerOptions | None = None,
     ) -> None:
-        self._demo_model_name = model_name
+        options = manager_options or WebRTCManagerOptions()
+        self._demo_manager_options = options
+        self._demo_model_name = options.model_name or model_name
+        if options.busy_message is not None:
+            self._busy_message = options.busy_message
+        if options.warmup_label is not None:
+            self._warmup_label = options.warmup_label
+        self._runtime_error_types = options.runtime_error_types
+        self._close_session_on_generation_error = (
+            options.close_session_on_generation_error
+        )
+        self._resampler_supported_keys = options.supported_keys
         super().__init__(
             runtime=runtime,
             runtime_config=runtime_config,
@@ -52,6 +139,45 @@ class SharedDemoWebRTCSessionManager(BaseWebRTCSessionManager[Any, Any]):
 
     def _model_name(self) -> str:
         return self._demo_model_name
+
+    def _peek_pending_session_input(self) -> Any:
+        hook = self._demo_manager_options.peek_pending_session_input
+        return None if hook is None else hook()
+
+    def _clear_pending_session_input(self) -> None:
+        hook = self._demo_manager_options.clear_pending_session_input
+        if hook is not None:
+            hook()
+
+    async def _reset_runtime_for_session(self, session_input: Any) -> None:
+        hook = self._demo_manager_options.reset_runtime_for_session
+        if hook is None:
+            await super()._reset_runtime_for_session(session_input)
+            return
+        result = hook(self._runtime, session_input)
+        if inspect.isawaitable(result):
+            await result
+
+    def _chunk_done_extra(self) -> dict[str, Any]:
+        hook = self._demo_manager_options.chunk_done_extra
+        if hook is None:
+            return {}
+        return dict(hook(self._runtime, self.runtime_config))
+
+    def _register_extra_peer_handlers(self, peer_connection: Any) -> None:
+        hook = self._demo_manager_options.register_extra_peer_handlers
+        if hook is not None:
+            hook(peer_connection)
+
+    def _on_offer_received(self, offer_sdp: str) -> None:
+        hook = self._demo_manager_options.on_offer_received
+        if hook is not None:
+            hook(offer_sdp)
+
+    def _on_answer_created(self, answer_sdp: str) -> None:
+        hook = self._demo_manager_options.on_answer_created
+        if hook is not None:
+            hook(answer_sdp)
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -207,13 +333,38 @@ def _create_session_manager(
             client_liveness_timeout_s=client_liveness_timeout_s,
         )
 
+    manager_options = _create_manager_options(
+        spec=spec,
+        adapter=adapter,
+        runtime=runtime,
+        runtime_config=runtime_config,
+    )
     return SharedDemoWebRTCSessionManager(
-        model_name=spec.model_id,
+        model_name=manager_options.model_name or spec.model_id,
         runtime=runtime,
         runtime_config=runtime_config,
         fps=fps,
         client_liveness_timeout_s=client_liveness_timeout_s,
+        manager_options=manager_options,
     )
+
+
+def _create_manager_options(
+    *,
+    spec: DemoSpec,
+    adapter: DemoAdapter,
+    runtime: Any,
+    runtime_config: Any,
+) -> WebRTCManagerOptions:
+    factory = getattr(adapter, "create_webrtc_manager_options", None)
+    if not callable(factory):
+        return WebRTCManagerOptions()
+    options = factory(spec=spec, runtime=runtime, runtime_config=runtime_config)
+    if not isinstance(options, WebRTCManagerOptions):
+        raise TypeError(
+            "create_webrtc_manager_options must return WebRTCManagerOptions."
+        )
+    return options
 
 
 def _create_app(
@@ -226,6 +377,22 @@ def _create_app(
     output = spec.output
     if not isinstance(output, WebRTCOutputSpec):
         raise ValueError("WebRTC app creation requires WebRTCOutputSpec output.")
+    extension = _create_app_extension(
+        spec=spec,
+        adapter=adapter,
+        session_manager=session_manager,
+        request_session_url=_request_session_url(output),
+    )
+    if extension is not None:
+        return _build_webrtc_app_from_extension(
+            output=output,
+            extension=extension,
+            session_manager=session_manager,
+            request_session_url=_request_session_url(output),
+            create_app_fn=create_app_fn,
+            fallback_preload_name=output.preload_name or spec.model_id,
+        )
+
     factory = getattr(adapter, "create_webrtc_app", None)
     if callable(factory):
         return factory(
@@ -239,6 +406,64 @@ def _create_app(
         create_app_fn=create_app_fn,
         preload_name=output.preload_name or spec.model_id,
     )
+
+
+def _create_app_extension(
+    *,
+    spec: DemoSpec,
+    adapter: DemoAdapter,
+    session_manager: BaseWebRTCSessionManager[Any, Any],
+    request_session_url: str,
+) -> WebRTCAppExtension | None:
+    factory = getattr(adapter, "create_webrtc_app_extension", None)
+    if not callable(factory):
+        return None
+    extension = factory(
+        spec=spec,
+        session_manager=session_manager,
+        request_session_url=request_session_url,
+    )
+    if extension is None:
+        return None
+    if not isinstance(extension, WebRTCAppExtension):
+        raise TypeError("create_webrtc_app_extension must return WebRTCAppExtension.")
+    return extension
+
+
+def _build_webrtc_app_from_extension(
+    *,
+    output: WebRTCOutputSpec,
+    extension: WebRTCAppExtension,
+    session_manager: BaseWebRTCSessionManager[Any, Any],
+    request_session_url: str,
+    create_app_fn: CreateWebRTCApp,
+    fallback_preload_name: str,
+) -> web.Application:
+    preload_name = extension.preload_name or fallback_preload_name
+    if extension.web_resource is not None:
+        return create_packaged_webrtc_app(
+            web_resource=extension.web_resource,
+            session_manager=session_manager,
+            request_session_url=request_session_url,
+            preload_name=preload_name,
+            configure_app=extension.configure_app,
+            index_filename=extension.index_filename,
+            create_app_fn=create_app_fn,
+        )
+
+    web_dir = extension.web_dir or output.web_dir
+    if web_dir is None:
+        raise ValueError("WebRTC app extension requires web_resource or web_dir.")
+    app = create_app_fn(
+        web_dir=Path(web_dir),
+        session_manager=session_manager,
+        request_session_url=request_session_url,
+        preload_name=preload_name,
+        index_filename=extension.index_filename,
+    )
+    if extension.configure_app is not None:
+        extension.configure_app(app)
+    return app
 
 
 def _build_webrtc_app(
@@ -267,7 +492,9 @@ __all__ = [
     "CreateWebRTCApp",
     "RunWebRTCServer",
     "SharedDemoWebRTCSessionManager",
+    "WebRTCAppExtension",
     "WebRTCDemo",
+    "WebRTCManagerOptions",
     "WebRTCDemoRuntimeConfig",
     "build_webrtc_demo",
     "serve_webrtc_demo",

--- a/flashdreams/flashdreams/runtime/inputs.py
+++ b/flashdreams/flashdreams/runtime/inputs.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""User- and model-input envelopes for the experimental runtime API."""
+"""User- and model-input envelopes for the experimental runtime API.
+
+This file separates timestamped user/control inputs, canonicalized inputs, and
+the model-facing ``InferenceInput`` payloads passed to runtime sessions.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/interfaces.py
+++ b/flashdreams/flashdreams/runtime/interfaces.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Protocols for model adapters, reusable runtimes, and sessions."""
+"""Protocols for model adapters, reusable runtimes, and sessions.
+
+This file is the model boundary: adapters describe capabilities, runtimes own
+heavyweight setup, and sessions own one rollout or stream of model state.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/mapping.py
+++ b/flashdreams/flashdreams/runtime/mapping.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Input mapping boundary from canonical inputs to encoded inference inputs."""
+"""Input mapping boundary from canonical inputs to encoded inference inputs.
+
+Mappings are model- or app-provided translators. They let a shared runner feed
+one runtime session without baking model-specific prompt/control semantics into
+the runner.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/metrics.py
+++ b/flashdreams/flashdreams/runtime/metrics.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Runtime metrics boundary for inference sessions."""
+"""Runtime metrics boundary for inference sessions.
+
+This file defines the small recorder interface used by shared runners to emit
+timing, throughput, and model/demo metrics without coupling to a report format.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/output.py
+++ b/flashdreams/flashdreams/runtime/output.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Output target boundary for generated inference results."""
+"""Output target boundary for generated inference results.
+
+Output targets consume ``StepResult`` objects and decide whether to store,
+stream, display, or discard them. Model sessions return data; output targets own
+presentation and persistence.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/runner.py
+++ b/flashdreams/flashdreams/runtime/runner.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Minimal synchronous standard runner for the runtime API."""
+"""Minimal synchronous standard runner for the runtime API.
+
+This file owns the replay/headless loop: create a runtime, start one session,
+map requested inputs for each step, write outputs, record metrics, and close
+resources.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/types.py
+++ b/flashdreams/flashdreams/runtime/types.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Plain data carriers shared by runtime protocols and adapters."""
+"""Plain data carriers shared by runtime protocols and adapters.
+
+These shapes describe what a session requests next and what it produced. They
+avoid putting runner, output-target, or model-specific behavior into the data
+objects themselves.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/runtime/video_output.py
+++ b/flashdreams/flashdreams/runtime/video_output.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Video output targets for the runtime API."""
+"""Video output targets for the runtime API.
+
+This file adapts runtime ``VideoStepResult`` chunks into concrete video
+artifacts such as MP4 files. It stays model-agnostic and is used by replay/demo
+output selection.
+"""
 
 from __future__ import annotations
 

--- a/flashdreams/flashdreams/serving/webrtc/encoders.py
+++ b/flashdreams/flashdreams/serving/webrtc/encoders.py
@@ -202,10 +202,43 @@ def select_encoder(
       — driver bug, session-pool exhaustion, hardware fault, or
       misconfiguration. Log with traceback and re-raise; do not silently
       degrade, because doing so would hide a real problem.
+
+    PyNvVideoCodec may replace the CUDA context current on the calling
+    thread, including when ``GetEncoderCaps`` fails. Preserve an already
+    initialized PyTorch device context so subsequent model work does not
+    inherit the encoder probe's context.
     """
     if backend == "default":
         return DefaultRTCEncoder(fps=fps)
 
+    restore_device = (
+        torch.cuda.current_device() if torch.cuda.is_initialized() else None
+    )
+    try:
+        return _select_hardware_encoder(
+            backend=backend,
+            width=width,
+            height=height,
+            fps=fps,
+            bitrate=bitrate,
+            gpu_id=gpu_id,
+            gop=gop,
+        )
+    finally:
+        if restore_device is not None:
+            torch.cuda.set_device(restore_device)
+
+
+def _select_hardware_encoder(
+    *,
+    backend: Literal["auto", "nvenc"],
+    width: int,
+    height: int,
+    fps: int,
+    bitrate: int,
+    gpu_id: int,
+    gop: int,
+) -> VideoEncoder:
     if not _pynvvideocodec_installed():
         reason = "PyNvVideoCodec library is not installed"
         if backend == "nvenc":

--- a/flashdreams/tests/test_encoders.py
+++ b/flashdreams/tests/test_encoders.py
@@ -210,6 +210,22 @@ class TestSelectStage1Failure:
         with pytest.raises(EncoderInitError, match="driver comms error"):
             select_encoder(backend="nvenc", **_SELECT_KW)
 
+    def test_caps_probe_restores_initialized_torch_cuda_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_nvc = MagicMock()
+        fake_nvc.GetEncoderCaps.side_effect = RuntimeError("unsupported GPU")
+        _install_fake_nvc(monkeypatch, fake_nvc)
+        set_device = MagicMock()
+        monkeypatch.setattr(enc_mod.torch.cuda, "is_initialized", lambda: True)
+        monkeypatch.setattr(enc_mod.torch.cuda, "current_device", lambda: 3)
+        monkeypatch.setattr(enc_mod.torch.cuda, "set_device", set_device)
+
+        enc = select_encoder(backend="auto", **_SELECT_KW)
+
+        assert isinstance(enc, DefaultRTCEncoder)
+        set_device.assert_called_once_with(3)
+
 
 # ---------------------------------------------------------------------------
 # select_encoder: Stage-1 deferred-import failure (package present but

--- a/flashdreams/tests/test_runtime_demo_api.py
+++ b/flashdreams/tests/test_runtime_demo_api.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
 import pytest
 import torch
+from aiohttp import web
 
 from flashdreams.infra.video_output import VideoStepResult
 from flashdreams.runtime import (
@@ -43,8 +45,14 @@ from flashdreams.runtime.demo import (
     build_output_target,
     run_replay_demo,
 )
-from flashdreams.runtime.demo.webrtc import build_webrtc_demo
+from flashdreams.runtime.demo.webrtc import (
+    SharedDemoWebRTCSessionManager,
+    WebRTCAppExtension,
+    WebRTCManagerOptions,
+    build_webrtc_demo,
+)
 from flashdreams.serving.webrtc.manager import BaseWebRTCSessionManager
+from flashdreams.serving.webrtc.server import PACKAGE_RESOURCE_STACK_KEY
 
 pytestmark = pytest.mark.ci_cpu
 
@@ -224,6 +232,161 @@ def test_webrtc_demo_uses_existing_session_manager_with_adapter_runtime() -> Non
     assert not adapter.create_runtime_called
 
 
+def test_webrtc_demo_builds_app_from_extension_routes() -> None:
+    async def fake_route(_: web.Request) -> web.StreamResponse:
+        return web.json_response({"ok": True})
+
+    def configure_app(app: web.Application) -> None:
+        app.router.add_get("/api/fake/model-info", fake_route)
+
+    app_extension = WebRTCAppExtension(
+        web_resource=files("flashdreams.runtime.demo"),
+        preload_name="Fake WebRTC",
+        configure_app=configure_app,
+    )
+    adapter = _FakeDemoAdapter(app_extension=app_extension)
+    spec = DemoSpec(
+        model_id="fake-demo",
+        scenario="valid-scenario",
+        input_mode="keyboard-driving",
+        output=WebRTCOutputSpec(
+            host="0.0.0.0",
+            port=8082,
+            fps=24,
+            video_width=16,
+            video_height=8,
+            warmup_chunks=0,
+            warmup_timeout_s=1.0,
+        ),
+    )
+
+    demo = build_webrtc_demo(spec=spec, adapter=adapter, create_app=True)
+
+    assert demo.app is not None
+    route_paths = {resource.canonical for resource in demo.app.router.resources()}
+    assert "/api/fake/model-info" in route_paths
+    assert adapter.create_webrtc_app_extension_calls == [
+        {
+            "spec": spec,
+            "session_manager": demo.session_manager,
+            "request_session_url": "http://127.0.0.1:8082/request_session",
+        }
+    ]
+    demo.app[PACKAGE_RESOURCE_STACK_KEY].close()
+
+
+@pytest.mark.asyncio
+async def test_webrtc_demo_manager_options_configure_shared_manager() -> None:
+    class FakeRuntimeError(RuntimeError):
+        pass
+
+    reset_calls: list[tuple[Any, Any]] = []
+    pending_inputs: list[object] = [object()]
+    clear_calls = 0
+    peer_hooks: list[Any] = []
+    offers: list[str] = []
+    answers: list[str] = []
+
+    async def reset_runtime(runtime: Any, session_input: Any) -> None:
+        reset_calls.append((runtime, session_input))
+
+    def clear_pending() -> None:
+        nonlocal clear_calls
+        clear_calls += 1
+
+    manager_options = WebRTCManagerOptions(
+        model_name="fake-model-v2",
+        busy_message="fake session busy",
+        warmup_label="Fake Warmup",
+        runtime_error_types=(FakeRuntimeError,),
+        close_session_on_generation_error=True,
+        supported_keys=frozenset({"w"}),
+        peek_pending_session_input=lambda: pending_inputs[0],
+        clear_pending_session_input=clear_pending,
+        reset_runtime_for_session=reset_runtime,
+        chunk_done_extra=lambda runtime, runtime_config: {
+            "runtime": runtime.marker,
+            "width": runtime_config.video_width,
+        },
+        register_extra_peer_handlers=peer_hooks.append,
+        on_offer_received=offers.append,
+        on_answer_created=answers.append,
+    )
+    adapter = _FakeDemoAdapter(manager_options=manager_options)
+    spec = DemoSpec(
+        model_id="fake-demo",
+        scenario="valid-scenario",
+        input_mode="keyboard-driving",
+        output=WebRTCOutputSpec(
+            fps=24,
+            video_width=16,
+            video_height=8,
+            warmup_chunks=0,
+            warmup_timeout_s=1.0,
+        ),
+    )
+
+    demo = build_webrtc_demo(spec=spec, adapter=adapter)
+    manager = demo.session_manager
+
+    assert isinstance(manager, SharedDemoWebRTCSessionManager)
+    assert manager._model_name() == "fake-model-v2"
+    assert manager._busy_message == "fake session busy"
+    assert manager._warmup_label == "Fake Warmup"
+    assert manager._runtime_error_types == (FakeRuntimeError,)
+    assert manager._close_session_on_generation_error is True
+    assert manager._peek_pending_session_input() is pending_inputs[0]
+    manager._clear_pending_session_input()
+    assert clear_calls == 1
+    await manager._reset_runtime_for_session(pending_inputs[0])
+    assert reset_calls == [(demo.runtime, pending_inputs[0])]
+    assert manager._chunk_done_extra() == {"runtime": "fake-webrtc", "width": 16}
+
+    peer = object()
+    manager._register_extra_peer_handlers(peer)
+    manager._on_offer_received("offer-sdp")
+    manager._on_answer_created("answer-sdp")
+    assert peer_hooks == [peer]
+    assert offers == ["offer-sdp"]
+    assert answers == ["answer-sdp"]
+
+    resampler = manager._make_resampler(start_v=1.0)
+    resampler.on_edge(arrival_t=0.5, event="keydown", key="q")
+    segments, _ = resampler.sample_chunk(num_frames=1)
+    assert segments[0][2] == frozenset()
+
+    resampler = manager._make_resampler(start_v=1.0)
+    resampler.on_edge(arrival_t=0.5, event="keydown", key="w")
+    segments, _ = resampler.sample_chunk(num_frames=1)
+    assert segments[0][2] == frozenset({"w"})
+
+
+def test_webrtc_app_extension_rejects_ambiguous_static_sources(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="either web_resource or web_dir"):
+        WebRTCAppExtension(web_resource=object(), web_dir=tmp_path)
+
+
+def test_webrtc_app_extension_requires_static_source_before_serving() -> None:
+    adapter = _FakeDemoAdapter(
+        app_extension=WebRTCAppExtension(configure_app=lambda app: None)
+    )
+    spec = DemoSpec(
+        model_id="fake-demo",
+        scenario="valid-scenario",
+        input_mode="keyboard-driving",
+        output=WebRTCOutputSpec(
+            fps=24,
+            video_width=16,
+            video_height=8,
+            warmup_chunks=0,
+            warmup_timeout_s=1.0,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requires web_resource or web_dir"):
+        build_webrtc_demo(spec=spec, adapter=adapter, create_app=True)
+
+
 class _ChunkIndexMapping:
     mapping_schema = InputMappingSchema(
         name="chunk-index",
@@ -278,11 +441,15 @@ class _FakeDemoAdapter:
         video_output: bool = False,
         input_modes: tuple[str, ...] = ("replay", "keyboard-driving"),
         output_modes: tuple[str, ...] = ("null", "mp4", "webrtc"),
+        manager_options: WebRTCManagerOptions | None = None,
+        app_extension: WebRTCAppExtension | None = None,
     ) -> None:
         self._scenario_valid = scenario_valid
         self._video_output = video_output
         self._input_modes = input_modes
         self._output_modes = output_modes
+        self._manager_options = manager_options
+        self._app_extension = app_extension
         self.mapping = _ChunkIndexMapping()
         self.prepared_scenario = PreparedScenario(
             initial_inputs=InferenceInput(
@@ -298,6 +465,8 @@ class _FakeDemoAdapter:
         self.runtime: _FakeRuntime | None = None
         self.webrtc_runtime: _FakeWebRTCRuntime | None = None
         self.create_webrtc_runtime_calls: list[DemoSpec] = []
+        self.create_webrtc_manager_options_calls: list[dict[str, Any]] = []
+        self.create_webrtc_app_extension_calls: list[dict[str, Any]] = []
 
     def supported_input_modes(self) -> tuple[str, ...]:
         return self._input_modes
@@ -331,6 +500,38 @@ class _FakeDemoAdapter:
         self.create_webrtc_runtime_calls.append(spec)
         self.webrtc_runtime = _FakeWebRTCRuntime()
         return self.webrtc_runtime
+
+    def create_webrtc_manager_options(
+        self,
+        *,
+        spec: DemoSpec,
+        runtime: "_FakeWebRTCRuntime",
+        runtime_config: Any,
+    ) -> WebRTCManagerOptions:
+        self.create_webrtc_manager_options_calls.append(
+            {
+                "spec": spec,
+                "runtime": runtime,
+                "runtime_config": runtime_config,
+            }
+        )
+        return self._manager_options or WebRTCManagerOptions()
+
+    def create_webrtc_app_extension(
+        self,
+        *,
+        spec: DemoSpec,
+        session_manager: BaseWebRTCSessionManager[Any, Any],
+        request_session_url: str,
+    ) -> WebRTCAppExtension | None:
+        self.create_webrtc_app_extension_calls.append(
+            {
+                "spec": spec,
+                "session_manager": session_manager,
+                "request_session_url": request_session_url,
+            }
+        )
+        return self._app_extension
 
 
 class _FakeRuntime:
@@ -427,6 +628,8 @@ class _RecordingOutputTarget:
 
 
 class _FakeWebRTCRuntime:
+    marker = "fake-webrtc"
+
     async def initialize(self) -> None:
         return None
 

--- a/flashdreams/tests/test_runtime_demo_api.py
+++ b/flashdreams/tests/test_runtime_demo_api.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 from importlib.resources import files
 from pathlib import Path
@@ -11,6 +12,7 @@ from typing import Any
 import pytest
 import torch
 from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 
 from flashdreams.infra.video_output import VideoStepResult
 from flashdreams.runtime import (
@@ -46,15 +48,31 @@ from flashdreams.runtime.demo import (
     run_replay_demo,
 )
 from flashdreams.runtime.demo.webrtc import (
+    PendingSessionInputState,
     SharedDemoWebRTCSessionManager,
     WebRTCAppExtension,
     WebRTCManagerOptions,
+    WebRTCRoute,
     build_webrtc_demo,
+    json_get_route,
+    session_input_route,
 )
 from flashdreams.serving.webrtc.manager import BaseWebRTCSessionManager
-from flashdreams.serving.webrtc.server import PACKAGE_RESOURCE_STACK_KEY
+from flashdreams.serving.webrtc.server import (
+    PACKAGE_RESOURCE_STACK_KEY,
+    SessionBusyError,
+)
 
 pytestmark = pytest.mark.ci_cpu
+
+
+def _json_response_payload(response: web.StreamResponse) -> dict[str, Any]:
+    assert isinstance(response, web.Response)
+    text = response.text
+    assert text is not None
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    return payload
 
 
 def test_replay_demo_uses_shared_runner() -> None:
@@ -233,16 +251,15 @@ def test_webrtc_demo_uses_existing_session_manager_with_adapter_runtime() -> Non
 
 
 def test_webrtc_demo_builds_app_from_extension_routes() -> None:
-    async def fake_route(_: web.Request) -> web.StreamResponse:
-        return web.json_response({"ok": True})
-
-    def configure_app(app: web.Application) -> None:
-        app.router.add_get("/api/fake/model-info", fake_route)
-
     app_extension = WebRTCAppExtension(
         web_resource=files("flashdreams.runtime.demo"),
         preload_name="Fake WebRTC",
-        configure_app=configure_app,
+        routes=(
+            json_get_route(
+                "/api/fake/model-info",
+                lambda manager: {"model": manager._model_name()},
+            ),
+        ),
     )
     adapter = _FakeDemoAdapter(app_extension=app_extension)
     spec = DemoSpec(
@@ -272,6 +289,41 @@ def test_webrtc_demo_builds_app_from_extension_routes() -> None:
             "request_session_url": "http://127.0.0.1:8082/request_session",
         }
     ]
+    demo.app[PACKAGE_RESOURCE_STACK_KEY].close()
+
+
+def test_webrtc_demo_app_extension_keeps_configure_app_callback() -> None:
+    async def fake_route(_: web.Request) -> web.StreamResponse:
+        return web.json_response({"ok": True})
+
+    def configure_app(app: web.Application) -> None:
+        app.router.add_get("/api/fake/configured", fake_route)
+
+    app_extension = WebRTCAppExtension(
+        web_resource=files("flashdreams.runtime.demo"),
+        configure_app=configure_app,
+    )
+    adapter = _FakeDemoAdapter(app_extension=app_extension)
+    spec = DemoSpec(
+        model_id="fake-demo",
+        scenario="valid-scenario",
+        input_mode="keyboard-driving",
+        output=WebRTCOutputSpec(
+            host="0.0.0.0",
+            port=8082,
+            fps=24,
+            video_width=16,
+            video_height=8,
+            warmup_chunks=0,
+            warmup_timeout_s=1.0,
+        ),
+    )
+
+    demo = build_webrtc_demo(spec=spec, adapter=adapter, create_app=True)
+
+    assert demo.app is not None
+    route_paths = {resource.canonical for resource in demo.app.router.resources()}
+    assert "/api/fake/configured" in route_paths
     demo.app[PACKAGE_RESOURCE_STACK_KEY].close()
 
 
@@ -359,6 +411,127 @@ async def test_webrtc_demo_manager_options_configure_shared_manager() -> None:
     resampler.on_edge(arrival_t=0.5, event="keydown", key="w")
     segments, _ = resampler.sample_chunk(num_frames=1)
     assert segments[0][2] == frozenset({"w"})
+
+
+@pytest.mark.asyncio
+async def test_json_get_route_builds_payload_from_shared_manager() -> None:
+    class _Manager:
+        def _model_name(self) -> str:
+            return "fake-demo"
+
+    route = json_get_route(
+        "/api/fake/model-info",
+        lambda manager: {"model": manager._model_name()},
+    )
+    request = make_mocked_request("GET", "/api/fake/model-info")
+
+    response = await route.handler(request, _Manager())
+
+    assert _json_response_payload(response) == {"model": "fake-demo"}
+
+
+def test_webrtc_route_normalizes_method_and_requires_absolute_path() -> None:
+    route = WebRTCRoute(
+        method=" get ",
+        path="/api/fake",
+        handler=lambda _request, _manager: web.json_response({}),
+    )
+
+    assert route.method == "GET"
+    assert route.path == "/api/fake"
+
+    with pytest.raises(ValueError, match="path must start"):
+        WebRTCRoute(
+            method="GET",
+            path="api/fake",
+            handler=lambda _request, _manager: web.json_response({}),
+        )
+
+
+def test_pending_session_input_state_stores_valid_input_and_rejects_busy() -> None:
+    class _Manager:
+        active = False
+
+        def has_active_session(self) -> bool:
+            return self.active
+
+    validated: list[str] = []
+    manager = _Manager()
+    state = PendingSessionInputState(
+        busy_message="fake session busy",
+        input_type=str,
+        validate_input=validated.append,
+    )
+
+    state.set(manager, "accepted")
+
+    assert state.peek() == "accepted"
+    assert validated == ["accepted"]
+    state.clear()
+    assert state.peek() is None
+
+    with pytest.raises(TypeError, match="Expected str"):
+        state.set(manager, object())
+
+    manager.active = True
+    with pytest.raises(SessionBusyError, match="fake session busy"):
+        state.set(manager, "next")
+
+
+@pytest.mark.asyncio
+async def test_session_input_route_applies_pending_input_and_maps_errors() -> None:
+    class _Manager:
+        active = False
+
+        def __init__(self) -> None:
+            self.state = PendingSessionInputState(
+                busy_message="fake session busy",
+                input_type=str,
+                validate_input=self._validate,
+            )
+
+        def has_active_session(self) -> bool:
+            return self.active
+
+        def set_pending_session_input(self, session_input: str) -> None:
+            self.state.set(self, session_input)
+
+        def _validate(self, session_input: str) -> None:
+            if session_input == "invalid":
+                raise ValueError("invalid input")
+
+    manager = _Manager()
+    request = make_mocked_request("POST", "/api/fake/session/input")
+    route = session_input_route(
+        "/api/fake/session/input",
+        parse_input=lambda _request, _manager: "accepted",
+        build_response=lambda session_input, _manager: {
+            "accepted": session_input,
+        },
+    )
+
+    response = await route.handler(request, manager)
+
+    assert _json_response_payload(response) == {"accepted": "accepted"}
+    assert manager.state.peek() == "accepted"
+
+    invalid_route = session_input_route(
+        "/api/fake/session/input",
+        parse_input=lambda _request, _manager: "invalid",
+    )
+    with pytest.raises(web.HTTPBadRequest, match="invalid input"):
+        await invalid_route.handler(request, manager)
+
+    wrong_type_route = session_input_route(
+        "/api/fake/session/input",
+        parse_input=lambda _request, _manager: object(),
+    )
+    with pytest.raises(web.HTTPBadRequest, match="Expected str"):
+        await wrong_type_route.handler(request, manager)
+
+    manager.active = True
+    with pytest.raises(web.HTTPConflict, match="fake session busy"):
+        await route.handler(request, manager)
 
 
 def test_webrtc_app_extension_rejects_ambiguous_static_sources(tmp_path: Path) -> None:

--- a/integrations/lingbot/lingbot/demo/adapter.py
+++ b/integrations/lingbot/lingbot/demo/adapter.py
@@ -22,16 +22,16 @@ from flashdreams.runtime.demo import (
     WebRTCOutputSpec,
 )
 from flashdreams.runtime.interfaces import InferenceRuntime
+from lingbot.input_mapping import (
+    KeyboardToCameraCommand,
+    TextEventSelection,
+)
 from lingbot.runtime import (
     LingbotModelAdapter,
     LingbotReplayRuntime,
     PipelineFactory,
     build_lingbot_webrtc_runtime_config,
     inference_input_from_replay_inputs,
-)
-from lingbot.input_mapping import (
-    KeyboardToCameraCommand,
-    TextEventSelection,
 )
 from lingbot.webrtc.session import (
     LingbotInferenceRuntime,

--- a/integrations/lingbot/lingbot/demo/spec.py
+++ b/integrations/lingbot/lingbot/demo/spec.py
@@ -101,8 +101,7 @@ def resolve_user_input_events(value: Any) -> UserInputs:
             continue
         if not isinstance(record, Mapping):
             raise TypeError(
-                "Lingbot scenario events must be UserInputEvent objects or "
-                "mappings."
+                "Lingbot scenario events must be UserInputEvent objects or mappings."
             )
         payload = {
             key: item
@@ -113,8 +112,7 @@ def resolve_user_input_events(value: Any) -> UserInputs:
         event_type = record.get("type", record.get("event_type"))
         if timestamp_s is None or event_type is None:
             raise ValueError(
-                "Lingbot scenario events require a timestamp ('t') and a "
-                "type ('type')."
+                "Lingbot scenario events require a timestamp ('t') and a type ('type')."
             )
         events.append(
             UserInputEvent(

--- a/integrations/lingbot/lingbot/input_mapping.py
+++ b/integrations/lingbot/lingbot/input_mapping.py
@@ -45,12 +45,12 @@ from flashdreams.runtime.inputs import (
 )
 from flashdreams.runtime.mapping import InputMappingSchema
 from flashdreams.runtime.types import StepRequest
+from flashdreams.serving.realtime.input import DEFAULT_SUPPORTED_KEYS
 from flashdreams.serving.webrtc.controls import (
     CameraPoseIntegrator,
     KeyboardState,
     PoseSegment,
 )
-from flashdreams.serving.realtime.input import DEFAULT_SUPPORTED_KEYS
 
 FIELD_CAMERA_TRAJECTORY = "camera_trajectory"
 FIELD_CAMERA_INTRINSICS = "camera_intrinsics"
@@ -333,9 +333,7 @@ def load_camera_trace(
     return LingbotCameraTrace(
         poses=torch.from_numpy(np.ascontiguousarray(poses)).to(torch.float32),
         intrinsics=intrinsics.to(torch.float32),
-        world_scale=float(
-            inferred_world_scale if world_scale is None else world_scale
-        ),
+        world_scale=float(inferred_world_scale if world_scale is None else world_scale),
     )
 
 
@@ -575,9 +573,11 @@ class LingbotInputMapping:
 
         window = request.user_input_window
         start_s = window.start_s if window is not None else frame_start / self._fps
-        end_s = window.end_s if window is not None else (
-            frame_start + num_frames
-        ) / self._fps
+        end_s = (
+            window.end_s
+            if window is not None
+            else (frame_start + num_frames) / self._fps
+        )
         segments = _pose_segments(command, start_s=start_s, end_s=end_s)
         frame_times = [start_s + (index + 1) / self._fps for index in range(num_frames)]
         # The integrator rejects frame times outside the segment span, and float

--- a/integrations/lingbot/lingbot/runner.py
+++ b/integrations/lingbot/lingbot/runner.py
@@ -61,6 +61,7 @@ land on the right pixel centers at the runner's actual frame size."""
 _INTRINSICS_REFERENCE_WIDTH = 832
 """Capture-resolution width matching :data:`_INTRINSICS_REFERENCE_HEIGHT`."""
 
+
 @dataclass(kw_only=True)
 class LingbotWorldRunnerConfig(RunnerConfig):
     """Runner config for every shipped LingBot-World variant."""

--- a/integrations/lingbot/lingbot/runtime.py
+++ b/integrations/lingbot/lingbot/runtime.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -78,6 +78,12 @@ FIELD_FPS = "fps"
 FIELD_WORLD_SCALE = "world_scale"
 
 PipelineFactory = Callable[[Any, str], Any]
+
+
+def _as_video_tensor_layout(value: object) -> VideoTensorLayout:
+    if value not in ("tchw", "btchw", "bcthw", "bvtchw"):
+        raise ValueError(f"Unsupported LingBot output layout: {value!r}.")
+    return cast(VideoTensorLayout, value)
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -310,7 +316,9 @@ class LingbotModelAdapter:
                 pipeline_config=self.pipeline_config(config),
                 pipeline=config.runtime_options.get("pipeline"),
                 pipeline_factory=self._pipeline_factory,
-                output_layout=str(config.runtime_options.get("output_layout", "tchw")),
+                output_layout=_as_video_tensor_layout(
+                    config.runtime_options.get("output_layout", "tchw")
+                ),
             ),
         )
 
@@ -938,7 +946,9 @@ def build_lingbot_webrtc_runtime_config(
     return _apply_webrtc_runtime_options(runtime_config, runtime_options or {})
 
 
-def _apply_webrtc_runtime_options(runtime_config: Any, options: Mapping[str, Any]) -> Any:
+def _apply_webrtc_runtime_options(
+    runtime_config: Any, options: Mapping[str, Any]
+) -> Any:
     overrides: dict[str, Any] = {}
     for name in (
         "world_scale",
@@ -992,15 +1002,19 @@ def _resolve_example_data_default(value: Mapping[str, Any]) -> bool:
     explicit = value.get("example_data")
     if explicit is not None:
         return _bool_value(explicit)
-    return not (
-        _has_nonempty_value(value, FIELD_FIRST_FRAME_PATH)
-        or _has_nonempty_value(value, "image_path")
-    ) or not (
-        _has_nonempty_value(value, FIELD_CAMERA_POSES_PATH)
-        or _has_nonempty_value(value, "pose_path")
-    ) or not (
-        _has_nonempty_value(value, FIELD_CAMERA_INTRINSICS_PATH)
-        or _has_nonempty_value(value, "intrinsic_path")
+    return (
+        not (
+            _has_nonempty_value(value, FIELD_FIRST_FRAME_PATH)
+            or _has_nonempty_value(value, "image_path")
+        )
+        or not (
+            _has_nonempty_value(value, FIELD_CAMERA_POSES_PATH)
+            or _has_nonempty_value(value, "pose_path")
+        )
+        or not (
+            _has_nonempty_value(value, FIELD_CAMERA_INTRINSICS_PATH)
+            or _has_nonempty_value(value, "intrinsic_path")
+        )
     )
 
 
@@ -1037,7 +1051,9 @@ def _require_path_value(value: Path | None, *, label: str) -> Path:
 
 def _require_existing_replay_paths(replay_inputs: LingbotReplayInputs) -> None:
     _require_existing_path(replay_inputs.first_frame_path, label=FIELD_FIRST_FRAME_PATH)
-    _require_existing_path(replay_inputs.camera_poses_path, label=FIELD_CAMERA_POSES_PATH)
+    _require_existing_path(
+        replay_inputs.camera_poses_path, label=FIELD_CAMERA_POSES_PATH
+    )
     _require_existing_path(
         replay_inputs.camera_intrinsics_path,
         label=FIELD_CAMERA_INTRINSICS_PATH,

--- a/integrations/lingbot/lingbot/webrtc/server.py
+++ b/integrations/lingbot/lingbot/webrtc/server.py
@@ -32,6 +32,7 @@ from loguru import logger
 from flashdreams.core.distributed import (
     init as distributed_init,
 )
+from flashdreams.runtime import InferenceConfig
 from flashdreams.serving.network import get_external_ip
 from flashdreams.serving.webrtc.bootstrap import (
     configure_logging,
@@ -48,7 +49,6 @@ from flashdreams.serving.webrtc.server import (
 from flashdreams.serving.webrtc.server import (
     close_package_resources as _close_package_resources,
 )
-from flashdreams.runtime import InferenceConfig
 from lingbot.example_data import (
     EXAMPLE_DATA_AVAILABLE_IDXS,
     ensure_example_data_downloaded,

--- a/integrations/lingbot/tests/test_demo_api.py
+++ b/integrations/lingbot/tests/test_demo_api.py
@@ -68,9 +68,7 @@ def _write_camera_assets(poses: Path, intrinsics: Path, *, frames: int = 64) -> 
     np.save(poses, trajectory)
     np.save(
         intrinsics,
-        np.tile(
-            np.array([416.0, 416.0, 416.0, 240.0], dtype=np.float32), (frames, 1)
-        ),
+        np.tile(np.array([416.0, 416.0, 416.0, 240.0], dtype=np.float32), (frames, 1)),
     )
 
 
@@ -100,9 +98,7 @@ def test_lingbot_demo_adapter_declares_mp4_and_webrtc_modes() -> None:
         FIELD_FPS,
     }.issubset(fields)
     # Camera control is per-step model input, not session-global scenario data.
-    step_fields = {
-        field.name for field in adapter.inference_input_schema.step_fields
-    }
+    step_fields = {field.name for field in adapter.inference_input_schema.step_fields}
     assert step_fields == {FIELD_CAMERA_TRAJECTORY, FIELD_CAMERA_INTRINSICS}
 
 
@@ -208,9 +204,7 @@ def test_lingbot_replay_cli_defaults_to_example_data(
     example_dir = tmp_path / "example"
     example_dir.mkdir()
     (example_dir / "image.jpg").write_bytes(b"fake")
-    _write_camera_assets(
-        example_dir / "poses.npy", example_dir / "intrinsics.npy"
-    )
+    _write_camera_assets(example_dir / "poses.npy", example_dir / "intrinsics.npy")
     (example_dir / "prompt.txt").write_text("drive through a forest\n")
     downloaded: list[int] = []
 

--- a/integrations/lingbot/tests/test_input_mapping.py
+++ b/integrations/lingbot/tests/test_input_mapping.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 import pytest
@@ -22,6 +23,7 @@ from lingbot.input_mapping import (
 
 from flashdreams.runtime import (
     CanonicalInputs,
+    DeclaresMappingSchema,
     InferenceInput,
     InputCanonicalizer,
     StepRequest,
@@ -36,9 +38,7 @@ pytestmark = pytest.mark.ci_cpu
 
 _KEYBOARD_SOURCE = UserInputSchema(
     capabilities=(
-        UserInputCapability(
-            event_type="key_down", payload_fields=frozenset({"key"})
-        ),
+        UserInputCapability(event_type="key_down", payload_fields=frozenset({"key"})),
         UserInputCapability(event_type="key_up", payload_fields=frozenset({"key"})),
         UserInputCapability(
             event_type="text_event", payload_fields=frozenset({"event_id"})
@@ -71,7 +71,9 @@ def test_keyboard_events_become_camera_command_axes() -> None:
     converter = KeyboardToCameraCommand()
     inputs = UserInputs(
         events=(
-            UserInputEvent(timestamp_s=0.0, event_type="key_down", payload={"key": "w"}),
+            UserInputEvent(
+                timestamp_s=0.0, event_type="key_down", payload={"key": "w"}
+            ),
         )
     )
     window = TimeWindow(start_s=0.0, end_s=1.0)
@@ -93,7 +95,9 @@ def test_camera_command_segments_preserve_sub_window_timing() -> None:
     window = TimeWindow(start_s=0.0, end_s=1.0)
     inputs = UserInputs(
         events=(
-            UserInputEvent(timestamp_s=0.5, event_type="key_down", payload={"key": "w"}),
+            UserInputEvent(
+                timestamp_s=0.5, event_type="key_down", payload={"key": "w"}
+            ),
         )
     )
 
@@ -111,7 +115,9 @@ def test_key_events_drive_a_camera_trajectory() -> None:
     mapping = _live_mapping()
     user_inputs = UserInputs(
         events=(
-            UserInputEvent(timestamp_s=0.0, event_type="key_down", payload={"key": "w"}),
+            UserInputEvent(
+                timestamp_s=0.0, event_type="key_down", payload={"key": "w"}
+            ),
         )
     )
     request = _step_request(step_index=0, frame_start=0, num_frames=4)
@@ -423,7 +429,8 @@ def test_event_driven_scenario_builds_a_live_mapping(tmp_path: Path) -> None:
     prepared = LingbotDemoAdapter().prepare_scenario(spec)
 
     assert prepared.mapping is not None
-    assert prepared.mapping.mapping_schema.consumes == (CAMERA_COMMAND, TEXT_EVENT)
+    mapping = cast(DeclaresMappingSchema, prepared.mapping)
+    assert mapping.mapping_schema.consumes == (CAMERA_COMMAND, TEXT_EVENT)
     assert len(prepared.user_inputs.events) == 2
     # The declared source must actually cover the trace it carries, or the
     # canonicalizer silently drops the keyboard converter.

--- a/integrations/lingbot/tests/test_runtime_gpu.py
+++ b/integrations/lingbot/tests/test_runtime_gpu.py
@@ -217,9 +217,7 @@ def test_event_driven_camera_control_on_cuda(
             UserInputCapability(
                 event_type="key_down", payload_fields=frozenset({"key"})
             ),
-            UserInputCapability(
-                event_type="key_up", payload_fields=frozenset({"key"})
-            ),
+            UserInputCapability(event_type="key_up", payload_fields=frozenset({"key"})),
         )
     )
     user_inputs = UserInputs(

--- a/integrations/lingbot/tests/test_runtime_session_inputs.py
+++ b/integrations/lingbot/tests/test_runtime_session_inputs.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import lingbot.runtime as runtime_module
 import pytest
 import torch
-import lingbot.runtime as runtime_module
 from lingbot.input_mapping import FIELD_CAMERA_INTRINSICS, FIELD_CAMERA_TRAJECTORY
 from lingbot.runtime import (
     LINGBOT_MODEL_ID,
@@ -267,7 +267,9 @@ def test_text_event_prompt_update_swaps_the_rollout_context(
     )
 
     assert pipeline.text_encoder_calls == [["a violent storm"]]
-    assert len(pipeline.diffusion_model.transformer.replaced) == 1
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, _FakeTransformer)
+    assert len(transformer.replaced) == 1
 
     # Re-sending the same prompt must not re-encode or re-swap.
     session.step(

--- a/integrations/lingbot/tests/test_smoke.py
+++ b/integrations/lingbot/tests/test_smoke.py
@@ -57,6 +57,7 @@ from lingbot.transformer import (
 
 from flashdreams.infra.config import derive_config
 from flashdreams.infra.runner import RunnerConfig
+from flashdreams.runtime import InferenceConfig, InferenceInput
 
 pytestmark = pytest.mark.ci_cpu
 
@@ -68,10 +69,9 @@ def _write_camera_assets(poses: Path, intrinsics: Path, *, frames: int = 64) -> 
     np.save(poses, trajectory)
     np.save(
         intrinsics,
-        np.tile(
-            np.array([416.0, 416.0, 416.0, 240.0], dtype=np.float32), (frames, 1)
-        ),
+        np.tile(np.array([416.0, 416.0, 416.0, 240.0], dtype=np.float32), (frames, 1)),
     )
+
 
 ENTRY_POINT_GROUP = "flashdreams.runner_configs"
 
@@ -235,11 +235,11 @@ def test_runner_delegates_to_runtime_api_with_direct_inputs(
     runner.run()
 
     assert isinstance(captured["adapter"], LingbotModelAdapter)
-    config = captured["config"]
-    assert getattr(config, "model_id") == LINGBOT_MODEL_ID
-    assert getattr(config, "device") == "cpu"
+    config = cast(InferenceConfig, captured["config"])
+    assert config.model_id == LINGBOT_MODEL_ID
+    assert config.device == "cpu"
     assert config.runtime_options["pipeline"] is pipeline
-    inputs = captured["initial_inputs"].global_conditioning
+    inputs = cast(InferenceInput, captured["initial_inputs"]).global_conditioning
     assert inputs[FIELD_PROMPT] == "drive through a city"
     assert inputs[FIELD_FIRST_FRAME_PATH] == image
     assert inputs[FIELD_TOTAL_BLOCKS] == 1

--- a/integrations/omnidreams/omnidreams/demo/README.md
+++ b/integrations/omnidreams/omnidreams/demo/README.md
@@ -50,9 +50,9 @@ compile/cache behavior is reliable enough for the demo path.
 
 ## WebRTC
 
-WebRTC uses the shared demo launcher around the existing Omnidreams live WebRTC
-runtime. It is still scene-driven and uses Ludus to render HDMap conditioning
-from a scene:
+WebRTC uses the shared demo launcher and shared WebRTC session manager around
+the OmniDreams demo-owned live runtime. It is still scene-driven and uses Ludus
+to render HDMap conditioning from a scene:
 
 ```bash
 uv run --package flashdreams-omnidreams omnidreams-demo webrtc \

--- a/integrations/omnidreams/omnidreams/demo/__init__.py
+++ b/integrations/omnidreams/omnidreams/demo/__init__.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Experimental OmniDreams demo adapter built on ``flashdreams.runtime.demo``."""
+"""Experimental OmniDreams demo package built on ``flashdreams.runtime.demo``.
+
+This package is the new shared-demo entrypoint; legacy OmniDreams demo and
+WebRTC server modules remain separate until the cleanup phase.
+"""
 
 from omnidreams.demo.adapter import OmnidreamsDemoAdapter
 from omnidreams.demo.spec import (

--- a/integrations/omnidreams/omnidreams/demo/adapter.py
+++ b/integrations/omnidreams/omnidreams/demo/adapter.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""OmniDreams adapter for the shared demo API."""
+"""OmniDreams model adapter for the shared demo API.
+
+This file binds OmniDreams-specific scenario/config/runtime construction to the
+shared replay and WebRTC launchers without owning the demo loops themselves.
+"""
 
 from __future__ import annotations
 

--- a/integrations/omnidreams/omnidreams/demo/adapter.py
+++ b/integrations/omnidreams/omnidreams/demo/adapter.py
@@ -10,10 +10,6 @@ from dataclasses import replace
 from typing import Any
 
 from omnidreams.config import OMNIDREAMS_CONFIGS, OMNIDREAMS_RUNNERS
-from omnidreams.webrtc.session import (
-    OmnidreamsInferenceRuntime,
-    OmnidreamsRuntimeConfig,
-)
 
 from flashdreams.infra.postprocess import VideoPostprocessChainConfig
 from flashdreams.runtime import (
@@ -41,6 +37,7 @@ from .replay import (
     OmnidreamsReplayRuntimeOptions,
     PipelineFactory,
 )
+from .live_runtime import OmnidreamsInferenceRuntime, OmnidreamsRuntimeConfig
 from .spec import (
     DEFAULT_OMNIDREAMS_PRESET,
     OMNIDREAMS_MODEL_ID,

--- a/integrations/omnidreams/omnidreams/demo/adapter.py
+++ b/integrations/omnidreams/omnidreams/demo/adapter.py
@@ -30,6 +30,8 @@ from flashdreams.runtime.demo import (
     DemoSpec,
     Mp4OutputSpec,
     PreparedScenario,
+    WebRTCAppExtension,
+    WebRTCManagerOptions,
     WebRTCOutputSpec,
 )
 from flashdreams.runtime.interfaces import InferenceRuntime
@@ -46,8 +48,8 @@ from .spec import (
     resolve_webrtc_scenario,
 )
 from .webrtc import (
-    OmnidreamsDemoWebRTCSessionManager,
-    create_omnidreams_webrtc_app,
+    create_omnidreams_webrtc_app_extension,
+    create_omnidreams_webrtc_manager_options,
     validate_postprocess_preset,
 )
 
@@ -194,31 +196,26 @@ class OmnidreamsDemoAdapter:
         )
         return _apply_webrtc_runtime_options(runtime_config, config.runtime_options)
 
-    def create_webrtc_session_manager(
+    def create_webrtc_manager_options(
         self,
         *,
         spec: DemoSpec,
         runtime: Any,
         runtime_config: OmnidreamsRuntimeConfig,
-        fps: int,
-        client_liveness_timeout_s: float,
-    ) -> OmnidreamsDemoWebRTCSessionManager:
-        del spec
-        return OmnidreamsDemoWebRTCSessionManager(
-            runtime=runtime,
+    ) -> WebRTCManagerOptions:
+        del spec, runtime
+        return create_omnidreams_webrtc_manager_options(
             runtime_config=runtime_config,
-            fps=fps,
-            client_liveness_timeout_s=client_liveness_timeout_s,
         )
 
-    def create_webrtc_app(
+    def create_webrtc_app_extension(
         self,
         *,
         spec: DemoSpec,
         session_manager: Any,
         request_session_url: str,
-    ) -> Any:
-        return create_omnidreams_webrtc_app(
+    ) -> WebRTCAppExtension:
+        return create_omnidreams_webrtc_app_extension(
             spec=spec,
             session_manager=session_manager,
             request_session_url=request_session_url,

--- a/integrations/omnidreams/omnidreams/demo/cli.py
+++ b/integrations/omnidreams/omnidreams/demo/cli.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""CLI for the experimental shared OmniDreams demo path."""
+"""CLI for the experimental shared OmniDreams demo path.
+
+This file turns command-line arguments into ``DemoSpec`` objects and then
+delegates execution to the shared replay or WebRTC demo launcher.
+"""
 
 from __future__ import annotations
 

--- a/integrations/omnidreams/omnidreams/demo/live_runtime.py
+++ b/integrations/omnidreams/omnidreams/demo/live_runtime.py
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""OmniDreams live generation runtime used by the new shared WebRTC demo.
+
+This file owns model-specific scene loading, Ludus conditioning, rollout reset,
+chunk generation, postprocessing, and encoder selection; shared WebRTC serving
+and session lifecycle live in ``flashdreams.runtime.demo.webrtc``.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/integrations/omnidreams/omnidreams/demo/live_runtime.py
+++ b/integrations/omnidreams/omnidreams/demo/live_runtime.py
@@ -1,0 +1,1097 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import tempfile
+import time
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import AbstractSet, Any, Callable, TypeVar
+
+import cv2
+import numpy as np
+import torch
+import torch.distributed as dist
+from filelock import FileLock
+from loguru import logger
+from omnidreams.conditioning.conditioning_wrapper import (
+    AV_POSITIVE_PROMPT,
+    OmnidreamsConditioningState,
+    OmnidreamsConditioningWrapper,
+    TextPrompt,
+)
+from omnidreams.conditioning.renderer import load_and_attach_ludus_scene
+from omnidreams.conditioning.world_scenario.data_loaders import load_scene
+from omnidreams.conditioning.world_scenario.settings import SETTINGS
+from omnidreams.config import OMNIDREAMS_CONFIGS
+from omnidreams.scenes import (
+    HF_DATASET_BROWSER_URL,
+    SCENE_CLIPGT_DIRNAME,
+    SCENE_FRAME_SUFFIXES,
+    SCENE_FRAMES_DIRNAME,
+    SCENE_IMAGE_SUFFIXES,
+    SCENE_PROMPT_FILENAME,
+    SCENE_VARIANT_DEFAULT,
+    hf_hub_download_scene,
+    hf_scenes_repo_id,
+    prompt_variant_for_scene_variant,
+    scenes_cache_root,
+)
+from omnidreams.transformer import CosmosTransformerConfig
+
+from flashdreams.core.distributed.rank_orchestration import (
+    RankCoordinator,
+    distributed_op,
+)
+from flashdreams.infra.postprocess import (
+    VideoPostprocessChainConfig,
+    VideoPostprocessStream,
+)
+from flashdreams.plugins.registry import resolve_postprocess_preset
+from flashdreams.serving.webrtc.controls import (
+    CameraPoseIntegrator,
+    PoseSegment,
+)
+from flashdreams.serving.webrtc.encoders import (
+    EncoderBackend,
+    VideoEncoder,
+    select_encoder,
+)
+from flashdreams.serving.webrtc.manager import (
+    WebRTCControlSignal,
+    WebRTCStepResult,
+    make_webrtc_step_result,
+)
+
+_T = TypeVar("_T")
+# Default scene (clear-weather base archive). Weather siblings are selected
+# via OmnidreamsRuntimeConfig.scene_variant / the server's --scene-variant.
+DEFAULT_WEBRTC_SCENE_UUID = "0d404ff7-2b66-498c-b047-1ed8cded60d4"
+# Back-compat aliases for ``omnidreams.scenes`` constants used by external imports.
+WEBRTC_SCENES_HF_BROWSER_URL = HF_DATASET_BROWSER_URL
+WEBRTC_SCENE_IMAGE_SUFFIXES = SCENE_IMAGE_SUFFIXES
+
+
+def _resolve_cuda_device(device_spec: str | torch.device) -> torch.device:
+    """Resolve a device spec, filling in the active CUDA index when unspecified."""
+    device = torch.device(device_spec)
+    if device.type == "cuda" and device.index is None:
+        device = torch.device(
+            f"cuda:{torch.cuda.current_device()}"
+            if torch.cuda.is_available()
+            else "cuda:0"
+        )
+    return device
+
+
+def _choose_existing_asset(
+    directory: Path,
+    *,
+    exact_name: str | None = None,
+    fallback_stems: tuple[str, ...] = (),
+    fallback_prefixes: tuple[str, ...] = (),
+    allowed_suffixes: AbstractSet[str] | None = None,
+    preferred_stems: tuple[str, ...] = (),
+) -> Path | None:
+    if not directory.is_dir():
+        return None
+
+    if exact_name is not None:
+        exact_path = directory / exact_name
+        if exact_path.is_file() and (
+            allowed_suffixes is None or exact_path.suffix.lower() in allowed_suffixes
+        ):
+            return exact_path
+
+    candidates = []
+    for path in directory.iterdir():
+        if not path.is_file():
+            continue
+        if allowed_suffixes is not None and path.suffix.lower() not in allowed_suffixes:
+            continue
+        if (
+            path.stem in preferred_stems
+            or path.stem in fallback_stems
+            or any(path.stem.startswith(f"{prefix}-") for prefix in fallback_prefixes)
+        ):
+            candidates.append(path)
+
+    if not candidates:
+        return None
+
+    preferred_order = {stem: index for index, stem in enumerate(preferred_stems)}
+    return sorted(
+        candidates,
+        key=lambda path: (
+            preferred_order.get(path.stem, len(preferred_order)),
+            path.name,
+        ),
+    )[0]
+
+
+def _camera_name_candidates(camera_name: str) -> tuple[str, ...]:
+    """Colon/underscore spellings of ``camera_name`` (dataset uses underscores)."""
+    underscore = camera_name.replace(":", "_")
+    colon = camera_name.replace("_", ":")
+    return tuple(dict.fromkeys((camera_name, underscore, colon)))
+
+
+def _first_frame_sort_key(path: Path) -> tuple[int, str]:
+    stem = path.stem
+    return (int(stem), path.name) if stem.isdigit() else (2**63 - 1, path.name)
+
+
+def _resolve_webrtc_first_frame(clipgt_dir: Path, camera_name: str) -> Path | None:
+    """Earliest GT frame under ``clipgt/frames/<camera>/``, else ``None``.
+
+    ``None`` when the bundle ships no such frames, so the caller can fall back
+    to ``first_image.*``.
+    """
+    frames_root = clipgt_dir / SCENE_FRAMES_DIRNAME
+    if not frames_root.is_dir():
+        return None
+    candidate_dirs = [
+        frames_root / name
+        for name in _camera_name_candidates(camera_name)
+        if (frames_root / name).is_dir()
+    ]
+    if not candidate_dirs:
+        # Fall back to any single camera directory present.
+        candidate_dirs = [
+            path for path in sorted(frames_root.iterdir()) if path.is_dir()
+        ]
+    for directory in candidate_dirs:
+        frames = [
+            path
+            for path in directory.iterdir()
+            if path.is_file() and path.suffix.lower() in SCENE_FRAME_SUFFIXES
+        ]
+        if frames:
+            return sorted(frames, key=_first_frame_sort_key)[0]
+    return None
+
+
+def _resolve_webrtc_scene_assets(
+    scene_dir: Path,
+    *,
+    prompt_filename: str,
+    clipgt_dirname: str,
+    camera_name: str = "camera_front_wide_120fov",
+    variant: str = SCENE_VARIANT_DEFAULT,
+) -> tuple[Path, Path, Path]:
+    missing_assets = []
+    clipgt_dir = scene_dir / clipgt_dirname
+    if not clipgt_dir.is_dir():
+        missing_assets.append(str(scene_dir / clipgt_dirname))
+        clipgt_dir = None
+
+    # Prefer the GT camera frame; fall back to ``first_image.*`` for bundles
+    # with no per-camera frames.
+    first_frame_path = (
+        None
+        if clipgt_dir is None
+        else _resolve_webrtc_first_frame(clipgt_dir, camera_name)
+    )
+    if first_frame_path is None and clipgt_dir is not None:
+        first_frame_path = _choose_existing_asset(
+            clipgt_dir,
+            fallback_stems=("first_image_1",),
+            allowed_suffixes=WEBRTC_SCENE_IMAGE_SUFFIXES,
+            preferred_stems=("first_image",),
+        )
+    if first_frame_path is None:
+        missing_assets.append(
+            f"frames/<camera>/*.jpeg or first_image.* under {clipgt_dir}/"
+        )
+
+    # Prompt matching the weather variant (``promptN.txt``); fall back to a
+    # bare ``prompt.txt`` for older bundles.
+    weather_prompt_stem = f"prompt{prompt_variant_for_scene_variant(variant)}"
+    prompt_path = (
+        None
+        if clipgt_dir is None
+        else _choose_existing_asset(
+            clipgt_dir,
+            fallback_stems=("prompt1", "prompt2", "prompt3", "prompt"),
+            allowed_suffixes={".txt"},
+            preferred_stems=(weather_prompt_stem, "prompt"),
+        )
+    )
+    if prompt_path is None:
+        missing_assets.append(f"{prompt_filename} under {clipgt_dir}/")
+
+    if missing_assets:
+        raise FileNotFoundError(
+            "Missing Omnidreams WebRTC scene assets: " + ", ".join(missing_assets)
+        )
+
+    assert clipgt_dir is not None
+    assert first_frame_path is not None
+    assert prompt_path is not None
+    return clipgt_dir, first_frame_path, prompt_path
+
+
+def _safe_extract_zip(source: Path, destination: Path) -> None:
+    if destination.exists():
+        if destination.is_file() or destination.is_symlink():
+            destination.unlink()
+        else:
+            shutil.rmtree(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+    destination_root = destination.resolve()
+    with zipfile.ZipFile(source) as zf:
+        for member in zf.infolist():
+            member_path = PurePosixPath(member.filename)
+            if (
+                member_path.is_absolute()
+                or not member_path.parts
+                or any(part in {"", ".", ".."} for part in member_path.parts)
+            ):
+                raise ValueError(
+                    f"Unsafe archive member in {source}: {member.filename}"
+                )
+            target = destination / Path(*member_path.parts)
+            target_resolved = target.resolve()
+            if destination_root != target_resolved and destination_root not in (
+                target_resolved.parents
+            ):
+                raise ValueError(
+                    f"Archive member escapes destination: {member.filename}"
+                )
+            if member.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(member) as src, target.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+
+
+def _variant_dir_suffix(variant: str | None) -> str:
+    """Cache subdir / filename suffix for ``variant`` (``""`` for default)."""
+    slug = (variant or SCENE_VARIANT_DEFAULT).strip()
+    return "" if slug in ("", SCENE_VARIANT_DEFAULT) else f"-{slug}"
+
+
+def _extract_local_webrtc_scene_if_needed(
+    scene_dir: Path,
+    *,
+    scene_uuid: str | None,
+    variant: str = SCENE_VARIANT_DEFAULT,
+    clipgt_dirname: str,
+) -> Path:
+    """Extract the ``scene_uuid`` (+ variant) archive into the local layout."""
+    if scene_uuid is None:
+        return scene_dir
+
+    scene_uuid = scene_uuid.strip()
+    assert scene_uuid, "scene_uuid must be non-empty when provided."
+    if not scene_dir.is_dir():
+        raise FileNotFoundError(f"scene_dir does not exist: {scene_dir}")
+
+    suffix = _variant_dir_suffix(variant)
+    expected_names = (
+        f"clipgt-{scene_uuid}{suffix}.usdz",
+        f"{scene_uuid}{suffix}.usdz",
+    )
+    archive_path = _choose_existing_asset(scene_dir, exact_name=expected_names[0]) or (
+        _choose_existing_asset(scene_dir, exact_name=expected_names[1])
+    )
+    if archive_path is None:
+        # Prefer the variant suffix but accept the base archive too.
+        archive_path = _choose_existing_asset(
+            scene_dir,
+            fallback_prefixes=(
+                f"clipgt-{scene_uuid}{suffix}",
+                f"{scene_uuid}{suffix}",
+                f"clipgt-{scene_uuid}",
+                scene_uuid,
+            ),
+            allowed_suffixes={".usdz"},
+            preferred_stems=(
+                f"clipgt-{scene_uuid}{suffix}",
+                f"{scene_uuid}{suffix}",
+                f"clipgt-{scene_uuid}",
+                scene_uuid,
+            ),
+        )
+    if archive_path is None:
+        raise FileNotFoundError(
+            "scene_uuid is set but no local USDZ archive was found in "
+            f"{scene_dir}. Expected one of: {', '.join(expected_names)}."
+        )
+
+    normalized_scene_dir = scene_dir / f"{scene_uuid}{suffix}"
+    normalized_clipgt_root = normalized_scene_dir / clipgt_dirname
+    _safe_extract_zip(archive_path, normalized_clipgt_root)
+    return normalized_scene_dir
+
+
+def _ensure_hf_webrtc_scene_synced(
+    scene_uuid: str,
+    *,
+    variant: str = SCENE_VARIANT_DEFAULT,
+    prompt_filename: str = SCENE_PROMPT_FILENAME,
+    clipgt_dirname: str = SCENE_CLIPGT_DIRNAME,
+) -> Path:
+    """Stage an HF scene variant into the WebRTC cache layout.
+
+    Downloads ``scenes/clipgt-<uuid>[-<variant>].usdz`` and extracts it under
+    ``FLASHDREAMS_CACHE_DIR/omnidreams-scenes/<uuid>[-<variant>]/clipgt/``. The
+    per-uuid+variant directory coexists with the desktop demo's archive files
+    in the same root.
+    """
+    del prompt_filename  # accepted for call-site symmetry; assets resolved later
+    scene_uuid = scene_uuid.strip()
+    assert scene_uuid, "scene_uuid must be set."
+    suffix = _variant_dir_suffix(variant)
+    cache_root = scenes_cache_root()
+    scene_dir = cache_root / f"{scene_uuid}{suffix}"
+    lock_path = cache_root / ".locks" / f"{scene_uuid}{suffix}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with FileLock(str(lock_path)):
+        archive_path = hf_hub_download_scene(scene_uuid, variant)
+        _safe_extract_zip(archive_path, scene_dir / clipgt_dirname)
+
+    logger.info(
+        "Synced Omnidreams WebRTC scene {} (variant {}) from Hugging Face ({}) to {}",
+        scene_uuid,
+        variant,
+        hf_scenes_repo_id(),
+        scene_dir,
+    )
+    return scene_dir
+
+
+def _summarize_sdp_candidates(sdp: str) -> str:
+    candidates = [
+        line.removeprefix("a=candidate:")
+        for line in sdp.splitlines()
+        if line.startswith("a=candidate:")
+    ]
+    if not candidates:
+        return "0 candidates"
+
+    protocols: dict[str, int] = {}
+    addresses: set[str] = set()
+    endpoints: list[str] = []
+    for candidate in candidates:
+        parts = candidate.split()
+        if len(parts) >= 5:
+            protocols[parts[2].lower()] = protocols.get(parts[2].lower(), 0) + 1
+            addresses.add(parts[4])
+        if len(parts) >= 6:
+            endpoints.append(f"{parts[2].lower()}://{parts[4]}:{parts[5]}")
+    protocol_summary = ",".join(
+        f"{key}={value}" for key, value in sorted(protocols.items())
+    )
+    address_summary = ",".join(sorted(addresses)[:8])
+    if len(addresses) > 8:
+        address_summary += f",+{len(addresses) - 8} more"
+    endpoint_summary = ",".join(endpoints[:12])
+    if len(endpoints) > 12:
+        endpoint_summary += f",+{len(endpoints) - 12} more"
+    return (
+        f"{len(candidates)} candidates protocols=[{protocol_summary}] "
+        f"addresses=[{address_summary}] endpoints=[{endpoint_summary}]"
+    )
+
+
+def _link_or_copy_file(source: Path, target: Path) -> None:
+    """Stage a file efficiently without requiring Windows symlink privileges."""
+    try:
+        os.symlink(source, target)
+        return
+    except OSError:
+        pass
+
+    try:
+        os.link(source, target)
+        return
+    except OSError:
+        shutil.copy2(source, target)
+
+
+class OmnidreamsRuntimeError(RuntimeError):
+    """Raised when the Omnidreams live demo runtime is used incorrectly."""
+
+
+@dataclass(slots=True)
+class OmnidreamsRuntimeConfig:
+    pipeline_config_name: str = (
+        "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae-perf"
+    )
+    pipeline_config: Any | None = None
+    manifest_path: Path | None = None
+    scene_dir: Path | None = None
+    scene_uuid: str | None = None
+    # Weather variant slug (default/rain/snow): picks the sibling USDZ + prompt.
+    scene_variant: str = SCENE_VARIANT_DEFAULT
+    seed: int | None = 42
+    device: str = "cuda:0"
+    video_height: int = 704
+    video_width: int = 1280
+    fps: int = 30
+    camera_name: str = "camera_front_wide_120fov"
+    prompt_filename: str = SCENE_PROMPT_FILENAME
+    clipgt_dirname: str = SCENE_CLIPGT_DIRNAME
+    move_speed_per_s: float = 6.0
+    rotate_speed_rad_per_s: float = float(np.deg2rad(35.0))
+    warmup_chunks: int = 10
+    warmup_timeout_s: float = 600.0
+    debug_serve_hdmaps: bool = False
+    postprocess: VideoPostprocessChainConfig = field(
+        default_factory=VideoPostprocessChainConfig
+    )
+    # Video encoder selection. ``"auto"`` prefers NVENC when the driver
+    # reports support at the target resolution (Stage-1 probe via
+    # ``PyNvVideoCodec.GetEncoderCaps``) and falls back to aiortc's
+    # software encoder otherwise. ``"nvenc"`` fails startup if NVENC
+    # cannot be initialized. ``"default"`` skips the probe entirely.
+    encoder_backend: EncoderBackend = "auto"
+    encoder_bitrate_bps: int = 6_000_000
+    encoder_gop: int = 30
+
+
+@dataclass(frozen=True, slots=True)
+class OmnidreamsSessionInput:
+    """Browser-selectable settings applied to the next WebRTC rollout."""
+
+    postprocess_preset: str | None = None
+    """Launched preset selection; ``None`` keeps the CLI default and ``""`` disables it."""
+
+
+def validate_requested_postprocess_preset(
+    *, requested_preset: str, configured_preset: str
+) -> None:
+    if not configured_preset:
+        raise ValueError(
+            "Post-processing is not enabled for this server; restart with "
+            "--postprocess-preset to make a preset available."
+        )
+    if requested_preset != configured_preset:
+        raise ValueError(
+            "Post-processing preset must match the launched preset "
+            f"{configured_preset!r}; got {requested_preset!r}."
+        )
+    resolve_postprocess_preset(requested_preset)
+
+
+class OmnidreamsInferenceRuntime:
+    """Single-scene, single-view Omnidreams runtime for live demo control."""
+
+    def __init__(self, config: OmnidreamsRuntimeConfig | None = None) -> None:
+        self.config = config or OmnidreamsRuntimeConfig()
+        self.MASTER_RANK = 0
+        self.rank = 0 if not dist.is_initialized() else dist.get_rank()
+
+        control_device = _resolve_cuda_device(self.config.device)
+
+        self.pose_integrator = CameraPoseIntegrator(
+            move_speed_per_s=self.config.move_speed_per_s,
+            rotate_speed_rad_per_s=self.config.rotate_speed_rad_per_s,
+            coordinate_system="FLU",
+        )
+        self.autoregressive_index = 0
+
+        self._device: torch.device | None = None
+        self._wrapper: OmnidreamsConditioningWrapper | None = None
+        self._state: OmnidreamsConditioningState | None = None
+        self._renderer: Any | None = None
+        self._scene_data: Any | None = None
+        self._initial_rgb_frames: torch.Tensor | None = None
+        self._text_prompts: list[TextPrompt] | None = None
+        self._camera_to_rig: torch.Tensor | None = None
+        self._initial_ego_pose: np.ndarray | None = None
+        self._next_timestamp_us: int = 0
+        self._postprocess_stream: VideoPostprocessStream | None = None
+        self._postprocess_preset = self.config.postprocess.preset
+        self._closed = False
+        self._clipgt_temp_dir: tempfile.TemporaryDirectory[str] | None = None
+        # Selected once at initialization; the concrete backend is chosen
+        # by ``select_encoder`` based on ``config.encoder_backend`` and
+        # the driver's ``GetEncoderCaps`` response at
+        # ``config.video_width`` / ``config.video_height``.
+        self._video_encoder: VideoEncoder | None = None
+        # Pin every blocking runtime call to one OS thread: Omnidreams' CUDA
+        # graph capture/replay state is thread-local, so spreading calls across
+        # workers (e.g. asyncio.to_thread) crashes capture after a few chunks.
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="omnidreams-webrtc-runtime",
+        )
+
+        self._step_lock = asyncio.Lock()
+        self.rank_coordinator = RankCoordinator(
+            device=control_device,
+            signal_type=WebRTCControlSignal,
+            is_master=self.is_master,
+            master_rank=self.MASTER_RANK,
+        )
+        self.rank_coordinator.register_distributed_ops(self)
+
+    @property
+    def is_master(self) -> bool:
+        return self.rank == self.MASTER_RANK
+
+    @property
+    def postprocess_preset(self) -> str:
+        """Preset active for the current rollout, or an empty string when off."""
+        return self._postprocess_preset
+
+    @property
+    def video_encoder(self) -> VideoEncoder:
+        """Return the encoder selected at :meth:`initialize` time."""
+        if self._video_encoder is None:
+            raise OmnidreamsRuntimeError(
+                "Video encoder is not initialized; call runtime.initialize() first."
+            )
+        return self._video_encoder
+
+    def wait_for_termination(self) -> None:
+        self.rank_coordinator.worker_loop(exit_signal=WebRTCControlSignal.EXIT)
+
+    def send_exit_signal(self) -> None:
+        if self.is_master:
+            self.rank_coordinator.send_exit(exit_signal=WebRTCControlSignal.EXIT)
+
+    async def initialize(self) -> None:
+        if self._wrapper is not None:
+            return
+        await self._run_on_runtime_thread(self._initialize_sync_all_ranks)
+
+    async def reset_for_new_session(
+        self, session_input: OmnidreamsSessionInput | None = None
+    ) -> None:
+        if self._closed:
+            raise OmnidreamsRuntimeError("Runtime is closed.")
+        if self._wrapper is None:
+            raise OmnidreamsRuntimeError("Runtime is not initialized.")
+        await self._run_on_runtime_thread(
+            self._reset_rollout_sync_all_ranks,
+            session_input,
+        )
+
+    async def close(self) -> None:
+        self._closed = True
+        try:
+            await self._run_on_runtime_thread(self._close_sync_all_ranks)
+        finally:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+
+    async def generate_chunk(
+        self,
+        *,
+        segments: list[PoseSegment],
+        frame_times: list[float],
+    ) -> WebRTCStepResult:
+        if self._closed:
+            raise OmnidreamsRuntimeError("Session is closed.")
+        if self._wrapper is None:
+            raise OmnidreamsRuntimeError("Runtime is not initialized.")
+
+        async with self._step_lock:
+            if self._closed:
+                raise OmnidreamsRuntimeError("Session is closed.")
+            return await self._run_on_runtime_thread(
+                self._generate_chunk_sync_all_ranks,
+                segments,
+                frame_times,
+            )
+
+    async def _run_on_runtime_thread(
+        self,
+        func: Callable[..., _T],
+        *args: Any,
+    ) -> _T:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            self._runtime_thread_entry,
+            func,
+            args,
+        )
+
+    def _runtime_thread_entry(
+        self,
+        func: Callable[..., _T],
+        args: tuple[Any, ...],
+    ) -> _T:
+        device = self._device
+        if device is None:
+            device = _resolve_cuda_device(self.config.device)
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+        return func(*args)
+
+    def peek_next_chunk_num_frames(self) -> int:
+        if self._wrapper is None:
+            raise OmnidreamsRuntimeError("Runtime is not initialized.")
+        if self._state is None:
+            return int(self._wrapper.initial_frame_chunk_size)
+        return int(self._wrapper.frame_chunk_size)
+
+    def peek_steady_chunk_num_frames(self) -> int:
+        if self._wrapper is None:
+            raise OmnidreamsRuntimeError("Runtime is not initialized.")
+        return int(self._wrapper.frame_chunk_size)
+
+    @distributed_op(WebRTCControlSignal.INITIALIZE)
+    def _initialize_sync_all_ranks(self) -> None:
+        self._initialize_sync()
+
+    @distributed_op(WebRTCControlSignal.RESET_SESSION)
+    def _reset_rollout_sync_all_ranks(
+        self, session_input: OmnidreamsSessionInput | None = None
+    ) -> None:
+        self._reset_rollout_sync(session_input=session_input)
+
+    @distributed_op(WebRTCControlSignal.ACTION_STEP)
+    def _generate_chunk_sync_all_ranks(
+        self,
+        segments: list[PoseSegment],
+        frame_times: list[float],
+    ) -> WebRTCStepResult:
+        return self._generate_one_chunk_sync(segments=segments, frame_times=frame_times)
+
+    @distributed_op(WebRTCControlSignal.CLOSE)
+    def _close_sync_all_ranks(self) -> None:
+        self._close_sync()
+
+    def _initialize_sync(self) -> None:
+        if self._wrapper is not None:
+            return
+
+        init_t0 = time.perf_counter()
+        cfg = self.config
+        if cfg.scene_dir is None:
+            scene_uuid = cfg.scene_uuid or DEFAULT_WEBRTC_SCENE_UUID
+            scene_dir = _ensure_hf_webrtc_scene_synced(
+                scene_uuid,
+                variant=cfg.scene_variant,
+                prompt_filename=cfg.prompt_filename,
+                clipgt_dirname=cfg.clipgt_dirname,
+            )
+        else:
+            scene_dir = _extract_local_webrtc_scene_if_needed(
+                cfg.scene_dir,
+                scene_uuid=cfg.scene_uuid,
+                variant=cfg.scene_variant,
+                clipgt_dirname=cfg.clipgt_dirname,
+            )
+
+        cfg.scene_dir = scene_dir
+        clipgt_dir, first_frame_path, prompt_path = _resolve_webrtc_scene_assets(
+            scene_dir,
+            prompt_filename=cfg.prompt_filename,
+            clipgt_dirname=cfg.clipgt_dirname,
+            camera_name=cfg.camera_name,
+            variant=cfg.scene_variant,
+        )
+        if (
+            cfg.pipeline_config is None
+            and cfg.pipeline_config_name not in OMNIDREAMS_CONFIGS
+        ):
+            supported = ", ".join(sorted(OMNIDREAMS_CONFIGS))
+            raise ValueError(
+                f"Unknown pipeline_config_name={cfg.pipeline_config_name!r}. "
+                f"Supported: {supported}"
+            )
+
+        pipeline_cfg = (
+            cfg.pipeline_config or OMNIDREAMS_CONFIGS[cfg.pipeline_config_name]
+        )
+        transformer_cfg = pipeline_cfg.diffusion_model.transformer
+        if not isinstance(transformer_cfg, CosmosTransformerConfig):
+            raise TypeError(
+                "Omnidreams WebRTC requires a CosmosTransformerConfig pipeline."
+            )
+        if transformer_cfg.num_views != 1:
+            raise ValueError(
+                "Omnidreams WebRTC v1 only supports single-view configs; "
+                f"{cfg.pipeline_config_name!r} has num_views={transformer_cfg.num_views}."
+            )
+
+        self._device = torch.device(cfg.device)
+        if self._device.type == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA is required for Omnidreams WebRTC runtime.")
+
+        logger.info("Loading Omnidreams first frame from {}", first_frame_path)
+        image_bgr = cv2.imread(str(first_frame_path), cv2.IMREAD_COLOR)
+        if image_bgr is None:
+            raise RuntimeError(f"Failed to read first frame from {first_frame_path}")
+        image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+        image_rgb = cv2.resize(
+            image_rgb,
+            (cfg.video_width, cfg.video_height),
+            interpolation=cv2.INTER_CUBIC,
+        )
+        self._initial_rgb_frames = (
+            torch.from_numpy(image_rgb)
+            .permute(2, 0, 1)
+            .contiguous()
+            .unsqueeze(0)
+            .unsqueeze(0)
+            .to(device=self._device, dtype=torch.uint8)
+        )
+
+        prompt = prompt_path.read_text(encoding="utf-8").strip() or AV_POSITIVE_PROMPT
+        self._text_prompts = [TextPrompt(positive=prompt)]
+
+        loadable_clipgt_dir = self._prepare_clipgt_dir(clipgt_dir)
+        logger.info("Loading Omnidreams scene data from {}", loadable_clipgt_dir)
+        scene_t0 = time.perf_counter()
+        scene_data = load_scene(
+            loadable_clipgt_dir,
+            camera_names=[cfg.camera_name],
+            max_frames=-1,
+            input_pose_fps=SETTINGS["INPUT_POSE_FPS"],
+            resize_resolution_hw=(cfg.video_height, cfg.video_width),
+        )
+        logger.info(
+            "Loaded Omnidreams scene data in {:.1f}s; attaching Ludus scene.",
+            time.perf_counter() - scene_t0,
+        )
+        ludus_t0 = time.perf_counter()
+        scene_data = load_and_attach_ludus_scene(
+            loadable_clipgt_dir,
+            scene_data,
+            device=self._device,
+        )
+        logger.info(
+            "Attached Omnidreams Ludus scene in {:.1f}s.",
+            time.perf_counter() - ludus_t0,
+        )
+        if not scene_data.ego_poses:
+            raise ValueError(f"Scene {loadable_clipgt_dir} has no ego poses.")
+        if cfg.camera_name not in scene_data.camera_models:
+            raise ValueError(
+                f"Camera {cfg.camera_name!r} was not loaded from {loadable_clipgt_dir}."
+            )
+        if cfg.camera_name not in scene_data.camera_extrinsics:
+            raise ValueError(
+                f"Camera {cfg.camera_name!r} has no extrinsics in {loadable_clipgt_dir}."
+            )
+
+        logger.info(
+            "Setting up Omnidreams pipeline {} on {}. This may load checkpoints, "
+            "compile modules, and initialize CUDA graphs.",
+            cfg.pipeline_config_name,
+            self._device,
+        )
+        pipeline_t0 = time.perf_counter()
+        self._wrapper = OmnidreamsConditioningWrapper(
+            pipeline_config_name=cfg.pipeline_config_name,
+            pipeline_config=cfg.pipeline_config,
+            resolution_wh=(cfg.video_width, cfg.video_height),
+            seed_for_every_rollout=cfg.seed,
+            device=self._device,
+        )
+        logger.info(
+            "Omnidreams pipeline setup complete in {:.1f}s.",
+            time.perf_counter() - pipeline_t0,
+        )
+        self._scene_data = scene_data
+        logger.info("Creating Omnidreams renderer for camera {}", cfg.camera_name)
+        renderer_t0 = time.perf_counter()
+        self._renderer = self._wrapper.create_renderer(scene_data, [cfg.camera_name])
+        logger.info(
+            "Omnidreams renderer ready in {:.1f}s.",
+            time.perf_counter() - renderer_t0,
+        )
+        self._camera_to_rig = torch.as_tensor(
+            scene_data.camera_extrinsics[cfg.camera_name],
+            device=self._device,
+            dtype=torch.float32,
+        )
+        self._initial_ego_pose = scene_data.ego_poses[0].transformation_matrix
+        self._next_timestamp_us = int(scene_data.ego_poses[0].timestamp)
+        self._reset_rollout_sync()
+        self._initialize_video_encoder_sync()
+        logger.info(
+            "Omnidreams runtime initialization complete in {:.1f}s.",
+            time.perf_counter() - init_t0,
+        )
+
+    def _initialize_video_encoder_sync(self) -> None:
+        """Select the video encoder for this runtime.
+
+        Runs on the runtime executor thread so any GPU-side probe
+        (``CreateEncoder``) sees the same CUDA context the model uses.
+
+        Non-master ranks skip encoder initialization. WebRTC media is
+        served only by the master rank, so allocating an NVENC session
+        on a worker would consume one of the local GPU's concurrent
+        session slots without ever encoding a frame — and could fail
+        the worker's startup if the pool cannot accommodate one
+        allocation per rank.
+        """
+        if not self.is_master:
+            return
+        if self._video_encoder is not None:
+            self._video_encoder.close()
+            self._video_encoder = None
+        device = (
+            self._device
+            if self._device is not None
+            else _resolve_cuda_device(
+                self.config.device,
+            )
+        )
+        gpu_id = device.index if device.index is not None else 0
+        self._video_encoder = select_encoder(
+            backend=self.config.encoder_backend,
+            width=self.config.video_width,
+            height=self.config.video_height,
+            fps=self.config.fps,
+            bitrate=self.config.encoder_bitrate_bps,
+            gpu_id=gpu_id,
+            gop=self.config.encoder_gop,
+        )
+
+    def _prepare_clipgt_dir(self, clipgt_dir: Path) -> Path:
+        def _has_prefixed_parquets(path: Path) -> bool:
+            return any(path.glob("*.calibration_estimate.parquet"))
+
+        def _has_unprefixed_parquets(path: Path) -> bool:
+            return (path / "calibration_estimate.parquet").exists()
+
+        if _has_prefixed_parquets(clipgt_dir):
+            return clipgt_dir
+
+        parquet_source_dir: Path | None = None
+        if _has_unprefixed_parquets(clipgt_dir):
+            parquet_source_dir = clipgt_dir
+        else:
+            # Some HF scenes extract into ``clipgt/clipgt`` (or another single
+            # nested directory) while first_image/prompt stay one level up.
+            # Discover that nested parquet root and normalize it for loader use.
+            nested_candidates = [
+                child for child in clipgt_dir.iterdir() if child.is_dir()
+            ]
+            for candidate in nested_candidates:
+                if _has_prefixed_parquets(candidate):
+                    return candidate
+                if _has_unprefixed_parquets(candidate):
+                    parquet_source_dir = candidate
+                    break
+
+        if parquet_source_dir is None:
+            return clipgt_dir
+
+        self._clipgt_temp_dir = tempfile.TemporaryDirectory(prefix="omnidreams-clipgt-")
+        staged = Path(self._clipgt_temp_dir.name)
+        for source in parquet_source_dir.glob("*.parquet"):
+            target = staged / f"clip.{source.name}"
+            _link_or_copy_file(source.resolve(), target)
+        return staged
+
+    def _reset_rollout_sync(
+        self, session_input: OmnidreamsSessionInput | None = None
+    ) -> None:
+        if self._wrapper is None or self._renderer is None:
+            raise OmnidreamsRuntimeError("Runtime is not initialized.")
+        if self._initial_ego_pose is None or self._scene_data is None:
+            raise OmnidreamsRuntimeError("Scene state is not initialized.")
+
+        self._reset_postprocess_stream(session_input)
+        if self._state is not None and self._state.pipeline_cache is not None:
+            del self._state.pipeline_cache
+        self._state = None
+        self.pose_integrator = CameraPoseIntegrator(
+            move_speed_per_s=self.config.move_speed_per_s,
+            rotate_speed_rad_per_s=self.config.rotate_speed_rad_per_s,
+            coordinate_system="FLU",
+        )
+        self.pose_integrator.reset(self._initial_ego_pose)
+        self.autoregressive_index = 0
+        self._next_timestamp_us = int(self._scene_data.ego_poses[0].timestamp)
+        self._wrapper.set_rollout_seed(self.config.seed)
+
+    def _close_sync(self) -> None:
+        state = self._state
+        wrapper = self._wrapper
+        self._state = None
+        self._wrapper = None
+        self._renderer = None
+        self._scene_data = None
+        self._initial_rgb_frames = None
+        self._text_prompts = None
+        self._camera_to_rig = None
+        self._initial_ego_pose = None
+        self._close_postprocess_stream()
+        if self._video_encoder is not None:
+            self._video_encoder.close()
+            self._video_encoder = None
+
+        if state is not None and wrapper is not None:
+            wrapper.cleanup(state)
+        if wrapper is not None:
+            del wrapper
+        if self._clipgt_temp_dir is not None:
+            self._clipgt_temp_dir.cleanup()
+            self._clipgt_temp_dir = None
+
+        if self._device is not None and self._device.type == "cuda":
+            torch.cuda.synchronize(device=self._device)
+            torch.cuda.empty_cache()
+
+    def _reset_postprocess_stream(
+        self, session_input: OmnidreamsSessionInput | None
+    ) -> None:
+        self._close_postprocess_stream()
+        configured = self.config.postprocess
+        preset = (
+            session_input.postprocess_preset
+            if session_input is not None
+            and session_input.postprocess_preset is not None
+            else configured.preset
+        )
+        if preset:
+            validate_requested_postprocess_preset(
+                requested_preset=preset,
+                configured_preset=configured.preset,
+            )
+        postprocess = VideoPostprocessChainConfig(
+            processors=configured.processors,
+            preset=preset,
+        )
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        postprocess.validate_execution(world_size=world_size)
+        self._postprocess_preset = preset
+        if not postprocess.is_enabled():
+            return
+        if not self.is_master and not postprocess.requires_all_ranks(
+            world_size=world_size
+        ):
+            return
+        self._postprocess_stream = VideoPostprocessStream(
+            postprocess=postprocess,
+            output_layout="bvtchw",
+            fps=self.config.fps,
+            per_view=False,
+            world_size=world_size,
+        )
+        logger.info(
+            "Omnidreams WebRTC post-processing enabled with preset {!r}.",
+            preset,
+        )
+
+    def _close_postprocess_stream(self) -> None:
+        if self._postprocess_stream is None:
+            return
+        self._postprocess_stream.finish()
+        self._postprocess_stream = None
+
+    def _generate_one_chunk_sync(
+        self,
+        *,
+        segments: list[PoseSegment],
+        frame_times: list[float],
+    ) -> WebRTCStepResult:
+        if (
+            self._wrapper is None
+            or self._renderer is None
+            or self._initial_rgb_frames is None
+            or self._text_prompts is None
+            or self._camera_to_rig is None
+        ):
+            raise OmnidreamsRuntimeError("Runtime is not initialized.")
+        if self._device is None:
+            raise OmnidreamsRuntimeError("Runtime device is not initialized.")
+
+        num_frames = self.peek_next_chunk_num_frames()
+        if len(frame_times) != num_frames:
+            raise OmnidreamsRuntimeError(
+                f"Expected {num_frames} frame_times for chunk={self.autoregressive_index}, "
+                f"got {len(frame_times)}."
+            )
+        if not segments:
+            raise OmnidreamsRuntimeError(
+                f"Chunk={self.autoregressive_index} received empty segments."
+            )
+
+        ego_poses = self.pose_integrator.integrate_chunk(
+            segments=segments, frame_times=frame_times
+        )
+        ego_poses_t = torch.from_numpy(ego_poses).to(
+            device=self._device, dtype=torch.float32
+        )
+        camera_poses = torch.einsum("nij,jk->nik", ego_poses_t, self._camera_to_rig)
+        frame_timestamps_us = self._consume_timestamps(num_frames)
+
+        camera_names = [self.config.camera_name]
+        camera_poses_per_view = {self.config.camera_name: camera_poses}
+        serve_hdmaps = self.config.debug_serve_hdmaps
+        if self._state is None:
+            output = self._wrapper.start_generation(
+                text_prompts=self._text_prompts,
+                initial_rgb_frames=self._initial_rgb_frames,
+                renderer=self._renderer,
+                camera_names=camera_names,
+                camera_poses_per_view=camera_poses_per_view,
+                frame_timestamps_us=frame_timestamps_us,
+                skip_video_generation=serve_hdmaps,
+            )
+            self._state = output.state
+        else:
+            output = self._wrapper.continue_generation(
+                state=self._state,
+                camera_names=camera_names,
+                camera_poses_per_view=camera_poses_per_view,
+                frame_timestamps_us=frame_timestamps_us,
+                skip_video_generation=serve_hdmaps,
+            )
+            self._state = output.state
+
+        if self._state.pipeline_cache is not None:
+            self._wrapper.finalize_block_generation(
+                self._state.pipeline_cache,
+                output.finalization_state,
+            )
+
+        if serve_hdmaps:
+            video_chunk = output.condition_frames
+        elif output.rgb_frames is None:
+            raise OmnidreamsRuntimeError("Omnidreams WebRTC received no RGB frames.")
+        else:
+            video_chunk = output.rgb_frames
+
+        if not serve_hdmaps and self._postprocess_stream is not None:
+            video_chunk = self._postprocess_stream.process(
+                video_chunk,
+                autoregressive_index=self.autoregressive_index,
+            )
+
+        result = make_webrtc_step_result(
+            chunk_index=self.autoregressive_index,
+            video_chunk=video_chunk,
+            layout="bvtchw",
+            stats=None,
+            sync_device=self._device,
+        )
+        self.autoregressive_index += 1
+        return result
+
+    def _consume_timestamps(self, num_frames: int) -> list[int]:
+        step_us = int(round(1_000_000 / self.config.fps))
+        timestamps = [self._next_timestamp_us + i * step_us for i in range(num_frames)]
+        self._next_timestamp_us += num_frames * step_us
+        return timestamps
+
+__all__ = [
+    "DEFAULT_WEBRTC_SCENE_UUID",
+    "OmnidreamsInferenceRuntime",
+    "OmnidreamsRuntimeConfig",
+    "OmnidreamsRuntimeError",
+    "OmnidreamsSessionInput",
+    "WEBRTC_SCENE_IMAGE_SUFFIXES",
+    "WEBRTC_SCENES_HF_BROWSER_URL",
+    "validate_requested_postprocess_preset",
+]

--- a/integrations/omnidreams/omnidreams/demo/replay.py
+++ b/integrations/omnidreams/omnidreams/demo/replay.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""OmniDreams replay runtime for the shared demo runner."""
+"""OmniDreams replay runtime for the shared demo runner.
+
+This file adapts benchmark-style fixed assets into an ``InferenceSession`` so
+the shared replay loop can write MP4/null outputs without OmniDreams demo code
+owning that loop.
+"""
 
 from __future__ import annotations
 

--- a/integrations/omnidreams/omnidreams/demo/spec.py
+++ b/integrations/omnidreams/omnidreams/demo/spec.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""OmniDreams demo-specific scenario shapes."""
+"""OmniDreams demo-specific scenario shapes and normalization.
+
+This file validates replay assets and live scene options before the shared demo
+launchers create runtimes, output targets, or WebRTC servers.
+"""
 
 from __future__ import annotations
 

--- a/integrations/omnidreams/omnidreams/demo/spec.py
+++ b/integrations/omnidreams/omnidreams/demo/spec.py
@@ -18,7 +18,8 @@ from omnidreams.runner import (
     _example_camera_names,
 )
 from omnidreams.scenes import SCENE_VARIANT_DEFAULT
-from omnidreams.webrtc.session import DEFAULT_WEBRTC_SCENE_UUID
+
+from .live_runtime import DEFAULT_WEBRTC_SCENE_UUID
 
 DEFAULT_OMNIDREAMS_PRESET = "omnidreams-sv-2steps-chunk2-loc6-lightvae-lighttae"
 OMNIDREAMS_MODEL_ID = "omnidreams"

--- a/integrations/omnidreams/omnidreams/demo/webrtc.py
+++ b/integrations/omnidreams/omnidreams/demo/webrtc.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from dataclasses import dataclass
+from importlib.resources import files
+from typing import Any, Protocol, cast
 
 from aiohttp import web
 from omnidreams.webrtc.session import (
@@ -17,78 +19,82 @@ from omnidreams.webrtc.session import (
 
 from flashdreams.plugins.registry import resolve_postprocess_preset
 from flashdreams.runtime.demo import DemoSpec
-from flashdreams.runtime.demo.webrtc import SharedDemoWebRTCSessionManager
+from flashdreams.runtime.demo.webrtc import WebRTCAppExtension, WebRTCManagerOptions
 from flashdreams.serving.webrtc.controls import WSAD_SUPPORTED_KEYS
-from flashdreams.serving.webrtc.manager import DEFAULT_CLIENT_LIVENESS_TIMEOUT_S
 from flashdreams.serving.webrtc.server import (
     SESSION_MANAGER_KEY,
     SessionBusyError,
-    create_packaged_webrtc_app,
-)
-from flashdreams.serving.webrtc.server import (
-    close_package_resources as _close_package_resources,
 )
 
+_BUSY_MESSAGE = "An Omnidreams session is already active."
+_WARMUP_LABEL = "Omnidreams WebRTC"
 
-class OmnidreamsDemoWebRTCSessionManager(SharedDemoWebRTCSessionManager):
-    """Shared WebRTC manager customized for OmniDreams session semantics."""
 
-    _busy_message = "An Omnidreams session is already active."
-    _warmup_label = "Omnidreams WebRTC"
-    _runtime_error_types = (OmnidreamsRuntimeError,)
-    _close_session_on_generation_error = True
-    _resampler_supported_keys = WSAD_SUPPORTED_KEYS
-
+class _OmnidreamsSessionManager(Protocol):
     runtime_config: OmnidreamsRuntimeConfig
-    _runtime: Any
 
-    def __init__(
-        self,
-        *,
-        runtime: Any,
-        runtime_config: OmnidreamsRuntimeConfig,
-        fps: int,
-        client_liveness_timeout_s: float = DEFAULT_CLIENT_LIVENESS_TIMEOUT_S,
-    ) -> None:
-        super().__init__(
-            model_name=runtime_config.pipeline_config_name,
-            runtime=runtime,
-            runtime_config=runtime_config,
-            fps=fps,
-            client_liveness_timeout_s=client_liveness_timeout_s,
-        )
-        self._pending_session_input: OmnidreamsSessionInput | None = None
+    def set_pending_session_input(
+        self, session_input: OmnidreamsSessionInput
+    ) -> None: ...
 
-    def _model_name(self) -> str:
-        return self.runtime_config.pipeline_config_name
 
-    def _chunk_done_extra(self) -> dict[str, Any]:
-        return {
-            "stream": "hdmap" if self.runtime_config.debug_serve_hdmaps else "rgb",
-            "postprocess_preset": self._runtime.postprocess_preset,
-        }
+@dataclass(slots=True)
+class _OmnidreamsPendingSessionInputState:
+    runtime_config: OmnidreamsRuntimeConfig
+    pending_session_input: OmnidreamsSessionInput | None = None
 
-    def _peek_pending_session_input(self) -> OmnidreamsSessionInput | None:
-        return self._pending_session_input
+    def peek(self) -> OmnidreamsSessionInput | None:
+        return self.pending_session_input
 
-    def _clear_pending_session_input(self) -> None:
-        self._pending_session_input = None
+    def clear(self) -> None:
+        self.pending_session_input = None
 
-    async def _reset_runtime_for_session(
-        self, session_input: OmnidreamsSessionInput | None
-    ) -> None:
-        await self._runtime.reset_for_new_session(session_input=session_input)
-
-    def set_pending_session_input(self, session_input: OmnidreamsSessionInput) -> None:
-        if self.has_active_session():
-            raise SessionBusyError(self._busy_message)
+    def set(self, manager: Any, session_input: Any) -> None:
+        if not isinstance(session_input, OmnidreamsSessionInput):
+            raise TypeError("Expected OmnidreamsSessionInput.")
+        if manager.has_active_session():
+            raise SessionBusyError(_BUSY_MESSAGE)
         preset = session_input.postprocess_preset
         if preset:
             _validate_requested_postprocess_preset(
                 requested_preset=preset,
                 configured_preset=self.runtime_config.postprocess.preset,
             )
-        self._pending_session_input = session_input
+        self.pending_session_input = session_input
+
+
+def create_omnidreams_webrtc_manager_options(
+    *,
+    runtime_config: OmnidreamsRuntimeConfig,
+) -> WebRTCManagerOptions:
+    """Build shared manager options for OmniDreams WebRTC semantics."""
+    session_input_state = _OmnidreamsPendingSessionInputState(
+        runtime_config=runtime_config
+    )
+
+    async def reset_runtime(runtime: Any, session_input: Any) -> None:
+        await runtime.reset_for_new_session(session_input=session_input)
+
+    def chunk_done_extra(runtime: Any, config: Any) -> dict[str, Any]:
+        runtime_config = cast(OmnidreamsRuntimeConfig, config)
+        return {
+            "stream": "hdmap" if runtime_config.debug_serve_hdmaps else "rgb",
+            "postprocess_preset": runtime.postprocess_preset,
+        }
+
+    return WebRTCManagerOptions(
+        model_name=runtime_config.pipeline_config_name,
+        busy_message=_BUSY_MESSAGE,
+        warmup_label=_WARMUP_LABEL,
+        runtime_error_types=(OmnidreamsRuntimeError,),
+        close_session_on_generation_error=True,
+        supported_keys=WSAD_SUPPORTED_KEYS,
+        peek_pending_session_input=session_input_state.peek,
+        clear_pending_session_input=session_input_state.clear,
+        set_pending_session_input=session_input_state.set,
+        reset_runtime_for_session=reset_runtime,
+        chunk_done_extra=chunk_done_extra,
+    )
 
 
 async def postprocess_options(request: web.Request) -> web.StreamResponse:
@@ -136,25 +142,20 @@ def configure_omnidreams_webrtc_app(app: web.Application) -> None:
     app.router.add_post("/api/session/input", session_input)
 
 
-def create_omnidreams_webrtc_app(
+def create_omnidreams_webrtc_app_extension(
     *,
     spec: DemoSpec,
     session_manager: Any,
     request_session_url: str,
-) -> web.Application:
-    """Create the packaged OmniDreams browser app through shared serving glue."""
-    from importlib.resources import as_file, files
-
+) -> WebRTCAppExtension:
+    """Describe OmniDreams browser assets and routes for the shared builder."""
+    del session_manager, request_session_url
     output_preload_name = getattr(spec.output, "preload_name", None)
     preload_name = output_preload_name if isinstance(output_preload_name, str) else ""
-    return create_packaged_webrtc_app(
+    return WebRTCAppExtension(
         web_resource=files("omnidreams.webrtc").joinpath("web"),
-        session_manager=session_manager,
         preload_name=preload_name or "Omnidreams",
-        request_session_url=request_session_url,
         configure_app=configure_omnidreams_webrtc_app,
-        as_file_fn=as_file,
-        cleanup_callback=_close_package_resources,
     )
 
 
@@ -164,14 +165,14 @@ def validate_postprocess_preset(preset: str) -> None:
         resolve_postprocess_preset(preset)
 
 
-def _get_omnidreams_manager(app: web.Application) -> OmnidreamsDemoWebRTCSessionManager:
-    return cast(OmnidreamsDemoWebRTCSessionManager, app[SESSION_MANAGER_KEY])
+def _get_omnidreams_manager(app: web.Application) -> _OmnidreamsSessionManager:
+    return cast(_OmnidreamsSessionManager, app[SESSION_MANAGER_KEY])
 
 
 __all__ = [
-    "OmnidreamsDemoWebRTCSessionManager",
     "configure_omnidreams_webrtc_app",
-    "create_omnidreams_webrtc_app",
+    "create_omnidreams_webrtc_app_extension",
+    "create_omnidreams_webrtc_manager_options",
     "postprocess_options",
     "session_input",
     "validate_postprocess_preset",

--- a/integrations/omnidreams/omnidreams/demo/webrtc.py
+++ b/integrations/omnidreams/omnidreams/demo/webrtc.py
@@ -9,12 +9,6 @@ from importlib.resources import files
 from typing import Any, cast
 
 from aiohttp import web
-from omnidreams.webrtc.session import (
-    OmnidreamsRuntimeConfig,
-    OmnidreamsRuntimeError,
-    OmnidreamsSessionInput,
-    _validate_requested_postprocess_preset,
-)
 
 from flashdreams.plugins.registry import resolve_postprocess_preset
 from flashdreams.runtime.demo import DemoSpec
@@ -27,6 +21,13 @@ from flashdreams.runtime.demo.webrtc import (
     session_input_route,
 )
 from flashdreams.serving.webrtc.controls import WSAD_SUPPORTED_KEYS
+
+from .live_runtime import (
+    OmnidreamsRuntimeConfig,
+    OmnidreamsRuntimeError,
+    OmnidreamsSessionInput,
+    validate_requested_postprocess_preset,
+)
 
 _BUSY_MESSAGE = "An Omnidreams session is already active."
 _WARMUP_LABEL = "Omnidreams WebRTC"
@@ -120,7 +121,7 @@ def validate_omnidreams_session_input(
     omnidreams_input = cast(OmnidreamsSessionInput, session_input)
     preset = omnidreams_input.postprocess_preset
     if preset:
-        _validate_requested_postprocess_preset(
+        validate_requested_postprocess_preset(
             requested_preset=preset,
             configured_preset=runtime_config.postprocess.preset,
         )

--- a/integrations/omnidreams/omnidreams/demo/webrtc.py
+++ b/integrations/omnidreams/omnidreams/demo/webrtc.py
@@ -5,9 +5,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from importlib.resources import files
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
 from aiohttp import web
 from omnidreams.webrtc.session import (
@@ -19,48 +18,18 @@ from omnidreams.webrtc.session import (
 
 from flashdreams.plugins.registry import resolve_postprocess_preset
 from flashdreams.runtime.demo import DemoSpec
-from flashdreams.runtime.demo.webrtc import WebRTCAppExtension, WebRTCManagerOptions
-from flashdreams.serving.webrtc.controls import WSAD_SUPPORTED_KEYS
-from flashdreams.serving.webrtc.server import (
-    SESSION_MANAGER_KEY,
-    SessionBusyError,
+from flashdreams.runtime.demo.webrtc import (
+    PendingSessionInputState,
+    WebRTCAppExtension,
+    WebRTCManagerOptions,
+    WebRTCRoute,
+    json_get_route,
+    session_input_route,
 )
+from flashdreams.serving.webrtc.controls import WSAD_SUPPORTED_KEYS
 
 _BUSY_MESSAGE = "An Omnidreams session is already active."
 _WARMUP_LABEL = "Omnidreams WebRTC"
-
-
-class _OmnidreamsSessionManager(Protocol):
-    runtime_config: OmnidreamsRuntimeConfig
-
-    def set_pending_session_input(
-        self, session_input: OmnidreamsSessionInput
-    ) -> None: ...
-
-
-@dataclass(slots=True)
-class _OmnidreamsPendingSessionInputState:
-    runtime_config: OmnidreamsRuntimeConfig
-    pending_session_input: OmnidreamsSessionInput | None = None
-
-    def peek(self) -> OmnidreamsSessionInput | None:
-        return self.pending_session_input
-
-    def clear(self) -> None:
-        self.pending_session_input = None
-
-    def set(self, manager: Any, session_input: Any) -> None:
-        if not isinstance(session_input, OmnidreamsSessionInput):
-            raise TypeError("Expected OmnidreamsSessionInput.")
-        if manager.has_active_session():
-            raise SessionBusyError(_BUSY_MESSAGE)
-        preset = session_input.postprocess_preset
-        if preset:
-            _validate_requested_postprocess_preset(
-                requested_preset=preset,
-                configured_preset=self.runtime_config.postprocess.preset,
-            )
-        self.pending_session_input = session_input
 
 
 def create_omnidreams_webrtc_manager_options(
@@ -68,8 +37,13 @@ def create_omnidreams_webrtc_manager_options(
     runtime_config: OmnidreamsRuntimeConfig,
 ) -> WebRTCManagerOptions:
     """Build shared manager options for OmniDreams WebRTC semantics."""
-    session_input_state = _OmnidreamsPendingSessionInputState(
-        runtime_config=runtime_config
+    session_input_state = PendingSessionInputState(
+        busy_message=_BUSY_MESSAGE,
+        input_type=OmnidreamsSessionInput,
+        validate_input=lambda session_input: validate_omnidreams_session_input(
+            session_input,
+            runtime_config=runtime_config,
+        ),
     )
 
     async def reset_runtime(runtime: Any, session_input: Any) -> None:
@@ -97,49 +71,74 @@ def create_omnidreams_webrtc_manager_options(
     )
 
 
-async def postprocess_options(request: web.Request) -> web.StreamResponse:
+def build_postprocess_options_payload(manager: Any) -> dict[str, Any]:
     """Return the postprocess preset selected at server launch."""
-    manager = _get_omnidreams_manager(request.app)
     configured_preset = manager.runtime_config.postprocess.preset
     presets = [configured_preset] if configured_preset else []
-    return web.json_response(
-        {
-            "default_preset": configured_preset,
-            "presets": presets,
-        }
-    )
+    return {
+        "default_preset": configured_preset,
+        "presets": presets,
+    }
 
 
-async def session_input(request: web.Request) -> web.StreamResponse:
-    """Apply browser-selected settings to the next WebRTC rollout."""
+async def parse_omnidreams_session_input(
+    request: web.Request,
+    manager: Any,
+) -> OmnidreamsSessionInput:
+    """Parse browser-selected settings for the next WebRTC rollout."""
+    del manager
     try:
         payload = await request.json()
     except Exception as exc:
-        raise web.HTTPBadRequest(reason="Expected JSON session input.") from exc
+        raise ValueError("Expected JSON session input.") from exc
     if not isinstance(payload, dict):
-        raise web.HTTPBadRequest(reason="Session input must be a JSON object.")
+        raise ValueError("Session input must be a JSON object.")
     preset = payload.get("postprocess_preset")
     if not isinstance(preset, str):
-        raise web.HTTPBadRequest(
-            reason="Session input must include string 'postprocess_preset'."
+        raise ValueError(
+            "Session input must include string 'postprocess_preset'."
+        )
+    return OmnidreamsSessionInput(postprocess_preset=preset)
+
+
+def build_session_input_response(
+    session_input: Any,
+    manager: Any,
+) -> dict[str, Any]:
+    """Return the browser-visible settings accepted for the next rollout."""
+    del manager
+    omnidreams_input = cast(OmnidreamsSessionInput, session_input)
+    return {"postprocess_preset": omnidreams_input.postprocess_preset}
+
+
+def validate_omnidreams_session_input(
+    session_input: Any,
+    *,
+    runtime_config: OmnidreamsRuntimeConfig,
+) -> None:
+    """Validate OmniDreams session input before storing it for next reset."""
+    omnidreams_input = cast(OmnidreamsSessionInput, session_input)
+    preset = omnidreams_input.postprocess_preset
+    if preset:
+        _validate_requested_postprocess_preset(
+            requested_preset=preset,
+            configured_preset=runtime_config.postprocess.preset,
         )
 
-    manager = _get_omnidreams_manager(request.app)
-    try:
-        manager.set_pending_session_input(
-            OmnidreamsSessionInput(postprocess_preset=preset)
-        )
-    except SessionBusyError as exc:
-        raise web.HTTPConflict(reason=str(exc)) from exc
-    except ValueError as exc:
-        raise web.HTTPBadRequest(reason=str(exc)) from exc
-    return web.json_response({"postprocess_preset": preset})
 
-
-def configure_omnidreams_webrtc_app(app: web.Application) -> None:
-    """Register OmniDreams browser support routes on a shared WebRTC app."""
-    app.router.add_get("/api/postprocess/options", postprocess_options)
-    app.router.add_post("/api/session/input", session_input)
+def create_omnidreams_webrtc_routes() -> tuple[WebRTCRoute, ...]:
+    """Describe OmniDreams browser support routes for the shared app builder."""
+    return (
+        json_get_route(
+            "/api/postprocess/options",
+            build_postprocess_options_payload,
+        ),
+        session_input_route(
+            "/api/session/input",
+            parse_input=parse_omnidreams_session_input,
+            build_response=build_session_input_response,
+        ),
+    )
 
 
 def create_omnidreams_webrtc_app_extension(
@@ -155,7 +154,7 @@ def create_omnidreams_webrtc_app_extension(
     return WebRTCAppExtension(
         web_resource=files("omnidreams.webrtc").joinpath("web"),
         preload_name=preload_name or "Omnidreams",
-        configure_app=configure_omnidreams_webrtc_app,
+        routes=create_omnidreams_webrtc_routes(),
     )
 
 
@@ -165,15 +164,13 @@ def validate_postprocess_preset(preset: str) -> None:
         resolve_postprocess_preset(preset)
 
 
-def _get_omnidreams_manager(app: web.Application) -> _OmnidreamsSessionManager:
-    return cast(_OmnidreamsSessionManager, app[SESSION_MANAGER_KEY])
-
-
 __all__ = [
-    "configure_omnidreams_webrtc_app",
+    "build_postprocess_options_payload",
+    "build_session_input_response",
     "create_omnidreams_webrtc_app_extension",
     "create_omnidreams_webrtc_manager_options",
-    "postprocess_options",
-    "session_input",
+    "create_omnidreams_webrtc_routes",
+    "parse_omnidreams_session_input",
+    "validate_omnidreams_session_input",
     "validate_postprocess_preset",
 ]

--- a/integrations/omnidreams/omnidreams/demo/webrtc.py
+++ b/integrations/omnidreams/omnidreams/demo/webrtc.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""OmniDreams WebRTC hooks for the shared demo API."""
+"""OmniDreams hooks for configuring the shared WebRTC demo session.
+
+This file supplies model-specific options, routes, payload parsing, and
+postprocess validation while shared code owns the WebRTC app and session
+manager.
+"""
 
 from __future__ import annotations
 

--- a/integrations/omnidreams/tests/test_demo_api.py
+++ b/integrations/omnidreams/tests/test_demo_api.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import ast
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, cast
 
+import omnidreams.demo as demo_package
 import omnidreams.demo.spec as spec_module
 import pytest
 import torch
@@ -24,7 +26,7 @@ from omnidreams.demo.replay import (
     OmnidreamsReplayRuntime,
     OmnidreamsReplayRuntimeOptions,
 )
-from omnidreams.webrtc.session import OmnidreamsSessionInput
+from omnidreams.demo.live_runtime import OmnidreamsSessionInput
 
 import flashdreams.runtime.demo.webrtc as runtime_demo_webrtc_module
 from flashdreams.infra.video_output import VideoStepResult
@@ -65,6 +67,26 @@ def test_omnidreams_demo_adapter_declares_mp4_and_webrtc_modes() -> None:
     assert adapter.model_id == OMNIDREAMS_MODEL_ID
     assert adapter.supported_input_modes() == ("replay", "keyboard-driving")
     assert adapter.supported_output_modes() == ("mp4", "webrtc")
+
+
+def test_omnidreams_demo_does_not_import_legacy_webrtc_session() -> None:
+    demo_dir = Path(demo_package.__file__).parent
+    offenders: list[str] = []
+
+    for path in sorted(demo_dir.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module == "omnidreams.webrtc.session":
+                    offenders.append(path.name)
+            elif isinstance(node, ast.Import):
+                if any(
+                    alias.name == "omnidreams.webrtc.session"
+                    for alias in node.names
+                ):
+                    offenders.append(path.name)
+
+    assert offenders == []
 
 
 def test_omnidreams_replay_demo_uses_shared_runner(tmp_path: Path) -> None:

--- a/integrations/omnidreams/tests/test_demo_api.py
+++ b/integrations/omnidreams/tests/test_demo_api.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, cast
 
 import omnidreams.demo.spec as spec_module
-import omnidreams.demo.webrtc as demo_webrtc_module
 import pytest
 import torch
 from aiohttp import web
@@ -25,8 +24,9 @@ from omnidreams.demo.replay import (
     OmnidreamsReplayRuntime,
     OmnidreamsReplayRuntimeOptions,
 )
-from omnidreams.demo.webrtc import OmnidreamsDemoWebRTCSessionManager
+from omnidreams.webrtc.session import OmnidreamsSessionInput
 
+import flashdreams.runtime.demo.webrtc as runtime_demo_webrtc_module
 from flashdreams.infra.video_output import VideoStepResult
 from flashdreams.runtime import (
     InferenceConfig,
@@ -42,7 +42,11 @@ from flashdreams.runtime.demo import (
     serve_flashdreams_demo,
 )
 from flashdreams.runtime.demo.replay import run_replay_demo
-from flashdreams.runtime.demo.webrtc import WebRTCDemo, build_webrtc_demo
+from flashdreams.runtime.demo.webrtc import (
+    SharedDemoWebRTCSessionManager,
+    WebRTCDemo,
+    build_webrtc_demo,
+)
 from flashdreams.serving.webrtc.server import SESSION_MANAGER_KEY
 
 pytestmark = pytest.mark.ci_cpu
@@ -363,7 +367,7 @@ def test_omnidreams_webrtc_demo_uses_shared_manager_with_model_config() -> None:
     demo = build_webrtc_demo(spec=spec, adapter=adapter)
 
     assert isinstance(demo.runtime, _FakeWebRTCRuntime)
-    assert isinstance(demo.session_manager, OmnidreamsDemoWebRTCSessionManager)
+    assert isinstance(demo.session_manager, SharedDemoWebRTCSessionManager)
     assert demo.session_manager._runtime is demo.runtime
     assert demo.session_manager.runtime_config is demo.runtime.config
     assert demo.runtime_config is demo.runtime.config
@@ -379,6 +383,16 @@ def test_omnidreams_webrtc_demo_uses_shared_manager_with_model_config() -> None:
     assert demo.runtime_config.debug_serve_hdmaps is True
     assert demo.runtime_config.encoder_backend == "default"
     assert demo.session_manager._model_name() == DEFAULT_OMNIDREAMS_PRESET
+    assert (
+        demo.session_manager._busy_message == "An Omnidreams session is already active."
+    )
+    assert demo.session_manager._warmup_label == "Omnidreams WebRTC"
+    assert demo.session_manager._close_session_on_generation_error is True
+    session_input = OmnidreamsSessionInput(postprocess_preset="")
+    demo.session_manager.set_pending_session_input(session_input)
+    assert demo.session_manager._peek_pending_session_input() == session_input
+    demo.session_manager._clear_pending_session_input()
+    assert demo.session_manager._peek_pending_session_input() is None
     assert demo.host == "0.0.0.0"
     assert demo.port == 8082
 
@@ -396,7 +410,7 @@ def test_omnidreams_webrtc_demo_installs_model_routes(
         return app
 
     monkeypatch.setattr(
-        demo_webrtc_module,
+        runtime_demo_webrtc_module,
         "create_packaged_webrtc_app",
         fake_create_packaged_webrtc_app,
     )
@@ -447,7 +461,7 @@ def test_omnidreams_webrtc_demo_serves_through_shared_runner(
         server_calls.append(kwargs)
 
     monkeypatch.setattr(
-        demo_webrtc_module,
+        runtime_demo_webrtc_module,
         "create_packaged_webrtc_app",
         fake_create_packaged_webrtc_app,
     )
@@ -485,7 +499,7 @@ def test_omnidreams_webrtc_demo_serves_through_shared_runner(
     assert server_calls[0]["app"] is demo.app
     assert server_calls[0]["host"] == "0.0.0.0"
     assert server_calls[0]["port"] == 8082
-    assert isinstance(demo.session_manager, OmnidreamsDemoWebRTCSessionManager)
+    assert isinstance(demo.session_manager, SharedDemoWebRTCSessionManager)
 
 
 class _RecordingOutputTarget:


### PR DESCRIPTION
Create a follow-up branch to consolidate the demo WebRTC path so OmniDreams and LingBot can use the same shared server/session construction, with model-specific behavior supplied through small adapter hooks. Cherry-pick the NVENC probing fix needed before refactoring the WebRTC stack.