### PR TITLE
[Running Flashdreams] Fix newer aarch64 container support

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4778,10 +4778,10 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.17.0"
+version = "2.17.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/26/e501a474a3f36c2d439561fa4f2094a3c0344df439500dda55937a8fccf7/transformer_engine-2.17.0-py3-none-any.whl", hash = "sha256:c274fd74ea2e4caa7132921e1ecfa3847931abbed9f6b8cab61346cdb833bc76", size = 1001710, upload-time = "2026-07-09T00:36:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ef/8685e8c1f04670acec637a5b99674ca14476cee0cb20a69b11a8105009ea/transformer_engine-2.17.1-py3-none-any.whl", hash = "sha256:8a4543c0b0ffe4c6117bfbe7a0b6bb9acba0d159782fa4922aaee202ba2cfdc9", size = 1004700, upload-time = "2026-08-05T23:14:46.259Z" },
 ]
 
 [package.optional-dependencies]
@@ -4794,7 +4794,7 @@ pytorch = [
 
 [[package]]
 name = "transformer-engine-cu13"
-version = "2.17.0"
+version = "2.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "sys_platform != 'win32'" },
@@ -4802,12 +4802,13 @@ dependencies = [
     { name = "pydantic", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/21/5e0ec562539798ffd375c218b8bd7612b387455ccc79ae14576f411c9609/transformer_engine_cu13-2.17.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1c8e6627cf02358201f513ab902c7b4f82f179214bd775edc97ce0f2001d82da", size = 244570183, upload-time = "2026-07-09T00:36:35.507Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c0/3a4445c98970607ab003c0cc0c3a78dc37c1840805ebf7549a8ffe67243e/transformer_engine_cu13-2.17.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:8f7131caa91f04bd2fe21b35d22d81564a7b43fc6ea33242288b0596abf094e1", size = 243292265, upload-time = "2026-08-05T23:29:01.411Z" },
+    { url = "https://files.pythonhosted.org/packages/20/58/3edd51d32ce2c87db3b26fb7ba284f399de5a40231621909c2da61b3149d/transformer_engine_cu13-2.17.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f24a3d84938da755127378e580c56d8918316e84d4ba65a74f50723a688fc29a", size = 244573051, upload-time = "2026-08-05T23:15:14.641Z" },
 ]
 
 [[package]]
 name = "transformer-engine-torch"
-version = "2.17.0"
+version = "2.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops", marker = "sys_platform != 'win32'" },
@@ -4819,7 +4820,7 @@ dependencies = [
     { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
     { name = "transformer-engine-cu13", marker = "sys_platform != 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/f1/ad613157261ac71262f5f260acf07fe22ae5ee0bb0675622c4f19a3e8afb/transformer_engine_torch-2.17.0.tar.gz", hash = "sha256:52ca109cdbc987ca02f87735fa375da8a02e117acb87e25dcb7e27dca37aa87f", size = 369712, upload-time = "2026-07-09T00:36:28.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/6d/49ce8a9369c744355ac29505400b275d73ac3c5c03b0feecab2e81df3b3e/transformer_engine_torch-2.17.1.tar.gz", hash = "sha256:5891479407be643c2c6df3b68b25a6b9497a996efe577eb88899c27c04dad9e2", size = 369810, upload-time = "2026-08-05T23:15:04.976Z" }
 
 [[package]]
 name = "transformers"


### PR DESCRIPTION
Currently, `uv sync --extra dev --extra runners` will fail on newer containers (`manylinux_2_39_aarch64`+) with `transformer-engine-cu13` incompatibility.

This PR changes the utilized version of `transformer-engine-cu13` into a supported version.