### PR TITLE
Port Wan 2.1 and FastVideo CausalWan 2.2 to application API

### DIFF
--- a/apps/t2v/README.md
+++ b/apps/t2v/README.md
@@ -15,6 +15,15 @@ local-window/serving dependencies without installing unrelated integrations:
 - `t2v-wan21` → `--package flashdreams-wan21`
 - `ti2v-wan22` → `--package flashdreams-wan22`
 
+The applications use one of two rollout modes:
+
+- `t2v-cosmos-predict2`, `t2v-wan21`, and `ti2v-wan22` are
+  **bidirectional**. They generate the complete clip in one rollout and require
+  exactly one block (`--total-blocks 1`, which is the default).
+- `t2v-causal-forcing`, `t2v-fastvideo-causal-wan22`, and
+  `t2v-self-forcing` are causal, streaming applications that can generate
+  multiple blocks.
+
 Native SlangPy window (default):
 
 ```bash

--- a/apps/t2v/README.md
+++ b/apps/t2v/README.md
@@ -10,7 +10,9 @@ local-window/serving dependencies without installing unrelated integrations:
 
 - `t2v-causal-forcing` → `--package flashdreams-causal-forcing`
 - `t2v-cosmos-predict2` → `--package flashdreams-cosmos-predict2`
+- `t2v-fastvideo-causal-wan22` → `--package flashdreams-fastvideo-causal-wan22`
 - `t2v-self-forcing` → `--package flashdreams-self-forcing`
+- `t2v-wan21` → `--package flashdreams-wan21`
 
 Native SlangPy window (default):
 
@@ -49,8 +51,8 @@ uv run --package flashdreams-causal-forcing flashdreams-run t2v-causal-forcing \
   --prompt "A robot walking through a forest."
 ```
 
-Available slugs are `t2v-cosmos-predict2`, `t2v-causal-forcing`, and
-`t2v-self-forcing`. All backends receive the same transport-neutral
-`InputHandler` and `OutputSink` API. Input handlers publish named,
-time-windowed `CanonicalInputWindow` values matching each application's
-`CanonicalInputSchema`.
+Available slugs are `t2v-cosmos-predict2`, `t2v-causal-forcing`,
+`t2v-fastvideo-causal-wan22`, `t2v-self-forcing`, and `t2v-wan21`. All
+backends receive the same transport-neutral `InputHandler` and `OutputSink`
+API. Input handlers publish named, time-windowed `CanonicalInputWindow` values
+matching each application's `CanonicalInputSchema`.

--- a/apps/t2v/README.md
+++ b/apps/t2v/README.md
@@ -13,6 +13,7 @@ local-window/serving dependencies without installing unrelated integrations:
 - `t2v-fastvideo-causal-wan22` → `--package flashdreams-fastvideo-causal-wan22`
 - `t2v-self-forcing` → `--package flashdreams-self-forcing`
 - `t2v-wan21` → `--package flashdreams-wan21`
+- `ti2v-wan22` → `--package flashdreams-wan22`
 
 Native SlangPy window (default):
 
