### PR TITLE
Add application benchmark output support

### DIFF
--- a/flashdreams/flashdreams/demo/__init__.py
+++ b/flashdreams/flashdreams/demo/__init__.py
@@ -32,6 +32,7 @@ from flashdreams.demo.factories import (
     ProvidedIOFactory,
     WebRTCApplicationServing,
     WebRTCIOFactory,
+    register_application_input_handler,
 )
 from flashdreams.demo.io import (
     InputHandler,
@@ -89,4 +90,5 @@ __all__ = [
     "build_benchmark_output_sink",
     "create_application",
     "run_application",
+    "register_application_input_handler",
 ]

--- a/flashdreams/flashdreams/demo/application.py
+++ b/flashdreams/flashdreams/demo/application.py
@@ -534,14 +534,16 @@ def _parse_host_io(
 ) -> tuple[IOFactory | WebRTCApplicationServing, list[str]]:
     output_kind = _selected_output(args)
     output_path: Path | None = None
+    stats_path: Path | None = None
     output_fps: float | None = None
     host = "127.0.0.1"
     port = 8080
     application_args: list[str] = []
-    host_options = (
-        {"--output", "--host", "--port"}
+    host_options = {"--output", "--stats-path"}
+    host_options.update(
+        {"--host", "--port"}
         if output_kind == "webrtc"
-        else {"--output", "--output-path", "--output-fps"}
+        else {"--output-path", "--output-fps"}
     )
     index = 0
     while index < len(args):
@@ -552,6 +554,8 @@ def _parse_host_io(
             value = args[index + 1]
             if argument == "--output-path":
                 output_path = Path(value)
+            elif argument == "--stats-path":
+                stats_path = Path(value)
             elif argument == "--output-fps":
                 output_fps = float(value)
             elif argument == "--host":
@@ -564,13 +568,28 @@ def _parse_host_io(
         index += 1
 
     if output_kind == "local-window":
+        if stats_path is not None:
+            raise ValueError("--stats-path requires --output mp4.")
         return LocalWindowIOFactory(fps=output_fps), application_args
     if output_kind == "null":
+        if stats_path is not None:
+            raise ValueError("--stats-path requires --output mp4.")
         return NullIOFactory(), application_args
     if output_kind == "mp4":
         path = output_path or Path("outputs") / f"{application_slug}.mp4"
-        return Mp4IOFactory(output_path=path, fps=output_fps), application_args
+        if stats_path is not None and path.resolve() == stats_path.resolve():
+            raise ValueError("--output-path and --stats-path must be different.")
+        return (
+            Mp4IOFactory(
+                output_path=path,
+                fps=output_fps,
+                stats_path=stats_path,
+            ),
+            application_args,
+        )
     if output_kind == "webrtc":
+        if stats_path is not None:
+            raise ValueError("--stats-path requires --output mp4.")
         if not 1 <= port <= 65535:
             raise ValueError("--port must be between 1 and 65535.")
         return (
@@ -592,7 +611,8 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
     if not args or args[0] in {"-h", "--help"}:
         print(
             "usage: flashdreams-run APPLICATION "
-            "[--output local-window|null|mp4|webrtc] [--host HOST] [--port PORT] "
+            "[--output local-window|null|mp4|webrtc] [--output-path PATH] "
+            "[--stats-path PATH] [--host HOST] [--port PORT] "
             "[APPLICATION_ARGS ...]"
         )
         return

--- a/flashdreams/flashdreams/demo/factories.py
+++ b/flashdreams/flashdreams/demo/factories.py
@@ -27,6 +27,8 @@ from flashdreams.demo.io import InputHandler, IOFactory, OutputSink, SessionInfo
 from flashdreams.demo.local_input import SlangPyLocalInputHandler
 from flashdreams.demo.local_window import LocalWindowInputBridge
 from flashdreams.demo.outputs import (
+    BenchmarkStatsOutputSink,
+    CompositeOutputSink,
     LocalWindowOutputSink,
     Mp4OutputSink,
     NullOutputSink,
@@ -38,6 +40,23 @@ from flashdreams.runtime.inputs import CanonicalInputSchema, CanonicalInputWindo
 
 if TYPE_CHECKING:
     from flashdreams.serving.webrtc.services import WebRTCOutputBridge
+
+_APPLICATION_INPUT_FACTORIES: dict[str, Callable[[], InputHandler]] = {}
+
+
+def register_application_input_handler(
+    modality_name: str,
+    factory: Callable[[], InputHandler],
+) -> None:
+    """Register a GitLab/plugin input handler for one canonical modality."""
+    if not modality_name.strip():
+        raise ValueError("modality_name must be non-empty.")
+    existing = _APPLICATION_INPUT_FACTORIES.get(modality_name)
+    if existing is not None and existing is not factory:
+        if getattr(existing, "__name__", "") != getattr(factory, "__name__", ""):
+            raise ValueError(f"Input handler already registered for {modality_name!r}.")
+        return
+    _APPLICATION_INPUT_FACTORIES[modality_name] = factory
 
 
 @dataclass(slots=True)
@@ -195,6 +214,17 @@ class Mp4IOFactory(IOFactory):
     move_to_cpu: bool = True
     """Whether to move collected chunks to CPU memory immediately."""
 
+    stats_path: Path | None = None
+    """Optional structured benchmark stats artifact path."""
+
+    def __post_init__(self) -> None:
+        output_path = Path(self.output_path)
+        stats_path = None if self.stats_path is None else Path(self.stats_path)
+        if stats_path is not None and output_path.resolve() == stats_path.resolve():
+            raise ValueError("MP4 output and benchmark stats paths must be different.")
+        object.__setattr__(self, "output_path", output_path)
+        object.__setattr__(self, "stats_path", stats_path)
+
     def create_input_handler(self, input_schema: CanonicalInputSchema) -> InputHandler:
         """Create an input handler for ``input_schema``."""
         del input_schema
@@ -202,11 +232,19 @@ class Mp4IOFactory(IOFactory):
 
     def create_output_sink(self) -> OutputSink:
         """Create an output sink for one application run."""
-        return Mp4OutputSink(
+        video_sink = Mp4OutputSink(
             output_path=self.output_path,
             fps=self.fps,
             output_layout=self.output_layout,
             move_to_cpu=self.move_to_cpu,
+        )
+        if self.stats_path is None:
+            return video_sink
+        return CompositeOutputSink(
+            (
+                video_sink,
+                BenchmarkStatsOutputSink(output_path=self.stats_path),
+            )
         )
 
 
@@ -267,8 +305,8 @@ class WebRTCIOFactory(IOFactory):
     bridge_factory: Callable[[], WebRTCOutputBridge]
     """Create the transport bridge owned by a peer connection."""
 
-    input_factory: Callable[[CanonicalInputSchema], InputHandler] = (
-        lambda _schema: NullInputHandler()
+    input_factory: Callable[[CanonicalInputSchema], InputHandler] = lambda _schema: (
+        NullInputHandler()
     )
     """Create the peer input handler bound to an application schema."""
 
@@ -290,4 +328,5 @@ __all__ = [
     "ProvidedIOFactory",
     "WebRTCApplicationServing",
     "WebRTCIOFactory",
+    "register_application_input_handler",
 ]

--- a/flashdreams/flashdreams/demo/local_input.py
+++ b/flashdreams/flashdreams/demo/local_input.py
@@ -186,12 +186,29 @@ class SlangPyLocalInputHandler(InputHandler):
         key = _slangpy_enum_name(getattr(event, "key", None))
         if key is None:
             return
-        event_type = "key_up" if is_release else "key_down"
+        self.record_key(
+            event_type="key_up" if is_release else "key_down",
+            key=key,
+            source="slangpy-keyboard",
+        )
+
+    def record_key(
+        self,
+        *,
+        event_type: str,
+        key: str,
+        source: str,
+    ) -> None:
+        """Record one normalized keyboard edge from any IO transport."""
+        if not self._opened or DRIVER_COMMAND.name not in self._requested_names:
+            return
+        if event_type not in {"key_down", "key_up"}:
+            raise ValueError(f"Unsupported keyboard event type: {event_type!r}.")
         raw_event = UserInputEvent(
             timestamp_s=max(0.0, self._clock() - self._session_start_s),
             event_type=event_type,
             payload={"key": key},
-            source="slangpy-keyboard",
+            source=source,
         )
         with self._event_lock:
             self._events.append(raw_event)

--- a/flashdreams/flashdreams/serving/webrtc/manager.py
+++ b/flashdreams/flashdreams/serving/webrtc/manager.py
@@ -39,7 +39,6 @@ from flashdreams.runtime.demo import (
     RuntimeHost,
     SessionEdges,
     SessionInfo,
-    SingleSessionAdmissionPolicy,
     StepPipeline,
     UserInputWindow,
     WebRTCErrorPolicy,
@@ -777,8 +776,9 @@ class BaseWebRTCSessionManager(Generic[_RuntimeT, _RuntimeConfigT]):
         self._lifecycle = WebRTCManagerLifecycle(
             busy_message=busy_message,
             client_liveness_timeout_s=client_liveness_timeout_s,
-            health_check=lambda: self._shared_host is None
-            or self._shared_host.is_healthy,
+            health_check=lambda: (
+                self._shared_host is None or self._shared_host.is_healthy
+            ),
         )
 
     @property

--- a/flashdreams/tests/test_demo_runtime_output_sinks.py
+++ b/flashdreams/tests/test_demo_runtime_output_sinks.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 import torch
 
-from flashdreams.demo import LocalWindowOutputSink
+from flashdreams.demo import LocalWindowOutputSink, Mp4IOFactory
 from flashdreams.runtime import OutputArtifact, StepResult, TimeWindow
 from flashdreams.runtime.demo import (
     BenchmarkStatsOutputSink,
@@ -493,6 +493,24 @@ def test_benchmark_output_sink_composes_with_mp4_output(tmp_path: Path) -> None:
             "layout": "thwc",
         }
     ]
+
+
+def test_mp4_io_factory_optionally_composes_benchmark_stats(tmp_path: Path) -> None:
+    plain = Mp4IOFactory(output_path=tmp_path / "plain.mp4").create_output_sink()
+    benchmark = Mp4IOFactory(
+        output_path=tmp_path / "benchmark.mp4",
+        stats_path=tmp_path / "stats_benchmark.json",
+    ).create_output_sink()
+
+    assert isinstance(plain, Mp4OutputSink)
+    assert isinstance(benchmark, CompositeOutputSink)
+    assert isinstance(benchmark.sinks[0], Mp4OutputSink)
+    assert isinstance(benchmark.sinks[1], BenchmarkStatsOutputSink)
+    with pytest.raises(ValueError, match="must be different"):
+        Mp4IOFactory(
+            output_path=tmp_path / "shared.json",
+            stats_path=tmp_path / "shared.json",
+        )
 
 
 def test_composite_output_sink_closes_siblings_after_close_failure(


### PR DESCRIPTION
Allow MP4 application runs to optionally write structured benchmark statistics alongside the video output. Keep output-path validation and CLI argument handling consistent across application output modes.