### PR TITLE
Migrate text2video models to use unified runtime API

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Standalone FlashDreams applications."""

--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone FlashDreams applications."""

--- a/apps/t2v_demo/README.md
+++ b/apps/t2v_demo/README.md
@@ -1,0 +1,22 @@
+# FlashDreams text-to-video demo
+
+This app uses the shared `flashdreams.runtime.demo` replay/session lifecycle.
+The selected integration owns its pipeline and checkpoint configuration; the
+app owns only prompt input, output selection, and the thin runtime adapter.
+
+Run a saved replay:
+
+```bash
+uv run python -m apps.t2v_demo.app replay --backend causal-forcing --output outputs/t2v.mp4
+```
+
+Serve streamed WebRTC output:
+
+```bash
+uv run python -m apps.t2v_demo.app webrtc --backend self-forcing
+```
+
+`--backend` accepts `causal-forcing`, `cosmos-predict2`, and `self-forcing`.
+Use `--preset-id` to select an integration-specific T2V runner preset. The
+browser UI accepts a prompt before opening a generation session, plays emitted
+chunks as they arrive, and records the received WebRTC stream for download.

--- a/apps/t2v_demo/__init__.py
+++ b/apps/t2v_demo/__init__.py
@@ -1,0 +1,1 @@
+"""Unified text-to-video demo backed by the FlashDreams runtime API."""

