### PR TITLE
docs: update OmniDreams citation to arXiv record

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,13 @@ If FlashDreams is useful in your research or product, please cite the project:
 }
 
 @misc{nvidia2026omnidreams,
-  title={OmniDreams: Real-Time Generative Closed-Loop Autonomous Vehicle Simulation Built on NVIDIA Cosmos},
-  author={Basant, Aarti and Kar, Amlan and Paschalidou, Despoina and Garcia Cobo, Guillermo and Turki, Haithem and Ling, Huan and Seo, Jaewoo and Wang, Jialiang and Lucas, James and Wu, Jay and Lorraine, Jonathan and Gao, Jun and He, Kai and Tothova, Katarina and Xie, Kevin and Tyszkiewicz, Michal and Wu, Qi and de Lutio, Riccardo and Li, Ruilong and Fidler, Sanja and Kim, Seung Wook and Shen, Tianchang and Cao, Tianshi and Pfaff, Tobias and Lew, William and Ren, Xuanchi and Lu, Yifan and Gojcic, Zan and Wang, Zian},
-  year={2026},
-  note={Technical report},
-  howpublished={\url{https://research.nvidia.com/labs/sil/projects/omnidreams-blog/paper.pdf}}
+  title         = {{NVIDIA} {OmniDreams}: Real-Time Generative World Model for Closed-Loop Autonomous Vehicle Simulation},
+  author        = {Basant, Aarti and Kar, Amlan and Paschalidou, Despoina and Wei, Fangyin and Ferroni, Francesco and Garcia Cobo, Guillermo and Turki, Haithem and Ling, Huan and Seo, Jaewoo and Lucas, James and Wu, Jay Zhangjie and Wang, Jialiang and Lorraine, Jonathan and Gao, Jun and He, Kai and Tothova, Katarina and Xie, Kevin and Tyszkiewicz, Micha{\l} and Wu, Qi and de Lutio, Riccardo and Li, Ruilong and Fidler, Sanja and Kim, Seung Wook and Shen, Tianchang and Cao, Tianshi and Pfaff, Tobias and Lew, William and Wu, Xindi and Ren, Xuanchi and Lu, Yifan and Zhang, Yuxuan and Gojcic, Zan and Wang, Zian},
+  year          = {2026},
+  eprint        = {2606.03159},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.CV},
+  doi           = {10.48550/arXiv.2606.03159},
+  url           = {https://arxiv.org/abs/2606.03159},
 }
 ```

--- a/docs/source/models/omnidreams.rst
+++ b/docs/source/models/omnidreams.rst
@@ -23,7 +23,7 @@ NVIDIA OmniDreams
 
       Blog page
 
-   .. button-link:: https://research.nvidia.com/labs/sil/projects/omnidreams-blog/paper.pdf
+   .. button-link:: https://arxiv.org/abs/2606.03159
       :color: primary
 
       Tech report
@@ -477,9 +477,12 @@ If you use OmniDreams, please cite the original work:
 .. code-block:: bibtex
 
    @misc{nvidia2026omnidreams,
-     title={OmniDreams: Real-Time Generative Closed-Loop Autonomous Vehicle Simulation Built on NVIDIA Cosmos},
-     author={Basant, Aarti and Kar, Amlan and Paschalidou, Despoina and Garcia Cobo, Guillermo and Turki, Haithem and Ling, Huan and Seo, Jaewoo and Wang, Jialiang and Lucas, James and Wu, Jay and Lorraine, Jonathan and Gao, Jun and He, Kai and Tothova, Katarina and Xie, Kevin and Tyszkiewicz, Michal and Wu, Qi and de Lutio, Riccardo and Li, Ruilong and Fidler, Sanja and Kim, Seung Wook and Shen, Tianchang and Cao, Tianshi and Pfaff, Tobias and Lew, William and Ren, Xuanchi and Lu, Yifan and Gojcic, Zan and Wang, Zian},
-     year={2026},
-     note={Technical report},
-     howpublished={\url{https://research.nvidia.com/labs/sil/projects/omnidreams-blog/paper.pdf}}
+     title         = {{NVIDIA} {OmniDreams}: Real-Time Generative World Model for Closed-Loop Autonomous Vehicle Simulation},
+     author        = {Basant, Aarti and Kar, Amlan and Paschalidou, Despoina and Wei, Fangyin and Ferroni, Francesco and Garcia Cobo, Guillermo and Turki, Haithem and Ling, Huan and Seo, Jaewoo and Lucas, James and Wu, Jay Zhangjie and Wang, Jialiang and Lorraine, Jonathan and Gao, Jun and He, Kai and Tothova, Katarina and Xie, Kevin and Tyszkiewicz, Micha{\l} and Wu, Qi and de Lutio, Riccardo and Li, Ruilong and Fidler, Sanja and Kim, Seung Wook and Shen, Tianchang and Cao, Tianshi and Pfaff, Tobias and Lew, William and Wu, Xindi and Ren, Xuanchi and Lu, Yifan and Zhang, Yuxuan and Gojcic, Zan and Wang, Zian},
+     year          = {2026},
+     eprint        = {2606.03159},
+     archivePrefix = {arXiv},
+     primaryClass  = {cs.CV},
+     doi           = {10.48550/arXiv.2606.03159},
+     url           = {https://arxiv.org/abs/2606.03159},
    }


### PR DESCRIPTION
## Summary

- replace the pre-arXiv OmniDreams title and direct PDF links with the current stable arXiv record and DOI
- synchronize the citation in the README and rendered OmniDreams model documentation
- update the author field to the current 33-person roster published by NVIDIA Research and arXiv, preserving the established individual-credit convention while omitting the malformed corporate-label prefix in the generated arXiv BibTeX

## Sources

- NVIDIA Research publication record: https://research.nvidia.com/publication/2026-06_nvidia-omnidreams-real-time-generative-world-model-closed-loop-autonomous
- arXiv v2: https://arxiv.org/abs/2606.03159v2

## Verification

- pre-commit passed for both modified files
- full Sphinx HTML build succeeded; its six optional-module autodoc warnings are unrelated to the changed page
- strict Pybtex parsing succeeded
- repository-wide scan found zero remaining stale-title or direct paper.pdf references
- the versionless arXiv record and DOI both returned HTTP 200

No code or dependencies changed.