@@ -52,7 +53,10 @@ uv run --package flashdreams-causal-forcing flashdreams-run t2v-causal-forcing \
 ```
 
 Available slugs are `t2v-cosmos-predict2`, `t2v-causal-forcing`,
-`t2v-fastvideo-causal-wan22`, `t2v-self-forcing`, and `t2v-wan21`. All
-backends receive the same transport-neutral `InputHandler` and `OutputSink`
-API. Input handlers publish named, time-windowed `CanonicalInputWindow` values
-matching each application's `CanonicalInputSchema`.
+`t2v-fastvideo-causal-wan22`, `t2v-self-forcing`, `t2v-wan21`, and
+`ti2v-wan22`. Wan 2.2 is first-frame conditioned and additionally requires
+`--image-path`; see its [integration README](../../integrations/wan22/README.md).
+All backends receive the same transport-neutral `InputHandler` and
+`OutputSink` API. Input handlers publish named, time-windowed
+`CanonicalInputWindow` values matching each application's
+`CanonicalInputSchema`.

--- a/apps/t2v/t2v.py
+++ b/apps/t2v/t2v.py
@@ -176,6 +176,12 @@ class T2VApplication(IFlashDreamsApplication):
             },
         )
 
+    def _configure_argument_parser(self, parser: argparse.ArgumentParser) -> None:
+        """Add integration-specific application arguments to ``parser``."""
+
+    def _apply_parsed_arguments(self, args: argparse.Namespace) -> None:
+        """Capture validated integration-specific application arguments."""
+
     def init(self, commandline_args: Sequence[str]) -> None:
         """Parse session overrides and retain the required initial prompt."""
         parser = argparse.ArgumentParser(prog="flashdreams-run <t2v-slug>")
@@ -196,6 +202,7 @@ class T2VApplication(IFlashDreamsApplication):
             action=argparse.BooleanOptionalAction,
             default=None,
         )
+        self._configure_argument_parser(parser)
         args = parser.parse_args(list(commandline_args))
 
         prompt = (args.prompt or "").strip()
@@ -208,6 +215,7 @@ class T2VApplication(IFlashDreamsApplication):
             )
         if args.fps <= 0:
             raise ValueError("--fps must be greater than zero.")
+        self._apply_parsed_arguments(args)
 
         pipeline_config = self.defaults.pipeline_config
         if args.compile is not None:

--- a/apps/t2v/t2v.py
+++ b/apps/t2v/t2v.py
@@ -71,14 +71,26 @@ class T2VApplicationDefaults:
     """Layout emitted by the integration pipeline."""
 
     @classmethod
-    def from_runner_config(cls, runner_config: Any) -> "T2VApplicationDefaults":
+    def from_runner_config(
+        cls,
+        runner_config: Any,
+        *,
+        total_blocks: int | None = None,
+    ) -> "T2VApplicationDefaults":
         """Derive application defaults from an integration-owned runner config."""
-        required = ("pipeline", "total_blocks", "pixel_height", "pixel_width")
+        required = ["pipeline", "pixel_height", "pixel_width"]
+        if total_blocks is None:
+            required.append("total_blocks")
         missing = [name for name in required if not hasattr(runner_config, name)]
         if missing:
             raise TypeError(
                 f"T2V runner config is missing application defaults: {missing}."
             )
+        resolved_total_blocks = (
+            int(runner_config.total_blocks)
+            if total_blocks is None
+            else int(total_blocks)
+        )
         output_layout = getattr(
             runner_config,
             "postprocess_output_layout",
@@ -88,7 +100,7 @@ class T2VApplicationDefaults:
             output_layout = "tchw"
         return cls(
             pipeline_config=runner_config.pipeline,
-            total_blocks=int(runner_config.total_blocks),
+            total_blocks=resolved_total_blocks,
             pixel_height=int(runner_config.pixel_height),
             pixel_width=int(runner_config.pixel_width),
             fps=float(getattr(runner_config, "fps", 16.0)),
@@ -146,6 +158,24 @@ class T2VApplication(IFlashDreamsApplication):
         """Return whether T2V sessions can rebuild per-generation state."""
         return True
 
+    def _validate_total_blocks(self, total_blocks: int) -> None:
+        """Integration hook for model-specific rollout-length validation."""
+        if total_blocks <= 0:
+            raise ValueError("--total-blocks must be greater than zero.")
+
+    def _apply_compile_override(
+        self,
+        pipeline_config: Any,
+        enabled: bool,
+    ) -> Any:
+        """Integration hook for applying compilation to transformer config."""
+        return derive_config(
+            pipeline_config,
+            diffusion_model={
+                "transformer": {"compile_network": enabled},
+            },
+        )
+
     def init(self, commandline_args: Sequence[str]) -> None:
         """Parse session overrides and retain the required initial prompt."""
         parser = argparse.ArgumentParser(prog="flashdreams-run <t2v-slug>")
@@ -171,8 +201,7 @@ class T2VApplication(IFlashDreamsApplication):
         prompt = (args.prompt or "").strip()
         if not prompt:
             raise ValueError("--prompt is required and must be non-empty.")
-        if args.total_blocks <= 0:
-            raise ValueError("--total-blocks must be greater than zero.")
+        self._validate_total_blocks(args.total_blocks)
         if args.pixel_height <= 0 or args.pixel_width <= 0:
             raise ValueError(
                 "--pixel-height and --pixel-width must be greater than zero."
@@ -182,11 +211,9 @@ class T2VApplication(IFlashDreamsApplication):
 
         pipeline_config = self.defaults.pipeline_config
         if args.compile is not None:
-            pipeline_config = derive_config(
+            pipeline_config = self._apply_compile_override(
                 pipeline_config,
-                diffusion_model={
-                    "transformer": {"compile_network": args.compile},
-                },
+                args.compile,
             )
         self._session_config = _T2VSessionConfig(
             pipeline_config=pipeline_config,

--- a/apps/t2v/tests/test_application.py
+++ b/apps/t2v/tests/test_application.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import inspect
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -147,6 +148,43 @@ def test_prompt_is_required() -> None:
     application = _application(_FakePipeline())
     with pytest.raises(ValueError, match="--prompt is required"):
         application.init([])
+
+
+def test_compile_override_updates_single_transformer_config() -> None:
+    application = _application(_FakePipeline())
+    pipeline_config = SimpleNamespace(
+        diffusion_model=SimpleNamespace(
+            transformer=SimpleNamespace(compile_network=True)
+        )
+    )
+
+    resolved = application._apply_compile_override(pipeline_config, False)
+
+    assert resolved.diffusion_model.transformer.compile_network is False
+    assert pipeline_config.diffusion_model.transformer.compile_network is True
+
+
+def test_total_block_validation_can_be_narrowed_by_an_integration() -> None:
+    class _SingleBlockApplication(T2VApplication):
+        def _validate_total_blocks(self, total_blocks: int) -> None:
+            super()._validate_total_blocks(total_blocks)
+            if total_blocks > 1:
+                raise ValueError("test application supports exactly one block")
+
+    application = _SingleBlockApplication(
+        defaults=T2VApplicationDefaults(
+            pipeline_config=_FakePipelineConfig(_FakePipeline()),
+            total_blocks=1,
+            pixel_height=480,
+            pixel_width=832,
+        )
+    )
+    application.init(["--prompt", "A waterfall", "--total-blocks", "1"])
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        application.init(["--prompt", "A waterfall", "--total-blocks", "0"])
+    with pytest.raises(ValueError, match="exactly one block"):
+        application.init(["--prompt", "A waterfall", "--total-blocks", "2"])
 
 
 def test_t2v_model_warmup_covers_observed_autoregressive_signatures() -> None:
@@ -585,3 +623,26 @@ def test_application_defaults_derive_from_runner_config() -> None:
     assert defaults.pixel_width == 640
     assert defaults.fps == 24
     assert defaults.output_layout == "cthw"
+
+
+def test_application_defaults_accept_explicit_total_blocks() -> None:
+    pipeline_config = object()
+    runner_config = type(
+        "RunnerConfig",
+        (),
+        {
+            "pipeline": pipeline_config,
+            "pixel_height": 480,
+            "pixel_width": 832,
+        },
+    )()
+
+    defaults = T2VApplicationDefaults.from_runner_config(
+        runner_config,
+        total_blocks=1,
+    )
+
+    assert defaults.pipeline_config is pipeline_config
+    assert defaults.total_blocks == 1
+    assert defaults.pixel_height == 480
+    assert defaults.pixel_width == 832

--- a/apps/t2v/tests/test_integration_apps.py
+++ b/apps/t2v/tests/test_integration_apps.py
@@ -38,7 +38,13 @@ def test_t2v_app_installs_dependencies_for_documented_outputs() -> None:
     [
         ("cosmos_predict2", "cosmos_predict2", "t2v-cosmos-predict2"),
         ("causal_forcing", "causal_forcing", "t2v-causal-forcing"),
+        (
+            "fastvideo_causal_wan22",
+            "fastvideo_causal_wan22",
+            "t2v-fastvideo-causal-wan22",
+        ),
         ("self_forcing", "self_forcing", "t2v-self-forcing"),
+        ("wan21", "wan21", "t2v-wan21"),
     ],
 )
 def test_concrete_t2v_app_is_owned_by_integration(

--- a/integrations/cosmos_predict2/README.md
+++ b/integrations/cosmos_predict2/README.md
@@ -7,7 +7,10 @@ This is a worked example of the
 [Add a new method](https://nvidia.github.io/flashdreams/main/developer_guides/new_integration.html)
 developer-guide flow.
 
-**In this plugin, bidirectional video generation is treated as a 1-rollout (large-windowed) causal rollout.**
+Cosmos-Predict2 is **bidirectional**: it generates the complete clip in one
+rollout instead of advancing through multiple causal blocks. It therefore
+requires exactly one block (`--total-blocks 1`); multi-block generation is not
+supported.
 
 ## Shipped slugs
 
@@ -15,6 +18,9 @@ developer-guide flow.
 | --- | --- |
 | `cosmos2-t2v-2b-720p` | Cosmos-Predict2 2B T2V at 720p (single AR step, prompt-only). |
 | `cosmos2-i2v-2b-720p` | Cosmos-Predict2 2B I2V at 720p (single AR step, prompt + first-frame image). |
+
+The higher-level T2V application is registered as `t2v-cosmos-predict2` and
+uses the same single-block bidirectional rollout.
 
 ## Install
 

--- a/integrations/fastvideo_causal_wan22/README.md
+++ b/integrations/fastvideo_causal_wan22/README.md
@@ -13,6 +13,10 @@ developer-guide flow.
 | --- | --- |
 | `fastvideo-causal-wan2.2-t2v-14b` | FastVideo CausalWan 2.2 14B MoE T2V (Wan VAE decoder, 8-step). |
 
+The higher-level T2V application is registered as
+`t2v-fastvideo-causal-wan22`; see the
+[shared T2V application guide](../../apps/t2v/README.md) for launch modes.
+
 The two MoE branches share every Wan 2.1 14B knob and only differ by
 checkpoint: `high_noise` runs above the boundary
 (`timestep / num_train_timesteps >= boundary_ratio`), `low_noise` runs

--- a/integrations/fastvideo_causal_wan22/README.md
+++ b/integrations/fastvideo_causal_wan22/README.md
@@ -14,8 +14,7 @@ developer-guide flow.
 | `fastvideo-causal-wan2.2-t2v-14b` | FastVideo CausalWan 2.2 14B MoE T2V (Wan VAE decoder, 8-step). |
 
 The higher-level T2V application is registered as
-`t2v-fastvideo-causal-wan22`; see the
-[shared T2V application guide](../../apps/t2v/README.md) for launch modes.
+`t2v-fastvideo-causal-wan22`.
 
 The two MoE branches share every Wan 2.1 14B knob and only differ by
 checkpoint: `high_noise` runs above the boundary
@@ -55,7 +54,53 @@ export HF_HOME=~/.cache/huggingface  # default
 
 ## Run
 
-Once installed, the slugs are discovered automatically by `flashdreams-run`:
+### T2V application
+
+The simplest application launch uses the default local window and model
+settings:
+
+```bash
+uv run --package flashdreams-fastvideo-causal-wan22 flashdreams-run \
+  t2v-fastvideo-causal-wan22 \
+  --prompt "A cat surfing."
+```
+
+Per-application help:
+
+```bash
+uv run --package flashdreams-fastvideo-causal-wan22 flashdreams-run \
+  t2v-fastvideo-causal-wan22 --help
+```
+
+Generate a shorter MP4 rollout by overriding the output and block count:
+
+```bash
+uv run --package flashdreams-fastvideo-causal-wan22 flashdreams-run \
+  t2v-fastvideo-causal-wan22 \
+  --output mp4 \
+  --output-path artifacts/t2v-fastvideo-causal-wan22.mp4 \
+  --total-blocks 7 \
+  --prompt "A cat surfing."
+```
+
+Serve the default rollout through WebRTC:
+
+```bash
+uv run --package flashdreams-fastvideo-causal-wan22 flashdreams-run \
+  t2v-fastvideo-causal-wan22 \
+  --output webrtc \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --prompt "A cat surfing."
+```
+
+Then open `http://localhost:8080/request_session`. See the
+[shared T2V application guide](../../apps/t2v/README.md) for all output modes.
+
+### Legacy runner
+
+The legacy runner slug is also discovered automatically by
+`flashdreams-run`:
 
 ```bash
 # List every registered runner (this plugin's slug appears under "fastvideo-causal-wan2.2-*").

--- a/integrations/fastvideo_causal_wan22/fastvideo_causal_wan22/t2v/__init__.py
+++ b/integrations/fastvideo_causal_wan22/fastvideo_causal_wan22/t2v/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FastVideo CausalWan 2.2 text-to-video application."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/integrations/fastvideo_causal_wan22/fastvideo_causal_wan22/t2v/app.py
+++ b/integrations/fastvideo_causal_wan22/fastvideo_causal_wan22/t2v/app.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FastVideo CausalWan 2.2 text-to-video application factory."""
+
+from typing import Any
+
+from t2v import (
+    T2VApplication,
+    T2VApplicationDefaults,
+    T2VApplicationSession,
+)
+
+from fastvideo_causal_wan22.config import RUNNER_WAN22_T2V_14B
+from flashdreams.demo import IFlashDreamsApplication
+from flashdreams.infra.config import derive_config
+
+
+class FastvideoCausalWan22T2VApplication(T2VApplication):
+    """FastVideo CausalWan 2.2 text-to-video application."""
+
+    session_type = T2VApplicationSession
+
+    def __init__(self) -> None:
+        super().__init__(
+            defaults=T2VApplicationDefaults.from_runner_config(RUNNER_WAN22_T2V_14B)
+        )
+
+    def _apply_compile_override(
+        self,
+        pipeline_config: Any,
+        enabled: bool,
+    ) -> Any:
+        """Apply compilation to both Wan 2.2 noise-level transformers."""
+        return derive_config(
+            pipeline_config,
+            diffusion_model={
+                "transformer": {
+                    "transformer_high_noise": {"compile_network": enabled},
+                    "transformer_low_noise": {"compile_network": enabled},
+                },
+            },
+        )
+
+
+def create_app() -> IFlashDreamsApplication:
+    """Create the FastVideo CausalWan 2.2 text-to-video application."""
+    return FastvideoCausalWan22T2VApplication()
+
+
+__all__ = [
+    "FastvideoCausalWan22T2VApplication",
+    "create_app",
+]

--- a/integrations/fastvideo_causal_wan22/pyproject.toml
+++ b/integrations/fastvideo_causal_wan22/pyproject.toml
@@ -26,9 +26,11 @@ requires-python = ">=3.10"
 dependencies = [
     "flashdreams",
     "mediapy>=1.1",
+    "flashdreams-t2v",
 ]
 
 [tool.uv.sources]
+flashdreams-t2v = { workspace = true }
 flashdreams = { workspace = true }
 
 [project.optional-dependencies]
@@ -42,6 +44,9 @@ dev = [
 # informational, the registry key always comes from ``cfg.runner_name``.
 [project.entry-points."flashdreams.runner_configs"]
 "fastvideo-causal-wan2.2-t2v-14b" = "fastvideo_causal_wan22.config:RUNNER_WAN22_T2V_14B"
+
+[project.entry-points."flashdreams.applications"]
+"t2v-fastvideo-causal-wan22" = "fastvideo_causal_wan22.t2v.app:create_app"
 
 [tool.setuptools.packages.find]
 include = ["fastvideo_causal_wan22*"]

--- a/integrations/fastvideo_causal_wan22/tests/test_smoke.py
+++ b/integrations/fastvideo_causal_wan22/tests/test_smoke.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Cheap import-time checks for the ``fastvideo_causal_wan22`` plugin."""
+"""Cheap configuration checks for the ``fastvideo_causal_wan22`` plugin."""
 
 from __future__ import annotations
 
@@ -25,6 +25,7 @@ import pytest
 import tomli as tomllib
 from fastvideo_causal_wan22 import config as config_mod
 from fastvideo_causal_wan22.config import RUNNER_CONFIGS
+from fastvideo_causal_wan22.t2v.app import FastvideoCausalWan22T2VApplication
 
 from flashdreams.infra.runner import RunnerConfig
 
@@ -54,6 +55,29 @@ def test_runners_have_descriptions() -> None:
         slug for slug, cfg in RUNNER_CONFIGS.items() if not cfg.description.strip()
     ]
     assert not empty, f"runners missing description: {empty}"
+
+
+@pytest.mark.parametrize(
+    ("compile_flag", "expected"),
+    [("--compile", True), ("--no-compile", False)],
+)
+def test_t2v_compile_override_updates_both_transformers(
+    compile_flag: str,
+    expected: bool,
+) -> None:
+    """Both FastVideo noise-level transformers honor the T2V compile flag."""
+    application = FastvideoCausalWan22T2VApplication()
+    application.init(["--prompt", "A waterfall", compile_flag])
+
+    session_config = application._session_config
+    assert session_config is not None
+    transformer = session_config.pipeline_config.diffusion_model.transformer
+    assert transformer.transformer_high_noise.compile_network is expected
+    assert transformer.transformer_low_noise.compile_network is expected
+
+    base_transformer = application.defaults.pipeline_config.diffusion_model.transformer
+    assert base_transformer.transformer_high_noise.compile_network is True
+    assert base_transformer.transformer_low_noise.compile_network is True
 
 
 def test_entry_points_match_module_literals() -> None:

--- a/integrations/wan21/README.md
+++ b/integrations/wan21/README.md
@@ -7,7 +7,10 @@ This is a worked example of the
 [Add a new method](https://nvidia.github.io/flashdreams/main/developer_guides/new_integration.html)
 developer-guide flow.
 
-**In this plugin, bidirectional video generation is treated as a 1-rollout (large-windowed) causal rollout.**
+Wan 2.1 is **bidirectional**: it generates the complete clip in one rollout
+instead of advancing through multiple causal blocks. It therefore requires
+exactly one block (`--total-blocks 1`); multi-block generation is not
+supported.
 
 ## Shipped slugs
 
@@ -16,7 +19,8 @@ developer-guide flow.
 | `wan21-t2v-1.3b-480p` | Wan 2.1 T2V 1.3B at 480p (single AR step, prompt-only). |
 | `wan21-i2v-14b-480p` | Wan 2.1 I2V 14B at 480p (single AR step, prompt + first-frame). |
 
-The higher-level T2V application is registered as `t2v-wan21`.
+The higher-level T2V application is registered as `t2v-wan21` and uses the
+same single-block bidirectional rollout.
 
 ## Install
 

--- a/integrations/wan21/README.md
+++ b/integrations/wan21/README.md
@@ -16,6 +16,9 @@ developer-guide flow.
 | `wan21-t2v-1.3b-480p` | Wan 2.1 T2V 1.3B at 480p (single AR step, prompt-only). |
 | `wan21-i2v-14b-480p` | Wan 2.1 I2V 14B at 480p (single AR step, prompt + first-frame). |
 
+The higher-level T2V application is registered as `t2v-wan21`; see the
+[shared T2V application guide](../../apps/t2v/README.md) for launch modes.
+
 ## Install
 
 The plugin is registered as a `uv` workspace member in the repo-root

--- a/integrations/wan21/README.md
+++ b/integrations/wan21/README.md
@@ -16,8 +16,7 @@ developer-guide flow.
 | `wan21-t2v-1.3b-480p` | Wan 2.1 T2V 1.3B at 480p (single AR step, prompt-only). |
 | `wan21-i2v-14b-480p` | Wan 2.1 I2V 14B at 480p (single AR step, prompt + first-frame). |
 
-The higher-level T2V application is registered as `t2v-wan21`; see the
-[shared T2V application guide](../../apps/t2v/README.md) for launch modes.
+The higher-level T2V application is registered as `t2v-wan21`.
 
 ## Install
 
@@ -49,7 +48,48 @@ export HF_HOME=~/.cache/huggingface  # default
 
 ## Run
 
-Once installed, the slugs are discovered automatically by `flashdreams-run`:
+### T2V application
+
+The simplest application launch uses the default local window and model
+settings:
+
+```bash
+uv run --package flashdreams-wan21 flashdreams-run t2v-wan21 \
+  --prompt "A cat surfing."
+```
+
+Per-application help:
+
+```bash
+uv run --package flashdreams-wan21 flashdreams-run t2v-wan21 --help
+```
+
+Generate an MP4 instead:
+
+```bash
+uv run --package flashdreams-wan21 flashdreams-run t2v-wan21 \
+  --output mp4 \
+  --output-path artifacts/t2v-wan21.mp4 \
+  --prompt "A cat surfing."
+```
+
+Serve the same application through WebRTC:
+
+```bash
+uv run --package flashdreams-wan21 flashdreams-run t2v-wan21 \
+  --output webrtc \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --prompt "A cat surfing."
+```
+
+Then open `http://localhost:8080/request_session`. See the
+[shared T2V application guide](../../apps/t2v/README.md) for all output modes.
+
+### Legacy runners
+
+The legacy runner slugs are also discovered automatically by
+`flashdreams-run`:
 
 ```bash
 # List every registered runner (this plugin's slugs appear under "wan21-*").

--- a/integrations/wan21/pyproject.toml
+++ b/integrations/wan21/pyproject.toml
@@ -27,9 +27,11 @@ dependencies = [
     "flashdreams",
     "mediapy>=1.1",
     "opencv-python-headless>=4.5",
+    "flashdreams-t2v",
 ]
 
 [tool.uv.sources]
+flashdreams-t2v = { workspace = true }
 flashdreams = { workspace = true }
 
 [project.optional-dependencies]
@@ -44,6 +46,9 @@ dev = [
 [project.entry-points."flashdreams.runner_configs"]
 "wan21-t2v-1.3b-480p" = "wan21.config:RUNNER_WAN21_T2V_1PT3B_480P"
 "wan21-i2v-14b-480p" = "wan21.config:RUNNER_WAN21_I2V_14B_480P"
+
+[project.entry-points."flashdreams.applications"]
+"t2v-wan21" = "wan21.t2v.app:create_app"
 
 [tool.setuptools.packages.find]
 include = ["wan21*"]

--- a/integrations/wan21/wan21/t2v/__init__.py
+++ b/integrations/wan21/wan21/t2v/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wan 2.1 text-to-video application."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/integrations/wan21/wan21/t2v/app.py
+++ b/integrations/wan21/wan21/t2v/app.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wan 2.1 text-to-video application factory."""
+
+from t2v import (
+    T2VApplication,
+    T2VApplicationDefaults,
+    T2VApplicationSession,
+)
+
+from flashdreams.demo import IFlashDreamsApplication
+from wan21.config import RUNNER_WAN21_T2V_1PT3B_480P
+
+
+class Wan21T2VApplication(T2VApplication):
+    """Wan 2.1 single-block text-to-video application."""
+
+    session_type = T2VApplicationSession
+
+    def __init__(self) -> None:
+        super().__init__(
+            defaults=T2VApplicationDefaults.from_runner_config(
+                RUNNER_WAN21_T2V_1PT3B_480P,
+                total_blocks=1,
+            )
+        )
+
+    def _validate_total_blocks(self, total_blocks: int) -> None:
+        """Reject multi-block requests unsupported by bidirectional Wan 2.1."""
+        super()._validate_total_blocks(total_blocks)
+        if total_blocks > 1:
+            raise ValueError(
+                "Wan 2.1 T2V supports exactly one autoregressive block; "
+                "--total-blocks must be 1."
+            )
+
+
+def create_app() -> IFlashDreamsApplication:
+    """Create the Wan 2.1 text-to-video application."""
+    return Wan21T2VApplication()
+
+
+__all__ = [
+    "Wan21T2VApplication",
+    "create_app",
+]

--- a/integrations/wan22/README.md
+++ b/integrations/wan22/README.md
@@ -49,7 +49,7 @@ Then open `http://localhost:8080/request_session`.
 ## Public surface
 
 - `PIPELINE_WAN22_TI2V_5B` — the assembled pipeline literal.
