### PR TITLE
fix(lingbot): drop undefined name from runtime __all__

### DIFF
--- a/integrations/lingbot/lingbot/runtime.py
+++ b/integrations/lingbot/lingbot/runtime.py
@@ -1106,6 +1106,5 @@ __all__ = [
     "inference_config_from_runner_config",
     "inference_input_from_replay_inputs",
     "inference_input_from_runner_config",
-    "replay_inputs_from_inference_input",
     "replay_inputs_from_mapping",
 ]

--- a/integrations/lingbot/tests/test_runtime_public_api.py
+++ b/integrations/lingbot/tests/test_runtime_public_api.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import lingbot.runtime as runtime
+
+import pytest
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_runtime_all_exports_are_defined() -> None:
+    """Every name in ``lingbot.runtime.__all__`` must exist on the module.
+
+    ``from lingbot.runtime import *`` raises ``AttributeError`` when
+    ``__all__`` lists a name the module does not define, so the public API
+    list must stay in sync with the module's definitions.
+    """
+    missing = [name for name in runtime.__all__ if not hasattr(runtime, name)]
+    assert not missing, (
+        "lingbot.runtime.__all__ references names that are not defined: "
+        f"{', '.join(missing)}."
+    )


### PR DESCRIPTION
## What
`integrations/lingbot/lingbot/runtime.py` declares `"replay_inputs_from_inference_input"` in `__all__`, but the module (and the whole repo) never defines that name — the implemented conversion is `inference_input_from_replay_inputs`, the opposite direction.

## Why it matters
`from lingbot.runtime import *` iterates `__all__` and raises `AttributeError: module 'lingbot.runtime' has no attribute 'replay_inputs_from_inference_input'` on the first missing name. The dangling entry also fails pyflakes (`undefined name ... in __all__`) and ruff's F822, so lint breaks on the file. `LingbotReplayInputs` requires `camera_poses_path`/`camera_intrinsics_path` that `InferenceInput` never carries, so a faithful inverse cannot be implemented — the entry is simply stale.

## Changes
- Remove the undefined `replay_inputs_from_inference_input` entry from `__all__`.
- Add `integrations/lingbot/tests/test_runtime_public_api.py` (ci_cpu) asserting every `__all__` name resolves on the module, guarding against future drift.

## Verification
- `python -m pyflakes integrations/lingbot/lingbot/runtime.py` no longer reports `undefined name 'replay_inputs_from_inference_input' in __all__`.
- Confirmed the name is absent from every other module in the repo and from docs.
- Reproduced the failure mode: a module whose `__all__` lists an undefined name fails `from <mod> import *` with `AttributeError`.