### PR TITLE
Document the v2 API, runtime and integrations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,227 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Architecture
+
+How a FlashDreams application is put together, and what happens when one runs.
+
+This is the mental model the v2 packages assume. Each package documents its own
+surface in detail; the job here is to say how they fit together and why the seams
+are where they are.
+
+- [`flashdreams.api_v2`](flashdreams/flashdreams/api_v2/README.md) - the
+  protocols an application implements.
+- [`flashdreams.runtime_v2`](flashdreams/flashdreams/runtime_v2/README.md) - the
+  machinery that runs one.
+- [`integrations_v2`](integrations_v2/README.md) - how to write an application.
+- [`flashdreams.t2v_v2`](flashdreams/flashdreams/t2v_v2/README.md) - the
+  text-to-video layer built on all of it.
+
+The model side has a mental model of its own, warmup, CUDA-graph capture, the
+autoregressive-step body, ring attention, finalize, described in the
+[inference pipeline overview](docs/source/developer_guides/inference_pipeline_overview.rst).
+That covers what happens inside one generation step; this covers what drives the
+steps.
+
+## The shape of it
+
+Four layers, each of which only knows about the one below.
+
+```mermaid
+flowchart TB
+  subgraph integration [An integration, under integrations_v2 or flashdreams.t2v_v2]
+    App["IApplication, arguments and whatever is expensive to load"]
+    Session["ISession, one run"]
+    Model["IModelLoop, generates"]
+    UI["IUILoop, optional, decides what is shown"]
+  end
+
+  subgraph api [flashdreams.api_v2, the protocols and nothing else]
+    Protocols["IApplication, ISession, ILoop, IClientWindow, InputSource, OutputSink"]
+  end
+
+  subgraph runtime [flashdreams.runtime_v2, everything that runs one]
+    Entry["cli, application_registry, find the application"]
+    Runner["ApplicationRunner, owns the lifecycle"]
+    RunSession["run_session, owns the two threads"]
+    Meet["EventBuffer, PresentationManager, where the threads meet"]
+    Default["BlitModelOutputToScreenLoop, the UI loop nothing has to write"]
+  end
+
+  subgraph windows [A client window, the runtime's rather than the application's]
+    Mp4["Mp4ClientWindow, over Mp4OutputSink"]
+    Web["WebRTCClientWindow, over WebRTCServer"]
+  end
+
+  App -->|creates| Session
+  Session -->|registers| Model
+  Session -.->|may register| UI
+  App -.->|implements| Protocols
+  Entry --> Runner
+  Runner -->|"init, create_session"| App
+  Runner --> RunSession
+  RunSession -->|"steps, through the protocols"| Model
+  RunSession -->|"steps, through the protocols"| UI
+  RunSession -->|moves input and frames through| Meet
+  Session -.->|registers this when given no IUILoop| Default
+  RunSession -->|input and output| Mp4
+  RunSession -->|input and output| Web
+```
+
+An integration knows the protocols and the runtime knows the protocols, and
+neither knows the other: every arrow crossing between them is a call through
+`api_v2`. The runtime holds the only reference to a window, and an integration
+holds none.
+
+**An application** is what someone writes. It parses its own arguments, holds
+whatever is expensive to load, and creates sessions. It implements two protocols
+and names nothing else, no windows, no sinks, no threads.
+
+**A session** is one run of that application. It owns the state for the run and
+registers the loops that do the work: a model loop that generates, and
+optionally a UI loop that turns what was generated into what is shown.
+
+**The runtime** owns everything else. It finds the application, decides which
+session to ask for, creates the window, starts the threads, moves frames between
+them, and closes it all down in the right order when the run ends.
+
+**A client window** is where the run goes and where input comes from, an MP4
+file, or a browser over WebRTC. It is the runtime's, not the application's, which
+is what lets the same application write a file in a benchmark and stream to a
+browser in a demo without knowing which is happening.
+
+The seam that matters is between the session and the runtime. An application
+describes what it would generate, the runtime asks for a session and honours
+that description, and from then on the two communicate only through
+`StepResult` objects going one way and input events going the other. Nothing
+about a window reaches an application, and nothing about a model reaches a
+window.
+
+## A run, end to end
+
+The same pieces again, but as calls rather than as layers: what happens in what
+order, and on which thread.
+
+```mermaid
+flowchart TB
+  CLI["flashdreams-run-v2, cli.entrypoint"]
+  Registry["application_registry.create_application"]
+  Runner["ApplicationRunner.run"]
+  Init["IApplication.init, then create_session"]
+  Take["ISession.init registers the loops"]
+  CLI --> Registry
+  Registry --> Runner
+  Runner --> Init
+  Init --> Take
+
+  subgraph mainThread [Main thread, run_session]
+    Window["IClientWindow, mp4 or webrtc"]
+    Buffer["EventBuffer"]
+    Present["PresentationManager"]
+    UILoop["IUILoop.step"]
+  end
+
+  subgraph modelThread [flashdreams-model-generation-thread]
+    ModelLoop["IModelLoop.step"]
+  end
+
+  Take --> Window
+  Window -->|"get_user_input_events"| Buffer
+  Buffer -->|"read, reader 0"| UILoop
+  Buffer -->|"read, reader 1"| ModelLoop
+  ModelLoop -->|"publish a list of StepResult"| Present
+  ModelLoop -->|"StepResult.metrics"| Metrics["MetricsOutputSink"]
+  Present -->|"advance, one frame per tick"| UILoop
+  UILoop -->|"write one StepResult"| Window
+```
+
+Starting a run is ordered so that the cheap ways to fail happen first. The
+command line resolves the application slug before it builds a window, so a name
+nothing installed matches costs nothing to discover. It validates the window
+arguments while it can still print usage, rather than after a checkpoint has
+loaded. And an application is asked what it would generate before it is asked to
+load anything, so a layout it was never going to accept is refused in
+milliseconds rather than gigabytes.
+
+Which session gets asked for is settled once, before the run: the application
+says what it would generate, and the frame arguments on the command line are laid
+over the top. An application that describes nothing gets the arguments alone.
+After that the description is fixed, and both the session and the window are
+configured from the same copy of it.
+
+## Two threads
+
+Generation and presentation run at different rates and cannot wait for each
+other, so they get a thread each.
+
+The **main thread**, whichever one called `run_session`, reads input from the
+window, advances the presentation buffer, runs the UI loop, and writes the result
+back to the window. It ticks at the session's UI rate, and it paces itself by
+waiting on the shutdown event rather than sleeping, so a client closing is
+noticed immediately rather than up to a tick later.
+
+The **model thread** runs the model loop and publishes each result. It paces
+itself to the session's step rate. Nothing else runs there, and it is the only
+thread that touches model state.
+
+This is the reason for most of the runtime's design. A window is only ever
+touched from the main thread, so window implementations need no locking except
+where their own backend delivers input from elsewhere. Model state is only ever
+touched from the model thread, so a model needs none either. The two places the
+threads do meet — input going one way, frames going the other — are the two
+buffers below, and they are the only synchronised objects in the system.
+
+Loops that genuinely need to reach across send a message instead of sharing
+memory: `invoke_async` queues an operation against the other loop's state, and
+that loop runs it on its own thread before its next step.
+
+## Where the threads meet
+
+**Input** is collected once, on the main thread, but both loops need it and they
+read at different rates. `EventBuffer` holds a flat list of events plus a cursor
+per reader, hands each reader only what it has not seen, and drops what they have
+all passed.
+
+**Frames** go the other way through `PresentationManager`, a bounded queue of
+generated chunks. The UI thread takes one frame per tick, walking through the
+frames within a chunk before taking another, so a step that generated twelve
+frames is presented over twelve ticks rather than eleven being thrown away.
+
+Because the queue is bounded, something has to give when the rates diverge, and
+which thing gives is a session's choice rather than the runtime's. A session
+declares whether a fast model should be held back or should drop old frames, and
+whether a fast UI should re-present the newest frame or wait for a new one. A run
+whose output has to be compared frame by frame picks the combination that keeps
+every frame and shows each exactly once; an interactive run picks the one that
+favours latency. The runtime does not decide this because the right answer
+depends on what the run is for.
+
+## Resets and failures
+
+A **reset** is a client asking to start over without closing the window. It
+arrives as an input event, and the event buffer turns it into a generation
+number. Every loop and the presentation manager compare that number against
+their own: loops reset their state and restart their step index, and frames
+generated before the reset are discarded rather than shown. One counter is the
+whole mechanism — none of those components has to know about the others.
+
+A **failure** ends the run, and whichever failure happened first is the one
+reported. A model-thread exception is handed to the session and sets the
+shutdown event; the main thread then joins the thread, shuts the loops down,
+closes every sink it opened, closes the session, closes the application, and only
+then raises. Failures that happen during that cleanup are logged rather than
+raised over the top of the failure that caused them, so a run always reports the
+thing that actually went wrong.
+
+A run ends normally in one of two ways: the client closes the window, or the
+model loop reports itself finished and the last frames are shown. Both matter,
+because one of the two windows has no client to close it — a run writing an MP4
+depends entirely on the session knowing when it is done.
+
+## Not built yet
+
+- A third fixed-rate thread for game logic.
+- A result field for the number of dropped frames.
+- Slowing model generation before the presentation buffer fills.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,9 +76,8 @@ neither knows the other: every arrow crossing between them is a call through
 `api_v2`. The runtime holds the only reference to a window, and an integration
 holds none.
 
-**An application** is what someone writes. It parses its own arguments, holds
-whatever is expensive to load, and creates sessions. It implements two protocols
-and names nothing else, no windows, no sinks, no threads.
+**An application** is what someone writes, and it names nothing beyond the two
+protocols it implements — no windows, no sinks, no threads.
 
 **A session** is one run of that application. It owns the state for the run and
 registers the loops that do the work: a model loop that generates, and
@@ -88,17 +87,15 @@ optionally a UI loop that turns what was generated into what is shown.
 session to ask for, creates the window, starts the threads, moves frames between
 them, and closes it all down in the right order when the run ends.
 
-**A client window** is where the run goes and where input comes from, an MP4
-file, or a browser over WebRTC. It is the runtime's, not the application's, which
-is what lets the same application write a file in a benchmark and stream to a
-browser in a demo without knowing which is happening.
+**A client window** is where the run goes and where input comes from — an MP4
+file, or a browser over WebRTC. Being the runtime's rather than the
+application's is what lets one application write a file in a benchmark and
+stream to a browser in a demo without knowing which is happening.
 
 The seam that matters is between the session and the runtime. An application
-describes what it would generate, the runtime asks for a session and honours
-that description, and from then on the two communicate only through
-`StepResult` objects going one way and input events going the other. Nothing
-about a window reaches an application, and nothing about a model reaches a
-window.
+describes what it would generate, the runtime honours that description, and from
+then on the two communicate only through `StepResult` objects going one way and
+input events going the other.
 
 ## A run, end to end
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -205,8 +205,9 @@ their own: loops reset their state and restart their step index, and frames
 generated before the reset are discarded rather than shown. One counter is the
 whole mechanism — none of those components has to know about the others.
 
-A **failure** ends the run, and whichever failure happened first is the one
-reported. A model-thread exception is handed to the session and sets the
+A **failure** ends the run, and a loop's failure is the one reported: a loop
+raised on either thread outranks one the main thread raised itself, whichever
+happened first. A model-thread exception is handed to the session and sets the
 shutdown event; the main thread then joins the thread, shuts the loops down,
 closes every sink it opened, closes the session, closes the application, and only
 then raises. Failures that happen during that cleanup are logged rather than

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ flowchart TB
     UI["IUILoop, optional, decides what is shown"]
   end
 
-  subgraph api [flashdreams.api_v2, the protocols and nothing else]
+  subgraph api [flashdreams.api_v2, the protocols an integration implements]
     Protocols["IApplication, ISession, ILoop, IClientWindow, InputSource, OutputSink"]
   end
 
@@ -48,6 +48,7 @@ flowchart TB
     RunSession["run_session, owns the two threads"]
     Meet["EventBuffer, PresentationManager, where the threads meet"]
     Default["BlitModelOutputToScreenLoop, the UI loop nothing has to write"]
+    Types["SessionDesc, StepResult, UserInputEvents, VideoTensorLayout"]
   end
 
   subgraph windows [A client window, the runtime's rather than the application's]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ to add your own.
 
 ## Developer guides
 