-- `WAN22_TI2V_5B_DIT_DIFFUSERS_PATH` — diffusers safetensors URL.
+- `WAN22_TI2V_5B_DIT_DIFFUSERS_PATH` — diffusers sharded-safetensors index URL.
 - `wan22_ti2v_5b_dit_state_dict_transform` — diffusers → flashdreams
   DiT key remap.
 - `WAN_CONFIGS` — `{name: pipeline_config}` registry dict.

--- a/integrations/wan22/README.md
+++ b/integrations/wan22/README.md
@@ -10,16 +10,19 @@ provides the pre-rolled `WanInferencePipelineConfig` literal, the diffusers
 `state_dict` remap for the Wan-AI `Wan2.2-TI2V-5B-Diffusers` checkpoint, and
 the `ti2v-wan22` application entry point.
 
-The application accepts a prompt and first-frame image, then generates the
-model's standard single-block 81-frame, 640x1280 rollout through the shared
-null, MP4, local-window, or WebRTC application host. HY-WorldPlay also reuses
-the pipeline config as its base recipe.
+Wan 2.2 TI2V-5B is **bidirectional**: the application accepts a prompt and
+first-frame image, then generates the complete 81-frame, 640x1280 clip in one
+rollout instead of advancing through multiple causal blocks. It therefore
+requires exactly one block (`--total-blocks 1`, which is the default);
+multi-block generation is not supported. The application runs through the
+shared null, MP4, local-window, or WebRTC host. HY-WorldPlay also reuses the
+pipeline config as its base recipe.
 
 ## Shipped slug
 
 | slug | description |
 | --- | --- |
