### PR TITLE
Update docs workflow setup-uv action

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
 
       # The doc build only needs `flashdreams` to be importable. The heavy
       # GPU stack (transformer-engine, pynvml, cv2, mediapy, boto3/botocore)


### PR DESCRIPTION
Bump the docs workflow from astral-sh/setup-uv@v4 to @v6 so it matches the rest of CI and avoids the Node certificate failure during action setup.