--- a/apps/t2v_demo/__init__.py
+++ b/apps/t2v_demo/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified text-to-video demo backed by the FlashDreams runtime API."""

--- a/apps/t2v_demo/app.py
+++ b/apps/t2v_demo/app.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Launch the shared-runtime text-to-video replay or WebRTC demo."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, replace
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+from aiohttp import web
+
+from flashdreams.runtime import InferenceConfig
+from flashdreams.runtime.demo import (
+    DemoSpec,
+    Mp4OutputSpec,
+    NullOutputSpec,
+    WebRTCAppResources,
+    WebRTCOutputSpec,
+)
+from flashdreams.runtime.demo.app import DemoApplication
+from flashdreams.runtime.demo.host import RuntimeHost
+from flashdreams.runtime.demo.webrtc import serve_webrtc_demo
+from flashdreams.serving.webrtc.manager import BaseWebRTCSessionManager
+from flashdreams.serving.webrtc.runtime import WebRTCRuntimeConfig
+
+from .backends import backend_choices, backend_metadata, resolve_backend
+from .runtime import (
+    FIELD_FPS,
+    FIELD_PIXEL_HEIGHT,
+    FIELD_PIXEL_WIDTH,
+    FIELD_PROMPT,
+    FIELD_TOTAL_BLOCKS,
+    T2VDemoAdapter,
+    make_adapter,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class T2VWebRTCConfig(WebRTCRuntimeConfig):
+    """Subset of the shared WebRTC configuration used by prompt-only T2V."""
+
+    video_width: int
+    video_height: int
+    warmup_chunks: int
+    warmup_timeout_s: float
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse replay and WebRTC launch options."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("replay", "webrtc"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--backend", choices=backend_choices(), default="causal-forcing")
+        subparser.add_argument("--preset-id", default=None)
+        subparser.add_argument("--device", default="cuda")
+        subparser.add_argument("--compile", action=argparse.BooleanOptionalAction, default=None)
+        subparser.add_argument("--prompt", default=None)
+        subparser.add_argument("--total-blocks", type=int, default=None)
+        subparser.add_argument("--pixel-height", type=int, default=None)
+        subparser.add_argument("--pixel-width", type=int, default=None)
+        subparser.add_argument("--fps", type=int, default=None)
+    replay = subparsers.choices["replay"]
+    replay.add_argument("--output-mode", choices=("mp4", "null"), default="mp4")
+    replay.add_argument("--output", type=Path, default=None)
+    webrtc = subparsers.choices["webrtc"]
+    webrtc.add_argument("--host", default="0.0.0.0")
+    webrtc.add_argument("--port", type=int, default=8080)
+    webrtc.add_argument("--warmup-chunks", type=int, default=0)
+    webrtc.add_argument("--warmup-timeout-s", type=float, default=600.0)
+    webrtc.add_argument("--client-liveness-timeout-s", type=float, default=30.0)
+    args = parser.parse_args(argv)
+    if args.command == "replay" and args.output_mode == "mp4" and args.output is None:
+        parser.error("replay --output is required when --output-mode=mp4.")
+    return args
+
+
+class T2VDemoApplication(DemoApplication):
+    """Text-to-video demo using the common replay and WebRTC runtimes."""
+
+    def __init__(self) -> None:
+        self._backend = "causal-forcing"
+
+    def parse_args(self, argv: list[str] | None = None) -> argparse.Namespace:
+        args = parse_args(argv)
+        self._backend = args.backend
+        return args
+
+    def replay_spec(self, args: argparse.Namespace) -> DemoSpec:
+        return _spec(args, input_mode="replay", output=_replay_output(args))
+
+    def replay_adapter(self) -> T2VDemoAdapter:
+        return make_adapter(self._backend)
+
+    def serve_webrtc(self, args: argparse.Namespace, *, context: Any) -> None:
+        adapter = make_adapter(args.backend)
+        output = WebRTCOutputSpec(
+            host=args.host,
+            port=args.port,
+            fps=_scenario(args)[FIELD_FPS],
+            video_width=_scenario(args)[FIELD_PIXEL_WIDTH],
+            video_height=_scenario(args)[FIELD_PIXEL_HEIGHT],
+            warmup_chunks=args.warmup_chunks,
+            warmup_timeout_s=args.warmup_timeout_s,
+            client_liveness_timeout_s=args.client_liveness_timeout_s,
+            preload_name="FlashDreams T2V",
+        )
+        spec = _spec(args, input_mode="webrtc", output=output, device=str(context.device))
+        prepared = adapter.prepare_scenario(spec)
+        runtime = adapter.create_runtime(spec.config)
+        manager = T2VWebRTCSessionManager(
+            runtime=runtime,
+            runtime_config=T2VWebRTCConfig(
+                video_width=output.video_width,
+                video_height=output.video_height,
+                warmup_chunks=output.warmup_chunks,
+                warmup_timeout_s=output.warmup_timeout_s,
+            ),
+            fps=output.fps,
+            identity=adapter.model_id,
+            supported_control_keys=frozenset({"g"}),
+            shared_host=RuntimeHost(runtime),
+            shared_adapter=adapter,
+            shared_spec=spec,
+            shared_scenario=prepared,
+            client_liveness_timeout_s=output.client_liveness_timeout_s,
+        )
+        serve_webrtc_demo(
+            output=output,
+            model_id=adapter.model_id,
+            session_manager=manager,
+            app_resources=WebRTCAppResources(
+                model_web_resource=files("apps.t2v_demo").joinpath("web"),
+                configure_app=lambda app: _configure_app(app, manager=manager, args=args),
+                preload_name="FlashDreams T2V",
+            ),
+            world_rank=context.world_rank,
+        )
+
+
+class T2VWebRTCSessionManager(BaseWebRTCSessionManager[Any, T2VWebRTCConfig]):
+    """Shared manager with a prompt update for the next browser session."""
+
+    def update_prompt(self, prompt: str) -> None:
+        if self.has_active_session():
+            raise RuntimeError("Wait for the current generation to finish before changing the prompt.")
+        if not prompt.strip():
+            raise ValueError("Prompt must be non-empty.")
+        scenario = dict(self._shared_spec.scenario or {})
+        scenario[FIELD_PROMPT] = prompt.strip()
+        self._shared_spec = replace(self._shared_spec, scenario=scenario)
+        self._shared_scenario = self._shared_adapter.prepare_scenario(self._shared_spec)
+
+
+def _configure_app(app: web.Application, *, manager: T2VWebRTCSessionManager, args: argparse.Namespace) -> None:
+    async def config(_: web.Request) -> web.StreamResponse:
+        return web.json_response({"backends": backend_metadata(), "selected_backend": args.backend})
+
+    async def update_prompt(request: web.Request) -> web.StreamResponse:
+        payload = await request.json()
+        if not isinstance(payload, dict) or not isinstance(payload.get("prompt"), str):
+            raise web.HTTPBadRequest(reason="Expected a JSON prompt.")
+        try:
+            manager.update_prompt(payload["prompt"])
+        except (RuntimeError, ValueError) as exc:
+            raise web.HTTPBadRequest(reason=str(exc)) from exc
+        return web.json_response({"status": "ok"})
+
+    app.router.add_get("/api/t2v/config", config)
+    app.router.add_post("/api/t2v/prompt", update_prompt)
+
+
+def _scenario(args: argparse.Namespace) -> dict[str, object]:
+    runner = resolve_backend(args.backend).resolve_runner(args.preset_id)
+    return {
+        FIELD_PROMPT: args.prompt or str(getattr(runner, FIELD_PROMPT)),
+        FIELD_TOTAL_BLOCKS: args.total_blocks or int(getattr(runner, FIELD_TOTAL_BLOCKS, 1)),
+        FIELD_PIXEL_HEIGHT: args.pixel_height or int(getattr(runner, FIELD_PIXEL_HEIGHT, 480)),
+        FIELD_PIXEL_WIDTH: args.pixel_width or int(getattr(runner, FIELD_PIXEL_WIDTH, 832)),
+        FIELD_FPS: args.fps or int(getattr(runner, FIELD_FPS, 16)),
+    }
+
+
+def _spec(args: argparse.Namespace, *, input_mode: str, output: object, device: str | None = None) -> DemoSpec:
+    backend = resolve_backend(args.backend)
+    return DemoSpec(
+        model_id="flashdreams-t2v",
+        preset_id=args.preset_id or backend.default_preset_name,
+        input_mode=input_mode,
+        scenario=_scenario(args),
+        output=output,
+        config=InferenceConfig(
+            model_id="flashdreams-t2v",
+            preset_id=args.preset_id or backend.default_preset_name,
+            device=device or args.device,
+            compile=args.compile,
+            runtime_options={"backend": backend.key},
+        ),
+    )
+
+
+def _replay_output(args: argparse.Namespace) -> Mp4OutputSpec | NullOutputSpec:
+    if args.output_mode == "null":
+        return NullOutputSpec()
+    return Mp4OutputSpec(path=args.output, fps=_scenario(args)[FIELD_FPS], output_layout="tchw")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the T2V demo."""
+    T2VDemoApplication().main(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/t2v_demo/app.py
+++ b/apps/t2v_demo/app.py
@@ -23,7 +23,10 @@ from flashdreams.runtime.demo import (
     WebRTCAppResources,
     WebRTCOutputSpec,
 )
-from flashdreams.runtime.demo.bootstrap import configure_logging, initialize_cuda_distributed
+from flashdreams.runtime.demo.bootstrap import (
+    configure_logging,
+    initialize_cuda_distributed,
+)
 from flashdreams.runtime.demo.host import RuntimeHost
 from flashdreams.runtime.demo.replay import run_replay_demo
 from flashdreams.serving.webrtc.demo import serve_webrtc_demo
@@ -90,11 +93,19 @@ def launch_t2v(
     if mode in {"mp4", "null"}:
         output = _replay_output(
             mode=mode,
-            output_path=output_overrides.get("path", output_overrides.get("output", config.output)),
+            output_path=output_overrides.get(
+                "path", output_overrides.get("output", config.output)
+            ),
             fps=int(output_overrides.get("fps", scenario[FIELD_FPS])),
         )
         result = run_replay_demo(
-            spec=_spec(config, adapter=adapter, scenario=scenario, input_mode="replay", output=output),
+            spec=_spec(
+                config,
+                adapter=adapter,
+                scenario=scenario,
+                input_mode="replay",
+                output=output,
+            ),
             adapter=adapter,
         )
         if result.status != "completed":
@@ -107,11 +118,17 @@ def launch_t2v(
         host=str(host or output_overrides.get("host", "0.0.0.0")),
         port=int(port if port is not None else output_overrides.get("port", 8080)),
         fps=int(output_overrides.get("fps", scenario[FIELD_FPS])),
-        video_width=int(output_overrides.get("video_width", scenario[FIELD_PIXEL_WIDTH])),
-        video_height=int(output_overrides.get("video_height", scenario[FIELD_PIXEL_HEIGHT])),
+        video_width=int(
+            output_overrides.get("video_width", scenario[FIELD_PIXEL_WIDTH])
+        ),
+        video_height=int(
+            output_overrides.get("video_height", scenario[FIELD_PIXEL_HEIGHT])
+        ),
         warmup_chunks=int(output_overrides.get("warmup_chunks", 0)),
         warmup_timeout_s=float(output_overrides.get("warmup_timeout_s", 600.0)),
-        client_liveness_timeout_s=float(output_overrides.get("client_liveness_timeout_s", 30.0)),
+        client_liveness_timeout_s=float(
+            output_overrides.get("client_liveness_timeout_s", 30.0)
+        ),
         preload_name="FlashDreams T2V",
     )
     spec = _spec(
@@ -165,8 +182,10 @@ def _scenario(
     def value(name: str, default: object) -> object:
         overridden = overrides.get(name)
         configured = getattr(config, name)
-        return default if overridden is None and configured is None else (
-            configured if overridden is None else overridden
+        return (
+            default
+            if overridden is None and configured is None
+            else (configured if overridden is None else overridden)
         )
 
     return {
@@ -210,9 +229,7 @@ def _replay_output(
         return NullOutputSpec()
     if output_path is None:
         raise ValueError("T2V MP4 mode requires an output path.")
-    return Mp4OutputSpec(
-        path=Path(str(output_path)), fps=fps, output_layout="tchw"
-    )
+    return Mp4OutputSpec(path=Path(str(output_path)), fps=fps, output_layout="tchw")
 
 
 def _configure_app(
@@ -264,7 +281,9 @@ def _configure_app(
             )
         return web.Response(
             body=buffer.getvalue(),
-            headers={"Content-Disposition": "attachment; filename=flashdreams-generation.zip"},
+            headers={
+                "Content-Disposition": "attachment; filename=flashdreams-generation.zip"
+            },
             content_type="application/zip",
         )
 

--- a/apps/t2v_demo/app.py
+++ b/apps/t2v_demo/app.py
@@ -128,6 +128,7 @@ class T2VDemoApplication(DemoApplication):
             shared_spec=spec,
             shared_scenario=prepared,
             client_liveness_timeout_s=output.client_liveness_timeout_s,
+            keep_connection_after_completed=True,
         )
         serve_webrtc_demo(
             output=output,
@@ -146,8 +147,6 @@ class T2VWebRTCSessionManager(BaseWebRTCSessionManager[Any, T2VWebRTCConfig]):
     """Shared manager with a prompt update for the next browser session."""
 
     def update_prompt(self, prompt: str) -> None:
-        if self.has_active_session():
-            raise RuntimeError("Wait for the current generation to finish before changing the prompt.")
         if not prompt.strip():
             raise ValueError("Prompt must be non-empty.")
         scenario = dict(self._shared_spec.scenario or {})

--- a/apps/t2v_demo/app.py
+++ b/apps/t2v_demo/app.py
@@ -6,6 +6,9 @@
 from __future__ import annotations
 
 import argparse
+import io
+import json
+import zipfile
 from dataclasses import dataclass, replace
 from importlib.resources import files
 from pathlib import Path
@@ -146,11 +149,16 @@ class T2VDemoApplication(DemoApplication):
 class T2VWebRTCSessionManager(BaseWebRTCSessionManager[Any, T2VWebRTCConfig]):
     """Shared manager with a prompt update for the next browser session."""
 
-    def update_prompt(self, prompt: str) -> None:
+    def update_prompt(self, prompt: str, duration_s: float) -> None:
         if not prompt.strip():
             raise ValueError("Prompt must be non-empty.")
+        if not 0 < duration_s <= 60:
+            raise ValueError("Duration must be greater than 0 and at most 60 seconds.")
         scenario = dict(self._shared_spec.scenario or {})
         scenario[FIELD_PROMPT] = prompt.strip()
+        scenario[FIELD_TOTAL_BLOCKS] = self.runtime.blocks_for_duration(
+            duration_s, fps=int(scenario[FIELD_FPS])
+        )
         self._shared_spec = replace(self._shared_spec, scenario=scenario)
         self._shared_scenario = self._shared_adapter.prepare_scenario(self._shared_spec)
 
@@ -163,14 +171,38 @@ def _configure_app(app: web.Application, *, manager: T2VWebRTCSessionManager, ar
         payload = await request.json()
         if not isinstance(payload, dict) or not isinstance(payload.get("prompt"), str):
             raise web.HTTPBadRequest(reason="Expected a JSON prompt.")
+        duration_s = payload.get("duration_s")
+        if not isinstance(duration_s, int | float):
+            raise web.HTTPBadRequest(reason="Expected numeric duration_s.")
         try:
-            manager.update_prompt(payload["prompt"])
+            manager.update_prompt(payload["prompt"], float(duration_s))
         except (RuntimeError, ValueError) as exc:
             raise web.HTTPBadRequest(reason=str(exc)) from exc
         return web.json_response({"status": "ok"})
 
+    async def download(_: web.Request) -> web.StreamResponse:
+        artifact = manager.runtime.latest_artifact
+        if artifact is None:
+            raise web.HTTPNotFound(reason="No completed generation is available yet.")
+        video_path, scenario = artifact
+        if not video_path.is_file():
+            raise web.HTTPNotFound(reason="Generated MP4 is no longer available.")
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.write(video_path, "video.mp4")
+            archive.writestr("prompt.json", json.dumps({"prompt": scenario.prompt, "total_blocks": scenario.total_blocks, "fps": scenario.fps, "width": scenario.pixel_width, "height": scenario.pixel_height}, indent=2))
+        return web.Response(body=buffer.getvalue(), headers={"Content-Disposition": "attachment; filename=flashdreams-generation.zip"}, content_type="application/zip")
+
+    async def playback(_: web.Request) -> web.StreamResponse:
+        artifact = manager.runtime.latest_artifact
+        if artifact is None or not artifact[0].is_file():
+            raise web.HTTPNotFound(reason="No completed MP4 is available yet.")
+        return web.FileResponse(artifact[0])
+
     app.router.add_get("/api/t2v/config", config)
     app.router.add_post("/api/t2v/prompt", update_prompt)
+    app.router.add_get("/api/t2v/download", download)
+    app.router.add_get("/api/t2v/playback", playback)
 
 
 def _scenario(args: argparse.Namespace) -> dict[str, object]:

--- a/apps/t2v_demo/app.py
+++ b/apps/t2v_demo/app.py
@@ -1,18 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Launch the shared-runtime text-to-video replay or WebRTC demo."""
+"""Typed ``flashdreams-run t2v`` launch implementation."""
 
 from __future__ import annotations
 
-import argparse
 import io
 import json
 import zipfile
 from dataclasses import dataclass, replace
 from importlib.resources import files
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from aiohttp import web
 
@@ -24,13 +23,14 @@ from flashdreams.runtime.demo import (
     WebRTCAppResources,
     WebRTCOutputSpec,
 )
-from flashdreams.runtime.demo.app import DemoApplication
+from flashdreams.runtime.demo.bootstrap import configure_logging, initialize_cuda_distributed
 from flashdreams.runtime.demo.host import RuntimeHost
-from flashdreams.runtime.demo.webrtc import serve_webrtc_demo
+from flashdreams.runtime.demo.replay import run_replay_demo
+from flashdreams.serving.webrtc.demo import serve_webrtc_demo
 from flashdreams.serving.webrtc.manager import BaseWebRTCSessionManager
 from flashdreams.serving.webrtc.runtime import WebRTCRuntimeConfig
 
-from .backends import backend_choices, backend_metadata, resolve_backend
+from .backends import backend_metadata, resolve_backend
 from .runtime import (
     FIELD_FPS,
     FIELD_PIXEL_HEIGHT,
@@ -41,109 +41,18 @@ from .runtime import (
     make_adapter,
 )
 
+if TYPE_CHECKING:
+    from .runner import T2VDemoRunnerConfig
+
 
 @dataclass(frozen=True, slots=True)
 class T2VWebRTCConfig(WebRTCRuntimeConfig):
-    """Subset of the shared WebRTC configuration used by prompt-only T2V."""
+    """Shared WebRTC settings required by the prompt-only T2V demo."""
 
     video_width: int
     video_height: int
     warmup_chunks: int
     warmup_timeout_s: float
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse replay and WebRTC launch options."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    for command in ("replay", "webrtc"):
-        subparser = subparsers.add_parser(command)
-        subparser.add_argument("--backend", choices=backend_choices(), default="causal-forcing")
-        subparser.add_argument("--preset-id", default=None)
-        subparser.add_argument("--device", default="cuda")
-        subparser.add_argument("--compile", action=argparse.BooleanOptionalAction, default=None)
-        subparser.add_argument("--prompt", default=None)
-        subparser.add_argument("--total-blocks", type=int, default=None)
-        subparser.add_argument("--pixel-height", type=int, default=None)
-        subparser.add_argument("--pixel-width", type=int, default=None)
-        subparser.add_argument("--fps", type=int, default=None)
-    replay = subparsers.choices["replay"]
-    replay.add_argument("--output-mode", choices=("mp4", "null"), default="mp4")
-    replay.add_argument("--output", type=Path, default=None)
-    webrtc = subparsers.choices["webrtc"]
-    webrtc.add_argument("--host", default="0.0.0.0")
-    webrtc.add_argument("--port", type=int, default=8080)
-    webrtc.add_argument("--warmup-chunks", type=int, default=0)
-    webrtc.add_argument("--warmup-timeout-s", type=float, default=600.0)
-    webrtc.add_argument("--client-liveness-timeout-s", type=float, default=30.0)
-    args = parser.parse_args(argv)
-    if args.command == "replay" and args.output_mode == "mp4" and args.output is None:
-        parser.error("replay --output is required when --output-mode=mp4.")
-    return args
-
-
-class T2VDemoApplication(DemoApplication):
-    """Text-to-video demo using the common replay and WebRTC runtimes."""
-
-    def __init__(self) -> None:
-        self._backend = "causal-forcing"
-
-    def parse_args(self, argv: list[str] | None = None) -> argparse.Namespace:
-        args = parse_args(argv)
-        self._backend = args.backend
-        return args
-
-    def replay_spec(self, args: argparse.Namespace) -> DemoSpec:
-        return _spec(args, input_mode="replay", output=_replay_output(args))
-
-    def replay_adapter(self) -> T2VDemoAdapter:
-        return make_adapter(self._backend)
-
-    def serve_webrtc(self, args: argparse.Namespace, *, context: Any) -> None:
-        adapter = make_adapter(args.backend)
-        output = WebRTCOutputSpec(
-            host=args.host,
-            port=args.port,
-            fps=_scenario(args)[FIELD_FPS],
-            video_width=_scenario(args)[FIELD_PIXEL_WIDTH],
-            video_height=_scenario(args)[FIELD_PIXEL_HEIGHT],
-            warmup_chunks=args.warmup_chunks,
-            warmup_timeout_s=args.warmup_timeout_s,
-            client_liveness_timeout_s=args.client_liveness_timeout_s,
-            preload_name="FlashDreams T2V",
-        )
-        spec = _spec(args, input_mode="webrtc", output=output, device=str(context.device))
-        prepared = adapter.prepare_scenario(spec)
-        runtime = adapter.create_runtime(spec.config)
-        manager = T2VWebRTCSessionManager(
-            runtime=runtime,
-            runtime_config=T2VWebRTCConfig(
-                video_width=output.video_width,
-                video_height=output.video_height,
-                warmup_chunks=output.warmup_chunks,
-                warmup_timeout_s=output.warmup_timeout_s,
-            ),
-            fps=output.fps,
-            identity=adapter.model_id,
-            supported_control_keys=frozenset({"g"}),
-            shared_host=RuntimeHost(runtime),
-            shared_adapter=adapter,
-            shared_spec=spec,
-            shared_scenario=prepared,
-            client_liveness_timeout_s=output.client_liveness_timeout_s,
-            keep_connection_after_completed=True,
-        )
-        serve_webrtc_demo(
-            output=output,
-            model_id=adapter.model_id,
-            session_manager=manager,
-            app_resources=WebRTCAppResources(
-                model_web_resource=files("apps.t2v_demo").joinpath("web"),
-                configure_app=lambda app: _configure_app(app, manager=manager, args=args),
-                preload_name="FlashDreams T2V",
-            ),
-            world_rank=context.world_rank,
-        )
 
 
 class T2VWebRTCSessionManager(BaseWebRTCSessionManager[Any, T2VWebRTCConfig]):
@@ -163,9 +72,159 @@ class T2VWebRTCSessionManager(BaseWebRTCSessionManager[Any, T2VWebRTCConfig]):
         self._shared_scenario = self._shared_adapter.prepare_scenario(self._shared_spec)
 
 
-def _configure_app(app: web.Application, *, manager: T2VWebRTCSessionManager, args: argparse.Namespace) -> None:
-    async def config(_: web.Request) -> web.StreamResponse:
-        return web.json_response({"backends": backend_metadata(), "selected_backend": args.backend})
+def launch_t2v(
+    *,
+    config: "T2VDemoRunnerConfig",
+    mode: Literal["mp4", "null", "webrtc"],
+    scenario_overrides: dict[str, object] | None = None,
+    output_overrides: dict[str, object] | None = None,
+    host: str | None = None,
+    port: int | None = None,
+) -> object:
+    """Launch T2V directly from its typed ``flashdreams-run`` configuration."""
+    configure_logging()
+    scenario_overrides = scenario_overrides or {}
+    output_overrides = output_overrides or {}
+    adapter = make_adapter(config.backend)
+    scenario = _scenario(config, scenario_overrides)
+    if mode in {"mp4", "null"}:
+        output = _replay_output(
+            mode=mode,
+            output_path=output_overrides.get("path", output_overrides.get("output", config.output)),
+            fps=int(output_overrides.get("fps", scenario[FIELD_FPS])),
+        )
+        result = run_replay_demo(
+            spec=_spec(config, adapter=adapter, scenario=scenario, input_mode="replay", output=output),
+            adapter=adapter,
+        )
+        if result.status != "completed":
+            reason = result.reason or str(result.error) or "T2V replay failed."
+            raise RuntimeError(reason)
+        return result
+
+    context = initialize_cuda_distributed(default_device=config.device)
+    output = WebRTCOutputSpec(
+        host=str(host or output_overrides.get("host", "0.0.0.0")),
+        port=int(port if port is not None else output_overrides.get("port", 8080)),
+        fps=int(output_overrides.get("fps", scenario[FIELD_FPS])),
+        video_width=int(output_overrides.get("video_width", scenario[FIELD_PIXEL_WIDTH])),
+        video_height=int(output_overrides.get("video_height", scenario[FIELD_PIXEL_HEIGHT])),
+        warmup_chunks=int(output_overrides.get("warmup_chunks", 0)),
+        warmup_timeout_s=float(output_overrides.get("warmup_timeout_s", 600.0)),
+        client_liveness_timeout_s=float(output_overrides.get("client_liveness_timeout_s", 30.0)),
+        preload_name="FlashDreams T2V",
+    )
+    spec = _spec(
+        config,
+        adapter=adapter,
+        scenario=scenario,
+        input_mode="webrtc",
+        output=output,
+        device=str(context.device),
+    )
+    prepared = adapter.prepare_scenario(spec)
+    runtime = adapter.create_runtime(spec.config)
+    manager = T2VWebRTCSessionManager(
+        runtime=runtime,
+        runtime_config=T2VWebRTCConfig(
+            video_width=output.video_width,
+            video_height=output.video_height,
+            warmup_chunks=output.warmup_chunks,
+            warmup_timeout_s=output.warmup_timeout_s,
+        ),
+        fps=output.fps,
+        identity=adapter.model_id,
+        supported_control_keys=frozenset({"g"}),
+        shared_host=RuntimeHost(runtime),
+        shared_adapter=adapter,
+        shared_spec=spec,
+        shared_scenario=prepared,
+        client_liveness_timeout_s=output.client_liveness_timeout_s,
+        keep_connection_after_completed=True,
+    )
+    return serve_webrtc_demo(
+        output=output,
+        model_id=adapter.model_id,
+        session_manager=manager,
+        app_resources=WebRTCAppResources(
+            model_web_resource=files(__package__).joinpath("web"),
+            configure_app=lambda app: _configure_app(
+                app, manager=manager, backend=config.backend
+            ),
+            preload_name="FlashDreams T2V",
+        ),
+        world_rank=context.world_rank,
+    )
+
+
+def _scenario(
+    config: "T2VDemoRunnerConfig", overrides: dict[str, object]
+) -> dict[str, object]:
+    runner = resolve_backend(config.backend).resolve_runner(config.preset_id)
+
+    def value(name: str, default: object) -> object:
+        overridden = overrides.get(name)
+        configured = getattr(config, name)
+        return default if overridden is None and configured is None else (
+            configured if overridden is None else overridden
+        )
+
+    return {
+        FIELD_PROMPT: value(FIELD_PROMPT, runner.prompt),
+        FIELD_TOTAL_BLOCKS: value(FIELD_TOTAL_BLOCKS, runner.total_blocks),
+        FIELD_PIXEL_HEIGHT: value(FIELD_PIXEL_HEIGHT, runner.pixel_height),
+        FIELD_PIXEL_WIDTH: value(FIELD_PIXEL_WIDTH, runner.pixel_width),
+        FIELD_FPS: value(FIELD_FPS, runner.fps),
+    }
+
+
+def _spec(
+    config: "T2VDemoRunnerConfig",
+    *,
+    adapter: T2VDemoAdapter,
+    scenario: dict[str, object],
+    input_mode: Literal["replay", "webrtc"],
+    output: Mp4OutputSpec | NullOutputSpec | WebRTCOutputSpec,
+    device: str | None = None,
+) -> DemoSpec:
+    return DemoSpec(
+        model_id=adapter.model_id,
+        preset_id=config.preset_id or adapter.backend.default_preset_name,
+        input_mode=input_mode,
+        scenario=scenario,
+        output=output,
+        config=InferenceConfig(
+            model_id=adapter.model_id,
+            preset_id=config.preset_id or adapter.backend.default_preset_name,
+            device=device or config.device,
+            compile=config.compile,
+            runtime_options={"backend": adapter.backend.key},
+        ),
+    )
+
+
+def _replay_output(
+    *, mode: Literal["mp4", "null"], output_path: object, fps: int
+) -> Mp4OutputSpec | NullOutputSpec:
+    if mode == "null":
+        return NullOutputSpec()
+    if output_path is None:
+        raise ValueError("T2V MP4 mode requires an output path.")
+    return Mp4OutputSpec(
+        path=Path(str(output_path)), fps=fps, output_layout="tchw"
+    )
+
+
+def _configure_app(
+    app: web.Application,
+    *,
+    manager: T2VWebRTCSessionManager,
+    backend: str,
+) -> None:
+    async def app_config(_: web.Request) -> web.StreamResponse:
+        return web.json_response(
+            {"backends": backend_metadata(), "selected_backend": backend}
+        )
 
     async def update_prompt(request: web.Request) -> web.StreamResponse:
         payload = await request.json()
@@ -190,8 +249,24 @@ def _configure_app(app: web.Application, *, manager: T2VWebRTCSessionManager, ar
         buffer = io.BytesIO()
         with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
             archive.write(video_path, "video.mp4")
-            archive.writestr("prompt.json", json.dumps({"prompt": scenario.prompt, "total_blocks": scenario.total_blocks, "fps": scenario.fps, "width": scenario.pixel_width, "height": scenario.pixel_height}, indent=2))
-        return web.Response(body=buffer.getvalue(), headers={"Content-Disposition": "attachment; filename=flashdreams-generation.zip"}, content_type="application/zip")
+            archive.writestr(
+                "prompt.json",
+                json.dumps(
+                    {
+                        "prompt": scenario.prompt,
+                        "total_blocks": scenario.total_blocks,
+                        "fps": scenario.fps,
+                        "width": scenario.pixel_width,
+                        "height": scenario.pixel_height,
+                    },
+                    indent=2,
+                ),
+            )
+        return web.Response(
+            body=buffer.getvalue(),
+            headers={"Content-Disposition": "attachment; filename=flashdreams-generation.zip"},
+            content_type="application/zip",
+        )
 
     async def playback(_: web.Request) -> web.StreamResponse:
         artifact = manager.runtime.latest_artifact
@@ -199,51 +274,10 @@ def _configure_app(app: web.Application, *, manager: T2VWebRTCSessionManager, ar
             raise web.HTTPNotFound(reason="No completed MP4 is available yet.")
         return web.FileResponse(artifact[0])
 
-    app.router.add_get("/api/t2v/config", config)
+    app.router.add_get("/api/t2v/config", app_config)
     app.router.add_post("/api/t2v/prompt", update_prompt)
     app.router.add_get("/api/t2v/download", download)
     app.router.add_get("/api/t2v/playback", playback)
 
 
-def _scenario(args: argparse.Namespace) -> dict[str, object]:
-    runner = resolve_backend(args.backend).resolve_runner(args.preset_id)
-    return {
-        FIELD_PROMPT: args.prompt or str(getattr(runner, FIELD_PROMPT)),
-        FIELD_TOTAL_BLOCKS: args.total_blocks or int(getattr(runner, FIELD_TOTAL_BLOCKS, 1)),
-        FIELD_PIXEL_HEIGHT: args.pixel_height or int(getattr(runner, FIELD_PIXEL_HEIGHT, 480)),
-        FIELD_PIXEL_WIDTH: args.pixel_width or int(getattr(runner, FIELD_PIXEL_WIDTH, 832)),
-        FIELD_FPS: args.fps or int(getattr(runner, FIELD_FPS, 16)),
-    }
-
-
-def _spec(args: argparse.Namespace, *, input_mode: str, output: object, device: str | None = None) -> DemoSpec:
-    backend = resolve_backend(args.backend)
-    return DemoSpec(
-        model_id="flashdreams-t2v",
-        preset_id=args.preset_id or backend.default_preset_name,
-        input_mode=input_mode,
-        scenario=_scenario(args),
-        output=output,
-        config=InferenceConfig(
-            model_id="flashdreams-t2v",
-            preset_id=args.preset_id or backend.default_preset_name,
-            device=device or args.device,
-            compile=args.compile,
-            runtime_options={"backend": backend.key},
-        ),
-    )
-
-
-def _replay_output(args: argparse.Namespace) -> Mp4OutputSpec | NullOutputSpec:
-    if args.output_mode == "null":
-        return NullOutputSpec()
-    return Mp4OutputSpec(path=args.output, fps=_scenario(args)[FIELD_FPS], output_layout="tchw")
-
-
-def main(argv: list[str] | None = None) -> None:
-    """Run the T2V demo."""
-    T2VDemoApplication().main(argv)
-
-
-if __name__ == "__main__":
-    main()
+__all__ = ["T2VWebRTCSessionManager", "launch_t2v"]

--- a/apps/t2v_demo/backends.py
+++ b/apps/t2v_demo/backends.py
@@ -33,18 +33,29 @@ class T2VBackend:
 
 BACKENDS: dict[str, T2VBackend] = {
     "causal-forcing": T2VBackend(
-        key="causal-forcing", label="Causal-Forcing (Wan 2.1)",
+        key="causal-forcing",
+        label="Causal-Forcing (Wan 2.1)",
         default_preset_name="causal-forcing-wan2.1-t2v-1.3b-chunkwise",
-        preset_names=("causal-forcing-wan2.1-t2v-1.3b-chunkwise", "causal-forcing-wan2.1-t2v-1.3b-framewise"),
+        preset_names=(
+            "causal-forcing-wan2.1-t2v-1.3b-chunkwise",
+            "causal-forcing-wan2.1-t2v-1.3b-framewise",
+        ),
     ),
     "cosmos-predict2": T2VBackend(
-        key="cosmos-predict2", label="Cosmos Predict2",
-        default_preset_name="cosmos2-t2v-2b-720p", preset_names=("cosmos2-t2v-2b-720p",),
+        key="cosmos-predict2",
+        label="Cosmos Predict2",
+        default_preset_name="cosmos2-t2v-2b-720p",
+        preset_names=("cosmos2-t2v-2b-720p",),
     ),
     "self-forcing": T2VBackend(
-        key="self-forcing", label="Self-Forcing (Wan 2.1)",
+        key="self-forcing",
+        label="Self-Forcing (Wan 2.1)",
         default_preset_name="self-forcing-wan2.1-t2v-1.3b",
-        preset_names=("self-forcing-wan2.1-t2v-1.3b", "self-forcing-wan2.1-t2v-1.3b-taehv", "self-forcing-wan2.1-t2v-1.3b-sink5-window7-rerope"),
+        preset_names=(
+            "self-forcing-wan2.1-t2v-1.3b",
+            "self-forcing-wan2.1-t2v-1.3b-taehv",
+            "self-forcing-wan2.1-t2v-1.3b-sink5-window7-rerope",
+        ),
     ),
 }
 
@@ -54,7 +65,9 @@ def resolve_backend(value: str) -> T2VBackend:
     try:
         return BACKENDS[value]
     except KeyError as exc:
-        raise ValueError(f"Unknown backend {value!r}. Available backends: {', '.join(BACKENDS)}.") from exc
+        raise ValueError(
+            f"Unknown backend {value!r}. Available backends: {', '.join(BACKENDS)}."
+        ) from exc
 
 
 def backend_choices() -> tuple[str, ...]:
@@ -65,6 +78,11 @@ def backend_choices() -> tuple[str, ...]:
 def backend_metadata() -> list[dict[str, Any]]:
     """Return browser-safe backend names and app-owned presets."""
     return [
-        {"key": backend.key, "label": backend.label, "default_preset": backend.default_preset_name, "presets": backend.preset_names}
+        {
+            "key": backend.key,
+            "label": backend.label,
+            "default_preset": backend.default_preset_name,
+            "presets": backend.preset_names,
+        }
         for backend in BACKENDS.values()
     ]

--- a/apps/t2v_demo/backends.py
+++ b/apps/t2v_demo/backends.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Text-to-video backend selection for the unified demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .presets import PRESETS, T2VPreset
+
+
+@dataclass(frozen=True, slots=True)
+class T2VBackend:
+    """One supported T2V model family and its app-owned presets."""
+
+    key: str
+    label: str
+    default_preset_name: str
+    preset_names: tuple[str, ...]
+
+    def resolve_runner(self, preset_name: str | None = None) -> T2VPreset:
+        """Return a preset without importing an integration package."""
+        name = preset_name or self.default_preset_name
+        if name not in self.preset_names:
+            raise ValueError(
+                f"Unknown {self.key} preset {name!r}. Available presets: "
+                f"{', '.join(self.preset_names)}."
+            )
+        return PRESETS[name]
+
+
+BACKENDS: dict[str, T2VBackend] = {
+    "causal-forcing": T2VBackend(
+        key="causal-forcing", label="Causal-Forcing (Wan 2.1)",
+        default_preset_name="causal-forcing-wan2.1-t2v-1.3b-chunkwise",
+        preset_names=("causal-forcing-wan2.1-t2v-1.3b-chunkwise", "causal-forcing-wan2.1-t2v-1.3b-framewise"),
+    ),
+    "cosmos-predict2": T2VBackend(
+        key="cosmos-predict2", label="Cosmos Predict2",
+        default_preset_name="cosmos2-t2v-2b-720p", preset_names=("cosmos2-t2v-2b-720p",),
+    ),
+    "self-forcing": T2VBackend(
+        key="self-forcing", label="Self-Forcing (Wan 2.1)",
+        default_preset_name="self-forcing-wan2.1-t2v-1.3b",
+        preset_names=("self-forcing-wan2.1-t2v-1.3b", "self-forcing-wan2.1-t2v-1.3b-taehv", "self-forcing-wan2.1-t2v-1.3b-sink5-window7-rerope"),
+    ),
+}
+
+
+def resolve_backend(value: str) -> T2VBackend:
+    """Resolve a CLI/UI backend key."""
+    try:
+        return BACKENDS[value]
+    except KeyError as exc:
+        raise ValueError(f"Unknown backend {value!r}. Available backends: {', '.join(BACKENDS)}.") from exc
+
+
+def backend_choices() -> tuple[str, ...]:
+    """Return stable CLI choices."""
+    return tuple(BACKENDS)
+
+
+def backend_metadata() -> list[dict[str, Any]]:
+    """Return browser-safe backend names and app-owned presets."""
+    return [
+        {"key": backend.key, "label": backend.label, "default_preset": backend.default_preset_name, "presets": backend.preset_names}
+        for backend in BACKENDS.values()
+    ]

--- a/apps/t2v_demo/launch.py
+++ b/apps/t2v_demo/launch.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Launch capability that routes ``flashdreams-run t2v`` to the T2V app."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Literal
+
+from flashdreams.infra.runner import RunnerConfig
+from flashdreams.serving.launch import LaunchMode, LaunchOptions, ResolvedLaunch
+
+
+class T2VLaunchCapability:
+    """Expose replay and persistent WebRTC modes for the app-owned T2V demo."""
+
+    def supported_modes(
+        self, config: RunnerConfig, options: LaunchOptions
+    ) -> tuple[LaunchMode, ...]:
+        del config, options
+        return ("mp4", "null", "webrtc")
+
+    def resolve(
+        self,
+        config: RunnerConfig,
+        *,
+        mode: LaunchMode,
+        options: LaunchOptions,
+    ) -> ResolvedLaunch | None:
+        if mode not in {"mp4", "null", "webrtc"}:
+            return None
+        return ResolvedLaunch(
+            mode=mode,
+            label=f"T2V {mode} launch",
+            summary={"runner": config.runner_name, "mode": mode, "device": config.device},
+            launch=partial(_launch, config=config, mode=mode, options=options),
+        )
+
+
+def _launch(
+    *, config: RunnerConfig, mode: LaunchMode, options: LaunchOptions
+) -> object:
+    from .app import launch_t2v
+
+    return launch_t2v(
+        config=config,
+        mode=mode,
+        host=options.host,
+        port=options.port,
+        scenario_overrides=dict(options.scenario),
+        output_overrides=dict(options.output),
+    )
+
+
+LAUNCH_CAPABILITY = T2VLaunchCapability()
+
+__all__ = ["LAUNCH_CAPABILITY", "T2VLaunchCapability"]

--- a/apps/t2v_demo/launch.py
+++ b/apps/t2v_demo/launch.py
@@ -33,7 +33,11 @@ class T2VLaunchCapability:
         return ResolvedLaunch(
             mode=mode,
             label=f"T2V {mode} launch",
-            summary={"runner": config.runner_name, "mode": mode, "device": config.device},
+            summary={
+                "runner": config.runner_name,
+                "mode": mode,
+                "device": config.device,
+            },
             launch=partial(_launch, config=config, mode=mode, options=options),
         )
 

--- a/apps/t2v_demo/presets.py
+++ b/apps/t2v_demo/presets.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""App-owned T2V pipeline presets, independent of workspace integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+from torch import Tensor
+
+from flashdreams.infra.config import derive_config
+from flashdreams.infra.diffusion.model import DiffusionModelConfig
+from flashdreams.infra.diffusion.scheduler import FlowMatchUniPCSchedulerConfig
+from flashdreams.infra.diffusion.scheduler.fm import FlowMatchSchedulerConfig
+from flashdreams.recipes.cosmos.pipeline import CosmosInferencePipelineConfig
+from flashdreams.recipes.cosmos.transformer import CosmosTransformerConfig
+from flashdreams.recipes.cosmos.transformer.impl.network import (
+    CosmosDiTNetworkConfig,
+    state_dict_transform as cosmos_state_dict_transform,
+)
+from flashdreams.recipes.taehv import TeahvVAEDecoderConfig
+from flashdreams.recipes.wan import (
+    Wan21TransformerConfig,
+    WanDiTNetwork1pt3BConfig,
+    WanInferencePipelineConfig,
+    WanVAEDecoderConfig,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class T2VPreset:
+    """One app-supported text-to-video pipeline configuration."""
+
+    name: str
+    pipeline: Any
+    prompt: str
+    total_blocks: int
+    pixel_height: int
+    pixel_width: int
+    fps: int
+
+
+CAUSAL_FORCING_PROMPT = "A cinematic closeup of a reindeer in a snowy forest at sunset."
+SELF_FORCING_PROMPT = "A stylish woman strolls down a neon-lit Tokyo street at night."
+COSMOS_PROMPT = "A high-definition video of a robotic arm welding in an industrial workshop."
+
+
+def _wan_state_dict_transform(state_dict: dict[str, Any]) -> dict[str, Tensor]:
+    """Normalize upstream Causal/Self-Forcing checkpoint wrapper keys."""
+    state_dict = state_dict.get("generator_ema", state_dict.get("generator", state_dict))
+    out: dict[str, Tensor] = {}
+    for key, value in state_dict.items():
+        key = key.removeprefix("model.").removeprefix("net.")
+        out[key.removeprefix("_fsdp_wrapped_module.")] = value
+    return out
+
+
+CAUSAL_FORCING_PIPELINE = WanInferencePipelineConfig(
+    name="causal-forcing-wan2.1-t2v-1.3b-chunkwise",
+    enable_sync_and_profile=True,
+    encoder=None,
+    decoder=WanVAEDecoderConfig(),
+    diffusion_model=DiffusionModelConfig(
+        seed=42,
+        transformer=Wan21TransformerConfig(
+            network=WanDiTNetwork1pt3BConfig(patch_embedding_type="conv3d", cp_method="ring"),
+            checkpoint_path="https://huggingface.co/zhuhz22/Causal-Forcing/blob/main/chunkwise/causal_forcing.pt",
+            state_dict_transform=_wan_state_dict_transform,
+            batch_shape=(), len_t=3, guidance_scale=1.0, window_size_t=21,
+            sink_size_t=0, stamp_image_latent=False, compile_network=True,
+        ),
+        scheduler=FlowMatchSchedulerConfig(
+            num_inference_steps=4, denoising_timesteps=[1000, 750, 500, 250],
+            warp_denoising_step=True, shift=5.0, sigma_min=0.0,
+            extra_one_step=True, num_train_timesteps=1000,
+        ),
+    ),
+)
+CAUSAL_FORCING_FRAMEWISE_PIPELINE = cast(WanInferencePipelineConfig, derive_config(
+    CAUSAL_FORCING_PIPELINE,
+    name="causal-forcing-wan2.1-t2v-1.3b-framewise",
+    diffusion_model=dict(transformer=dict(
+        checkpoint_path="https://huggingface.co/zhuhz22/Causal-Forcing/blob/main/framewise/causal_forcing.pt", len_t=1,
+    )),
+))
+
+SELF_FORCING_PIPELINE = WanInferencePipelineConfig(
+    name="self-forcing-wan2.1-t2v-1.3b",
+    enable_sync_and_profile=True, encoder=None, decoder=WanVAEDecoderConfig(),
+    diffusion_model=DiffusionModelConfig(
+        seed=42,
+        transformer=Wan21TransformerConfig(
+            network=WanDiTNetwork1pt3BConfig(patch_embedding_type="conv3d", cp_method="ring"),
+            checkpoint_path="https://huggingface.co/gdhe17/Self-Forcing/blob/main/checkpoints/self_forcing_dmd.pt",
+            state_dict_transform=_wan_state_dict_transform,
+            batch_shape=(), len_t=3, guidance_scale=1.0, window_size_t=21,
+            sink_size_t=0, stamp_image_latent=False, compile_network=True,
+        ),
+        scheduler=FlowMatchSchedulerConfig(
+            num_inference_steps=4, denoising_timesteps=[1000, 750, 500, 250],
+            warp_denoising_step=True, shift=8.0, sigma_min=0.0,
+            extra_one_step=True, num_train_timesteps=1000,
+        ),
+    ),
+)
+SELF_FORCING_TAEHV_PIPELINE = cast(WanInferencePipelineConfig, derive_config(
+    SELF_FORCING_PIPELINE, name="self-forcing-wan2.1-t2v-1.3b-taehv", decoder=TeahvVAEDecoderConfig(),
+))
+SELF_FORCING_REROPE_PIPELINE = cast(WanInferencePipelineConfig, derive_config(
+    SELF_FORCING_PIPELINE, name="self-forcing-wan2.1-t2v-1.3b-sink5-window7-rerope",
+    diffusion_model=dict(seed=0, transformer=dict(window_size_t=7, sink_size_t=5, compile_network=False, use_cuda_graph=False, network=dict(apply_rope_before_kvcache=False))),
+))
+
+COSMOS_PIPELINE = CosmosInferencePipelineConfig(
+    name="cosmos2-t2v-2b-720p", enable_sync_and_profile=True, encoder=None,
+    decoder=WanVAEDecoderConfig(),
+    diffusion_model=DiffusionModelConfig(
+        seed=42,
+        transformer=CosmosTransformerConfig(
+            network=CosmosDiTNetworkConfig(cp_method="ring"),
+            checkpoint_path="https://huggingface.co/nvidia/Cosmos-Predict2.5-2B/blob/main/base/post-trained/81edfebe-bd6a-4039-8c1d-737df1a790bf_ema_bf16.pt",
+            state_dict_transform=cosmos_state_dict_transform, batch_shape=(), len_t=24,
+            window_size_t=24, guidance_scale=8.0, compile_network=True, use_cuda_graph=False,
+        ),
+        scheduler=FlowMatchUniPCSchedulerConfig(num_inference_steps=35, shift=5.0, use_kerras_sigma=True, enable_tqdm=True),
+    ),
+)
+
+PRESETS: dict[str, T2VPreset] = {
+    preset.name: preset for preset in (
+        T2VPreset(name=CAUSAL_FORCING_PIPELINE.name, pipeline=CAUSAL_FORCING_PIPELINE, prompt=CAUSAL_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
+        T2VPreset(name=CAUSAL_FORCING_FRAMEWISE_PIPELINE.name, pipeline=CAUSAL_FORCING_FRAMEWISE_PIPELINE, prompt=CAUSAL_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
+        T2VPreset(name=SELF_FORCING_PIPELINE.name, pipeline=SELF_FORCING_PIPELINE, prompt=SELF_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
+        T2VPreset(name=SELF_FORCING_TAEHV_PIPELINE.name, pipeline=SELF_FORCING_TAEHV_PIPELINE, prompt=SELF_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
+        T2VPreset(name=SELF_FORCING_REROPE_PIPELINE.name, pipeline=SELF_FORCING_REROPE_PIPELINE, prompt=SELF_FORCING_PROMPT, total_blocks=80, pixel_height=480, pixel_width=832, fps=16),
+        T2VPreset(name=COSMOS_PIPELINE.name, pipeline=COSMOS_PIPELINE, prompt=COSMOS_PROMPT, total_blocks=1, pixel_height=720, pixel_width=1280, fps=16),
+    )
+}

--- a/apps/t2v_demo/presets.py
+++ b/apps/t2v_demo/presets.py
@@ -18,6 +18,8 @@ from flashdreams.recipes.cosmos.pipeline import CosmosInferencePipelineConfig
 from flashdreams.recipes.cosmos.transformer import CosmosTransformerConfig
 from flashdreams.recipes.cosmos.transformer.impl.network import (
     CosmosDiTNetworkConfig,
+)
+from flashdreams.recipes.cosmos.transformer.impl.network import (
     state_dict_transform as cosmos_state_dict_transform,
 )
 from flashdreams.recipes.taehv import TeahvVAEDecoderConfig
@@ -44,12 +46,16 @@ class T2VPreset:
 
 CAUSAL_FORCING_PROMPT = "A cinematic closeup of a reindeer in a snowy forest at sunset."
 SELF_FORCING_PROMPT = "A stylish woman strolls down a neon-lit Tokyo street at night."
-COSMOS_PROMPT = "A high-definition video of a robotic arm welding in an industrial workshop."
+COSMOS_PROMPT = (
+    "A high-definition video of a robotic arm welding in an industrial workshop."
+)
 
 
 def _wan_state_dict_transform(state_dict: dict[str, Any]) -> dict[str, Tensor]:
     """Normalize upstream Causal/Self-Forcing checkpoint wrapper keys."""
-    state_dict = state_dict.get("generator_ema", state_dict.get("generator", state_dict))
+    state_dict = state_dict.get(
+        "generator_ema", state_dict.get("generator", state_dict)
+    )
     out: dict[str, Tensor] = {}
     for key, value in state_dict.items():
         key = key.removeprefix("model.").removeprefix("net.")
@@ -65,76 +71,182 @@ CAUSAL_FORCING_PIPELINE = WanInferencePipelineConfig(
     diffusion_model=DiffusionModelConfig(
         seed=42,
         transformer=Wan21TransformerConfig(
-            network=WanDiTNetwork1pt3BConfig(patch_embedding_type="conv3d", cp_method="ring"),
+            network=WanDiTNetwork1pt3BConfig(
+                patch_embedding_type="conv3d", cp_method="ring"
+            ),
             checkpoint_path="https://huggingface.co/zhuhz22/Causal-Forcing/blob/main/chunkwise/causal_forcing.pt",
             state_dict_transform=_wan_state_dict_transform,
-            batch_shape=(), len_t=3, guidance_scale=1.0, window_size_t=21,
-            sink_size_t=0, stamp_image_latent=False, compile_network=True,
+            batch_shape=(),
+            len_t=3,
+            guidance_scale=1.0,
+            window_size_t=21,
+            sink_size_t=0,
+            stamp_image_latent=False,
+            compile_network=True,
         ),
         scheduler=FlowMatchSchedulerConfig(
-            num_inference_steps=4, denoising_timesteps=[1000, 750, 500, 250],
-            warp_denoising_step=True, shift=5.0, sigma_min=0.0,
-            extra_one_step=True, num_train_timesteps=1000,
+            num_inference_steps=4,
+            denoising_timesteps=[1000, 750, 500, 250],
+            warp_denoising_step=True,
+            shift=5.0,
+            sigma_min=0.0,
+            extra_one_step=True,
+            num_train_timesteps=1000,
         ),
     ),
 )
-CAUSAL_FORCING_FRAMEWISE_PIPELINE = cast(WanInferencePipelineConfig, derive_config(
-    CAUSAL_FORCING_PIPELINE,
-    name="causal-forcing-wan2.1-t2v-1.3b-framewise",
-    diffusion_model=dict(transformer=dict(
-        checkpoint_path="https://huggingface.co/zhuhz22/Causal-Forcing/blob/main/framewise/causal_forcing.pt", len_t=1,
-    )),
-))
+CAUSAL_FORCING_FRAMEWISE_PIPELINE = cast(
+    WanInferencePipelineConfig,
+    derive_config(
+        CAUSAL_FORCING_PIPELINE,
+        name="causal-forcing-wan2.1-t2v-1.3b-framewise",
+        diffusion_model=dict(
+            transformer=dict(
+                checkpoint_path="https://huggingface.co/zhuhz22/Causal-Forcing/blob/main/framewise/causal_forcing.pt",
+                len_t=1,
+            )
+        ),
+    ),
+)
 
 SELF_FORCING_PIPELINE = WanInferencePipelineConfig(
     name="self-forcing-wan2.1-t2v-1.3b",
-    enable_sync_and_profile=True, encoder=None, decoder=WanVAEDecoderConfig(),
+    enable_sync_and_profile=True,
+    encoder=None,
+    decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(
         seed=42,
         transformer=Wan21TransformerConfig(
-            network=WanDiTNetwork1pt3BConfig(patch_embedding_type="conv3d", cp_method="ring"),
+            network=WanDiTNetwork1pt3BConfig(
+                patch_embedding_type="conv3d", cp_method="ring"
+            ),
             checkpoint_path="https://huggingface.co/gdhe17/Self-Forcing/blob/main/checkpoints/self_forcing_dmd.pt",
             state_dict_transform=_wan_state_dict_transform,
-            batch_shape=(), len_t=3, guidance_scale=1.0, window_size_t=21,
-            sink_size_t=0, stamp_image_latent=False, compile_network=True,
+            batch_shape=(),
+            len_t=3,
+            guidance_scale=1.0,
+            window_size_t=21,
+            sink_size_t=0,
+            stamp_image_latent=False,
+            compile_network=True,
         ),
         scheduler=FlowMatchSchedulerConfig(
-            num_inference_steps=4, denoising_timesteps=[1000, 750, 500, 250],
-            warp_denoising_step=True, shift=8.0, sigma_min=0.0,
-            extra_one_step=True, num_train_timesteps=1000,
+            num_inference_steps=4,
+            denoising_timesteps=[1000, 750, 500, 250],
+            warp_denoising_step=True,
+            shift=8.0,
+            sigma_min=0.0,
+            extra_one_step=True,
+            num_train_timesteps=1000,
         ),
     ),
 )
-SELF_FORCING_TAEHV_PIPELINE = cast(WanInferencePipelineConfig, derive_config(
-    SELF_FORCING_PIPELINE, name="self-forcing-wan2.1-t2v-1.3b-taehv", decoder=TeahvVAEDecoderConfig(),
-))
-SELF_FORCING_REROPE_PIPELINE = cast(WanInferencePipelineConfig, derive_config(
-    SELF_FORCING_PIPELINE, name="self-forcing-wan2.1-t2v-1.3b-sink5-window7-rerope",
-    diffusion_model=dict(seed=0, transformer=dict(window_size_t=7, sink_size_t=5, compile_network=False, use_cuda_graph=False, network=dict(apply_rope_before_kvcache=False))),
-))
+SELF_FORCING_TAEHV_PIPELINE = cast(
+    WanInferencePipelineConfig,
+    derive_config(
+        SELF_FORCING_PIPELINE,
+        name="self-forcing-wan2.1-t2v-1.3b-taehv",
+        decoder=TeahvVAEDecoderConfig(),
+    ),
+)
+SELF_FORCING_REROPE_PIPELINE = cast(
+    WanInferencePipelineConfig,
+    derive_config(
+        SELF_FORCING_PIPELINE,
+        name="self-forcing-wan2.1-t2v-1.3b-sink5-window7-rerope",
+        diffusion_model=dict(
+            seed=0,
+            transformer=dict(
+                window_size_t=7,
+                sink_size_t=5,
+                compile_network=False,
+                use_cuda_graph=False,
+                network=dict(apply_rope_before_kvcache=False),
+            ),
+        ),
+    ),
+)
 
 COSMOS_PIPELINE = CosmosInferencePipelineConfig(
-    name="cosmos2-t2v-2b-720p", enable_sync_and_profile=True, encoder=None,
+    name="cosmos2-t2v-2b-720p",
+    enable_sync_and_profile=True,
+    encoder=None,
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(
         seed=42,
         transformer=CosmosTransformerConfig(
             network=CosmosDiTNetworkConfig(cp_method="ring"),
             checkpoint_path="https://huggingface.co/nvidia/Cosmos-Predict2.5-2B/blob/main/base/post-trained/81edfebe-bd6a-4039-8c1d-737df1a790bf_ema_bf16.pt",
-            state_dict_transform=cosmos_state_dict_transform, batch_shape=(), len_t=24,
-            window_size_t=24, guidance_scale=8.0, compile_network=True, use_cuda_graph=False,
+            state_dict_transform=cosmos_state_dict_transform,
+            batch_shape=(),
+            len_t=24,
+            window_size_t=24,
+            guidance_scale=8.0,
+            compile_network=True,
+            use_cuda_graph=False,
         ),
-        scheduler=FlowMatchUniPCSchedulerConfig(num_inference_steps=35, shift=5.0, use_kerras_sigma=True, enable_tqdm=True),
+        scheduler=FlowMatchUniPCSchedulerConfig(
+            num_inference_steps=35, shift=5.0, use_kerras_sigma=True, enable_tqdm=True
+        ),
     ),
 )
 
 PRESETS: dict[str, T2VPreset] = {
-    preset.name: preset for preset in (
-        T2VPreset(name=CAUSAL_FORCING_PIPELINE.name, pipeline=CAUSAL_FORCING_PIPELINE, prompt=CAUSAL_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
-        T2VPreset(name=CAUSAL_FORCING_FRAMEWISE_PIPELINE.name, pipeline=CAUSAL_FORCING_FRAMEWISE_PIPELINE, prompt=CAUSAL_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
-        T2VPreset(name=SELF_FORCING_PIPELINE.name, pipeline=SELF_FORCING_PIPELINE, prompt=SELF_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
-        T2VPreset(name=SELF_FORCING_TAEHV_PIPELINE.name, pipeline=SELF_FORCING_TAEHV_PIPELINE, prompt=SELF_FORCING_PROMPT, total_blocks=60, pixel_height=480, pixel_width=832, fps=16),
-        T2VPreset(name=SELF_FORCING_REROPE_PIPELINE.name, pipeline=SELF_FORCING_REROPE_PIPELINE, prompt=SELF_FORCING_PROMPT, total_blocks=80, pixel_height=480, pixel_width=832, fps=16),
-        T2VPreset(name=COSMOS_PIPELINE.name, pipeline=COSMOS_PIPELINE, prompt=COSMOS_PROMPT, total_blocks=1, pixel_height=720, pixel_width=1280, fps=16),
+    preset.name: preset
+    for preset in (
+        T2VPreset(
+            name=CAUSAL_FORCING_PIPELINE.name,
+            pipeline=CAUSAL_FORCING_PIPELINE,
+            prompt=CAUSAL_FORCING_PROMPT,
+            total_blocks=60,
+            pixel_height=480,
+            pixel_width=832,
+            fps=16,
+        ),
+        T2VPreset(
+            name=CAUSAL_FORCING_FRAMEWISE_PIPELINE.name,
+            pipeline=CAUSAL_FORCING_FRAMEWISE_PIPELINE,
+            prompt=CAUSAL_FORCING_PROMPT,
+            total_blocks=60,
+            pixel_height=480,
+            pixel_width=832,
+            fps=16,
+        ),
+        T2VPreset(
+            name=SELF_FORCING_PIPELINE.name,
+            pipeline=SELF_FORCING_PIPELINE,
+            prompt=SELF_FORCING_PROMPT,
+            total_blocks=60,
+            pixel_height=480,
+            pixel_width=832,
+            fps=16,
+        ),
+        T2VPreset(
+            name=SELF_FORCING_TAEHV_PIPELINE.name,
+            pipeline=SELF_FORCING_TAEHV_PIPELINE,
+            prompt=SELF_FORCING_PROMPT,
+            total_blocks=60,
+            pixel_height=480,
+            pixel_width=832,
+            fps=16,
+        ),
+        T2VPreset(
+            name=SELF_FORCING_REROPE_PIPELINE.name,
+            pipeline=SELF_FORCING_REROPE_PIPELINE,
+            prompt=SELF_FORCING_PROMPT,
+            total_blocks=80,
+            pixel_height=480,
+            pixel_width=832,
+            fps=16,
+        ),
+        T2VPreset(
+            name=COSMOS_PIPELINE.name,
+            pipeline=COSMOS_PIPELINE,
+            prompt=COSMOS_PROMPT,
+            total_blocks=1,
+            pixel_height=720,
+            pixel_width=1280,
+            fps=16,
+        ),
     )
 }

--- a/apps/t2v_demo/pyproject.toml
+++ b/apps/t2v_demo/pyproject.toml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flashdreams-t2v-demo"
+version = "0.1.0"
+description = "FlashDreams text-to-video runtime demo launcher"
+requires-python = ">=3.10"
+dependencies = ["flashdreams[serving]"]
+
+[project.entry-points."flashdreams.runner_configs"]
+t2v = "t2v_demo.runner:RUNNER_T2V"
+
+[tool.uv.sources]
+flashdreams = { workspace = true }
+
+[tool.setuptools]
+packages = ["t2v_demo"]
+package-dir = { t2v_demo = "." }
+
+[tool.setuptools.package-data]
+t2v_demo = ["web/*.js", "web/*.css"]

--- a/apps/t2v_demo/runner.py
+++ b/apps/t2v_demo/runner.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``flashdreams-run t2v`` configuration and default replay runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Annotated, Any
+
+import tyro
+
+from flashdreams.infra.runner import Runner, RunnerConfig
+
+from .backends import backend_choices, resolve_backend
+
+
+@dataclass(kw_only=True)
+class T2VDemoRunnerConfig(RunnerConfig):
+    """Configuration exposed by the ``flashdreams-run t2v`` slug."""
+
+    _target: type["T2VDemoRunner"] = field(default_factory=lambda: T2VDemoRunner)
+    launch_capability: Annotated[str | None, tyro.conf.Suppress] = (
+        "t2v_demo.launch:LAUNCH_CAPABILITY"
+    )
+    pipeline: Annotated[Any, tyro.conf.Suppress] = field(
+        default_factory=lambda: resolve_backend("causal-forcing").resolve_runner().pipeline
+    )
+    backend: str = "causal-forcing"
+    """Backend key: one of ``causal-forcing``, ``cosmos-predict2``, or ``self-forcing``."""
+
+    preset_id: str | None = None
+    prompt: str | None = None
+    total_blocks: int | None = None
+    pixel_height: int | None = None
+    pixel_width: int | None = None
+    fps: int | None = None
+    compile: bool | None = None
+    output: Path = Path("outputs/t2v.mp4")
+
+    def __post_init__(self) -> None:
+        if self.backend not in backend_choices():
+            raise ValueError(
+                f"Unknown T2V backend {self.backend!r}; choose one of "
+                f"{', '.join(backend_choices())}."
+            )
+
+
+class T2VDemoRunner(Runner[T2VDemoRunnerConfig, Any]):
+    """Default ``run`` mode delegates to the same app replay entry point."""
+
+    def __init__(self, config: T2VDemoRunnerConfig) -> None:
+        # The demo runtime owns pipeline construction so that replay and
+        # WebRTC share identical lifecycle handling. Avoid constructing a
+        # second Runner pipeline here.
+        self.config = config
+
+    def run(self) -> None:
+        from .app import launch_t2v
+
+        launch_t2v(config=self.config, mode="mp4")
+
+
+RUNNER_T2V = T2VDemoRunnerConfig(
+    runner_name="t2v",
+    description="Text-to-video runtime demo (replay or WebRTC).",
+)
+
+__all__ = ["RUNNER_T2V", "T2VDemoRunner", "T2VDemoRunnerConfig"]

--- a/apps/t2v_demo/runner.py
+++ b/apps/t2v_demo/runner.py
@@ -25,7 +25,9 @@ class T2VDemoRunnerConfig(RunnerConfig):
         "t2v_demo.launch:LAUNCH_CAPABILITY"
     )
     pipeline: Annotated[Any, tyro.conf.Suppress] = field(
-        default_factory=lambda: resolve_backend("causal-forcing").resolve_runner().pipeline
+        default_factory=lambda: resolve_backend("causal-forcing")
+        .resolve_runner()
+        .pipeline
     )
     backend: str = "causal-forcing"
     """Backend key: one of ``causal-forcing``, ``cosmos-predict2``, or ``self-forcing``."""

--- a/apps/t2v_demo/runtime.py
+++ b/apps/t2v_demo/runtime.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime API adapter for the T2V demo's integration pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from flashdreams.infra.decoder import StreamingVideoDecoder
+from flashdreams.infra.video_output import VideoOutputStream
+from flashdreams.runtime import (
+    CanonicalInputSchema,
+    IdentityInputMapping,
+    InferenceConfig,
+    InferenceInput,
+    InferenceInputSchema,
+    InputField,
+    ModelAdapter,
+    StepRequest,
+)
+from flashdreams.runtime.demo import DemoSpec, PreparedScenario
+from flashdreams.runtime.demo.session_inputs import (
+    PreparedStep,
+    ProviderCapabilities,
+    UserInputWindow,
+)
+from flashdreams.runtime.interfaces import InferenceSession
+from flashdreams.runtime.types import StepResult
+
+from .backends import T2VBackend, resolve_backend
+
+FIELD_PROMPT = "prompt"
+FIELD_TOTAL_BLOCKS = "total_blocks"
+FIELD_PIXEL_HEIGHT = "pixel_height"
+FIELD_PIXEL_WIDTH = "pixel_width"
+FIELD_FPS = "fps"
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class T2VScenario:
+    """Prompt and output geometry for a finite text-to-video rollout."""
+
+    prompt: str
+    total_blocks: int
+    pixel_height: int
+    pixel_width: int
+    fps: int
+
+
+class T2VDemoAdapter(ModelAdapter):
+    """Model adapter shared by replay and WebRTC T2V launch paths."""
+
+    model_id = "flashdreams-t2v"
+    inference_input_schema = InferenceInputSchema(
+        global_conditioning_fields=(InputField(name=FIELD_PROMPT),),
+        description="Text-to-video prompt and rollout settings.",
+    )
+    canonical_input_schema = CanonicalInputSchema()
+
+    def __init__(self, *, backend: T2VBackend) -> None:
+        self.backend = backend
+
+    def supported_input_modes(self) -> tuple[str, ...]:
+        return ("replay", "webrtc")
+
+    def supported_output_modes(self) -> tuple[str, ...]:
+        return ("mp4", "null", "webrtc")
+
+    def default_input_mapping(self) -> IdentityInputMapping:
+        return IdentityInputMapping()
+
+    def validate_config(self, config: InferenceConfig) -> None:
+        if config.model_id != self.model_id:
+            raise ValueError(f"Expected model_id={self.model_id!r}, got {config.model_id!r}.")
+        if config.runtime_options.get("backend") != self.backend.key:
+            raise ValueError("T2V runtime backend does not match its demo adapter.")
+
+    def prepare_scenario(self, spec: DemoSpec) -> PreparedScenario:
+        scenario = _scenario_from_value(spec.scenario, self.backend)
+        return PreparedScenario(
+            initial_inputs=InferenceInput(
+                global_conditioning={
+                    FIELD_PROMPT: scenario.prompt,
+                    FIELD_TOTAL_BLOCKS: scenario.total_blocks,
+                    FIELD_PIXEL_HEIGHT: scenario.pixel_height,
+                    FIELD_PIXEL_WIDTH: scenario.pixel_width,
+                    FIELD_FPS: scenario.fps,
+                }
+            )
+        )
+
+    def create_runtime(self, config: InferenceConfig) -> "T2VRuntime":
+        self.validate_config(config)
+        return T2VRuntime(config=config, backend=self.backend)
+
+    def create_model_input_provider(
+        self, spec: DemoSpec, scenario: PreparedScenario
+    ) -> "T2VInputProvider":
+        """Supply fixed prompt conditioning to every shared-demo step."""
+        del spec
+        return T2VInputProvider(initial_inputs=scenario.initial_inputs)
+
+
+class T2VInputProvider:
+    """No-control input provider for finite prompt-only generation."""
+
+    capabilities = ProviderCapabilities(
+        supports_realtime_clock=True,
+        supports_recorded_input=True,
+        deterministic_given_inputs=True,
+    )
+
+    def __init__(self, *, initial_inputs: InferenceInput) -> None:
+        self._initial_inputs = initial_inputs
+
+    def prepare_initial_input(self) -> InferenceInput:
+        return self._initial_inputs
+
+    def prepare_step(
+        self, *, request: Any, user_window: UserInputWindow
+    ) -> PreparedStep:
+        del request, user_window
+        return PreparedStep(inference_input=InferenceInput())
+
+    def reset(self, inputs: InferenceInput | None = None) -> None:
+        if inputs is not None:
+            self._initial_inputs = inputs
+
+    def close(self) -> None:
+        pass
+
+
+class T2VRuntime:
+    """One heavyweight selected pipeline, reusable across demo sessions."""
+
+    def __init__(self, *, config: InferenceConfig, backend: T2VBackend) -> None:
+        self.config = config
+        self.backend = backend
+        runner = backend.resolve_runner(config.preset_id)
+        pipeline_config = runner.pipeline
+        if config.compile is not None:
+            from flashdreams.infra.config import derive_config
+
+            pipeline_config = derive_config(
+                base_config=pipeline_config,
+                diffusion_model={"transformer": {"compile_network": config.compile}},
+            )
+        self.pipeline = pipeline_config.setup().to(config.device or "cuda").eval()
+
+    def start_session(self, inputs: InferenceInput) -> "T2VSession":
+        return T2VSession(pipeline=self.pipeline, scenario=_scenario_from_inputs(inputs))
+
+    def close(self) -> None:
+        close = getattr(self.pipeline, "close", None)
+        if callable(close):
+            close()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+
+class T2VSession(InferenceSession):
+    """A cache-isolated T2V session that yields chunks as they are generated."""
+
+    def __init__(self, *, pipeline: Any, scenario: T2VScenario) -> None:
+        self.pipeline = pipeline
+        self.scenario = scenario
+        self._step_index = 0
+        self._closed = False
+        self._output_stream = VideoOutputStream(postprocess_stream=None, output_layout="tchw")
+        assert isinstance(pipeline.decoder, StreamingVideoDecoder)
+        ratio = pipeline.decoder.spatial_compression_ratio
+        if scenario.pixel_height % ratio or scenario.pixel_width % ratio:
+            raise ValueError("T2V dimensions must be divisible by the decoder spatial compression ratio.")
+        self._cache = pipeline.initialize_cache(
+            text=[scenario.prompt],
+            image=None,
+            height=scenario.pixel_height // ratio,
+            width=scenario.pixel_width // ratio,
+        )
+
+    def next_step_request(self) -> StepRequest | None:
+        if self._closed or self._step_index >= self.scenario.total_blocks:
+            return None
+        return StepRequest(step_index=self._step_index)
+
+    def step(self, inputs: InferenceInput) -> StepResult:
+        del inputs
+        if self._closed:
+            raise RuntimeError("T2V session is closed.")
+        index = self._step_index
+        video = self.pipeline.generate(autoregressive_index=index, cache=self._cache)
+        stats = self.pipeline.finalize(autoregressive_index=index, cache=self._cache)
+        self._step_index += 1
+        return self._output_stream.process(
+            video,
+            autoregressive_index=index,
+            metrics=stats,
+            metadata={"prompt": self.scenario.prompt},
+        )
+
+    def reset(self, inputs: InferenceInput | None = None) -> None:
+        if inputs is not None and _scenario_from_inputs(inputs) != self.scenario:
+            raise ValueError("Create a new T2V session to change the prompt or dimensions.")
+        raise RuntimeError("T2V sessions are finite; create a new session instead of reset().")
+
+    def close(self) -> None:
+        self._closed = True
+
+
+def _scenario_from_value(value: Any, backend: T2VBackend) -> T2VScenario:
+    runner = backend.resolve_runner()
+    source = value if isinstance(value, dict) else {}
+    prompt = str(source.get(FIELD_PROMPT, getattr(runner, FIELD_PROMPT, ""))).strip()
+    if not prompt:
+        raise ValueError("A non-empty text-to-video prompt is required.")
+    return T2VScenario(
+        prompt=prompt,
+        total_blocks=int(source.get(FIELD_TOTAL_BLOCKS, getattr(runner, FIELD_TOTAL_BLOCKS, 1))),
+        pixel_height=int(source.get(FIELD_PIXEL_HEIGHT, getattr(runner, FIELD_PIXEL_HEIGHT, 480))),
+        pixel_width=int(source.get(FIELD_PIXEL_WIDTH, getattr(runner, FIELD_PIXEL_WIDTH, 832))),
+        fps=int(source.get(FIELD_FPS, getattr(runner, FIELD_FPS, 16))),
+    )
+
+
+def _scenario_from_inputs(inputs: InferenceInput) -> T2VScenario:
+    source = inputs.global_conditioning
+    return T2VScenario(
+        prompt=str(source[FIELD_PROMPT]),
+        total_blocks=int(source[FIELD_TOTAL_BLOCKS]),
+        pixel_height=int(source[FIELD_PIXEL_HEIGHT]),
+        pixel_width=int(source[FIELD_PIXEL_WIDTH]),
+        fps=int(source[FIELD_FPS]),
+    )
+
+
+def make_adapter(backend: str) -> T2VDemoAdapter:
+    """Build an adapter from a CLI/UI backend key."""
+    return T2VDemoAdapter(backend=resolve_backend(backend))

--- a/apps/t2v_demo/runtime.py
+++ b/apps/t2v_demo/runtime.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import torch
 
 from flashdreams.infra.decoder import StreamingVideoDecoder
 from flashdreams.infra.video_output import VideoOutputStream
+from flashdreams.runtime.video_output import Mp4VideoOutputTarget
 from flashdreams.runtime import (
     CanonicalInputSchema,
     IdentityInputMapping,
@@ -150,9 +153,27 @@ class T2VRuntime:
                 diffusion_model={"transformer": {"compile_network": config.compile}},
             )
         self.pipeline = pipeline_config.setup().to(config.device or "cuda").eval()
+        self._latest_artifact: tuple[Path, T2VScenario] | None = None
+
+    def blocks_for_duration(self, duration_s: float, *, fps: int) -> int:
+        """Return enough autoregressive chunks to reach the requested duration."""
+        target_frames = int(duration_s * fps)
+        frames = 0
+        index = 0
+        while frames < target_frames:
+            frames += int(self.pipeline.get_num_output_frames(index))
+            index += 1
+        return index
+
+    def record_artifact(self, path: Path, scenario: T2VScenario) -> None:
+        self._latest_artifact = (path, scenario)
+
+    @property
+    def latest_artifact(self) -> tuple[Path, T2VScenario] | None:
+        return self._latest_artifact
 
     def start_session(self, inputs: InferenceInput) -> "T2VSession":
-        return T2VSession(pipeline=self.pipeline, scenario=_scenario_from_inputs(inputs))
+        return T2VSession(pipeline=self.pipeline, scenario=_scenario_from_inputs(inputs), runtime=self)
 
     def close(self) -> None:
         close = getattr(self.pipeline, "close", None)
@@ -165,9 +186,14 @@ class T2VRuntime:
 class T2VSession(InferenceSession):
     """A cache-isolated T2V session that yields chunks as they are generated."""
 
-    def __init__(self, *, pipeline: Any, scenario: T2VScenario) -> None:
+    def __init__(self, *, pipeline: Any, scenario: T2VScenario, runtime: T2VRuntime) -> None:
         self.pipeline = pipeline
         self.scenario = scenario
+        self._runtime = runtime
+        self._artifact_path = Path("outputs/t2v-webrtc") / f"{uuid4()}.mp4"
+        self._artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        self._artifact_output = Mp4VideoOutputTarget(output_path=self._artifact_path, fps=scenario.fps, output_layout="tchw")
+        self._artifact_output.open()
         self._step_index = 0
         self._closed = False
         self._output_stream = VideoOutputStream(postprocess_stream=None, output_layout="tchw")
@@ -195,12 +221,12 @@ class T2VSession(InferenceSession):
         video = self.pipeline.generate(autoregressive_index=index, cache=self._cache)
         stats = self.pipeline.finalize(autoregressive_index=index, cache=self._cache)
         self._step_index += 1
-        return self._output_stream.process(
-            video,
-            autoregressive_index=index,
-            metrics=stats,
+        result = self._output_stream.process(
+            video, autoregressive_index=index, metrics=stats,
             metadata={"prompt": self.scenario.prompt},
         )
+        self._artifact_output.write(result)
+        return result
 
     def reset(self, inputs: InferenceInput | None = None) -> None:
         if inputs is not None and _scenario_from_inputs(inputs) != self.scenario:
@@ -208,7 +234,12 @@ class T2VSession(InferenceSession):
         raise RuntimeError("T2V sessions are finite; create a new session instead of reset().")
 
     def close(self) -> None:
+        if self._closed:
+            return
         self._closed = True
+        artifacts = self._artifact_output.close()
+        if artifacts:
+            self._runtime.record_artifact(self._artifact_path, self.scenario)
 
 
 def _scenario_from_value(value: Any, backend: T2VBackend) -> T2VScenario:

--- a/apps/t2v_demo/runtime.py
+++ b/apps/t2v_demo/runtime.py
@@ -14,7 +14,6 @@ import torch
 
 from flashdreams.infra.decoder import StreamingVideoDecoder
 from flashdreams.infra.video_output import VideoOutputStream
-from flashdreams.runtime.video_output import Mp4VideoOutputTarget
 from flashdreams.runtime import (
     CanonicalInputSchema,
     IdentityInputMapping,
@@ -33,6 +32,7 @@ from flashdreams.runtime.demo.session_inputs import (
 )
 from flashdreams.runtime.interfaces import InferenceSession
 from flashdreams.runtime.types import StepResult
+from flashdreams.runtime.video_output import Mp4VideoOutputTarget
 
 from .backends import T2VBackend, resolve_backend
 
@@ -78,7 +78,9 @@ class T2VDemoAdapter(ModelAdapter):
 
     def validate_config(self, config: InferenceConfig) -> None:
         if config.model_id != self.model_id:
-            raise ValueError(f"Expected model_id={self.model_id!r}, got {config.model_id!r}.")
+            raise ValueError(
+                f"Expected model_id={self.model_id!r}, got {config.model_id!r}."
+            )
         if config.runtime_options.get("backend") != self.backend.key:
             raise ValueError("T2V runtime backend does not match its demo adapter.")
 
@@ -173,7 +175,9 @@ class T2VRuntime:
         return self._latest_artifact
 
     def start_session(self, inputs: InferenceInput) -> "T2VSession":
-        return T2VSession(pipeline=self.pipeline, scenario=_scenario_from_inputs(inputs), runtime=self)
+        return T2VSession(
+            pipeline=self.pipeline, scenario=_scenario_from_inputs(inputs), runtime=self
+        )
 
     def close(self) -> None:
         close = getattr(self.pipeline, "close", None)
@@ -186,21 +190,29 @@ class T2VRuntime:
 class T2VSession(InferenceSession):
     """A cache-isolated T2V session that yields chunks as they are generated."""
 
-    def __init__(self, *, pipeline: Any, scenario: T2VScenario, runtime: T2VRuntime) -> None:
+    def __init__(
+        self, *, pipeline: Any, scenario: T2VScenario, runtime: T2VRuntime
+    ) -> None:
         self.pipeline = pipeline
         self.scenario = scenario
         self._runtime = runtime
         self._artifact_path = Path("outputs/t2v-webrtc") / f"{uuid4()}.mp4"
         self._artifact_path.parent.mkdir(parents=True, exist_ok=True)
-        self._artifact_output = Mp4VideoOutputTarget(output_path=self._artifact_path, fps=scenario.fps, output_layout="tchw")
+        self._artifact_output = Mp4VideoOutputTarget(
+            output_path=self._artifact_path, fps=scenario.fps, output_layout="tchw"
+        )
         self._artifact_output.open()
         self._step_index = 0
         self._closed = False
-        self._output_stream = VideoOutputStream(postprocess_stream=None, output_layout="tchw")
+        self._output_stream = VideoOutputStream(
+            postprocess_stream=None, output_layout="tchw"
+        )
         assert isinstance(pipeline.decoder, StreamingVideoDecoder)
         ratio = pipeline.decoder.spatial_compression_ratio
         if scenario.pixel_height % ratio or scenario.pixel_width % ratio:
-            raise ValueError("T2V dimensions must be divisible by the decoder spatial compression ratio.")
+            raise ValueError(
+                "T2V dimensions must be divisible by the decoder spatial compression ratio."
+            )
         self._cache = pipeline.initialize_cache(
             text=[scenario.prompt],
             image=None,
@@ -222,7 +234,9 @@ class T2VSession(InferenceSession):
         stats = self.pipeline.finalize(autoregressive_index=index, cache=self._cache)
         self._step_index += 1
         result = self._output_stream.process(
-            video, autoregressive_index=index, metrics=stats,
+            video,
+            autoregressive_index=index,
+            metrics=stats,
             metadata={"prompt": self.scenario.prompt},
         )
         self._artifact_output.write(result)
@@ -230,8 +244,12 @@ class T2VSession(InferenceSession):
 
     def reset(self, inputs: InferenceInput | None = None) -> None:
         if inputs is not None and _scenario_from_inputs(inputs) != self.scenario:
-            raise ValueError("Create a new T2V session to change the prompt or dimensions.")
-        raise RuntimeError("T2V sessions are finite; create a new session instead of reset().")
+            raise ValueError(
+                "Create a new T2V session to change the prompt or dimensions."
+            )
+        raise RuntimeError(
+            "T2V sessions are finite; create a new session instead of reset()."
+        )
 
     def close(self) -> None:
         if self._closed:
@@ -250,9 +268,15 @@ def _scenario_from_value(value: Any, backend: T2VBackend) -> T2VScenario:
         raise ValueError("A non-empty text-to-video prompt is required.")
     return T2VScenario(
         prompt=prompt,
-        total_blocks=int(source.get(FIELD_TOTAL_BLOCKS, getattr(runner, FIELD_TOTAL_BLOCKS, 1))),
-        pixel_height=int(source.get(FIELD_PIXEL_HEIGHT, getattr(runner, FIELD_PIXEL_HEIGHT, 480))),
-        pixel_width=int(source.get(FIELD_PIXEL_WIDTH, getattr(runner, FIELD_PIXEL_WIDTH, 832))),
+        total_blocks=int(
+            source.get(FIELD_TOTAL_BLOCKS, getattr(runner, FIELD_TOTAL_BLOCKS, 1))
+        ),
+        pixel_height=int(
+            source.get(FIELD_PIXEL_HEIGHT, getattr(runner, FIELD_PIXEL_HEIGHT, 480))
+        ),
+        pixel_width=int(
+            source.get(FIELD_PIXEL_WIDTH, getattr(runner, FIELD_PIXEL_WIDTH, 832))
+        ),
         fps=int(source.get(FIELD_FPS, getattr(runner, FIELD_FPS, 16))),
     )
 

--- a/apps/t2v_demo/tests/test_runner.py
+++ b/apps/t2v_demo/tests/test_runner.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import pytest
-
 from t2v_demo import app
 from t2v_demo.runner import RUNNER_T2V, T2VDemoRunnerConfig
 

--- a/apps/t2v_demo/tests/test_runner.py
+++ b/apps/t2v_demo/tests/test_runner.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from t2v_demo import app
+from t2v_demo.runner import RUNNER_T2V, T2VDemoRunnerConfig
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_t2v_runner_slug_has_launch_capability() -> None:
+    assert RUNNER_T2V.runner_name == "t2v"
+    assert RUNNER_T2V.launch_capability == "t2v_demo.launch:LAUNCH_CAPABILITY"
+
+
+def test_runner_mp4_launch_uses_demo_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = []
+
+    def fake_replay_demo(*, spec: object, adapter: object) -> object:
+        captured.append((spec, adapter))
+        return type("Result", (), {"status": "completed"})()
+
+    monkeypatch.setattr(app, "run_replay_demo", fake_replay_demo)
+    config = T2VDemoRunnerConfig(
+        runner_name="t2v",
+        description="test",
+        backend="self-forcing",
+        prompt="A waterfall",
+        total_blocks=3,
+    )
+
+    app.launch_t2v(
+        config=config,
+        mode="mp4",
+        output_overrides={"path": "outputs/test.mp4", "fps": 24},
+    )
+
+    spec, _adapter = captured[0]
+    assert spec.input_mode == "replay"
+    assert spec.scenario["prompt"] == "A waterfall"
+    assert spec.scenario["total_blocks"] == 3
+    assert str(spec.output.path) == "outputs/test.mp4"
+    assert spec.output.fps == 24

--- a/apps/t2v_demo/web/adapter.css
+++ b/apps/t2v_demo/web/adapter.css
@@ -1,0 +1,3 @@
+.t2vPanel { display: grid; gap: .75rem; padding: 1rem; max-width: 32rem; }
+.t2vPanel textarea { display: block; width: 100%; margin-top: .35rem; resize: vertical; }
+.t2vPanel button { margin-right: .5rem; }

--- a/apps/t2v_demo/web/adapter.js
+++ b/apps/t2v_demo/web/adapter.js
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+let promptInput
+let generateButton
+let downloadButton
+let recorder
+let chunks = []
+
+async function savePrompt(context) {
+  const response = await fetch("/api/t2v/prompt", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ prompt: promptInput.value }),
+  })
+  if (!response.ok) throw new Error(await response.text())
+  context.logEvent("prompt queued for this generation", { source: "client" })
+}
+
+export default {
+  modelName: "Text-to-Video",
+  controls: [{ label: "Generate", keys: [{ key: "g", label: "Generate" }] }],
+  async mount(context) {
+    const panel = document.createElement("section")
+    panel.className = "t2vPanel"
+    panel.innerHTML = `
+      <label>Prompt<textarea rows="5" placeholder="Describe the video you want to generate"></textarea></label>
+      <p>Press Generate to stream chunks to the player. The browser records the live stream for download.</p>
+      <div><button type="button" class="t2vGenerate">Generate</button><button type="button" class="t2vDownload" disabled>Download MP4/WebM</button></div>`
+    context.slots.panel.append(panel)
+    promptInput = panel.querySelector("textarea")
+    generateButton = panel.querySelector(".t2vGenerate")
+    downloadButton = panel.querySelector(".t2vDownload")
+    generateButton.addEventListener("click", async () => {
+      try {
+        await savePrompt(context)
+        context.logEvent("click the G control to begin the shared WebRTC session", { source: "client" })
+      } catch (error) { context.logEvent(error.message, { source: "client", level: "error" }) }
+    })
+    downloadButton.addEventListener("click", () => {
+      const blob = new Blob(chunks, { type: recorder?.mimeType || "video/webm" })
+      const anchor = Object.assign(document.createElement("a"), { href: URL.createObjectURL(blob), download: "flashdreams-t2v.webm" })
+      anchor.click(); URL.revokeObjectURL(anchor.href)
+    })
+    const video = document.getElementById("remoteVideo")
+    video.addEventListener("play", () => {
+      if (recorder || !video.srcObject || !window.MediaRecorder) return
+      chunks = []
+      recorder = new MediaRecorder(video.srcObject)
+      recorder.ondataavailable = event => { if (event.data.size) chunks.push(event.data) }
+      recorder.onstop = () => { downloadButton.disabled = chunks.length === 0 }
+      recorder.start(1000)
+    })
+  },
+  onDisconnect() { if (recorder?.state === "recording") recorder.stop(); recorder = null },
+}

--- a/apps/t2v_demo/web/adapter.js
+++ b/apps/t2v_demo/web/adapter.js
@@ -4,10 +4,20 @@
 /** Model metadata only; shared WebRTC UI renders prompt/video controls. */
 export default {
   modelName: "Text-to-Video",
+  async mount(context) {
+    const response = await fetch("/api/t2v/config")
+    if (!response.ok) return
+    const config = await response.json()
+    const selected = config.backends?.find((backend) => backend.key === config.selected_backend)
+    context.setModelName(selected?.label || config.selected_backend || "Text-to-Video")
+  },
   promptGeneration: {
     endpoint: "/api/t2v/prompt",
     label: "Describe the video",
     placeholder: "A cinematic drone shot over snowy mountains at sunrise",
     generateLabel: "Generate video",
+    downloadEndpoint: "/api/t2v/download",
+    playbackEndpoint: "/api/t2v/playback",
+    hideControls: true,
   },
 }

--- a/apps/t2v_demo/web/adapter.js
+++ b/apps/t2v_demo/web/adapter.js
@@ -1,56 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-let promptInput
-let generateButton
-let downloadButton
-let recorder
-let chunks = []
-
-async function savePrompt(context) {
-  const response = await fetch("/api/t2v/prompt", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ prompt: promptInput.value }),
-  })
-  if (!response.ok) throw new Error(await response.text())
-  context.logEvent("prompt queued for this generation", { source: "client" })
-}
-
+/** Model metadata only; shared WebRTC UI renders prompt/video controls. */
 export default {
   modelName: "Text-to-Video",
-  controls: [{ label: "Generate", keys: [{ key: "g", label: "Generate" }] }],
-  async mount(context) {
-    const panel = document.createElement("section")
-    panel.className = "t2vPanel"
-    panel.innerHTML = `
-      <label>Prompt<textarea rows="5" placeholder="Describe the video you want to generate"></textarea></label>
-      <p>Press Generate to stream chunks to the player. The browser records the live stream for download.</p>
-      <div><button type="button" class="t2vGenerate">Generate</button><button type="button" class="t2vDownload" disabled>Download MP4/WebM</button></div>`
-    context.slots.panel.append(panel)
-    promptInput = panel.querySelector("textarea")
-    generateButton = panel.querySelector(".t2vGenerate")
-    downloadButton = panel.querySelector(".t2vDownload")
-    generateButton.addEventListener("click", async () => {
-      try {
-        await savePrompt(context)
-        context.logEvent("click the G control to begin the shared WebRTC session", { source: "client" })
-      } catch (error) { context.logEvent(error.message, { source: "client", level: "error" }) }
-    })
-    downloadButton.addEventListener("click", () => {
-      const blob = new Blob(chunks, { type: recorder?.mimeType || "video/webm" })
-      const anchor = Object.assign(document.createElement("a"), { href: URL.createObjectURL(blob), download: "flashdreams-t2v.webm" })
-      anchor.click(); URL.revokeObjectURL(anchor.href)
-    })
-    const video = document.getElementById("remoteVideo")
-    video.addEventListener("play", () => {
-      if (recorder || !video.srcObject || !window.MediaRecorder) return
-      chunks = []
-      recorder = new MediaRecorder(video.srcObject)
-      recorder.ondataavailable = event => { if (event.data.size) chunks.push(event.data) }
-      recorder.onstop = () => { downloadButton.disabled = chunks.length === 0 }
-      recorder.start(1000)
-    })
+  promptGeneration: {
+    endpoint: "/api/t2v/prompt",
+    label: "Describe the video",
+    placeholder: "A cinematic drone shot over snowy mountains at sunrise",
+    generateLabel: "Generate video",
   },
-  onDisconnect() { if (recorder?.state === "recording") recorder.stop(); recorder = null },
 }

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -681,6 +681,7 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
         shared_scenario: PreparedScenario | None = None,
         shared_pipeline_factory: Callable[[], StepPipeline] | None = None,
         legacy_segment_resampler_factory: Callable[..., Any] | None = None,
+        keep_connection_after_completed: bool = False,
     ) -> None:
         if client_liveness_timeout_s <= 0:
             raise ValueError("client_liveness_timeout_s must be > 0")
@@ -712,6 +713,7 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
         self._shared_spec_factory = shared_spec_factory
         self._shared_scenario = shared_scenario
         self._shared_pipeline_factory = shared_pipeline_factory
+        self._keep_connection_after_completed = keep_connection_after_completed
         self._shared_video_encoder: VideoEncoder | None = None
         self._legacy_segment_resampler_factory = legacy_segment_resampler_factory
 
@@ -1873,22 +1875,7 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
         context: RunContext,
         session_input: Any,
     ) -> None:
-        adapter = self._shared_adapter
-        spec = self._shared_spec
-        scenario = self._shared_scenario
-        spec_factory = self._shared_spec_factory
-        if adapter is None or spec is None:
-            adapter = _LegacyWebRTCDemoAdapter(
-                runtime=self._runtime,
-                identity=self.identity,
-                session_input=session_input,
-            )
-            spec = self._shared_demo_spec()
-        elif spec_factory is not None and session_input is not None:
-            spec = spec_factory(session_input)
-            scenario = None
-        if scenario is None:
-            scenario = adapter.prepare_scenario(spec)
+        """Run one or more shared-demo generations on a peer connection."""
         run_mode = WebRTCRunMode(
             edge_factory=_ManagedWebRTCSessionEdgeFactory(
                 manager=self,
@@ -1897,31 +1884,60 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
             )
         )
         try:
-            result = await run_demo_session_async(
-                context=context,
-                spec=spec,
-                scenario=scenario,
-                adapter=adapter,
-                run_mode=run_mode,
-                pipeline=(
-                    self._shared_pipeline_factory()
-                    if self._shared_pipeline_factory is not None
-                    else StepPipeline()
-                ),
-                reservation=managed_session.reservation,
-            )
-            if result.status == "completed":
-                logger.info("Shared WebRTC session completed.")
-            else:
-                logger.warning(
-                    "Shared WebRTC session ended with status={} reason={}",
-                    result.status,
-                    result.reason,
+            while not managed_session.closed:
+                adapter = self._shared_adapter
+                spec = self._shared_spec
+                scenario = self._shared_scenario
+                spec_factory = self._shared_spec_factory
+                if adapter is None or spec is None:
+                    adapter = _LegacyWebRTCDemoAdapter(
+                        runtime=self._runtime,
+                        identity=self.identity,
+                        session_input=session_input,
+                    )
+                    spec = self._shared_demo_spec()
+                elif spec_factory is not None and session_input is not None:
+                    spec = spec_factory(session_input)
+                    scenario = None
+                if scenario is None:
+                    scenario = adapter.prepare_scenario(spec)
+                result = await run_demo_session_async(
+                    context=context,
+                    spec=spec,
+                    scenario=scenario,
+                    adapter=adapter,
+                    run_mode=run_mode,
+                    pipeline=(
+                        self._shared_pipeline_factory()
+                        if self._shared_pipeline_factory is not None
+                        else StepPipeline()
+                    ),
+                    reservation=managed_session.reservation,
                 )
-            if result.status != "completed" and result.reason:
-                channel = managed_session.control_channel
-                if channel is not None:
-                    self._send_json(channel, make_error_payload(result.reason))
+                managed_session.reservation = None
+                if result.status != "completed":
+                    logger.warning(
+                        "Shared WebRTC session ended with status={} reason={}",
+                        result.status,
+                        result.reason,
+                    )
+                    if result.reason and managed_session.control_channel is not None:
+                        self._send_json(
+                            managed_session.control_channel,
+                            make_error_payload(result.reason),
+                        )
+                    break
+                logger.info("Shared WebRTC generation completed.")
+                if not self._keep_connection_after_completed:
+                    break
+                if managed_session.control_channel is not None:
+                    self._send_json(
+                        managed_session.control_channel,
+                        {"type": "generation_complete"},
+                    )
+                input_source = managed_session.input_source
+                if input_source is not None:
+                    input_source.reset(start_v=asyncio.get_running_loop().time())
         finally:
             managed_session.reservation = None
             if self._active_session is managed_session:

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -555,6 +555,7 @@ class _ManagedWebRTCSessionEdgeFactory:
             loop=self._loop,
             video_encoder=self._managed_session.video_encoder,
             video_track=self._managed_session.video_track,
+            close_track=not self._manager._keep_connection_after_completed,
             on_chunk_delivery=self._on_chunk_delivery,
             on_error=self._on_delivery_error,
         )
@@ -1916,6 +1917,12 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                 )
                 managed_session.reservation = None
                 if result.status != "completed":
+                    if (
+                        self._keep_connection_after_completed
+                        and result.status == "not_activated"
+                        and result.reason == "transport closed"
+                    ):
+                        break
                     logger.warning(
                         "Shared WebRTC session ended with status={} reason={}",
                         result.status,
@@ -1936,8 +1943,23 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
                         {"type": "generation_complete"},
                     )
                 input_source = managed_session.input_source
-                if input_source is not None:
-                    input_source.reset(start_v=asyncio.get_running_loop().time())
+                transport = managed_session.transport
+                if input_source is None or transport is None:
+                    break
+                input_source.reset(start_v=asyncio.get_running_loop().time())
+                # Do not construct another driver until the user submits the
+                # next prompt/generation. This keeps an idle T2V peer alive
+                # without surfacing an expected disconnect as a failed run.
+                activated = asyncio.create_task(input_source.activation_signal.wait())
+                closed = asyncio.create_task(transport.closed_signal.wait())
+                done, pending = await asyncio.wait(
+                    {activated, closed}, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                if closed in done or not transport.is_active():
+                    break
         finally:
             managed_session.reservation = None
             if self._active_session is managed_session:

--- a/flashdreams/flashdreams/serving/webrtc/web/request_session.css
+++ b/flashdreams/flashdreams/serving/webrtc/web/request_session.css
@@ -602,3 +602,5 @@ body[data-status="generating"] .statusLine strong {
 .promptGenerationActions button { min-height: 34px; border: 1px solid rgba(142,240,28,.45); border-radius: 6px; background: rgba(142,240,28,.12); color: var(--text); cursor: pointer; font-weight: 700; padding: 0 10px; }
 .promptGenerationActions button:disabled { cursor: not-allowed; opacity: .5; }
 .promptGenerationHint { margin: 10px 0 0; color: var(--muted); font-size: .78rem; line-height: 1.35; }
+.controlCard[hidden] { display: none; }
+.promptDurationInput { width: 8rem; min-height: 34px; margin-top: 12px; border: 1px solid rgba(255,255,255,.22); border-radius: 6px; background: rgba(12,14,15,.86); color: var(--text); padding: 0 9px; }

--- a/flashdreams/flashdreams/serving/webrtc/web/request_session.css
+++ b/flashdreams/flashdreams/serving/webrtc/web/request_session.css
@@ -587,3 +587,18 @@ body[data-status="generating"] .statusLine strong {
     border-bottom: 0;
   }
 }
+
+.promptGenerationPanel {
+  position: absolute;
+  z-index: 4;
+  left: clamp(18px, 3vw, 52px);
+  bottom: clamp(92px, 13vw, 150px);
+  width: min(430px, calc(100vw - 36px));
+  padding: 16px 18px;
+}
+.promptGenerationField { display: grid; gap: 7px; color: var(--muted); font-size: .72rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.promptGenerationField textarea { width: 100%; resize: vertical; min-height: 92px; border: 1px solid rgba(255,255,255,.22); border-radius: 6px; background: rgba(12,14,15,.86); color: var(--text); padding: 9px; font: inherit; text-transform: none; letter-spacing: normal; }
+.promptGenerationActions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+.promptGenerationActions button { min-height: 34px; border: 1px solid rgba(142,240,28,.45); border-radius: 6px; background: rgba(142,240,28,.12); color: var(--text); cursor: pointer; font-weight: 700; padding: 0 10px; }
+.promptGenerationActions button:disabled { cursor: not-allowed; opacity: .5; }
+.promptGenerationHint { margin: 10px 0 0; color: var(--muted); font-size: .78rem; line-height: 1.35; }

--- a/flashdreams/flashdreams/serving/webrtc/web/request_session.js
+++ b/flashdreams/flashdreams/serving/webrtc/web/request_session.js
@@ -67,6 +67,7 @@ let connected = false
 let disconnecting = false
 let heldKeySequence = 0
 let postprocessAvailable = false
+let liveVideoStream = null
 
 const metrics = {
   fps: null,
@@ -341,6 +342,7 @@ async function loadModelAdapter() {
     }
   }
   configurePromptGeneration(adapter.promptGeneration)
+  document.querySelector(".controlCard")?.toggleAttribute("hidden", adapter.promptGeneration?.hideControls === true)
   await adapter.mount?.(modelContext)
 }
 
@@ -699,10 +701,23 @@ function handleControlMessage(rawMessage) {
 
   if (payload.type === "generation_complete") {
     inferenceInFlight = false
-    if (promptGenerationControls) promptGenerationControls.generate.disabled = false
+    if (promptGenerationControls) {
+      promptGenerationControls.generate.disabled = false
+      promptGenerationControls.download.disabled = false
+    }
     setStatus("Waiting", "waiting")
     setFlow("generation complete; ready for another prompt")
     logEvent("generation complete", { source: "server" })
+    stopPromptRecording()
+    const playbackEndpoint = promptGenerationControls?.config.playbackEndpoint
+    if (playbackEndpoint) {
+      remoteVideo.pause()
+      remoteVideo.srcObject = null
+      remoteVideo.src = `${playbackEndpoint}?generation=${Date.now()}`
+      remoteVideo.loop = true
+      remoteVideo.playbackRate = 1
+      void remoteVideo.play()
+    }
     return
   }
 
@@ -943,6 +958,7 @@ async function connectSession() {
     pc.ontrack = (event) => {
       const [stream] = event.streams
       if (stream) {
+        liveVideoStream = stream
         remoteVideo.srcObject = stream
         updateMetricsFromVideo()
       }
@@ -1149,10 +1165,13 @@ function configurePromptGeneration(config) {
   panel.innerHTML = `<label class="promptGenerationField"><span>${label}</span><textarea rows="5" placeholder="${placeholder}"></textarea></label><div class="promptGenerationActions"><button type="button" class="promptGenerateButton">${generateLabel}</button><button type="button" class="promptPlaybackButton" disabled>Pause</button><button type="button" class="promptDownloadButton" disabled>Download recording</button></div><p class="promptGenerationHint">Keep this session open and submit another prompt whenever you are ready.</p>`
   modelPanelSlot.append(panel)
   const prompt = panel.querySelector("textarea")
+  const duration = document.createElement("input")
+  duration.type = "number"; duration.min = "1"; duration.max = "60"; duration.value = "5"; duration.className = "promptDurationInput"; duration.setAttribute("aria-label", "Video duration in seconds")
+  panel.querySelector(".promptGenerationActions").before(duration)
   const generate = panel.querySelector(".promptGenerateButton")
   const playback = panel.querySelector(".promptPlaybackButton")
   const download = panel.querySelector(".promptDownloadButton")
-  promptGenerationControls = { config, prompt, generate, playback, download }
+  promptGenerationControls = { config, prompt, duration, generate, playback, download }
   generate.addEventListener("click", () => void requestPromptGeneration())
   playback.addEventListener("click", () => {
     if (remoteVideo.paused) { void remoteVideo.play(); playback.textContent = "Pause" } else { remoteVideo.pause(); playback.textContent = "Play" }
@@ -1165,10 +1184,12 @@ async function requestPromptGeneration() {
   const controls = promptGenerationControls
   if (!controls) return
   const prompt = controls.prompt.value.trim()
+  const duration_s = Number(controls.duration.value)
+  if (!Number.isFinite(duration_s) || duration_s < 1 || duration_s > 60) { controls.duration.focus(); setFlow("choose 1–60 seconds"); return }
   if (!prompt) { controls.prompt.focus(); setFlow("enter a prompt"); return }
   controls.generate.disabled = true
   try {
-    const response = await fetch(controls.config.endpoint, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ prompt }) })
+    const response = await fetch(controls.config.endpoint, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ prompt, duration_s }) })
     if (!response.ok) throw new Error(await response.text())
     logEvent("prompt accepted", { source: "client" })
     if (!connected) {
@@ -1186,6 +1207,7 @@ async function requestPromptGeneration() {
 }
 
 function triggerPromptGeneration() {
+  if (remoteVideo.src) { remoteVideo.pause(); URL.revokeObjectURL(remoteVideo.src); remoteVideo.removeAttribute("src"); remoteVideo.srcObject = liveVideoStream; remoteVideo.loop = false }
   if (!sendModelMessage({ type: "action", action: { event: "step" } })) return
   inferenceInFlight = true
   if (promptGenerationControls) promptGenerationControls.generate.disabled = true
@@ -1210,10 +1232,6 @@ function stopPromptRecording() {
 }
 
 function downloadPromptRecording() {
-  if (!recordedChunks.length) return
-  const blob = new Blob(recordedChunks, { type: recording?.mimeType || "video/webm" })
-  const url = URL.createObjectURL(blob)
-  const anchor = Object.assign(document.createElement("a"), { href: url, download: "flashdreams-generation.webm" })
-  anchor.click()
-  URL.revokeObjectURL(url)
+  const endpoint = promptGenerationControls?.config.downloadEndpoint
+  if (endpoint) { window.location.assign(endpoint); return }
 }

--- a/flashdreams/flashdreams/serving/webrtc/web/request_session.js
+++ b/flashdreams/flashdreams/serving/webrtc/web/request_session.js
@@ -9,6 +9,7 @@ const mockMode = new URLSearchParams(window.location.search).has("mock")
  * @property {string=} stylesheet
  * @property {Array<{label: string, keys: Array<string|{key: string, label?: string}>}>=} controls
  * @property {{postprocess?: boolean}=} capabilities
+ * @property {{endpoint: string, label?: string, placeholder?: string, generateLabel?: string}=} promptGeneration
  * @property {(context: Object) => (void|Promise<void>)=} mount
  * @property {(context: Object) => (void|Promise<void>)=} beforeConnect
  * @property {(action: Object, context: Object) => void=} onActionSent
@@ -258,6 +259,7 @@ function sendModelCommand(payload, label = "model command") {
     return false
   }
   inferenceInFlight = true
+  if (promptGenerationControls) promptGenerationControls.generate.disabled = true
   setStatus("Generating", "generating")
   setFlow(`sent ${label}`)
   logEvent(label, { source: "client" })
@@ -338,6 +340,7 @@ async function loadModelAdapter() {
       })
     }
   }
+  configurePromptGeneration(adapter.promptGeneration)
   await adapter.mount?.(modelContext)
 }
 
@@ -694,6 +697,15 @@ function handleControlMessage(rawMessage) {
     return
   }
 
+  if (payload.type === "generation_complete") {
+    inferenceInFlight = false
+    if (promptGenerationControls) promptGenerationControls.generate.disabled = false
+    setStatus("Waiting", "waiting")
+    setFlow("generation complete; ready for another prompt")
+    logEvent("generation complete", { source: "server" })
+    return
+  }
+
   if (payload.type === "server_log") {
     logEvent(payload.message || "server log")
     return
@@ -707,6 +719,7 @@ function handleControlMessage(rawMessage) {
 
   if (payload.type === "error") {
     inferenceInFlight = false
+    if (promptGenerationControls) promptGenerationControls.generate.disabled = false
     logEvent(`server error: ${payload.message}`, { level: "error" })
     setStatus("Error", "error")
     setFlow("server error")
@@ -857,6 +870,7 @@ function disconnectSession({ notify = true } = {}) {
   connected = false
   connectButton.disabled = false
   setPostprocessDisabled(false)
+  stopPromptRecording()
   modelAdapter?.onDisconnect?.(modelContext)
   if (notify && controlChannel && controlChannel.readyState === "open") {
     try {
@@ -901,6 +915,10 @@ async function connectSession() {
       setFlow("connected; waiting for input")
       logEvent("control data channel open")
       startHeartbeat()
+      if (pendingPromptGeneration) {
+        pendingPromptGeneration = false
+        triggerPromptGeneration()
+      }
     }
     channel.onclose = () => {
       connected = false
@@ -1113,3 +1131,89 @@ window.addEventListener("beforeunload", () => {
 })
 
 void initialize()
+
+// Shared finite-generation controls. Models opt in through
+// `adapter.promptGeneration`; the transport remains model-agnostic.
+let promptGenerationControls = null
+let pendingPromptGeneration = false
+let recording = null
+let recordedChunks = []
+
+function configurePromptGeneration(config) {
+  if (!config || typeof config.endpoint !== "string" || !config.endpoint) return
+  const panel = document.createElement("section")
+  panel.className = "promptGenerationPanel overlayPanel"
+  const label = config.label || "Prompt"
+  const placeholder = config.placeholder || "Describe the video to generate"
+  const generateLabel = config.generateLabel || "Generate"
+  panel.innerHTML = `<label class="promptGenerationField"><span>${label}</span><textarea rows="5" placeholder="${placeholder}"></textarea></label><div class="promptGenerationActions"><button type="button" class="promptGenerateButton">${generateLabel}</button><button type="button" class="promptPlaybackButton" disabled>Pause</button><button type="button" class="promptDownloadButton" disabled>Download recording</button></div><p class="promptGenerationHint">Keep this session open and submit another prompt whenever you are ready.</p>`
+  modelPanelSlot.append(panel)
+  const prompt = panel.querySelector("textarea")
+  const generate = panel.querySelector(".promptGenerateButton")
+  const playback = panel.querySelector(".promptPlaybackButton")
+  const download = panel.querySelector(".promptDownloadButton")
+  promptGenerationControls = { config, prompt, generate, playback, download }
+  generate.addEventListener("click", () => void requestPromptGeneration())
+  playback.addEventListener("click", () => {
+    if (remoteVideo.paused) { void remoteVideo.play(); playback.textContent = "Pause" } else { remoteVideo.pause(); playback.textContent = "Play" }
+  })
+  download.addEventListener("click", () => downloadPromptRecording())
+  remoteVideo.addEventListener("play", startPromptRecording)
+}
+
+async function requestPromptGeneration() {
+  const controls = promptGenerationControls
+  if (!controls) return
+  const prompt = controls.prompt.value.trim()
+  if (!prompt) { controls.prompt.focus(); setFlow("enter a prompt"); return }
+  controls.generate.disabled = true
+  try {
+    const response = await fetch(controls.config.endpoint, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ prompt }) })
+    if (!response.ok) throw new Error(await response.text())
+    logEvent("prompt accepted", { source: "client" })
+    if (!connected) {
+      pendingPromptGeneration = true
+      await connectSession()
+      return
+    }
+    triggerPromptGeneration()
+  } catch (error) {
+    logEvent(`prompt failed: ${error.message}`, { source: "client", level: "error" })
+    setStatus("Error", "error")
+  } finally {
+    if (!inferenceInFlight) controls.generate.disabled = false
+  }
+}
+
+function triggerPromptGeneration() {
+  if (!sendModelMessage({ type: "action", action: { event: "step" } })) return
+  inferenceInFlight = true
+  if (promptGenerationControls) promptGenerationControls.generate.disabled = true
+  setStatus("Generating", "generating")
+  setFlow("generation started")
+  logEvent("generation started", { source: "client" })
+}
+
+function startPromptRecording() {
+  if (!promptGenerationControls || recording || !remoteVideo.srcObject || !window.MediaRecorder) return
+  recordedChunks = []
+  recording = new MediaRecorder(remoteVideo.srcObject)
+  recording.ondataavailable = event => { if (event.data.size) recordedChunks.push(event.data) }
+  recording.onstop = () => { if (promptGenerationControls) promptGenerationControls.download.disabled = recordedChunks.length === 0 }
+  recording.start(1000)
+  promptGenerationControls.playback.disabled = false
+}
+
+function stopPromptRecording() {
+  if (recording?.state === "recording") recording.stop()
+  recording = null
+}
+
+function downloadPromptRecording() {
+  if (!recordedChunks.length) return
+  const blob = new Blob(recordedChunks, { type: recording?.mimeType || "video/webm" })
+  const url = URL.createObjectURL(blob)
+  const anchor = Object.assign(document.createElement("a"), { href: url, download: "flashdreams-generation.webm" })
+  anchor.click()
+  URL.revokeObjectURL(url)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ members = [
     # folders alongside them are intentional placeholders for future
     # extractions and don't ship a ``pyproject.toml`` yet.
     "integrations/*",
+    "apps/*",
     # Nested sub-packages that the ``integrations/*`` glob does not reach.
     "integrations/omnidreams/ludus-renderer",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ members = [
     "flashdreams-omnidreams",
     "flashdreams-sana-wm",
     "flashdreams-self-forcing",
+    "flashdreams-t2v-demo",
     "flashdreams-wan21",
     "flashdreams-wan22",
     "ludus-renderer",
@@ -1388,6 +1389,17 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "flashdreams-t2v-demo"
+version = "0.1.0"
+source = { editable = "apps/t2v_demo" }
+dependencies = [
+    { name = "flashdreams", extra = ["serving"] },
+]
+
+[package.metadata]
+requires-dist = [{ name = "flashdreams", extras = ["serving"], editable = "flashdreams" }]
 
 [[package]]
 name = "flashdreams-wan21"


### PR DESCRIPTION
CLI / Web UI
    ↓
DemoSpec + InferenceConfig
    ↓
T2VDemoAdapter
    ↓
T2VRuntime (one selected heavyweight pipeline)
    ↓
T2VSession (one finite prompt rollout)
    ↓
StepResult video chunks
    ├─ replay: shared MP4 output path
    └─ WebRTC: shared session manager, encoder, transport, UI