-| `ti2v-wan22` | Wan 2.2 TI2V-5B at 640x1280, conditioned on a prompt and first frame. |
+| `ti2v-wan22` | Bidirectional, single-block Wan 2.2 TI2V-5B at 640x1280, conditioned on a prompt and first frame. |
 
 ## Install
 

--- a/integrations/wan22/README.md
+++ b/integrations/wan22/README.md
@@ -15,7 +15,57 @@ model's standard single-block 81-frame, 640x1280 rollout through the shared
 null, MP4, local-window, or WebRTC application host. HY-WorldPlay also reuses
 the pipeline config as its base recipe.
 
-## Application
+## Shipped slug
+
+| slug | description |
+| --- | --- |
+| `ti2v-wan22` | Wan 2.2 TI2V-5B at 640x1280, conditioned on a prompt and first frame. |
+
+## Install
+
+The package is registered as a `uv` workspace member, so a repo-root sync
+installs it:
+
+```bash
+uv sync
+```
+
+For a targeted workspace environment:
+
+```bash
+uv sync --package flashdreams-wan22
+```
+
+Standalone editable installation also works:
+
+```bash
+uv pip install -e integrations/wan22
+```
+
+## Hugging Face setup
+
+Checkpoints are downloaded from Hugging Face on first use. Set an authentication
+token if required by your environment:
+
+```bash
+export HF_TOKEN=<your-hf-token>
+```
+
+## Run
+
+Native SlangPy window (default):
+
+```bash
+uv run --package flashdreams-wan22 flashdreams-run ti2v-wan22 \
+  --prompt "A cinematic ocean wave at sunset." \
+  --image-path /path/to/first-frame.png
+```
+
+Per-application help:
+
+```bash
+uv run --package flashdreams-wan22 flashdreams-run ti2v-wan22 --help
+```
 
 MP4 output:
 