+- [Architecture](ARCHITECTURE.md)
 - [Inference pipeline overview](https://nvidia.github.io/flashdreams/main/developer_guides/inference_pipeline_overview.html)
 - [Config system](https://nvidia.github.io/flashdreams/main/developer_guides/config_system.html)
 - [Add a new method](https://nvidia.github.io/flashdreams/main/developer_guides/new_integration.html)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -227,6 +227,10 @@ autodoc_mock_imports = [
     "mediapy",
     "cv2",
     "triton",
+    # Declared by `flashdreams` but not installed, since the docs build uses
+    # `uv pip install --no-deps`. Without it, autodoc cannot import the recipes
+    # that build their CLI with it.
+    "tyro",
     # Mocked rather than installed: with no torch source binding active
     # under the docs-ci sync, uv can't disambiguate between the PyPI,
     # +cu128, and +cu130 lock candidates.

--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -3,69 +3,66 @@ SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-Protocols for the FlashDreams v2 API.
+The protocols a FlashDreams v2 application implements. Everything here is a
+contract; the runtime creates every other object and passes it in.
 
-- `application.py`: `IApplication` loads shared state and creates sessions.
-- `session.py`: `ISession` represents one session and owns a model loop and a UI loop.
-- `thread.py`: `ILoop` holds shared loop state and messaging;
-  `IModelLoop` and `IUILoop` define model and UI work.
-- `input_source.py` / `output_sink.py` / `client_window.py`: `IClientWindow`
-  groups one client's input and output.
-- `user_input_event_data.py`: base class for input event data.
+[ARCHITECTURE.md](../../../ARCHITECTURE.md) covers how an application, a session
+and the runtime fit together. [`runtime_v2`](../runtime_v2/README.md) covers what
+runs one, including the command line. This page is only what you implement, and
+what each contract promises.
 
-Running an application
-----------------------
+## What is in here
 
-`flashdreams-run-v2` finds an application through the
-`flashdreams.applications_v2` entry point and runs it with `ApplicationRunner`.
-The application chooses its default `SessionDesc`; `--pixel-width`,
-`--pixel-height`, `--fps`, `--layout`, `--backpressure-mode`, and
-`--presentation-mode` can override it.
+- `application.py`: `IApplication` parses arguments, holds what its sessions
+  share, and creates them.
+- `session.py`: `ISession` is one run, and registers the loops that do its work.
+- `loop.py`: `ILoop` holds per-loop state, messaging and lifecycle;
+  `IModelLoop` generates, `IUILoop` presents.
+- `input_source.py`, `output_sink.py`, `client_window.py`: `IClientWindow` is
+  both an `InputSource` and an `OutputSink`, grouping one client's input and
+  output.
+- `user_input_event_data.py`: base class for input event data. The concrete
+  types belong to the runtime.
 
-The selected client-window mode handles the run's input and output. MP4 mode
-writes a file and has no input. WebRTC mode streams to a browser. Mode-specific
-arguments are defined in `runtime_v2/client_window_factory.py`.
+Three of these are things you write: an application, a session, and a model
+loop. A UI loop is optional. Windows and sinks you only implement if you are
+adding a new way to watch a run.
 
-Model generation stops when the client closes, the model loop reports that it
-is finished, or a model-loop step limit is reached. `run_session` presents
-any queued frames before returning. An MP4 window never sends a close event, so
-its model loop must finish on its own.
+## `IApplication`
 
-`--stats-path` adds a `MetricsOutputSink`. It writes measurements provided in a
-`StepResult` returned via `step`. The client window still receives only the UI
-loop's output. Metrics collection does not change either presentation setting.
-For equality evaluations, use `PresentationMode.ONLY_PRESENT_NEW` and
-`BackpressureMode.BLOCK` so every model frame is presented exactly once and in
-order.
+Lives as long as the process. It parses its own arguments in `init`, loads
+whatever its sessions share, and creates them one at a time. Anything expensive
+belongs here, loaded once, and released in `close`.
 
-See [`configs/v2_model_benchmarks.json`](../../../configs/v2_model_benchmarks.json)
-and the [benchmark README](../../tools/benchmarks/README.md) for the benchmark
-suite.
+It can also answer `session_desc` before `init` runs, so a caller can ask what
+this application would generate without paying to start it. Returning `None`
+means it will generate whatever it is asked for.
 
-`flashdreams.t2v_v2` builds the text-to-video API on these protocols. See
-[its README](../t2v_v2/README.md).
+Reject a description you cannot honour, from `create_session`. A session that
+quietly ignores the layout it was asked for produces tensors an output sink then
+refuses, much further along and much harder to place.
 
-Loops and threading
--------------------
+## `ISession`
 
-An application lives for the length of the parent process. A
-session (stored in `IApplication`) lives for one run and owns two `ILoop`
-objects: an `IModelLoop` and an `IUILoop`. In `ISession.init`, it must call
-`register_model_loop` and may call `register_ui_loop`.
+One run. It registers a model loop in `init` and may register a UI loop. A
+session that registers no UI loop gets
+`flashdreams.runtime_v2.blit_model_output_to_screen_loop.BlitModelOutputToScreenLoop`,
+which draws every model channel into one frame as if they were image layers.
 
-| Runs on | Calls | Owns | Frame rate |
-| --- | --- | --- | --- |
-| The thread that called `run_session` | `IUILoop.step` | UI-loop state, `run_session` state | `frames_per_second_for_ui` |
-| A new Python thread | `IModelLoop.step` | Model-loop state and model logic | `frames_per_second_for_step` |
+Each loop is registered with the state it owns, and the call returns the loop:
 
-## Using the loop model to build your own application
+```python
+self.register_model_loop(ModelLoop, state=ModelState(self._desc))
+```
 
-### Loop-to-loop communication
+`state` is required for a model loop and optional for a UI loop. Registration
+also fixes each loop's rate — the model loop at the session's
+`frames_per_second_for_step`, the UI loop at its `frames_per_second_for_ui`.
 
-Each `ILoop` has mutable `state` when the session registers it. The
-registration call (`register_model_loop` or `register_ui_loop`) returns the new
-loop object. The only way one loop should change another loop's state is via
-`invoke_async`:
+## Loops
+
+The two loops run on different threads, so neither should reach into the other's
+state directly. `invoke_async` is the way across:
 
 ```python
 new_prompt = str(text_from_ui)
@@ -75,53 +72,47 @@ invoke_async(
 )
 ```
 
-The call returns immediately, sending the operation to the target loop's message
-queue (`self.state.model_loop`). The target loop runs the operation in its next
-`step`. It takes a snapshot of queued operations first and only processes this
-snapshot until the next `step` is complete. Operations from `invoke_async` must
-return `None`. Queued operations that have not run are dropped during shutdown
-to prevent endless ping-ponging between loops.
+The call returns immediately and queues the operation against the target loop.
+That loop takes a snapshot of its queue before its next `step` and runs only
+what was in it. Operations must return `None`. Anything still queued at shutdown
+is dropped, so two loops cannot keep each other alive by messaging back and
+forth.
 
-### Loop reset
+`ILoop.is_finished` returns `False` by default. Override it when the model should
+end the run on its own, which is what a run writing an MP4 depends on, an MP4
+window never sends a close event, so nothing else will stop it.
 
-A reset event sent by an application calls `reset` on each loop, clears its
-`latest_result`, and restarts the loop's `step_index` at zero.
+`ILoop.reset` raises `NotImplementedError` by default. A reset arrives as a
+client event, and when one does, every loop's `reset` is called, its
+`latest_result` is cleared, and its `step_index` restarts at zero. A loop that
+does not override `reset` therefore fails the first time a client asks for one,
+implement it, even if the body is `return`.
 
-### Loop output
+## What a step returns
 
-All output from your model loop's `step` method returns a list of
-`StepResult` channels. The metrics inside this `StepResult` are recorded immediately by a metrics output sink; the actual full `StepResult` is passed along to a presentation manager.
+The two loops have different return contracts, and the runtime enforces both:
 
-The UI loop pulls from the presentation manager and sends results to the client
-window. `presented_model_frame` or `presented_model_frames` can be used to draw
-the model output.
+- A model loop returns `list[StepResult]`, one entry per channel. A single
+  `StepResult` or `None` raises `TypeError`.
+- A UI loop returns one `StepResult`, or `None` to present nothing this tick.
 
-Import `SlangPyUILoop` from `flashdreams.runtime_v2.slangpy_ui_loop`, subclass
-it, and implement `step_ui(ui, step_index, events)`. The `ui` argument exposes:
+Every channel in one model step must report the same `frame_count`. A step may
+generate several frames at once; the runtime presents them one per UI tick
+rather than dropping all but the last.
 
-- `ui.screen`, the root [`slangpy.ui.Screen`](https://slangpy.shader-slang.org/en/stable/src/api_reference.html#slangpy.ui.Screen)
-  that receives top-level widgets.
-- Every public type from `slangpy.ui`, including widget constructors such as
-  `Window`, `Group`, `Text`, `Button`, `ComboBox`, sliders, drag controls, and
-  input controls.
+A UI loop reads what the model produced through `presented_model_frame` and
+`presented_model_frames`, which return `[C, H, W]` frames with one, three or
+four channels. Four channels is RGBA, and composites over what is beneath it.
 
-The [SlangPy UI API reference](https://slangpy.shader-slang.org/en/stable/src/api_reference.html#ui)
-is the source of truth for every available widget constructor, method,
-property, flag, and callback. FlashDreams delegates these names directly to
-`slangpy.ui`; it does not maintain a smaller wrapper API. See the
-[`slangpy_ui_demo` examples](../../../integrations_v2/slangpy_ui_demo/README.md)
-for examples that use model-loop output as part of the UI.
+Output sinks read floating-point frames as `[-1, 1]` and integer frames as
+`[0, 255]`. No `SessionDesc` setting remaps this; a UI loop that works in some
+other range converts before returning.
 
-If a UI loop is not registered, the runtime uses the default `IUILoop`
-implementation
-(`blit_model_output_to_screen_loop.py:BlitModelOutputToScreenLoop`).
-It blits the model output to the screen, flattening channels into one frame as
-if they were image layers.
+## A minimal application
 
-This is a minimal session using the default UI-loop implementation:
+Using the default UI loop, so there is only a model loop to write:
 
 ```python
-
 @dataclass
 class ModelState:
     desc: SessionDesc
@@ -142,7 +133,7 @@ class ModelLoop(IModelLoop[ModelState]):
         ]
 
     def reset(self) -> None:
-        pass
+        return
 
 class Session(ISession):
     def __init__(self, desc: SessionDesc) -> None:
@@ -158,45 +149,22 @@ class Session(ISession):
         self.register_model_loop(ModelLoop, state=ModelState(self._desc))
 ```
 
-`ILoop.is_finished` returns `False` by default. Override it when the model
-should end the run on its own, as an MP4-producing model may set if not limiting the maximum number of steps.
+This loop runs forever. Override `is_finished` to make it stop.
 
-### Presentation knobs for loops and benchmarking
----------
+## Writing a UI loop
 
-The runtime buffers completed model steps and presents at most one frame per UI
-tick. Two independent `SessionDesc` settings control mismatched model and UI
-rates.
+For widgets drawn over the model output, subclass `SlangPyUILoop` from
+`flashdreams.runtime_v2.slangpy_ui_loop` and implement
+`step_ui(ui, step_index, events)` rather than `step`. The
+[`slangpy_ui_demo` integration](../../../integrations_v2/slangpy_ui_demo/README.md)
+is the reference, including one example that uses model output inside the UI.
 
-`SessionDesc.backpressure_mode` handles a model thread producing frames faster
-than the UI thread can consume them:
+## Where to go next
 
-- `BackpressureMode.BLOCK` waits when the presentation queue is full. This keeps
-  every generated frame and can slow the model thread to the UI thread's pace.
-- `BackpressureMode.DROP_OLDEST` discards old buffered work so the UI can catch
-  up to newer output. This favors low latency over preserving every frame.
-
-`SessionDesc.presentation_mode` handles the UI thread ticking faster than the
-model thread produces frames:
-
-- `PresentationMode.ONLY_PRESENT_NEWEST` is eager: the UI runs every tick and
-  may present the newest generated model frame more-than-once when a new frame is not ready.
-- `PresentationMode.ONLY_PRESENT_NEW` is safe: the UI runs only after the
-  presentation manager advances to a new model frame, preventing duplicate
-  output frames.
-
-For equality evaluations, enable `PresentationMode.ONLY_PRESENT_NEW`
-with `BackpressureMode.BLOCK`. Together they preserve all generated frames and
-present each one exactly once and in order.
-
-Output sinks read floating-point frames as `[-1, 1]` and integer frames as
-`[0, 255]`. This is not remappable via a `SessionDesc` setting; the UI loop
-should implement its own remapping logic.
-
-
-Not built yet
--------------
-
-- A third fixed-rate thread for game logic.
-- A result field for the number of dropped frames.
-- Slowing model generation before the presentation buffer fills.
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) - how the layers fit together.
+- [Runtime](../runtime_v2/README.md) - what runs an application, and the command
+  line that does it.
+- [Writing an integration](../../../integrations_v2/README.md) - the checklist
+  for a new application.
+- [`flashdreams.t2v_v2`](../t2v_v2/README.md) - the text-to-video API built on
+  these protocols, and how to add a model to it.

--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -112,15 +112,11 @@ other range converts before returning.
 Using the default UI loop, so there is only a model loop to write:
 
 ```python
-@dataclass
-class ModelState:
-    desc: SessionDesc
-
-class ModelLoop(IModelLoop[ModelState]):
+class ModelLoop(IModelLoop[SessionDesc]):
     def step(self, step_index: int, events: UserInputEvents) -> list[StepResult]:
         del events
         frame = torch.zeros(
-            (1, 3, self.state.desc.video_height, self.state.desc.video_width)
+            (1, 3, self.state.video_height, self.state.video_width)
         )
         return [
             StepResult(
@@ -145,8 +141,11 @@ class Session(ISession):
         return self._desc
 
     def init(self) -> None:
-        self.register_model_loop(ModelLoop, state=ModelState(self._desc))
+        self.register_model_loop(ModelLoop, state=self._desc)
 ```
+
+A loop's state can be any object; this one keeps the session description and
+nothing else.
 
 This loop runs forever. Override `is_finished` to make it stop.
 

--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -38,9 +38,8 @@ It can also answer `session_desc` before `init` runs, so a caller can ask what
 this application would generate without paying to start it. Returning `None`
 means it will generate whatever it is asked for.
 
-Reject a description you cannot honour, from `create_session`. A session that
-quietly ignores the layout it was asked for produces tensors an output sink then
-refuses, much further along and much harder to place.
+Reject a description you cannot honour, from `create_session`, rather than
+generating something else instead.
 
 ## `ISession`
 
@@ -55,9 +54,9 @@ Each loop is registered with the state it owns, and the call returns the loop:
 self.register_model_loop(ModelLoop, state=ModelState(self._desc))
 ```
 
-`state` is required for a model loop and optional for a UI loop. Registration
-also fixes each loop's rate — the model loop at the session's
-`frames_per_second_for_step`, the UI loop at its `frames_per_second_for_ui`.
+`state` is required for a model loop and optional for a UI loop. Each loop's rate
+comes from the session description: the model loop steps at
+`frames_per_second_for_step`, and the UI ticks at `frames_per_second_for_ui`.
 
 ## Loops
 
@@ -84,9 +83,9 @@ window never sends a close event, so nothing else will stop it.
 
 `ILoop.reset` raises `NotImplementedError` by default. A reset arrives as a
 client event, and when one does, every loop's `reset` is called, its
-`latest_result` is cleared, and its `step_index` restarts at zero. A loop that
-does not override `reset` therefore fails the first time a client asks for one,
-implement it, even if the body is `return`.
+`latest_result` is cleared, and the `step_index` handed to `step` starts again
+at zero. A loop that does not override `reset` therefore fails the first time a
+client asks for one, implement it, even if the body is `return`.
 
 ## What a step returns
 
@@ -96,9 +95,9 @@ The two loops have different return contracts, and the runtime enforces both:
   `StepResult` or `None` raises `TypeError`.
 - A UI loop returns one `StepResult`, or `None` to present nothing this tick.
 
-Every channel in one model step must report the same `frame_count`. A step may
-generate several frames at once; the runtime presents them one per UI tick
-rather than dropping all but the last.
+Every channel in one model step must report the same `frame_count`, and a
+mismatch raises `ValueError`. A step may generate several frames at once; the
+runtime presents them one per UI tick rather than dropping all but the last.
 
 A UI loop reads what the model produced through `presented_model_frame` and
 `presented_model_frames`, which return `[C, H, W]` frames with one, three or

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -34,7 +34,13 @@ class _Message(Generic[StateT]):
 
 
 class ILoop(ABC, Generic[StateT]):
-    """Shared state, messaging, and lifecycle for a session loop."""
+    """Shared state, messaging, and lifecycle for a session loop.
+
+    A session registers one of each kind: an :class:`IModelLoop` that generates
+    and an :class:`IUILoop` that presents. They run on separate threads and own
+    their own ``state``, so the only supported way for one to change the other's
+    is :func:`invoke_async`.
+    """
 
     @final
     def register_session_loop_objects(
@@ -80,12 +86,18 @@ class ILoop(ABC, Generic[StateT]):
     ) -> StepResult | list[StepResult] | None:
         """Run one step.
 
+        The two kinds of loop return different things, and the runtime rejects
+        the wrong one: a model loop must return ``list[StepResult]``, one entry
+        per channel, and a UI loop must return one :class:`StepResult` or
+        ``None`` to present nothing this step.
+
         Args:
             step_index: Zero-based index since the latest reset.
             events: Input events not seen by this loop before.
 
         Returns:
-            Model channels, one UI frame, or ``None``.
+            Model channels from a model loop; one frame, or ``None``, from a UI
+            loop.
         """
         ...
 
@@ -95,6 +107,10 @@ class ILoop(ABC, Generic[StateT]):
 
     def reset(self) -> None:
         """Reset loop-owned state for a new session generation.
+
+        Called when a client asks for a reset, before the next :meth:`step`.
+        Overriding this is what makes a loop resettable, so implement it even
+        when there is nothing to undo.
 
         Raises:
             NotImplementedError: This loop does not support reset.
@@ -189,7 +205,12 @@ class ILoop(ABC, Generic[StateT]):
 
 
 class IModelLoop(ILoop[StateT], ABC):
-    """Loop that generates model results on the model thread."""
+    """Loop that generates model results on the model thread.
+
+    :meth:`ILoop.step` must return ``list[StepResult]`` here, one entry per
+    channel, with every channel reporting the same ``frame_count``. Returning a
+    bare :class:`StepResult` or ``None`` raises :class:`TypeError`.
+    """
 
     @final
     def _run_model_loop(
@@ -237,7 +258,12 @@ class IModelLoop(ILoop[StateT], ABC):
 
 
 class IUILoop(ILoop[StateT], ABC):
-    """Loop whose output is sent to the client window."""
+    """Loop whose output is sent to the client window.
+
+    :meth:`ILoop.step` must return one :class:`StepResult` or ``None`` here.
+    Model frames to draw come from :meth:`presented_model_frame` and
+    :meth:`presented_model_frames` rather than from the model loop directly.
+    """
 
     @final
     def register_session_ui_loop_objects(
@@ -257,12 +283,29 @@ class IUILoop(ILoop[StateT], ABC):
 
     @final
     def presented_model_frame(self, channel_index: int = 0) -> Tensor | None:
-        """Return the current frame from one model-result channel."""
+        """Return the current frame from one model-result channel.
+
+        Args:
+            channel_index: Channel to read, indexed as the model loop returned
+                them.
+
+        Returns:
+            A ``[C, H, W]`` frame with one, three or four channels, or ``None``
+            before the first model result has been presented.
+
+        Raises:
+            IndexError: The presented result has no such channel.
+        """
         return self._presentation_manager.presented_frame(channel_index)
 
     @final
     def presented_model_frames(self) -> tuple[Tensor, ...]:
-        """Return the current frame from every model-result channel."""
+        """Return the current frame from every model-result channel.
+
+        Returns:
+            One ``[C, H, W]`` frame per channel, bottom channel first, or an
+            empty tuple before the first model result has been presented.
+        """
         return self._presentation_manager.presented_frames()
 
 
@@ -282,7 +325,20 @@ def _model_results(
 
 
 def invoke_async(loop: ILoop[StateT], operation: Callable[[StateT], None]) -> None:
-    """Queue ``operation`` against ``loop`` state before its next step."""
+    """Queue ``operation`` against ``loop`` state before its next step.
+
+    Returns immediately. ``loop`` snapshots its queue before its next
+    :meth:`ILoop.step` and runs what was in it, on its own thread. Anything
+    still queued at shutdown is dropped, so two loops cannot keep each other
+    alive by messaging back and forth.
+
+    Args:
+        loop: Loop whose state the operation runs against.
+        operation: Callable receiving that loop's state. Must return ``None``.
+
+    Raises:
+        RuntimeError: ``loop`` is shutting down.
+    """
     loop._invoke_async(operation)
 
 

--- a/flashdreams/flashdreams/api_v2/session.py
+++ b/flashdreams/flashdreams/api_v2/session.py
@@ -45,7 +45,15 @@ class ISession(ABC):
 
     @abstractmethod
     def init(self) -> None:
-        """Initialize state and register the UI and model loops."""
+        """Initialize state and register this session's loops.
+
+        A model loop is required. Registering a UI loop is optional; without one
+        the runtime uses :class:`BlitModelOutputToScreenLoop`.
+
+        Raises:
+            RuntimeError: No model loop was registered by the time the runtime
+                asks for the loops.
+        """
         ...
 
     @property
@@ -62,9 +70,21 @@ class ISession(ABC):
         state: Any = None,
         **kwargs: Any,
     ) -> IUILoop[Any]:
-        """Create and register the UI loop.
+        """Create and register the UI loop, and return it.
 
-        Omit this call to use the default UI.
+        Omit this call to use the default UI. The loop is paced at the session's
+        ``frames_per_second_for_ui``.
+
+        Args:
+            loop_type: UI loop class to instantiate.
+            state: State the loop owns. Unlike a model loop, a UI loop is
+                allowed to hold none.
+            **kwargs: Passed to ``loop_type``.
+
+        Raises:
+            RuntimeError: The runtime already took the loops, or a UI loop was
+                registered already.
+            TypeError: ``loop_type`` does not derive from :class:`IUILoop`.
         """
         if self._registrations_frozen:
             raise RuntimeError("Loop registrations are already in use.")
@@ -94,7 +114,21 @@ class ISession(ABC):
         state: Any,
         **kwargs: Any,
     ) -> IModelLoop[Any]:
-        """Create and register the model loop."""
+        """Create and register the model loop, and return it.
+
+        The loop is paced at the session's ``frames_per_second_for_step``.
+
+        Args:
+            loop_type: Model loop class to instantiate.
+            state: State the loop owns. Required, since a model loop with no
+                state has nothing to generate from.
+            **kwargs: Passed to ``loop_type``.
+
+        Raises:
+            RuntimeError: The runtime already took the loops, or a model loop
+                was registered already.
+            TypeError: ``loop_type`` does not derive from :class:`IModelLoop`.
+        """
         if self._registrations_frozen:
             raise RuntimeError("Loop registrations are already in use.")
         if self._registered_model_loop is not None:

--- a/flashdreams/flashdreams/api_v2/user_input_event_data.py
+++ b/flashdreams/flashdreams/api_v2/user_input_event_data.py
@@ -7,11 +7,12 @@ from abc import ABC, abstractmethod
 
 
 class UserInputEventData(ABC):
-    """Base class for data stored in ``UserInputEvent``.
+    """Base class for data stored in a user input event.
 
     Implementations provide :meth:`get_type_name` and may add fields for their
-    event data when implementing. The runtime owns the set of concrete types,
-    which covers the input modalities supported today.
+    event data. The runtime owns the set of concrete types, in
+    :mod:`flashdreams.runtime_v2.user_input_event`, which covers the input
+    modalities supported today.
     """
 
     @classmethod

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -28,7 +28,8 @@ Finding and starting an application:
 Running a session:
 
 - `session_runner.py` is `run_session`, which everything above ends up calling.
-  It is the only place that starts a thread.
+  It is the only place that starts a generation thread; the WebRTC server and
+  the video encoder run threads of their own, but neither touches a loop.
 - `event_buffer.py` holds client input until both loops have read it.
 - `presentation_manager.py` buffers generated frames between the two threads and
   decides which one the UI sees.
@@ -181,8 +182,8 @@ focus events into input and a disconnecting browser into a close; because those
 arrive on the server's own thread, it queues them and hands them over in batches
 when the session asks.
 
-Output sinks read floating-point frames as `[-1, 1]` and integer frames as
-`[0, 255]`. Nothing remaps this.
+What a sink expects of the pixel values it is handed is part of the result
+contract, in [`api_v2`](../api_v2/README.md#what-a-step-returns).
 
 ## Adding a mode
 

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -107,8 +107,9 @@ finished and no frames are still pending.
 
 On the way out it sets the shutdown event, joins the model thread, shuts both
 loops down, clears the presentation buffer, unregisters the readers, closes every
-sink it opened, and closes the session. Then it raises whichever failure happened
-first, logging any that occurred during that cleanup.
+sink it opened, and closes the session. Then it raises a loop's failure if one
+was queued, otherwise its own, otherwise the first cleanup failure, logging the
+rest.
 
 ## `EventBuffer`
 
@@ -153,8 +154,9 @@ ready:
 
 For output that has to be compared frame by frame, use `BLOCK` with
 `ONLY_PRESENT_NEW`: together they keep every frame and present each exactly once,
-in order. Frames that could not be kept are counted in `dropped_for_space` and
-`discarded_at_reset`, and logged when the run ends.
+in order. Steps that could not be kept are counted in `dropped_for_space` and
+`discarded_at_reset`, and logged when the run ends. Both count model steps rather
+than frames, so one step of twelve frames counts once.
 
 ## Presenting and writing
 

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -1,0 +1,194 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+The machinery that runs a v2 application: it finds one, asks it for a session,
+runs that session's two loops on two threads, and delivers what they generate to
+a file or a browser.
+
+This is the implementation. For how the pieces fit together and why the seams are
+where they are, read [ARCHITECTURE.md](../../../ARCHITECTURE.md) first; for the
+protocols an application implements, see [`api_v2`](../api_v2/README.md).
+
+## What is in here
+
+Finding and starting an application:
+
+- `application_registry.py` reads the `flashdreams.applications_v2` entry points
+  to turn a slug into an `IApplication`, falling back to importing the slug as a
+  module name.
+- `cli.py` is `flashdreams-run-v2`: it splits its own arguments from the
+  application's at `--`, decides which session to ask for, and builds the window.
+- `application_runner.py` owns the application lifecycle around one run —
+  `init`, `create_session`, `run_session`, `close`.
+- `client_window_factory.py` turns `--mode` into a window, and owns the
+  arguments each mode takes.
+
+Running a session:
+
+- `session_runner.py` is `run_session`, which everything above ends up calling.
+  It is the only place that starts a thread.
+- `event_buffer.py` holds client input until both loops have read it.
+- `presentation_manager.py` buffers generated frames between the two threads and
+  decides which one the UI sees.
+- `session_desc.py` describes the session being run: frame size, rates, layout,
+  and the two policy knobs below.
+- `step_result.py` is what one generation step produces.
+
+Presenting it:
+
+- `blit_model_output_to_screen_loop.py` is the UI loop a session gets when it
+  registers none of its own.
+- `slangpy_ui_loop.py` and `_slangpy_ui_renderer.py` are the UI loop for
+  applications that draw widgets over the model output.
+- `mp4_client_window.py` and `webrtc_client_window.py` are the two windows.
+- `mp4_output_sink.py`, `metrics_output_sink.py`, `video_encoder.py` and
+  `video_tensor.py` are what output is written through.
+- `serving/` is the HTTP and WebRTC server behind the browser window.
+
+Input:
+
+- `user_input_event.py` defines the event data types, `user_input_events.py` the
+  batch of them a source hands over.
+
+## The command line
+
+`flashdreams-run-v2 SLUG` finds an application through the
+`flashdreams.applications_v2` entry point group and runs it with
+`ApplicationRunner`. Arguments after `--` go to the application, so
+`flashdreams-run-v2 SLUG -- --help` describes the application rather than this
+command. The split is stated rather than guessed because an application may
+declare arguments this command also has.
+
+`--mode` picks where the run goes, and each mode owns its own arguments in
+`client_window_factory.py`:
+
+| Mode | Takes | Input | Ends when |
+| --- | --- | --- | --- |
+| `mp4` (default) | `--output-path` | none | the session reports itself finished |
+| `webrtc` | `--host`, `--port` | keyboard, mouse, focus, reset, close | the browser disconnects, or the session finishes |
+
+These override whatever session the application asked for:
+
+| Argument | Sets |
+| --- | --- |
+| `--pixel-width`, `--pixel-height` | Frame size to generate. |
+| `--fps` | `frames_per_second_for_step`, which is also the rate an MP4 plays back at. |
+| `--layout` | Tensor layout to generate results in. |
+| `--backpressure-mode` | What the model thread does when the presentation queue is full. |
+| `--presentation-mode` | Whether the UI presents eagerly or only for new model frames. |
+
+Each defaults to asking for nothing, so a run that names none of them gets what
+the application generates. There is no argument for the UI tick rate, and none
+for `run_session`'s `steps` limit — a caller that needs to bound a run by steps
+drives the runtime from Python.
+
+`--stats-path` adds a `MetricsOutputSink`. It receives the **model** loop's
+results as they are published, not the UI loop's output, so a benchmark measures
+what the model generated while the window still sees one composited frame per
+tick. See [`configs/v2_model_benchmarks.json`](../../../configs/v2_model_benchmarks.json)
+and the [benchmark README](../../tools/benchmarks/README.md) for the suite.
+
+## Starting and stopping a run
+
+`ApplicationRunner.run` calls `init`, `create_session` and `run_session` in
+order, and closes the application on the way out whether or not the run
+succeeded. It also closes the window itself when the run never started, because
+`run_session` is what otherwise owns the window, and a WebRTC window may already
+be serving a browser before the application has finished loading.
+
+`run_session` then opens the window and any metrics sink, collects one batch of
+input, presents one tick, and only then starts the model thread — so a client that
+closed during startup is never generated for. Its main loop services input and
+presents frames until the shutdown event is set, or until the model thread has
+finished and no frames are still pending.
+
+On the way out it sets the shutdown event, joins the model thread, shuts both
+loops down, clears the presentation buffer, unregisters the readers, closes every
+sink it opened, and closes the session. Then it raises whichever failure happened
+first, logging any that occurred during that cleanup.
+
+## `EventBuffer`
+
+Input arrives once per tick on the main thread and is appended here. The buffer
+keeps a flat list plus a cursor per registered reader: `read` returns everything
+that reader has not seen and moves its cursor to the end, and
+`collect_garbage` deletes the prefix every reader has passed. The UI loop is
+reader 0 and the model loop is reader 1.
+
+Appending also counts resets. Every `ResetUserInputEventData` in a batch bumps
+the generation number that loops and the presentation manager compare against
+their own.
+
+A close event is handled twice over, deliberately: `run_session` sets the
+shutdown event when it sees one in a collected batch, and `ILoop._begin_run` sets
+it again when a loop reads one. Either path alone would end the run; both means
+neither thread waits on the other to notice.
+
+## `PresentationManager`
+
+The model thread publishes a list of channels per step into a bounded queue
+(`max_pending`, two by default). The main thread calls `advance` once per tick,
+which walks the frames within the chunk it is already showing before taking
+another off the queue.
+
+`SessionDesc.backpressure_mode` decides what publishing does when the queue is
+full:
+
+- `BLOCK` waits for room, in `put_timeout` slices so a shutdown is still
+  noticed. Every generated frame survives, and the model thread is held back to
+  the rate the UI can consume.
+- `DROP_OLDEST` evicts queued work so the UI can catch up to the newest output,
+  trading frames for latency.
+
+`SessionDesc.presentation_mode` decides what the UI does when no new frame is
+ready:
+
+- `ONLY_PRESENT_NEWEST` runs the UI loop every tick, re-presenting the newest
+  model frame.
+- `ONLY_PRESENT_NEW` runs the UI loop only on a tick where `advance` actually
+  moved to a new frame.
+
+For output that has to be compared frame by frame, use `BLOCK` with
+`ONLY_PRESENT_NEW`: together they keep every frame and present each exactly once,
+in order. Frames that could not be kept are counted in `dropped_for_space` and
+`discarded_at_reset`, and logged when the run ends.
+
+## Presenting and writing
+
+A UI loop reads model frames through `presented_model_frame` and
+`presented_model_frames`, composites whatever it wants, and returns one
+`StepResult` that `run_session` writes to the window.
+
+The default UI loop, `BlitModelOutputToScreenLoop`, composites every model
+channel in list order as if they were image layers and reshapes the result into
+the session's layout. `SlangPyUILoop` is the alternative, for widgets drawn over
+the model output; it returns a `[1, C, H, W]` frame, so a session using it
+declares a `tchw` layout.
+
+`IClientWindow` is both an `InputSource` and an `OutputSink`, so a window is
+written to with the same three calls as any sink: `open` with the session
+description, `write` per result, `close` at the end. Both windows are thin
+delegates over the thing that does the work — `Mp4ClientWindow` over
+`Mp4OutputSink`, `WebRTCClientWindow` over `WebRTCServer` — and neither describes
+the output shape, because the session already did.
+
+They differ in what they can do rather than in how they are driven. The MP4
+window reports no input and never sends a close, so a session written to a file
+has to finish on its own. The WebRTC window turns browser keyboard, mouse and
+focus events into input and a disconnecting browser into a close; because those
+arrive on the server's own thread, it queues them and hands them over in batches
+when the session asks.
+
+Output sinks read floating-point frames as `[-1, 1]` and integer frames as
+`[0, 255]`. Nothing remaps this.
+
+## Adding a mode
+
+A mode is one way to watch a run. Subclass `ClientWindowMode` in
+`client_window_factory.py`, declare the arguments only it takes, and add it to
+`_MODES`; a command line offering the modes never has to know what any of them
+are. `check_arguments` is called while the command can still print usage, and
+`starting` and `finished` are what it prints — which is how a WebRTC run reports
+a URL nobody could have guessed when the port was chosen by the operating system.

--- a/flashdreams/flashdreams/runtime_v2/__init__.py
+++ b/flashdreams/flashdreams/runtime_v2/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Runtime data types for FlashDreams v2."""
+"""Runtime that runs a FlashDreams v2 application against a client window."""
 
 from flashdreams.runtime_v2.session_desc import (
     BackpressureMode,

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -102,9 +102,9 @@ def _close_output_sink(output_sink: OutputSink) -> None:
 def _close_application(application: IApplication, *, run_failed: bool) -> None:
     """Close an application, keeping its close from hiding an earlier failure.
 
-    This is ``session_runner._close_session`` for the application: whatever
-    failed first is what a run reports, and a failure while cleaning up after it
-    is logged.
+    The same rule ``run_session`` follows for the session and its sinks:
+    whatever failed first is what a run reports, and a failure while cleaning up
+    after it is logged.
 
     Args:
         application: Application to close.

--- a/flashdreams/flashdreams/runtime_v2/cli.py
+++ b/flashdreams/flashdreams/runtime_v2/cli.py
@@ -44,6 +44,9 @@ An application declares whatever arguments it likes, including ones this
 command also has, so the split is stated rather than guessed.
 """
 
+_HELP_FLAGS = frozenset({"-h", "--help"})
+"""What an application's own arguments use to ask for its help."""
+
 
 def entrypoint(argv: Sequence[str] | None = None) -> None:
     """Run the command, reporting where to watch what it generates."""
@@ -53,13 +56,22 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
     parsed = parser.parse_args(own_args)
 
     mode = client_window_mode(parsed.mode)
-    try:
-        mode.check_arguments(parsed)
-    except ValueError as error:
-        parser.error(str(error))
+    # Asking an application what it takes is answered by the application alone,
+    # so a run that only wants its help neither checks the arguments for a
+    # window nor opens one.
+    wants_application_help = bool(_HELP_FLAGS.intersection(application_args))
+    if not wants_application_help:
+        try:
+            mode.check_arguments(parsed)
+        except ValueError as error:
+            parser.error(str(error))
 
     # Before the window, so a slug this cannot run costs nothing to find out.
     application = create_application(parsed.slug)
+    if wants_application_help:
+        # Parsing is init's first job, so this prints the help and exits.
+        application.init(application_args)
+        return
     session_desc = _session_desc(application, parsed)
     window = mode.create(parsed)
     _report(mode.starting(window))

--- a/flashdreams/flashdreams/runtime_v2/event_buffer.py
+++ b/flashdreams/flashdreams/runtime_v2/event_buffer.py
@@ -13,7 +13,18 @@ from flashdreams.runtime_v2.user_input_events import UserInputEvents
 
 
 class EventBuffer:
-    """Keep input events until every loop has read them."""
+    """Keep input events until every loop has read them.
+
+    Input is collected once, on the thread running the UI, but both loops need it
+    and they read at different rates. So this holds a flat list of events plus a
+    cursor per registered reader, hands each reader only what it has not seen,
+    and drops the prefix they have all passed.
+
+    It also counts resets. Every :class:`ResetUserInputEventData` appended bumps
+    :attr:`generation`, which the loops and the presentation manager compare
+    against their own; that counter is how a reset reaches all of them without
+    any of them talking to each other.
+    """
 
     def __init__(self) -> None:
         self._events: list[UserInputEvent] = []

--- a/flashdreams/flashdreams/runtime_v2/presentation_manager.py
+++ b/flashdreams/flashdreams/runtime_v2/presentation_manager.py
@@ -24,9 +24,9 @@ class PresentationManager:
     twelve ticks rather than eleven being skipped.
 
     :class:`BackpressureMode` decides what publishing does when the queue is
-    full. Frames that could not be kept are counted in
+    full. Chunks that could not be kept are counted in
     :attr:`dropped_for_space` and :attr:`discarded_at_reset` rather than lost
-    silently.
+    silently, one count per chunk however many frames it held.
     """
 
     def __init__(self) -> None:

--- a/flashdreams/flashdreams/runtime_v2/presentation_manager.py
+++ b/flashdreams/flashdreams/runtime_v2/presentation_manager.py
@@ -15,7 +15,19 @@ from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 
 class PresentationManager:
-    """Buffer model output for a session's UI thread."""
+    """Buffer model output for a session's UI thread.
+
+    The model thread publishes a chunk of channels per step into a bounded
+    queue; the UI thread calls :meth:`advance` once per tick to move to the next
+    frame. A chunk holding several frames is walked frame by frame before
+    another is taken, so a step that generated twelve frames is presented over
+    twelve ticks rather than eleven being skipped.
+
+    :class:`BackpressureMode` decides what publishing does when the queue is
+    full. Frames that could not be kept are counted in
+    :attr:`dropped_for_space` and :attr:`discarded_at_reset` rather than lost
+    silently.
+    """
 
     def __init__(self) -> None:
         self._buffer: queue.Queue[tuple[int, list[StepResult]]] = queue.Queue(maxsize=2)
@@ -26,7 +38,10 @@ class PresentationManager:
         self._presented_chunk: list[StepResult] | None = None
         self._frame_index = -1
         self.dropped_for_space = 0
+        """Chunks dropped because the UI could not keep up with the model."""
+
         self.discarded_at_reset = 0
+        """Chunks discarded for having been generated before a reset."""
 
     def configure(
         self,
@@ -36,7 +51,21 @@ class PresentationManager:
         stop: threading.Event,
         put_timeout: float,
     ) -> None:
-        """Set the queue size and backpressure mode."""
+        """Set the queue size and backpressure mode.
+
+        Called by ``run_session`` before either thread uses this.
+
+        Args:
+            max_pending: Model steps that may wait to be shown. Replaces the
+                queue, so anything already buffered is discarded.
+            backpressure_mode: What :meth:`publish` does when the queue is full.
+            stop: Session shutdown event, so a blocked publish gives up.
+            put_timeout: How long a blocked publish waits before rechecking
+                ``stop``, in seconds.
+
+        Raises:
+            ValueError: ``max_pending`` is not positive.
+        """
         if max_pending <= 0:
             raise ValueError(f"max_pending must be > 0, got {max_pending}.")
         self._buffer = queue.Queue(maxsize=max_pending)
@@ -51,7 +80,19 @@ class PresentationManager:
     ) -> None:
         """Add one completed model step to the presentation queue.
 
-        ``BLOCK`` waits here when the queue is full.
+        Called on the model thread. ``BLOCK`` waits here when the queue is full,
+        until there is room or the session stops; ``DROP_OLDEST`` evicts instead
+        and returns.
+
+        Args:
+            generation: Reset generation the chunk was generated in. A chunk
+                from an earlier one is discarded rather than presented.
+            chunk: One :class:`StepResult` per model channel.
+
+        Raises:
+            ValueError: ``chunk`` is empty, or its channels disagree about
+                ``frame_count``.
+            TypeError: ``chunk`` holds something other than results.
         """
         if not chunk:
             raise ValueError("A presented chunk must contain at least one channel.")
@@ -74,8 +115,17 @@ class PresentationManager:
     def advance(self, generation: int) -> tuple[bool, list[StepResult] | None]:
         """Move to the next model frame, if one is available.
 
+        Called on the UI thread, once per tick. A ``generation`` other than the
+        last one seen drops what is being presented, so nothing generated before
+        a reset survives it.
+
+        Args:
+            generation: Current reset generation, from the event buffer.
+
         Returns:
-            Whether the frame changed, and the newly selected model step.
+            Whether the frame changed, and the chunk newly taken off the queue,
+            which is ``None`` when the change was to another frame of the chunk
+            already being presented.
         """
         if generation != self._generation:
             self._generation = generation
@@ -130,7 +180,21 @@ class PresentationManager:
         )
 
     def composite(self, bottom: Tensor | None, top: Tensor) -> Tensor:
-        """Draw ``top`` over ``bottom``."""
+        """Draw ``top`` over ``bottom``.
+
+        Args:
+            bottom: ``[C, H, W]`` frame to draw onto, or ``None`` to start from
+                black.
+            top: ``[C, H, W]`` frame to draw. Four channels is RGBA and blends;
+                anything else replaces.
+
+        Returns:
+            An RGB ``[3, H, W]`` frame.
+
+        Raises:
+            ValueError: The frames disagree about size, device or dtype, or
+                either is not a presentable frame.
+        """
         return _composite_frame(bottom, top)
 
     def has_pending_frames(self) -> bool:

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -46,17 +46,25 @@ def run_session(
     """Run a session's UI and model loops.
 
     The calling thread handles the window and UI. The model runs on a separate
-    Python thread.
+    Python thread. Returns when the client closes the window, when the model
+    loop has finished and no generated frames are still waiting, or when either
+    loop fails.
+
+    Both loops are shut down, every sink opened is closed, and the session is
+    closed, before this returns or raises.
 
     Args:
         session: Session to run.
         window: Source of input and destination for UI output.
-        metrics_output_sink: Sink for model measurements, if requested.
+        metrics_output_sink: Sink for model measurements, if requested. Receives
+            the model loop's results rather than the UI loop's.
         steps: Maximum model steps; ``None`` runs until stopped.
         max_pending: Maximum model steps waiting to be shown.
 
     Raises:
         ValueError: ``steps`` is negative, or ``max_pending`` is not positive.
+        BaseException: Whatever failed the run first. A failure while cleaning
+            up after it is logged instead.
     """
     if steps is not None and steps < 0:
         raise ValueError(f"steps must be >= 0 or None, got {steps}.")

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -63,8 +63,9 @@ def run_session(
 
     Raises:
         ValueError: ``steps`` is negative, or ``max_pending`` is not positive.
-        BaseException: Whatever failed the run first. A failure while cleaning
-            up after it is logged instead.
+        BaseException: A loop's failure if one was queued, otherwise this
+            function's own, otherwise the first cleanup failure. The rest are
+            logged.
     """
     if steps is not None and steps < 0:
         raise ValueError(f"steps must be >= 0 or None, got {steps}.")
@@ -214,12 +215,12 @@ def run_session(
 
     if presentation_manager.dropped_for_space:
         _LOGGER.warning(
-            "Dropped %d results the window could not keep up with.",
+            "Dropped %d model steps the window could not keep up with.",
             presentation_manager.dropped_for_space,
         )
     if presentation_manager.discarded_at_reset:
         _LOGGER.info(
-            "Discarded %d results generated before a reset.",
+            "Discarded %d model steps generated before a reset.",
             presentation_manager.discarded_at_reset,
         )
     if primary_failure is not None:

--- a/flashdreams/flashdreams/runtime_v2/slangpy_ui_loop.py
+++ b/flashdreams/flashdreams/runtime_v2/slangpy_ui_loop.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""SlangPy UI loop for FlashDreams applications."""
+"""UI loop drawing SlangPy widgets over the model output."""
 
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar, final
@@ -20,7 +20,13 @@ _StateT = TypeVar("_StateT")
 
 
 class SlangPyUILoop(IUILoop[_StateT], ABC, Generic[_StateT]):
-    """Render a SlangPy UI over an optional model frame."""
+    """Render a SlangPy UI over an optional model frame.
+
+    Subclass this and implement :meth:`step_ui` instead of ``step``: the widget
+    tree is drawn once per UI tick, and whatever :meth:`step_ui` returns is
+    composited beneath it. Needs CUDA, Vulkan/CUDA interop and SlangPy, so the
+    renderer is created on the first render rather than at construction.
+    """
 
     def __init__(
         self,
@@ -51,12 +57,28 @@ class SlangPyUILoop(IUILoop[_StateT], ABC, Generic[_StateT]):
     def step_ui(
         self, ui: Any, step_index: int, events: UserInputEvents
     ) -> Tensor | None:
-        """Draw widgets and optionally return the frame beneath them."""
+        """Draw widgets and optionally return the frame beneath them.
+
+        Args:
+            ui: SlangPy UI surface. ``ui.screen`` takes top-level widgets, and
+                every public ``slangpy.ui`` type is reachable from it.
+            step_index: Zero-based index since the latest reset.
+            events: Input events not seen by this loop before.
+
+        Returns:
+            A ``[C, H, W]`` frame to composite beneath the widgets, usually from
+            :meth:`presented_model_frame`, or ``None`` for widgets on black.
+        """
         ...
 
     @final
     def step(self, step_index: int, events: UserInputEvents) -> StepResult:
-        """Render the UI over the optional back-buffer returned by :meth:`step_ui`."""
+        """Render the UI over the optional back-buffer returned by :meth:`step_ui`.
+
+        Returns:
+            One composited frame, as ``[1, C, H, W]``. Sessions using this loop
+            therefore declare a ``tchw`` layout.
+        """
         back_buffer: Tensor | None = None
 
         def draw(ui: Any, index: int, current_events: UserInputEvents) -> None:

--- a/flashdreams/flashdreams/runtime_v2/step_result.py
+++ b/flashdreams/flashdreams/runtime_v2/step_result.py
@@ -12,15 +12,25 @@ from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 @dataclass(frozen=True, slots=True)
 class StepResult:
-    """Generated output returned by one inference step."""
+    """Generated output returned by one inference step.
+
+    A model loop returns a list of these, one per channel, and a UI loop returns
+    one. Channels in the same list must agree about ``frame_count``.
+    """
 
     step_index: int
     """Zero-based index of the step that produced this result."""
+
     output: Tensor
-    """Generated frames, laid out as ``output_layout`` says."""
+    """Generated frames, laid out as ``output_layout`` says. Floating-point
+    values are read as ``[-1, 1]`` and integer values as ``[0, 255]``."""
+
     frame_count: int
     """Number of frames in ``output``."""
+
     output_layout: VideoTensorLayout
     """Layout of ``output``."""
+
     metrics: dict[str, float | int] = field(default_factory=dict)
-    """Measurements for this step, such as timings, keyed by name."""
+    """Measurements for this step, such as timings, keyed by name. Recorded only
+    when a run asked for a metrics sink, and only from a model loop."""

--- a/flashdreams/flashdreams/runtime_v2/user_input_event.py
+++ b/flashdreams/flashdreams/runtime_v2/user_input_event.py
@@ -117,10 +117,9 @@ class FocusUserInputEventData(UserInputEventData):
     """Whether the video viewport owns keyboard focus."""
 
 
-## Stubs for input modalities no client produces yet
-#
-# Named so that a client gaining one of these has somewhere to put it. Nothing
-# creates or reads them today, and none carries any data.
+# Stubs for input modalities no client produces yet. Named so that a client
+# gaining one of these has somewhere to put it. Nothing creates or reads them
+# today, and none carries any data.
 
 
 @dataclass(frozen=True, slots=True, eq=False)

--- a/flashdreams/flashdreams/runtime_v2/user_input_event.py
+++ b/flashdreams/flashdreams/runtime_v2/user_input_event.py
@@ -68,8 +68,9 @@ class CloseUserInputEventData(UserInputEventData):
 class ResetUserInputEventData(UserInputEventData):
     """The client asked to start the run over.
 
-    Each registered thread resets before its next ``step``, and its step index
-    starts again from zero. The window stays open.
+    Every registered loop resets before its next ``step``, its step index starts
+    again from zero, and frames generated before the reset are discarded rather
+    than presented. The window stays open.
     """
 
     @classmethod
@@ -116,7 +117,10 @@ class FocusUserInputEventData(UserInputEventData):
     """Whether the video viewport owns keyboard focus."""
 
 
-# Below are stubbed input event data implementations for future clients.
+## Stubs for input modalities no client produces yet
+#
+# Named so that a client gaining one of these has somewhere to put it. Nothing
+# creates or reads them today, and none carries any data.
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -171,13 +175,17 @@ class UnknownUserInputEventData(UserInputEventData):
 
 @dataclass(frozen=True, slots=True)
 class UserInputEvent:
-    """User input event."""
+    """One input event: when it happened, and what happened.
+
+    The data decides what the event is, so a loop reading input dispatches on
+    the type of :meth:`get_event_data` rather than on anything here.
+    """
 
     timestamp: uint64
     """Timestamp in microseconds since the start of the session."""
 
     event_data: UserInputEventData
-    """Event data."""
+    """What happened, as one of the types in this module."""
 
     def get_timestamp(self) -> uint64:
         """Return the timestamp."""

--- a/flashdreams/flashdreams/runtime_v2/user_input_events.py
+++ b/flashdreams/flashdreams/runtime_v2/user_input_events.py
@@ -28,7 +28,8 @@ class UserInputEvents:
     """Immutable event collection data."""
 
     def __init__(self, events: list[UserInputEvent]) -> None:
-        """
+        """Sort the events by timestamp and hold them.
+
         Args:
             events: Events to hold, in any order.
         """

--- a/flashdreams/flashdreams/runtime_v2/user_input_events.py
+++ b/flashdreams/flashdreams/runtime_v2/user_input_events.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""User input event collection implementation."""
+"""One batch of input events, as an input source hands them over."""
 
 from dataclasses import dataclass
 
@@ -10,19 +10,28 @@ from flashdreams.runtime_v2.user_input_event import UserInputEvent
 
 @dataclass(frozen=True)
 class UserInputEventsData:
-    """Data for user input events."""
+    """Sorted events held by one :class:`UserInputEvents` batch."""
 
     events: list[UserInputEvent]
     """Input events ordered by timestamp."""
 
 
 class UserInputEvents:
-    """One batch of user input events, sorted by timestamp and not modifiable."""
+    """One batch of user input events, sorted by timestamp and not modifiable.
+
+    What :meth:`~flashdreams.api_v2.input_source.InputSource.get_user_input_events`
+    returns and what a loop's ``step`` receives. Sorting happens once, here, so
+    neither end has to.
+    """
 
     _data: UserInputEventsData
     """Immutable event collection data."""
 
     def __init__(self, events: list[UserInputEvent]) -> None:
+        """
+        Args:
+            events: Events to hold, in any order.
+        """
         self._data = UserInputEventsData(
             events=sorted(events, key=lambda event: event.get_timestamp()),
         )

--- a/flashdreams/flashdreams/runtime_v2/user_input_events.py
+++ b/flashdreams/flashdreams/runtime_v2/user_input_events.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""One batch of input events, as an input source hands them over."""
+"""One batch of input events that an input source passes to a loop."""
 
 from dataclasses import dataclass
 

--- a/flashdreams/flashdreams/runtime_v2/video_tensor.py
+++ b/flashdreams/flashdreams/runtime_v2/video_tensor.py
@@ -1,15 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Video tensor layout implementation."""
+"""Tensor layouts a generated video result can be laid out in."""
 
 from enum import Enum
 
 
 class VideoTensorLayout(Enum):
-    """Supported/Recognized tensor layouts."""
+    """Axis order of a generated video tensor.
+
+    ``b`` is batch, ``v`` view, ``t`` time, ``c`` colour channel, and ``h`` and
+    ``w`` the frame. Presentation reads one frame at a time and so needs a batch
+    of one, and one view, from the layouts that carry them.
+    """
 
     tchw = "tchw"
+    """Frames, channels, height, width. The default, and what the text-to-video
+    models emit."""
+
     btchw = "btchw"
+    """Batch of ``tchw``."""
+
     bcthw = "bcthw"
+    """Batch of channel-major clips, as a diffusion pipeline usually holds them."""
+
     bvtchw = "bvtchw"
+    """Batch of multi-view clips, one ``tchw`` per camera."""

--- a/flashdreams/flashdreams/runtime_v2/video_tensor.py
+++ b/flashdreams/flashdreams/runtime_v2/video_tensor.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tensor layouts a generated video result can be laid out in."""
+"""Tensor layouts a generated video result can take."""
 
 from enum import Enum
 

--- a/flashdreams/flashdreams/runtime_v2/webrtc_client_window.py
+++ b/flashdreams/flashdreams/runtime_v2/webrtc_client_window.py
@@ -14,7 +14,16 @@ from flashdreams.runtime_v2.user_input_events import UserInputEvents
 
 
 class WebRTCClientWindow(IClientWindow):
-    """Implement ``IClientWindow`` with WebRTC input and presentation."""
+    """Client window streaming a run to a browser.
+
+    A thin pairing of the :class:`IClientWindow` protocol with
+    :class:`WebRTCServer`, which does the serving. Browser events arrive on the
+    server's own thread, so they are queued here and handed over in batches when
+    the session asks, as the protocol requires.
+
+    A browser that disconnects becomes a close event, so a run through this
+    window ends on its own even when the session would generate forever.
+    """
 
     def __init__(
         self,

--- a/flashdreams/flashdreams/t2v_v2/README.md
+++ b/flashdreams/flashdreams/t2v_v2/README.md
@@ -217,21 +217,10 @@ def test_the_model_generates_a_clip_worth_watching(tmp_path: Path) -> None:
 environment variable is unset, there is no GPU, or `ffmpeg` is missing, or
 `None` when it can.
 
-Running them:
-
-```bash
-uv sync --package flashdreams-t2v-wan21 --group test --inexact
-uv run --no-sync pytest integrations_v2/t2v_wan21 -m ci_cpu -v
-```
-
-```bash
-T2V_WAN21_REAL_MODEL_RUN=1 uv run --no-sync pytest \
-    integrations_v2/t2v_wan21 -m ci_gpu -s --basetemp="$HOME/t2v-out"
-vlc "$HOME"/t2v-out/*current/clip.mp4
-```
-
-`--basetemp` under your home rather than `/tmp` is so a sandboxed player can see
-the file, since pytest's real `/tmp` is private to the test process. The
+Each integration's own README carries the two commands that run these for its
+package. The real-model one writes under `$HOME` rather than `/tmp`, so that a
+sandboxed player can open the clip afterwards; pytest's real `/tmp` is private
+to the test process. The
 [integration guide](../../../integrations_v2/README.md#testing-it) covers
 `--inexact` and the markers.
 

--- a/flashdreams/flashdreams/t2v_v2/README.md
+++ b/flashdreams/flashdreams/t2v_v2/README.md
@@ -6,6 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 Text-to-video on the v2 API: one application every t2v model configures rather
 than writes. A prompt goes in, an MP4 comes out.
 
+Every text-to-video model takes a prompt and generates blocks of frames at a
+size and rate it was trained for, so the command line for one is the command
+line for all of them. An integration supplies its defaults and inherits
+everything else, which is why each of the five under `integrations_v2/` is one
+subclass and a `pyproject.toml`.
+
 ## Run a model
 
 ```bash
@@ -16,8 +22,9 @@ uv run --project integrations_v2/t2v_self_forcing flashdreams-run-v2 \
 ```
 
 The slug names the model, arguments before `--` describe the run, and arguments
-after it go to the model. The first run downloads the checkpoint, which is tens
-of gigabytes.
+after it go to the model. The first run fetches the checkpoint from Hugging Face,
+tens of gigabytes including the text encoder, so set a token and expect to wait.
+Writing an MP4 also needs `ffmpeg` on `PATH`.
 
 | Slug | Model | A run |
 | --- | --- | --- |
@@ -27,8 +34,8 @@ of gigabytes.
 | `t2v-wan21` | Wan 2.1 1.3B, 480p | one block, 81 frames |
 | `t2v-cosmos-predict2` | Cosmos Predict2 2B, 720p | one block, 93 frames |
 
-Each has a README of its own under `integrations_v2/`, with the frame
-arithmetic for that model.
+Each has a README of its own under `integrations_v2/`, with the frame arithmetic
+for that model.
 
 ## Arguments
 
@@ -43,34 +50,203 @@ After the `--`, the same for every model, and listed by
 | `--compile` / `--no-compile` | Compile the network: minutes once, milliseconds a step. |
 | `--seed` | Seed the noise, so the same command generates the same clip. |
 
+`--no-compile` is usually right for a short clip. Compilation is on in most of
+the model configs, and paying minutes to save milliseconds a block is the wrong
+trade for a handful of blocks.
+
 Before the `--` are `flashdreams-run-v2`'s own, including `--output-path`,
-`--pixel-width`, `--pixel-height`, and `--fps`. Unasked, a model generates at
-the size and rate its checkpoint was trained for, which is what `session_desc()`
+`--pixel-width`, `--pixel-height` and `--fps`. Unasked, a model generates at the
+size and rate its checkpoint was trained for, which is what `session_desc()`
 answers with.
+
+## What a t2v run generates
+
+`[-1, 1]` floats on the GPU, in the layout the model's runner config declares —
+`tchw` for all five today. The frame size and rate are the checkpoint's, read off
+that runner config rather than written down in the integration.
+
+Another size can be asked for with `--pixel-width` and `--pixel-height`, as long
+as each dimension is a whole number of latents across; the application checks
+against the decoder's spatial compression ratio, which is 8 for these models. A
+layout the model does not emit is refused before the checkpoint loads, since
+several gigabytes is a long wait for an answer of no.
+
+`--fps` sets the rate the frames are meant to play at, and so the rate an MP4
+plays back at. It is not a generation speed.
 
 ## What is here
 
-- `defaults.py`: what an integration contributes, read off the runner config it
-  already ships so a model's frame size and rate are not written down twice.
-- `application.py`: the shared command line above, and the model loaded once for
-  every session. `_configure_argument_parser` and `_apply_parsed_arguments` are
-  where a model adds a flag of its own.
-- `session.py`: one rollout. It omits custom UI registration so the default
-  model-output blitter is used, and registers a `T2VModelLoop`; the model loop
-  owns the prompt cache, generates one block per `step`, and finishes
-  after `--total-blocks` blocks.
-- `testing.py`: the check an integration's tests run, and the stand-in model
-  they run it against on a CPU.
+- `defaults.py` - `T2VApplicationDefaults`, what an integration contributes.
+  `from_runner_config` reads the frame size, rate, layout and rollout length off
+  the runner config the model package already ships, so nothing is written twice.
+- `application.py` - `T2VApplication`: the shared command line above, the model
+  loaded once and shared by every session, and the hooks an integration
+  overrides.
+- `session.py` - `T2VSession` and `T2VModelLoop`: one rollout. The session
+  encodes the prompt into a per-run cache in `init` and registers the model loop;
+  the loop generates one block per `step` and reports itself finished after
+  `--total-blocks`. No UI loop is registered, so the runtime's default blitter
+  presents the frames.
+- `testing.py` - the shared check an integration's tests call, and the stand-in
+  pipeline they call it against on a CPU.
 
 ## Adding a model
 
-Subclass `T2VApplication` with defaults from the integration's runner config.
-The shared session supplies the registered-loop runtime contract for all five
-packages. Override
-`_validate_total_blocks` for a model that generates its whole clip in one
-bidirectional block, and `_apply_compile_override` for one whose transformers
-the shared override does not reach.
+Four things, of which only the first is more than a few lines.
 
-Comparing the models against each other is
-[`configs/v2_model_benchmarks.json`](../../../configs/v2_model_benchmarks.json),
-and running it is [beside the harness](../../tools/benchmarks/README.md).
+**Subclass `T2VApplication`**, reading defaults off the runner config the model
+package already ships:
+
+```python
+class Wan21T2VApplication(T2VApplication):
+    def __init__(self, pipeline_config: Any | None = None) -> None:
+        defaults = T2VApplicationDefaults.from_runner_config(
+            RUNNER_WAN21_T2V_1PT3B_480P,
+            total_blocks=1,
+        )
+        if pipeline_config is not None:
+            defaults = dataclasses.replace(defaults, pipeline_config=pipeline_config)
+        super().__init__(defaults=defaults)
+
+
+def create_app() -> IApplication:
+    return Wan21T2VApplication()
+```
+
+The optional `pipeline_config` is what lets the CPU tests substitute a stand-in.
+`total_blocks` is passed explicitly only when the runner config states none,
+which is the case for a model that does not roll out.
+
+**Override a hook** if the model differs from the shared assumptions. All five
+are on `T2VApplication`, and most integrations override none:
+
+| Hook | Override it when |
+| --- | --- |
+| `_validate_total_blocks` | The model generates its whole clip at once, so a rollout has to be refused rather than quietly producing a second clip. |
+| `_apply_compile_override` | `--compile` does not reach every network. CausalWan 2.2 has a high-noise and a low-noise transformer, and the shared override reaches one. |
+| `_apply_seed_override` | The seed does not live on the diffusion model config. |
+| `_configure_argument_parser` | The model takes an argument the shared five do not. |
+| `_apply_parsed_arguments` | Something added by the hook above has to be kept. |
+
+There is also `session_type`, for a model needing a session other than
+`T2VSession`. Nothing overrides it today; a model whose step is not one
+autoregressive block would.
+
+**Write the `pyproject.toml`**, depending on `flashdreams` and the model package,
+and registering the slug:
+
+```toml
+[project.entry-points."flashdreams.applications_v2"]
+"t2v-wan21" = "t2v_wan21.app:create_app"
+```
+
+**Re-export `create_app`** from the package `__init__.py`, alongside the
+application class the tests import.
+
+## Testing a t2v integration
+
+Two files, split by what they need.
+
+`test_stand_in_model.py` is `ci_cpu` and covers only what is particular to this
+integration, which model it runs, its defaults, and any hook it overrode. Pass
+`FakeT2VPipelineConfig` in place of the checkpoint. For Wan 2.1 that is enough to
+check the defaults came off the runner config and that a rollout is refused,
+without generating anything.
+
+To generate, hand the whole application to `check_t2v_model_impl`:
+
+```python
+pytestmark = pytest.mark.ci_cpu
+
+def test_the_model_generates_from_a_prompt() -> None:
+    pipeline = FakeT2VPipeline()
+    result = check_t2v_model_impl(
+        SelfForcingT2VApplication(pipeline_config=FakeT2VPipelineConfig(pipeline)),
+        # The stand-in generates its own size rather than the checkpoint's, so
+        # it says so here rather than asking the application.
+        SessionDesc(
+            output_layout=VideoTensorLayout.tchw,
+            backpressure_mode=BackpressureMode.BLOCK,
+            presentation_mode=PresentationMode.ONLY_PRESENT_NEW,
+            video_width=pipeline.width,
+            video_height=pipeline.height,
+        ),
+        steps=3,
+        commandline_args=["--prompt", _PROMPT, "--device", "cpu"],
+        expected=ExpectedFrameStats(frame_count=33),
+    )
+    assert result.passed, result.failures
+```
+
+`check_t2v_model_impl` runs the whole path, the application initializes,
+resolves a session, generates, and the frames are read the way an output sink
+reads them, and returns what it measured alongside the expectations it missed.
+`ExpectedFrameStats` checks a frame count, a mean luminance band, and a minimum
+change between frames. Every field is optional, because a model that samples
+cannot be expected to produce a particular picture, only to produce a picture.
+
+Two details in that call are worth copying. `BLOCK` with `ONLY_PRESENT_NEW` is
+what makes the frame count assertable, since every generated frame is then
+presented exactly once. And `steps` is `run_session`'s own limit rather than
+`--total-blocks`, so a run stops at whichever comes first, which is why a
+stand-in test asking for more steps than the model's rollout length sees fewer
+frames than it expected.
+
+`test_real_model.py` is `ci_gpu` and downloads the checkpoint, so it asks to be
+run rather than running automatically:
+
+```python
+pytestmark = pytest.mark.ci_gpu
+
+_SKIP = real_model_run_skip_reason("T2V_WAN21_REAL_MODEL_RUN")
+
+@pytest.mark.skipif(_SKIP is not None, reason=_SKIP or "")
+def test_the_model_generates_a_clip_worth_watching(tmp_path: Path) -> None:
+    result = check_real_model_generates_a_clip(
+        Wan21T2VApplication(),
+        prompt=DEFAULT_PROMPT,
+        steps=1,
+        frame_count=81,
+        mp4_path=tmp_path / "clip.mp4",
+    )
+    assert result.passed, result.failures
+```
+
+`real_model_run_skip_reason` returns why the run cannot happen here, the
+environment variable is unset, there is no GPU, or `ffmpeg` is missing, or
+`None` when it can.
+
+Running them:
+
+```bash
+uv sync --package flashdreams-t2v-wan21 --group test --inexact
+uv run --no-sync pytest integrations_v2/t2v_wan21 -m ci_cpu -v
+```
+
+```bash
+T2V_WAN21_REAL_MODEL_RUN=1 uv run --no-sync pytest \
+    integrations_v2/t2v_wan21 -m ci_gpu -s --basetemp="$HOME/t2v-out"
+vlc "$HOME"/t2v-out/*current/clip.mp4
+```
+
+`--inexact` stops `uv` from uninstalling the workspace members it was not asked
+about, which the framework tests import. `--basetemp` under your home rather than
+`/tmp` is so a sandboxed player can see the file, since pytest's real `/tmp` is
+private to the test process.
+
+How a t2v application behaves in general is covered once, in
+`flashdreams/test_v2`, and a run reaching a real file once, in the Self-Forcing
+integration. An integration's own tests do not repeat either.
+
+## Where to go next
+
+- [Writing an integration](../../../integrations_v2/README.md) - for an
+  application that is not text-to-video.
+- [Architecture](../../../ARCHITECTURE.md) - how the layers a rollout runs
+  through fit together.
+- [v2 API protocols](../api_v2/README.md) - what `T2VApplication` implements.
+- [Runtime](../runtime_v2/README.md) - what runs a rollout, and the command line
+  that starts it.
+- [`configs/v2_model_benchmarks.json`](../../../configs/v2_model_benchmarks.json)
+  and the [benchmark harness](../../tools/benchmarks/README.md) - comparing the
+  models against each other.

--- a/flashdreams/flashdreams/t2v_v2/README.md
+++ b/flashdreams/flashdreams/t2v_v2/README.md
@@ -50,26 +50,23 @@ After the `--`, the same for every model, and listed by
 | `--compile` / `--no-compile` | Compile the network: minutes once, milliseconds a step. |
 | `--seed` | Seed the noise, so the same command generates the same clip. |
 
-`--no-compile` is usually right for a short clip. Compilation is on in most of
-the model configs, and paying minutes to save milliseconds a block is the wrong
-trade for a handful of blocks.
+Compilation is on in most of the model configs, so pass `--no-compile` for a
+short clip rather than paying minutes to save milliseconds a block.
 
 Before the `--` are `flashdreams-run-v2`'s own, including `--output-path`,
-`--pixel-width`, `--pixel-height` and `--fps`. Unasked, a model generates at the
-size and rate its checkpoint was trained for, which is what `session_desc()`
-answers with.
+`--pixel-width`, `--pixel-height`, `--fps` and `--layout`. Unasked, a model
+generates at the size and rate its checkpoint was trained for.
 
 ## What a t2v run generates
 
 `[-1, 1]` floats on whichever device `--device` loaded the model onto, in the
-layout the model's runner config declares,
-`tchw` for all five today. The frame size and rate are the checkpoint's, read off
-that runner config rather than written down in the integration.
+layout the model's runner config declares, `tchw` for all five today. The frame
+size and rate are the checkpoint's, read off that runner config rather than
+written down in the integration.
 
 Another size can be asked for with `--pixel-width` and `--pixel-height`, as long
-as each dimension is a whole number of latents across; the application checks
-against the decoder's spatial compression ratio, which is 8 for these models. A
-layout the model does not emit is refused before the checkpoint loads, since
+as each dimension is a multiple of 8, the decoder's spatial compression ratio. A
+`--layout` the model does not emit is refused before the checkpoint loads, since
 several gigabytes is a long wait for an answer of no.
 
 `--fps` sets the rate the frames are meant to play at, and so the rate an MP4
@@ -129,9 +126,8 @@ are on `T2VApplication`, and most integrations override none:
 | `_configure_argument_parser` | The model takes an argument the shared five do not. |
 | `_apply_parsed_arguments` | Something added by the hook above has to be kept. |
 
-There is also `session_type`, for a model needing a session other than
-`T2VSession`. Nothing overrides it today; a model whose step is not one
-autoregressive block would.
+There is also `session_type`, unused today, for a model whose step is not one
+autoregressive block and so needs a session other than `T2VSession`.
 
 **Write the `pyproject.toml`**, depending on `flashdreams` and the model package,
 and registering the slug:
@@ -180,11 +176,11 @@ def test_the_model_generates_from_a_prompt() -> None:
 ```
 
 `check_t2v_model_impl` runs the whole path, the application initializes,
-resolves a session, generates, and the frames are read the way an output sink
+resolves a session and generates, and the frames are read the way an output sink
 reads them, and returns what it measured alongside the expectations it missed.
-`ExpectedFrameStats` checks a frame count, a mean luminance band, and a minimum
-change between frames. Every field is optional, because a model that samples
-cannot be expected to produce a particular picture, only to produce a picture.
+`ExpectedFrameStats` checks a frame count, a mean luminance band and a minimum
+change between frames, every field optional, since a model that samples can only
+be expected to produce a picture, not a particular one.
 
 Two details in that call are worth copying. `BLOCK` with `ONLY_PRESENT_NEW` is
 what makes the frame count assertable, since every generated frame is then
@@ -213,20 +209,16 @@ def test_the_model_generates_a_clip_worth_watching(tmp_path: Path) -> None:
     assert result.passed, result.failures
 ```
 
-`real_model_run_skip_reason` returns why the run cannot happen here, the
-environment variable is unset, there is no GPU, or `ffmpeg` is missing, or
-`None` when it can.
+`real_model_run_skip_reason` returns why the run cannot happen here, no
+environment variable, no GPU, no `ffmpeg`, or `None` when it can.
 
 Each integration's own README carries the two commands that run these for its
-package. The real-model one writes under `$HOME` rather than `/tmp`, so that a
-sandboxed player can open the clip afterwards; pytest's real `/tmp` is private
-to the test process. The
+package, writing the real-model clip under `$HOME` so that a sandboxed player can
+open it afterwards. The
 [integration guide](../../../integrations_v2/README.md#testing-it) covers
-`--inexact` and the markers.
-
-How a t2v application behaves in general is covered once, in
-`flashdreams/test_v2`, and a run reaching a real file once, in the Self-Forcing
-integration. An integration's own tests do not repeat either.
+`--inexact` and the markers. General t2v behaviour is covered once in
+`flashdreams/test_v2`, and a run reaching a real file once in the Self-Forcing
+integration, so an integration's own tests repeat neither.
 
 ## Where to go next
 

--- a/flashdreams/flashdreams/t2v_v2/README.md
+++ b/flashdreams/flashdreams/t2v_v2/README.md
@@ -61,7 +61,8 @@ answers with.
 
 ## What a t2v run generates
 
-`[-1, 1]` floats on the GPU, in the layout the model's runner config declares —
+`[-1, 1]` floats on whichever device `--device` loaded the model onto, in the
+layout the model's runner config declares,
 `tchw` for all five today. The frame size and rate are the checkpoint's, read off
 that runner config rather than written down in the integration.
 
@@ -229,10 +230,10 @@ T2V_WAN21_REAL_MODEL_RUN=1 uv run --no-sync pytest \
 vlc "$HOME"/t2v-out/*current/clip.mp4
 ```
 
-`--inexact` stops `uv` from uninstalling the workspace members it was not asked
-about, which the framework tests import. `--basetemp` under your home rather than
-`/tmp` is so a sandboxed player can see the file, since pytest's real `/tmp` is
-private to the test process.
+`--basetemp` under your home rather than `/tmp` is so a sandboxed player can see
+the file, since pytest's real `/tmp` is private to the test process. The
+[integration guide](../../../integrations_v2/README.md#testing-it) covers
+`--inexact` and the markers.
 
 How a t2v application behaves in general is covered once, in
 `flashdreams/test_v2`, and a run reaching a real file once, in the Self-Forcing

--- a/flashdreams/test_v2/test_cli.py
+++ b/flashdreams/test_v2/test_cli.py
@@ -484,3 +484,46 @@ def test_the_run_goes_to_the_window_the_mode_asked_for(
 def test_the_command_needs_somewhere_to_write() -> None:
     with pytest.raises(SystemExit):
         cli.entrypoint(["stub"])
+
+
+class HelpfulApplication(IApplication):
+    """An application that parses its arguments, as every application does."""
+
+    def init(self, commandline_args: Sequence[str]) -> None:
+        parser = argparse.ArgumentParser(prog="flashdreams-run-v2 SLUG --")
+        parser.add_argument("--seconds", type=int, default=1, help="How long for.")
+        parser.parse_args(list(commandline_args))
+
+    def create_session(self, session_desc: SessionDesc) -> ISession:
+        return OneStepSession(session_desc)
+
+
+class RefusingMode(ClientWindowMode):
+    """A mode that fails if a run reaches its arguments or its window."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def check_arguments(self, parsed_args: argparse.Namespace) -> None:
+        del parsed_args
+        raise AssertionError("Application help must not check window arguments.")
+
+    def create(self, parsed_args: argparse.Namespace) -> IClientWindow:
+        del parsed_args
+        raise AssertionError("Application help must not create a window.")
+
+
+def test_an_application_describes_itself_without_a_window(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Only the application can say what it takes, and it needs no window to say
+    it. The default mode would otherwise refuse the run for want of an
+    ``--output-path`` that nothing was going to be written to."""
+    _install(monkeypatch, HelpfulApplication())
+    monkeypatch.setattr(cli, "client_window_mode", RefusingMode)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.entrypoint(["stub", "--", "--help"])
+
+    assert exit_info.value.code == 0
+    assert "--seconds" in capsys.readouterr().out

--- a/flashdreams/test_v2/test_v2_documentation.py
+++ b/flashdreams/test_v2/test_v2_documentation.py
@@ -108,19 +108,51 @@ def _repository_paths() -> tuple[str, ...]:
     return tuple(paths)
 
 
-def _file_name_resolves(span: str) -> bool:
-    """Return whether a backticked file name matches something that exists.
+_CONVENTION_NAMES = frozenset(
+    {
+        "__init__.py",
+        "app.py",
+        "pyproject.toml",
+        "test_real_model.py",
+        "test_stand_in_model.py",
+    }
+)
+"""Names that describe a convention every package follows, not one file.
 
-    Looser than a link, deliberately. Prose names a file the way the sentence
-    around it reads rather than relative to the document, so
+A guide saying an integration re-exports ``create_app`` from its
+``__init__.py``, or names its tests ``test_real_model.py``, means all of them
+at once. These match anywhere; everything else has to be placed.
+"""
+
+
+def _file_name_resolves(span: str, document: Path) -> bool:
+    """Return whether a backticked file name matches the file it meant.
+
+    Looser than a link, because prose names a file the way the sentence around
+    it reads rather than relative to the document:
     ``runtime_v2/client_window_factory.py`` appears in documents at three
     different depths and none of them mean it as a path. A whole path segment
-    has to match, so ``session.py`` does not resolve through
-    ``my_session.py``, but which ``session.py`` it meant is not checked.
+    still has to match, so ``session.py`` does not resolve through
+    ``my_session.py``.
+
+    Where the name is ambiguous it has to resolve under the document that names
+    it, so ``api_v2/README.md`` saying ``session.py`` means the one beside it
+    and fails if that is renamed, rather than passing on the strength of a
+    namesake in another package. A name unique in the repository, or one of the
+    conventions above, is accepted from anywhere.
     """
-    return any(
-        path == span or path.endswith(f"/{span}") for path in _repository_paths()
-    )
+    matches = [
+        path
+        for path in _repository_paths()
+        if path == span or path.endswith(f"/{span}")
+    ]
+    if not matches:
+        return False
+    if len(matches) == 1 or span.rsplit("/", 1)[-1] in _CONVENTION_NAMES:
+        return True
+    directory = document.parent
+    prefix = "" if directory == _ROOT else f"{directory.relative_to(_ROOT)}/"
+    return any(path.startswith(prefix) for path in matches)
 
 
 def _links(document: Path) -> list[str]:
@@ -186,7 +218,11 @@ def test_v2_documentation_file_names_exist(relative_path: str) -> None:
     """Every backticked file name matches a file somewhere in the repository."""
     document = _ROOT / relative_path
     broken = sorted(
-        {span for span in _file_names(document) if not _file_name_resolves(span)}
+        {
+            span
+            for span in _file_names(document)
+            if not _file_name_resolves(span, document)
+        }
     )
 
     assert not broken, f"{relative_path} names files that do not exist: {broken}"

--- a/flashdreams/test_v2/test_v2_documentation.py
+++ b/flashdreams/test_v2/test_v2_documentation.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check that the v2 documentation still points at things that exist.
+
+Nothing else reads the v2 Markdown, so a renamed module leaves a reference
+behind and nobody finds out until someone follows it. This checks the two kinds
+of reference that can be checked mechanically: relative links, and backticked
+file names.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci_cpu
+
+_FENCED_BLOCK = re.compile(r"^```.*?^```", re.MULTILINE | re.DOTALL)
+"""Fenced code block, stripped before extraction.
+
+Examples are allowed to name files that do not exist, such as the placeholder
+``test_<name>.py`` in the integration guide's directory listing.
+"""
+
+_MARKDOWN_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+"""Markdown inline link, capturing its target."""
+
+_BACKTICKED = re.compile(r"`([^`\n]+)`")
+"""Single-backticked span, capturing its contents."""
+
+_FILE_SUFFIXES = (".py", ".md", ".json", ".toml", ".yml", ".sh")
+"""Suffixes that make a backticked span worth resolving as a file."""
+
+
+def _repository_root() -> Path:
+    """Return the repository root, found by looking for ``integrations_v2``."""
+    for directory in Path(__file__).resolve().parents:
+        if (directory / "integrations_v2").is_dir():
+            return directory
+    raise AssertionError("Could not find the repository root from this test file.")
+
+
+_ROOT = _repository_root()
+
+_DOCUMENTS = (
+    "ARCHITECTURE.md",
+    "flashdreams/flashdreams/api_v2/README.md",
+    "flashdreams/flashdreams/runtime_v2/README.md",
+    "flashdreams/flashdreams/t2v_v2/README.md",
+    "integrations_v2/README.md",
+    *sorted(
+        str(path.relative_to(_ROOT))
+        for path in (_ROOT / "integrations_v2").glob("*/README.md")
+    ),
+)
+"""Every v2 Markdown document, listed so a missing one fails rather than passes."""
+
+
+def _prose(document: Path) -> str:
+    """Return ``document`` with its fenced code blocks removed."""
+    return _FENCED_BLOCK.sub("", document.read_text(encoding="utf-8"))
+
+
+def _resolves(reference: str, document: Path) -> bool:
+    """Return whether ``reference`` names something that exists.
+
+    A reference carrying a directory is resolved against the document's own
+    directory and each of its ancestors, so both ``../api_v2/README.md`` and
+    ``runtime_v2/client_window_factory.py`` reach their target. A bare file name
+    is accepted if anything in the repository is called that, which is enough to
+    catch a module that was renamed or never existed.
+    """
+    if "/" in reference:
+        for directory in (document.parent, *document.parent.parents):
+            if (directory / reference).exists():
+                return True
+            if directory == _ROOT:
+                break
+        return False
+    return any(_ROOT.rglob(reference))
+
+
+def _file_references(document: Path) -> list[str]:
+    """Return the relative links and backticked file names in ``document``."""
+    prose = _prose(document)
+    references = [
+        target.split("#", 1)[0]
+        for target in _MARKDOWN_LINK.findall(prose)
+        if not target.startswith(("http://", "https://", "#"))
+    ]
+    references += [
+        span
+        for span in _BACKTICKED.findall(prose)
+        if span.endswith(_FILE_SUFFIXES) and " " not in span
+    ]
+    return [reference for reference in references if reference]
+
+
+@pytest.mark.parametrize("relative_path", _DOCUMENTS)
+def test_every_v2_document_exists(relative_path: str) -> None:
+    """The documents this checks are the documents that are there."""
+    assert (_ROOT / relative_path).is_file(), (
+        f"{relative_path} is listed here but not in the repository."
+    )
+
+
+@pytest.mark.parametrize("relative_path", _DOCUMENTS)
+def test_v2_documentation_references_resolve(relative_path: str) -> None:
+    """Every link and backticked file name reaches something."""
+    document = _ROOT / relative_path
+    broken = sorted(
+        {
+            reference
+            for reference in _file_references(document)
+            if not _resolves(reference, document)
+        }
+    )
+
+    assert not broken, f"{relative_path} refers to files that do not exist: {broken}"

--- a/flashdreams/test_v2/test_v2_documentation.py
+++ b/flashdreams/test_v2/test_v2_documentation.py
@@ -9,6 +9,8 @@ of reference that can be checked mechanically: relative links, and backticked
 file names.
 """
 
+import functools
+import os
 import re
 from pathlib import Path
 
@@ -32,6 +34,16 @@ _BACKTICKED = re.compile(r"`([^`\n]+)`")
 _FILE_SUFFIXES = (".py", ".md", ".json", ".toml", ".yml", ".sh")
 """Suffixes that make a backticked span worth resolving as a file."""
 
+_IGNORED_DIRECTORIES = frozenset(
+    {".git", ".venv", "__pycache__", ".pytest_cache", ".ruff_cache", "node_modules"}
+)
+"""Directories to keep out of the file index, alongside any ``.egg-info``.
+
+Build output is skipped so that a package left half-installed cannot make a
+reference to it resolve. ``integrations_v2/omnidreams`` is the live example: an
+``egg-info`` and stale bytecode with no source beside them.
+"""
+
 
 def _repository_root() -> Path:
     """Return the repository root, found by looking for ``integrations_v2``."""
@@ -48,6 +60,8 @@ _DOCUMENTS = (
     "flashdreams/flashdreams/api_v2/README.md",
     "flashdreams/flashdreams/runtime_v2/README.md",
     "flashdreams/flashdreams/t2v_v2/README.md",
+    "flashdreams/test_v2/README.md",
+    "flashdreams/tools/benchmarks/README.md",
     "integrations_v2/README.md",
     *sorted(
         str(path.relative_to(_ROOT))
@@ -75,19 +89,37 @@ def _link_resolves(target: str, document: Path) -> bool:
     return destination.is_relative_to(_ROOT) and destination.exists()
 
 
+@functools.lru_cache(maxsize=1)
+def _repository_paths() -> tuple[str, ...]:
+    """Return every file in the repository, relative to its root.
+
+    Built once and scanned per reference, rather than walking the tree once per
+    reference.
+    """
+    paths: list[str] = []
+    for directory, subdirectories, file_names in os.walk(_ROOT):
+        subdirectories[:] = [
+            name
+            for name in subdirectories
+            if name not in _IGNORED_DIRECTORIES and not name.endswith(".egg-info")
+        ]
+        relative = Path(directory).relative_to(_ROOT)
+        paths.extend(str(relative / name) for name in file_names)
+    return tuple(paths)
+
+
 def _file_name_resolves(span: str) -> bool:
     """Return whether a backticked file name matches something that exists.
 
     Looser than a link, deliberately. Prose names a file the way the sentence
     around it reads rather than relative to the document, so
     ``runtime_v2/client_window_factory.py`` appears in documents at three
-    different depths and none of them mean it as a path. Anything whose path
-    ends with the span therefore counts, which still catches the thing these
-    get wrong: a module renamed, or never written.
+    different depths and none of them mean it as a path. A whole path segment
+    has to match, so ``session.py`` does not resolve through
+    ``my_session.py``, but which ``session.py`` it meant is not checked.
     """
     return any(
-        str(path.relative_to(_ROOT)).endswith(span)
-        for path in _ROOT.rglob(span.rsplit("/", 1)[-1])
+        path == span or path.endswith(f"/{span}") for path in _repository_paths()
     )
 
 
@@ -116,6 +148,22 @@ def test_every_v2_document_exists(relative_path: str) -> None:
     """The documents this checks are the documents that are there."""
     assert (_ROOT / relative_path).is_file(), (
         f"{relative_path} is listed here but not in the repository."
+    )
+
+
+@pytest.mark.parametrize("relative_path", _DOCUMENTS)
+def test_v2_documentation_fences_are_balanced(relative_path: str) -> None:
+    """Fences pair up, so stripping code blocks cannot swallow a document.
+
+    ``_FENCED_BLOCK`` pairs fences in order. An odd one out would silently take
+    the rest of the file with it, and every reference after it would go
+    unchecked.
+    """
+    document = _ROOT / relative_path
+    fences = re.findall(r"^```", document.read_text(encoding="utf-8"), re.MULTILINE)
+
+    assert len(fences) % 2 == 0, (
+        f"{relative_path} has {len(fences)} code fences, so one is unclosed."
     )
 
 

--- a/flashdreams/test_v2/test_v2_documentation.py
+++ b/flashdreams/test_v2/test_v2_documentation.py
@@ -62,39 +62,53 @@ def _prose(document: Path) -> str:
     return _FENCED_BLOCK.sub("", document.read_text(encoding="utf-8"))
 
 
-def _resolves(reference: str, document: Path) -> bool:
-    """Return whether ``reference`` names something that exists.
+def _link_resolves(target: str, document: Path) -> bool:
+    """Return whether a link reaches a file, resolved the way a reader's does.
 
-    A reference carrying a directory is resolved against the document's own
-    directory and each of its ancestors, so both ``../api_v2/README.md`` and
-    ``runtime_v2/client_window_factory.py`` reach their target. A bare file name
-    is accepted if anything in the repository is called that, which is enough to
-    catch a module that was renamed or never existed.
+    Against the document's own directory and nowhere else, because that is what
+    a Markdown renderer does with a relative link. A link is clickable, so a
+    target that only happens to exist somewhere else in the repository is
+    broken for the reader and fails here. A target climbing out of the
+    repository fails too, having nothing to reach.
     """
-    if "/" in reference:
-        for directory in (document.parent, *document.parent.parents):
-            if (directory / reference).exists():
-                return True
-            if directory == _ROOT:
-                break
-        return False
-    return any(_ROOT.rglob(reference))
+    destination = (document.parent / target).resolve()
+    return destination.is_relative_to(_ROOT) and destination.exists()
 
 
-def _file_references(document: Path) -> list[str]:
-    """Return the relative links and backticked file names in ``document``."""
-    prose = _prose(document)
-    references = [
-        target.split("#", 1)[0]
-        for target in _MARKDOWN_LINK.findall(prose)
+def _file_name_resolves(span: str) -> bool:
+    """Return whether a backticked file name matches something that exists.
+
+    Looser than a link, deliberately. Prose names a file the way the sentence
+    around it reads rather than relative to the document, so
+    ``runtime_v2/client_window_factory.py`` appears in documents at three
+    different depths and none of them mean it as a path. Anything whose path
+    ends with the span therefore counts, which still catches the thing these
+    get wrong: a module renamed, or never written.
+    """
+    return any(
+        str(path.relative_to(_ROOT)).endswith(span)
+        for path in _ROOT.rglob(span.rsplit("/", 1)[-1])
+    )
+
+
+def _links(document: Path) -> list[str]:
+    """Return the in-repository link targets in ``document``, anchors stripped."""
+    return [
+        stripped
+        for target in _MARKDOWN_LINK.findall(_prose(document))
         if not target.startswith(("http://", "https://", "#"))
+        for stripped in [target.split("#", 1)[0]]
+        if stripped
     ]
-    references += [
+
+
+def _file_names(document: Path) -> list[str]:
+    """Return the backticked spans in ``document`` that name a file."""
+    return [
         span
-        for span in _BACKTICKED.findall(prose)
+        for span in _BACKTICKED.findall(_prose(document))
         if span.endswith(_FILE_SUFFIXES) and " " not in span
     ]
-    return [reference for reference in references if reference]
 
 
 @pytest.mark.parametrize("relative_path", _DOCUMENTS)
@@ -106,15 +120,25 @@ def test_every_v2_document_exists(relative_path: str) -> None:
 
 
 @pytest.mark.parametrize("relative_path", _DOCUMENTS)
-def test_v2_documentation_references_resolve(relative_path: str) -> None:
-    """Every link and backticked file name reaches something."""
+def test_v2_documentation_links_resolve(relative_path: str) -> None:
+    """Every link reaches a file from where the document that carries it sits."""
     document = _ROOT / relative_path
     broken = sorted(
-        {
-            reference
-            for reference in _file_references(document)
-            if not _resolves(reference, document)
-        }
+        {target for target in _links(document) if not _link_resolves(target, document)}
     )
 
-    assert not broken, f"{relative_path} refers to files that do not exist: {broken}"
+    assert not broken, (
+        f"{relative_path} links to targets that do not resolve from "
+        f"{document.parent.relative_to(_ROOT) or '.'}: {broken}"
+    )
+
+
+@pytest.mark.parametrize("relative_path", _DOCUMENTS)
+def test_v2_documentation_file_names_exist(relative_path: str) -> None:
+    """Every backticked file name matches a file somewhere in the repository."""
+    document = _ROOT / relative_path
+    broken = sorted(
+        {span for span in _file_names(document) if not _file_name_resolves(span)}
+    )
+
+    assert not broken, f"{relative_path} names files that do not exist: {broken}"

--- a/integrations_v2/README.md
+++ b/integrations_v2/README.md
@@ -37,9 +37,11 @@ integrations_v2/<name>/
       test_<name>.py
 ```
 
-Nothing enforces this shape, but every integration follows it, and the workspace
-glob in the root `pyproject.toml` picks up any directory here that has a
-`pyproject.toml`.
+Nothing enforces this shape, and it bends where a package has more than one
+application: `slangpy_ui_demo` names a module per application rather than
+`app.py`, and the t2v integrations split their tests into
+`test_stand_in_model.py` and `test_real_model.py`. The workspace glob in the
+root `pyproject.toml` picks up any directory here that has a `pyproject.toml`.
 
 ## The package metadata
 
@@ -53,22 +55,24 @@ name = "flashdreams-color-fade"
 requires-python = ">=3.10"
 dependencies = ["flashdreams"]
 
-[project.entry-points."flashdreams.applications_v2"]
-"color-fade" = "color_fade.app:create_app"
-
 [tool.uv.sources]
 flashdreams = { workspace = true }
 
 [tool.setuptools.packages.find]
 include = ["color_fade*"]
+
+# color_fade registers no entry point and is found by the module fallback below.
+# Anything real should register one, the way t2v_self_forcing does:
+[project.entry-points."flashdreams.applications_v2"]
+"t2v-self-forcing" = "t2v_self_forcing.app:create_app"
 ```
 
 An integration depends on the framework and never the reverse. `tool.uv.sources`
 resolves `flashdreams` from this repository while developing; a published
 integration would resolve a released version instead. A real model adds its
-model package alongside, also as a workspace source, and the browser
-integrations depend on `flashdreams[local-window,serving]` rather than plain
-`flashdreams`.
+model package alongside, also as a workspace source. An integration that streams
+to a browser depends on `flashdreams[serving]`, and `slangpy_ui_demo` adds
+`local-window` on top of that for its renderer.
 
 ## Being found
 
@@ -189,8 +193,8 @@ ApplicationRunner(create_app(), Mp4ClientWindow(path)).run(session_desc, args)
 
 ## Testing it
 
-Every test carries exactly one of the `ci_cpu`, `ci_gpu` or `manual` markers,
-enforced by a pytest plugin, so a file usually sets `pytestmark` once:
+Every test carries a `ci_cpu`, `ci_gpu` or `manual` marker, enforced by a pytest
+plugin, so a file usually sets `pytestmark` once:
 
 ```python
 pytestmark = pytest.mark.ci_cpu

--- a/integrations_v2/README.md
+++ b/integrations_v2/README.md
@@ -1,0 +1,239 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+Applications built on the v2 API. Each directory is a standalone package that
+depends on `flashdreams` and holds no framework code of its own.
+
+This is the guide to writing one. If the model generates video from a prompt,
+read [`flashdreams.t2v_v2`](../flashdreams/flashdreams/t2v_v2/README.md)
+instead, that path is a subclass and a `pyproject.toml`, and most of what
+follows is already done for you.
+
+## What is here
+
+- `color_fade` — the smallest integration that writes a file. No model, CPU
+  only, and the worked example for the rest of this guide.
+- `red_screen` — the smallest interactive one, streaming to a browser.
+- `slangpy_ui_demo` — three applications that draw widgets over model output,
+  and the reference for writing a UI loop.
+- `t2v_self_forcing`, `t2v_causal_forcing`, `t2v_fastvideo_causal_wan22`,
+  `t2v_wan21`, `t2v_cosmos_predict2` — real models, each a thin wrapper over
+  `flashdreams.t2v_v2`.
+- `null_model` — not an application. A v1 pipeline the framework tests use as a
+  fixture.
+
+## The layout
+
+```text
+integrations_v2/<name>/
+  pyproject.toml
+  README.md
+  <package>/
+    __init__.py        # exports create_app
+    app.py             # IApplication, ISession, IModelLoop
+    tests/
+      test_<name>.py
+```
+
+Nothing enforces this shape, but every integration follows it, and the workspace
+glob in the root `pyproject.toml` picks up any directory here that has a
+`pyproject.toml`.
+
+## The package metadata
+
+The parts that matter, taking
+[`color_fade`](color_fade/pyproject.toml) as the shape and
+[`t2v_self_forcing`](t2v_self_forcing/pyproject.toml) for the entry point:
+
+```toml
+[project]
+name = "flashdreams-color-fade"
+requires-python = ">=3.10"
+dependencies = ["flashdreams"]
+
+[project.entry-points."flashdreams.applications_v2"]
+"color-fade" = "color_fade.app:create_app"
+
+[tool.uv.sources]
+flashdreams = { workspace = true }
+
+[tool.setuptools.packages.find]
+include = ["color_fade*"]
+```
+
+An integration depends on the framework and never the reverse. `tool.uv.sources`
+resolves `flashdreams` from this repository while developing; a published
+integration would resolve a released version instead. A real model adds its
+model package alongside, also as a workspace source, and the browser
+integrations depend on `flashdreams[local-window,serving]` rather than plain
+`flashdreams`.
+
+## Being found
+
+`flashdreams-run-v2` takes a slug and resolves it two ways, in order. A
+registered `flashdreams.applications_v2` entry point wins. Failing that, the slug
+is read as a module name with hyphens turned into underscores, and that module
+must expose `create_app`.
+
+The fallback is why `color_fade` and `red_screen` run while registering nothing:
+the slug `color-fade` finds the `color_fade` package, whose `__init__.py`
+re-exports `create_app`. Every t2v integration and `slangpy_ui_demo` register
+properly instead. Do the same for anything real, so the slug is listed by
+`flashdreams-run-v2 --help` rather than having to be known already.
+
+`create_app` takes no arguments and returns an uninitialized `IApplication`. It
+must not load anything; that is what `init` is for.
+
+## What to implement
+
+Three classes, and a fourth only if you want custom UI. The full versions are in
+[`color_fade/color_fade/app.py`](color_fade/color_fade/app.py).
+
+**The application** parses its own arguments and holds whatever its sessions
+share. Arguments arrive as a list, after `--` on the command line, so it owns a
+parser of its own and may reuse names the runtime also uses:
+
+```python
+class ColorFadeApplication(IApplication):
+    def init(self, commandline_args: Sequence[str]) -> None:
+        parser = argparse.ArgumentParser(prog="color-fade")
+        parser.add_argument("--seconds", type=float, default=10.0)
+        args = parser.parse_args(list(commandline_args))
+        self._config = ColorFadeConfig(seconds=args.seconds)
+
+    def create_session(self, session_desc: SessionDesc) -> ISession:
+        return ColorFadeSession(self._config, session_desc)
+```
+
+Validate arguments here rather than at the first step. `color_fade` rejects a
+fade of `nan` seconds because every frame would then be `nan`, and `nan` frames
+reach an output sink as a picture rather than as an error.
+
+An application may also implement `session_desc` to say what it would generate
+before it has loaded anything, which is how a real model reports the frame size
+its checkpoint was trained for. Returning `None`, the default, means it
+generates whatever it is asked for.
+
+**The session** is one run. It checks the description it was handed, registers a
+model loop in `init`, and reports the description back:
+
+```python
+class ColorFadeSession(ISession):
+    def __init__(self, config: ColorFadeConfig, session_desc: SessionDesc) -> None:
+        if session_desc.output_layout is not VideoTensorLayout.bcthw:
+            raise ValueError("Colour fade only produces bcthw output.")
+        self._session_desc = session_desc
+
+    def init(self) -> None:
+        self.register_model_loop(ColorFadeModelLoop, state=...)
+
+    @property
+    def session_desc(self) -> SessionDesc:
+        return self._session_desc
+```
+
+Reject a description you cannot honour, in the constructor or in
+`create_session`. A session that quietly ignores the layout it was asked for
+produces tensors an output sink then refuses, much further along.
+
+**The model loop** generates. It returns a list of channels, and it decides when
+the run is over:
+
+```python
+class ColorFadeModelLoop(IModelLoop[ColorFadeModelState]):
+    def step(self, step_index: int, events: UserInputEvents) -> list[StepResult]:
+        del events
+        self.state.steps_generated += 1
+        return [StepResult(step_index=step_index, output=..., frame_count=8,
+                           output_layout=self.state.session_desc.output_layout)]
+
+    def is_finished(self) -> bool:
+        return self.state.steps_generated >= self.state.total_steps
+
+    def reset(self) -> None:
+        self.state.steps_generated = 0
+```
+
+Three things catch people out here. A model loop must return a `list`, even of
+one channel. `is_finished` is what ends a run writing to a file, since an MP4
+window never sends a close event. And `reset` raises by default, so implement it
+even when the body is one line — a browser client can ask for one at any time.
+
+Register no UI loop unless you need one. The default composites every model
+channel into one frame, which is what all of these except `slangpy_ui_demo` do.
+
+## Running it
+
+```bash
+uv sync --package flashdreams-color-fade --inexact
+uv run --no-sync flashdreams-run-v2 color-fade --output-path fade.mp4 -- --seconds 4
+```
+
+Arguments before `--` belong to the runtime, after it to the application, so
+`flashdreams-run-v2 color-fade -- --help` describes the application. Writing an
+MP4 needs `ffmpeg` on `PATH` and a frame size even in both directions.
+
+To stream to a browser instead:
+
+```bash
+uv run --no-sync flashdreams-run-v2 red-screen --mode webrtc
+```
+
+Driving it from Python takes the same two objects the command line builds:
+
+```python
+ApplicationRunner(create_app(), Mp4ClientWindow(path)).run(session_desc, args)
+```
+
+## Testing it
+
+Every test carries exactly one of the `ci_cpu`, `ci_gpu` or `manual` markers,
+enforced by a pytest plugin, so a file usually sets `pytestmark` once:
+
+```python
+pytestmark = pytest.mark.ci_cpu
+```
+
+An integration with no model should be entirely `ci_cpu`, testing the session
+directly by stepping its model loop, and end to end through `ApplicationRunner`
+against a real `Mp4ClientWindow`. Skip the file tests when `ffmpeg` is missing
+rather than failing them. For interactive integrations, drive input with a
+scripted `IClientWindow`, as `red_screen` does.
+
+```bash
+uv sync --package flashdreams-color-fade --group test --inexact
+uv run --no-sync pytest integrations_v2/color_fade -m ci_cpu -v
+```
+
+`--inexact` matters: without it `uv` uninstalls the workspace members it was not
+asked about, which the framework tests import.
+
+Point an end-to-end test at a size a player will open, and write it somewhere you
+can watch it:
+
+```bash
+uv run --no-sync pytest integrations_v2/color_fade -k mp4 --basetemp="$HOME/fade-out"
+vlc "$HOME"/fade-out/*current/fade.mp4
+```
+
+Use a throwaway directory under your home rather than `/tmp`: pytest clears the
+base temp before using it, and a sandboxed player gets a private `/tmp` and
+cannot see files in the real one.
+
+A real model needs a second file. Keep the CPU tests on a stand-in pipeline and
+put the run that loads a checkpoint behind `ci_gpu` and an environment variable,
+so a GPU runner opts in explicitly. `flashdreams.t2v_v2.testing` provides both
+halves for text-to-video models.
+
+## Where to go next
+
+- [Architecture](../ARCHITECTURE.md) - how an application, a session and the
+  runtime fit together, and the two threads your loops run on.
+- [v2 API protocols](../flashdreams/flashdreams/api_v2/README.md) - the contracts
+  in detail.
+- [Runtime](../flashdreams/flashdreams/runtime_v2/README.md) - the buffering
+  between those threads, and the command line that starts them.
+- [`flashdreams.t2v_v2`](../flashdreams/flashdreams/t2v_v2/README.md) - adding a
+  text-to-video model.

--- a/integrations_v2/color_fade/README.md
+++ b/integrations_v2/color_fade/README.md
@@ -5,48 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 
 # Colour Fade
 
-Smallest end-to-end application that writes a file. It holds no model: a session
-emits solid frames fading from red to green over a fixed number of seconds, and
-finishes once it has. It runs the whole file path — `IApplication`, `ISession`,
-`ApplicationRunner`, `run_session`, `Mp4ClientWindow`, `Mp4OutputSink`, on CPU.
+Smallest end-to-end application that writes a file, and the worked example in the
+[integration guide](../README.md). It holds no model: a session emits solid frames
+fading from red to green over a fixed number of seconds, and finishes once it
+has. That exercises the whole file path — `IApplication`, `ISession`,
+`ApplicationRunner`, `run_session`, `Mp4ClientWindow`, `Mp4OutputSink` — on CPU.
 
 `red_screen` is the interactive counterpart. This one responds to nothing, which
 is what makes the file it writes the same on every run.
 
+## Generate a fade
+
+```bash
+uv sync --package flashdreams-color-fade --inexact
+uv run --no-sync flashdreams-run-v2 color-fade --output-path fade.mp4 \
+    -- --seconds 4
+```
+
 Writing an MP4 needs an `ffmpeg` executable on `PATH`, and a frame size that is
-even in both directions.
-
-## Tests
-
-Run from the repository root. The tests that write a file are skipped when
-`ffmpeg` is missing.
-
-```bash
-uv sync --package flashdreams-color-fade --package flashdreams-red-screen --package flashdreams-null-model --group test --inexact
-uv run --no-sync pytest integrations_v2/color_fade -m ci_cpu -v
-```
-
-Together with the framework tests:
-
-```bash
-uv run --no-sync pytest flashdreams/test_v2 integrations_v2 -m ci_cpu -v
-```
-
-`--inexact` matters: it stops `uv` from uninstalling the other workspace members
-it was not asked about, which the framework tests import.
-
-The end-to-end test writes a real 854x480 file, a size a player will open, so it
-can be watched as well as asserted on:
-
-```bash
-uv run --no-sync pytest integrations_v2/color_fade -k mp4 --basetemp="$HOME/fade-out"
-vlc "$HOME"/fade-out/*current/fade.mp4
-```
-
-Point `--basetemp` at a throwaway directory under your home rather than `/tmp`:
-pytest clears it before using it, and a sandboxed player gets a private `/tmp`
-and cannot see files in the real one. `*current` is the symlink pytest points at
-the newest run.
+even in both directions. The run ends on its own: the session knows how long its
+fade is, so nothing has to pass a step count.
 
 ## Arguments
 
@@ -55,10 +33,27 @@ the newest run.
 | `--seconds` | `10` | How long the fade from red to green takes. |
 | `--frames-per-step` | `8` | Frames one step generates. A frame's colour comes from when it plays, so this does not change the video. |
 
-The frame width and height come from the `SessionDesc`, along with the rate the
-frames are meant to play at. How long the run lasts comes from `--seconds`: the
-session reports itself finished once it has generated that much fade, so the
-caller driving it passes no step count.
+Frame width, height and playback rate come from the `SessionDesc`, so they are
+set with `--pixel-width`, `--pixel-height` and `--fps` before the `--`.
 
 Output is a `[1, 3, frames_per_step, H, W]` float32 tensor in `bcthw` layout,
-carrying `[-1, 1]` values.
+carrying `[-1, 1]` values. Any other layout is refused.
+
+## Tests
+
+```bash
+uv sync --package flashdreams-color-fade --group test --inexact
+uv run --no-sync pytest integrations_v2/color_fade -m ci_cpu -v
+```
+
+The tests that write a file are skipped when `ffmpeg` is missing. The end-to-end
+one writes a real 854x480 file, a size a player will open, so it can be watched
+as well as asserted on:
+
+```bash
+uv run --no-sync pytest integrations_v2/color_fade -k mp4 --basetemp="$HOME/fade-out"
+vlc "$HOME"/fade-out/*current/fade.mp4
+```
+
+See the [integration guide](../README.md) for what `--inexact` and `--basetemp`
+are doing there.

--- a/integrations_v2/null_model/README.md
+++ b/integrations_v2/null_model/README.md
@@ -26,7 +26,7 @@ For a v2 application to copy, use
 
 ## Files
 
-| File | |
+| File | What it does |
 | --- | --- |
 | `config.py` | Defines the null-model pipeline. |
 | `encoder.py` | Adds 100 to the input, as minor obfuscation. |

--- a/integrations_v2/null_model/README.md
+++ b/integrations_v2/null_model/README.md
@@ -5,15 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 
 # FlashDreams NULL Model
 
-**Not a v2 application.** This is a v1 pipeline — an encoder, transformer,
-scheduler and decoder — whose output is arithmetic rather than video, so the
-framework tests can drive a whole pipeline without a checkpoint. It implements
-none of the v2 protocols and is not reachable through `flashdreams-run-v2`.
+A simple pipeline wth an encoder, transformer, scheduler and decoder, whose output
+is arithmetic rather than video, so it needs no checkpoint and runs on a CPU. It
+was written alongside the v2 protocols as the pipeline they were developed against,
+something whole that could be driven end to end while they were still changing,
+which is why it sits here rather than under `integrations/`.
 
-For a v2 application to copy, use
-[`color_fade`](../color_fade/README.md) for the file path or
-[`red_screen`](../red_screen/README.md) for the interactive one, and read the
-[integration guide](../README.md). What follows is about the pipeline.
+`flashdreams/test_v2/test_client_window.py` still drives it that way, through
+`IClientWindow`, `InputSource` and `OutputSink`. It implements none of those
+itself and registers no entry point, so `flashdreams-run-v2` cannot reach it. For
+a v2 application to copy, use [`color_fade`](../color_fade/README.md) for the
+file path or [`red_screen`](../red_screen/README.md) for the interactive one, and
+read the [integration guide](../README.md). What follows is about the pipeline.
 
 ## Observable contract
 
@@ -53,8 +56,7 @@ NULL_MODEL_CONFIG = NullModelConfig(
 ### A real integration package
 
 [`pyproject.toml`](pyproject.toml) declares `flashdreams-null-model` as a
-workspace package depending on `flashdreams`. Keeping it isolated lets it declare
-dependencies without affecting the other integrations.
+workspace package depending on `flashdreams`.
 
 ### The per-step encoder
 

--- a/integrations_v2/null_model/README.md
+++ b/integrations_v2/null_model/README.md
@@ -4,81 +4,100 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 # FlashDreams NULL Model
+
+**Not a v2 application.** This is a v1 pipeline — an encoder, transformer,
+scheduler and decoder — whose output is arithmetic rather than video, so the
+framework tests can drive a whole pipeline without a checkpoint. It implements
+none of the v2 protocols and is not reachable through `flashdreams-run-v2`.
+
+For a v2 application to copy, use
+[`color_fade`](../color_fade/README.md) for the file path or
+[`red_screen`](../red_screen/README.md) for the interactive one, and read the
+[integration guide](../README.md). What follows is about the pipeline.
+
 ## Observable contract
 
 | Property | Value |
 | --- | --- |
 | Input | Tensor with shape `[1, 1]` |
 | Output shape | Tensor with shape `[1, 3, 1, 1, 1]` |
-| Output value | Output is `Input + cache.autoregressive_index` |
+| Output value | `Input + cache.autoregressive_index` |
 | Output layout | `VideoTensorLayout.bcthw` |
 
 ## Files
 
-`config.py`           Defines the 'null model' pipeline
-`encoder.py`          Adds 100 to the input for minor obfuscation
-`transformer.py`      Processes the encoded-input into a latent/flow that scheduler must 'denoise'
-`decoder.py`          Removes the minor obfuscation created by the encoder by subtracting 100
+| File | |
+| --- | --- |
+| `config.py` | Defines the null-model pipeline. |
+| `encoder.py` | Adds 100 to the input, as minor obfuscation. |
+| `transformer.py` | Turns the encoded input into a flow for the scheduler to denoise. |
+| `decoder.py` | Subtracts the 100 back off. |
 
 ```python
 NULL_MODEL_CONFIG = NullModelConfig(
     name="null-model",
-    encoder=NullInputEncoderConfig(), # Encoder of inputs
-    diffusion_model=DiffusionModelConfig( # "Archtype" of our pipeline
-        transformer=NullTransformerConfig(), # Transformer
-        scheduler=FlowMatchSchedulerConfig( # Scheduler
+    encoder=NullInputEncoderConfig(),
+    diffusion_model=DiffusionModelConfig(
+        transformer=NullTransformerConfig(),
+        scheduler=FlowMatchSchedulerConfig(
             num_inference_steps=1,
             denoising_timesteps=[1000],
         ),
     ),
-    decoder=NullDecoderConfig(), # Decoder of latents/output-tensor
+    decoder=NullDecoderConfig(),
 )
 ```
 
-## How the integration was designed, step by step
+## How the pipeline is put together
 
-### Make a real integration package
+### A real integration package
 
 [`pyproject.toml`](pyproject.toml) declares `flashdreams-null-model` as a
-workspace package that depends on `flashdreams`. This issolated `pyproject.toml`
-This keeps our integration isolated so it can safely declare dependencies without
-affecting other integrations.
+workspace package depending on `flashdreams`. Keeping it isolated lets it declare
+dependencies without affecting the other integrations.
 
-### Implement the per-step encoder
+### The per-step encoder
 
 [`encoder.py`](null_model/encoder.py) defines `NullInputEncoder` as a
-`StreamingEncoder` (bound in config to `NullModelConfig::encoder`).
-This is important because it allows us to define an encoder that runs for each auto-regressive step.
-This contrasts the `NullModelConfig::diffusion_model::transformer::context_encoder` which is designed to run only once at the beginning of a session for generation.
+`StreamingEncoder`, bound in the config to `NullModelConfig.encoder`. A streaming
+encoder runs on every autoregressive step, unlike
+`NullModelConfig.diffusion_model.transformer.context_encoder`, which runs once at
+the start of a generation.
 
-The encoder performs minor obfuscation by adding 100 to the 1 by 1 input tensor.
+It adds 100 to the 1x1 input tensor.
 
-### Implement the transformer
+### The transformer
 
-In order the following were defined:
-1. `latent_shape` declares one batch, three channels, one frame, and one pixel as the shape of the output tensor.
-2. `initialize_autoregressive_cache()` creates a cache object which tracks the autoregressive step of each continuous generation.
-3. `initial_noise()` returns zeros so that the scheduler does not have any 'noise' to 'denoise' from the `predict_flow` method result.
-4. `predict_flow()` computes the flow utilizing our encoded_input tensor and the autoregressive step reported by the autoregressive cache.
+[`transformer.py`](null_model/transformer.py) defines, in order:
 
-The flow is computed as follows:
+1. `latent_shape` — one batch, three channels, one frame, one pixel.
+2. `initialize_autoregressive_cache()` — a cache tracking the autoregressive step
+   of a continuous generation.
+3. `initial_noise()` — zeros, so the scheduler has no noise to denoise beyond the
+   flow `predict_flow` returns.
+4. `predict_flow()` — the flow, from the encoded input and the step index the
+   cache reports.
+
 ```text
-# Explicit computation of our implemented `NullTransformer`
+# NullTransformer
 target = encoded_input + cache.autoregressive_index
 flow   = noisy_latent - target
 
-# `FlowMatchScheduler` implicit logic to denoise the flow into the final output tensor, sigma defaults to 1.0, 1 step.
+# FlowMatchScheduler, sigma 1.0, one step
 clean = noisy_latent - 1.0 * flow
       = noisy_latent - (noisy_latent - target)
       = target
 ```
 
-This is why one scheduler step is sufficient and why every output tensor is exactly the expected value.
+Which is why one scheduler step is enough, and why every output tensor is exactly
+the expected value.
 
-### Implement the per-step decoder
+### The per-step decoder
 
-[`decoder.py`](null_model/decoder.py) defines `NullDecoder`, which removes the
-minor obfuscation by subtracting 100 from the transformer's output.
+[`decoder.py`](null_model/decoder.py) defines `NullDecoder`, which subtracts the
+encoder's 100 back off the transformer's output.
+
+## Tests
 
 ```bash
 uv run --no-sync pytest integrations_v2/null_model

--- a/integrations_v2/red_screen/README.md
+++ b/integrations_v2/red_screen/README.md
@@ -16,9 +16,8 @@ uv sync --package flashdreams-red-screen --inexact
 uv run --no-sync red-screen-webrtc
 ```
 
-Open the URL it prints. Hold `r` to turn the generated video red, or click
-**Activate** to send the same keyboard event. Press `w` to raise the red
-intensity by 0.1 and `s` to lower it.
+Open the URL it prints. Hold `r` to turn the generated video red, `w` to raise
+the red intensity by 0.1, and `s` to lower it.
 
 This integration ships its own launcher rather than relying on
 `flashdreams-run-v2`, which is why the session arguments are spelled differently

--- a/integrations_v2/red_screen/README.md
+++ b/integrations_v2/red_screen/README.md
@@ -5,58 +5,59 @@ SPDX-License-Identifier: Apache-2.0
 
 # Red Screen
 
-Smallest end-to-end application on the v2 API. It holds no model: a session emits
-red frames controlled by activation and intensity keys. It runs the whole path —
-`IApplication`, `ISession`, `run_session`, `IClientWindow` — on CPU.
+Smallest interactive application on the v2 API. It holds no model: a session emits
+red frames whose intensity is driven by keys held in the browser. `color_fade` is
+the counterpart that writes a file; this one is about input.
 
-## What it demonstrates
+## Run it
+
+```bash
+uv sync --package flashdreams-red-screen --inexact
+uv run --no-sync red-screen-webrtc
+```
+
+Open the URL it prints. Hold `r` to turn the generated video red, or click
+**Activate** to send the same keyboard event. Press `w` to raise the red
+intensity by 0.1 and `s` to lower it.
+
+This integration ships its own launcher rather than relying on
+`flashdreams-run-v2`, which is why the session arguments are spelled differently
+here:
+
+```bash
+uv run --no-sync red-screen-webrtc --host 0.0.0.0 --port 8080 \
+    --width 1280 --height 720 --fps 30 -- --key x
+```
+
+It is also reachable the usual way, through the module fallback in the
+application registry:
+
+```bash
+uv run --no-sync flashdreams-run-v2 red-screen --mode webrtc
+```
+
+| Argument | Default | Meaning |
+|---|---|---|
+| `--key` | `r` | Key whose held state selects red over black. |
+
+Output is a `[1, 3, 1, H, W]` float32 tensor in `bcthw` layout carrying `[-1, 1]`
+values: red is `1.0` on channel 0 and `-1.0` on the others, black is `-1.0`
+everywhere. Any other layout is refused.
+
+## What it is worth reading it for
 
 - An application module implements `IApplication` and `ISession` and nothing
   else. This one never names `IClientWindow`, `InputSource` or `OutputSink`.
-- A session is created from a `SessionDesc` with no client window involved, so it
-  works before any client connects. It reports what it resolved to in
-  `ISession.session_desc`, which `run_session` hands to `IClientWindow.open`.
-- An application can reject a description it cannot honour: this one raises on
-  any layout other than `bcthw`.
-- The runner drives the loop and hands the session each `step_index`, so the
-  session keeps no step count of its own. The `steps=4` below is what bounds this
-  example; an interactive window would pass `steps=None` and end the run by
-  reporting a close event instead.
-- Keyboard events are edges, not levels. A key stays held across steps that carry
+- A session is created from a `SessionDesc` before any client connects, and
+  reports back what it resolved to.
+- Keyboard events are edges, not levels. A key stays held across steps carrying
   no events for it, so a key-down at step 0 keeps the screen red until the
-  matching key-up arrives.
-- `reset()` is implemented, so one session can run again.
+  matching key-up arrives. Anything reading input needs this bookkeeping.
+- `reset()` is implemented, so a browser client can start the session over.
 
-## Usage
-
-Start the WebRTC server and open the printed URL:
-
-```bash
-uv run red-screen-webrtc
-```
-
-Hold `r` in the browser to turn the generated video red, or click **Activate**
-to toggle the same keyboard event. Press `w` to increase the red intensity by
-0.1 and `s` to decrease it by 0.1. Runtime options configure the browser session:
-
-```bash
-uv run red-screen-webrtc --mode webrtc --host 0.0.0.0 --port 8080 --width 1280 --height 720 --fps 30
-```
-
-Arguments after `--` belong to the application:
-
-```bash
-uv run red-screen-webrtc -- --key x
-```
-
-The same application can be driven directly without WebRTC:
+Driving it from Python takes the same objects the launcher builds:
 
 ```python
-from flashdreams.runtime_v2.session_desc import SessionDesc
-from flashdreams.runtime_v2.session_runner import run_session
-from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
-from red_screen import create_app
-
 app = create_app()
 app.init([])
 session = app.create_session(
@@ -70,33 +71,17 @@ run_session(session, my_client_window, steps=4)
 app.close()
 ```
 
+`steps` bounds the run for a test. An interactive run leaves it `None` and ends
+when the browser disconnects.
+
 ## Tests
 
-Run from the repository root.
-
 ```bash
-uv sync --package flashdreams-red-screen --package flashdreams-null-model --package flashdreams-color-fade --group test --inexact
+uv sync --package flashdreams-red-screen --group test --inexact
 uv run --no-sync pytest integrations_v2/red_screen -m ci_cpu -v
 ```
 
-Together with the framework tests:
-
-```bash
-uv run --no-sync pytest flashdreams/test_v2 integrations_v2 -m ci_cpu -v
-```
-
-`--inexact` matters: it stops `uv` from uninstalling the other workspace members
-it was not asked about, which the framework tests import.
-
-## Arguments
-
-| Argument | Default | Meaning |
-|---|---|---|
-| `--key` | `r` | Key whose held state selects red over black. |
-
-The frame width and height come from the `SessionDesc`, and the step count from
-the caller that drives the session. Neither is a command-line argument.
-
-Output is a `[1, 3, 1, H, W]` float32 tensor in `bcthw` layout, carrying the
-`[-1, 1]` values a client window expects: red is `1.0` on channel 0 and `-1.0`
-on the others, and black is `-1.0` everywhere.
+Input is driven by `ScriptedClientWindow` in
+[`red_screen/tests/test_red_screen.py`](red_screen/tests/test_red_screen.py), which is
+the pattern to copy for anything else that reads events. See the
+[integration guide](../README.md) for what `--inexact` is doing there.

--- a/integrations_v2/slangpy_ui_demo/README.md
+++ b/integrations_v2/slangpy_ui_demo/README.md
@@ -5,26 +5,53 @@ SPDX-License-Identifier: Apache-2.0
 
 # SlangPy UI demos
 
-Three small v2 examples:
+The reference for writing a UI loop. Everywhere else here registers no UI loop and
+lets the runtime blit the model output; these three register one and draw widgets
+over it.
 
 - `slangpy-ui-text-input` keeps an editable text field in UI-loop-owned state.
-- `slangpy-ui-model-output` generates a three-layer RGBA result chunk and lets the UI
-  select the channel composited beneath the UI.
+- `slangpy-ui-model-output` generates a three-layer RGBA result chunk and lets the
+  UI select which channel is composited beneath it. The one to read for how a UI
+  loop reaches model output.
 - `slangpy-ui-invoke-async` signals a `W` press from the UI loop to the model
-  loop with `invoke_async`, toggling its output between red and blue.
+  loop with `invoke_async`, toggling its output between red and blue. The one to
+  read for crossing between the two threads.
 
-## Usage
+## Run them
 
 ```bash
-uv sync --package flashdreams-slangpy-ui-demo
-uv run flashdreams-run-v2 slangpy-ui-text-input --mode webrtc
-uv run flashdreams-run-v2 slangpy-ui-model-output --mode webrtc
-uv run flashdreams-run-v2 slangpy-ui-invoke-async --mode webrtc
+uv sync --package flashdreams-slangpy-ui-demo --inexact
+uv run --no-sync flashdreams-run-v2 slangpy-ui-text-input --mode webrtc
+uv run --no-sync flashdreams-run-v2 slangpy-ui-model-output --mode webrtc
+uv run --no-sync flashdreams-run-v2 slangpy-ui-invoke-async --mode webrtc
 ```
 
-Open the URL printed by the WebRTC window. The live renderer requires CUDA,
-Vulkan/CUDA interop, and SlangPy.
+Open the URL the WebRTC window prints. The live renderer needs CUDA,
+Vulkan/CUDA interop, and SlangPy, which is why these are the only integrations
+here that will not run on a CPU.
 
-The `step_ui` callback exposes SlangPy's complete `slangpy.ui` widget surface.
-See the [SlangPy UI API reference](https://slangpy.shader-slang.org/en/stable/src/api_reference.html#ui)
-for every available widget constructor, method, property, flag, and callback.
+## Writing one
+
+Subclass `SlangPyUILoop` from `flashdreams.runtime_v2.slangpy_ui_loop` and
+implement `step_ui(ui, step_index, events)` rather than `step`. The `ui` argument
+exposes `ui.screen`, the root `slangpy.ui.Screen` that receives top-level
+widgets, and every public type from `slangpy.ui` alongside it.
+
+FlashDreams delegates those names straight through rather than wrapping them, so
+the [SlangPy UI API reference](https://slangpy.shader-slang.org/en/stable/src/api_reference.html#ui)
+is the source of truth for every widget constructor, method, property, flag and
+callback.
+
+Model frames come from `presented_model_frame` and `presented_model_frames`, not
+from the model loop directly, see [the architecture](../../ARCHITECTURE.md) for
+why the two loops do not share memory.
+
+## Tests
+
+```bash
+uv sync --package flashdreams-slangpy-ui-demo --group test --inexact
+uv run --no-sync pytest integrations_v2/slangpy_ui_demo -m ci_cpu -v
+```
+
+These cover the loops without a renderer, so they run on a CPU even though the
+applications themselves do not.

--- a/integrations_v2/t2v_causal_forcing/README.md
+++ b/integrations_v2/t2v_causal_forcing/README.md
@@ -22,7 +22,7 @@ flashdreams-run-v2 t2v-causal-forcing --output-path clip.mp4 \
 
 Streaming, so `--total-blocks` is how long the clip is. The first block decodes 9
 frames and every block after it 12, at 16 frames per second, so seven blocks is
-about four and a half seconds.
+about five seconds.
 
 832x480, `tchw`. It overrides none of the `T2VApplication` hooks.
 

--- a/integrations_v2/t2v_causal_forcing/README.md
+++ b/integrations_v2/t2v_causal_forcing/README.md
@@ -5,51 +5,30 @@ SPDX-License-Identifier: Apache-2.0
 
 # Causal-Forcing text-to-video
 
-A prompt goes in, a clip comes out as an MP4 file. The model is Causal-Forcing
-Wan 2.1 1.3B in its chunkwise configuration, which the
+Causal-Forcing Wan 2.1 1.3B in its chunkwise configuration, which the
 `flashdreams-causal-forcing` package already configures for the v1 runner; this
 package is the application around it and holds no model code of its own.
 
-## Generate a clip
+The shared command line, the `HF_TOKEN` first run, and how these integrations are
+built and tested are in the
+[t2v guide](../../flashdreams/flashdreams/t2v_v2/README.md).
 
 ```bash
 flashdreams-run-v2 t2v-causal-forcing --output-path clip.mp4 \
     -- --prompt "A cat surfing" --total-blocks 7 --no-compile
 ```
 
-Arguments after `--` go to the application, and
-`flashdreams-run-v2 t2v-causal-forcing -- --help` lists them.
+## The model
 
-`--total-blocks` is how many autoregressive blocks to generate, and the run ends
-when the session has generated them. The first block decodes 9 frames and every
-block after it 12, at 16 frames per second, so seven blocks is about four and a
-half seconds.
+Streaming, so `--total-blocks` is how long the clip is. The first block decodes 9
+frames and every block after it 12, at 16 frames per second, so seven blocks is
+about four and a half seconds.
 
-`--no-compile` is worth it for a short clip. Compilation is on in the model's
-own config; it costs minutes on the first run and saves milliseconds a block.
-
-## What it generates
-
-832x480 frames at 16fps, laid out `tchw`, as `[-1, 1]` floats on the GPU. Those
-numbers are the checkpoint's, read off the runner config the
-`flashdreams-causal-forcing` package ships by
-[`T2VApplication`](../../flashdreams/flashdreams/t2v_v2/README.md) rather than
-written down here. Something else can be asked for with `--pixel-width`,
-`--pixel-height`, and `--fps` before the `--`, each dimension being a multiple
-of 8.
+832x480, `tchw`. It overrides none of the `T2VApplication` hooks.
 
 The framewise configuration this integration also ships generates one latent
 frame a block rather than three. It is not what this application runs, since a
 block of one frame is a great deal of overhead per frame.
-
-## First run
-
-The checkpoint is fetched from Hugging Face the first time, which is tens of
-gigabytes including the text encoder, so set a token and expect to wait:
-
-```bash
-export HF_TOKEN=<your-hf-token>
-```
 
 ## Tests
 
@@ -57,14 +36,6 @@ export HF_TOKEN=<your-hf-token>
 uv sync --package flashdreams-t2v-causal-forcing --group test --inexact
 uv run --no-sync pytest integrations_v2/t2v_causal_forcing -m ci_cpu -v
 ```
-
-Those cover this integration's defaults against the stand-in model in
-`flashdreams.t2v_v2.testing`. How an application of this kind behaves is
-covered once in `flashdreams/test_v2`, and a run reaching a file once in the
-Self-Forcing integration.
-
-The run that uses the real model needs a GPU, and skips unless its environment
-variable is set:
 
 ```bash
 T2V_CAUSAL_FORCING_REAL_MODEL_RUN=1 uv run --no-sync pytest \

--- a/integrations_v2/t2v_cosmos_predict2/README.md
+++ b/integrations_v2/t2v_cosmos_predict2/README.md
@@ -5,52 +5,31 @@ SPDX-License-Identifier: Apache-2.0
 
 # Cosmos Predict2 text-to-video
 
-A prompt goes in, a clip comes out as an MP4 file. The model is Cosmos Predict2
-2B at 720p, which the `flashdreams-cosmos-predict2` package already configures
-for the v1 runner; this package is the application around it and holds no model
-code of its own.
+Cosmos Predict2 2B at 720p, which the `flashdreams-cosmos-predict2` package
+already configures for the v1 runner; this package is the application around it
+and holds no model code of its own.
 
-Like Wan 2.1 and unlike the streaming models here, this one generates its whole
-clip in a single block, so a run is one step and the clip is however long the
-checkpoint generates. It is also the largest and slowest model here.
-
-## Generate a clip
+The shared command line, the `HF_TOKEN` first run, and how these integrations are
+built and tested are in the
+[t2v guide](../../flashdreams/flashdreams/t2v_v2/README.md).
 
 ```bash
 flashdreams-run-v2 t2v-cosmos-predict2 --output-path clip.mp4 \
     -- --prompt "A cat surfing" --no-compile
 ```
 
-Arguments after `--` go to the application, and
-`flashdreams-run-v2 t2v-cosmos-predict2 -- --help` lists them.
+## The model
 
-`--total-blocks` is 1 and has to be: a second block would not continue the
-first, so asking for more is refused rather than quietly generating a second
-clip. One block decodes 93 frames at 16 frames per second, so a clip is about
-six seconds.
+Like Wan 2.1 and unlike the streaming models here, this one generates its whole
+clip in a single block, so a run is one step. It is also the largest and slowest
+model here.
 
-`--no-compile` is worth it for a single clip. Compilation is on in the model's
-own config; it costs minutes on the first run and saves milliseconds, which is
-the wrong trade for one block.
+`--total-blocks` is 1 and has to be, so this integration overrides
+`_validate_total_blocks` to refuse a rollout. One block decodes 93 frames at 16
+frames per second, so a clip is about six seconds.
 
-## What it generates
-
-1280x720 frames at 16fps, laid out `tchw`, as `[-1, 1]` floats on the GPU. Those
-numbers are the checkpoint's, block count included, read off the runner config
-the `flashdreams-cosmos-predict2` package ships by
-[`T2VApplication`](../../flashdreams/flashdreams/t2v_v2/README.md) rather than
-written down here. Something else can be asked for with `--pixel-width`,
-`--pixel-height`, and `--fps` before the `--`, each dimension being a multiple
-of 8.
-
-## First run
-
-The checkpoint is fetched from Hugging Face the first time, which is tens of
-gigabytes including the text encoder, so set a token and expect to wait:
-
-```bash
-export HF_TOKEN=<your-hf-token>
-```
+1280x720, `tchw`, and the only 720p model of the five, which is why its frames
+per second are not comparable with theirs.
 
 ## Tests
 
@@ -58,14 +37,6 @@ export HF_TOKEN=<your-hf-token>
 uv sync --package flashdreams-t2v-cosmos-predict2 --group test --inexact
 uv run --no-sync pytest integrations_v2/t2v_cosmos_predict2 -m ci_cpu -v
 ```
-
-Those cover this integration's defaults, and that a rollout is refused, against
-the stand-in model in `flashdreams.t2v_v2.testing`. How an application of this
-kind behaves is covered once in `flashdreams/test_v2`, and a run reaching a file
-once in the Self-Forcing integration.
-
-The run that uses the real model needs a GPU, and skips unless its environment
-variable is set:
 
 ```bash
 T2V_COSMOS_PREDICT2_REAL_MODEL_RUN=1 uv run --no-sync pytest \

--- a/integrations_v2/t2v_cosmos_predict2/README.md
+++ b/integrations_v2/t2v_cosmos_predict2/README.md
@@ -28,8 +28,9 @@ model here.
 `_validate_total_blocks` to refuse a rollout. One block decodes 93 frames at 16
 frames per second, so a clip is about six seconds.
 
-1280x720, `tchw`, and the only 720p model of the five, which is why its frames
-per second are not comparable with theirs.
+1280x720, `tchw`, and the only 720p model of the five. It plays back at 16
+frames per second like the rest, but it is generating four times the pixels per
+frame, so the rate it generates them at is not comparable with theirs.
 
 ## Tests
 

--- a/integrations_v2/t2v_fastvideo_causal_wan22/README.md
+++ b/integrations_v2/t2v_fastvideo_causal_wan22/README.md
@@ -5,55 +5,36 @@ SPDX-License-Identifier: Apache-2.0
 
 # FastVideo CausalWan 2.2 text-to-video
 
-A prompt goes in, a clip comes out as an MP4 file. The model is FastVideo
-CausalWan 2.2 14B, which the `flashdreams-fastvideo-causal-wan22` package
-already configures for the v1 runner; this package is the application around it
-and holds no model code of its own.
+FastVideo CausalWan 2.2 14B, which the `flashdreams-fastvideo-causal-wan22`
+package already configures for the v1 runner; this package is the application
+around it and holds no model code of its own.
 
-It denoises with two transformers rather than one, a high-noise branch and a
-low-noise branch, so it holds two 14B checkpoints and wants a GPU to match.
-
-## Generate a clip
+The shared command line, the `HF_TOKEN` first run, and how these integrations are
+built and tested are in the
+[t2v guide](../../flashdreams/flashdreams/t2v_v2/README.md).
 
 ```bash
 flashdreams-run-v2 t2v-fastvideo-causal-wan22 --output-path clip.mp4 \
     -- --prompt "A cat surfing" --total-blocks 7 --no-compile
 ```
 
-Arguments after `--` go to the application, and
-`flashdreams-run-v2 t2v-fastvideo-causal-wan22 -- --help` lists them.
+## The model
 
-`--total-blocks` is how many autoregressive blocks to generate, and the run ends
-when the session has generated them. The first block decodes 9 frames and every
-block after it 12, at 16 frames per second, so seven blocks is about four and a
-half seconds.
+Streaming, so `--total-blocks` is how long the clip is. The first block decodes 9
+frames and every block after it 12, at 16 frames per second, so seven blocks is
+about four and a half seconds.
 
-`--no-compile` is worth it for a short clip, and doubly so here: compilation is
-on in the model's own config and costs minutes per transformer on the first run,
-against milliseconds saved a block.
+832x480, `tchw`. It denoises with two transformers rather than one, a high-noise
+branch and a low-noise branch, so it holds two 14B checkpoints and wants a GPU to
+match. That is also why it overrides `_apply_compile_override`: the shared
+override reaches one branch and would leave the other out of step. `--no-compile`
+is worth doubly as much here, compilation costing minutes per transformer.
 
-## What it generates
+Both checkpoints download on the first run, which is a large download even by the
+standards of the other models here.
 
-832x480 frames at 16fps, laid out `tchw`, as `[-1, 1]` floats on the GPU. Those
-numbers are the checkpoint's, read off the runner config the
-`flashdreams-fastvideo-causal-wan22` package ships by
-[`T2VApplication`](../../flashdreams/flashdreams/t2v_v2/README.md) rather than
-written down here. Something else can be asked for with `--pixel-width`,
-`--pixel-height`, and `--fps` before the `--`, each dimension being a multiple
-of 8.
-
-Image-to-video is not wired up in the v1 package this wraps, so there is
-nothing here for it either.
-
-## First run
-
-Both checkpoints are fetched from Hugging Face the first time, which is a large
-download even by the standards of the other models here, so set a token and
-expect to wait:
-
-```bash
-export HF_TOKEN=<your-hf-token>
-```
+Image-to-video is not wired up in the v1 package this wraps, so there is nothing
+here for it either.
 
 ## Tests
 
@@ -62,13 +43,7 @@ uv sync --package flashdreams-t2v-fastvideo-causal-wan22 --group test --inexact
 uv run --no-sync pytest integrations_v2/t2v_fastvideo_causal_wan22 -m ci_cpu -v
 ```
 
-Those cover this integration's defaults, and that `--no-compile` reaches both
-transformers, against the stand-in model in `flashdreams.t2v_v2.testing`. How an
-application of this kind behaves is covered once in `flashdreams/test_v2`, and a
-run reaching a file once in the Self-Forcing integration.
-
-The run that uses the real model needs a GPU, and skips unless its environment
-variable is set:
+Those include the check that `--no-compile` reaches both transformers.
 
 ```bash
 T2V_FASTVIDEO_CAUSAL_WAN22_REAL_MODEL_RUN=1 uv run --no-sync pytest \

--- a/integrations_v2/t2v_fastvideo_causal_wan22/README.md
+++ b/integrations_v2/t2v_fastvideo_causal_wan22/README.md
@@ -22,7 +22,7 @@ flashdreams-run-v2 t2v-fastvideo-causal-wan22 --output-path clip.mp4 \
 
 Streaming, so `--total-blocks` is how long the clip is. The first block decodes 9
 frames and every block after it 12, at 16 frames per second, so seven blocks is
-about four and a half seconds.
+about five seconds.
 
 832x480, `tchw`. It denoises with two transformers rather than one, a high-noise
 branch and a low-noise branch, so it holds two 14B checkpoints and wants a GPU to

--- a/integrations_v2/t2v_self_forcing/README.md
+++ b/integrations_v2/t2v_self_forcing/README.md
@@ -22,7 +22,7 @@ flashdreams-run-v2 t2v-self-forcing --output-path clip.mp4 \
 
 Streaming, so `--total-blocks` is how long the clip is. The first block decodes 9
 frames and every block after it 12, at 16 frames per second, so seven blocks is
-about four and a half seconds.
+about five seconds.
 
 832x480, `tchw`. It overrides none of the `T2VApplication` hooks.
 

--- a/integrations_v2/t2v_self_forcing/README.md
+++ b/integrations_v2/t2v_self_forcing/README.md
@@ -5,47 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 
 # Self-Forcing text-to-video
 
-The first real model on the v2 API. A prompt goes in, a clip comes out as an
-MP4 file. The model is Self-Forcing distilled Wan 2.1 1.3B, which the
-`flashdreams-self-forcing` package already configures for the v1 runner; this
+The first real model on the v2 API. Self-Forcing distilled Wan 2.1 1.3B, which
+the `flashdreams-self-forcing` package already configures for the v1 runner; this
 package is the application around it and holds no model code of its own.
 
-## Generate a clip
+The shared command line, the `HF_TOKEN` first run, and how these integrations are
+built and tested are in the
+[t2v guide](../../flashdreams/flashdreams/t2v_v2/README.md).
 
 ```bash
 flashdreams-run-v2 t2v-self-forcing --output-path clip.mp4 \
     -- --prompt "A cat surfing" --total-blocks 7 --no-compile
 ```
 
-Arguments after `--` go to the application, and
-`flashdreams-run-v2 t2v-self-forcing -- --help` lists them.
+## The model
 
-`--total-blocks` is how many autoregressive blocks to generate, and the run ends
-when the session has generated them. The first block decodes 9 frames and every
-block after it 12, at 16 frames per second, so seven blocks is about four and a
-half seconds.
+Streaming, so `--total-blocks` is how long the clip is. The first block decodes 9
+frames and every block after it 12, at 16 frames per second, so seven blocks is
+about four and a half seconds.
 
-`--no-compile` is worth it for a short clip. Compilation is on in the model's
-own config; it costs minutes on the first run and saves milliseconds a block.
-
-## What it generates
-
-832x480 frames at 16fps, laid out `tchw`, as `[-1, 1]` floats on the GPU. Those
-numbers are the checkpoint's, read off the runner config the
-`flashdreams-self-forcing` package ships by
-[`T2VApplication`](../../flashdreams/flashdreams/t2v_v2/README.md) rather than
-written down here. Something else can be asked for with `--pixel-width`,
-`--pixel-height`, and `--fps` before the `--`, each dimension being a multiple
-of 8.
-
-## First run
-
-The checkpoint is fetched from Hugging Face the first time, which is tens of
-gigabytes including the text encoder, so set a token and expect to wait:
-
-```bash
-export HF_TOKEN=<your-hf-token>
-```
+832x480, `tchw`. It overrides none of the `T2VApplication` hooks.
 
 ## Tests
 
@@ -54,13 +33,9 @@ uv sync --package flashdreams-t2v-self-forcing --group test --inexact
 uv run --no-sync pytest integrations_v2/t2v_self_forcing -m ci_cpu -v
 ```
 
-Those cover this integration's defaults and compile override against the
-stand-in model in `flashdreams.t2v_v2.testing`, and a run to a real MP4 on
-behalf of all five integrations, each being the same factory over the same
-shared layer.
-
-The run that uses the real model needs a GPU, and skips unless its environment
-variable is set:
+Alongside this integration's own defaults and compile override, these carry the
+one stand-in run that reaches a real MP4 on behalf of all five integrations, each
+being the same factory over the same shared layer.
 
 ```bash
 T2V_SELF_FORCING_REAL_MODEL_RUN=1 uv run --no-sync pytest \

--- a/integrations_v2/t2v_wan21/README.md
+++ b/integrations_v2/t2v_wan21/README.md
@@ -5,56 +5,33 @@ SPDX-License-Identifier: Apache-2.0
 
 # Wan 2.1 text-to-video
 
-A prompt goes in, a clip comes out as an MP4 file. The model is Wan 2.1 1.3B at
-480p, which the `flashdreams-wan21` package already configures for the v1
-runner; this package is the application around it and holds no model code of its
-own.
+Wan 2.1 1.3B at 480p, which the `flashdreams-wan21` package already configures
+for the v1 runner; this package is the application around it and holds no model
+code of its own.
 
-Unlike the streaming models here, this one is bidirectional: it attends over the
-whole clip at once and generates it in a single block. A run is therefore one
-step, and the clip is however long the checkpoint generates rather than however
-long it is asked for.
-
-## Generate a clip
+The shared command line, the `HF_TOKEN` first run, and how these integrations are
+built and tested are in the
+[t2v guide](../../flashdreams/flashdreams/t2v_v2/README.md).
 
 ```bash
 flashdreams-run-v2 t2v-wan21 --output-path clip.mp4 \
     -- --prompt "A cat surfing" --no-compile
 ```
 
-Arguments after `--` go to the application, and
-`flashdreams-run-v2 t2v-wan21 -- --help` lists them.
+## The model
 
-`--total-blocks` is 1 and has to be: a second block would not continue the
-first, so asking for more is refused rather than quietly generating a second
-clip. One block decodes 81 frames at 16 frames per second, so a clip is about
-five seconds.
+Bidirectional rather than streaming: it attends over the whole clip at once and
+generates it in a single block. A run is therefore one step, and the clip is
+however long the checkpoint generates rather than however long it is asked for.
 
-`--no-compile` is worth it for a single clip. Compilation is on by default; it
-costs minutes on the first run and saves milliseconds, which is the wrong trade
-for one block.
+`--total-blocks` is 1 and has to be, so this integration overrides
+`_validate_total_blocks` to refuse a rollout rather than quietly generate a
+second, unrelated clip. One block decodes 81 frames at 16 frames per second, so
+a clip is about five seconds.
 
-## What it generates
-
-832x480 frames at 16fps, laid out `tchw`, as `[-1, 1]` floats on the GPU. Those
-numbers are the checkpoint's, read off the runner config the
-`flashdreams-wan21` package ships by
-[`T2VApplication`](../../flashdreams/flashdreams/t2v_v2/README.md) rather than
-written down here. Something else can be asked for with `--pixel-width`,
-`--pixel-height`, and `--fps` before the `--`, each dimension being a multiple
-of 8.
-
-The rollout length is the one thing this package states rather than reads, a
-runner config for a model that does not roll out carrying no block count.
-
-## First run
-
-The checkpoint is fetched from Hugging Face the first time, which is tens of
-gigabytes including the text encoder, so set a token and expect to wait:
-
-```bash
-export HF_TOKEN=<your-hf-token>
-```
+832x480, `tchw`. The rollout length is the one default this package states rather
+than reads, a runner config for a model that does not roll out carrying no block
+count.
 
 ## Tests
 
@@ -62,14 +39,6 @@ export HF_TOKEN=<your-hf-token>
 uv sync --package flashdreams-t2v-wan21 --group test --inexact
 uv run --no-sync pytest integrations_v2/t2v_wan21 -m ci_cpu -v
 ```
-
-Those cover this integration's defaults, and that a rollout is refused, against
-the stand-in model in `flashdreams.t2v_v2.testing`. How an application of this
-kind behaves is covered once in `flashdreams/test_v2`, and a run reaching a file
-once in the Self-Forcing integration.
-
-The run that uses the real model needs a GPU, and skips unless its environment
-variable is set:
 
 ```bash
 T2V_WAN21_REAL_MODEL_RUN=1 uv run --no-sync pytest \


### PR DESCRIPTION
ARCHITECTURE.md holds the design that spans packages: the layers, the control flow of a run, and the two threads it runs on. The api_v2 and runtime_v2 READMEs are each now only their own package, so the flashdreams-run-v2 command line moves to the runtime.

Adds a general integration guide and expands t2v_v2 into the t2v one, absorbing the boilerplate the nine integration READMEs repeated. Docstrings and comments across both packages match what the code does. A ci_cpu test checks the references in all of it still resolve, since nothing else reads Markdown.