@@ -54,10 +104,17 @@ Then open `http://localhost:8080/request_session`.
   DiT key remap.
 - `WAN_CONFIGS` — `{name: pipeline_config}` registry dict.
 
-## Install
+## Programmatic access
 
-Workspace member; pulled in by repo-root `uv sync`.
+The pipeline config remains available directly for downstream integrations:
 
 ```python
 from wan22.config import PIPELINE_WAN22_TI2V_5B
+```
+
+## Tests
+
+```bash
+uv run --group test --package flashdreams-wan22 \
+  pytest integrations/wan22/tests
 ```

--- a/integrations/wan22/README.md
+++ b/integrations/wan22/README.md
@@ -5,13 +5,46 @@ SPDX-License-Identifier: Apache-2.0
 
 # `wan22`
 
-Wan 2.2 TI2V-5B inference recipe config — the pre-rolled
-`WanInferencePipelineConfig` literal and the diffusers `state_dict`
-remap for the Wan-AI `Wan2.2-TI2V-5B-Diffusers` checkpoint.
+Wan 2.2 TI2V-5B inference recipe and standalone application. The package
+provides the pre-rolled `WanInferencePipelineConfig` literal, the diffusers
+`state_dict` remap for the Wan-AI `Wan2.2-TI2V-5B-Diffusers` checkpoint, and
+the `ti2v-wan22` application entry point.
 
-Config-only package; downstream runners
-(`integrations/hy_worldplay`, `flashdreams-run` slugs) layer the I/O
-wrapper on top.
+The application accepts a prompt and first-frame image, then generates the
+model's standard single-block 81-frame, 640x1280 rollout through the shared
+null, MP4, local-window, or WebRTC application host. HY-WorldPlay also reuses
+the pipeline config as its base recipe.
+
+## Application
+
+MP4 output:
+
+```bash
+uv run --package flashdreams-wan22 flashdreams-run ti2v-wan22 \
+  --output mp4 --output-path artifacts/ti2v-wan22.mp4 \
+  --prompt "A cinematic ocean wave at sunset." \
+  --image-path /path/to/first-frame.png
+```
+
+Null output:
+
+```bash
+uv run --package flashdreams-wan22 flashdreams-run ti2v-wan22 \
+  --output null \
+  --prompt "A cinematic ocean wave at sunset." \
+  --image-path /path/to/first-frame.png
+```
+
+WebRTC output:
+
+```bash
+uv run --package flashdreams-wan22 flashdreams-run ti2v-wan22 \
+  --output webrtc --host 0.0.0.0 --port 8080 \
+  --prompt "A cinematic ocean wave at sunset." \
+  --image-path /path/to/first-frame.png
+```
+
+Then open `http://localhost:8080/request_session`.
 
 ## Public surface
 

--- a/integrations/wan22/pyproject.toml
+++ b/integrations/wan22/pyproject.toml
@@ -20,20 +20,27 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "flashdreams-wan22"
 version = "0.1.0"
-description = "Wan 2.2 TI2V-5B inference recipe config for flashdreams."
+description = "Wan 2.2 TI2V-5B inference recipe and application for flashdreams."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "flashdreams",
+    "flashdreams-t2v",
+    "mediapy>=1.1",
+    "opencv-python-headless>=4.5",
 ]
 
 [tool.uv.sources]
 flashdreams = { workspace = true }
+flashdreams-t2v = { workspace = true }
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
 ]
+
+[project.entry-points."flashdreams.applications"]
+"ti2v-wan22" = "wan22.ti2v.app:create_app"
 
 [tool.setuptools.packages.find]
 include = ["wan22*"]

--- a/integrations/wan22/tests/test_application.py
+++ b/integrations/wan22/tests/test_application.py
@@ -24,6 +24,7 @@ from typing import Any
 import pytest
 import tomli as tomllib
 import torch
+from wan22.config import WAN22_TI2V_5B_DIT_DIFFUSERS_PATH
 from wan22.ti2v import app as app_module
 from wan22.ti2v.app import Wan22TI2VApplication, create_app
 
@@ -93,6 +94,16 @@ def test_factory_exposes_static_ti2v_application_defaults() -> None:
     assert application.defaults.pixel_width == 1280
     assert application.defaults.fps == 16
     assert not application.input_schema.modalities
+
+
+def test_transformer_uses_the_published_sharded_checkpoint_index() -> None:
+    application = Wan22TI2VApplication()
+    transformer = application.defaults.pipeline_config.diffusion_model.transformer
+
+    assert transformer.checkpoint_path == WAN22_TI2V_5B_DIT_DIFFUSERS_PATH
+    assert WAN22_TI2V_5B_DIT_DIFFUSERS_PATH.endswith(
+        "transformer/diffusion_pytorch_model.safetensors.index.json"
+    )
 
 
 def test_application_requires_prompt_and_existing_first_frame(tmp_path: Path) -> None:

--- a/integrations/wan22/tests/test_application.py
+++ b/integrations/wan22/tests/test_application.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU application checks for the Wan 2.2 TI2V demo."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tomli as tomllib
+import torch
+from wan22.ti2v import app as app_module
+from wan22.ti2v.app import Wan22TI2VApplication, create_app
+
+from flashdreams.demo import CanonicalInputWindow, IFlashDreamsApplication
+from flashdreams.infra.time import TimeWindow
+
+pytestmark = pytest.mark.ci_cpu
+
+
+class _FakePipeline:
+    def __init__(self) -> None:
+        self.device = torch.device("cpu")
+        self.initialize_calls: list[dict[str, Any]] = []
+        self.generated: list[int] = []
+        self.finalized: list[int] = []
+        self.closed = False
+
+    def to(self, device: str) -> "_FakePipeline":
+        self.device = torch.device(device)
+        return self
+
+    def eval(self) -> "_FakePipeline":
+        return self
+
+    def initialize_cache(self, **kwargs: Any) -> object:
+        self.initialize_calls.append(kwargs)
+        return object()
+
+    def get_num_output_frames(self, autoregressive_index: int) -> int:
+        assert autoregressive_index == 0
+        return 81
+
+    def generate(self, *, autoregressive_index: int, cache: object) -> torch.Tensor:
+        del cache
+        self.generated.append(autoregressive_index)
+        return torch.zeros((81, 3, 4, 4))
+
+    def finalize(self, *, autoregressive_index: int, cache: object) -> None:
+        del cache
+        self.finalized.append(autoregressive_index)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakePipelineConfig:
+    def __init__(self, pipeline: _FakePipeline) -> None:
+        self.pipeline = pipeline
+
+    def setup(self) -> _FakePipeline:
+        return self.pipeline
+
+
+def _first_frame(tmp_path: Path) -> Path:
+    path = tmp_path / "first-frame.png"
+    path.write_bytes(b"test image placeholder")
+    return path
+
+
+def test_factory_exposes_static_ti2v_application_defaults() -> None:
+    application = create_app()
+
+    assert isinstance(application, IFlashDreamsApplication)
+    assert isinstance(application, Wan22TI2VApplication)
+    assert application.defaults.total_blocks == 1
+    assert application.defaults.pixel_height == 640
+    assert application.defaults.pixel_width == 1280
+    assert application.defaults.fps == 16
+    assert not application.input_schema.modalities
+
+
+def test_application_requires_prompt_and_existing_first_frame(tmp_path: Path) -> None:
+    application = Wan22TI2VApplication()
+    first_frame = _first_frame(tmp_path)
+
+    with pytest.raises(ValueError, match="--prompt is required"):
+        application.init(["--image-path", str(first_frame)])
+    with pytest.raises(SystemExit):
+        application.init(["--prompt", "A waterfall"])
+    with pytest.raises(FileNotFoundError, match="first-frame image does not exist"):
+        application.init(
+            [
+                "--prompt",
+                "A waterfall",
+                "--image-path",
+                str(tmp_path / "missing.png"),
+            ]
+        )
+
+
+def test_application_rejects_multiple_blocks(tmp_path: Path) -> None:
+    application = Wan22TI2VApplication()
+
+    with pytest.raises(ValueError, match="exactly one autoregressive block"):
+        application.init(
+            [
+                "--prompt",
+                "A waterfall",
+                "--image-path",
+                str(_first_frame(tmp_path)),
+                "--total-blocks",
+                "2",
+            ]
+        )
+
+
+def test_session_initializes_from_first_frame_and_completes_one_step(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_frame_path = _first_frame(tmp_path)
+    first_frame = torch.zeros((1, 3, 4, 4), dtype=torch.bfloat16)
+    load_calls: list[dict[str, Any]] = []
+
+    def _load_first_frame(path: Path, **kwargs: Any) -> torch.Tensor:
+        load_calls.append({"path": path, **kwargs})
+        return first_frame
+
+    monkeypatch.setattr(app_module, "load_first_frame_tensor", _load_first_frame)
+    pipeline = _FakePipeline()
+    application = Wan22TI2VApplication()
+    application.init(
+        [
+            "--prompt",
+            "A waterfall",
+            "--image-path",
+            str(first_frame_path),
+            "--device",
+            "cpu",
+        ]
+    )
+    assert application._session_config is not None
+    application._session_config = replace(
+        application._session_config,
+        pipeline_config=_FakePipelineConfig(pipeline),
+    )
+
+    session = application.create_session()
+    session.init()
+
+    assert load_calls == [
+        {
+            "path": first_frame_path,
+            "pixel_height": 640,
+            "pixel_width": 1280,
+            "device": torch.device("cpu"),
+            "dtype": torch.bfloat16,
+        }
+    ]
+    assert pipeline.initialize_calls == [
+        {"text": ["A waterfall"], "image": first_frame}
+    ]
+    assert session.session_info().steady_output_frame_count == 81
+    assert session.next_step_requirements() is not None
+
+    result = session.step(
+        CanonicalInputWindow(window=TimeWindow(start_s=0.0, end_s=1.0))
+    )
+
+    assert result.step_index == 0
+    assert pipeline.generated == [0]
+    assert pipeline.finalized == [0]
+    assert session.next_step_requirements() is None
+
+    session.close()
+    application.close()
+    assert pipeline.closed
+
+
+def test_application_entry_point_is_owned_by_wan22_package() -> None:
+    project_dir = Path(__file__).resolve().parents[1]
+    manifest = tomllib.loads((project_dir / "pyproject.toml").read_text())
+
+    assert "flashdreams-t2v" in manifest["project"]["dependencies"]
+    assert "mediapy>=1.1" in manifest["project"]["dependencies"]
+    assert "opencv-python-headless>=4.5" in manifest["project"]["dependencies"]
+    assert manifest["project"]["entry-points"]["flashdreams.applications"] == {
+        "ti2v-wan22": "wan22.ti2v.app:create_app"
+    }

--- a/integrations/wan22/wan22/config.py
+++ b/integrations/wan22/wan22/config.py
@@ -56,9 +56,9 @@ DEFAULT_VIDEO_FPS = 16
 
 WAN22_TI2V_5B_DIT_DIFFUSERS_PATH = (
     "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers/resolve/main/"
-    "transformer/diffusion_pytorch_model.safetensors"
+    "transformer/diffusion_pytorch_model.safetensors.index.json"
 )
-"""HF diffusers checkpoint for the Wan 2.2 TI2V-5B DiT (``transformer/`` subfolder)."""
+"""HF sharded-checkpoint index for the Wan 2.2 TI2V-5B DiT."""
 
 
 # Diffusers ``WanTransformer3DModel`` -> ``WanDiTNetwork`` key remap:

--- a/integrations/wan22/wan22/config.py
+++ b/integrations/wan22/wan22/config.py
@@ -21,8 +21,8 @@ TI2V mode reuses :class:`WanInferencePipeline`: the I2V control encoder
 on it via ``stamp_image_latent`` and ``ti2v_first_frame_per_token_timestep``
 (frame-0 tokens see ``t=0``, the rest denoise at the scheduler step). The
 ``Wan-AI/Wan2.2-TI2V-5B-Diffusers`` checkpoints load through the DiT and
-VAE remap transforms. Downstream runners (e.g. ``hy_worldplay``) layer the
-I/O wrapper on top.
+VAE remap transforms. The package's application and downstream runners
+(e.g. ``hy_worldplay``) layer their I/O behavior on top.
 """
 
 from __future__ import annotations
@@ -44,6 +44,15 @@ from flashdreams.recipes.wan.transformer.impl.network import (
     WanDiTNetworkTI2V5BConfig,
 )
 from flashdreams.recipes.wan.transformer.wan21 import Wan21TransformerConfig
+
+DEFAULT_VIDEO_HEIGHT = 640
+"""Default output height for the standard Wan 2.2 TI2V-5B rollout."""
+
+DEFAULT_VIDEO_WIDTH = 1280
+"""Default output width for the standard Wan 2.2 TI2V-5B rollout."""
+
+DEFAULT_VIDEO_FPS = 16
+"""Default presentation frame rate for the Wan 2.2 TI2V-5B demo."""
 
 WAN22_TI2V_5B_DIT_DIFFUSERS_PATH = (
     "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers/resolve/main/"
@@ -146,6 +155,9 @@ WAN_CONFIGS: dict[str, WanInferencePipelineConfig] = {
 
 
 __all__ = [
+    "DEFAULT_VIDEO_FPS",
+    "DEFAULT_VIDEO_HEIGHT",
+    "DEFAULT_VIDEO_WIDTH",
     "PIPELINE_WAN22_TI2V_5B",
     "WAN22_TI2V_5B_DIT_DIFFUSERS_PATH",
     "WAN_CONFIGS",

--- a/integrations/wan22/wan22/ti2v/__init__.py
+++ b/integrations/wan22/wan22/ti2v/__init__.py
@@ -13,4 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Wan 2.2 TI2V-5B inference recipe and application."""
+"""Wan 2.2 text-and-image-to-video application."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/integrations/wan22/wan22/ti2v/app.py
+++ b/integrations/wan22/wan22/ti2v/app.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wan 2.2 text-and-image-to-video application factory."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import torch
+from t2v import (
+    T2VApplication,
+    T2VApplicationDefaults,
+    T2VApplicationSession,
+)
+
+from flashdreams.demo import (
+    CanonicalInputSchema,
+    IFlashDreamsApplication,
+    IFlashDreamsApplicationSession,
+)
+from flashdreams.infra.runner_io import load_first_frame_tensor
+from wan22.config import (
+    DEFAULT_VIDEO_FPS,
+    DEFAULT_VIDEO_HEIGHT,
+    DEFAULT_VIDEO_WIDTH,
+    PIPELINE_WAN22_TI2V_5B,
+)
+
+
+class Wan22TI2VApplicationSession(T2VApplicationSession):
+    """Cache-isolated Wan 2.2 session conditioned on one first frame."""
+
+    def __init__(self, *, config: Any, pipeline: Any) -> None:
+        super().__init__(config=config, pipeline=pipeline)
+        self._first_frame_path: Path | None = None
+
+    def set_first_frame_path(self, first_frame_path: Path) -> None:
+        """Set the first-frame path before model cache initialization."""
+        if self._cache is not None:
+            raise RuntimeError(
+                "Cannot change the first frame after session initialization."
+            )
+        self._first_frame_path = first_frame_path
+
+    def _initialize_cache(self, pipeline: Any) -> Any:
+        first_frame_path = self._first_frame_path
+        if first_frame_path is None:
+            raise RuntimeError(
+                "Set a first-frame path before initializing the Wan 2.2 session."
+            )
+        if self._prompt is None:
+            raise RuntimeError("Set a prompt before initializing the Wan 2.2 session.")
+
+        first_frame = load_first_frame_tensor(
+            first_frame_path,
+            pixel_height=self.config.pixel_height,
+            pixel_width=self.config.pixel_width,
+            device=torch.device(pipeline.device),
+            dtype=torch.bfloat16,
+        )
+        return pipeline.initialize_cache(
+            text=[self._prompt],
+            image=first_frame,
+        )
+
+
+class Wan22TI2VApplication(T2VApplication):
+    """Wan 2.2 single-block text-and-image-to-video application."""
+
+    session_type = Wan22TI2VApplicationSession
+
+    def __init__(self) -> None:
+        super().__init__(
+            defaults=T2VApplicationDefaults(
+                pipeline_config=PIPELINE_WAN22_TI2V_5B,
+                total_blocks=1,
+                pixel_height=DEFAULT_VIDEO_HEIGHT,
+                pixel_width=DEFAULT_VIDEO_WIDTH,
+                fps=DEFAULT_VIDEO_FPS,
+            )
+        )
+        self._first_frame_path: Path | None = None
+
+    @property
+    def input_schema(self) -> CanonicalInputSchema:
+        """Declare static first-frame conditioning with no live controls."""
+        return CanonicalInputSchema(
+            description="first-frame-conditioned text-and-image-to-video"
+        )
+
+    def _configure_argument_parser(self, parser: argparse.ArgumentParser) -> None:
+        """Add the required first-frame argument."""
+        parser.add_argument("--image-path", type=Path, required=True)
+
+    def _apply_parsed_arguments(self, args: argparse.Namespace) -> None:
+        """Validate and retain the first-frame path."""
+        first_frame_path = args.image_path
+        if not first_frame_path.is_file():
+            raise FileNotFoundError(
+                f"Wan 2.2 first-frame image does not exist: {first_frame_path}"
+            )
+        self._first_frame_path = first_frame_path
+
+    def _validate_total_blocks(self, total_blocks: int) -> None:
+        """Reject multi-block requests unsupported by bidirectional Wan 2.2."""
+        super()._validate_total_blocks(total_blocks)
+        if total_blocks > 1:
+            raise ValueError(
+                "Wan 2.2 TI2V supports exactly one autoregressive block; "
+                "--total-blocks must be 1."
+            )
+
+    def create_session(self) -> IFlashDreamsApplicationSession:
+        """Create a Wan 2.2 session with its static first frame."""
+        first_frame_path = self._first_frame_path
+        if first_frame_path is None:
+            raise RuntimeError(
+                "Wan22TI2VApplication.init() must run before create_session()."
+            )
+        session = super().create_session()
+        if not isinstance(session, Wan22TI2VApplicationSession):
+            raise TypeError("Wan 2.2 application created an unexpected session type.")
+        session.set_first_frame_path(first_frame_path)
+        return session
+
+
+def create_app() -> IFlashDreamsApplication:
+    """Create the Wan 2.2 text-and-image-to-video application."""
+    return Wan22TI2VApplication()
+
+
+__all__ = [
+    "Wan22TI2VApplication",
+    "Wan22TI2VApplicationSession",
+    "create_app",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1167,6 +1167,7 @@ version = "0.1.0"
 source = { editable = "integrations/fastvideo_causal_wan22" }
 dependencies = [
     { name = "flashdreams" },
+    { name = "flashdreams-t2v" },
     { name = "mediapy" },
 ]
 
@@ -1178,6 +1179,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
+    { name = "flashdreams-t2v", editable = "apps/t2v" },
     { name = "mediapy", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
@@ -1445,6 +1447,7 @@ version = "0.1.0"
 source = { editable = "integrations/wan21" }
 dependencies = [
     { name = "flashdreams" },
+    { name = "flashdreams-t2v" },
     { name = "mediapy" },
     { name = "opencv-python-headless" },
 ]
@@ -1457,6 +1460,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
+    { name = "flashdreams-t2v", editable = "apps/t2v" },
     { name = "mediapy", specifier = ">=1.1" },
     { name = "opencv-python-headless", specifier = ">=4.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1473,6 +1473,9 @@ version = "0.1.0"
 source = { editable = "integrations/wan22" }
 dependencies = [
     { name = "flashdreams" },
+    { name = "flashdreams-t2v" },
+    { name = "mediapy" },
+    { name = "opencv-python-headless" },
 ]
 
 [package.optional-dependencies]
@@ -1483,6 +1486,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flashdreams", editable = "flashdreams" },
+    { name = "flashdreams-t2v", editable = "apps/t2v" },
+    { name = "mediapy", specifier = ">=1.1" },
+    { name = "opencv-python-headless", specifier = ">=4.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Add integration-owned T2V application entry points backed by the shared T2VApplicationSession.

Extend the shared application with model-specific block-validation and compile-override hooks. Enforce Wan 2.1's single-block limit and update both FastVideo noise-level transformers for --compile/--no-compile.

Update workspace dependencies, entry-point coverage, documentation, and the lockfile for both integrations.