### PR TITLE
Add Waypoint 1.5 1B support with V2 interactive runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ runner slugs, multi-GPU commands, and (where available) profiling benchmarks.
 | [Self-Forcing](https://nvidia.github.io/flashdreams/main/models/self_forcing.html) | Streaming Wan2.1 T2V |
 | [OmniDreams](https://nvidia.github.io/flashdreams/main/models/omnidreams.html) | HDMap-conditioned driving world model |
 | [LingBot-World](https://nvidia.github.io/flashdreams/main/models/lingbot_world.html) | Camera-controllable I2V world model |
+| [Waypoint 1.5](https://nvidia.github.io/flashdreams/main/models/waypoint.html) | Interactive image-established keyboard/mouse-controlled world model |
 | [Wan2.1](https://nvidia.github.io/flashdreams/main/models/wan21.html) | Bidirectional T2V / I2V |
 | [Causal-Forcing](https://nvidia.github.io/flashdreams/main/models/causal_forcing.html) | Streaming Wan2.1 T2V / I2V |
 | [Causal Wan2.2](https://nvidia.github.io/flashdreams/main/models/causal_wan22.html) | FastVideo Causal Wan 2.2 14B MoE T2V |

--- a/assets/example_data/waypoint/example_controls.json
+++ b/assets/example_data/waypoint/example_controls.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "actions": [
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {}, {}, {}, {}, {}, {}, {}, {},
+    {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]},
+    {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]},
+    {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]},
+    {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]},
+    {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+  ]
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -239,6 +239,13 @@ invocation, the checkpoint source, and the per-implementation knobs.
 
       Camera-controllable image-to-video world model.
 
+   .. grid-item-card:: Waypoint 1.5
+      :class-card: fd-feature
+      :link: models/waypoint
+      :link-type: doc
+
+      Interactive image-established world model controlled by keyboard and mouse.
+
    .. grid-item-card:: SANA-WM_streaming
       :class-card: fd-feature
       :link: models/sana_wm_streaming

--- a/docs/source/models/index.rst
+++ b/docs/source/models/index.rst
@@ -28,6 +28,7 @@ Models
    flashvsr
    hy_worldplay
    lingbot_world
+   waypoint
    sana_wm_streaming
    sana_wm_bidirectional
    wan21
@@ -126,6 +127,19 @@ uses, and the settings you can tune.
          </div>
 
       Camera-controllable image-to-video world model.
+
+   .. grid-item-card:: Waypoint 1.5
+      :class-card: fd-feature
+      :link: /models/waypoint
+      :link-type: doc
+
+      .. raw:: html
+
+         <video class="fd-card-video" autoplay muted loop playsinline preload="metadata">
+           <source src="https://huggingface.co/Overworld/Waypoint-1.5-1B/resolve/main/assets/wp_1.5.mp4" type="video/mp4">
+         </video>
+
+      Interactive image-established world model controlled by keyboard and mouse.
 
    .. grid-item-card:: HY-WorldPlay
       :class-card: fd-feature

--- a/docs/source/models/waypoint.rst
+++ b/docs/source/models/waypoint.rst
@@ -80,7 +80,11 @@ Support summary
 The checkpoint's pinned configuration sets prompt_conditioning to null.
 Although the generic upstream APIs accept prompts for other models, this
 checkpoint-compatible FlashDreams path has no text encoder or prompt-conditioned
-weights and deliberately exposes no prompt argument.
+weights and deliberately exposes no prompt argument. In the upstream runtime,
+this configuration leaves the prompt encoder uninitialized and calling
+``set_prompt`` raises. The pinned safetensors artifact contains 393 tensor keys,
+with no keys for prompt or cross-attention modules. Consequently, this model
+does not accept a text prompt that can influence its output.
 
 Requirements
 ------------

--- a/docs/source/models/waypoint.rst
+++ b/docs/source/models/waypoint.rst
@@ -1,0 +1,299 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+.. http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
+Waypoint 1.5
+============
+
+.. container:: fd-cta-row
+
+   .. button-link:: https://huggingface.co/Overworld/Waypoint-1.5-1B
+      :color: primary
+
+      Checkpoint and upstream model card
+
+   .. button-link:: https://github.com/Overworldai/world_engine
+      :color: primary
+
+      Official inference code
+
+   .. button-link:: https://github.com/Overworldai/Biome
+      :color: primary
+
+      Official desktop client
+
+Waypoint-1.5-1B is Overworld's dense, autoregressive interactive video world
+model. FlashDreams integrates the published BF16 checkpoint as an
+image-established, keyboard/mouse-controlled V2 application with deterministic
+MP4 replay, per-action metrics, and live WebRTC presentation.
+
+.. raw:: html
+
+   <div class="model-video-card" style="width: 100%; margin: 10px auto 14px;">
+     <video class="model-video-player" autoplay muted loop playsinline preload="metadata">
+       <source src="https://huggingface.co/Overworld/Waypoint-1.5-1B/resolve/main/assets/wp_1.5.mp4" type="video/mp4">
+       Your browser does not support the video tag.
+     </video>
+   </div>
+   <p class="model-footnote">
+     Upstream Waypoint 1.5 teaser from the
+     <a href="https://huggingface.co/Overworld/Waypoint-1.5-1B">Overworld model card</a>;
+     this is not a FlashDreams benchmark artifact.
+   </p>
+
+Support summary
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Surface
+     - FlashDreams support
+   * - Application slug
+     - waypoint-1-5-1b through flashdreams-run-v2
+   * - Input modalities
+     - RGB/RGBA seed image; keyboard and mouse buttons; relative mouse motion;
+       ternary scroll-wheel direction
+   * - Output modality
+     - Four RGB frames per action, native 1024x512 TCHW in the [-1, 1] range
+   * - Control modes
+     - Live browser events or a finite, versioned JSON action timeline
+   * - Output modes
+     - WebRTC, MP4, null output, and optional per-action metrics
+   * - Precision and device
+     - BF16 on CUDA; no FlashDreams quantized or CPU inference path
+   * - Not implemented
+     - Text prompting, the 360P checkpoint, quantization, and multi-GPU execution
+
+The checkpoint's pinned configuration sets prompt_conditioning to null.
+Although the generic upstream APIs accept prompts for other models, this
+checkpoint-compatible FlashDreams path has no text encoder or prompt-conditioned
+weights and deliberately exposes no prompt argument.
+
+Requirements
+------------
+
+- A CUDA-capable NVIDIA GPU with BF16 and PyTorch FlexAttention support.
+- The FlashDreams path was validated on one NVIDIA RTX PRO 6000 Blackwell
+  Workstation Edition. The measured PyTorch peak allocation was 6.061 GiB, but
+  this is not a minimum-VRAM guarantee and excludes non-PyTorch process memory.
+- The first run downloads the 3.72 GB BF16 Waypoint safetensors file and the
+  separate Overworld-Models/taehv1_5 checkpoint into the Hugging Face cache.
+- ffmpeg on PATH is required for MP4 output.
+
+Installation
+------------
+
+From the FlashDreams repository root:
+
+.. code-block:: bash
+
+   uv sync --package flashdreams-waypoint-v2 --inexact
+
+The V2 application package depends on the sibling flashdreams-waypoint model
+package, so both are installed together.
+
+Running the model
+-----------------
+
+Generate a deterministic 40-action MP4 using the pinned public example image
+and bundled control timeline:
+
+.. code-block:: bash
+
+   uv run --no-sync flashdreams-run-v2 waypoint-1-5-1b \
+       --output-path waypoint.mp4 --stats-path waypoint.metrics.json \
+       -- --example-data --actions 40 --seed 464 --profile
+
+Run the same application interactively in a browser:
+
+.. code-block:: bash
+
+   uv run --no-sync flashdreams-run-v2 waypoint-1-5-1b \
+       --mode webrtc --host 127.0.0.1 --port 8766 \
+       -- --seed-image seed.png --seed 464
+
+Open http://127.0.0.1:8766/. Arguments before the separator configure the V2
+runtime; arguments after it configure Waypoint. To inspect all model arguments:
+
+.. code-block:: bash
+
+   uv run --no-sync flashdreams-run-v2 waypoint-1-5-1b -- --help
+
+Model and integration architecture
+----------------------------------
+
+The pinned checkpoint configuration and FlashDreams implementation agree on
+these model-facing invariants:
+
+- Dense 24-block autoregressive diffusion transformer, width 2048.
+- 32 query heads, 16 K/V heads, and a four-times-width feed-forward network.
+- One model action is a 32-channel, 32x64 latent frame patchified into 512
+  spatial tokens.
+- Four rectified-flow Euler evaluations at sigmas 1.0, 0.9, 0.75, and 0.3;
+  the terminal 0.0 evaluation commits clean cache state.
+- Control conditioning uses 256 button IDs, two mouse-delta values, and one
+  ternary wheel value. Control fusion is present every third block.
+- Most blocks retain 16 latent actions densely. Blocks 3, 7, 11, 15, 19, and
+  23 use a 128-action horizon with every eighth historical action pinned.
+- TAEHV encodes four seed RGB frames into one latent action and decodes every
+  generated latent action into four RGB frames.
+
+The 128-action global horizon corresponds to 512 presented RGB frames, matching
+the context length stated by the upstream model card. FlashDreams presents the
+codec's native 1024x512 canvas. The official world_engine client can instead
+resize 1280x720 input to that native canvas and resize decoded output back to
+1280x720; FlashDreams intentionally omits those extra spatial resamples.
+
+The upstream model card advertises a **1.2B parameter count**. Independently,
+the pinned model.safetensors header contains **1,860,823,096 BF16 tensor
+elements across 393 tensors** (3,721,694,304 bytes). These are different
+published-model versus serialized-checkpoint accounting figures; FlashDreams
+reports both rather than relabeling the upstream model.
+
+The package-level design review contains component, class, use-case, and
+sequence diagrams:
+
+.. button-link:: https://github.com/NVIDIA/flashdreams/blob/main/integrations/waypoint/README.md
+   :color: secondary
+   :outline:
+
+   Waypoint architecture design
+
+Measured FlashDreams performance
+--------------------------------
+
+The final FlashDreams path was measured on 2026-08-26 using an RTX PRO 6000
+Blackwell Workstation Edition (96 GiB), driver 595.84, PyTorch 2.12.1+cu130,
+CUDA 13.0, BF16 weights, the pinned example seed/control timeline, seed 464,
+native 1024x512 output, four denoise evaluations, and synchronous profiling.
+Actions 1-19 were warmup; actions 20-40 were the steady-state sample.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 55 45
+
+   * - Measurement
+     - Result
+   * - Mean action latency
+     - 68.791 ms per four generated frames
+   * - Median action latency
+     - 68.887 ms
+   * - p90 action latency
+     - 69.737 ms
+   * - Throughput derived from mean latency
+     - 58.15 generated RGB frames/s
+   * - Peak PyTorch CUDA allocation
+     - 6.061 GiB
+   * - Encoded output
+     - 164 frames: 4 seed + 40 actions x 4 frames
+
+The declared 60 FPS is presentation timing, not a throughput guarantee.
+Overworld separately reports 56 FPS for its unquantized runtime on an RTX 5090;
+that result was not reproduced here and is not directly comparable across
+different GPU, runtime, and presentation stacks.
+
+Parity and rollout validation
+-----------------------------
+
+FlashDreams loaded the same BF16 checkpoint and matched the pinned official
+world_engine implementation through one complete controlled action. The final
+comparison includes the four-step Euler solve and both cache commits:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - Comparison
+     - Mean absolute error
+     - Max absolute error
+     - Cosine similarity
+   * - Seed cache flow
+     - 0.010793
+     - 0.218750
+     - 0.999586
+   * - Clean latent after four steps
+     - 0.005682
+     - 0.033691
+     - 0.999869
+   * - Final cache flow
+     - 0.010511
+     - 0.265625
+     - 0.999487
+
+The residual is consistent with BF16 execution through different compiled
+kernel boundaries. Review optimizations retained a byte-identical 40-action
+MP4. Additional inference completed 15 distinct scenes at 40 actions each and
+one 118-action rollout: 718 generated actions and 2,936 decoded frames in total,
+with complete finite metrics and exact frame accounting. This demonstrates
+execution, cache longevity, and scene coverage; it is not a qualitative
+gameplay or physical-accuracy score.
+
+.. button-link:: https://github.com/NVIDIA/flashdreams/blob/main/integrations_v2/waypoint/VALIDATION.md
+   :color: secondary
+   :outline:
+
+   Complete validation record
+
+Intended use and limitations
+----------------------------
+
+Waypoint is suitable for research and prototyping around interactive video
+worlds, creative exploration, control-conditioned generation, and low-latency
+world-model systems. It is a generative model, not a physically grounded
+simulator.
+
+Important limitations:
+
+- Long rollouts can drift, collapse, or become inconsistent.
+- Geometry, motion, object identity, and persistence can be unstable.
+- Outputs may reflect biases or unsafe patterns learned from training data.
+- The FlashDreams integration has no content-safety filter of its own.
+- It is not appropriate for safety-critical decisions, surveillance,
+  high-stakes automation, or deployments that remove reasonable safeguards.
+- The current server accepts one WebRTC browser client per process. Multiple
+  sessions may share model weights, but model execution is serialized.
+- Live results depend on browser event timing. Use a control file and fixed
+  seed when reproducibility matters.
+
+Review the upstream model card and world-model safety discussion before
+deployment:
+
+.. container:: fd-cta-row
+
+   .. button-link:: https://huggingface.co/Overworld/Waypoint-1.5-1B
+      :color: secondary
+      :outline:
+
+      Upstream model card
+
+   .. button-link:: https://over.world/blog/engineering-safety-for-interactive-world-models
+      :color: secondary
+      :outline:
+
+      Upstream safety discussion
+
+Provenance
+----------
+
+- Model: Overworld/Waypoint-1.5-1B, revision
+  391f92827075edcf4a8b3c8a2ddae010698f8636, Apache-2.0.
+- Model SHA-256:
+  b872ad07968bae082a120a29072e61a13565086f042384ad7fdb79a7b0c50994.
+- TAEHV: Overworld-Models/taehv1_5, revision
+  a0253886b13b9c4c3bd224bd479be03f5988a3df.
+- Official parity implementation: Overworldai/world_engine at
+  b3f1e725dedac17ccbfaf9ee37f5e068bb44bed4.
+- FlashDreams integration and documentation: Apache-2.0.

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TAEHV video decoder."""
+"""TAEHV video decoder and Hunyuan Video 1.5 codec configs."""
 
 from __future__ import annotations
 
@@ -26,16 +26,18 @@ import tyro
 from torch import Tensor
 
 from flashdreams.infra.decoder import DecoderConfig, StreamingVideoDecoder
+from flashdreams.infra.encoder import EncoderConfig, StreamingVideoEncoder
 from flashdreams.recipes.taehv.checkpoint import (
     StateDictTransform,
     compose,
     legacy_to_blocks_keys,
     truncate_oversize_tgrow_weights,
 )
-from flashdreams.recipes.taehv.impl import TAEHV, TAEHVCache
+from flashdreams.recipes.taehv.impl import TAEHV, TAEHVCache, TAEHVEncoderCache
 
 AVAILABLE_TAEHV_CHECKPOINT_PATHS = {
     "lighttae": "https://huggingface.co/lightx2v/Autoencoders/resolve/main/lighttaew2_1.pth",
+    "hy1_5": "https://huggingface.co/Overworld-Models/taehv1_5/resolve/main/taehv1_5.pth",
 }
 """Checkpoint paths for the TAEHV decoder."""
 
@@ -230,9 +232,136 @@ class TeahvVAEDecoder(StreamingVideoDecoder[TAEHVCache]):
         return output_temporal_size // r
 
 
-if __name__ == "__main__":
-    import tyro
+@dataclass(kw_only=True)
+class Hy15TAEHVDecoderConfig(DecoderConfig):
+    """Config for the Hunyuan Video 1.5 TAEHV decoder."""
 
+    _target: Annotated[type, tyro.conf.Suppress] = field(
+        default_factory=lambda: Hy15TAEHVDecoder
+    )
+
+    checkpoint_path: str = AVAILABLE_TAEHV_CHECKPOINT_PATHS["hy1_5"]
+    """Path or URL for the Hunyuan Video 1.5 TAEHV checkpoint."""
+
+    state_dict_transform: StateDictTransform | None = legacy_to_blocks_keys
+    """Pre-load state-dict remap from the published flat key layout."""
+
+    dtype: torch.dtype = torch.bfloat16
+    """Network parameter / activation dtype."""
+
+    use_cuda_graph: bool = True
+    """Wrap the decoder forward in a CUDA graph for replay."""
+
+    use_compile: bool = True
+    """``torch.compile(mode="max-autotune-no-cudagraphs")``."""
+
+
+class Hy15TAEHVDecoder(TeahvVAEDecoder):
+    """Hunyuan Video 1.5 TAEHV decoder with raw 32-channel latents."""
+
+    TEMPORAL_COMPRESSION_RATIO = 4
+    SPATIAL_COMPRESSION_RATIO = 16
+
+    def __init__(self, config: Hy15TAEHVDecoderConfig) -> None:
+        StreamingVideoDecoder.__init__(self, config)
+        self.config: Hy15TAEHVDecoderConfig = config
+        self.need_scaled = False
+        self.taehv = TAEHV(
+            checkpoint_path=config.checkpoint_path,
+            model_type="hy1_5",
+            use_cuda_graph=config.use_cuda_graph,
+            use_compile=config.use_compile,
+            state_dict_transform=config.state_dict_transform,
+        ).to(dtype=config.dtype)
+
+
+@dataclass(kw_only=True)
+class Hy15TAEHVEncoderConfig(EncoderConfig):
+    """Config for the Hunyuan Video 1.5 TAEHV encoder."""
+
+    _target: Annotated[type, tyro.conf.Suppress] = field(
+        default_factory=lambda: Hy15TAEHVEncoder
+    )
+
+    checkpoint_path: str = AVAILABLE_TAEHV_CHECKPOINT_PATHS["hy1_5"]
+    """Path or URL for the Hunyuan Video 1.5 TAEHV checkpoint."""
+
+    state_dict_transform: StateDictTransform | None = legacy_to_blocks_keys
+    """Pre-load state-dict remap from the published flat key layout."""
+
+    dtype: torch.dtype = torch.bfloat16
+    """Network parameter / activation dtype."""
+
+
+class Hy15TAEHVEncoder(StreamingVideoEncoder[TAEHVEncoderCache]):
+    """Hunyuan Video 1.5 TAEHV pixel-video encoder."""
+
+    TEMPORAL_COMPRESSION_RATIO = 4
+    SPATIAL_COMPRESSION_RATIO = 16
+
+    def __init__(self, config: Hy15TAEHVEncoderConfig) -> None:
+        super().__init__(config)
+        self.config: Hy15TAEHVEncoderConfig = config
+        self.taehv = TAEHV(
+            checkpoint_path=config.checkpoint_path,
+            model_type="hy1_5",
+            enable_encoder=True,
+            use_cuda_graph=False,
+            use_compile=False,
+            state_dict_transform=config.state_dict_transform,
+        ).to(dtype=config.dtype)
+
+    def initialize_autoregressive_cache(self) -> TAEHVEncoderCache:
+        """Return an empty causal encoder cache."""
+        return self.taehv.prepare_encoder_cache()
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input: Tensor,
+        autoregressive_index: int = 0,
+        cache: TAEHVEncoderCache | None = None,
+    ) -> Tensor:
+        """Encode frames in ``[-1, 1]`` to raw Hunyuan Video 1.5 latents."""
+        if cache is None:
+            cache = self.initialize_autoregressive_cache()
+        assert input.ndim >= 4, "Expected input to have shape [..., T, C, H, W]"
+
+        *batch_shape, T, C, H, W = input.shape
+        batch_size = math.prod(batch_shape)
+        x = input.reshape(batch_size, T, C, H, W).add(1).mul_(0.5)
+        z = self.taehv.encode(x, cache=cache)
+        return z.reshape(*batch_shape, *z.shape[1:])
+
+    @property
+    def temporal_compression_ratio(self) -> int:
+        """Pixel frames / latent frames for complete causal groups."""
+        return self.TEMPORAL_COMPRESSION_RATIO
+
+    @property
+    def spatial_compression_ratio(self) -> int:
+        """Pixel side / latent side."""
+        return self.SPATIAL_COMPRESSION_RATIO
+
+    def get_output_temporal_size(
+        self, autoregressive_index: int, input_temporal_size: int
+    ) -> int:
+        """Return latent count emitted from complete input frame groups."""
+        r = self.temporal_compression_ratio
+        assert input_temporal_size % r == 0, (
+            f"Hy15 TAEHV encoder input_temporal_size={input_temporal_size} must be "
+            f"divisible by temporal_compression_ratio={r}."
+        )
+        return input_temporal_size // r
+
+    def get_input_temporal_size(
+        self, autoregressive_index: int, output_temporal_size: int
+    ) -> int:
+        """Return pixel frame count needed for ``output_temporal_size`` latents."""
+        return output_temporal_size * self.temporal_compression_ratio
+
+
+if __name__ == "__main__":
     config = tyro.cli(TeahvVAEDecoderConfig)
     model = config.setup()
     print(model)

--- a/flashdreams/flashdreams/recipes/taehv/__init__.py
+++ b/flashdreams/flashdreams/recipes/taehv/__init__.py
@@ -302,6 +302,8 @@ class Hy15TAEHVEncoder(StreamingVideoEncoder[TAEHVEncoderCache]):
     def __init__(self, config: Hy15TAEHVEncoderConfig) -> None:
         super().__init__(config)
         self.config: Hy15TAEHVEncoderConfig = config
+        # This instance only establishes the seed latent; its decoder is unused,
+        # so decoder graph/compile settings would add setup work without speeding it up.
         self.taehv = TAEHV(
             checkpoint_path=config.checkpoint_path,
             model_type="hy1_5",

--- a/flashdreams/flashdreams/recipes/taehv/checkpoint.py
+++ b/flashdreams/flashdreams/recipes/taehv/checkpoint.py
@@ -36,22 +36,22 @@ StateDictTransform = Callable[[Mapping[str, torch.Tensor]], dict[str, torch.Tens
 def legacy_to_blocks_keys(
     sd: Mapping[str, torch.Tensor],
 ) -> dict[str, torch.Tensor]:
-    """Re-key legacy ``decoder.<i>.*`` weights to ``decoder.blocks.<i>.*``.
+    """Re-key flat encoder and decoder weights to their ``blocks`` layouts.
 
-    The current :class:`~flashdreams.recipes.taehv.impl.Decoder` wraps
-    its ``Sequential`` in a ``blocks`` attribute, so older checkpoints
-    whose keys flatten to ``decoder.<idx>.*`` need rewriting to line up.
-    Keys already under ``decoder.blocks.`` (and keys outside the
-    ``decoder.`` subtree) pass through unchanged.
+    The current :class:`~flashdreams.recipes.taehv.impl.Encoder` and
+    :class:`~flashdreams.recipes.taehv.impl.Decoder` each wrap their
+    ``Sequential`` in a ``blocks`` attribute. Published checkpoints use
+    flat ``encoder.<idx>.*`` and ``decoder.<idx>.*`` keys. Keys already
+    under ``*.blocks.`` (and unrelated keys) pass through unchanged.
     """
-    return {
-        (
-            k.replace("decoder.", "decoder.blocks.", 1)
-            if k.startswith("decoder.") and not k.startswith("decoder.blocks.")
-            else k
-        ): v
-        for k, v in sd.items()
-    }
+    out: dict[str, torch.Tensor] = {}
+    for key, value in sd.items():
+        for prefix in ("encoder.", "decoder."):
+            if key.startswith(prefix) and not key.startswith(f"{prefix}blocks."):
+                key = key.replace(prefix, f"{prefix}blocks.", 1)
+                break
+        out[key] = value
+    return out
 
 
 def truncate_oversize_tgrow_weights(

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Streaming causal decoder for TAEHV (Tiny AutoEncoder for Hunyuan Video)."""
+"""Streaming causal TAEHV encoder and decoder."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, cast
 
 import torch
 import torch.nn as nn
@@ -28,6 +28,7 @@ from flashdreams.core.checkpoint.load import load_checkpoint
 from flashdreams.infra.compile import compile_module
 from flashdreams.infra.cuda_graph import CUDAGraphWrapper, set_or_copy
 from flashdreams.infra.decoder import StreamingDecoderCache
+from flashdreams.infra.encoder import StreamingEncoderCache
 from flashdreams.recipes.taehv.checkpoint import (
     StateDictTransform,
     compose,
@@ -46,6 +47,19 @@ class TAEHVCache(StreamingDecoderCache):
     """
 
     dec_state: Dict[int, torch.Tensor] = field(default_factory=dict)
+
+
+@dataclass
+class TAEHVEncoderCache(StreamingEncoderCache):
+    """Streaming encoder work queue and per-layer causal state."""
+
+    enc_state: list[torch.Tensor | list[torch.Tensor] | None] = field(
+        default_factory=list
+    )
+    """Causal ``MemBlock`` frames and partial ``TPool`` groups per encoder layer."""
+
+    work_queue: list[tuple[torch.Tensor, int]] = field(default_factory=list)
+    """Pending ``(frame, block_index)`` items in causal evaluation order."""
 
 
 def _conv(n_in: int, n_out: int, **kwargs) -> nn.Conv2d:
@@ -118,6 +132,19 @@ class TGrow(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         _NT, C, H, W = x.shape
         return self.conv(x).reshape(-1, C, H, W)
+
+
+class TPool(nn.Module):
+    """Temporal downsample by ``stride`` (channel-pack + projection)."""
+
+    def __init__(self, n_f: int, stride: int):
+        super().__init__()
+        self.stride = stride
+        self.conv = nn.Conv2d(n_f * stride, n_f, 1, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _NT, C, H, W = x.shape
+        return self.conv(x.reshape(-1, self.stride * C, H, W))
 
 
 class Decoder(nn.Module):
@@ -224,18 +251,119 @@ class Decoder(nn.Module):
                 x = blk(x)
 
 
+class Encoder(nn.Module):
+    """TAEHV encoder body with causal temporal pools and memory blocks."""
+
+    def __init__(
+        self,
+        latent_channels: int,
+        image_channels: int,
+        patch_size: int,
+        act_func: nn.Module,
+    ):
+        super().__init__()
+        self.blocks = nn.Sequential(
+            _conv(image_channels * patch_size**2, 64),
+            act_func,
+            TPool(64, 2),
+            _conv(64, 64, stride=2, bias=False),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            TPool(64, 2),
+            _conv(64, 64, stride=2, bias=False),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            TPool(64, 1),
+            _conv(64, 64, stride=2, bias=False),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            MemBlock(64, 64, act_func),
+            _conv(64, latent_channels),
+        )
+
+    def initialize_state(
+        self, state: list[torch.Tensor | list[torch.Tensor] | None]
+    ) -> None:
+        """Populate empty per-layer causal encoder state."""
+        state[:] = [None] * len(self.blocks)
+
+    def _advance_work_queue(
+        self,
+        state: list[torch.Tensor | list[torch.Tensor] | None],
+        work_queue: list[tuple[torch.Tensor, int]],
+    ) -> torch.Tensor | None:
+        """Advance queued work until one latent frame is ready."""
+        while work_queue:
+            x, block_index = work_queue.pop(0)
+            if block_index == len(self.blocks):
+                return x.unsqueeze(1)
+
+            block = self.blocks[block_index]
+            if isinstance(block, MemBlock):
+                past = cast(torch.Tensor | None, state[block_index])
+                state[block_index] = x
+                x = block(x, x * 0 if past is None else past)
+                work_queue.insert(0, (x, block_index + 1))
+            elif isinstance(block, TPool):
+                group = cast(list[torch.Tensor] | None, state[block_index])
+                if group is None:
+                    group = []
+                    state[block_index] = group
+                group = cast(list[torch.Tensor], group)
+                group.append(x)
+                if len(group) == block.stride:
+                    state[block_index] = []
+                    batch, channels, height, width = x.shape
+                    x = block(
+                        torch.cat(group, dim=1).view(
+                            batch * block.stride, channels, height, width
+                        )
+                    )
+                    work_queue.insert(0, (x, block_index + 1))
+                elif len(group) > block.stride:
+                    raise RuntimeError("TAEHV TPool cache overflow.")
+            else:
+                work_queue.insert(0, (block(x), block_index + 1))
+        return None
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        state: list[torch.Tensor | list[torch.Tensor] | None],
+        work_queue: list[tuple[torch.Tensor, int]],
+    ) -> torch.Tensor:
+        """Encode a frame chunk with causal ``MemBlock`` and ``TPool`` state.
+
+        ``x`` has shape ``[B, T, C, H, W]``. Incomplete temporal groups remain
+        in ``work_queue`` / ``state`` and can therefore yield an empty ``T``
+        dimension.
+        """
+        work_queue.extend((frame, 0) for frame in x.unbind(dim=1))
+
+        outputs: list[torch.Tensor] = []
+        while (output := self._advance_work_queue(state, work_queue)) is not None:
+            outputs.append(output)
+        if outputs:
+            return torch.cat(outputs, dim=1)
+        output_projection = cast(nn.Conv2d, self.blocks[-1])
+        return x.new_empty(
+            x.shape[0],
+            0,
+            output_projection.out_channels,
+            x.shape[-2] // 8,
+            x.shape[-1] // 8,
+        )
+
+
 class TAEHV(nn.Module):
-    """TAEHV streaming decode-only network.
+    """TAEHV streaming network with configurable decoder and encoder.
 
-    Loads a TAEHV checkpoint and exposes ``decode``. Encoder weights in the
-    checkpoint are silently dropped. With ``use_cuda_graph=True``, rollout 1
-    drains Inductor autotune on the eager path; rollout 2 warms up and
-    captures, after which same-shape body chunks replay.
-
-    Supported ``model_type``: ``"wan21"`` (default; ReLU, patch_size=1,
-    latent_channels=16) and ``"wan22"`` (ReLU, patch_size=2,
-    latent_channels=48). The legacy ``"hy15"`` and ``"taecvx"`` variants are
-    not ported.
+    Loads a TAEHV checkpoint and exposes ``decode`` and ``encode``. With
+    ``use_cuda_graph=True``, rollout 1 drains Inductor autotune on the eager
+    path; rollout 2 warms up and captures, after which same-shape body chunks
+    replay.
 
     Examples:
 
@@ -268,10 +396,11 @@ class TAEHV(nn.Module):
     TEMPORAL_COMPRESSION_RATIO = 4
     SPATIAL_COMPRESSION_RATIO = 8
 
-    SUPPORTED_MODEL_TYPES = ("wan21", "wan22")
+    SUPPORTED_MODEL_TYPES = ("wan21", "wan22", "hy1_5")
 
-    # Concrete type so ``self.decoder`` access doesn't go through
+    # Concrete types so module access doesn't go through
     # ``nn.Module.__getattr__``'s ``Tensor | Module``.
+    encoder: "Encoder"
     decoder: "Decoder"
 
     def __init__(
@@ -288,14 +417,16 @@ class TAEHV(nn.Module):
         use_compile: bool = False,
         warmup_iters: int = 2,
         state_dict_transform: StateDictTransform | None = None,
+        *,
+        enable_encoder: bool = False,
     ):
         super().__init__()
         if model_type not in self.SUPPORTED_MODEL_TYPES:
             raise ValueError(
                 f"TAEHV: model_type={model_type!r} is not supported by this slim "
                 f"impl (supported: {self.SUPPORTED_MODEL_TYPES}). The legacy "
-                f"'hy15' / 'taecvx' branches (different activation, clamp range, "
-                f"or trim semantics) were dropped in the decode-only refactor."
+                f"'taecvx' branches (different activation, clamp range, "
+                f"or trim semantics) were dropped in the refactor."
             )
         if checkpoint_path is not None and "taecvx" in checkpoint_path:
             raise ValueError(
@@ -304,6 +435,8 @@ class TAEHV(nn.Module):
             )
         if model_type == "wan22":
             patch_size, latent_channels = 2, 48
+        elif model_type == "hy1_5":
+            patch_size, latent_channels = 2, 32
         act_func = nn.ReLU(inplace=True)
 
         self.patch_size = patch_size
@@ -327,6 +460,10 @@ class TAEHV(nn.Module):
                 decoder_space_upscale=decoder_space_upscale,
                 act_func=act_func,
             )
+            if enable_encoder:
+                self.encoder = Encoder(
+                    latent_channels, self.image_channels, patch_size, act_func
+                )
 
         # Runtime knobs consumed by ``load_from_checkpoint``; stashed here
         # so subclasses that defer the load (``checkpoint_path=None``)
@@ -380,8 +517,8 @@ class TAEHV(nn.Module):
             )
         sd = load_checkpoint(checkpoint_path)
         sd = state_dict_transform(sd)
-        # assign=True: meta params become the checkpoint tensors directly;
-        # strict=False: silently drop encoder-only weights.
+        # ``assign=True`` moves checkpoint tensors into meta parameters directly;
+        # ``strict=False`` lets decoder-only instances ignore encoder weights.
         self.load_state_dict(sd, strict=False, assign=True)
 
         self.eval().requires_grad_(False)
@@ -419,6 +556,40 @@ class TAEHV(nn.Module):
             assert self._decoder_wrapper is not None
             self._decoder_wrapper.reset()
         return TAEHVCache()
+
+    def prepare_encoder_cache(self) -> TAEHVEncoderCache:
+        """Return a fresh cache for a causal streaming encode rollout."""
+        cache = TAEHVEncoderCache()
+        self.encoder.initialize_state(cache.enc_state)
+        return cache
+
+    @torch.no_grad()
+    def encode(
+        self,
+        x: torch.Tensor,
+        cache: TAEHVEncoderCache | None = None,
+    ) -> torch.Tensor:
+        """Encode pixel frames in ``[0, 1]`` with causal temporal pooling.
+
+        Frames that do not complete the encoder's temporal factor remain in
+        ``cache`` for the next call. The returned tensor can therefore have zero
+        time frames when the caller submits an incomplete temporal group.
+        """
+        if cache is None:
+            cache = self.prepare_encoder_cache()
+
+        batch, _time, _channels, height, width = x.shape
+        if self.patch_size > 1:
+            x = F.pixel_unshuffle(
+                x.reshape(-1, x.shape[2], height, width), self.patch_size
+            ).reshape(
+                batch,
+                -1,
+                self.image_channels * self.patch_size**2,
+                height // self.patch_size,
+                width // self.patch_size,
+            )
+        return self.encoder(x, cache.enc_state, cache.work_queue)
 
     @torch.inference_mode()
     def decode(

--- a/flashdreams/flashdreams/recipes/taehv/impl.py
+++ b/flashdreams/flashdreams/recipes/taehv/impl.py
@@ -520,6 +520,19 @@ class TAEHV(nn.Module):
         # ``assign=True`` moves checkpoint tensors into meta parameters directly;
         # ``strict=False`` lets decoder-only instances ignore encoder weights.
         self.load_state_dict(sd, strict=False, assign=True)
+        meta_tensors = [
+            f"parameter {name}"
+            for name, parameter in self.named_parameters()
+            if parameter.is_meta
+        ]
+        meta_tensors.extend(
+            f"buffer {name}" for name, buffer in self.named_buffers() if buffer.is_meta
+        )
+        if meta_tensors:
+            raise RuntimeError(
+                "TAEHV checkpoint left module tensors on meta: "
+                f"{meta_tensors[:5]} ({len(meta_tensors)} total)"
+            )
 
         self.eval().requires_grad_(False)
 

--- a/flashdreams/tests/test_vae.py
+++ b/flashdreams/tests/test_vae.py
@@ -21,9 +21,13 @@ import torch
 
 from flashdreams.recipes.taehv import (
     AVAILABLE_TAEHV_CHECKPOINT_PATHS,
+    Hy15TAEHVDecoderConfig,
+    Hy15TAEHVEncoderConfig,
     TeahvVAEDecoder,
     TeahvVAEDecoderConfig,
 )
+from flashdreams.recipes.taehv.checkpoint import legacy_to_blocks_keys
+from flashdreams.recipes.taehv.impl import TAEHV
 from flashdreams.recipes.wan.autoencoder.vae import (
     AVAILABLE_WAN_VAE_CHECKPOINT_PATHS,
     WanVAEDecoder,
@@ -31,6 +35,52 @@ from flashdreams.recipes.wan.autoencoder.vae import (
     WanVAEEncoder,
     WanVAEEncoderConfig,
 )
+
+
+@pytest.mark.ci_cpu
+def test_hy15_taehv_checkpoint_layout_is_a_full_bijection() -> None:
+    """The Hunyuan Video 1.5 architecture matches the TAEHV checkpoint layout.
+
+    Builds both branches on ``meta`` and recreates the published flat decoder
+    naming convention. This guards the 32-channel / patch-2 architecture and
+    verifies that the generic TAEHV remap covers every parameter without a
+    checkpoint download.
+    """
+    with torch.device("meta"):
+        codec = TAEHV(
+            checkpoint_path=None,
+            model_type="hy1_5",
+            enable_encoder=True,
+            use_cuda_graph=False,
+        )
+    model = codec.state_dict()
+    raw: dict[str, torch.Tensor] = {}
+    for key, value in model.items():
+        for prefix in ("encoder.blocks.", "decoder.blocks."):
+            if key.startswith(prefix):
+                key = key.replace(prefix, prefix.replace(".blocks.", "."), 1)
+                break
+        raw[key] = value
+    transformed = legacy_to_blocks_keys(raw)
+
+    assert len(model) == len(transformed) == 128
+    assert set(model) == set(transformed)
+    assert all(model[key].shape == transformed[key].shape for key in model)
+    assert tuple(model["encoder.blocks.0.weight"].shape) == (64, 12, 3, 3)
+    assert tuple(model["decoder.blocks.1.weight"].shape) == (256, 32, 3, 3)
+    assert tuple(model["decoder.blocks.22.weight"].shape) == (12, 64, 3, 3)
+
+
+@pytest.mark.ci_cpu
+def test_hy15_taehv_configs_select_raw_32_channel_latents() -> None:
+    """The Hunyuan Video 1.5 presets use the published checkpoint unchanged."""
+    encoder = Hy15TAEHVEncoderConfig()
+    decoder = Hy15TAEHVDecoderConfig()
+
+    assert encoder.checkpoint_path == AVAILABLE_TAEHV_CHECKPOINT_PATHS["hy1_5"]
+    assert decoder.checkpoint_path == AVAILABLE_TAEHV_CHECKPOINT_PATHS["hy1_5"]
+    assert encoder.state_dict_transform is legacy_to_blocks_keys
+    assert decoder.state_dict_transform is legacy_to_blocks_keys
 
 
 @torch.no_grad()

--- a/flashdreams/tests/test_vae.py
+++ b/flashdreams/tests/test_vae.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from typing import Literal
+from unittest.mock import patch
 
 import mediapy
 import pytest
@@ -81,6 +82,19 @@ def test_hy15_taehv_configs_select_raw_32_channel_latents() -> None:
     assert decoder.checkpoint_path == AVAILABLE_TAEHV_CHECKPOINT_PATHS["hy1_5"]
     assert encoder.state_dict_transform is legacy_to_blocks_keys
     assert decoder.state_dict_transform is legacy_to_blocks_keys
+
+
+@pytest.mark.ci_cpu
+def test_taehv_rejects_an_incomplete_meta_checkpoint() -> None:
+    """Permissive key loading must not leave runtime module state on meta."""
+    with torch.device("meta"):
+        codec = TAEHV(checkpoint_path=None, use_cuda_graph=False)
+
+    with (
+        patch("flashdreams.recipes.taehv.impl.load_checkpoint", return_value={}),
+        pytest.raises(RuntimeError, match="left module tensors on meta"),
+    ):
+        codec.load_from_checkpoint("unused", state_dict_transform=dict)
 
 
 @torch.no_grad()

--- a/integrations/waypoint/README.md
+++ b/integrations/waypoint/README.md
@@ -1,0 +1,55 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Waypoint model package for FlashDreams
+
+This package loads the published [Overworld/Waypoint-1.5-1B](https://huggingface.co/Overworld/Waypoint-1.5-1B) checkpoint through
+FlashDreams.
+
+## Model
+
+- One action produces one 32-channel latent frame and four presented RGB frames.
+- Waypoint 1.5 has no text-conditioning input in its published checkpoint
+  configuration, so this integration will not expose a prompt encoder.
+- User controls are 256 button IDs, mouse delta, and scroll movement.
+
+## Integration baseline
+
+- FlashDreams target: `8fd97fa38f04bc32c288760fa0fbf5da52464cea`
+  (the post-#506 V2 runtime).
+- Source integration: PR #464 at
+  `0f1782346f33cc47cc0bd456c3c48c5f3b7145f4`.
+- Published checkpoint:
+  `Overworld/Waypoint-1.5-1B/model.safetensors`.
+- Upstream parity implementation:
+  [Overworldai/world_engine](https://github.com/Overworldai/world_engine).
+- Closest reusable FlashDreams component: the shared Hunyuan Video 1.5 TAEHV
+  streaming codec. Waypoint's DiT and cache topology are model-specific.
+
+Runtime orchestration is intentionally outside this package. The V2 application
+adapter owns argument parsing, sessions, input events, presentation, and file or
+WebRTC output.
+
+## Control files
+
+Pass a JSON action timeline with ``--controls-file``. It uses every listed
+action unless ``--actions N`` selects a prefix. The file format is:
+
+```json
+{
+  "schema_version": 1,
+  "actions": [
+    {"buttons": [32], "mouse_dx": 0.1, "mouse_dy": 0.0, "scroll_wheel": 0},
+    {},
+    {"buttons": [1, 32]}
+  ]
+}
+```
+
+Every field within an action is optional. ``buttons`` is an array of model
+button IDs, ``mouse_dx`` / ``mouse_dy`` are finite numbers, and
+``scroll_wheel`` is ``-1``, ``0``, or ``1``. A control file takes precedence
+over the repeated-control options, so it can be used without ``--buttons``,
+``--mouse-dx``, ``--mouse-dy``, or ``--scroll``.

--- a/integrations/waypoint/README.md
+++ b/integrations/waypoint/README.md
@@ -212,7 +212,7 @@ sequenceDiagram
     participant Runtime as V2 runtime
     participant App as WaypointApplication
     participant Session as WaypointSession
-    participant Loop as WaypointModelLoop
+    participant ModelLoop as WaypointModelLoop
     participant Pipeline as WaypointInferencePipeline
     participant DiT as WaypointTransformer / DiT
     participant Cache as K/V + TAEHV caches
@@ -230,27 +230,27 @@ sequenceDiagram
     DiT->>Cache: commit action 0 K/V
 
     alt step 0
-        Runtime->>Loop: step(0, events)
-        Loop-->>Runtime: detached seed StepResult (4 frames)
+        Runtime->>ModelLoop: step(0, events)
+        ModelLoop-->>Runtime: detached seed StepResult (4 frames)
     else generated action N
-        Runtime->>Loop: step(N, ordered input events)
-        Loop->>Pipeline: generate(N, cache, control)
+        Runtime->>ModelLoop: step(N, ordered input events)
+        ModelLoop->>Pipeline: generate(N, cache, control)
         loop sigmas 1.0 to 0.3
             Pipeline->>DiT: predict provisional flow
             DiT->>Cache: replace provisional action-N K/V
         end
         Pipeline->>Cache: decode clean latent to 4 RGB frames
-        Loop->>Pipeline: finalize(N, cache)
+        ModelLoop->>Pipeline: finalize(N, cache)
         Pipeline->>DiT: sigma-zero clean-state evaluation
         DiT->>Cache: commit action-N K/V
-        Loop-->>Runtime: detached TCHW StepResult
+        ModelLoop-->>Runtime: detached TCHW StepResult
     end
 
     Runtime->>Sink: present or encode four frames
     opt browser reset
         Client->>Runtime: reset event
-        Runtime->>Loop: reset()
-        Loop->>Pipeline: rebuild cache from retained seed
+        Runtime->>ModelLoop: reset()
+        ModelLoop->>Pipeline: rebuild cache from retained seed
     end
 ```
 

--- a/integrations/waypoint/README.md
+++ b/integrations/waypoint/README.md
@@ -32,8 +32,13 @@ hardware, parity metrics, and long-rollout evidence are recorded in
 | Concurrency | An application lock serializes shared model/RNG work; output tensors leave the model loop detached |
 
 The published config has `prompt_conditioning: null`; this integration therefore
-does not load a text encoder or expose a prompt. It also does not currently
-implement the upstream 360P checkpoint, quantization, or multi-GPU execution.
+does not load a text encoder or expose a prompt. The generic upstream
+`WorldEngine` has a `set_prompt` method for other configurations, but for this
+checkpoint it does not instantiate a prompt encoder and `set_prompt` raises.
+The pinned checkpoint also has no prompt or cross-attention tensor keys. A
+prompt argument would therefore be ignored or rejected rather than condition
+generation. The integration also does not currently implement the upstream
+360P checkpoint, quantization, or multi-GPU execution.
 
 ## Use cases and modalities
 
@@ -77,6 +82,7 @@ flowchart TB
         registry[application_registry.py<br/>slug discovery]
         runner[application_runner.py / session_runner.py]
         api[IApplication / ISession / IModelLoop]
+        input[UserInputEvents / EventBuffer<br/>transport and reset lifecycle]
         sinks[WebRTCClientWindow / Mp4ClientWindow<br/>MetricsOutputSink]
         base[StreamInferencePipeline<br/>DiffusionModel / Transformer]
         taehv[recipes/taehv<br/>Hy15TAEHVEncoder and Decoder]
@@ -85,7 +91,7 @@ flowchart TB
     subgraph adapter[integrations_v2/waypoint]
         app[app.py<br/>WaypointApplication]
         session[session.py<br/>WaypointSession and ModelLoop]
-        events[control_events.py<br/>ControlEventAdapter]
+        events[control_events.py<br/>WaypointControlEventAdapter]
     end
 
     subgraph waypoint[integrations/waypoint]
@@ -105,11 +111,14 @@ flowchart TB
     api -. implemented by .-> app
     api -. implemented by .-> session
     runner --> session
+    runner --> input
     runner --> sinks
     app --> session
     app --> pipeline
     session --> events
     session --> pipeline
+    input --> events
+    events --> controls
     pipeline --> controls
     pipeline --> transformer
     pipeline --> scheduler
@@ -128,6 +137,35 @@ The package boundary is intentional: `integrations/waypoint` is reusable model
 inference code and imports no V2 runtime classes. `integrations_v2/waypoint` is
 the thin application adapter and depends on both FlashDreams and the model
 package.
+
+## V2 reuse and action-mapping boundary
+
+The V2 runtime already provides device-neutral, timestamped input events;
+event fan-out to model and UI loops; reset/focus lifecycle; WebRTC transport;
+and generic presentation, MP4, and metrics sinks. It deliberately delivers raw
+events to each model loop. It does not currently provide an action-to-video
+application, a stateful action coalescer, or a protocol from user events to a
+model's control object.
+
+`WaypointControlEventAdapter` is therefore integration-owned. It contains two
+seams that a later shared action-to-video package can separate:
+
+1. A model-neutral accumulator can retain held key names and mouse-button
+   indices, convert absolute pointer positions to relative normalized motion,
+   collect wheel deltas, and clear state on focus loss or reset.
+2. A model-owned mapper can convert that snapshot to Waypoint's Windows
+   virtual-key vocabulary, apply canvas and sensitivity scaling, reduce the
+   wheel to a ternary value, and construct `WaypointControl`. The existing
+   `WaypointControlEncoder` remains responsible for control-to-tensor encoding.
+
+The legacy `flashdreams.runtime.mapping.InputMapping` API is not a V2
+dependency and should not be revived inside this integration. `apps/cam2v`
+demonstrates the desired shared-app organization, but its keyboard-to-camera
+trajectory resampling is a different semantic contract. A future
+`apps/action2v`-style package should be extracted when a second interactive
+world-model integration can validate the common snapshot, mapper, replay, and
+control-help UI contracts. Until then, keeping this adapter explicitly named
+and scoped to Waypoint avoids freezing its virtual-key assumptions into V2.
 
 ## Class and ownership view
 
@@ -320,8 +358,9 @@ mapping and reset/focus semantics.
 - The integration preserves upstream model behavior, including possible
   long-rollout drift, unstable geometry, inconsistent objects, and implausible
   motion. It is not a physically accurate or safety-critical simulator.
-- Consolidating this application with the shared Cam2V app is deferred until
-  Cam2V exposes Waypoint's raw mouse/button/wheel control contract.
+- A generic action-to-video application and shared control-help overlay remain
+  follow-up work. Cam2V is an organizational precedent, not a compatible
+  control contract for Waypoint.
 
 ## Validation
 

--- a/integrations/waypoint/README.md
+++ b/integrations/waypoint/README.md
@@ -3,39 +3,295 @@ SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Waypoint model package for FlashDreams
+# Waypoint 1.5 architecture
 
-This package loads the published [Overworld/Waypoint-1.5-1B](https://huggingface.co/Overworld/Waypoint-1.5-1B) checkpoint through
-FlashDreams.
+This package is the model layer for the published
+[Overworld/Waypoint-1.5-1B](https://huggingface.co/Overworld/Waypoint-1.5-1B)
+checkpoint. It implements checkpoint loading, controls, the autoregressive
+diffusion pipeline, sparse K/V history, and the shared TAEHV codec. The
+[V2 application](../../integrations_v2/waypoint/README.md) owns CLI arguments,
+sessions, browser events, and presentation.
 
-## Model
+This document is the concise design-review reference. Exact validation commands,
+hardware, parity metrics, and long-rollout evidence are recorded in
+[VALIDATION.md](../../integrations_v2/waypoint/VALIDATION.md).
 
-- One action produces one 32-channel latent frame and four presented RGB frames.
-- Waypoint 1.5 has no text-conditioning input in its published checkpoint
-  configuration, so this integration will not expose a prompt encoder.
-- User controls are 256 button IDs, mouse delta, and scroll movement.
+## Scope and decisions
 
-## Integration baseline
+| Area | Design |
+|---|---|
+| Model | Dense BF16 autoregressive DiT, 24 blocks, width 2048, 32 query heads, 16 K/V heads |
+| Parameter accounting | Upstream model card: 1.2B; pinned BF16 checkpoint: 1,860,823,096 serialized tensor elements |
+| Inputs | Four-frame image seed plus one keyboard/mouse/wheel control per action |
+| Output | One 32-channel latent and four RGB frames per action |
+| Denoising | Fixed four-step rectified-flow Euler schedule: 1.0, 0.9, 0.75, 0.3, 0.0 |
+| History | Dense 16-action local window; sparse 128-action global horizon in every fourth block |
+| Context | 128 latent actions / 512 presented RGB frames on global-attention blocks |
+| Presentation | Native TAEHV canvas, 1024x512 TCHW in [-1, 1], four frames per result |
+| State | Model weights shared by the application; cache, RNG, controls, and seed isolated per session |
+| Concurrency | An application lock serializes shared model/RNG work; output tensors leave the model loop detached |
 
-- FlashDreams target: `8fd97fa38f04bc32c288760fa0fbf5da52464cea`
-  (the post-#506 V2 runtime).
-- Source integration: PR #464 at
-  `0f1782346f33cc47cc0bd456c3c48c5f3b7145f4`.
-- Published checkpoint:
-  `Overworld/Waypoint-1.5-1B/model.safetensors`.
-- Upstream parity implementation:
-  [Overworldai/world_engine](https://github.com/Overworldai/world_engine).
-- Closest reusable FlashDreams component: the shared Hunyuan Video 1.5 TAEHV
-  streaming codec. Waypoint's DiT and cache topology are model-specific.
+The published config has `prompt_conditioning: null`; this integration therefore
+does not load a text encoder or expose a prompt. It also does not currently
+implement the upstream 360P checkpoint, quantization, or multi-GPU execution.
 
-Runtime orchestration is intentionally outside this package. The V2 application
-adapter owns argument parsing, sessions, input events, presentation, and file or
-WebRTC output.
+## Use cases and modalities
+
+```mermaid
+flowchart LR
+    user([Interactive user])
+    replay([Replay, test, or benchmark])
+    seed[RGB or RGBA seed image]
+    live[Keyboard, mouse buttons,<br/>relative motion, wheel]
+    file[Versioned JSON controls]
+    app((waypoint-1-5-1b))
+    model[Waypoint 1.5 DiT + TAEHV]
+    browser[Live WebRTC video]
+    mp4[Deterministic MP4]
+    metrics[Per-action metrics JSON]
+    prompt[Text prompt<br/>not supported]
+
+    user --> seed
+    user --> live
+    replay --> seed
+    replay --> file
+    seed --> app
+    live --> app
+    file --> app
+    prompt -. excluded by checkpoint .-> app
+    app --> model
+    model --> browser
+    model --> mp4
+    model --> metrics
+```
+
+The seed establishes visual state; it is not a continuing image-conditioning
+stream. File controls select finite, reproducible MP4/metrics runs. Omitting a
+control file selects an open-ended live session driven by V2 browser events.
+
+## Component and file view
+
+```mermaid
+flowchart TB
+    subgraph core[flashdreams core and V2 runtime]
+        registry[application_registry.py<br/>slug discovery]
+        runner[application_runner.py / session_runner.py]
+        api[IApplication / ISession / IModelLoop]
+        sinks[WebRTCClientWindow / Mp4ClientWindow<br/>MetricsOutputSink]
+        base[StreamInferencePipeline<br/>DiffusionModel / Transformer]
+        taehv[recipes/taehv<br/>Hy15TAEHVEncoder and Decoder]
+    end
+
+    subgraph adapter[integrations_v2/waypoint]
+        app[app.py<br/>WaypointApplication]
+        session[session.py<br/>WaypointSession and ModelLoop]
+        events[control_events.py<br/>ControlEventAdapter]
+    end
+
+    subgraph waypoint[integrations/waypoint]
+        config[config.py and spec.py<br/>checkpoint contract]
+        pipeline[pipeline.py<br/>WaypointInferencePipeline]
+        controls[controls.py / encoder.py<br/>WaypointControl]
+        transformer[transformer/impl.py<br/>WaypointTransformer]
+        network[transformer/network.py<br/>WaypointDiT]
+        cache[transformer/cache.py<br/>WaypointKVCache]
+        scheduler[scheduler.py<br/>fixed Euler schedule]
+        codec[decoder.py<br/>WaypointTAEHVDecoder]
+        checkpoint[checkpoint.py<br/>strict state-dict mapping]
+    end
+
+    registry --> app
+    runner --> app
+    api -. implemented by .-> app
+    api -. implemented by .-> session
+    runner --> session
+    runner --> sinks
+    app --> session
+    app --> pipeline
+    session --> events
+    session --> pipeline
+    pipeline --> controls
+    pipeline --> transformer
+    pipeline --> scheduler
+    pipeline --> codec
+    transformer --> network
+    network --> cache
+    transformer --> checkpoint
+    config --> pipeline
+    base -. specialized by .-> pipeline
+    base -. specialized by .-> transformer
+    taehv -. reused by .-> pipeline
+    taehv -. specialized by .-> codec
+```
+
+The package boundary is intentional: `integrations/waypoint` is reusable model
+inference code and imports no V2 runtime classes. `integrations_v2/waypoint` is
+the thin application adapter and depends on both FlashDreams and the model
+package.
+
+## Class and ownership view
+
+```mermaid
+classDiagram
+    direction LR
+
+    class IApplication
+    class ISession
+    class IModelLoop
+    class StreamInferencePipeline
+    class Transformer
+    class StreamingEncoder
+    class Hy15TAEHVDecoder
+
+    class WaypointApplication {
+        -pipeline
+        -pipeline_lock
+        +init(args)
+        +session_desc()
+        +create_session(desc)
+    }
+    class WaypointSession {
+        -seed_frames
+        -controls
+        -state
+        +init()
+        +close()
+    }
+    class WaypointModelLoop {
+        +step(index, events)
+        +reset()
+        +close()
+    }
+    class WaypointModelState {
+        +cache
+        +rng_state
+        +control_events
+        +controls_generated
+    }
+    class WaypointInferencePipeline {
+        +initialize_cache(seed_pixels)
+        +generate(index, cache, control)
+        +finalize(index, cache)
+    }
+    class WaypointControlEncoder
+    class WaypointTransformer
+    class WaypointDiT
+    class WaypointKVCache
+    class WaypointTAEHVDecoder
+
+    IApplication <|-- WaypointApplication
+    ISession <|-- WaypointSession
+    IModelLoop <|-- WaypointModelLoop
+    StreamInferencePipeline <|-- WaypointInferencePipeline
+    StreamingEncoder <|-- WaypointControlEncoder
+    Transformer <|-- WaypointTransformer
+    Hy15TAEHVDecoder <|-- WaypointTAEHVDecoder
+
+    WaypointApplication o-- WaypointInferencePipeline : shares weights
+    WaypointApplication --> WaypointSession : creates
+    WaypointSession *-- WaypointModelState : owns
+    WaypointSession --> WaypointModelLoop : registers
+    WaypointModelLoop --> WaypointInferencePipeline : drives
+    WaypointInferencePipeline *-- WaypointControlEncoder
+    WaypointInferencePipeline *-- WaypointTransformer
+    WaypointInferencePipeline *-- WaypointTAEHVDecoder
+    WaypointTransformer *-- WaypointDiT
+    WaypointDiT --> WaypointKVCache : updates
+```
+
+The application owns expensive immutable modules. A session owns all mutable
+rollout state, including the transformer K/V cache, TAEHV state, seed tensors,
+RNG state, and control adapter. `StepResult` tensors are detached before
+publication so runtime queues and encoders do not retain model autograd state.
+
+## Initialization and action sequence
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Runtime as V2 runtime
+    participant App as WaypointApplication
+    participant Session as WaypointSession
+    participant Loop as WaypointModelLoop
+    participant Pipeline as WaypointInferencePipeline
+    participant DiT as WaypointTransformer / DiT
+    participant Cache as K/V + TAEHV caches
+    participant Sink as WebRTC or MP4 sink
+
+    Client->>Runtime: slug, runtime args, Waypoint args
+    Runtime->>App: init(args)
+    Runtime->>App: create_session(session_desc)
+    App->>App: lazily load one BF16 model
+    App-->>Runtime: new session with shared model + lock
+    Runtime->>Session: init()
+    Session->>Pipeline: initialize_cache(four seed frames)
+    Pipeline->>Cache: TAEHV encode and prime decoder state
+    Pipeline->>DiT: sigma-zero seed flow
+    DiT->>Cache: commit action 0 K/V
+
+    alt step 0
+        Runtime->>Loop: step(0, events)
+        Loop-->>Runtime: detached seed StepResult (4 frames)
+    else generated action N
+        Runtime->>Loop: step(N, ordered input events)
+        Loop->>Pipeline: generate(N, cache, control)
+        loop sigmas 1.0 to 0.3
+            Pipeline->>DiT: predict provisional flow
+            DiT->>Cache: replace provisional action-N K/V
+        end
+        Pipeline->>Cache: decode clean latent to 4 RGB frames
+        Loop->>Pipeline: finalize(N, cache)
+        Pipeline->>DiT: sigma-zero clean-state evaluation
+        DiT->>Cache: commit action-N K/V
+        Loop-->>Runtime: detached TCHW StepResult
+    end
+
+    Runtime->>Sink: present or encode four frames
+    opt browser reset
+        Client->>Runtime: reset event
+        Runtime->>Loop: reset()
+        Loop->>Pipeline: rebuild cache from retained seed
+    end
+```
+
+The four denoise evaluations may overwrite only the current provisional slot.
+`finalize` performs the separate sigma-zero evaluation that commits clean K/V
+state for the next action. Skipping or reordering that transition changes the
+autoregressive world state.
+
+## Tensor and control contracts
+
+| Boundary | Contract |
+|---|---|
+| Display seed | `[4, 3, 512, 1024]` TCHW float, normalized to `[-1, 1]` |
+| Codec seed | `[B, 4, 3, 512, 1024]` float in `[0, 1]` |
+| One model action | `[B, 1, 32, 32, 64]` latent before 2x2 patchification |
+| DiT token stream | 512 tokens per action, width 2048 |
+| Public control | 256-way multi-hot buttons, `mouse_dx`, `mouse_dy`, ternary wheel |
+| Model result | `[4, 3, 512, 1024]` detached TCHW float in `[-1, 1]` |
+
+The upstream runtime can resize a 1280x720 client image to the model's
+1024x512 codec canvas and resize decoded frames back to 1280x720. FlashDreams
+deliberately exposes the native 1024x512 canvas and performs no post-generation
+spatial resample.
+
+## Cache policy
+
+Each action has 512 spatial tokens. Most transformer blocks retain the latest
+16 actions densely. Global blocks occur at indices 3, 7, 11, 15, 19, and 23;
+they span 128 actions but pin only every eighth historical action plus the
+current action. On CUDA, fixed-capacity ring storage and a compiled
+`FlexAttention` block mask avoid reallocating or concatenating history. CPU
+tests use a compact dictionary representation as the readable reference.
+
+During denoising the cache is frozen: repeated evaluations replace a tail slot
+without advancing history. During seed establishment and `finalize`, it is
+unfrozen so the clean action is committed exactly once.
 
 ## Control files
 
-Pass a JSON action timeline with ``--controls-file``. It uses every listed
-action unless ``--actions N`` selects a prefix. The file format is:
+Pass a JSON action timeline with `--controls-file`. Every field within an
+action is optional:
 
 ```json
 {
@@ -48,8 +304,33 @@ action unless ``--actions N`` selects a prefix. The file format is:
 }
 ```
 
-Every field within an action is optional. ``buttons`` is an array of model
-button IDs, ``mouse_dx`` / ``mouse_dy`` are finite numbers, and
-``scroll_wheel`` is ``-1``, ``0``, or ``1``. A control file takes precedence
-over the repeated-control options, so it can be used without ``--buttons``,
-``--mouse-dx``, ``--mouse-dy``, or ``--scroll``.
+`buttons` must contain IDs in `[0, 256)`; mouse values must be finite; wheel
+is `-1`, `0`, or `1`. See
+[ADR-1](../../integrations_v2/waypoint/ADR-1-control-events.md) for browser-event
+mapping and reset/focus semantics.
+
+## Review boundaries and known limitations
+
+- One V2 application may create multiple sessions, but shared model execution
+  is serialized. The current WebRTC server accepts one browser client.
+- Reset is deterministic for a fixed seed and control sequence and rebuilds the
+  cache without temporarily retaining two full GPU caches.
+- The session advertises 60 FPS for playback pacing. Generation throughput is
+  hardware- and stack-dependent; it is not guaranteed to sustain that rate.
+- The integration preserves upstream model behavior, including possible
+  long-rollout drift, unstable geometry, inconsistent objects, and implausible
+  motion. It is not a physically accurate or safety-critical simulator.
+- Consolidating this application with the shared Cam2V app is deferred until
+  Cam2V exposes Waypoint's raw mouse/button/wheel control contract.
+
+## Validation
+
+CPU tests cover checkpoint contracts, controls, lifecycle, reset, detached
+outputs, MP4 frame accounting, and session isolation. CUDA tests cover local
+and global fixed-cache attention through ring wraparound. Published-weight
+validation covers official-reference parity, 15 distinct scenes at 40 actions,
+one 118-action rollout, native-resolution MP4 output, and steady-state
+performance on an RTX PRO 6000 Blackwell.
+
+See [the V2 validation record](../../integrations_v2/waypoint/VALIDATION.md) for
+the exact revisions, hashes, commands, metrics, and acceptance evidence.

--- a/integrations/waypoint/pyproject.toml
+++ b/integrations/waypoint/pyproject.toml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flashdreams-waypoint"
+version = "0.1.0"
+description = "FlashDreams integration for the Waypoint 1.5 world-model checkpoint."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = ["flashdreams"]
+
+[tool.uv.sources]
+flashdreams = { workspace = true }
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[tool.setuptools.packages.find]
+include = ["waypoint*"]
+exclude = ["tests"]
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib -p flashdreams._pytest_plugins.marker_enforcement"
+markers = [
+    "ci_cpu: CPU-safe test, runs on the CPU CI runner",
+    "ci_gpu: requires GPU or libGL (cv2), runs on the GPU CI runner",
+    "manual: heavy or environment-specific test, opt-in only",
+]

--- a/integrations/waypoint/tests/test_cuda.py
+++ b/integrations/waypoint/tests/test_cuda.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA equivalence tests for Waypoint's fixed-capacity attention cache."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+import torch.nn.functional as F
+from waypoint import WAYPOINT_1_5
+from waypoint.transformer import WaypointAttentionPolicy, WaypointKVCache
+from waypoint.transformer.network import _compiled_fixed_attention
+
+pytestmark = pytest.mark.ci_gpu
+
+
+@pytest.mark.parametrize("layer_index", [0, 3], ids=["local", "global"])
+def test_fixed_cuda_attention_matches_compact_reference(layer_index: int) -> None:
+    """Fixed CUDA history produces the compact policy's attention results."""
+    assert torch.cuda.is_available()
+    spec = replace(
+        WAYPOINT_1_5,
+        n_layers=4,
+        local_window=2,
+        global_window=6,
+        global_pinned_dilation=2,
+    )
+    policy = WaypointAttentionPolicy(spec=spec)
+    compact = WaypointKVCache(policy=policy)
+    fixed = WaypointKVCache(policy=policy, use_fixed_attention=True)
+    generator = torch.Generator(device="cuda").manual_seed(464)
+
+    for frame_index in range(8):
+        key = torch.randn(
+            1,
+            1,
+            128,
+            16,
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        value = torch.randn(
+            key.shape,
+            device="cuda",
+            dtype=key.dtype,
+            generator=generator,
+        )
+        query = torch.randn(
+            1,
+            2,
+            128,
+            16,
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        reference_view = compact.update(
+            layer_index=layer_index,
+            frame_index=frame_index,
+            key=key,
+            value=value,
+        )
+        fixed.set_frozen(False)
+        fixed_view = fixed.update(
+            layer_index=layer_index,
+            frame_index=frame_index,
+            key=key,
+            value=value,
+        )
+        fixed.set_frozen(True)
+
+        reference = F.scaled_dot_product_attention(
+            query,
+            reference_view.key,
+            reference_view.value,
+            enable_gqa=True,
+        )
+        assert fixed_view.block_mask is not None
+        actual = _compiled_fixed_attention(
+            query,
+            fixed_view.key,
+            fixed_view.value,
+            fixed_view.block_mask,
+        )
+        torch.testing.assert_close(actual, reference, atol=2e-2, rtol=2e-2)

--- a/integrations/waypoint/tests/test_cuda.py
+++ b/integrations/waypoint/tests/test_cuda.py
@@ -62,6 +62,20 @@ def test_fixed_cuda_attention_matches_compact_reference(layer_index: int) -> Non
             key=key,
             value=value,
         )
+        fixed.set_frozen(True)
+        provisional_view = fixed.update(
+            layer_index=layer_index,
+            frame_index=frame_index,
+            key=key,
+            value=value,
+        )
+        repeated_view = fixed.update(
+            layer_index=layer_index,
+            frame_index=frame_index,
+            key=key,
+            value=value,
+        )
+        assert repeated_view.block_mask is provisional_view.block_mask
         fixed.set_frozen(False)
         fixed_view = fixed.update(
             layer_index=layer_index,
@@ -69,6 +83,7 @@ def test_fixed_cuda_attention_matches_compact_reference(layer_index: int) -> Non
             key=key,
             value=value,
         )
+        assert fixed_view.block_mask is provisional_view.block_mask
         fixed.set_frozen(True)
 
         reference = F.scaled_dot_product_attention(

--- a/integrations/waypoint/tests/test_spec.py
+++ b/integrations/waypoint/tests/test_spec.py
@@ -84,6 +84,7 @@ def test_waypoint_1_5_static_contract() -> None:
     assert WAYPOINT_1_5.global_pinned_dilation == 8
     assert WAYPOINT_1_5.value_residual
     assert WAYPOINT_1_5.noise_conditioning == "wan"
+    assert WAYPOINT_1_5.noise_embedding_dim == 512
     assert WAYPOINT_1_5.rope_theta == 10_000.0
     assert WAYPOINT_1_5.rope_nyquist_fraction == 0.8
     assert not WAYPOINT_1_5.text_conditioning

--- a/integrations/waypoint/tests/test_spec.py
+++ b/integrations/waypoint/tests/test_spec.py
@@ -1,0 +1,596 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only contract tests for the independently authored Waypoint adapter."""
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+from waypoint import (
+    WAYPOINT_1_5,
+    WaypointControl,
+    load_controls_from_file,
+    make_control_context,
+)
+from waypoint.checkpoint import (
+    expected_waypoint_1_5_checkpoint_keys,
+    expected_waypoint_1_5_checkpoint_shapes,
+    load_waypoint_state_dict,
+    validate_waypoint_1_5_checkpoint_keys,
+    validate_waypoint_1_5_checkpoint_shapes,
+)
+from waypoint.config import PIPELINE_WAYPOINT_1_5
+from waypoint.decoder import WaypointTAEHVDecoder
+from waypoint.encoder import WaypointControlEncoderConfig
+from waypoint.pipeline import WaypointInferencePipeline, WaypointInferencePipelineConfig
+from waypoint.transformer import (
+    WaypointAttentionPolicy,
+    WaypointDiTConfig,
+    WaypointKVCache,
+    WaypointOrthoRoPEAngles,
+    WaypointTransformerConfig,
+    adaptive_gate,
+    adaptive_rms_norm,
+    apply_waypoint_ortho_rope,
+)
+from waypoint.transformer.impl import WaypointTransformerCache
+from waypoint.transformer.network import (
+    _ConditionHead,
+    _ControlFusion,
+    _WaypointAttention,
+    _WaypointBlock,
+    sinusoidal_noise_embedding,
+)
+
+EXAMPLE_CONTROL_FILE = (
+    Path(__file__).parents[3]
+    / "assets"
+    / "example_data"
+    / "waypoint"
+    / "example_controls.json"
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_waypoint_1_5_static_contract() -> None:
+    """The published Waypoint configuration has stable model-shape invariants."""
+    assert isinstance(PIPELINE_WAYPOINT_1_5, WaypointInferencePipelineConfig)
+    assert WAYPOINT_1_5.latent_shape() == (1, 1, 32, 32, 64)
+    assert WAYPOINT_1_5.tokens_per_latent_frame == 512
+    assert WAYPOINT_1_5.patch_grid_height == 16
+    assert WAYPOINT_1_5.patch_grid_width == 32
+    assert WAYPOINT_1_5.frames_per_action == 4
+    assert WAYPOINT_1_5.num_denoising_steps == 4
+    assert WAYPOINT_1_5.frame_timestamp_stride == 1
+    assert WAYPOINT_1_5.head_dim == 64
+    assert WAYPOINT_1_5.global_attention_layers == (3, 7, 11, 15, 19, 23)
+    assert WAYPOINT_1_5.global_pinned_dilation == 8
+    assert WAYPOINT_1_5.value_residual
+    assert WAYPOINT_1_5.noise_conditioning == "wan"
+    assert WAYPOINT_1_5.rope_theta == 10_000.0
+    assert WAYPOINT_1_5.rope_nyquist_fraction == 0.8
+    assert not WAYPOINT_1_5.text_conditioning
+
+
+def test_control_context_preserves_waypoint_action_semantics() -> None:
+    """Buttons, motion, scroll, and latent-frame time use model-ready shapes."""
+    context = make_control_context(
+        WaypointControl(buttons=frozenset({65, 87}), mouse_dx=0.125, mouse_dy=-0.25),
+        frame_index=7,
+        dtype=torch.float32,
+    )
+    assert context["button"].shape == (1, 1, 256)
+    assert context["button"][0, 0, 65].item() == 1.0
+    assert context["button"][0, 0, 87].item() == 1.0
+    assert context["mouse"].tolist() == [[[0.125, -0.25]]]
+    assert context["scroll"].tolist() == [[[0.0]]]
+    assert context["frame_idx"].tolist() == [[7]]
+    assert context["frame_timestamp"].tolist() == [[7]]
+
+
+def test_control_timeline_file_preserves_per_action_inputs(tmp_path) -> None:
+    """JSON control files retain neutral defaults and explicit action values."""
+    path = tmp_path / "controls.json"
+    path.write_text(
+        """{
+  "schema_version": 1,
+  "actions": [
+    {"buttons": [32], "mouse_dx": 0.1, "scroll_wheel": -1},
+    {}
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    controls = load_controls_from_file(path)
+    assert controls == (
+        WaypointControl(buttons=frozenset({32}), mouse_dx=0.1, scroll_wheel=-1),
+        WaypointControl(),
+    )
+
+
+def test_example_controls_are_complete() -> None:
+    """The runner example uses the complete fixed 118-action demonstration."""
+    controls = load_controls_from_file(EXAMPLE_CONTROL_FILE)
+    assert len(controls) == 118
+    assert controls[0] == WaypointControl(mouse_dx=0.2, mouse_dy=0.2)
+    assert controls[1] == WaypointControl(buttons=frozenset({32}))
+    assert controls[8] == WaypointControl(buttons=frozenset({1, 32}))
+    assert controls[68] == WaypointControl(buttons=frozenset({32}))
+    assert controls[78] == WaypointControl(buttons=frozenset({65}))
+    assert controls[88] == WaypointControl(buttons=frozenset({68}))
+    assert controls[98] == WaypointControl(buttons=frozenset({83}))
+
+
+@pytest.mark.parametrize("buttons", [frozenset({-1}), frozenset({256})])
+def test_control_context_rejects_invalid_button_ids(buttons: frozenset[int]) -> None:
+    """The native adapter must never index outside the fixed button vocabulary."""
+    with pytest.raises(ValueError, match="button IDs"):
+        make_control_context(WaypointControl(buttons=buttons), frame_index=0)
+
+
+def test_waypoint_raw_checkpoint_schema_accounts_for_every_tensor() -> None:
+    """The checkpoint schema captures the published raw 393-tensor layout."""
+    keys = expected_waypoint_1_5_checkpoint_keys()
+    assert len(keys) == 393
+    validate_waypoint_1_5_checkpoint_keys(keys)
+
+
+def test_waypoint_raw_checkpoint_schema_rejects_unknown_tensor() -> None:
+    """Loader work must not silently accept a changed checkpoint format."""
+    keys = set(expected_waypoint_1_5_checkpoint_keys())
+    keys.add("transformer.blocks.0.unknown.weight")
+    with pytest.raises(ValueError, match="extra"):
+        validate_waypoint_1_5_checkpoint_keys(keys)
+
+
+def test_raw_checkpoint_shapes_match_the_published_schema() -> None:
+    """The checkpoint contract records every raw tensor shape without a fake network."""
+    shapes = expected_waypoint_1_5_checkpoint_shapes()
+    assert set(shapes) == expected_waypoint_1_5_checkpoint_keys()
+    assert shapes["patchify.weight"] == (2048, 32, 2, 2)
+    assert shapes["unpatchify.weight"] == (2048, 32, 2, 2)
+    assert shapes["transformer.blocks.0.attn.k_proj.weight"] == (1024, 2048)
+    validate_waypoint_1_5_checkpoint_shapes(shapes)
+
+
+def test_checkpoint_loader_requires_the_exact_native_namespace() -> None:
+    """Validated raw tensors load without a hidden key remap."""
+    tiny_spec = replace(
+        WAYPOINT_1_5,
+        n_layers=1,
+        d_model=16,
+        n_heads=1,
+        n_kv_heads=1,
+        mlp_ratio=2,
+    )
+    source = WaypointDiTConfig(spec=tiny_spec).setup()
+    target = WaypointDiTConfig(spec=tiny_spec).setup()
+    state_dict = source.state_dict()
+    load_waypoint_state_dict(target, state_dict, spec=tiny_spec)
+    assert torch.equal(target.patchify.weight, source.patchify.weight)
+
+
+def test_raw_checkpoint_shape_validation_rejects_a_mismatch() -> None:
+    """Loader work must not accept a changed raw tensor shape."""
+    shapes = expected_waypoint_1_5_checkpoint_shapes()
+    shapes["patchify.weight"] = (1,)
+    with pytest.raises(ValueError, match="shape mismatch"):
+        validate_waypoint_1_5_checkpoint_shapes(shapes)
+
+
+def test_native_dit_topology_matches_the_raw_checkpoint_schema() -> None:
+    """The native DiT module graph can load every published raw tensor name."""
+    with torch.device("meta"):
+        network = WaypointDiTConfig().setup()
+    state_shapes = {
+        key: tuple(value.shape) for key, value in network.state_dict().items()
+    }
+    assert state_shapes == expected_waypoint_1_5_checkpoint_shapes()
+    query, key, value = network.transformer.blocks[0].attn.project_qkv(
+        torch.empty(2, 512, WAYPOINT_1_5.d_model, device="meta")
+    )
+    assert query.shape == (2, 512, 32, 64)
+    assert key.shape == value.shape == (2, 512, 16, 64)
+
+
+def test_orthogonal_rope_angles_match_waypoint_geometry() -> None:
+    """RoPE reserves x, y, and time frequency bands in that exact order."""
+    rope = WaypointOrthoRoPEAngles()
+    cosine, sine = rope(
+        frame_index=torch.tensor([0, 1]),
+        row_index=torch.tensor([0, 1]),
+        column_index=torch.tensor([0, 1]),
+    )
+    assert cosine.shape == (2, 1, 32)
+    assert sine.shape == (2, 1, 32)
+    # At x=0, the first frequency is pi / 16 at the centered patch x=-15.5.
+    assert cosine[0, 0, 0].item() == pytest.approx(-0.9951847, abs=1e-6)
+    assert sine[0, 0, 0].item() == pytest.approx(-0.0980171, abs=1e-6)
+    # The temporal band follows the two eight-value spatial bands.
+    assert cosine[1, 0, 16].item() == pytest.approx(torch.cos(torch.tensor(1.0)).item())
+    assert sine[1, 0, 16].item() == pytest.approx(torch.sin(torch.tensor(1.0)).item())
+
+
+def test_wan_noise_features_use_waypoints_scaled_sine_cosine_order() -> None:
+    """Noise modulation uses the checkpoint's 1000x, sqrt-two Fourier basis."""
+    features = sinusoidal_noise_embedding(512, torch.tensor([1.0]))
+    assert features.shape == (1, 512)
+    assert features[0, 0].item() == pytest.approx(1.1693842, abs=1e-6)
+    assert features[0, 256].item() == pytest.approx(0.7953241, abs=1e-6)
+
+
+def test_orthogonal_rope_rotates_two_half_heads() -> None:
+    """RoPE rotates each packed half-head pair without mixing attention heads."""
+    tokens = torch.zeros(1, 1, 1, 64)
+    tokens[..., 0] = 1.0
+    cosine = torch.full((1, 1, 32), 0.6)
+    sine = torch.full((1, 1, 32), 0.8)
+    output = apply_waypoint_ortho_rope(tokens, cosine, sine)
+    assert output[..., 0].item() == pytest.approx(0.6)
+    assert output[..., 32].item() == pytest.approx(0.8)
+
+
+def test_adaptive_rms_norm_conditions_each_latent_frame() -> None:
+    """AdaRMSNorm broadcasts a separate scale and bias over each frame's tokens."""
+    tokens = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [2.0, 4.0], [6.0, 8.0]]])
+    scale = torch.tensor([[[1.0, 0.0], [0.0, 1.0]]])
+    bias = torch.tensor([[[0.1, 0.2], [0.3, 0.4]]])
+    output = adaptive_rms_norm(tokens, scale, bias)
+    rms = torch.rsqrt(torch.mean(tokens.square(), dim=-1, keepdim=True))
+    expected = tokens * rms
+    expected[:, :2] = expected[:, :2] * torch.tensor([2.0, 1.0]) + torch.tensor(
+        [0.1, 0.2]
+    )
+    expected[:, 2:] = expected[:, 2:] * torch.tensor([1.0, 2.0]) + torch.tensor(
+        [0.3, 0.4]
+    )
+    assert torch.allclose(output, expected)
+
+
+def test_adaptive_gate_scales_each_latent_frame() -> None:
+    """AdaGate broadcasts each frame's learned residual multiplier over its tokens."""
+    tokens = torch.ones(1, 4, 2)
+    gate = torch.tensor([[[2.0, 3.0], [5.0, 7.0]]])
+    output = adaptive_gate(tokens, gate)
+    assert torch.equal(
+        output,
+        torch.tensor([[[2.0, 3.0], [2.0, 3.0], [5.0, 7.0], [5.0, 7.0]]]),
+    )
+
+
+def test_value_residual_blends_with_the_first_block_value_stream() -> None:
+    """Later blocks linearly blend their V tensor with the retained first V tensor."""
+    attention = _WaypointAttention(
+        replace(WAYPOINT_1_5, d_model=8, n_heads=1, n_kv_heads=1)
+    )
+    current = torch.tensor([[[[1.0, 2.0]]]])
+    initial = torch.tensor([[[[10.0, 20.0]]]])
+    attention.v_lamb.data.fill_(2.0)
+    mixed, retained = attention.blend_value_residual(current, initial)
+    assert torch.equal(mixed, torch.tensor([[[[19.0, 38.0]]]]))
+    assert retained is initial
+
+
+def test_attention_uses_grouped_query_sparse_kv_view() -> None:
+    """Attention accepts cached KV heads without expanding them to query heads."""
+    tiny_spec = replace(
+        WAYPOINT_1_5,
+        n_layers=4,
+        d_model=16,
+        n_heads=1,
+        n_kv_heads=1,
+        local_window=2,
+        global_window=6,
+        global_pinned_dilation=2,
+    )
+    attention = _WaypointAttention(tiny_spec)
+    for projection in (
+        attention.q_proj,
+        attention.k_proj,
+        attention.v_proj,
+        attention.out_proj,
+    ):
+        projection.weight.data.copy_(torch.eye(16))
+    attention.v_lamb.data.zero_()
+    cache = WaypointKVCache(policy=WaypointAttentionPolicy(spec=tiny_spec))
+    tokens = torch.tensor([[[1.0] * 16, [2.0] * 16]])
+    cosine = torch.ones(2, 1, 8)
+    sine = torch.zeros(2, 1, 8)
+    output, retained = attention(
+        tokens,
+        cosine=cosine,
+        sine=sine,
+        layer_index=0,
+        frame_index=0,
+        kv_cache=cache,
+        initial_value=None,
+    )
+    assert output.shape == tokens.shape
+    assert retained.shape == (1, 2, 1, 16)
+
+
+def test_block_composes_adaptive_attention_control_and_mlp_paths() -> None:
+    """The block preserves frame-aware conditioning through both residual paths."""
+    tiny_spec = replace(
+        WAYPOINT_1_5,
+        n_layers=4,
+        d_model=16,
+        n_heads=1,
+        n_kv_heads=1,
+        mlp_ratio=2,
+        local_window=2,
+        global_window=6,
+        global_pinned_dilation=2,
+    )
+    block = _WaypointBlock(tiny_spec, has_control_fusion=True)
+    cache = WaypointKVCache(policy=WaypointAttentionPolicy(spec=tiny_spec))
+    tokens = torch.randn(1, 2, 16)
+    conditioning = torch.randn(1, 1, 16)
+    control = torch.randn(1, 2, 16)
+    output, initial_value = block(
+        tokens,
+        conditioning=conditioning,
+        control=control,
+        cosine=torch.ones(2, 1, 8),
+        sine=torch.zeros(2, 1, 8),
+        layer_index=0,
+        frame_index=0,
+        kv_cache=cache,
+        initial_value=None,
+    )
+    assert output.shape == tokens.shape
+    assert initial_value.shape == (1, 2, 1, 16)
+
+
+def test_dit_runs_one_complete_latent_action() -> None:
+    """The native DiT keeps controller, RoPE, cache, and output layouts aligned."""
+    tiny_spec = replace(
+        WAYPOINT_1_5,
+        n_layers=4,
+        d_model=16,
+        n_heads=1,
+        n_kv_heads=1,
+        mlp_ratio=2,
+        local_window=2,
+        global_window=6,
+        global_pinned_dilation=2,
+    )
+    network = WaypointDiTConfig(spec=tiny_spec).setup()
+    for parameter in network.parameters():
+        parameter.data.zero_()
+    cache = WaypointKVCache(policy=WaypointAttentionPolicy(spec=tiny_spec))
+    latent = torch.randn(1, 1, 32, 32, 64)
+    output = network(
+        latent,
+        sigma=torch.ones(1),
+        frame_index=0,
+        kv_cache=cache,
+        button=torch.zeros(1, 1, 256),
+        mouse=torch.zeros(1, 1, 2),
+        scroll=torch.zeros(1, 1, 1),
+    )
+    assert output.shape == latent.shape
+    assert torch.equal(output, torch.zeros_like(latent))
+
+
+def test_flashdreams_transformer_adapter_owns_action_layout_and_control() -> None:
+    """The framework adapter passes one public action into the native DiT."""
+    tiny_spec = replace(
+        WAYPOINT_1_5,
+        n_layers=4,
+        d_model=16,
+        n_heads=1,
+        n_kv_heads=1,
+        mlp_ratio=2,
+        local_window=2,
+        global_window=6,
+        global_pinned_dilation=2,
+    )
+    transformer = WaypointTransformerConfig(
+        network=WaypointDiTConfig(spec=tiny_spec), dtype=torch.float32
+    ).setup()
+    for parameter in transformer.parameters():
+        parameter.data.zero_()
+    cache = transformer.initialize_autoregressive_cache(batch_size=1)
+    cache.start(0)
+    noisy = torch.randn(1, 1, 32, 32, 64)
+    output = transformer.predict_flow(
+        noisy,
+        torch.tensor(1.0),
+        cache,
+        WaypointControl(buttons=frozenset({87})),
+    )
+    assert output.shape == noisy.shape
+    assert torch.equal(output, torch.zeros_like(noisy))
+    external = transformer.unpatchify_and_maybe_gather_cp(output)
+    assert external.shape == (1, 32, 1, 32, 64)
+    assert torch.equal(transformer.patchify_and_maybe_split_cp(external), output)
+
+
+def test_pipeline_runs_fixed_euler_steps_for_one_controlled_action() -> None:
+    """The generic pipeline can drive Waypoint without a custom serving loop."""
+    from flashdreams.infra.diffusion.model import DiffusionModelConfig
+    from flashdreams.infra.diffusion.scheduler import (
+        FlowMatchEulerDiscreteSchedulerConfig,
+    )
+    from flashdreams.infra.pipeline import StreamInferencePipelineConfig
+
+    tiny_spec = replace(
+        WAYPOINT_1_5,
+        n_layers=1,
+        d_model=16,
+        n_heads=1,
+        n_kv_heads=1,
+        mlp_ratio=2,
+    )
+    pipeline = StreamInferencePipelineConfig(
+        name="waypoint-test",
+        diffusion_model=DiffusionModelConfig(
+            transformer=WaypointTransformerConfig(
+                network=WaypointDiTConfig(spec=tiny_spec), dtype=torch.float32
+            ),
+            scheduler=FlowMatchEulerDiscreteSchedulerConfig(
+                num_inference_steps=4,
+                num_train_timesteps=1,
+                fixed_timesteps=tiny_spec.scheduler_sigmas,
+            ),
+        ),
+        encoder=WaypointControlEncoderConfig(),
+    ).setup()
+    for parameter in pipeline.parameters():
+        parameter.data.zero_()
+    cache = pipeline.initialize_cache(transformer_context={"batch_size": 1})
+    output = pipeline.generate(0, cache, WaypointControl(buttons=frozenset({87})))
+    pipeline.finalize(0, cache)
+    assert output.shape == (1, 32, 1, 32, 64)
+
+
+def test_seed_initialization_advances_decoder_history_once() -> None:
+    """The seed latent establishes one matching transformer and decoder action."""
+    pipeline = WaypointInferencePipeline.__new__(WaypointInferencePipeline)
+    torch.nn.Module.__init__(pipeline)
+
+    seed_latent = torch.zeros(1, 1, 32, 32, 64)
+    decoder_cache = object()
+    decoder = WaypointTAEHVDecoder.__new__(WaypointTAEHVDecoder)
+    torch.nn.Module.__init__(decoder)
+    decoder.initialize_autoregressive_cache = Mock(return_value=decoder_cache)
+    decoder.forward = Mock()
+
+    transformer_cache = WaypointTransformerCache(batch_size=1)
+    transformer = SimpleNamespace(
+        initialize_autoregressive_cache=Mock(return_value=transformer_cache),
+        predict_flow=Mock(),
+    )
+    pipeline.seed_encoder = SimpleNamespace(
+        taehv=SimpleNamespace(encode=Mock(return_value=seed_latent))
+    )
+    pipeline.encoder = None
+    pipeline.decoder = decoder
+    pipeline.diffusion_model = SimpleNamespace(
+        device=torch.device("cpu"), transformer=transformer
+    )
+
+    cache = pipeline.initialize_cache(
+        seed_pixels=torch.zeros(1, 4, 3, 512, 1024),
+    )
+
+    transformer.predict_flow.assert_called_once()
+    decoder.forward.assert_called_once()
+    assert decoder.forward.call_args.args[0].shape == (1, 32, 1, 32, 64)
+    assert decoder.forward.call_args.kwargs == {
+        "autoregressive_index": 0,
+        "cache": decoder_cache,
+    }
+    assert cache.autoregressive_index == 0
+
+
+def test_attention_policy_selects_dense_local_and_pinned_global_history() -> None:
+    """Waypoint uses a short dense history or a dilated long-range history."""
+    policy = WaypointAttentionPolicy()
+    assert not policy.is_global_layer(2)
+    assert policy.is_global_layer(3)
+    assert policy.visible_frame_indices(layer_index=2, frame_index=17) == tuple(
+        range(2, 18)
+    )
+    assert policy.visible_frame_indices(layer_index=3, frame_index=130) == (
+        8,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+        72,
+        80,
+        88,
+        96,
+        104,
+        112,
+        120,
+        128,
+        130,
+    )
+
+
+def test_kv_cache_replaces_provisional_frame_and_evicts_hidden_history() -> None:
+    """A cache view contains only the frames the checkpoint can attend to."""
+    small_spec = replace(
+        WAYPOINT_1_5,
+        n_layers=4,
+        local_window=2,
+        global_window=6,
+        global_pinned_dilation=2,
+    )
+    cache = WaypointKVCache(policy=WaypointAttentionPolicy(spec=small_spec))
+
+    for frame_index in range(7):
+        value = torch.full((1, 1, 2, 2), float(frame_index))
+        global_view = cache.update(
+            layer_index=3,
+            frame_index=frame_index,
+            key=value,
+            value=-value,
+        )
+    assert global_view.frame_indices == (2, 4, 6)
+    assert global_view.key[0, 0, ::2, 0].tolist() == [2.0, 4.0, 6.0]
+
+    replacement = torch.full((1, 1, 2, 2), 99.0)
+    global_view = cache.update(
+        layer_index=3,
+        frame_index=6,
+        key=replacement,
+        value=-replacement,
+    )
+    assert global_view.key[0, 0, ::2, 0].tolist() == [2.0, 4.0, 99.0]
+
+    for frame_index in range(4):
+        value = torch.full((1, 1, 2, 2), float(frame_index))
+        local_view = cache.update(
+            layer_index=0,
+            frame_index=frame_index,
+            key=value,
+            value=value,
+        )
+    assert local_view.frame_indices == (2, 3)
+    assert local_view.key[0, 0, ::2, 0].tolist() == [2.0, 3.0]
+
+
+def test_condition_and_control_fusion_primitives_use_silu_paths() -> None:
+    """Checkpoint projection names retain the observed conditioning semantics."""
+    condition = _ConditionHead(2)
+    condition.bias_in.data.copy_(torch.tensor([0.5, -0.5]))
+    for projection in condition.cond_proj:
+        assert isinstance(projection, torch.nn.Linear)
+        projection.weight.data.copy_(torch.eye(2))
+    values = condition(torch.tensor([[-1.0, 2.0]]))
+    expected = torch.nn.functional.silu(torch.tensor([[-0.5, 1.5]]))
+    assert all(torch.allclose(value, expected) for value in values)
+
+    fusion = _ControlFusion(2)
+    fusion.fc1_x.weight.data.copy_(torch.eye(2))
+    fusion.fc1_c.weight.data.copy_(torch.eye(2))
+    fusion.fc2.weight.data.copy_(torch.eye(2))
+    output = fusion(torch.tensor([[[1.0, 2.0]]]), torch.tensor([[[3.0, 4.0]]]))
+    assert torch.allclose(
+        output, torch.nn.functional.silu(torch.tensor([[[4.0, 6.0]]]))
+    )

--- a/integrations/waypoint/waypoint/__init__.py
+++ b/integrations/waypoint/waypoint/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Waypoint 1.5 integration contracts."""
+
+from waypoint.controls import (
+    WaypointControl,
+    load_controls_from_file,
+    make_control_context,
+)
+from waypoint.encoder import WaypointControlEncoder, WaypointControlEncoderConfig
+from waypoint.spec import WAYPOINT_1_5, WaypointModelSpec
+
+__all__ = [
+    "WAYPOINT_1_5",
+    "WaypointControl",
+    "WaypointControlEncoder",
+    "WaypointControlEncoderConfig",
+    "WaypointModelSpec",
+    "load_controls_from_file",
+    "make_control_context",
+]

--- a/integrations/waypoint/waypoint/checkpoint.py
+++ b/integrations/waypoint/waypoint/checkpoint.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Waypoint checkpoint metadata and key-layout validation."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+import torch
+from torch import nn
+
+from waypoint.spec import WAYPOINT_1_5, WaypointModelSpec
+
+
+@dataclass(frozen=True, kw_only=True)
+class CheckpointInventory:
+    """Small, CPU-only description of a safetensors checkpoint."""
+
+    tensor_count: int
+    """Number of tensors in the safetensors artifact."""
+    dtypes: dict[str, int]
+    """Count of tensors by safetensors dtype label."""
+    total_elements: int
+    """Total scalar element count across all tensors."""
+
+
+def expected_waypoint_1_5_checkpoint_shapes(
+    spec: WaypointModelSpec = WAYPOINT_1_5,
+) -> dict[str, tuple[int, ...]]:
+    """Return raw checkpoint tensor shapes for the published 1.5 artifact.
+
+    Args:
+        spec: Static checkpoint contract that defines the block layout.
+
+    Returns:
+        Raw safetensors names mapped to their expected shapes.
+    """
+    d_model = spec.d_model
+    hidden_dim = spec.mlp_ratio * d_model
+    kv_dim = spec.n_kv_heads * spec.head_dim
+    shapes = {
+        "ctrl_cfg.null_emb": (1, 1, d_model),
+        "ctrl_emb.mlp.fc1.weight": (hidden_dim, spec.n_buttons + 3),
+        "ctrl_emb.mlp.fc2.weight": (d_model, hidden_dim),
+        "denoise_step_emb.mlp.fc1.weight": (hidden_dim, 512),
+        "denoise_step_emb.mlp.fc2.weight": (d_model, hidden_dim),
+        "out_norm.fc.weight": (2 * d_model, d_model),
+        "patchify.weight": (
+            d_model,
+            spec.channels,
+            spec.patch_height,
+            spec.patch_width,
+        ),
+        "unpatchify.bias": (spec.channels,),
+        "unpatchify.weight": (
+            d_model,
+            spec.channels,
+            spec.patch_height,
+            spec.patch_width,
+        ),
+    }
+    for layer_index in range(spec.n_layers):
+        prefix = f"transformer.blocks.{layer_index}."
+        shapes.update(
+            {
+                prefix + "attn.k_proj.weight": (kv_dim, d_model),
+                prefix + "attn.out_proj.weight": (d_model, d_model),
+                prefix + "attn.q_proj.weight": (d_model, d_model),
+                prefix + "attn.v_lamb": (),
+                prefix + "attn.v_proj.weight": (kv_dim, d_model),
+                prefix + "attn_cond_head.bias_in": (d_model,),
+                **{
+                    prefix + f"attn_cond_head.cond_proj.{index}.weight": (
+                        d_model,
+                        d_model,
+                    )
+                    for index in range(3)
+                },
+                prefix + "dit_mlp.fc1.weight": (hidden_dim, d_model),
+                prefix + "dit_mlp.fc2.weight": (d_model, hidden_dim),
+                prefix + "mlp_cond_head.bias_in": (d_model,),
+                **{
+                    prefix + f"mlp_cond_head.cond_proj.{index}.weight": (
+                        d_model,
+                        d_model,
+                    )
+                    for index in range(3)
+                },
+            }
+        )
+        if layer_index % spec.controller_conditioning_period == 0:
+            shapes.update(
+                {
+                    prefix + "ctrl_mlpfusion.fc1_c.weight": (d_model, d_model),
+                    prefix + "ctrl_mlpfusion.fc1_x.weight": (d_model, d_model),
+                    prefix + "ctrl_mlpfusion.fc2.weight": (d_model, d_model),
+                }
+            )
+    return shapes
+
+
+def expected_waypoint_1_5_checkpoint_keys(
+    spec: WaypointModelSpec = WAYPOINT_1_5,
+) -> frozenset[str]:
+    """Return raw checkpoint names for the published 1.5 artifact.
+
+    Args:
+        spec: Static checkpoint contract that defines the block layout.
+
+    Returns:
+        Every raw safetensors key expected from the target checkpoint.
+    """
+    return frozenset(expected_waypoint_1_5_checkpoint_shapes(spec))
+
+
+def validate_waypoint_1_5_checkpoint_keys(
+    keys: set[str] | frozenset[str] | tuple[str, ...] | list[str],
+    *,
+    spec: WaypointModelSpec = WAYPOINT_1_5,
+) -> None:
+    """Reject a checkpoint whose raw tensor-key layout differs from Waypoint 1.5.
+
+    Args:
+        keys: Raw key names read from a safetensors checkpoint.
+        spec: Static checkpoint contract that defines the expected layout.
+
+    Raises:
+        ValueError: The artifact contains missing or unexpected tensor keys.
+    """
+    actual = set(keys)
+    expected = expected_waypoint_1_5_checkpoint_keys(spec)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing or extra:
+        raise ValueError(
+            "Waypoint 1.5 checkpoint key layout mismatch: "
+            f"missing={missing[:5]} ({len(missing)} total), "
+            f"extra={extra[:5]} ({len(extra)} total)"
+        )
+
+
+def validate_waypoint_1_5_checkpoint_shapes(
+    shapes: Mapping[str, tuple[int, ...]],
+    *,
+    spec: WaypointModelSpec = WAYPOINT_1_5,
+) -> None:
+    """Reject a checkpoint whose tensor shapes differ from Waypoint 1.5.
+
+    Args:
+        shapes: Raw tensor names mapped to shapes read from safetensors headers.
+        spec: Static checkpoint contract that defines expected tensor shapes.
+
+    Raises:
+        ValueError: The artifact contains missing, unexpected, or mismatched tensors.
+    """
+    expected = expected_waypoint_1_5_checkpoint_shapes(spec)
+    validate_waypoint_1_5_checkpoint_keys(tuple(shapes), spec=spec)
+    mismatched = sorted(
+        key
+        for key, expected_shape in expected.items()
+        if tuple(shapes[key]) != expected_shape
+    )
+    if mismatched:
+        key = mismatched[0]
+        raise ValueError(
+            "Waypoint 1.5 checkpoint shape mismatch: "
+            f"{key} expected={expected[key]}, actual={tuple(shapes[key])}; "
+            f"{len(mismatched)} tensors differ"
+        )
+
+
+def load_waypoint_state_dict(
+    module: nn.Module,
+    state_dict: Mapping[str, torch.Tensor],
+    *,
+    spec: WaypointModelSpec = WAYPOINT_1_5,
+) -> None:
+    """Validate and strictly load a raw Waypoint checkpoint into ``module``.
+
+    Args:
+        module: Native module with the published raw state-dict namespace.
+        state_dict: Checkpoint tensors already materialized on the target device.
+        spec: Architecture contract used to validate the raw tensor layout.
+
+    Raises:
+        ValueError: The checkpoint layout or tensor shapes differ from ``spec``.
+        RuntimeError: The module does not expose exactly the validated namespace.
+    """
+    validate_waypoint_1_5_checkpoint_shapes(
+        {key: tuple(tensor.shape) for key, tensor in state_dict.items()}, spec=spec
+    )
+    module.load_state_dict(state_dict, strict=True)
+
+
+def inspect_safetensors_checkpoint(path: Path) -> CheckpointInventory:
+    """Read safetensors headers without materializing tensor payloads.
+
+    Args:
+        path: Local safetensors artifact to inspect.
+
+    Returns:
+        Tensor-count, dtype, and element-count metadata.
+
+    Raises:
+        ImportError: An importable ``safetensors`` build is unavailable.
+    """
+    try:
+        from safetensors import safe_open
+    except ImportError as error:  # pragma: no cover - import environment dependent.
+        raise ImportError(
+            "Inspecting a Waypoint checkpoint requires an importable safetensors build. "
+            "Install the FlashDreams checkpoint dependencies first."
+        ) from error
+
+    dtypes: Counter[str] = Counter()
+    total_elements = 0
+    with safe_open(str(path), framework="pt", device="cpu") as checkpoint:
+        keys = list(checkpoint.keys())
+        for key in keys:
+            tensor_slice = checkpoint.get_slice(key)
+            dtypes[str(tensor_slice.get_dtype())] += 1
+            shape = tensor_slice.get_shape()
+            elements = 1
+            for dimension in shape:
+                elements *= dimension
+            total_elements += elements
+    return CheckpointInventory(
+        tensor_count=len(keys), dtypes=dict(dtypes), total_elements=total_elements
+    )
+
+
+def validate_waypoint_1_5_checkpoint(path: Path) -> CheckpointInventory:
+    """Validate published Waypoint 1.5 safetensors metadata before native loading.
+
+    This validates raw artifact identity only. The caller must still load it
+    into a checkpoint-compatible module.
+
+    Args:
+        path: Local Waypoint 1.5 safetensors artifact.
+
+    Returns:
+        Validated artifact metadata.
+
+    Raises:
+        ImportError: An importable ``safetensors`` build is unavailable.
+        ValueError: The raw key layout or metadata differs from Waypoint 1.5.
+    """
+    try:
+        from safetensors import safe_open
+    except ImportError as error:  # pragma: no cover - import environment dependent.
+        raise ImportError(
+            "Validating a Waypoint checkpoint requires an importable safetensors build."
+        ) from error
+
+    dtypes: Counter[str] = Counter()
+    total_elements = 0
+    shapes: dict[str, tuple[int, ...]] = {}
+    with safe_open(str(path), framework="pt", device="cpu") as checkpoint:
+        for key in checkpoint.keys():
+            tensor_slice = checkpoint.get_slice(key)
+            shape = tuple(tensor_slice.get_shape())
+            shapes[key] = shape
+            dtypes[str(tensor_slice.get_dtype())] += 1
+            elements = 1
+            for dimension in shape:
+                elements *= dimension
+            total_elements += elements
+    validate_waypoint_1_5_checkpoint_shapes(shapes)
+    inventory = CheckpointInventory(
+        tensor_count=len(shapes), dtypes=dict(dtypes), total_elements=total_elements
+    )
+    if inventory.dtypes != {"BF16": 393} or inventory.total_elements != 1_860_823_096:
+        raise ValueError(f"Waypoint 1.5 checkpoint metadata mismatch: {inventory}")
+    return inventory

--- a/integrations/waypoint/waypoint/checkpoint.py
+++ b/integrations/waypoint/waypoint/checkpoint.py
@@ -17,27 +17,12 @@
 
 from __future__ import annotations
 
-from collections import Counter
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Mapping
 
 import torch
 from torch import nn
 
 from waypoint.spec import WAYPOINT_1_5, WaypointModelSpec
-
-
-@dataclass(frozen=True, kw_only=True)
-class CheckpointInventory:
-    """Small, CPU-only description of a safetensors checkpoint."""
-
-    tensor_count: int
-    """Number of tensors in the safetensors artifact."""
-    dtypes: dict[str, int]
-    """Count of tensors by safetensors dtype label."""
-    total_elements: int
-    """Total scalar element count across all tensors."""
 
 
 def expected_waypoint_1_5_checkpoint_shapes(
@@ -58,7 +43,7 @@ def expected_waypoint_1_5_checkpoint_shapes(
         "ctrl_cfg.null_emb": (1, 1, d_model),
         "ctrl_emb.mlp.fc1.weight": (hidden_dim, spec.n_buttons + 3),
         "ctrl_emb.mlp.fc2.weight": (d_model, hidden_dim),
-        "denoise_step_emb.mlp.fc1.weight": (hidden_dim, 512),
+        "denoise_step_emb.mlp.fc1.weight": (hidden_dim, spec.noise_embedding_dim),
         "denoise_step_emb.mlp.fc2.weight": (d_model, hidden_dim),
         "out_norm.fc.weight": (2 * d_model, d_model),
         "patchify.weight": (
@@ -206,85 +191,3 @@ def load_waypoint_state_dict(
         {key: tuple(tensor.shape) for key, tensor in state_dict.items()}, spec=spec
     )
     module.load_state_dict(state_dict, strict=True)
-
-
-def inspect_safetensors_checkpoint(path: Path) -> CheckpointInventory:
-    """Read safetensors headers without materializing tensor payloads.
-
-    Args:
-        path: Local safetensors artifact to inspect.
-
-    Returns:
-        Tensor-count, dtype, and element-count metadata.
-
-    Raises:
-        ImportError: An importable ``safetensors`` build is unavailable.
-    """
-    try:
-        from safetensors import safe_open
-    except ImportError as error:  # pragma: no cover - import environment dependent.
-        raise ImportError(
-            "Inspecting a Waypoint checkpoint requires an importable safetensors build. "
-            "Install the FlashDreams checkpoint dependencies first."
-        ) from error
-
-    dtypes: Counter[str] = Counter()
-    total_elements = 0
-    with safe_open(str(path), framework="pt", device="cpu") as checkpoint:
-        keys = list(checkpoint.keys())
-        for key in keys:
-            tensor_slice = checkpoint.get_slice(key)
-            dtypes[str(tensor_slice.get_dtype())] += 1
-            shape = tensor_slice.get_shape()
-            elements = 1
-            for dimension in shape:
-                elements *= dimension
-            total_elements += elements
-    return CheckpointInventory(
-        tensor_count=len(keys), dtypes=dict(dtypes), total_elements=total_elements
-    )
-
-
-def validate_waypoint_1_5_checkpoint(path: Path) -> CheckpointInventory:
-    """Validate published Waypoint 1.5 safetensors metadata before native loading.
-
-    This validates raw artifact identity only. The caller must still load it
-    into a checkpoint-compatible module.
-
-    Args:
-        path: Local Waypoint 1.5 safetensors artifact.
-
-    Returns:
-        Validated artifact metadata.
-
-    Raises:
-        ImportError: An importable ``safetensors`` build is unavailable.
-        ValueError: The raw key layout or metadata differs from Waypoint 1.5.
-    """
-    try:
-        from safetensors import safe_open
-    except ImportError as error:  # pragma: no cover - import environment dependent.
-        raise ImportError(
-            "Validating a Waypoint checkpoint requires an importable safetensors build."
-        ) from error
-
-    dtypes: Counter[str] = Counter()
-    total_elements = 0
-    shapes: dict[str, tuple[int, ...]] = {}
-    with safe_open(str(path), framework="pt", device="cpu") as checkpoint:
-        for key in checkpoint.keys():
-            tensor_slice = checkpoint.get_slice(key)
-            shape = tuple(tensor_slice.get_shape())
-            shapes[key] = shape
-            dtypes[str(tensor_slice.get_dtype())] += 1
-            elements = 1
-            for dimension in shape:
-                elements *= dimension
-            total_elements += elements
-    validate_waypoint_1_5_checkpoint_shapes(shapes)
-    inventory = CheckpointInventory(
-        tensor_count=len(shapes), dtypes=dict(dtypes), total_elements=total_elements
-    )
-    if inventory.dtypes != {"BF16": 393} or inventory.total_elements != 1_860_823_096:
-        raise ValueError(f"Waypoint 1.5 checkpoint metadata mismatch: {inventory}")
-    return inventory

--- a/integrations/waypoint/waypoint/config.py
+++ b/integrations/waypoint/waypoint/config.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static FlashDreams configuration for the published Waypoint 1.5 checkpoint."""
+
+from __future__ import annotations
+
+from flashdreams.infra.diffusion.model import DiffusionModelConfig
+from flashdreams.infra.pipeline import StreamInferencePipelineConfig
+from waypoint.decoder import WaypointTAEHVDecoderConfig
+from waypoint.encoder import WaypointControlEncoderConfig
+from waypoint.pipeline import WaypointInferencePipelineConfig
+from waypoint.scheduler import WaypointEulerSchedulerConfig
+from waypoint.spec import WAYPOINT_1_5
+from waypoint.transformer import WaypointTransformerConfig
+
+WAYPOINT_1_5_CHECKPOINT = (
+    "https://huggingface.co/Overworld/Waypoint-1.5-1B/resolve/main/model.safetensors"
+)
+"""Published raw Waypoint 1.5 DiT checkpoint."""
+
+PIPELINE_WAYPOINT_1_5 = WaypointInferencePipelineConfig(
+    name="waypoint-1.5-1b",
+    diffusion_model=DiffusionModelConfig(
+        transformer=WaypointTransformerConfig(checkpoint_path=WAYPOINT_1_5_CHECKPOINT),
+        scheduler=WaypointEulerSchedulerConfig(
+            num_inference_steps=WAYPOINT_1_5.num_denoising_steps,
+            num_train_timesteps=1,
+            fixed_timesteps=WAYPOINT_1_5.scheduler_sigmas,
+        ),
+        context_noise=0,
+    ),
+    encoder=WaypointControlEncoderConfig(),
+    decoder=WaypointTAEHVDecoderConfig(
+        use_cuda_graph=False,
+        use_compile=False,
+    ),
+)
+"""Waypoint 1.5 DiT, fixed four-step Euler schedule, and matching TAEHV decoder."""
+
+WAYPOINT_CONFIGS: dict[str, StreamInferencePipelineConfig] = {
+    PIPELINE_WAYPOINT_1_5.name: PIPELINE_WAYPOINT_1_5,
+}
+"""Waypoint pipeline variants keyed by stable slug."""

--- a/integrations/waypoint/waypoint/controls.py
+++ b/integrations/waypoint/waypoint/controls.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Waypoint's public per-action control representation."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+import torch
+from torch import Tensor
+
+from waypoint.spec import WAYPOINT_1_5, WaypointModelSpec
+
+
+def load_controls_from_file(path: Path) -> tuple["WaypointControl", ...]:
+    """Load a versioned JSON sequence of per-action controller inputs.
+
+    The file format is ``{"schema_version": 1, "actions": [...]}``.
+    Each action may specify ``buttons`` (integer array), ``mouse_dx``,
+    ``mouse_dy``, and ``scroll_wheel``; omitted values use the neutral control.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise FileNotFoundError(f"control timeline does not exist: {path}") from None
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"control timeline is not valid JSON: {path}: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise ValueError("control timeline root must be an object")
+    unexpected = set(payload) - {"schema_version", "actions"}
+    if unexpected:
+        raise ValueError(
+            f"control timeline has unsupported fields: {sorted(unexpected)}"
+        )
+    if payload.get("schema_version") != 1:
+        raise ValueError("control timeline schema_version must be 1")
+    actions = payload.get("actions")
+    if not isinstance(actions, list) or not actions:
+        raise ValueError("control timeline actions must be a non-empty array")
+    return tuple(
+        _parse_control_action(action, index) for index, action in enumerate(actions)
+    )
+
+
+def _parse_control_action(payload: Any, index: int) -> "WaypointControl":
+    if not isinstance(payload, dict):
+        raise ValueError(f"control action {index} must be an object")
+    allowed = {"buttons", "mouse_dx", "mouse_dy", "scroll_wheel"}
+    unexpected = set(payload) - allowed
+    if unexpected:
+        raise ValueError(
+            f"control action {index} has unsupported fields: {sorted(unexpected)}"
+        )
+    buttons_value = payload.get("buttons", [])
+    if not isinstance(buttons_value, list) or any(
+        not isinstance(button, int) or isinstance(button, bool)
+        for button in buttons_value
+    ):
+        raise ValueError(f"control action {index} buttons must be an integer array")
+    buttons = cast(list[int], buttons_value)
+    invalid_buttons = sorted(
+        button for button in buttons if not 0 <= button < WAYPOINT_1_5.n_buttons
+    )
+    if invalid_buttons:
+        raise ValueError(
+            f"control action {index} button IDs must be in "
+            f"[0, {WAYPOINT_1_5.n_buttons}), got {invalid_buttons}"
+        )
+    mouse_dx = _finite_number(payload.get("mouse_dx", 0.0), "mouse_dx", index)
+    mouse_dy = _finite_number(payload.get("mouse_dy", 0.0), "mouse_dy", index)
+    scroll_wheel = payload.get("scroll_wheel", 0)
+    if (
+        not isinstance(scroll_wheel, int)
+        or isinstance(scroll_wheel, bool)
+        or scroll_wheel not in (-1, 0, 1)
+    ):
+        raise ValueError(
+            f"control action {index} scroll_wheel must be one of -1, 0, or 1"
+        )
+    return WaypointControl(
+        buttons=frozenset(buttons),
+        mouse_dx=mouse_dx,
+        mouse_dy=mouse_dy,
+        scroll_wheel=scroll_wheel,
+    )
+
+
+def _finite_number(value: Any, name: str, index: int) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"control action {index} {name} must be a finite number")
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"control action {index} {name} must be a finite number")
+    return value
+
+
+@dataclass(frozen=True, kw_only=True)
+class WaypointControl:
+    """Keyboard and mouse state that conditions one autoregressive action."""
+
+    buttons: frozenset[int] = field(default_factory=frozenset)
+    """Pressed button identifiers in the fixed 256-entry control vocabulary."""
+    mouse_dx: float = 0.0
+    """Mouse displacement along the horizontal axis."""
+    mouse_dy: float = 0.0
+    """Mouse displacement along the vertical axis."""
+    scroll_wheel: int = 0
+    """Ternary wheel direction: ``-1``, ``0``, or ``1``."""
+
+
+def make_control_context(
+    control: WaypointControl,
+    *,
+    frame_index: int,
+    batch_size: int = 1,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device | str | None = None,
+    spec: WaypointModelSpec = WAYPOINT_1_5,
+) -> dict[str, Tensor]:
+    """Convert one public control event into model-ready per-action tensors.
+
+    Args:
+        control: Keyboard and mouse event for one autoregressive action.
+        frame_index: Zero-based latent-frame index in the rollout.
+        batch_size: Number of identical control contexts to construct.
+        dtype: Floating-point dtype for continuous control tensors.
+        device: Target device; ``None`` keeps tensors on the current default device.
+        spec: Static checkpoint contract that defines control dimensions.
+
+    Returns:
+        Pre-network button, mouse, scroll, and latent-frame timestamp tensors.
+
+    Raises:
+        ValueError: A frame index, batch size, scroll value, or button ID is invalid.
+    """
+    if frame_index < 0:
+        raise ValueError(f"frame_index must be non-negative, got {frame_index}")
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if control.scroll_wheel not in (-1, 0, 1):
+        raise ValueError(
+            f"scroll_wheel must be one of -1, 0, or 1, got {control.scroll_wheel}"
+        )
+
+    invalid_buttons = sorted(
+        button for button in control.buttons if not 0 <= button < spec.n_buttons
+    )
+    if invalid_buttons:
+        raise ValueError(
+            f"button IDs must be in [0, {spec.n_buttons}), got {invalid_buttons}"
+        )
+
+    resolved_device = torch.device(device) if device is not None else None
+    buttons = torch.zeros(
+        (batch_size, 1, spec.n_buttons), dtype=dtype, device=resolved_device
+    )
+    if control.buttons:
+        buttons[..., sorted(control.buttons)] = 1
+
+    mouse = (
+        torch.tensor(
+            (control.mouse_dx, control.mouse_dy), dtype=dtype, device=resolved_device
+        )
+        .view(1, 1, 2)
+        .expand(batch_size, -1, -1)
+        .clone()
+    )
+    scroll = torch.full(
+        (batch_size, 1, 1), control.scroll_wheel, dtype=dtype, device=resolved_device
+    )
+    frame_idx = torch.full(
+        (batch_size, 1), frame_index, dtype=torch.long, device=resolved_device
+    )
+    frame_timestamp = torch.full(
+        (batch_size, 1),
+        frame_index * spec.frame_timestamp_stride,
+        dtype=torch.long,
+        device=resolved_device,
+    )
+    return {
+        "button": buttons,
+        "mouse": mouse,
+        "scroll": scroll,
+        "frame_idx": frame_idx,
+        "frame_timestamp": frame_timestamp,
+    }

--- a/integrations/waypoint/waypoint/decoder.py
+++ b/integrations/waypoint/waypoint/decoder.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TAEHV layout adapter for the Waypoint video pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from torch import Tensor
+
+from flashdreams.recipes.taehv import Hy15TAEHVDecoder, Hy15TAEHVDecoderConfig
+from flashdreams.recipes.taehv.impl import TAEHVCache
+
+
+@dataclass(kw_only=True)
+class WaypointTAEHVDecoderConfig(Hy15TAEHVDecoderConfig):
+    """Config for the matching TAEHV decoder behind the Waypoint pipeline."""
+
+    _target: type["WaypointTAEHVDecoder"] = field(
+        default_factory=lambda: WaypointTAEHVDecoder
+    )
+
+
+class WaypointTAEHVDecoder(Hy15TAEHVDecoder):
+    """Decode FlashDreams video latents using TAEHV's frame-first layout."""
+
+    def forward(
+        self,
+        input: Tensor,
+        autoregressive_index: int = 0,
+        cache: TAEHVCache | None = None,
+    ) -> Tensor:
+        """Decode a Waypoint action into ``[B, T, C, H, W]`` RGB frames.
+
+        Args:
+            input: FlashDreams latent video in ``[B, C, T, H, W]`` layout.
+            autoregressive_index: Current latent action index.
+            cache: Long-lived causal TAEHV state.
+
+        Returns:
+            Decoded RGB video in ``[B, T, C, H, W]`` layout and ``[-1, 1]`` range.
+
+        Raises:
+            ValueError: The latent does not use FlashDreams' five-dimensional layout.
+        """
+        if input.ndim != 5:
+            raise ValueError(
+                "Waypoint TAEHV input must have [B, C, T, H, W] layout, got "
+                f"{tuple(input.shape)}"
+            )
+        return super().forward(
+            input.permute(0, 2, 1, 3, 4).contiguous(),
+            autoregressive_index=autoregressive_index,
+            cache=cache,
+        )

--- a/integrations/waypoint/waypoint/encoder.py
+++ b/integrations/waypoint/waypoint/encoder.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-action control passthrough for the Waypoint pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from flashdreams.infra.encoder import (
+    EncoderConfig,
+    StreamingEncoder,
+    StreamingEncoderCache,
+)
+from waypoint.controls import WaypointControl
+
+
+@dataclass(kw_only=True)
+class WaypointControlEncoderConfig(EncoderConfig):
+    """Config for the Waypoint per-action control passthrough."""
+
+    _target: type["WaypointControlEncoder"] = field(
+        default_factory=lambda: WaypointControlEncoder
+    )
+
+
+class WaypointControlEncoder(StreamingEncoder[StreamingEncoderCache]):
+    """Carry one public Waypoint control event into the diffusion model.
+
+    The learned control embedding lives inside the checkpoint-compatible DiT.
+    This streaming encoder exists only because FlashDreams reserves the
+    pipeline encoder slot for per-action user input.
+    """
+
+    def initialize_autoregressive_cache(self) -> StreamingEncoderCache:
+        """Return empty state because public controls have no temporal preprocessing."""
+        return StreamingEncoderCache()
+
+    def forward(
+        self,
+        input: WaypointControl,
+        autoregressive_index: int = 0,
+        cache: StreamingEncoderCache | None = None,
+    ) -> WaypointControl:
+        """Validate and return the control event unchanged.
+
+        Args:
+            input: Public keyboard, mouse, and wheel input for this action.
+            autoregressive_index: Action index; accepted for the streaming interface.
+            cache: Empty passthrough cache; accepted for the streaming interface.
+
+        Returns:
+            The same :class:`WaypointControl` instance.
+
+        Raises:
+            TypeError: ``input`` is not a public Waypoint control event.
+        """
+        del autoregressive_index, cache
+        if not isinstance(input, WaypointControl):
+            raise TypeError(
+                f"Waypoint control encoder requires WaypointControl, got {type(input)}"
+            )
+        return input

--- a/integrations/waypoint/waypoint/pipeline.py
+++ b/integrations/waypoint/waypoint/pipeline.py
@@ -102,7 +102,8 @@ class WaypointInferencePipeline(StreamInferencePipeline):
             raise TypeError("Waypoint pipeline requires a WaypointTAEHVDecoder")
         if cache.decoder_cache is None:
             raise RuntimeError("Waypoint pipeline requires a decoder cache")
-        decoder_input = seed_latent.permute(0, 2, 1, 3, 4).contiguous()
+        # The decoder permutes this view back before its first contiguous-only op.
+        decoder_input = seed_latent.permute(0, 2, 1, 3, 4)
         self.decoder(
             decoder_input,
             autoregressive_index=0,

--- a/integrations/waypoint/waypoint/pipeline.py
+++ b/integrations/waypoint/waypoint/pipeline.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Waypoint pipeline initialization for an image-established world state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import torch
+from torch import Tensor
+
+from flashdreams.infra.pipeline import (
+    StreamInferencePipeline,
+    StreamInferencePipelineCache,
+    StreamInferencePipelineConfig,
+)
+from flashdreams.recipes.taehv import Hy15TAEHVEncoder, Hy15TAEHVEncoderConfig
+from waypoint.controls import WaypointControl
+from waypoint.decoder import WaypointTAEHVDecoder
+from waypoint.transformer.impl import WaypointTransformerCache
+
+
+@dataclass(kw_only=True)
+class WaypointInferencePipelineConfig(StreamInferencePipelineConfig):
+    """Configuration for an image-established Waypoint rollout."""
+
+    _target: type["WaypointInferencePipeline"] = field(
+        default_factory=lambda: WaypointInferencePipeline
+    )
+
+    seed_encoder: Hy15TAEHVEncoderConfig = field(default_factory=Hy15TAEHVEncoderConfig)
+    """Codec encoder that converts the initial displayed image into history."""
+
+
+class WaypointInferencePipeline(StreamInferencePipeline):
+    """Initialize persistent model state from the image that establishes the world."""
+
+    seed_encoder: Hy15TAEHVEncoder
+
+    def __init__(self, config: WaypointInferencePipelineConfig) -> None:
+        super().__init__(config)
+        self.config: WaypointInferencePipelineConfig = config
+        self.seed_encoder = config.seed_encoder.setup()
+
+    @torch.no_grad()
+    def initialize_cache(
+        self,
+        *,
+        seed_pixels: Tensor,
+        transformer_context: dict[str, Any] | None = None,
+        encoder_context: dict[str, Any] | None = None,
+        decoder_context: dict[str, Any] | None = None,
+    ) -> StreamInferencePipelineCache:
+        """Create a cache whose first historical action is the seed image.
+
+        ``seed_pixels`` is four identical RGB frames in the codec's native
+        ``[0, 1]`` domain and ``[B, 4, 3, 512, 1024]`` layout. It is committed
+        as action zero; callers therefore begin generated actions at index one.
+        """
+        if seed_pixels.ndim != 5 or tuple(seed_pixels.shape[1:]) != (4, 3, 512, 1024):
+            raise ValueError(
+                "seed_pixels must have [B, 4, 3, 512, 1024] layout, got "
+                f"{tuple(seed_pixels.shape)}"
+            )
+        if seed_pixels.device != self.device:
+            raise ValueError(
+                f"seed_pixels is on {seed_pixels.device}, expected {self.device}"
+            )
+
+        batch_size = seed_pixels.shape[0]
+        transformer_context = dict(transformer_context or {})
+        supplied_batch_size = transformer_context.setdefault("batch_size", batch_size)
+        if supplied_batch_size != batch_size:
+            raise ValueError(
+                "transformer_context batch_size must match seed_pixels batch size, got "
+                f"{supplied_batch_size} and {batch_size}"
+            )
+        cache = super().initialize_cache(
+            transformer_context=transformer_context,
+            encoder_context=encoder_context,
+            decoder_context=decoder_context,
+        )
+
+        seed_latent = self.seed_encoder.taehv.encode(seed_pixels)
+        transformer = self.diffusion_model.transformer
+        transformer_cache = cast(WaypointTransformerCache, cache.transformer_cache)
+        transformer_cache.start(0)
+        transformer_cache.kv_cache.set_frozen(False)
+        try:
+            transformer.predict_flow(
+                seed_latent,
+                torch.zeros((), device=seed_latent.device, dtype=seed_latent.dtype),
+                transformer_cache,
+                WaypointControl(),
+            )
+        finally:
+            transformer_cache.kv_cache.set_frozen(True)
+
+        if not isinstance(self.decoder, WaypointTAEHVDecoder):
+            raise TypeError("Waypoint pipeline requires a WaypointTAEHVDecoder")
+        if cache.decoder_cache is None:
+            raise RuntimeError("Waypoint pipeline requires a decoder cache")
+        decoder_input = seed_latent.permute(0, 2, 1, 3, 4).contiguous()
+        self.decoder(
+            decoder_input,
+            autoregressive_index=0,
+            cache=cache.decoder_cache,
+        )
+        cache.autoregressive_index = 0
+        return cache

--- a/integrations/waypoint/waypoint/scheduler.py
+++ b/integrations/waypoint/waypoint/scheduler.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Waypoint's checkpoint-specific rectified-flow Euler schedule."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import torch
+from torch import Tensor
+
+from flashdreams.infra.diffusion.scheduler.fm_euler import (
+    FlowMatchEulerDiscreteScheduler,
+    FlowMatchEulerDiscreteSchedulerConfig,
+)
+
+
+@dataclass(kw_only=True)
+class WaypointEulerSchedulerConfig(FlowMatchEulerDiscreteSchedulerConfig):
+    """Fixed four-step scheduler whose BF16 arithmetic matches Waypoint."""
+
+    _target: type["WaypointEulerScheduler"] = field(
+        default_factory=lambda: WaypointEulerScheduler
+    )
+
+
+class WaypointEulerScheduler(FlowMatchEulerDiscreteScheduler):
+    """Apply Euler steps from a BF16-quantized fixed sigma schedule.
+
+    The checkpoint's inference path stores its schedule in the same BF16 dtype
+    as its latent. Computing adjacent differences after that quantization is
+    part of the learned four-step trajectory, not merely a storage choice.
+    """
+
+    def sample(
+        self,
+        initial_noise: Tensor,
+        predict_flow: Callable[[Tensor, Tensor], Tensor],
+        rng: torch.Generator | None = None,
+    ) -> Tensor:
+        """Denoise one action with checkpoint-equivalent Euler updates."""
+        del rng
+        schedule = self.sigmas.to(
+            device=initial_noise.device, dtype=initial_noise.dtype
+        )
+        noisy = initial_noise
+        for sigma, next_sigma in zip(schedule[:-1], schedule[1:], strict=True):
+            flow = predict_flow(noisy, sigma)
+            noisy = (noisy.float() + (next_sigma - sigma).float() * flow.float()).to(
+                dtype=initial_noise.dtype
+            )
+        return noisy

--- a/integrations/waypoint/waypoint/spec.py
+++ b/integrations/waypoint/waypoint/spec.py
@@ -72,6 +72,8 @@ class WaypointModelSpec:
     """Whether attention outputs use an additional learned gate."""
     noise_conditioning: str
     """Published noise-conditioning family used by the checkpoint."""
+    noise_embedding_dim: int
+    """Width of the Fourier features consumed by the noise-conditioning MLP."""
     rope_theta: float
     """Base frequency of the geometric temporal rotary spectrum."""
     rope_nyquist_fraction: float
@@ -170,6 +172,7 @@ WAYPOINT_1_5 = WaypointModelSpec(
     value_residual=True,
     gated_attention=False,
     noise_conditioning="wan",
+    noise_embedding_dim=512,
     rope_theta=10_000.0,
     rope_nyquist_fraction=0.8,
     scheduler_sigmas=(1.0, 0.9, 0.75, 0.3, 0.0),

--- a/integrations/waypoint/waypoint/spec.py
+++ b/integrations/waypoint/waypoint/spec.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Waypoint 1.5 checkpoint configuration contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class WaypointModelSpec:
+    """Architecture and rollout invariants for a published Waypoint checkpoint."""
+
+    model_id: str
+    """Published Hugging Face checkpoint identifier."""
+    channels: int
+    """Number of channels in a single latent frame."""
+    latent_height: int
+    """Pre-patchify latent-frame height."""
+    latent_width: int
+    """Pre-patchify latent-frame width."""
+    patch_height: int
+    """Spatial patch height."""
+    patch_width: int
+    """Spatial patch width."""
+    temporal_compression: int
+    """Presented RGB frames emitted per autoregressive latent frame."""
+    inference_fps: int
+    """Presented RGB frame rate."""
+    base_fps: int
+    """Timestamp base rate expected by the checkpoint."""
+    n_layers: int
+    """Number of transformer blocks."""
+    d_model: int
+    """Transformer channel width."""
+    n_heads: int
+    """Number of query-attention heads."""
+    n_kv_heads: int
+    """Number of key/value attention heads."""
+    mlp_ratio: int
+    """Hidden-width multiplier of each transformer feed-forward network."""
+    n_buttons: int
+    """Size of the multi-hot button-control vocabulary."""
+    local_window: int
+    """Recent latent-frame capacity of local attention layers."""
+    global_window: int
+    """Latent-frame horizon of global attention layers."""
+    global_pinned_dilation: int
+    """Temporal stride of pinned history in global-attention layers."""
+    global_attention_period: int
+    """Stride between global-attention transformer blocks."""
+    global_attention_offset: int
+    """Offset used to select global-attention transformer blocks."""
+    controller_conditioning_period: int
+    """Stride between transformer blocks with controller fusion weights."""
+    value_residual: bool
+    """Whether attention values carry a residual stream across blocks."""
+    gated_attention: bool
+    """Whether attention outputs use an additional learned gate."""
+    noise_conditioning: str
+    """Published noise-conditioning family used by the checkpoint."""
+    rope_theta: float
+    """Base frequency of the geometric temporal rotary spectrum."""
+    rope_nyquist_fraction: float
+    """Fraction of the spatial Nyquist limit used by rotary features."""
+    scheduler_sigmas: tuple[float, ...]
+    """Fixed rectified-flow Euler schedule, including the terminal sigma."""
+    text_conditioning: bool
+    """Whether the checkpoint provides a text-conditioning input."""
+
+    @property
+    def head_dim(self) -> int:
+        """Return the channel dimension of an attention head."""
+        assert self.d_model % self.n_heads == 0
+        return self.d_model // self.n_heads
+
+    @property
+    def tokens_per_latent_frame(self) -> int:
+        """Return the number of spatial tokens generated for one action."""
+        assert self.latent_height % self.patch_height == 0
+        assert self.latent_width % self.patch_width == 0
+        return (self.latent_height // self.patch_height) * (
+            self.latent_width // self.patch_width
+        )
+
+    @property
+    def patch_grid_height(self) -> int:
+        """Return the number of patch tokens along the latent-image height."""
+        return self.latent_height // self.patch_height
+
+    @property
+    def patch_grid_width(self) -> int:
+        """Return the number of patch tokens along the latent-image width."""
+        return self.latent_width // self.patch_width
+
+    @property
+    def frames_per_action(self) -> int:
+        """Return the number of presented RGB frames decoded from one latent frame."""
+        return self.temporal_compression
+
+    @property
+    def num_denoising_steps(self) -> int:
+        """Return the number of Euler velocity evaluations in the fixed schedule."""
+        return len(self.scheduler_sigmas) - 1
+
+    @property
+    def latent_fps(self) -> int:
+        """Return the autoregressive latent-frame rate."""
+        assert self.inference_fps % self.temporal_compression == 0
+        return self.inference_fps // self.temporal_compression
+
+    @property
+    def frame_timestamp_stride(self) -> int:
+        """Return the model timestamp increment per latent frame."""
+        assert self.base_fps % self.latent_fps == 0
+        return self.base_fps // self.latent_fps
+
+    @property
+    def global_attention_layers(self) -> tuple[int, ...]:
+        """Return zero-indexed transformer layers that use global cache policy."""
+        return tuple(
+            index
+            for index in range(self.n_layers)
+            if (index - self.global_attention_offset) % self.global_attention_period
+            == 0
+        )
+
+    def latent_shape(self, batch_size: int = 1) -> tuple[int, int, int, int, int]:
+        """Return the pre-patchify DiT shape for one autoregressive action."""
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        return (batch_size, 1, self.channels, self.latent_height, self.latent_width)
+
+
+WAYPOINT_1_5 = WaypointModelSpec(
+    model_id="Overworld/Waypoint-1.5-1B",
+    channels=32,
+    latent_height=32,
+    latent_width=64,
+    patch_height=2,
+    patch_width=2,
+    temporal_compression=4,
+    inference_fps=60,
+    base_fps=15,
+    n_layers=24,
+    d_model=2048,
+    n_heads=32,
+    n_kv_heads=16,
+    mlp_ratio=4,
+    n_buttons=256,
+    local_window=16,
+    global_window=128,
+    global_pinned_dilation=8,
+    global_attention_period=4,
+    global_attention_offset=-1,
+    controller_conditioning_period=3,
+    value_residual=True,
+    gated_attention=False,
+    noise_conditioning="wan",
+    rope_theta=10_000.0,
+    rope_nyquist_fraction=0.8,
+    scheduler_sigmas=(1.0, 0.9, 0.75, 0.3, 0.0),
+    text_conditioning=False,
+)
+"""Static contract for the published ``Overworld/Waypoint-1.5-1B`` checkpoint."""

--- a/integrations/waypoint/waypoint/transformer/__init__.py
+++ b/integrations/waypoint/waypoint/transformer/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native Waypoint DiT topology and conditioning primitives."""
+
+from waypoint.transformer.cache import (
+    WaypointAttentionPolicy,
+    WaypointKVCache,
+    WaypointKVView,
+)
+from waypoint.transformer.impl import (
+    WaypointTransformer,
+    WaypointTransformerCache,
+    WaypointTransformerConfig,
+)
+from waypoint.transformer.network import (
+    WaypointDiT,
+    WaypointDiTConfig,
+    sinusoidal_noise_embedding,
+)
+from waypoint.transformer.norm import adaptive_gate, adaptive_rms_norm
+from waypoint.transformer.rope import WaypointOrthoRoPEAngles, apply_waypoint_ortho_rope
+
+__all__ = [
+    "WaypointDiT",
+    "WaypointDiTConfig",
+    "WaypointAttentionPolicy",
+    "WaypointKVCache",
+    "WaypointKVView",
+    "WaypointTransformer",
+    "WaypointTransformerCache",
+    "WaypointTransformerConfig",
+    "WaypointOrthoRoPEAngles",
+    "adaptive_gate",
+    "adaptive_rms_norm",
+    "apply_waypoint_ortho_rope",
+    "sinusoidal_noise_embedding",
+]

--- a/integrations/waypoint/waypoint/transformer/cache.py
+++ b/integrations/waypoint/waypoint/transformer/cache.py
@@ -107,9 +107,10 @@ class _FixedKVLayer:
     """One lazy fixed-capacity K/V store used by the published runtime."""
 
     kv: Tensor
-    written: Tensor
+    written_frames: list[bool]
     history_tokens: int
     pinned_dilation: int
+    block_masks: dict[tuple[bool, ...], BlockMask] = field(default_factory=dict)
 
 
 @dataclass(kw_only=True)
@@ -232,16 +233,7 @@ class WaypointKVCache:
                     device=key.device,
                     dtype=key.dtype,
                 ),
-                written=torch.cat(
-                    (
-                        torch.zeros(
-                            history_tokens, device=key.device, dtype=torch.bool
-                        ),
-                        torch.ones(
-                            tokens_per_frame, device=key.device, dtype=torch.bool
-                        ),
-                    )
-                ),
+                written_frames=[False] * frame_capacity + [True],
                 history_tokens=history_tokens,
                 pinned_dilation=pinned_dilation,
             )
@@ -258,14 +250,26 @@ class WaypointKVCache:
         state.kv[..., tail_slice, :].copy_(current)
 
         write_step = frame_index % state.pinned_dilation == 0
-        visible = state.written.clone()
-        visible[ring_slice] &= not write_step
-        block_mask = _fixed_block_mask(tokens_per_frame, visible)
+        visible_frames = list(state.written_frames)
+        ring_frame = ring_start // tokens_per_frame
+        if write_step:
+            # The ring slot still represents the evicted historical frame while the
+            # provisional current frame is exposed through the tail slot. Hide it
+            # even after commit so the current frame is never attended to twice.
+            visible_frames[ring_frame] = False
+        visibility = tuple(visible_frames)
+        block_mask = state.block_masks.get(visibility)
+        if block_mask is None:
+            block_mask = _fixed_block_mask(
+                tokens_per_frame, visibility, device=key.device
+            )
+            state.block_masks[visibility] = block_mask
 
         if not self._fixed_frozen:
             destination = ring_slice if write_step else tail_slice
             state.kv[..., destination, :].copy_(current)
-            state.written[destination] = True
+            if write_step:
+                state.written_frames[ring_frame] = True
 
         key_full, value_full = state.kv.unbind(0)
         return WaypointKVView(
@@ -302,7 +306,12 @@ class WaypointKVCache:
             )
 
 
-def _fixed_block_mask(tokens_per_frame: int, written: Tensor) -> BlockMask:
+def _fixed_block_mask(
+    tokens_per_frame: int,
+    written_frames: tuple[bool, ...],
+    *,
+    device: torch.device,
+) -> BlockMask:
     """Create one visibility contract for compiled and eager attention.
 
     ``full_kv_*`` is the compiled kernel's efficient representation of active
@@ -312,32 +321,39 @@ def _fixed_block_mask(tokens_per_frame: int, written: Tensor) -> BlockMask:
     compiled path.
     """
     block_size = _DEFAULT_SPARSE_BLOCK_SIZE
-    if tokens_per_frame % block_size or written.numel() % block_size:
+    if tokens_per_frame % block_size:
         raise ValueError("Waypoint fixed attention requires block-aligned cache sizes")
     query_blocks = tokens_per_frame // block_size
-    key_blocks = written.numel() // block_size
-    visible = written.view(key_blocks, block_size)
-    if not torch.equal(visible.any(-1), visible.all(-1)):
-        raise RuntimeError("Waypoint fixed cache visibility must be block aligned")
-    active = visible.all(-1).nonzero(as_tuple=False).flatten().to(torch.int32)
+    blocks_per_frame = tokens_per_frame // block_size
+    key_blocks = len(written_frames) * blocks_per_frame
+    active_blocks = [
+        frame_index * blocks_per_frame + block_offset
+        for frame_index, is_written in enumerate(written_frames)
+        if is_written
+        for block_offset in range(blocks_per_frame)
+    ]
+    active = torch.tensor(active_blocks, dtype=torch.int32, device=device)
     # ``BlockMask`` stores a key-block list for *each* query block.  Every
     # Waypoint query token sees the same cache slots, but omitting the query
     # axis makes the mask structurally different and leaves the attention
     # backend to interpret a malformed index tensor.
     full_indices = torch.zeros(
-        1, 1, query_blocks, key_blocks, dtype=torch.int32, device=written.device
+        1, 1, query_blocks, key_blocks, dtype=torch.int32, device=device
     )
     full_indices[..., : active.numel()] = active
     full_count = torch.full(
         (1, 1, query_blocks),
         active.numel(),
         dtype=torch.int32,
-        device=written.device,
+        device=device,
     )
     empty_count = torch.zeros_like(full_count)
     empty_indices = torch.zeros(
-        1, 1, query_blocks, key_blocks, dtype=torch.int32, device=written.device
+        1, 1, query_blocks, key_blocks, dtype=torch.int32, device=device
     )
+    visible_tokens = torch.tensor(
+        written_frames, dtype=torch.bool, device=device
+    ).repeat_interleave(tokens_per_frame)
 
     def visible_slot(
         batch_index: Tensor,
@@ -346,7 +362,7 @@ def _fixed_block_mask(tokens_per_frame: int, written: Tensor) -> BlockMask:
         key_index: Tensor,
     ) -> Tensor:
         del batch_index, head_index, query_index
-        return written[key_index]
+        return visible_tokens[key_index]
 
     return BlockMask.from_kv_blocks(
         empty_count,
@@ -355,6 +371,6 @@ def _fixed_block_mask(tokens_per_frame: int, written: Tensor) -> BlockMask:
         full_indices,
         BLOCK_SIZE=block_size,
         mask_mod=visible_slot,
-        seq_lengths=(tokens_per_frame, written.numel()),
+        seq_lengths=(tokens_per_frame, visible_tokens.numel()),
         compute_q_blocks=False,
     )

--- a/integrations/waypoint/waypoint/transformer/cache.py
+++ b/integrations/waypoint/waypoint/transformer/cache.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sparse causal KV-history policy for the Waypoint transformer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+from torch import Tensor
+from torch.nn.attention.flex_attention import _DEFAULT_SPARSE_BLOCK_SIZE, BlockMask
+
+from waypoint.spec import WAYPOINT_1_5, WaypointModelSpec
+
+
+@dataclass(frozen=True, kw_only=True)
+class WaypointAttentionPolicy:
+    """Choose the causal history visible to one Waypoint attention block.
+
+    Most blocks need dense short-term state for motion continuity.  Every
+    fourth block instead sees a stride-sampled long history, which supplies
+    long-range scene anchors without giving every block a 128-frame attention
+    cost.  The selection is expressed in latent-frame indices so the KV store
+    and a future fused attention backend share one unambiguous contract.
+    """
+
+    spec: WaypointModelSpec = WAYPOINT_1_5
+    """Checkpoint architecture whose attention schedule is represented."""
+
+    def is_global_layer(self, layer_index: int) -> bool:
+        """Return whether ``layer_index`` uses sparse global history.
+
+        Args:
+            layer_index: Zero-indexed transformer block.
+
+        Raises:
+            ValueError: The layer index is outside the checkpoint's block range.
+        """
+        self._validate_layer_index(layer_index)
+        return (
+            layer_index - self.spec.global_attention_offset
+        ) % self.spec.global_attention_period == 0
+
+    def visible_frame_indices(
+        self, *, layer_index: int, frame_index: int
+    ) -> tuple[int, ...]:
+        """Return causal latent frames visible while denoising ``frame_index``.
+
+        A local block sees a dense trailing window.  A global block sees only
+        pinned frames aligned to the configured dilation inside its longer
+        trailing horizon; a non-pinned current frame is added so every action
+        can attend to itself.
+
+        Args:
+            layer_index: Zero-indexed transformer block.
+            frame_index: Zero-indexed latent-frame index of the current action.
+
+        Returns:
+            Strictly increasing, causal latent-frame indices.
+
+        Raises:
+            ValueError: ``frame_index`` is negative or the layer index is invalid.
+        """
+        self._validate_layer_index(layer_index)
+        if frame_index < 0:
+            raise ValueError(f"frame_index must be non-negative, got {frame_index}")
+
+        if not self.is_global_layer(layer_index):
+            first = max(0, frame_index - self.spec.local_window + 1)
+            return tuple(range(first, frame_index + 1))
+
+        first = max(0, frame_index - self.spec.global_window + 1)
+        dilation = self.spec.global_pinned_dilation
+        first_pinned = ((first + dilation - 1) // dilation) * dilation
+        pinned = tuple(range(first_pinned, frame_index + 1, dilation))
+        if pinned and pinned[-1] == frame_index:
+            return pinned
+        return (*pinned, frame_index)
+
+    def _validate_layer_index(self, layer_index: int) -> None:
+        if not 0 <= layer_index < self.spec.n_layers:
+            raise ValueError(
+                f"layer_index must be in [0, {self.spec.n_layers}), got {layer_index}"
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
+class WaypointKVView:
+    """The selected key/value frames for one causal attention evaluation."""
+
+    key: Tensor
+    """Concatenated keys in ``[B, H_kv, selected_frames * S, d_h]`` layout."""
+
+    value: Tensor
+    """Concatenated values with the same layout as ``key``."""
+
+    frame_indices: tuple[int, ...]
+    """Latent-frame origin of each contiguous ``S``-token segment."""
+
+    block_mask: BlockMask | None = None
+    """Optional fixed-cache block mask for checkpoint-equivalent attention."""
+
+
+@dataclass
+class _FixedKVLayer:
+    """One lazy fixed-capacity K/V store used by the published runtime."""
+
+    kv: Tensor
+    written: Tensor
+    history_tokens: int
+    pinned_dilation: int
+
+
+@dataclass(kw_only=True)
+class WaypointKVCache:
+    """Keep exactly the model-visible KV history for each Waypoint block.
+
+    A diffusion step may evaluate the same latent frame more than once.  An
+    update for that frame replaces its provisional K/V tensors instead of
+    extending history; advancing to a later frame evicts entries the sparse
+    policy can no longer expose. The CUDA path uses a fixed-capacity store and
+    block mask; CPU uses a compact dictionary representation for the same
+    selection policy.
+    """
+
+    policy: WaypointAttentionPolicy = field(default_factory=WaypointAttentionPolicy)
+    """Frame-selection policy shared by all transformer blocks."""
+
+    use_fixed_attention: bool = False
+    """Use the checkpoint runtime's fixed-capacity masked-attention semantics."""
+
+    _layers: dict[int, dict[int, tuple[Tensor, Tensor]]] = field(default_factory=dict)
+    """Stored K/V tensors indexed by block, then latent-frame index."""
+
+    _latest_frame_indices: dict[int, int] = field(default_factory=dict)
+    """Latest frame written per block; equal writes replace a diffusion provisional."""
+
+    _fixed_layers: dict[int, _FixedKVLayer] = field(default_factory=dict)
+    _fixed_frozen: bool = True
+
+    def update(
+        self, *, layer_index: int, frame_index: int, key: Tensor, value: Tensor
+    ) -> WaypointKVView:
+        """Store K/V for one action and return the model-visible sparse view.
+
+        Args:
+            layer_index: Zero-indexed transformer block that produced the tensors.
+            frame_index: Zero-indexed latent action being evaluated.
+            key: RoPE-applied keys in ``[B, H_kv, S, d_h]`` layout.
+            value: Values in ``[B, H_kv, S, d_h]`` layout.
+
+        Returns:
+            Causally selected keys and values concatenated along their token axis.
+
+        Raises:
+            ValueError: Tensor layouts differ, a frame is negative, or a write
+                attempts to move a layer's history backwards.
+        """
+        self._validate_kv(key, value)
+        latest = self._latest_frame_indices.get(layer_index)
+        if latest is not None and frame_index < latest:
+            raise ValueError(
+                f"layer {layer_index} cannot move from frame {latest} back to {frame_index}"
+            )
+        self._latest_frame_indices[layer_index] = frame_index
+
+        if self.use_fixed_attention and key.device.type == "cuda":
+            return self._fixed_view(
+                layer_index=layer_index,
+                frame_index=frame_index,
+                key=key,
+                value=value,
+            )
+
+        # CPU contract tests use this compact reference representation. The
+        # CUDA rollout takes the fixed-cache path above and never duplicates
+        # K/V tensors in a Python dictionary.
+        visible = self.policy.visible_frame_indices(
+            layer_index=layer_index, frame_index=frame_index
+        )
+        layer = self._layers.setdefault(layer_index, {})
+        layer[frame_index] = (key, value)
+
+        retained = {index: layer[index] for index in visible if index in layer}
+        if frame_index not in retained:
+            raise RuntimeError("current frame was not retained by its attention policy")
+        self._layers[layer_index] = retained
+        return self._view(layer_index=layer_index, frame_indices=visible)
+
+    def reset(self) -> None:
+        """Discard all retained K/V tensors while preserving the policy."""
+        self._layers.clear()
+        self._latest_frame_indices.clear()
+        self._fixed_layers.clear()
+        self._fixed_frozen = True
+
+    def set_frozen(self, frozen: bool) -> None:
+        """Choose whether writes update only the provisional current action."""
+        self._fixed_frozen = frozen
+
+    def _fixed_view(
+        self,
+        *,
+        layer_index: int,
+        frame_index: int,
+        key: Tensor,
+        value: Tensor,
+    ) -> WaypointKVView:
+        """Write one frame into the runtime-shaped fixed cache and mask it."""
+        state = self._fixed_layers.get(layer_index)
+        tokens_per_frame = key.shape[2]
+        if state is None:
+            global_layer = self.policy.is_global_layer(layer_index)
+            frame_capacity = (
+                self.policy.spec.global_window
+                if global_layer
+                else self.policy.spec.local_window
+            )
+            pinned_dilation = (
+                self.policy.spec.global_pinned_dilation if global_layer else 1
+            )
+            history_tokens = frame_capacity * tokens_per_frame
+            capacity = history_tokens + tokens_per_frame
+            state = _FixedKVLayer(
+                kv=torch.zeros(
+                    2,
+                    key.shape[0],
+                    key.shape[1],
+                    capacity,
+                    key.shape[-1],
+                    device=key.device,
+                    dtype=key.dtype,
+                ),
+                written=torch.cat(
+                    (
+                        torch.zeros(
+                            history_tokens, device=key.device, dtype=torch.bool
+                        ),
+                        torch.ones(
+                            tokens_per_frame, device=key.device, dtype=torch.bool
+                        ),
+                    )
+                ),
+                history_tokens=history_tokens,
+                pinned_dilation=pinned_dilation,
+            )
+            self._fixed_layers[layer_index] = state
+
+        bucket_count = state.history_tokens // tokens_per_frame // state.pinned_dilation
+        bucket = (frame_index + state.pinned_dilation - 1) // state.pinned_dilation
+        ring_start = (bucket % bucket_count) * tokens_per_frame
+        ring_slice = slice(ring_start, ring_start + tokens_per_frame)
+        tail_slice = slice(
+            state.history_tokens, state.history_tokens + tokens_per_frame
+        )
+        current = torch.stack((key, value))
+        state.kv[..., tail_slice, :].copy_(current)
+
+        write_step = frame_index % state.pinned_dilation == 0
+        visible = state.written.clone()
+        visible[ring_slice] &= not write_step
+        block_mask = _fixed_block_mask(tokens_per_frame, visible)
+
+        if not self._fixed_frozen:
+            destination = ring_slice if write_step else tail_slice
+            state.kv[..., destination, :].copy_(current)
+            state.written[destination] = True
+
+        key_full, value_full = state.kv.unbind(0)
+        return WaypointKVView(
+            key=key_full,
+            value=value_full,
+            frame_indices=(frame_index,),
+            block_mask=block_mask,
+        )
+
+    def _view(
+        self, *, layer_index: int, frame_indices: tuple[int, ...]
+    ) -> WaypointKVView:
+        layer = self._layers[layer_index]
+        selected = tuple(index for index in frame_indices if index in layer)
+        if not selected:
+            raise RuntimeError(f"layer {layer_index} has no K/V tensors to attend to")
+        keys, values = zip(*(layer[index] for index in selected), strict=True)
+        return WaypointKVView(
+            key=torch.cat(keys, dim=2),
+            value=torch.cat(values, dim=2),
+            frame_indices=selected,
+        )
+
+    @staticmethod
+    def _validate_kv(key: Tensor, value: Tensor) -> None:
+        if key.ndim != 4:
+            raise ValueError(
+                f"key must have [B, H_kv, S, d_h] layout, got {tuple(key.shape)}"
+            )
+        if value.shape != key.shape:
+            raise ValueError(
+                "value must have the same [B, H_kv, S, d_h] shape as key, got "
+                f"{tuple(value.shape)} and {tuple(key.shape)}"
+            )
+
+
+def _fixed_block_mask(tokens_per_frame: int, written: Tensor) -> BlockMask:
+    """Create one visibility contract for compiled and eager attention.
+
+    ``full_kv_*`` is the compiled kernel's efficient representation of active
+    blocks.  ``mask_mod`` independently states the same per-token rule for
+    implementations that materialize dense scores.  Keeping both prevents a
+    fixed-capacity cache from making unwritten zero slots visible outside the
+    compiled path.
+    """
+    block_size = _DEFAULT_SPARSE_BLOCK_SIZE
+    if tokens_per_frame % block_size or written.numel() % block_size:
+        raise ValueError("Waypoint fixed attention requires block-aligned cache sizes")
+    query_blocks = tokens_per_frame // block_size
+    key_blocks = written.numel() // block_size
+    visible = written.view(key_blocks, block_size)
+    if not torch.equal(visible.any(-1), visible.all(-1)):
+        raise RuntimeError("Waypoint fixed cache visibility must be block aligned")
+    active = visible.all(-1).nonzero(as_tuple=False).flatten().to(torch.int32)
+    # ``BlockMask`` stores a key-block list for *each* query block.  Every
+    # Waypoint query token sees the same cache slots, but omitting the query
+    # axis makes the mask structurally different and leaves the attention
+    # backend to interpret a malformed index tensor.
+    full_indices = torch.zeros(
+        1, 1, query_blocks, key_blocks, dtype=torch.int32, device=written.device
+    )
+    full_indices[..., : active.numel()] = active
+    full_count = torch.full(
+        (1, 1, query_blocks),
+        active.numel(),
+        dtype=torch.int32,
+        device=written.device,
+    )
+    empty_count = torch.zeros_like(full_count)
+    empty_indices = torch.zeros(
+        1, 1, query_blocks, key_blocks, dtype=torch.int32, device=written.device
+    )
+
+    def visible_slot(
+        batch_index: Tensor,
+        head_index: Tensor,
+        query_index: Tensor,
+        key_index: Tensor,
+    ) -> Tensor:
+        del batch_index, head_index, query_index
+        return written[key_index]
+
+    return BlockMask.from_kv_blocks(
+        empty_count,
+        empty_indices,
+        full_count,
+        full_indices,
+        BLOCK_SIZE=block_size,
+        mask_mod=visible_slot,
+        seq_lengths=(tokens_per_frame, written.numel()),
+        compute_q_blocks=False,
+    )

--- a/integrations/waypoint/waypoint/transformer/impl.py
+++ b/integrations/waypoint/waypoint/transformer/impl.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FlashDreams transformer adapter for one-action Waypoint denoising."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from flashdreams.infra.diffusion.transformer import (
+    Transformer,
+    TransformerAutoregressiveCache,
+    TransformerConfig,
+)
+from waypoint.checkpoint import load_waypoint_state_dict
+from waypoint.controls import WaypointControl, make_control_context
+from waypoint.spec import WaypointModelSpec
+from waypoint.transformer.cache import WaypointKVCache
+from waypoint.transformer.network import WaypointDiT, WaypointDiTConfig
+
+
+@dataclass(kw_only=True)
+class WaypointTransformerCache(TransformerAutoregressiveCache):
+    """Long-lived sparse history for an autoregressive Waypoint rollout."""
+
+    kv_cache: WaypointKVCache = field(default_factory=WaypointKVCache)
+    """Per-block sparse causal K/V history."""
+
+    batch_size: int
+    """Batch size fixed when the rollout starts."""
+
+    autoregressive_index: int = -1
+    """Current latent action index; ``-1`` before the first ``start`` call."""
+
+    def start(self, autoregressive_index: int) -> None:
+        """Mark the action whose repeated denoise passes may replace K/V state.
+
+        Args:
+            autoregressive_index: Zero-indexed latent action to generate.
+
+        Raises:
+            ValueError: The action index is negative or skips rollout history.
+        """
+        if autoregressive_index < 0:
+            raise ValueError(
+                f"autoregressive_index must be non-negative, got {autoregressive_index}"
+            )
+        if self.autoregressive_index >= 0 and autoregressive_index not in (
+            self.autoregressive_index,
+            self.autoregressive_index + 1,
+        ):
+            raise ValueError(
+                "Waypoint actions must be generated in order or re-evaluated in place; "
+                f"got {autoregressive_index} after {self.autoregressive_index}"
+            )
+        self.autoregressive_index = autoregressive_index
+        self.kv_cache.set_frozen(True)
+
+
+@dataclass(kw_only=True)
+class WaypointTransformerConfig(TransformerConfig):
+    """Construction config for the one-action Waypoint transformer adapter."""
+
+    _target: type["WaypointTransformer"] = field(
+        default_factory=lambda: WaypointTransformer
+    )
+
+    network: WaypointDiTConfig = field(default_factory=WaypointDiTConfig)
+    """Native checkpoint-compatible Waypoint DiT."""
+
+    dtype: torch.dtype = torch.bfloat16
+    """Network parameter and activation dtype."""
+
+    checkpoint_path: str | None = None
+    """Raw Waypoint safetensors path; ``None`` retains random initialization."""
+
+
+class WaypointTransformer(Transformer[WaypointTransformerCache]):
+    """Adapt Waypoint's internal patchifier to FlashDreams flow prediction.
+
+    Waypoint owns its spatial patchifier, so FlashDreams sees a one-frame
+    latent action rather than pre-patchified tokens.  This keeps the external
+    streaming layout conventional while preserving the checkpoint's learned
+    convolutional patch embedding exactly.
+    """
+
+    config: WaypointTransformerConfig
+    network: WaypointDiT
+
+    def __init__(self, config: WaypointTransformerConfig) -> None:
+        super().__init__(config)
+        self.config = config
+        self.network = config.network.setup().to(dtype=config.dtype)
+        self.network.eval()
+        if config.checkpoint_path is not None:
+            from flashdreams.core.checkpoint.load import load_checkpoint
+
+            state_dict = load_checkpoint(config.checkpoint_path)
+            if not isinstance(state_dict, dict):
+                raise RuntimeError(
+                    "Waypoint checkpoint loader did not return a state dict"
+                )
+            load_waypoint_state_dict(self.network, state_dict, spec=self.spec)
+        self._batch_size: int | None = None
+
+    @property
+    def spec(self) -> WaypointModelSpec:
+        """Return the immutable architecture contract of the owned DiT."""
+        return self.network.spec
+
+    @property
+    def latent_shape(self) -> tuple[int, ...]:
+        """Return the internal one-action latent layout ``[B, 1, C, H, W]``."""
+        if self._batch_size is None:
+            raise RuntimeError(
+                "latent_shape requires initialize_autoregressive_cache(batch_size=...)"
+            )
+        return self.spec.latent_shape(self._batch_size)
+
+    def initialize_autoregressive_cache(
+        self, *, batch_size: int, **context: Any
+    ) -> WaypointTransformerCache:
+        """Allocate sparse history for a fixed-batch Waypoint rollout.
+
+        Args:
+            batch_size: Number of actions generated together.
+            context: Rejected when non-empty; Waypoint 1.5 has no one-shot context.
+
+        Returns:
+            Empty K/V history ready for ``cache.start(0)``.
+
+        Raises:
+            ValueError: The batch size is invalid or one-shot context was supplied.
+        """
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if context:
+            raise ValueError(
+                "Waypoint 1.5 has no text/image context encoder; unexpected "
+                f"cache context keys: {sorted(context)}"
+            )
+        self._batch_size = batch_size
+        return WaypointTransformerCache(
+            batch_size=batch_size,
+            kv_cache=WaypointKVCache(use_fixed_attention=True),
+        )
+
+    def patchify_and_maybe_split_cp(self, x: Any) -> Any:
+        """Convert external video latents to Waypoint's internal frame-first layout.
+
+        Args:
+            x: Video latent in ``[B, C, T, H, W]`` layout or a non-tensor control.
+
+        Returns:
+            Tensor latents in ``[B, T, C, H, W]`` layout; controls are unchanged.
+        """
+        if not isinstance(x, Tensor):
+            return x
+        if x.ndim != 5:
+            raise ValueError(f"Waypoint latent must have rank 5, got {x.ndim}")
+        return x.permute(0, 2, 1, 3, 4).contiguous()
+
+    def unpatchify_and_maybe_gather_cp(self, x: Tensor) -> Tensor:
+        """Convert Waypoint's internal frame-first latent layout to video layout.
+
+        Args:
+            x: Internal latent in ``[B, T, C, H, W]`` layout.
+
+        Returns:
+            Video latent in ``[B, C, T, H, W]`` layout.
+        """
+        if x.ndim != 5:
+            raise ValueError(f"Waypoint latent must have rank 5, got {x.ndim}")
+        return x.permute(0, 2, 1, 3, 4).contiguous()
+
+    def predict_flow(
+        self,
+        noisy_latent: Tensor,
+        timestep: Tensor,
+        cache: WaypointTransformerCache,
+        input: WaypointControl | None = None,
+    ) -> Tensor:
+        """Predict one flow field using the current action's control event.
+
+        Args:
+            noisy_latent: Internal noisy action in ``[B, 1, C, H, W]`` layout.
+            timestep: Scalar sigma supplied by the fixed Euler scheduler.
+            cache: Per-rollout K/V history after ``cache.start``.
+            input: Optional public keyboard/mouse control for this action.
+
+        Returns:
+            Flow prediction with the same layout as ``noisy_latent``.
+
+        Raises:
+            RuntimeError: Called before an action has been selected with ``start``.
+            TypeError: ``input`` is not a :class:`WaypointControl`.
+        """
+        if cache.autoregressive_index < 0:
+            raise RuntimeError("cache.start(autoregressive_index) must run first")
+        if input is not None and not isinstance(input, WaypointControl):
+            raise TypeError(
+                f"Waypoint input must be WaypointControl or None, got {type(input)}"
+            )
+        sigma = (
+            timestep.reshape(1)
+            .expand(cache.batch_size)
+            .to(device=noisy_latent.device, dtype=noisy_latent.dtype)
+        )
+        if input is None:
+            return self.network(
+                noisy_latent,
+                sigma=sigma,
+                frame_index=cache.autoregressive_index,
+                kv_cache=cache.kv_cache,
+            )
+        control = make_control_context(
+            input,
+            frame_index=cache.autoregressive_index,
+            batch_size=cache.batch_size,
+            dtype=noisy_latent.dtype,
+            device=noisy_latent.device,
+            spec=self.spec,
+        )
+        return self.network(
+            noisy_latent,
+            sigma=sigma,
+            frame_index=cache.autoregressive_index,
+            kv_cache=cache.kv_cache,
+            button=control["button"],
+            mouse=control["mouse"],
+            scroll=control["scroll"],
+        )
+
+    def finalize_kv_cache(
+        self,
+        noisy_latent: Tensor,
+        timestep: Tensor,
+        cache: WaypointTransformerCache,
+        input: WaypointControl | None = None,
+    ) -> None:
+        """Commit the clean action's K/V entries after its Euler solve.
+
+        Denoising repeatedly replaces a provisional current-frame slot. Only
+        this final sigma-zero pass may persist that slot into long-term history;
+        otherwise the next action has no visual world state to condition on.
+        """
+        cache.kv_cache.set_frozen(False)
+        try:
+            _ = self.predict_flow(noisy_latent, timestep, cache, input)
+        finally:
+            cache.kv_cache.set_frozen(True)

--- a/integrations/waypoint/waypoint/transformer/network.py
+++ b/integrations/waypoint/waypoint/transformer/network.py
@@ -393,12 +393,24 @@ class _NoiseEmbedder(nn.Module):
 
     def __init__(self, spec: WaypointModelSpec) -> None:
         super().__init__()
+        if spec.noise_embedding_dim % 2:
+            raise ValueError("Waypoint noise embedding width must be even")
         self.register_buffer(
             "freq",
-            torch.logspace(0, -1, steps=256, base=10_000.0, dtype=torch.float32),
+            torch.logspace(
+                0,
+                -1,
+                steps=spec.noise_embedding_dim // 2,
+                base=10_000.0,
+                dtype=torch.float32,
+            ),
             persistent=False,
         )
-        self.mlp = _TwoLayerMLP(512, spec.d_model * spec.mlp_ratio, spec.d_model)
+        self.mlp = _TwoLayerMLP(
+            spec.noise_embedding_dim,
+            spec.d_model * spec.mlp_ratio,
+            spec.d_model,
+        )
 
     def _apply(self, fn):
         """Move the conditioner while retaining FP32 Fourier-MLP arithmetic."""
@@ -600,7 +612,7 @@ class WaypointDiT(nn.Module):
             Noise embedding with shape ``[*sigma.shape, D]``.
         """
         features = sinusoidal_noise_embedding(
-            512,
+            self.spec.noise_embedding_dim,
             sigma,
             frequencies=self.denoise_step_emb.freq,
         )

--- a/integrations/waypoint/waypoint/transformer/network.py
+++ b/integrations/waypoint/waypoint/transformer/network.py
@@ -286,8 +286,9 @@ class _WaypointBlock(nn.Module):
         super().__init__()
         self.attn = _WaypointAttention(spec)
         self.attn_cond_head = _ConditionHead(spec.d_model)
-        if has_control_fusion:
-            self.ctrl_mlpfusion = _ControlFusion(spec.d_model)
+        self.ctrl_mlpfusion: _ControlFusion | None = (
+            _ControlFusion(spec.d_model) if has_control_fusion else None
+        )
         self.dit_mlp = _TwoLayerMLP(
             spec.d_model,
             spec.d_model * spec.mlp_ratio,
@@ -339,7 +340,7 @@ class _WaypointBlock(nn.Module):
         )
         tokens = tokens + adaptive_gate(attn_residual, attn_gate)
 
-        if control is not None and hasattr(self, "ctrl_mlpfusion"):
+        if control is not None and self.ctrl_mlpfusion is not None:
             if control.shape != tokens.shape:
                 raise ValueError(
                     "Waypoint control tokens must match hidden states, got "

--- a/integrations/waypoint/waypoint/transformer/network.py
+++ b/integrations/waypoint/waypoint/transformer/network.py
@@ -1,0 +1,719 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkpoint-compatible Waypoint DiT topology and local tensor operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import cast
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.attention.flex_attention import BlockMask
+
+from flashdreams.infra.config import InstantiateConfig
+from waypoint.spec import WAYPOINT_1_5, WaypointModelSpec
+from waypoint.transformer.cache import WaypointKVCache
+from waypoint.transformer.norm import adaptive_gate, adaptive_rms_norm
+from waypoint.transformer.rope import WaypointOrthoRoPEAngles, apply_waypoint_ortho_rope
+
+
+# Compile the pure fixed-attention operation so FlexAttention receives the
+# block-index representation required by the fixed cache.
+@torch.compile(dynamic=False)
+def _compiled_fixed_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    block_mask: BlockMask,
+) -> Tensor:
+    """Run fixed-cache GQA through FlexAttention's compiled kernel path."""
+    from torch.nn.attention.flex_attention import flex_attention
+
+    return flex_attention(
+        query,
+        key,
+        value,
+        block_mask=block_mask,
+        enable_gqa=True,
+    )
+
+
+def sinusoidal_noise_embedding(
+    dim: int,
+    sigma: Tensor,
+    *,
+    frequencies: Tensor | None = None,
+) -> Tensor:
+    """Embed continuous noise levels with Waypoint's Wan-style Fourier basis.
+
+    Args:
+        dim: Even output feature width.
+        sigma: Noise levels with arbitrary leading shape.
+        frequencies: Optional precomputed positive Fourier frequencies. Supplying
+            the conditioner's buffer preserves its checkpoint-runtime numeric
+            behavior after a precision move.
+
+    Returns:
+        Cosine/sine features with shape ``[*sigma.shape, dim]``.
+
+    Raises:
+        ValueError: ``dim`` is not even.
+    """
+    if dim % 2:
+        raise ValueError(f"noise embedding width must be even, got {dim}")
+    half = dim // 2
+    sigma = sigma.to(dtype=torch.float32)
+    if frequencies is None:
+        frequencies = torch.logspace(
+            0,
+            -1,
+            steps=half,
+            base=10_000.0,
+            device=sigma.device,
+            dtype=torch.float32,
+        )
+    elif frequencies.ndim != 1 or frequencies.numel() != half:
+        raise ValueError(
+            f"expected {half} one-dimensional Fourier frequencies, got "
+            f"{tuple(frequencies.shape)}"
+        )
+    frequencies = frequencies.to(device=sigma.device, dtype=torch.float32)
+    angles = sigma[..., None] * 1_000 * frequencies
+    return torch.cat((torch.sin(angles), torch.cos(angles)), dim=-1) * (2**0.5)
+
+
+class _TwoLayerMLP(nn.Module):
+    """Bias-free two-projection MLP with raw checkpoint names."""
+
+    def __init__(
+        self, in_features: int, hidden_features: int, out_features: int
+    ) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(in_features, hidden_features, bias=False)
+        self.fc2 = nn.Linear(hidden_features, out_features, bias=False)
+
+    def forward(self, input: Tensor) -> Tensor:
+        """Apply the SiLU MLP used by the public control and noise conditioners."""
+        return self.fc2(F.silu(self.fc1(input)))
+
+
+class _NullControl(nn.Module):
+    """Classifier-free null-control embedding container."""
+
+    def __init__(self, d_model: int) -> None:
+        super().__init__()
+        self.null_emb = nn.Parameter(torch.empty(1, 1, d_model))
+
+
+class _ConditionHead(nn.Module):
+    """Three-projection adaptive-conditioning parameter group."""
+
+    def __init__(self, d_model: int) -> None:
+        super().__init__()
+        self.bias_in = nn.Parameter(torch.empty(d_model))
+        self.cond_proj = nn.ModuleList(
+            [nn.Linear(d_model, d_model, bias=False) for _ in range(3)]
+        )
+
+    def forward(self, conditioning: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        """Project one conditioner into an AdaLN scale, shift, and gate tuple."""
+        features = F.silu(conditioning + self.bias_in)
+        return tuple(projection(features) for projection in self.cond_proj)  # type: ignore[return-value]
+
+
+class _WaypointAttention(nn.Module):
+    """Grouped-query attention projections and value-residual coefficient."""
+
+    def __init__(self, spec: WaypointModelSpec) -> None:
+        super().__init__()
+        kv_dim = spec.n_kv_heads * spec.head_dim
+        self.n_heads = spec.n_heads
+        self.n_kv_heads = spec.n_kv_heads
+        self.head_dim = spec.head_dim
+        self.k_proj = nn.Linear(spec.d_model, kv_dim, bias=False)
+        self.out_proj = nn.Linear(spec.d_model, spec.d_model, bias=False)
+        self.q_proj = nn.Linear(spec.d_model, spec.d_model, bias=False)
+        self.v_lamb = nn.Parameter(torch.empty(()))
+        self.v_proj = nn.Linear(spec.d_model, kv_dim, bias=False)
+
+    def project_qkv(self, tokens: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        """Project tokens into RMS-normalized Q/K and unnormalized grouped V.
+
+        Args:
+            tokens: Hidden states shaped ``[batch, tokens, d_model]``.
+
+        Returns:
+            Query, key, and value tensors shaped ``[batch, tokens, heads, head_dim]``.
+
+        Raises:
+            ValueError: ``tokens`` does not have Waypoint's model width.
+        """
+        if tokens.ndim != 3 or tokens.shape[-1] != self.q_proj.in_features:
+            raise ValueError(
+                "Waypoint attention requires [batch, tokens, d_model] input; "
+                f"got {tuple(tokens.shape)}"
+            )
+        batch_size, token_count, _ = tokens.shape
+        query = self.q_proj(tokens).reshape(
+            batch_size, token_count, self.n_heads, self.head_dim
+        )
+        key = self.k_proj(tokens).reshape(
+            batch_size, token_count, self.n_kv_heads, self.head_dim
+        )
+        value = self.v_proj(tokens).reshape(
+            batch_size, token_count, self.n_kv_heads, self.head_dim
+        )
+        return (
+            F.rms_norm(query, (self.head_dim,), weight=None, eps=None),
+            F.rms_norm(key, (self.head_dim,), weight=None, eps=None),
+            value,
+        )
+
+    def blend_value_residual(
+        self, current_value: Tensor, initial_value: Tensor | None
+    ) -> tuple[Tensor, Tensor]:
+        """Blend current values with the first block's value stream.
+
+        Args:
+            current_value: Values projected by the current transformer block.
+            initial_value: First-block values; ``None`` on the first block.
+
+        Returns:
+            Values for attention and the value stream retained for later blocks.
+
+        Raises:
+            ValueError: A retained value stream does not match the current layout.
+        """
+        if initial_value is None:
+            return current_value, current_value
+        if initial_value.shape != current_value.shape:
+            raise ValueError(
+                "Waypoint value residual requires matching current and initial "
+                f"value shapes, got {tuple(current_value.shape)} and "
+                f"{tuple(initial_value.shape)}"
+            )
+        return torch.lerp(current_value, initial_value, self.v_lamb), initial_value
+
+    def forward(
+        self,
+        tokens: Tensor,
+        *,
+        cosine: Tensor,
+        sine: Tensor,
+        layer_index: int,
+        frame_index: int,
+        kv_cache: WaypointKVCache,
+        initial_value: Tensor | None,
+    ) -> tuple[Tensor, Tensor]:
+        """Attend over the sparse causal history of one Waypoint block.
+
+        Args:
+            tokens: Normalized hidden states shaped ``[B, S, D]``.
+            cosine: Current-frame packed RoPE cosine factors.
+            sine: Current-frame packed RoPE sine factors.
+            layer_index: Zero-indexed transformer block owning the K/V history.
+            frame_index: Zero-indexed latent action being denoised.
+            kv_cache: Per-rollout sparse K/V history.
+            initial_value: Value tensor retained from the first transformer block.
+
+        Returns:
+            Attention residual in ``[B, S, D]`` layout and the value stream to
+            retain for subsequent blocks.
+        """
+        query, key, current_value = self.project_qkv(tokens)
+        query = apply_waypoint_ortho_rope(query, cosine, sine)
+        key = apply_waypoint_ortho_rope(key, cosine, sine)
+        value, retained_value = self.blend_value_residual(current_value, initial_value)
+
+        view = kv_cache.update(
+            layer_index=layer_index,
+            frame_index=frame_index,
+            key=key.transpose(1, 2),
+            value=value.transpose(1, 2),
+        )
+        query = query.transpose(1, 2)
+        if view.block_mask is None:
+            attention = F.scaled_dot_product_attention(
+                query,
+                view.key,
+                view.value,
+                enable_gqa=True,
+            )
+        else:
+            attention = _compiled_fixed_attention(
+                query, view.key, view.value, view.block_mask
+            )
+        batch_size, _, token_count, _ = attention.shape
+        attention = attention.transpose(1, 2).reshape(
+            batch_size, token_count, self.out_proj.in_features
+        )
+        return self.out_proj(attention), retained_value
+
+
+class _ControlFusion(nn.Module):
+    """Controller-fusion projections for every third Waypoint block."""
+
+    def __init__(self, d_model: int) -> None:
+        super().__init__()
+        self.fc1_c = nn.Linear(d_model, d_model, bias=False)
+        self.fc1_x = nn.Linear(d_model, d_model, bias=False)
+        self.fc2 = nn.Linear(d_model, d_model, bias=False)
+
+    def forward(self, tokens: Tensor, control: Tensor) -> Tensor:
+        """Fuse controller features through the published residual MLP path."""
+        return self.fc2(F.silu(self.fc1_x(tokens) + self.fc1_c(control)))
+
+
+class _WaypointBlock(nn.Module):
+    """One checkpoint-compatible Waypoint transformer block."""
+
+    def __init__(self, spec: WaypointModelSpec, *, has_control_fusion: bool) -> None:
+        super().__init__()
+        self.attn = _WaypointAttention(spec)
+        self.attn_cond_head = _ConditionHead(spec.d_model)
+        if has_control_fusion:
+            self.ctrl_mlpfusion = _ControlFusion(spec.d_model)
+        self.dit_mlp = _TwoLayerMLP(
+            spec.d_model,
+            spec.d_model * spec.mlp_ratio,
+            spec.d_model,
+        )
+        self.mlp_cond_head = _ConditionHead(spec.d_model)
+
+    def forward(
+        self,
+        tokens: Tensor,
+        *,
+        conditioning: Tensor,
+        control: Tensor | None,
+        cosine: Tensor,
+        sine: Tensor,
+        layer_index: int,
+        frame_index: int,
+        kv_cache: WaypointKVCache,
+        initial_value: Tensor | None,
+    ) -> tuple[Tensor, Tensor]:
+        """Apply one conditionally gated Waypoint transformer block.
+
+        Args:
+            tokens: Hidden states in ``[B, T * S, D]`` layout.
+            conditioning: Noise/control features in ``[B, T, D]`` layout.
+            control: Per-token controller features; ``None`` skips periodic fusion.
+            cosine: Current-frame packed RoPE cosine factors.
+            sine: Current-frame packed RoPE sine factors.
+            layer_index: Zero-indexed block index for sparse-history selection.
+            frame_index: Zero-indexed latent action being denoised.
+            kv_cache: Per-rollout sparse attention K/V history.
+            initial_value: First-block value stream; ``None`` for block zero.
+
+        Returns:
+            Updated hidden states and the first-block value stream.
+
+        Raises:
+            ValueError: Control tokens do not match the hidden-state layout.
+        """
+        attn_scale, attn_bias, attn_gate = self.attn_cond_head(conditioning)
+        attn_residual, initial_value = self.attn(
+            adaptive_rms_norm(tokens, attn_scale, attn_bias),
+            cosine=cosine,
+            sine=sine,
+            layer_index=layer_index,
+            frame_index=frame_index,
+            kv_cache=kv_cache,
+            initial_value=initial_value,
+        )
+        tokens = tokens + adaptive_gate(attn_residual, attn_gate)
+
+        if control is not None and hasattr(self, "ctrl_mlpfusion"):
+            if control.shape != tokens.shape:
+                raise ValueError(
+                    "Waypoint control tokens must match hidden states, got "
+                    f"control={tuple(control.shape)}, tokens={tuple(tokens.shape)}"
+                )
+            channels = tokens.shape[-1]
+            fused_tokens = F.rms_norm(tokens, (channels,), weight=None, eps=None)
+            fused_control = F.rms_norm(control, (channels,), weight=None, eps=None)
+            tokens = tokens + self.ctrl_mlpfusion(fused_tokens, fused_control)
+
+        mlp_scale, mlp_bias, mlp_gate = self.mlp_cond_head(conditioning)
+        mlp_residual = self.dit_mlp(adaptive_rms_norm(tokens, mlp_scale, mlp_bias))
+        return tokens + adaptive_gate(mlp_residual, mlp_gate), initial_value
+
+
+class _WaypointBlockStack(nn.Module):
+    """Ordered Waypoint transformer blocks with periodic control fusion."""
+
+    def __init__(self, spec: WaypointModelSpec) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                _WaypointBlock(
+                    spec,
+                    has_control_fusion=(
+                        layer_index % spec.controller_conditioning_period == 0
+                    ),
+                )
+                for layer_index in range(spec.n_layers)
+            ]
+        )
+
+
+class _ControlEmbedder(nn.Module):
+    """Waypoint controller embedding MLP."""
+
+    def __init__(self, spec: WaypointModelSpec) -> None:
+        super().__init__()
+        self.mlp = _TwoLayerMLP(
+            spec.n_buttons + 3,
+            spec.d_model * spec.mlp_ratio,
+            spec.d_model,
+        )
+
+
+class _NoiseEmbedder(nn.Module):
+    """Waypoint diffusion-noise embedding MLP."""
+
+    freq: Tensor
+    mlp: _TwoLayerMLP
+
+    def __init__(self, spec: WaypointModelSpec) -> None:
+        super().__init__()
+        self.register_buffer(
+            "freq",
+            torch.logspace(0, -1, steps=256, base=10_000.0, dtype=torch.float32),
+            persistent=False,
+        )
+        self.mlp = _TwoLayerMLP(512, spec.d_model * spec.mlp_ratio, spec.d_model)
+
+    def _apply(self, fn):
+        """Move the conditioner while retaining FP32 Fourier-MLP arithmetic."""
+
+        def keep_dtype(tensor: Tensor) -> Tensor:
+            return fn(tensor).to(dtype=tensor.dtype)
+
+        return super()._apply(keep_dtype)
+
+
+class _OutputNorm(nn.Module):
+    """Checkpoint-compatible final adaptive-normalization projection."""
+
+    def __init__(self, d_model: int) -> None:
+        super().__init__()
+        self.fc = nn.Linear(d_model, 2 * d_model, bias=False)
+
+
+@dataclass(kw_only=True)
+class WaypointDiTConfig(InstantiateConfig):
+    """Static construction config for the published Waypoint 1.5 DiT."""
+
+    _target: type["WaypointDiT"] = field(default_factory=lambda: WaypointDiT)
+
+    spec: WaypointModelSpec = WAYPOINT_1_5
+    """Immutable architecture contract for the target checkpoint."""
+
+
+class WaypointDiT(nn.Module):
+    """Denoise one controllable autoregressive Waypoint latent frame.
+
+    Waypoint generates a four-frame video chunk from each 32-channel latent
+    frame, then feeds that latent history back into the next action. Its control
+    embedding, grouped-query transformer widths, and fixed checkpoint namespace
+    are coupled to that rollout contract, so it cannot be represented by a
+    generic image-to-video DiT without changing the learned function.
+    """
+
+    ctrl_cfg: _NullControl
+    ctrl_emb: _ControlEmbedder
+    denoise_step_emb: _NoiseEmbedder
+    out_norm: _OutputNorm
+    patchify: nn.Conv2d
+    transformer: _WaypointBlockStack
+    rope_angles: WaypointOrthoRoPEAngles
+    unpatchify: nn.ConvTranspose2d
+
+    def __init__(self, config: WaypointDiTConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.spec = config.spec
+        self.ctrl_cfg = _NullControl(self.spec.d_model)
+        self.ctrl_emb = _ControlEmbedder(self.spec)
+        self.denoise_step_emb = _NoiseEmbedder(self.spec)
+        self.out_norm = _OutputNorm(self.spec.d_model)
+        self.patchify = nn.Conv2d(
+            self.spec.channels,
+            self.spec.d_model,
+            kernel_size=(self.spec.patch_height, self.spec.patch_width),
+            stride=(self.spec.patch_height, self.spec.patch_width),
+            bias=False,
+        )
+        self.transformer = _WaypointBlockStack(self.spec)
+        self.rope_angles = WaypointOrthoRoPEAngles(self.spec)
+        self.unpatchify = nn.ConvTranspose2d(
+            self.spec.d_model,
+            self.spec.channels,
+            kernel_size=(self.spec.patch_height, self.spec.patch_width),
+            stride=(self.spec.patch_height, self.spec.patch_width),
+            bias=True,
+        )
+
+    def patchify_latent(self, latent: Tensor) -> Tensor:
+        """Patchify one or more Waypoint latent frames into DiT tokens.
+
+        Args:
+            latent: Raw latent video with shape ``[B, T, C, H, W]``.
+
+        Returns:
+            Tokens ordered by ``(T, H, W)`` with shape ``[B, T * L, D]``.
+
+        Raises:
+            ValueError: The latent shape differs from the published contract.
+        """
+        if latent.ndim != 5:
+            raise ValueError(
+                "Waypoint latent must have shape [B, T, C, H, W], "
+                f"got {tuple(latent.shape)}"
+            )
+        batch_size, frames, channels, height, width = latent.shape
+        expected = (self.spec.channels, self.spec.latent_height, self.spec.latent_width)
+        if (channels, height, width) != expected:
+            raise ValueError(
+                "Waypoint latent C/H/W mismatch: "
+                f"expected {expected}, got {(channels, height, width)}"
+            )
+        x = self.patchify(latent.reshape(batch_size * frames, channels, height, width))
+        patch_height, patch_width = x.shape[-2:]
+        x = x.reshape(batch_size, frames, self.spec.d_model, patch_height, patch_width)
+        return x.permute(0, 1, 3, 4, 2).reshape(batch_size, -1, self.spec.d_model)
+
+    def unpatchify_tokens(self, tokens: Tensor, *, frames: int = 1) -> Tensor:
+        """Unpatchify DiT tokens into raw Waypoint latents.
+
+        Args:
+            tokens: Tokens with shape ``[B, T * L, D]``.
+            frames: Latent-frame count ``T`` represented by ``tokens``.
+
+        Returns:
+            Latent video with shape ``[B, T, C, H, W]``.
+
+        Raises:
+            ValueError: Token rank, width, count, or frame count is invalid.
+        """
+        if tokens.ndim != 3:
+            raise ValueError(f"Waypoint tokens must have rank 3, got {tokens.ndim}")
+        if frames < 1:
+            raise ValueError(f"frames must be positive, got {frames}")
+        batch_size, token_count, width = tokens.shape
+        if width != self.spec.d_model:
+            raise ValueError(
+                f"Waypoint token width must be {self.spec.d_model}, got {width}"
+            )
+        tokens_per_frame = self.spec.tokens_per_latent_frame
+        if token_count != frames * tokens_per_frame:
+            raise ValueError(
+                f"Waypoint token count must be frames * {tokens_per_frame}, "
+                f"got frames={frames}, token_count={token_count}"
+            )
+        patch_height = self.spec.latent_height // self.spec.patch_height
+        patch_width = self.spec.latent_width // self.spec.patch_width
+        # The published tensor is laid out as a convolution kernel, but its
+        # inference operator emits the ``C * patch_h * patch_w`` pixel vector
+        # independently for every token. Keep the raw kernel layout in the
+        # module state dict, then expose that learned operator directly here.
+        output_weight = self.unpatchify.weight.permute(1, 2, 3, 0).reshape(
+            -1, self.spec.d_model
+        )
+        output_bias = cast(Tensor, self.unpatchify.bias)
+        output_bias = (
+            output_bias[:, None, None]
+            .expand(-1, self.spec.patch_height, self.spec.patch_width)
+            .reshape(-1)
+        )
+        x = F.linear(tokens, output_weight, output_bias)
+        x = x.reshape(
+            batch_size,
+            frames,
+            patch_height,
+            patch_width,
+            self.spec.channels,
+            self.spec.patch_height,
+            self.spec.patch_width,
+        )
+        return x.permute(0, 1, 4, 2, 5, 3, 6).reshape(
+            batch_size,
+            frames,
+            self.spec.channels,
+            self.spec.latent_height,
+            self.spec.latent_width,
+        )
+
+    def embed_control(self, *, button: Tensor, mouse: Tensor, scroll: Tensor) -> Tensor:
+        """Embed one controller state per autoregressive latent frame.
+
+        Args:
+            button: Multi-hot button tensor with shape ``[B, T, 256]``.
+            mouse: Pointer deltas with shape ``[B, T, 2]``.
+            scroll: Wheel direction with shape ``[B, T, 1]``.
+
+        Returns:
+            Controller embeddings with shape ``[B, T, D]``.
+
+        Raises:
+            ValueError: Controller tensors do not share the published shapes.
+        """
+        expected_prefix = button.shape[:-1]
+        if (
+            button.ndim != 3
+            or button.shape[-1] != self.spec.n_buttons
+            or mouse.shape != expected_prefix + (2,)
+            or scroll.shape != expected_prefix + (1,)
+        ):
+            raise ValueError(
+                "Waypoint controls require button=[B, T, 256], mouse=[B, T, 2], "
+                f"scroll=[B, T, 1]; got button={tuple(button.shape)}, "
+                f"mouse={tuple(mouse.shape)}, scroll={tuple(scroll.shape)}"
+            )
+        controls = torch.cat((mouse, button, scroll), dim=-1)
+        return self.ctrl_emb.mlp(controls)
+
+    def embed_noise(self, sigma: Tensor) -> Tensor:
+        """Embed continuous rectified-flow noise levels.
+
+        Args:
+            sigma: Scalar or batch-shaped noise level.
+
+        Returns:
+            Noise embedding with shape ``[*sigma.shape, D]``.
+        """
+        features = sinusoidal_noise_embedding(
+            512,
+            sigma,
+            frequencies=self.denoise_step_emb.freq,
+        )
+        return self.denoise_step_emb.mlp(features).to(dtype=self.patchify.weight.dtype)
+
+    def forward(
+        self,
+        latent: Tensor,
+        *,
+        sigma: Tensor,
+        frame_index: int,
+        kv_cache: WaypointKVCache,
+        button: Tensor | None = None,
+        mouse: Tensor | None = None,
+        scroll: Tensor | None = None,
+    ) -> Tensor:
+        """Predict rectified-flow velocity for one autoregressive latent action.
+
+        Args:
+            latent: Noisy latent video in ``[B, 1, C, H, W]`` layout.
+            sigma: One noise level per batch item, shaped ``[B]``.
+            frame_index: Zero-indexed latent action shared by the batch.
+            kv_cache: Per-rollout sparse attention K/V history.
+            button: Optional multi-hot buttons in ``[B, 1, 256]`` layout.
+            mouse: Optional pointer deltas in ``[B, 1, 2]`` layout.
+            scroll: Optional wheel directions in ``[B, 1, 1]`` layout.
+
+        Returns:
+            Rectified-flow velocity with the same shape as ``latent``.
+
+        Raises:
+            ValueError: The latent, noise, or partial controller state does not
+                match Waypoint's one-action execution contract.
+        """
+        if latent.ndim != 5 or latent.shape[1] != 1:
+            raise ValueError(
+                "WaypointDiT forward expects one latent action in [B, 1, C, H, W] "
+                f"layout, got {tuple(latent.shape)}"
+            )
+        if sigma.ndim != 1 or sigma.shape[0] != latent.shape[0]:
+            raise ValueError(
+                f"sigma must have one value per batch item, got {tuple(sigma.shape)}"
+            )
+        if frame_index < 0:
+            raise ValueError(f"frame_index must be non-negative, got {frame_index}")
+        controls = (button, mouse, scroll)
+        if any(control is not None for control in controls) and any(
+            control is None for control in controls
+        ):
+            raise ValueError("button, mouse, and scroll must be supplied together")
+
+        tokens = self.patchify_latent(latent)
+        batch_size, token_count, _ = tokens.shape
+        conditioning = self.embed_noise(sigma.to(device=tokens.device)).to(tokens.dtype)
+
+        if button is None:
+            control_frame = self.ctrl_cfg.null_emb.to(dtype=tokens.dtype).expand(
+                batch_size, 1, -1
+            )
+        else:
+            mouse = cast(Tensor, mouse)
+            scroll = cast(Tensor, scroll)
+            control_frame = self.embed_control(
+                button=button.to(device=tokens.device, dtype=tokens.dtype),
+                mouse=mouse.to(device=tokens.device, dtype=tokens.dtype),
+                scroll=scroll.to(device=tokens.device, dtype=tokens.dtype),
+            )
+            if control_frame.shape[:2] != (batch_size, 1):
+                raise ValueError(
+                    "Waypoint controller state must describe one frame per batch item, "
+                    f"got {tuple(control_frame.shape)}"
+                )
+        control_tokens = control_frame.expand(-1, token_count, -1)
+        cosine, sine = self._current_rope_angles(
+            frame_index=frame_index, device=tokens.device
+        )
+
+        initial_value: Tensor | None = None
+        conditioning = conditioning[:, None]
+        for layer_index, block in enumerate(self.transformer.blocks):
+            tokens, initial_value = block(
+                tokens,
+                conditioning=conditioning,
+                control=control_tokens,
+                cosine=cosine,
+                sine=sine,
+                layer_index=layer_index,
+                frame_index=frame_index,
+                kv_cache=kv_cache,
+                initial_value=initial_value,
+            )
+
+        scale, bias = self.out_norm.fc(F.silu(conditioning)).chunk(2, dim=-1)
+        tokens = F.silu(adaptive_rms_norm(tokens, scale, bias))
+        return self.unpatchify_tokens(tokens)
+
+    def _current_rope_angles(
+        self, *, frame_index: int, device: torch.device
+    ) -> tuple[Tensor, Tensor]:
+        """Build the fixed spatial and current temporal RoPE factors."""
+        rows = torch.arange(self.spec.patch_grid_height, device=device)
+        columns = torch.arange(self.spec.patch_grid_width, device=device)
+        row_index = rows.repeat_interleave(self.spec.patch_grid_width)
+        column_index = columns.repeat(self.spec.patch_grid_height)
+        # The cache advances once per latent action.  Temporal RoPE uses the
+        # checkpoint's base-rate timestamp, whose stride is part of the
+        # checkpoint contract (and is one for Waypoint 1.5).
+        frame_indices = torch.full_like(
+            row_index,
+            frame_index * self.spec.frame_timestamp_stride,
+        )
+        return self.rope_angles(
+            frame_index=frame_indices,
+            row_index=row_index,
+            column_index=column_index,
+        )

--- a/integrations/waypoint/waypoint/transformer/norm.py
+++ b/integrations/waypoint/waypoint/transformer/norm.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parameter-free RMS normalization operations used by Waypoint DiT blocks."""
+
+from __future__ import annotations
+
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def adaptive_rms_norm(tokens: Tensor, scale: Tensor, bias: Tensor) -> Tensor:
+    """Apply per-latent-frame adaptive RMS normalization.
+
+    Args:
+        tokens: Token tensor shaped ``[batch, frames * tokens_per_frame, channels]``.
+        scale: Adaptive RMSNorm scale tensor shaped ``[batch, frames, channels]``.
+        bias: Adaptive RMSNorm bias tensor shaped ``[batch, frames, channels]``.
+
+    Returns:
+        Adaptively normalized tokens with the same shape and dtype as ``tokens``.
+
+    Raises:
+        ValueError: The token and conditioner layouts are incompatible.
+    """
+    if tokens.ndim != 3 or scale.ndim != 3 or bias.ndim != 3:
+        raise ValueError("tokens, scale, and bias must each have three dimensions")
+    if scale.shape != bias.shape:
+        raise ValueError("AdaRMSNorm scale and bias shapes must match")
+    batch_size, token_count, channels = tokens.shape
+    if scale.shape[0] != batch_size or scale.shape[2] != channels:
+        raise ValueError("AdaRMSNorm conditioning must match token batch and channels")
+    frames = scale.shape[1]
+    if frames < 1 or token_count % frames:
+        raise ValueError(
+            "token count must be divisible by the number of conditioned frames"
+        )
+
+    tokens_per_frame = token_count // frames
+    x = tokens.reshape(batch_size, frames, tokens_per_frame, channels)
+    output = F.rms_norm(x, (channels,), weight=None, eps=None)
+    output = output * (1 + scale[:, :, None]) + bias[:, :, None]
+    return output.reshape_as(tokens)
+
+
+def adaptive_gate(tokens: Tensor, gate: Tensor) -> Tensor:
+    """Scale each latent frame's residual branch with a conditioner gate.
+
+    Args:
+        tokens: Residual tensor shaped ``[batch, frames * tokens_per_frame, channels]``.
+        gate: Per-frame gate tensor shaped ``[batch, frames, channels]``.
+
+    Returns:
+        Gated residual tensor with the same shape and dtype as ``tokens``.
+
+    Raises:
+        ValueError: The residual and gate layouts are incompatible.
+    """
+    if tokens.ndim != 3 or gate.ndim != 3:
+        raise ValueError("tokens and gate must each have three dimensions")
+    batch_size, token_count, channels = tokens.shape
+    if gate.shape[0] != batch_size or gate.shape[2] != channels:
+        raise ValueError("AdaGate conditioning must match residual batch and channels")
+    frames = gate.shape[1]
+    if frames < 1 or token_count % frames:
+        raise ValueError("token count must be divisible by the number of gated frames")
+    tokens_per_frame = token_count // frames
+    gated = tokens.reshape(batch_size, frames, tokens_per_frame, channels)
+    return (gated * gate[:, :, None]).reshape_as(tokens)

--- a/integrations/waypoint/waypoint/transformer/rope.py
+++ b/integrations/waypoint/waypoint/transformer/rope.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Orthogonal three-axis rotary-angle construction for Waypoint attention."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+from waypoint.spec import WAYPOINT_1_5, WaypointModelSpec
+
+
+def apply_waypoint_ortho_rope(tokens: Tensor, cosine: Tensor, sine: Tensor) -> Tensor:
+    """Apply Waypoint's half-head rotary transform to attention tensors.
+
+    Args:
+        tokens: Query or key tensor shaped ``[batch, tokens, heads, head_dim]``.
+        cosine: Packed RoPE cosine factors shaped ``[tokens, 1, head_dim / 2]``.
+        sine: Packed RoPE sine factors shaped ``[tokens, 1, head_dim / 2]``.
+
+    Returns:
+        The rotary-transformed tensor with the same shape and dtype as ``tokens``.
+
+    Raises:
+        ValueError: Tensor or angle shapes cannot represent the same token sequence.
+    """
+    if tokens.ndim != 4 or tokens.shape[-1] % 2:
+        raise ValueError("tokens must have shape [batch, tokens, heads, even_head_dim]")
+    expected_angles = (tokens.shape[1], 1, tokens.shape[-1] // 2)
+    if cosine.shape != expected_angles or sine.shape != expected_angles:
+        raise ValueError(
+            "RoPE angles must have shape "
+            f"{expected_angles}, got cosine={tuple(cosine.shape)}, sine={tuple(sine.shape)}"
+        )
+    # Projection channels arrive as adjacent real/imaginary pairs. The attention
+    # kernel receives the rotated result in its packed real-half / imaginary-half
+    # layout, matching Waypoint's grouped-query projections.
+    first = tokens.float()[..., 0::2]
+    second = tokens.float()[..., 1::2]
+    cosine = cosine.unsqueeze(0).float()
+    sine = sine.unsqueeze(0).float()
+    rotated = torch.cat(
+        (first * cosine - second * sine, first * sine + second * cosine), dim=-1
+    )
+    return rotated.to(dtype=tokens.dtype)
+
+
+class WaypointOrthoRoPEAngles(nn.Module):
+    """Construct the parameter-free three-axis rotary angles used by Waypoint.
+
+    One quarter of each head's complex dimensions represents horizontal location,
+    one quarter represents vertical location, and the remaining half represents
+    autoregressive time. Spatial coordinates are patch centers relative to the
+    latent-image center. The spatial frequency ceiling preserves circular
+    frequency under the checkpoint's 16:32 aspect ratio.
+    """
+
+    spatial_frequencies: Tensor
+    temporal_frequencies: Tensor
+
+    def __init__(self, spec: WaypointModelSpec = WAYPOINT_1_5) -> None:
+        """Initialize an angle generator from a checkpoint architecture contract.
+
+        Args:
+            spec: Published Waypoint architecture and RoPE constants.
+
+        Raises:
+            ValueError: The head dimension cannot be evenly partitioned.
+        """
+        super().__init__()
+        if spec.head_dim % 8:
+            raise ValueError(
+                "Waypoint orthogonal RoPE requires a head dimension divisible "
+                f"by 8, got {spec.head_dim}"
+            )
+        self.spec = spec
+        spatial_dim = spec.head_dim // 8
+        temporal_dim = spec.head_dim // 4
+        spatial_frequency_count = (spatial_dim + 1) // 2
+        max_frequency = min(spec.patch_grid_height, spec.patch_grid_width) * (
+            spec.rope_nyquist_fraction
+        )
+        spatial = (
+            torch.linspace(
+                1.0,
+                max_frequency / 2,
+                spatial_frequency_count,
+                dtype=torch.float32,
+            )
+            * torch.pi
+        ).repeat_interleave(2)[:spatial_dim]
+        temporal = torch.pow(
+            torch.tensor(spec.rope_theta, dtype=torch.float32),
+            -torch.arange(0, temporal_dim, 2, dtype=torch.float32) / temporal_dim,
+        ).repeat_interleave(2)
+        self.register_buffer("spatial_frequencies", spatial, persistent=False)
+        self.register_buffer("temporal_frequencies", temporal, persistent=False)
+
+    def _apply(self, fn):
+        """Retain FP32 angle arithmetic after device precision conversion."""
+
+        def keep_dtype(tensor: Tensor) -> Tensor:
+            return fn(tensor).to(dtype=tensor.dtype)
+
+        return super()._apply(keep_dtype)
+
+    def forward(
+        self,
+        *,
+        frame_index: Tensor,
+        row_index: Tensor,
+        column_index: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Return packed cosine and sine factors for token positions.
+
+        Args:
+            frame_index: Integer latent-frame positions with shape ``[tokens]``.
+            row_index: Integer patch-row positions with shape ``[tokens]``.
+            column_index: Integer patch-column positions with shape ``[tokens]``.
+
+        Returns:
+            Cosine and sine tensors, each shaped ``[tokens, 1, head_dim / 2]``.
+
+        Raises:
+            ValueError: Position tensors do not share one one-dimensional shape.
+        """
+        positions = (frame_index, row_index, column_index)
+        token_count = frame_index.numel()
+        if any(
+            position.ndim != 1 or position.numel() != token_count
+            for position in positions
+        ):
+            raise ValueError(
+                "all RoPE position tensors must have matching [tokens] shape"
+            )
+        if not (frame_index.device == row_index.device == column_index.device):
+            raise ValueError("all RoPE position tensors must be on one device")
+
+        dtype = torch.float32
+        device = frame_index.device
+        column_position = (
+            2.0 * column_index.to(dtype) + 1.0
+        ) / self.spec.patch_grid_width - 1.0
+        row_position = (
+            2.0 * row_index.to(dtype) + 1.0
+        ) / self.spec.patch_grid_height - 1.0
+        temporal_position = frame_index.to(dtype)
+        angles = torch.cat(
+            (
+                column_position[:, None] * self.spatial_frequencies.to(device=device),
+                row_position[:, None] * self.spatial_frequencies.to(device=device),
+                temporal_position[:, None]
+                * self.temporal_frequencies.to(device=device),
+            ),
+            dim=-1,
+        )
+        return torch.cos(angles)[:, None], torch.sin(angles)[:, None]

--- a/integrations/waypoint/waypoint/transformer/rope.py
+++ b/integrations/waypoint/waypoint/transformer/rope.py
@@ -48,8 +48,9 @@ def apply_waypoint_ortho_rope(tokens: Tensor, cosine: Tensor, sine: Tensor) -> T
     # Projection channels arrive as adjacent real/imaginary pairs. The attention
     # kernel receives the rotated result in its packed real-half / imaginary-half
     # layout, matching Waypoint's grouped-query projections.
-    first = tokens.float()[..., 0::2]
-    second = tokens.float()[..., 1::2]
+    promoted = tokens.float()
+    first = promoted[..., 0::2]
+    second = promoted[..., 1::2]
     cosine = cosine.unsqueeze(0).float()
     sine = sine.unsqueeze(0).float()
     rotated = torch.cat(

--- a/integrations_v2/README.md
+++ b/integrations_v2/README.md
@@ -20,6 +20,8 @@ follows is already done for you.
   and the reference for writing a UI loop.
 - `cam2v_lingbot` — the Lingbot World specialization of the shared interactive
   camera-to-video application.
+- `waypoint` — the interactive Waypoint 1.5 image-established application
+  with deterministic control replay and live keyboard/mouse input.
 - `t2v_self_forcing`, `t2v_causal_forcing`, `t2v_fastvideo_causal_wan22`,
   `t2v_wan21`, `t2v_cosmos_predict2` — real models, each a thin wrapper over
   `flashdreams.t2v_v2`.

--- a/integrations_v2/waypoint/ADR-1-control-events.md
+++ b/integrations_v2/waypoint/ADR-1-control-events.md
@@ -1,0 +1,46 @@
+# ADR-1: Waypoint live control event semantics
+
+Status: accepted for the V2 integration.
+
+The Waypoint model consumes a set of held IDs from a fixed 256-entry button
+vocabulary, relative mouse motion, and a ternary wheel direction. FlashDreams
+V2 clients instead report keyboard strings, mouse-button indices, normalized
+absolute pointer coordinates, and wheel deltas.
+
+The canonical button mapping follows the official Overworld Biome client at
+revision `e3bc3715ba32f787d1f9719f183d4fddf6917cbe`. It mirrors Windows virtual-key
+codes:
+
+- `A`–`Z` map to 65–90 and `0`–`9` map to 48–57. Browser key case is ignored.
+- arrows map to `0x25`–`0x28`; Shift, Control, Space, Tab, and Enter map to
+  `0x10`, `0x11`, `0x20`, `0x09`, and `0x0d`.
+- V2 mouse indices left/middle/right (`0/1/2`) map to Waypoint IDs
+  `0x01/0x04/0x02`.
+- Unknown keys and additional mouse buttons are ignored. Escape remains a
+  client/runtime command rather than model input.
+
+Key and mouse-button press/release events update held state. Held state is
+included in every generated action until a matching release, focus loss, or
+reset. Focus loss and reset clear every held input and discard the pointer
+origin so controls cannot stick.
+
+Mouse movement uses normalized coordinates. The first move after focus/reset
+establishes an origin and emits no motion. Later moves are converted to
+presentation pixels as `(current - previous) * (width, height)`, multiplied by
+the configured sensitivity, and accumulated across the event batch. Button and
+wheel events update the origin without creating look motion. This intentionally
+matches Biome's pixel-delta contract while adapting V2's absolute coordinates.
+
+Vertical wheel deltas are summed across the batch and reduced to `-1`, `0`, or
+`1`. Positive means wheel up, matching the V2 browser client's sign convention
+and Waypoint's `down/stationary/up` ordering. Horizontal wheel input is ignored
+because the checkpoint has one wheel channel.
+
+Events are processed in V2 timestamp order. Edge state is persistent; mouse and
+wheel accumulators are per generated action. A reset inside a batch clears both
+persistent and accumulated state before later events in that batch are applied.
+
+File-driven mode has complete precedence over live input: keyboard and mouse
+events do not alter a controls-file rollout. Reset and close remain runtime
+lifecycle events in either mode. Live mode samples one coalesced control for
+every model-loop action.

--- a/integrations_v2/waypoint/ADR-1-control-events.md
+++ b/integrations_v2/waypoint/ADR-1-control-events.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # ADR-1: Waypoint live control event semantics
 
-Status: accepted for the V2 integration.
+Status: accepted for Waypoint; shared V2 extraction deferred.
 
 The Waypoint model consumes a set of held IDs from a fixed 256-entry button
 vocabulary, relative mouse motion, and a ternary wheel direction. FlashDreams
@@ -49,3 +49,39 @@ File-driven mode has complete precedence over live input: keyboard and mouse
 events do not alter a controls-file rollout. Reset and close remain runtime
 lifecycle events in either mode. Live mode samples one coalesced control for
 every model-loop action.
+
+## Reuse review
+
+The review found no existing V2 user-event-to-model-action mapping contract.
+V2 currently owns typed and timestamped events, event ordering and fan-out,
+reset generation, focus events, and WebRTC/native-window transport. Each model
+loop receives the unread raw `UserInputEvents` batch and remains responsible for
+semantic interpretation.
+
+The older `flashdreams.runtime.mapping.InputMapping` protocol belongs to the
+legacy runtime's canonical/inference-input schema and is not compatible with
+the V2 loop contract. The shared `apps/cam2v` package has useful application,
+session, UI, and reset organization, but its keyboard resampler produces camera
+trajectories and does not handle Waypoint's button vocabulary, mouse motion, or
+wheel channel. Neither is a dependency for this integration.
+
+`WaypointControlEventAdapter` is intentionally named as an integration-specific
+adapter even though some of its mechanics can later be shared. A reusable
+action-to-video design should keep three boundaries:
+
+1. **Runtime event transport:** `UserInputEvents` and lifecycle events, already
+   supplied by V2.
+2. **Model-neutral action snapshot:** persistent key and mouse-button state plus
+   transient normalized mouse and wheel deltas. This stateful accumulator can
+   be shared after another integration validates its timing and focus rules.
+3. **Model mapping and encoding:** an integration maps the snapshot to its
+   domain control (`WaypointControl` here), then its model package converts that
+   object to checkpoint-specific tensors (`WaypointControlEncoder`).
+
+A future generic action-to-video app can also own seed/replay/live-mode
+selection, reset wiring, and a control-help overlay while accepting the mapper
+and model pipeline as integration-provided strategies. This PR does not add
+that public protocol: with only one direct consumer, doing so would make
+Waypoint's Windows virtual-key and pixel-delta policies accidental framework
+contracts. The extraction should be validated jointly with the next compatible
+interactive world model.

--- a/integrations_v2/waypoint/ADR-1-control-events.md
+++ b/integrations_v2/waypoint/ADR-1-control-events.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # ADR-1: Waypoint live control event semantics
 
 Status: accepted for the V2 integration.

--- a/integrations_v2/waypoint/README.md
+++ b/integrations_v2/waypoint/README.md
@@ -1,0 +1,17 @@
+# Waypoint 1.5 V2 application
+
+This package adapts the independently authored `flashdreams-waypoint` model
+package to FlashDreams' V2 application, session, model-loop, event, and output
+APIs. Model modules are loaded once per application; the image-established
+transformer/decoder cache, RNG stream, and live controls are isolated per
+session.
+
+The application always declares four-frame `TCHW` results at 1280x720 and
+60 FPS playback. Waypoint generates on its native 1024x512 canvas and the
+adapter resizes results for presentation. File controls use blocking,
+new-results-only presentation so MP4 output retains every generated frame.
+
+See [ADR-1-control-events.md](ADR-1-control-events.md) for the live keyboard and
+mouse contract. Passing `--controls-file` selects finite deterministic mode;
+omitting it selects live input. `--example-data` uses the pinned public seed
+and bundled 118-action timeline.

--- a/integrations_v2/waypoint/README.md
+++ b/integrations_v2/waypoint/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Waypoint 1.5 V2 application
 
 This package adapts the independently authored `flashdreams-waypoint` model
@@ -5,6 +10,35 @@ package to FlashDreams' V2 application, session, model-loop, event, and output
 APIs. Model modules are loaded once per application; the image-established
 transformer/decoder cache, RNG stream, and live controls are isolated per
 session.
+
+## Run Waypoint
+
+Write a deterministic example rollout and its step metrics:
+
+```bash
+flashdreams-run-v2 waypoint-1-5-1b \
+    --output-path waypoint.mp4 --stats-path waypoint.metrics.json \
+    -- --example-data --actions 40 --seed 464 --profile
+```
+
+Use a local image and a controls JSON file in the same finite MP4 mode:
+
+```bash
+flashdreams-run-v2 waypoint-1-5-1b --output-path waypoint.mp4 \
+    -- --seed-image seed.png --controls-file controls.json --seed 464
+```
+
+For live keyboard and mouse input, use the browser window and omit a controls
+file:
+
+```bash
+flashdreams-run-v2 waypoint-1-5-1b --mode webrtc \
+    -- --seed-image seed.png --seed 464
+```
+
+Arguments after `--` belong to Waypoint. Run
+`flashdreams-run-v2 waypoint-1-5-1b -- --help` for the complete list. The first
+run downloads the public Waypoint 1.5 1B and TAEHV checkpoints.
 
 The application always declares four-frame `TCHW` results at 1280x720 and
 60 FPS playback. Waypoint generates on its native 1024x512 canvas and the
@@ -14,4 +48,5 @@ new-results-only presentation so MP4 output retains every generated frame.
 See [ADR-1-control-events.md](ADR-1-control-events.md) for the live keyboard and
 mouse contract. Passing `--controls-file` selects finite deterministic mode;
 omitting it selects live input. `--example-data` uses the pinned public seed
-and bundled 118-action timeline.
+and bundled 118-action timeline. See [VALIDATION.md](VALIDATION.md) for CPU,
+CUDA, real-checkpoint, MP4, performance, and official-reference parity evidence.

--- a/integrations_v2/waypoint/README.md
+++ b/integrations_v2/waypoint/README.md
@@ -40,10 +40,17 @@ Arguments after `--` belong to Waypoint. Run
 `flashdreams-run-v2 waypoint-1-5-1b -- --help` for the complete list. The first
 run downloads the public Waypoint 1.5 1B and TAEHV checkpoints.
 
-The application always declares four-frame `TCHW` results at 1280x720 and
-60 FPS playback. Waypoint generates on its native 1024x512 canvas and the
-adapter resizes results for presentation. File controls use blocking,
-new-results-only presentation so MP4 output retains every generated frame.
+The application declares four-frame `TCHW` results on Waypoint's native
+1024x512 canvas at 60 FPS playback. Seed images are resized once to that native
+canvas; generated frames are presented without another spatial resample. File
+controls use blocking, new-results-only presentation so MP4 output retains
+every generated frame.
+
+Sessions created by one application intentionally start from the configured
+seed, which makes the same control sequence reproducible across reset and
+session recreation. Model modules are shared, and model/RNG work is serialized
+by an application lock while each session restores its own RNG and cache state.
+The current WebRTC runtime accepts one browser client per server process.
 
 See [ADR-1-control-events.md](ADR-1-control-events.md) for the live keyboard and
 mouse contract. Passing `--controls-file` selects finite deterministic mode;

--- a/integrations_v2/waypoint/README.md
+++ b/integrations_v2/waypoint/README.md
@@ -57,3 +57,9 @@ mouse contract. Passing `--controls-file` selects finite deterministic mode;
 omitting it selects live input. `--example-data` uses the pinned public seed
 and bundled 118-action timeline. See [VALIDATION.md](VALIDATION.md) for CPU,
 CUDA, real-checkpoint, MP4, performance, and official-reference parity evidence.
+
+V2 supplies raw input transport, loop/reset lifecycle, WebRTC, and output
+sinks, but it has no generic action-to-video application or event-to-action
+mapping protocol today. The Waypoint-specific adapter remains local to this
+package; ADR-1 records the reviewed extraction boundary for a future shared
+action snapshot, mapper protocol, and control-help UI.

--- a/integrations_v2/waypoint/VALIDATION.md
+++ b/integrations_v2/waypoint/VALIDATION.md
@@ -57,6 +57,28 @@ generation throughput. For context, the PR discussion reported 286.04 ms at
 action 20 and 235.39 ms at action 40 on an RTX 5090; this comparison is not
 hardware-normalized.
 
+### Review follow-up: native output and cached masks
+
+On 2026-08-26, the same RTX PRO was used to validate the review-driven native
+1024x512 presentation contract and fixed-cache visibility-mask reuse. Both
+measurements used a fresh process, the same checkpoints, the pinned example
+seed and controls, `--actions 40 --seed 464 --profile`, and actions 20 through
+40 as the steady-state window.
+
+| Fixed-cache mask handling | Mean | Median | p90 | Peak allocated |
+|---|---:|---:|---:|---:|
+| Rebuild every evaluation | 88.514 ms | 88.427 ms | 88.964 ms | 6.033 GiB |
+| Reuse by visibility pattern | 69.605 ms | 69.507 ms | 70.670 ms | 6.061 GiB |
+
+Mask reuse reduced median action latency by 21.4%, to 57.55 generated frames/s,
+at a 0.028 GiB peak-allocation cost. The before/after 40-action MP4s were
+byte-identical (SHA-256
+`d2730c2357c77c25616c9c602eb68bfd2bec80a311b31ee3d6417faf02d5268c`).
+The CUDA local/global cache test also traversed eight frames, including ring
+wraparound, and verified that repeated provisional evaluations reuse the same
+`BlockMask` object while remaining equivalent to compact reference attention.
+The native MP4 is 1024x512 and contains exactly 164 frames.
+
 ## Official implementation parity
 
 Parity uses the same BF16 checkpoint and inputs in the integrated transformer

--- a/integrations_v2/waypoint/VALIDATION.md
+++ b/integrations_v2/waypoint/VALIDATION.md
@@ -65,10 +65,11 @@ measurements used a fresh process, the same checkpoints, the pinned example
 seed and controls, `--actions 40 --seed 464 --profile`, and actions 20 through
 40 as the steady-state window.
 
-| Fixed-cache mask handling | Mean | Median | p90 | Peak allocated |
+| Optimization stage | Mean | Median | p90 | Peak allocated |
 |---|---:|---:|---:|---:|
 | Rebuild every evaluation | 88.514 ms | 88.427 ms | 88.964 ms | 6.033 GiB |
 | Reuse by visibility pattern | 69.605 ms | 69.507 ms | 70.670 ms | 6.061 GiB |
+| Reuse plus one FP32 RoPE promotion | 68.791 ms | 68.887 ms | 69.737 ms | 6.061 GiB |
 
 Mask reuse reduced median action latency by 21.4%, to 57.55 generated frames/s,
 at a 0.028 GiB peak-allocation cost. The before/after 40-action MP4s were
@@ -77,7 +78,9 @@ byte-identical (SHA-256
 The CUDA local/global cache test also traversed eight frames, including ring
 wraparound, and verified that repeated provisional evaluations reuse the same
 `BlockMask` object while remaining equivalent to compact reference attention.
-The native MP4 is 1024x512 and contains exactly 164 frames.
+Reusing each Q/K tensor's FP32 RoPE promotion reduced median latency by another
+0.9% and retained the same MP4 hash. The native MP4 is 1024x512 and contains
+exactly 164 frames.
 
 ## Official implementation parity
 

--- a/integrations_v2/waypoint/VALIDATION.md
+++ b/integrations_v2/waypoint/VALIDATION.md
@@ -82,6 +82,16 @@ Reusing each Q/K tensor's FP32 RoPE promotion reduced median latency by another
 0.9% and retained the same MP4 hash. The native MP4 is 1024x512 and contains
 exactly 164 frames.
 
+Final review gates also passed the complete pre-commit suite (Ruff check/fix,
+Ruff format, lockfile/version checks, and `ty`), 52 focused CPU tests across
+TAEHV and both Waypoint packages, and the two CUDA fixed-cache tests. The broad
+CPU run passed 1,584 tests with 2 skipped and 337 deselected after excluding
+only `integrations/omnidreams/tests/interactive_drive`; collecting that
+unrelated directory requires the optional `pyvirtualdisplay` and
+`flip_evaluator` packages, which were not installed in the Waypoint worktree.
+The final published-weight one-action MP4 remained byte-identical to the
+post-optimization reference.
+
 ## Official implementation parity
 
 Parity uses the same BF16 checkpoint and inputs in the integrated transformer

--- a/integrations_v2/waypoint/VALIDATION.md
+++ b/integrations_v2/waypoint/VALIDATION.md
@@ -22,10 +22,10 @@ Validated on 2026-08-25 against FlashDreams main `8fd97fa3`, source PR #464
 - TAEHV SHA-256:
   `806f78a06266ba58bb982d8680add1a249aefcc96237e8a0aa60298617744682`.
 
-Large outputs remain in the ignored local directory `artifacts/waypoint-pr464/`:
-the 40-action MP4 and its V2 metrics JSON. The MP4 decodes as exactly 164
-frames (four seed frames plus 40 four-frame actions), with no duplicate or
-dropped frames.
+Large outputs remain in the ignored local directory `artifacts/waypoint-pr464/`.
+The initial 40-action MP4 decodes as exactly 164 frames (four seed frames plus
+40 four-frame actions), with no duplicate or dropped frames. Additional scene
+and long-rollout outputs are under its `additional-inference/` directory.
 
 ## Automated gates
 
@@ -81,3 +81,25 @@ four-step BF16 Euler schedule:
 
 The remaining BF16 difference is consistent with whole-model fusion in the
 official compiled graph versus separately compiled attention in FlashDreams.
+
+## Additional scene and long-rollout validation
+
+All 15 seed images from the pinned Biome checkout were each run for 40 actions.
+The original pinned example was also run through all 118 bundled actions. One
+loaded application and model served fresh sequential sessions, exercising both
+model reuse and per-session image cache/RNG isolation.
+
+- 16 runs completed, totaling 718 generated actions and 2,936 decoded frames.
+- Every metrics sequence was complete, ordered, and finite.
+- Every 40-action MP4 decoded as exactly 164 frames; the 118-action MP4 decoded
+  as exactly 476 frames.
+- Downsampled seed and final frames were nonblank. Seed-to-final mean absolute
+  pixel difference ranged from 21.09 to 51.73 on the 0-255 scale.
+- Action-40 latency across the 15 scenes averaged 90.986 ms, ranging from
+  89.029 to 92.622 ms.
+- Action 118 completed in 91.479 ms. Maximum measured peak allocation across
+  the batch was 6.355 GiB.
+
+All scenes used seed 464 and the same bundled control timeline. This validates
+execution, cache longevity, scene diversity, output encoding, and stable
+performance; it is not a qualitative gameplay ranking of the scenes.

--- a/integrations_v2/waypoint/VALIDATION.md
+++ b/integrations_v2/waypoint/VALIDATION.md
@@ -1,0 +1,83 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Waypoint 1.5 V2 validation
+
+Validated on 2026-08-25 against FlashDreams main `8fd97fa3`, source PR #464
+`0f178234`, and the official `world_engine` implementation at
+`b3f1e725dedac17ccbfaf9ee37f5e068bb44bed4`.
+
+## Artifacts and hardware
+
+- GPU: NVIDIA RTX PRO 6000 Blackwell Workstation Edition (96 GiB), driver
+  595.84.
+- PyTorch: 2.12.1+cu130, CUDA 13.0.
+- Waypoint revision: `391f92827075edcf4a8b3c8a2ddae010698f8636`.
+- Waypoint SHA-256:
+  `b872ad07968bae082a120a29072e61a13565086f042384ad7fdb79a7b0c50994`.
+- Waypoint inventory: 393 BF16 tensors and 1,860,823,096 elements.
+- TAEHV revision: `a0253886b13b9c4c3bd224bd479be03f5988a3df`.
+- TAEHV SHA-256:
+  `806f78a06266ba58bb982d8680add1a249aefcc96237e8a0aa60298617744682`.
+
+Large outputs remain in the ignored local directory `artifacts/waypoint-pr464/`:
+the 40-action MP4 and its V2 metrics JSON. The MP4 decodes as exactly 164
+frames (four seed frames plus 40 four-frame actions), with no duplicate or
+dropped frames.
+
+## Automated gates
+
+- Ruff 0.12.7 check and format: passed.
+- ty 0.0.53 for both integration packages: passed.
+- CPU model, TAEHV, V2 lifecycle, reset, input, and MP4 tests: 51 passed and
+  7 deselected.
+- CUDA fixed-cache FlexAttention equivalence, local and global layers over
+  eight autoregressive frames: 2 passed.
+- Built-wheel entry-point discovery: `waypoint-1-5-1b` resolves to
+  `WaypointApplication`; all 118 bundled actions are available.
+
+## Real V2 inference
+
+The real application ran with `--example-data --actions 40 --seed 464
+--device cuda --profile`, using V2 `ApplicationRunner`, `Mp4ClientWindow`, and
+`MetricsOutputSink`. It loaded the published checkpoints, established action
+zero from the pinned seed image, generated actions 1 through 40, finalized each
+cache entry, and encoded every presented frame.
+
+| AR action | Diffuse | Decode | Finalize | Total | Peak allocated |
+|---:|---:|---:|---:|---:|---:|
+| 20 | 70.383 ms | 1.889 ms | 17.199 ms | 89.487 ms | 6.049 GiB |
+| 40 | 71.909 ms | 1.863 ms | 17.623 ms | 91.413 ms | 6.049 GiB |
+
+Actions 20 through 40 average 91.712 ms per four generated frames, or 43.61
+generated frames/s. The session's 60 FPS value is playback timing, not measured
+generation throughput. For context, the PR discussion reported 286.04 ms at
+action 20 and 235.39 ms at action 40 on an RTX 5090; this comparison is not
+hardware-normalized.
+
+## Official implementation parity
+
+Parity uses the same BF16 checkpoint and inputs in the integrated transformer
+and the pinned official `world_engine`. The official reference must use its
+inference patches and compiled FlexAttention path; its eager FlexAttention
+fallback warns that it materializes dense scores and does not produce the
+runtime kernel's result. Before attention, patchify, noise and control
+embeddings, RoPE, adaptive projections, normalized tokens, Q/K/V, rotated Q/K,
+cache tensors, and active mask blocks are bit-identical.
+
+Two independently committed flow-prediction frames reached cosine similarity
+of at least 0.999902, mean absolute error at most 0.011621, and max absolute
+error at most 0.09375. A stronger seeded rollout comparison established action
+zero in both caches and ran one controlled action through the complete official
+four-step BF16 Euler schedule:
+
+| Comparison | Mean absolute error | Max absolute error | Cosine similarity |
+|---|---:|---:|---:|
+| Seed cache flow | 0.010793 | 0.218750 | 0.999586 |
+| Clean latent after four steps | 0.005682 | 0.033691 | 0.999869 |
+| Final cache flow | 0.010511 | 0.265625 | 0.999487 |
+
+The remaining BF16 difference is consistent with whole-model fusion in the
+official compiled graph versus separately compiled attention in FlashDreams.

--- a/integrations_v2/waypoint/pyproject.toml
+++ b/integrations_v2/waypoint/pyproject.toml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flashdreams-waypoint-v2"
+version = "0.1.0"
+description = "FlashDreams V2 application for the Waypoint 1.5 world model."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "flashdreams",
+    "flashdreams-waypoint",
+    "pillow>=10",
+]
+
+[project.entry-points."flashdreams.applications_v2"]
+waypoint-1-5-1b = "waypoint_v2.app:create_app"
+
+[tool.uv.sources]
+flashdreams = { workspace = true }
+flashdreams-waypoint = { workspace = true }
+
+[tool.setuptools.packages.find]
+include = ["waypoint_v2*"]
+exclude = ["tests"]
+
+[tool.setuptools.package-data]
+waypoint_v2 = ["assets/*.json"]
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib -p flashdreams._pytest_plugins.marker_enforcement"
+markers = [
+    "ci_cpu: CPU-safe test, runs on the CPU CI runner",
+    "ci_gpu: requires GPU or libGL (cv2), runs on the GPU CI runner",
+    "manual: heavy or environment-specific test, opt-in only",
+]

--- a/integrations_v2/waypoint/waypoint_v2/__init__.py
+++ b/integrations_v2/waypoint/waypoint_v2/__init__.py
@@ -4,12 +4,12 @@
 """FlashDreams V2 application for Waypoint 1.5."""
 
 from waypoint_v2.app import WaypointApplication, create_app
-from waypoint_v2.control_events import ControlEventAdapter
+from waypoint_v2.control_events import WaypointControlEventAdapter
 from waypoint_v2.session import WaypointModelLoop, WaypointSession
 
 __all__ = [
-    "ControlEventAdapter",
     "WaypointApplication",
+    "WaypointControlEventAdapter",
     "WaypointModelLoop",
     "WaypointSession",
     "create_app",

--- a/integrations_v2/waypoint/waypoint_v2/__init__.py
+++ b/integrations_v2/waypoint/waypoint_v2/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FlashDreams V2 application for Waypoint 1.5."""
+
+from waypoint_v2.app import WaypointApplication, create_app
+from waypoint_v2.control_events import ControlEventAdapter
+from waypoint_v2.session import WaypointModelLoop, WaypointSession
+
+__all__ = [
+    "ControlEventAdapter",
+    "WaypointApplication",
+    "WaypointModelLoop",
+    "WaypointSession",
+    "create_app",
+]

--- a/integrations_v2/waypoint/waypoint_v2/app.py
+++ b/integrations_v2/waypoint/waypoint_v2/app.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import secrets
 import threading
 from collections.abc import Callable, Sequence
@@ -32,8 +33,8 @@ from flashdreams.runtime_v2.session_desc import (
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 from waypoint_v2.session import WaypointSession
 
-_OUTPUT_WIDTH = 1280
-_OUTPUT_HEIGHT = 720
+_OUTPUT_WIDTH = 1024
+_OUTPUT_HEIGHT = 512
 _PLAYBACK_FPS = 60
 _EXAMPLE_IMAGE_FILENAME = "crystal_desert_blade.jpg"
 _EXAMPLE_IMAGE_URL = (
@@ -91,7 +92,7 @@ class WaypointApplication(IApplication):
             ValueError: Inputs do not describe a valid file or live rollout.
         """
         parser = argparse.ArgumentParser(
-            prog="waypoint-1.5-1b",
+            prog="flashdreams-run-v2 waypoint-1-5-1b --",
             description="Run Waypoint 1.5 from an image using file or live controls.",
         )
         parser.add_argument("--seed-image", type=Path)
@@ -112,10 +113,7 @@ class WaypointApplication(IApplication):
             raise ValueError("pass --seed-image or --example-data")
         if args.seed is not None and args.seed < 0:
             raise ValueError(f"--seed must be non-negative, got {args.seed}")
-        if (
-            not torch.isfinite(torch.tensor(args.mouse_sensitivity)).item()
-            or args.mouse_sensitivity < 0
-        ):
+        if not math.isfinite(args.mouse_sensitivity) or args.mouse_sensitivity < 0:
             raise ValueError("--mouse-sensitivity must be finite and non-negative")
 
         controls_path = args.controls_file
@@ -148,7 +146,7 @@ class WaypointApplication(IApplication):
         )
 
     def session_desc(self) -> SessionDesc:
-        """Return Waypoint's fixed 720p TCHW presentation contract."""
+        """Return Waypoint's native 1024x512 TCHW presentation contract."""
         return SessionDesc(
             output_layout=VideoTensorLayout.tchw,
             backpressure_mode=BackpressureMode.BLOCK,
@@ -210,7 +208,7 @@ class WaypointApplication(IApplication):
 
 
 def load_seed_display_frames(path: Path) -> Tensor:
-    """Load one RGB/RGBA image as four normalized 720p TCHW seed frames.
+    """Load one RGB/RGBA image as four normalized 1024x512 TCHW seed frames.
 
     Args:
         path: Image used to establish the initial world state.

--- a/integrations_v2/waypoint/waypoint_v2/app.py
+++ b/integrations_v2/waypoint/waypoint_v2/app.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Waypoint 1.5 V2 application."""
+
+from __future__ import annotations
+
+import argparse
+import secrets
+import threading
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import torch
+from loguru import logger
+from torch import Tensor
+
+from flashdreams.api_v2.application import IApplication
+from flashdreams.core.io.disk import default_flashdreams_cache_dir
+from flashdreams.core.io.download import download_to_cache
+from flashdreams.infra.config import derive_config
+from flashdreams.runtime_v2.session_desc import (
+    BackpressureMode,
+    PresentationMode,
+    SessionDesc,
+)
+from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+from waypoint import WaypointControl, load_controls_from_file
+from waypoint.config import PIPELINE_WAYPOINT_1_5
+from waypoint.pipeline import WaypointInferencePipeline
+
+from waypoint_v2.session import WaypointSession
+
+_OUTPUT_WIDTH = 1280
+_OUTPUT_HEIGHT = 720
+_PLAYBACK_FPS = 60
+_EXAMPLE_IMAGE_FILENAME = "crystal_desert_blade.jpg"
+_EXAMPLE_IMAGE_URL = (
+    "https://raw.githubusercontent.com/Overworldai/Biome/14343a6/seeds/"
+    + _EXAMPLE_IMAGE_FILENAME
+)
+_EXAMPLE_CONTROLS = Path(__file__).parent / "assets" / "example_controls.json"
+
+PipelineFactory = Callable[[int, torch.device, bool], WaypointInferencePipeline]
+SeedLoader = Callable[[Path], Tensor]
+ExampleResolver = Callable[[], Path]
+
+
+@dataclass(frozen=True, slots=True)
+class _ApplicationConfig:
+    seed_image: Path | None
+    controls: tuple[WaypointControl, ...] | None
+    seed: int
+    device: torch.device
+    profile: bool
+    mouse_sensitivity: float
+
+
+class WaypointApplication(IApplication):
+    """Load one Waypoint model and create isolated image-established sessions."""
+
+    def __init__(
+        self,
+        *,
+        pipeline_factory: PipelineFactory | None = None,
+        seed_loader: SeedLoader | None = None,
+        example_resolver: ExampleResolver | None = None,
+    ) -> None:
+        """Create a lazy Waypoint application.
+
+        Args:
+            pipeline_factory: Test seam replacing real checkpoint construction.
+            seed_loader: Test seam replacing image decode and normalization.
+            example_resolver: Test seam replacing the example image download.
+        """
+        self._pipeline_factory = pipeline_factory or _create_pipeline
+        self._seed_loader = seed_loader or load_seed_display_frames
+        self._example_resolver = example_resolver or _download_example_image
+        self._config: _ApplicationConfig | None = None
+        self._pipeline: WaypointInferencePipeline | None = None
+        self._pipeline_lock = threading.Lock()
+
+    def init(self, commandline_args: Sequence[str]) -> None:
+        """Parse seed, control mode, device, and deterministic rollout settings.
+
+        Args:
+            commandline_args: Application-specific command-line arguments.
+
+        Raises:
+            ValueError: Inputs do not describe a valid file or live rollout.
+        """
+        parser = argparse.ArgumentParser(
+            prog="waypoint-1.5-1b",
+            description="Run Waypoint 1.5 from an image using file or live controls.",
+        )
+        parser.add_argument("--seed-image", type=Path)
+        parser.add_argument("--example-data", action="store_true")
+        parser.add_argument("--controls-file", type=Path)
+        parser.add_argument(
+            "--actions",
+            type=int,
+            help="Use this many actions from a controls file.",
+        )
+        parser.add_argument("--seed", type=int)
+        parser.add_argument("--device", default="cuda")
+        parser.add_argument("--profile", action="store_true")
+        parser.add_argument("--mouse-sensitivity", type=float, default=1.0)
+        args = parser.parse_args(list(commandline_args))
+
+        if args.seed_image is None and not args.example_data:
+            raise ValueError("pass --seed-image or --example-data")
+        if args.seed is not None and args.seed < 0:
+            raise ValueError(f"--seed must be non-negative, got {args.seed}")
+        if (
+            not torch.isfinite(torch.tensor(args.mouse_sensitivity)).item()
+            or args.mouse_sensitivity < 0
+        ):
+            raise ValueError("--mouse-sensitivity must be finite and non-negative")
+
+        controls_path = args.controls_file
+        if controls_path is None and args.example_data:
+            controls_path = _EXAMPLE_CONTROLS
+        controls = (
+            load_controls_from_file(controls_path)
+            if controls_path is not None
+            else None
+        )
+        if args.actions is not None:
+            if controls is None:
+                raise ValueError("--actions requires --controls-file or --example-data")
+            if not 1 <= args.actions <= len(controls):
+                raise ValueError(
+                    f"--actions must be in [1, {len(controls)}], got {args.actions}"
+                )
+            controls = controls[: args.actions]
+
+        seed = secrets.randbits(63) if args.seed is None else args.seed
+        if args.seed is None:
+            logger.info(f"[waypoint-1.5-1b] generated seed {seed}")
+        self._config = _ApplicationConfig(
+            seed_image=args.seed_image,
+            controls=controls,
+            seed=seed,
+            device=torch.device(args.device),
+            profile=args.profile,
+            mouse_sensitivity=args.mouse_sensitivity,
+        )
+
+    def session_desc(self) -> SessionDesc:
+        """Return Waypoint's fixed 720p TCHW presentation contract."""
+        return SessionDesc(
+            output_layout=VideoTensorLayout.tchw,
+            backpressure_mode=BackpressureMode.BLOCK,
+            presentation_mode=PresentationMode.ONLY_PRESENT_NEW,
+            frames_per_second_for_ui=_PLAYBACK_FPS,
+            frames_per_second_for_step=_PLAYBACK_FPS,
+            video_width=_OUTPUT_WIDTH,
+            video_height=_OUTPUT_HEIGHT,
+            metadata={
+                "model": "waypoint-1.5-1b",
+                "frames_per_action": 4,
+                "internal_resolution": "1024x512",
+            },
+        )
+
+    def create_session(self, session_desc: SessionDesc) -> WaypointSession:
+        """Resolve cheap inputs, load the shared model once, and create a session.
+
+        Args:
+            session_desc: Runtime-requested presentation settings.
+
+        Returns:
+            An uninitialized session with independent cache, controls, and RNG.
+
+        Raises:
+            RuntimeError: The application has not been initialized.
+            ValueError: Waypoint cannot honor the requested layout or dimensions.
+        """
+        config = self._require_config()
+        _validate_session_desc(session_desc)
+        seed_image = config.seed_image or self._example_resolver()
+        seed_frames = self._seed_loader(seed_image)
+        pipeline = self._ensure_pipeline(config)
+        return WaypointSession(
+            pipeline=pipeline,
+            pipeline_lock=self._pipeline_lock,
+            session_desc=session_desc,
+            seed_frames=seed_frames,
+            seed=config.seed,
+            controls=config.controls,
+            mouse_sensitivity=config.mouse_sensitivity,
+        )
+
+    def close(self) -> None:
+        """Release the application-owned model reference."""
+        self._pipeline = None
+
+    def _require_config(self) -> _ApplicationConfig:
+        if self._config is None:
+            raise RuntimeError("WaypointApplication.init() must run first")
+        return self._config
+
+    def _ensure_pipeline(self, config: _ApplicationConfig) -> WaypointInferencePipeline:
+        if self._pipeline is None:
+            self._pipeline = self._pipeline_factory(
+                config.seed, config.device, config.profile
+            )
+        return self._pipeline
+
+
+def load_seed_display_frames(path: Path) -> Tensor:
+    """Load one RGB/RGBA image as four normalized 720p TCHW seed frames.
+
+    Args:
+        path: Image used to establish the initial world state.
+
+    Returns:
+        Four identical float32 RGB frames in the ``[-1, 1]`` range.
+
+    Raises:
+        FileNotFoundError: The image path does not exist.
+        ValueError: Pillow cannot decode an RGB or RGBA image.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"seed image does not exist: {path}")
+
+    from PIL import Image, UnidentifiedImageError
+
+    try:
+        with Image.open(path) as image:
+            image.load()
+            if image.mode not in {"RGB", "RGBA"}:
+                raise ValueError(
+                    f"seed image must be RGB or RGBA, got mode {image.mode}"
+                )
+            image = image.convert("RGB").resize(
+                (_OUTPUT_WIDTH, _OUTPUT_HEIGHT),
+                resample=Image.Resampling.BILINEAR,
+            )
+            pixels = torch.frombuffer(bytearray(image.tobytes()), dtype=torch.uint8)
+    except UnidentifiedImageError as error:
+        raise ValueError(f"seed image is not decodable: {path}") from error
+
+    frame = pixels.view(_OUTPUT_HEIGHT, _OUTPUT_WIDTH, 3).permute(2, 0, 1)
+    return frame.unsqueeze(0).repeat(4, 1, 1, 1).float().div(127.5).sub(1.0)
+
+
+def _validate_session_desc(session_desc: SessionDesc) -> None:
+    if session_desc.output_layout is not VideoTensorLayout.tchw:
+        raise ValueError(
+            "Waypoint only produces tchw output, got "
+            f"{session_desc.output_layout.value}."
+        )
+    size = (session_desc.video_width, session_desc.video_height)
+    expected = (_OUTPUT_WIDTH, _OUTPUT_HEIGHT)
+    if size != expected:
+        raise ValueError(
+            f"Waypoint presentation size must be {expected[0]}x{expected[1]}, "
+            f"got {size[0]}x{size[1]}."
+        )
+
+
+def _create_pipeline(
+    seed: int, device: torch.device, profile: bool
+) -> WaypointInferencePipeline:
+    config = derive_config(
+        PIPELINE_WAYPOINT_1_5,
+        diffusion_model={"seed": seed},
+        enable_sync_and_profile=profile,
+    )
+    return cast(
+        WaypointInferencePipeline,
+        config.setup().to(device=device).eval(),
+    )
+
+
+def _download_example_image() -> Path:
+    return download_to_cache(
+        _EXAMPLE_IMAGE_URL,
+        cache_dir=default_flashdreams_cache_dir() / "example_data" / "waypoint",
+        filename=_EXAMPLE_IMAGE_FILENAME,
+        validator=load_seed_display_frames,
+    )
+
+
+def create_app() -> IApplication:
+    """Return a new lazy Waypoint 1.5 V2 application."""
+    return WaypointApplication()
+
+
+__all__ = ["WaypointApplication", "create_app", "load_seed_display_frames"]

--- a/integrations_v2/waypoint/waypoint_v2/app.py
+++ b/integrations_v2/waypoint/waypoint_v2/app.py
@@ -16,6 +16,9 @@ from typing import cast
 import torch
 from loguru import logger
 from torch import Tensor
+from waypoint import WaypointControl, load_controls_from_file
+from waypoint.config import PIPELINE_WAYPOINT_1_5
+from waypoint.pipeline import WaypointInferencePipeline
 
 from flashdreams.api_v2.application import IApplication
 from flashdreams.core.io.disk import default_flashdreams_cache_dir
@@ -27,10 +30,6 @@ from flashdreams.runtime_v2.session_desc import (
     SessionDesc,
 )
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
-from waypoint import WaypointControl, load_controls_from_file
-from waypoint.config import PIPELINE_WAYPOINT_1_5
-from waypoint.pipeline import WaypointInferencePipeline
-
 from waypoint_v2.session import WaypointSession
 
 _OUTPUT_WIDTH = 1280

--- a/integrations_v2/waypoint/waypoint_v2/assets/example_controls.json
+++ b/integrations_v2/waypoint/waypoint_v2/assets/example_controls.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "actions": [
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {"mouse_dx": 0.2, "mouse_dy": 0.2}, {"buttons": [32]}, {}, {}, {}, {"buttons": [1]}, {}, {}, {"buttons": [1, 32]}, {}, {}, {}, {}, {}, {},
+    {}, {}, {}, {}, {}, {}, {}, {},
+    {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]}, {"buttons": [32]},
+    {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]}, {"buttons": [65]},
+    {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]}, {"buttons": [68]},
+    {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]}, {"buttons": [83]},
+    {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+  ]
+}

--- a/integrations_v2/waypoint/waypoint_v2/control_events.py
+++ b/integrations_v2/waypoint/waypoint_v2/control_events.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Translate v2 keyboard and mouse events into Waypoint controls."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from flashdreams.runtime_v2.user_input_event import (
+    FocusUserInputEventData,
+    KeyboardInputState,
+    KeyboardUserInputEventData,
+    MouseUserInputEventData,
+    ResetUserInputEventData,
+)
+from flashdreams.runtime_v2.user_input_events import UserInputEvents
+from waypoint import WaypointControl
+
+_NAMED_KEY_CODES = {
+    "ARROWDOWN": 0x28,
+    "ARROWLEFT": 0x25,
+    "ARROWRIGHT": 0x27,
+    "ARROWUP": 0x26,
+    "CONTROL": 0x11,
+    "CTRL": 0x11,
+    "ENTER": 0x0D,
+    "SHIFT": 0x10,
+    "SPACE": 0x20,
+    "SPACEBAR": 0x20,
+    "TAB": 0x09,
+}
+
+# Browser/SlangPy order is left, middle, right. Waypoint follows the Windows
+# virtual-key mouse IDs used by the official Biome client.
+_MOUSE_BUTTON_CODES = {0: 0x01, 1: 0x04, 2: 0x02}
+
+
+@dataclass(slots=True)
+class ControlEventAdapter:
+    """Coalesce one ordered v2 event batch into a Waypoint action.
+
+    Keyboard and mouse-button edges update held state. Mouse coordinates are
+    absolute and normalized by the v2 clients, so moves become pixel deltas
+    relative to the preceding pointer position. The first move only establishes
+    an origin. Motion and wheel input are consumed by one action, while held
+    buttons persist until release, reset, or focus loss.
+
+    Args:
+        video_width: Width used to convert normalized horizontal motion to pixels.
+        video_height: Height used to convert normalized vertical motion to pixels.
+        mouse_sensitivity: Finite non-negative multiplier applied after pixel
+            conversion.
+
+    Raises:
+        ValueError: A dimension or sensitivity is invalid.
+    """
+
+    video_width: int
+    video_height: int
+    mouse_sensitivity: float = 1.0
+    _held_buttons: set[int] = field(default_factory=set, init=False)
+    _pointer_position: tuple[float, float] | None = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        if self.video_width <= 0 or self.video_height <= 0:
+            raise ValueError("video dimensions must be positive")
+        if not math.isfinite(self.mouse_sensitivity) or self.mouse_sensitivity < 0:
+            raise ValueError("mouse_sensitivity must be finite and non-negative")
+
+    def consume(self, events: UserInputEvents) -> WaypointControl:
+        """Apply ``events`` in timestamp order and return one coalesced action."""
+        mouse_dx = 0.0
+        mouse_dy = 0.0
+        wheel = 0.0
+
+        for event in events.get_events():
+            data = event.get_event_data()
+            if isinstance(data, ResetUserInputEventData):
+                self.reset()
+                mouse_dx = mouse_dy = wheel = 0.0
+            elif isinstance(data, FocusUserInputEventData):
+                if not data.focused:
+                    self.reset()
+                    mouse_dx = mouse_dy = wheel = 0.0
+            elif isinstance(data, KeyboardUserInputEventData):
+                button = _key_code(data.key)
+                if button is None:
+                    continue
+                if data.state is KeyboardInputState.PRESSED:
+                    self._held_buttons.add(button)
+                else:
+                    self._held_buttons.discard(button)
+            elif isinstance(data, MouseUserInputEventData):
+                if data.action == "move":
+                    if self._pointer_position is not None:
+                        previous_x, previous_y = self._pointer_position
+                        mouse_dx += (
+                            (data.x - previous_x)
+                            * self.video_width
+                            * self.mouse_sensitivity
+                        )
+                        mouse_dy += (
+                            (data.y - previous_y)
+                            * self.video_height
+                            * self.mouse_sensitivity
+                        )
+                    self._pointer_position = (data.x, data.y)
+                elif data.action == "button":
+                    self._pointer_position = (data.x, data.y)
+                    button = _MOUSE_BUTTON_CODES.get(data.button)
+                    if button is None:
+                        continue
+                    if data.pressed:
+                        self._held_buttons.add(button)
+                    else:
+                        self._held_buttons.discard(button)
+                elif data.action == "wheel":
+                    self._pointer_position = (data.x, data.y)
+                    wheel += data.wheel_y
+
+        scroll_wheel = 1 if wheel > 0 else -1 if wheel < 0 else 0
+        return WaypointControl(
+            buttons=frozenset(self._held_buttons),
+            mouse_dx=mouse_dx,
+            mouse_dy=mouse_dy,
+            scroll_wheel=scroll_wheel,
+        )
+
+    def reset(self) -> None:
+        """Clear held controls and the absolute-pointer origin."""
+        self._held_buttons.clear()
+        self._pointer_position = None
+
+
+def _key_code(key: str) -> int | None:
+    if key == " ":
+        return 0x20
+    if len(key) == 1:
+        upper = key.upper()
+        if "A" <= upper <= "Z" or "0" <= upper <= "9":
+            return ord(upper)
+        return None
+    normalized = key.replace("_", "").replace("-", "").replace(" ", "").upper()
+    return _NAMED_KEY_CODES.get(normalized)
+
+
+__all__ = ["ControlEventAdapter"]

--- a/integrations_v2/waypoint/waypoint_v2/control_events.py
+++ b/integrations_v2/waypoint/waypoint_v2/control_events.py
@@ -11,11 +11,11 @@ from dataclasses import dataclass, field
 from waypoint import WaypointControl
 
 from flashdreams.runtime_v2.user_input_event import (
-    FocusUserInputEventData,
+    FocusUserInputEvent,
     KeyboardInputState,
-    KeyboardUserInputEventData,
-    MouseUserInputEventData,
-    ResetUserInputEventData,
+    KeyboardUserInputEvent,
+    MouseUserInputEvent,
+    ResetUserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 
@@ -39,7 +39,7 @@ _MOUSE_BUTTON_CODES = {0: 0x01, 1: 0x04, 2: 0x02}
 
 
 @dataclass(slots=True)
-class ControlEventAdapter:
+class WaypointControlEventAdapter:
     """Coalesce one ordered v2 event batch into a Waypoint action.
 
     Keyboard and mouse-button edges update held state. Mouse coordinates are
@@ -77,49 +77,48 @@ class ControlEventAdapter:
         wheel = 0.0
 
         for event in events.get_events():
-            data = event.get_event_data()
-            if isinstance(data, ResetUserInputEventData):
+            if isinstance(event, ResetUserInputEvent):
                 self.reset()
                 mouse_dx = mouse_dy = wheel = 0.0
-            elif isinstance(data, FocusUserInputEventData):
-                if not data.focused:
+            elif isinstance(event, FocusUserInputEvent):
+                if not event.focused:
                     self.reset()
                     mouse_dx = mouse_dy = wheel = 0.0
-            elif isinstance(data, KeyboardUserInputEventData):
-                button = _key_code(data.key)
+            elif isinstance(event, KeyboardUserInputEvent):
+                button = _key_code(event.key)
                 if button is None:
                     continue
-                if data.state is KeyboardInputState.PRESSED:
+                if event.state is KeyboardInputState.PRESSED:
                     self._held_buttons.add(button)
                 else:
                     self._held_buttons.discard(button)
-            elif isinstance(data, MouseUserInputEventData):
-                if data.action == "move":
+            elif isinstance(event, MouseUserInputEvent):
+                if event.action == "move":
                     if self._pointer_position is not None:
                         previous_x, previous_y = self._pointer_position
                         mouse_dx += (
-                            (data.x - previous_x)
+                            (event.x - previous_x)
                             * self.video_width
                             * self.mouse_sensitivity
                         )
                         mouse_dy += (
-                            (data.y - previous_y)
+                            (event.y - previous_y)
                             * self.video_height
                             * self.mouse_sensitivity
                         )
-                    self._pointer_position = (data.x, data.y)
-                elif data.action == "button":
-                    self._pointer_position = (data.x, data.y)
-                    button = _MOUSE_BUTTON_CODES.get(data.button)
+                    self._pointer_position = (event.x, event.y)
+                elif event.action == "button":
+                    self._pointer_position = (event.x, event.y)
+                    button = _MOUSE_BUTTON_CODES.get(event.button)
                     if button is None:
                         continue
-                    if data.pressed:
+                    if event.pressed:
                         self._held_buttons.add(button)
                     else:
                         self._held_buttons.discard(button)
-                elif data.action == "wheel":
-                    self._pointer_position = (data.x, data.y)
-                    wheel += data.wheel_y
+                elif event.action == "wheel":
+                    self._pointer_position = (event.x, event.y)
+                    wheel += event.wheel_y
 
         scroll_wheel = 1 if wheel > 0 else -1 if wheel < 0 else 0
         return WaypointControl(
@@ -147,4 +146,4 @@ def _key_code(key: str) -> int | None:
     return _NAMED_KEY_CODES.get(normalized)
 
 
-__all__ = ["ControlEventAdapter"]
+__all__ = ["WaypointControlEventAdapter"]

--- a/integrations_v2/waypoint/waypoint_v2/control_events.py
+++ b/integrations_v2/waypoint/waypoint_v2/control_events.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 
+from waypoint import WaypointControl
+
 from flashdreams.runtime_v2.user_input_event import (
     FocusUserInputEventData,
     KeyboardInputState,
@@ -16,7 +18,6 @@ from flashdreams.runtime_v2.user_input_event import (
     ResetUserInputEventData,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
-from waypoint import WaypointControl
 
 _NAMED_KEY_CODES = {
     "ARROWDOWN": 0x28,

--- a/integrations_v2/waypoint/waypoint_v2/session.py
+++ b/integrations_v2/waypoint/waypoint_v2/session.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 from torch import Tensor
 from waypoint import WAYPOINT_1_5, WaypointControl
 from waypoint.pipeline import WaypointInferencePipeline
@@ -22,9 +21,6 @@ from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 from waypoint_v2.control_events import ControlEventAdapter
-
-_MODEL_HEIGHT = 512
-_MODEL_WIDTH = 1024
 
 
 @dataclass(slots=True)
@@ -116,6 +112,9 @@ class WaypointModelLoop(IModelLoop[WaypointModelState]):
         state.controls_generated = 0
         state.rng_state = state.initial_rng_state.clone()
         with state.pipeline_lock:
+            # Drop the old cache before allocating its replacement so reset does not
+            # temporarily retain two full KV caches on the GPU.
+            state.cache = None
             state.cache = state.pipeline.initialize_cache(seed_pixels=state.seed_pixels)
 
     def close(self) -> None:
@@ -236,14 +235,7 @@ class WaypointSession(ISession):
 
 
 def _seed_pixels(seed_frames: Tensor) -> Tensor:
-    pixels = seed_frames.add(1.0).mul(0.5)
-    pixels = F.interpolate(
-        pixels,
-        size=(_MODEL_HEIGHT, _MODEL_WIDTH),
-        mode="bilinear",
-        align_corners=False,
-    )
-    return pixels.unsqueeze(0)
+    return seed_frames.add(1.0).mul(0.5).unsqueeze(0)
 
 
 def _presentation_frames(video: Tensor, session_desc: SessionDesc) -> Tensor:
@@ -261,11 +253,10 @@ def _presentation_frames(video: Tensor, session_desc: SessionDesc) -> Tensor:
         )
     target_size = (session_desc.video_height, session_desc.video_width)
     if tuple(output.shape[-2:]) != target_size:
-        output = F.interpolate(
-            output,
-            size=target_size,
-            mode="bilinear",
-            align_corners=False,
+        raise ValueError(
+            "Waypoint pipeline output spatial size must match the session: expected "
+            f"{target_size[1]}x{target_size[0]}, got "
+            f"{output.shape[-1]}x{output.shape[-2]}"
         )
     return output.contiguous()
 

--- a/integrations_v2/waypoint/waypoint_v2/session.py
+++ b/integrations_v2/waypoint/waypoint_v2/session.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Waypoint V2 session and autoregressive model loop."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from flashdreams.api_v2.loop import IModelLoop
+from flashdreams.api_v2.session import ISession
+from flashdreams.runtime_v2.session_desc import SessionDesc
+from flashdreams.runtime_v2.step_result import StepResult
+from flashdreams.runtime_v2.user_input_events import UserInputEvents
+from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+from waypoint import WAYPOINT_1_5, WaypointControl
+from waypoint.pipeline import WaypointInferencePipeline
+
+from waypoint_v2.control_events import ControlEventAdapter
+
+_MODEL_HEIGHT = 512
+_MODEL_WIDTH = 1024
+
+
+@dataclass(slots=True)
+class WaypointModelState:
+    """Mutable state isolated to one Waypoint model loop."""
+
+    pipeline: WaypointInferencePipeline
+    pipeline_lock: threading.Lock
+    session_desc: SessionDesc
+    seed_frames: Tensor
+    seed_pixels: Tensor
+    seed: int
+    controls: tuple[WaypointControl, ...] | None
+    control_events: ControlEventAdapter
+    cache: Any | None
+    initial_rng_state: Tensor
+    rng_state: Tensor
+    seed_emitted: bool = False
+    controls_generated: int = 0
+
+
+class WaypointModelLoop(IModelLoop[WaypointModelState]):
+    """Emit the established seed, then four frames for every model action."""
+
+    def step(self, step_index: int, events: UserInputEvents) -> list[StepResult]:
+        """Generate the seed result or one controlled autoregressive action."""
+        state = self.state
+        if step_index == 0:
+            if state.seed_emitted or state.controls_generated:
+                raise RuntimeError("Waypoint seed step is out of sequence")
+            state.seed_emitted = True
+            return [
+                StepResult(
+                    step_index=0,
+                    output=state.seed_frames,
+                    frame_count=WAYPOINT_1_5.frames_per_action,
+                    output_layout=state.session_desc.output_layout,
+                    metrics={"autoregressive_index": 0, "seed_frames": 4},
+                )
+            ]
+
+        expected_index = state.controls_generated + 1
+        if step_index != expected_index:
+            raise RuntimeError(
+                f"Waypoint action step is out of sequence: expected {expected_index}, "
+                f"got {step_index}"
+            )
+        control = self._control_for_step(events)
+        cache = self._require_cache()
+
+        with state.pipeline_lock:
+            rng = state.pipeline.diffusion_model.rng
+            if rng is None:
+                raise RuntimeError("Waypoint pipeline must have a deterministic seed")
+            rng.set_state(state.rng_state)
+            video = state.pipeline.generate(step_index, cache, control)
+            stats = state.pipeline.finalize(step_index, cache)
+            state.rng_state = rng.get_state()
+
+        output = _presentation_frames(video, state.session_desc)
+        state.controls_generated += 1
+        metrics: dict[str, float | int] = dict(stats or {})
+        metrics.setdefault("autoregressive_index", step_index)
+        metrics.setdefault("generated_frames", output.shape[0])
+        return [
+            StepResult(
+                step_index=step_index,
+                output=output,
+                frame_count=output.shape[0],
+                output_layout=state.session_desc.output_layout,
+                metrics=metrics,
+            )
+        ]
+
+    def is_finished(self) -> bool:
+        """Finish after the seed and every file-driven control; live mode persists."""
+        controls = self.state.controls
+        return (
+            controls is not None
+            and self.state.seed_emitted
+            and self.state.controls_generated >= len(controls)
+        )
+
+    def reset(self) -> None:
+        """Re-establish the seed cache, RNG stream, and live-input state."""
+        state = self.state
+        state.control_events.reset()
+        state.seed_emitted = False
+        state.controls_generated = 0
+        state.rng_state = state.initial_rng_state.clone()
+        with state.pipeline_lock:
+            state.cache = state.pipeline.initialize_cache(seed_pixels=state.seed_pixels)
+
+    def close(self) -> None:
+        """Release the rollout cache and transient control state."""
+        self.state.cache = None
+        self.state.control_events.reset()
+
+    def _control_for_step(self, events: UserInputEvents) -> WaypointControl:
+        state = self.state
+        if state.controls is None:
+            return state.control_events.consume(events)
+        return state.controls[state.controls_generated]
+
+    def _require_cache(self) -> Any:
+        cache = self.state.cache
+        if cache is None:
+            raise RuntimeError("Waypoint session cache is closed")
+        return cache
+
+
+class WaypointSession(ISession):
+    """One image-established Waypoint rollout with isolated cache and controls."""
+
+    def __init__(
+        self,
+        *,
+        pipeline: WaypointInferencePipeline,
+        pipeline_lock: threading.Lock,
+        session_desc: SessionDesc,
+        seed_frames: Tensor,
+        seed: int,
+        controls: tuple[WaypointControl, ...] | None,
+        mouse_sensitivity: float,
+    ) -> None:
+        """Create an uninitialized Waypoint session.
+
+        Args:
+            pipeline: Model modules shared by sessions from one application.
+            pipeline_lock: Lock protecting the shared model RNG while a session
+                restores and advances its own RNG state.
+            session_desc: Declared TCHW presentation contract.
+            seed_frames: Four normalized TCHW frames establishing the world.
+            seed: Fixed per-session diffusion seed.
+            controls: Finite file-driven actions, or ``None`` for live input.
+            mouse_sensitivity: Multiplier used by the live input adapter.
+
+        Raises:
+            ValueError: The layout or seed-frame shape does not match the session.
+        """
+        if session_desc.output_layout is not VideoTensorLayout.tchw:
+            raise ValueError(
+                "Waypoint only produces tchw output, got "
+                f"{session_desc.output_layout.value}."
+            )
+        expected_shape = (
+            WAYPOINT_1_5.frames_per_action,
+            3,
+            session_desc.video_height,
+            session_desc.video_width,
+        )
+        if tuple(seed_frames.shape) != expected_shape:
+            raise ValueError(
+                f"seed_frames must have shape {expected_shape}, got "
+                f"{tuple(seed_frames.shape)}"
+            )
+        self._pipeline = pipeline
+        self._pipeline_lock = pipeline_lock
+        self._session_desc = session_desc
+        self._seed_frames = seed_frames
+        self._seed = seed
+        self._controls = controls
+        self._mouse_sensitivity = mouse_sensitivity
+        self._state: WaypointModelState | None = None
+
+    def init(self) -> None:
+        """Move the seed to the model device, establish cache, and register the loop."""
+        dtype = self._pipeline.diffusion_model.dtype
+        seed_frames = self._seed_frames.to(
+            device=self._pipeline.device, dtype=dtype
+        ).contiguous()
+        seed_pixels = _seed_pixels(seed_frames)
+        generator = torch.Generator(device=self._pipeline.device).manual_seed(
+            self._seed
+        )
+        initial_rng_state = generator.get_state()
+        with self._pipeline_lock:
+            cache = self._pipeline.initialize_cache(seed_pixels=seed_pixels)
+        state = WaypointModelState(
+            pipeline=self._pipeline,
+            pipeline_lock=self._pipeline_lock,
+            session_desc=self._session_desc,
+            seed_frames=seed_frames,
+            seed_pixels=seed_pixels,
+            seed=self._seed,
+            controls=self._controls,
+            control_events=ControlEventAdapter(
+                video_width=self._session_desc.video_width,
+                video_height=self._session_desc.video_height,
+                mouse_sensitivity=self._mouse_sensitivity,
+            ),
+            cache=cache,
+            initial_rng_state=initial_rng_state,
+            rng_state=initial_rng_state.clone(),
+        )
+        self._state = state
+        self.register_model_loop(WaypointModelLoop, state=state)
+
+    @property
+    def session_desc(self) -> SessionDesc:
+        """Return the presentation contract accepted by the application."""
+        return self._session_desc
+
+    def close(self) -> None:
+        """Drop session-owned tensors that retain rollout state."""
+        if self._state is not None:
+            self._state.cache = None
+            self._state.control_events.reset()
+
+
+def _seed_pixels(seed_frames: Tensor) -> Tensor:
+    pixels = seed_frames.add(1.0).mul(0.5)
+    pixels = F.interpolate(
+        pixels,
+        size=(_MODEL_HEIGHT, _MODEL_WIDTH),
+        mode="bilinear",
+        align_corners=False,
+    )
+    return pixels.unsqueeze(0)
+
+
+def _presentation_frames(video: Tensor, session_desc: SessionDesc) -> Tensor:
+    if video.ndim != 5 or video.shape[0] != 1:
+        raise ValueError(
+            "Waypoint pipeline output must have [1, T, C, H, W] layout, got "
+            f"{tuple(video.shape)}"
+        )
+    output = video[0]
+    expected = (WAYPOINT_1_5.frames_per_action, 3)
+    if tuple(output.shape[:2]) != expected:
+        raise ValueError(
+            f"Waypoint pipeline must emit {expected[0]} RGB frames, got "
+            f"{tuple(output.shape)}"
+        )
+    target_size = (session_desc.video_height, session_desc.video_width)
+    if tuple(output.shape[-2:]) != target_size:
+        output = F.interpolate(
+            output,
+            size=target_size,
+            mode="bilinear",
+            align_corners=False,
+        )
+    return output.contiguous()
+
+
+__all__ = ["WaypointModelLoop", "WaypointModelState", "WaypointSession"]

--- a/integrations_v2/waypoint/waypoint_v2/session.py
+++ b/integrations_v2/waypoint/waypoint_v2/session.py
@@ -12,6 +12,8 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from waypoint import WAYPOINT_1_5, WaypointControl
+from waypoint.pipeline import WaypointInferencePipeline
 
 from flashdreams.api_v2.loop import IModelLoop
 from flashdreams.api_v2.session import ISession
@@ -19,9 +21,6 @@ from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
-from waypoint import WAYPOINT_1_5, WaypointControl
-from waypoint.pipeline import WaypointInferencePipeline
-
 from waypoint_v2.control_events import ControlEventAdapter
 
 _MODEL_HEIGHT = 512

--- a/integrations_v2/waypoint/waypoint_v2/session.py
+++ b/integrations_v2/waypoint/waypoint_v2/session.py
@@ -20,7 +20,7 @@ from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
-from waypoint_v2.control_events import ControlEventAdapter
+from waypoint_v2.control_events import WaypointControlEventAdapter
 
 
 @dataclass(slots=True)
@@ -34,7 +34,7 @@ class WaypointModelState:
     seed_pixels: Tensor
     seed: int
     controls: tuple[WaypointControl, ...] | None
-    control_events: ControlEventAdapter
+    control_events: WaypointControlEventAdapter
     cache: Any | None
     initial_rng_state: Tensor
     rng_state: Tensor
@@ -210,7 +210,7 @@ class WaypointSession(ISession):
             seed_pixels=seed_pixels,
             seed=self._seed,
             controls=self._controls,
-            control_events=ControlEventAdapter(
+            control_events=WaypointControlEventAdapter(
                 video_width=self._session_desc.video_width,
                 video_height=self._session_desc.video_height,
                 mouse_sensitivity=self._mouse_sensitivity,

--- a/integrations_v2/waypoint/waypoint_v2/session.py
+++ b/integrations_v2/waypoint/waypoint_v2/session.py
@@ -55,7 +55,7 @@ class WaypointModelLoop(IModelLoop[WaypointModelState]):
             return [
                 StepResult(
                     step_index=0,
-                    output=state.seed_frames,
+                    output=state.seed_frames.detach(),
                     frame_count=WAYPOINT_1_5.frames_per_action,
                     output_layout=state.session_desc.output_layout,
                     metrics={"autoregressive_index": 0, "seed_frames": 4},
@@ -258,7 +258,7 @@ def _presentation_frames(video: Tensor, session_desc: SessionDesc) -> Tensor:
             f"{target_size[1]}x{target_size[0]}, got "
             f"{output.shape[-1]}x{output.shape[-2]}"
         )
-    return output.contiguous()
+    return output.detach().contiguous()
 
 
 __all__ = ["WaypointModelLoop", "WaypointModelState", "WaypointSession"]

--- a/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
+++ b/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
@@ -1,0 +1,492 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU contract tests for the Waypoint V2 application and session."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import torch
+from numpy import uint64
+from torch import Tensor
+from waypoint import WaypointControl
+from waypoint.pipeline import WaypointInferencePipeline
+
+from flashdreams.api_v2.user_input_event_data import UserInputEventData
+from flashdreams.runtime_v2.mp4_client_window import Mp4ClientWindow
+from flashdreams.runtime_v2.session_desc import (
+    BackpressureMode,
+    PresentationMode,
+    SessionDesc,
+)
+from flashdreams.runtime_v2.session_runner import run_session
+from flashdreams.runtime_v2.user_input_event import (
+    FocusUserInputEventData,
+    KeyboardInputState,
+    KeyboardUserInputEventData,
+    MouseUserInputEventData,
+    ResetUserInputEventData,
+    UserInputEvent,
+)
+from flashdreams.runtime_v2.user_input_events import UserInputEvents
+from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+from waypoint_v2.app import WaypointApplication, load_seed_display_frames
+from waypoint_v2.control_events import ControlEventAdapter
+from waypoint_v2.session import WaypointModelLoop, WaypointSession
+
+pytestmark = pytest.mark.ci_cpu
+
+
+class _FakeDiffusionModel:
+    dtype = torch.float32
+
+    def __init__(self, seed: int) -> None:
+        self.rng = torch.Generator().manual_seed(seed)
+
+
+class _FakePipeline:
+    device = torch.device("cpu")
+
+    def __init__(self, seed: int = 7) -> None:
+        self.diffusion_model = _FakeDiffusionModel(seed)
+        self.initialized_caches: list[dict[str, Any]] = []
+        self.generate_calls: list[tuple[int, WaypointControl]] = []
+
+    def initialize_cache(self, *, seed_pixels: Tensor) -> dict[str, Any]:
+        assert seed_pixels.shape == (1, 4, 3, 512, 1024)
+        assert seed_pixels.dtype is torch.float32
+        cache: dict[str, Any] = {"autoregressive_index": 0}
+        self.initialized_caches.append(cache)
+        return cache
+
+    def generate(
+        self,
+        autoregressive_index: int,
+        cache: dict[str, Any],
+        control: WaypointControl,
+    ) -> Tensor:
+        assert autoregressive_index == cache["autoregressive_index"] + 1
+        cache["autoregressive_index"] = autoregressive_index
+        self.generate_calls.append((autoregressive_index, control))
+        random_value = torch.rand((), generator=self.diffusion_model.rng)
+        control_value = sum(control.buttons) / 1000
+        return (random_value + control_value).expand(1, 4, 3, 2, 4).clone()
+
+    def finalize(
+        self, autoregressive_index: int, cache: dict[str, Any]
+    ) -> dict[str, float]:
+        assert cache["autoregressive_index"] == autoregressive_index
+        return {"diffuse_ms": 1.25, "finalize_ms": 0.25}
+
+
+def _pipeline(seed: int = 7) -> WaypointInferencePipeline:
+    return cast(WaypointInferencePipeline, _FakePipeline(seed))
+
+
+def _desc(*, width: int = 8, height: int = 4) -> SessionDesc:
+    return SessionDesc(
+        backpressure_mode=BackpressureMode.BLOCK,
+        presentation_mode=PresentationMode.ONLY_PRESENT_NEW,
+        output_layout=VideoTensorLayout.tchw,
+        video_width=width,
+        video_height=height,
+    )
+
+
+def _seed_frames(session_desc: SessionDesc) -> Tensor:
+    return torch.zeros(
+        4,
+        3,
+        session_desc.video_height,
+        session_desc.video_width,
+        dtype=torch.float32,
+    )
+
+
+def _session(
+    pipeline: WaypointInferencePipeline,
+    *,
+    controls: tuple[WaypointControl, ...] | None,
+    seed: int = 7,
+) -> WaypointSession:
+    session_desc = _desc()
+    return WaypointSession(
+        pipeline=pipeline,
+        pipeline_lock=threading.Lock(),
+        session_desc=session_desc,
+        seed_frames=_seed_frames(session_desc),
+        seed=seed,
+        controls=controls,
+        mouse_sensitivity=1.0,
+    )
+
+
+def _events(*data: UserInputEventData) -> UserInputEvents:
+    return UserInputEvents(
+        [
+            UserInputEvent(timestamp=uint64(index), event_data=event_data)
+            for index, event_data in enumerate(data)
+        ]
+    )
+
+
+def _empty_events() -> UserInputEvents:
+    return UserInputEvents([])
+
+
+def test_application_description_is_cheap_and_mp4_complete() -> None:
+    """Session metadata is available before args, downloads, or model loading."""
+    app = WaypointApplication()
+    session_desc = app.session_desc()
+    assert session_desc.output_layout is VideoTensorLayout.tchw
+    assert session_desc.video_width == 1280
+    assert session_desc.video_height == 720
+    assert session_desc.frames_per_second_for_step == 60
+    assert session_desc.backpressure_mode.value == "block"
+    assert session_desc.presentation_mode.value == "only_present_new"
+
+
+def test_application_requires_a_seed_source_and_actions_require_a_file() -> None:
+    """Invalid argument combinations fail without constructing model state."""
+    app = WaypointApplication()
+    with pytest.raises(ValueError, match="seed-image"):
+        app.init([])
+    with pytest.raises(ValueError, match="actions requires"):
+        app.init(["--seed-image", "seed.png", "--actions", "2"])
+
+
+def test_invalid_session_contract_precedes_image_or_model_work() -> None:
+    """Layout and size rejection happen before image decode or checkpoint setup."""
+    calls: list[str] = []
+    app = WaypointApplication(
+        seed_loader=lambda path: calls.append(f"seed:{path}") or torch.empty(0),
+        pipeline_factory=lambda seed, device, profile: calls.append("pipeline")
+        or _pipeline(seed),
+    )
+    app.init(["--seed-image", "missing.png", "--seed", "11"])
+    with pytest.raises(ValueError, match="tchw"):
+        app.create_session(SessionDesc(output_layout=VideoTensorLayout.bcthw))
+    with pytest.raises(ValueError, match="1280x720"):
+        app.create_session(
+            SessionDesc(
+                output_layout=VideoTensorLayout.tchw,
+                video_width=640,
+                video_height=360,
+            )
+        )
+    assert calls == []
+
+
+def test_application_loads_one_pipeline_for_two_sessions(tmp_path: Path) -> None:
+    """One application shares model modules while each session stays distinct."""
+    controls_path = tmp_path / "controls.json"
+    controls_path.write_text(
+        '{"schema_version":1,"actions":[{"buttons":[87]},{}]}',
+        encoding="utf-8",
+    )
+    factory_calls: list[tuple[int, torch.device, bool]] = []
+    fake_pipeline = _pipeline(19)
+    seed_frames = torch.zeros(1).expand(4, 3, 720, 1280)
+
+    def pipeline_factory(
+        seed: int, device: torch.device, profile: bool
+    ) -> WaypointInferencePipeline:
+        factory_calls.append((seed, device, profile))
+        return fake_pipeline
+
+    app = WaypointApplication(
+        pipeline_factory=pipeline_factory,
+        seed_loader=lambda path: seed_frames,
+    )
+    app.init(
+        [
+            "--seed-image",
+            "seed.png",
+            "--controls-file",
+            str(controls_path),
+            "--actions",
+            "1",
+            "--seed",
+            "19",
+            "--device",
+            "cpu",
+        ]
+    )
+    first = app.create_session(app.session_desc())
+    second = app.create_session(app.session_desc())
+    assert first is not second
+    assert first.session_desc == second.session_desc
+    assert factory_calls == [(19, torch.device("cpu"), False)]
+
+
+def test_seed_loader_normalizes_rgb_and_repeats_four_frames(tmp_path: Path) -> None:
+    """Pillow input becomes the exact normalized 720p seed display contract."""
+    from PIL import Image
+
+    path = tmp_path / "seed.png"
+    Image.new("RGB", (2, 1), color=(255, 0, 127)).save(path)
+    frames = load_seed_display_frames(path)
+    assert frames.shape == (4, 3, 720, 1280)
+    assert frames.dtype is torch.float32
+    assert torch.equal(frames[0], frames[3])
+    assert frames[0, 0, 0, 0].item() == pytest.approx(1.0)
+    assert frames[0, 1, 0, 0].item() == pytest.approx(-1.0)
+
+
+def test_file_session_emits_seed_then_exactly_four_frames_per_action() -> None:
+    """Finite mode maps V2 step zero to seed and generated steps to AR 1..N."""
+    fake = _FakePipeline()
+    controls = (
+        WaypointControl(buttons=frozenset({87})),
+        WaypointControl(mouse_dx=2.5),
+    )
+    session = _session(cast(WaypointInferencePipeline, fake), controls=controls)
+    session.init()
+    loop = cast(WaypointModelLoop, session.model_loop)
+
+    seed = loop.step(0, _empty_events())[0]
+    first = loop.step(
+        1,
+        _events(KeyboardUserInputEventData(key="d", state=KeyboardInputState.PRESSED)),
+    )[0]
+    second = loop.step(2, _empty_events())[0]
+
+    assert (
+        seed.output.shape == first.output.shape == second.output.shape == (4, 3, 4, 8)
+    )
+    assert [seed.frame_count, first.frame_count, second.frame_count] == [4, 4, 4]
+    assert [call[0] for call in fake.generate_calls] == [1, 2]
+    assert [call[1] for call in fake.generate_calls] == list(controls)
+    assert first.metrics == {
+        "diffuse_ms": 1.25,
+        "finalize_ms": 0.25,
+        "autoregressive_index": 1,
+        "generated_frames": 4,
+    }
+    assert loop.is_finished()
+
+
+def test_reset_rebuilds_cache_and_replays_first_action_deterministically() -> None:
+    """A fixed seed/control reproduces its first generated result after reset."""
+    fake = _FakePipeline(seed=31)
+    session = _session(
+        cast(WaypointInferencePipeline, fake),
+        controls=(WaypointControl(buttons=frozenset({32})),),
+        seed=31,
+    )
+    session.init()
+    loop = cast(WaypointModelLoop, session.model_loop)
+    loop.step(0, _empty_events())
+    first = loop.step(1, _empty_events())[0].output.clone()
+    first_cache = fake.initialized_caches[-1]
+
+    loop.reset()
+    loop.step(0, _empty_events())
+    replay = loop.step(1, _empty_events())[0].output
+    second_cache = fake.initialized_caches[-1]
+
+    assert torch.equal(first, replay)
+    assert first_cache is not second_cache
+    loop.close()
+    assert loop.state.cache is None
+
+
+def test_two_sessions_share_modules_but_keep_cache_and_rng_state_isolated() -> None:
+    """Interleaved sessions replay the same seeded sequence independently."""
+    fake = _FakePipeline(seed=43)
+    pipeline = cast(WaypointInferencePipeline, fake)
+    shared_lock = threading.Lock()
+    controls = (WaypointControl(), WaypointControl())
+    first = WaypointSession(
+        pipeline=pipeline,
+        pipeline_lock=shared_lock,
+        session_desc=_desc(),
+        seed_frames=_seed_frames(_desc()),
+        seed=43,
+        controls=controls,
+        mouse_sensitivity=1.0,
+    )
+    second = WaypointSession(
+        pipeline=pipeline,
+        pipeline_lock=shared_lock,
+        session_desc=_desc(),
+        seed_frames=_seed_frames(_desc()),
+        seed=43,
+        controls=controls,
+        mouse_sensitivity=1.0,
+    )
+    first.init()
+    second.init()
+    first_loop = cast(WaypointModelLoop, first.model_loop)
+    second_loop = cast(WaypointModelLoop, second.model_loop)
+    first_loop.step(0, _empty_events())
+    second_loop.step(0, _empty_events())
+
+    first_one = first_loop.step(1, _empty_events())[0].output
+    second_one = second_loop.step(1, _empty_events())[0].output
+    first_two = first_loop.step(2, _empty_events())[0].output
+    second_two = second_loop.step(2, _empty_events())[0].output
+
+    assert first_loop.state.cache is not second_loop.state.cache
+    assert torch.equal(first_one, second_one)
+    assert torch.equal(first_two, second_two)
+
+
+def test_live_session_coalesces_events_for_each_generated_action() -> None:
+    """Live mode samples held state and transient motion once per model step."""
+    fake = _FakePipeline()
+    session = _session(cast(WaypointInferencePipeline, fake), controls=None)
+    session.init()
+    loop = cast(WaypointModelLoop, session.model_loop)
+    loop.step(0, _empty_events())
+    loop.step(
+        1,
+        _events(
+            KeyboardUserInputEventData(key="w", state=KeyboardInputState.PRESSED),
+            MouseUserInputEventData(action="move", x=0.25, y=0.5),
+            MouseUserInputEventData(action="move", x=0.5, y=0.25),
+        ),
+    )
+    loop.step(2, _empty_events())
+
+    first_control = fake.generate_calls[0][1]
+    second_control = fake.generate_calls[1][1]
+    assert first_control == WaypointControl(
+        buttons=frozenset({87}),
+        mouse_dx=2.0,
+        mouse_dy=-1.0,
+    )
+    assert second_control == WaypointControl(buttons=frozenset({87}))
+    assert not loop.is_finished()
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("a", 65),
+        ("W", 87),
+        ("9", 57),
+        ("ArrowLeft", 0x25),
+        ("Shift", 0x10),
+        ("Control", 0x11),
+        (" ", 0x20),
+        ("Enter", 0x0D),
+    ],
+)
+def test_control_adapter_uses_canonical_waypoint_keycodes(
+    key: str, expected: int
+) -> None:
+    """Browser key strings map to the official Biome/Waypoint numeric IDs."""
+    adapter = ControlEventAdapter(video_width=100, video_height=50)
+    pressed = adapter.consume(
+        _events(KeyboardUserInputEventData(key=key, state=KeyboardInputState.PRESSED))
+    )
+    held = adapter.consume(_empty_events())
+    released = adapter.consume(
+        _events(
+            KeyboardUserInputEventData(
+                key=key.swapcase(), state=KeyboardInputState.RELEASED
+            )
+        )
+    )
+    assert pressed.buttons == held.buttons == frozenset({expected})
+    assert released.buttons == frozenset()
+
+
+def test_control_adapter_maps_mouse_motion_buttons_and_wheel() -> None:
+    """Absolute pointer events become accumulated deltas and canonical button IDs."""
+    adapter = ControlEventAdapter(
+        video_width=100, video_height=50, mouse_sensitivity=2.0
+    )
+    first = adapter.consume(
+        _events(MouseUserInputEventData(action="move", x=0.25, y=0.5))
+    )
+    second = adapter.consume(
+        _events(
+            MouseUserInputEventData(
+                action="button", x=0.25, y=0.5, button=1, pressed=True
+            ),
+            MouseUserInputEventData(action="move", x=0.5, y=0.25),
+            MouseUserInputEventData(action="move", x=0.6, y=0.5),
+            MouseUserInputEventData(action="wheel", x=0.6, y=0.5, wheel_y=1.0),
+            MouseUserInputEventData(action="wheel", x=0.6, y=0.5, wheel_y=-0.25),
+        )
+    )
+    assert first == WaypointControl()
+    assert second == WaypointControl(
+        buttons=frozenset({0x04}),
+        mouse_dx=70.0,
+        mouse_dy=0.0,
+        scroll_wheel=1,
+    )
+
+
+def test_focus_loss_and_reset_clear_held_state_and_pointer_origin() -> None:
+    """Lifecycle edges prevent stuck controls and discard pending pointer history."""
+    adapter = ControlEventAdapter(video_width=100, video_height=50)
+    adapter.consume(
+        _events(
+            KeyboardUserInputEventData(key="w", state=KeyboardInputState.PRESSED),
+            MouseUserInputEventData(action="button", button=0, pressed=True),
+            MouseUserInputEventData(action="move", x=0.2, y=0.3),
+        )
+    )
+    unfocused = adapter.consume(
+        _events(
+            MouseUserInputEventData(action="move", x=0.4, y=0.5),
+            FocusUserInputEventData(focused=False),
+        )
+    )
+    after_focus = adapter.consume(
+        _events(MouseUserInputEventData(action="move", x=0.8, y=0.9))
+    )
+    reset = adapter.consume(
+        _events(
+            KeyboardUserInputEventData(key="d", state=KeyboardInputState.PRESSED),
+            ResetUserInputEventData(),
+        )
+    )
+    assert unfocused == after_focus == reset == WaypointControl()
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="writing an MP4 needs ffmpeg on PATH"
+)
+def test_v2_runtime_writes_seed_plus_four_frames_per_action(
+    tmp_path: Path,
+) -> None:
+    """The generic MP4 window preserves every frame without Waypoint branches."""
+    fake = _FakePipeline(seed=53)
+    session = _session(
+        cast(WaypointInferencePipeline, fake),
+        controls=(WaypointControl(), WaypointControl(buttons=frozenset({32}))),
+        seed=53,
+    )
+    path = tmp_path / "waypoint.mp4"
+
+    run_session(session, Mp4ClientWindow(path), steps=None)
+
+    raw = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "-",
+        ],
+        check=True,
+        capture_output=True,
+    ).stdout
+    assert len(raw) // (8 * 4 * 3) == 12
+    assert path.stat().st_size > 0

--- a/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
+++ b/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
@@ -85,6 +85,25 @@ class _FakePipeline:
         return {"diffuse_ms": 1.25, "finalize_ms": 0.25}
 
 
+class _AutogradFakePipeline(_FakePipeline):
+    """Fake pipeline that exposes a graph-owning output for boundary tests."""
+
+    def __init__(self, seed: int = 7) -> None:
+        super().__init__(seed)
+        self.last_output: Tensor | None = None
+
+    def generate(
+        self,
+        autoregressive_index: int,
+        cache: dict[str, Any],
+        control: WaypointControl,
+    ) -> Tensor:
+        self.last_output = (
+            super().generate(autoregressive_index, cache, control).requires_grad_()
+        )
+        return self.last_output
+
+
 def _pipeline(seed: int = 7) -> WaypointInferencePipeline:
     return cast(WaypointInferencePipeline, _FakePipeline(seed))
 
@@ -270,6 +289,28 @@ def test_file_session_emits_seed_then_exactly_four_frames_per_action() -> None:
         "generated_frames": 4,
     }
     assert loop.is_finished()
+
+
+def test_model_loop_detaches_results_from_model_owned_tensors() -> None:
+    """Presentation results never retain model-owned autograd state."""
+    fake = _AutogradFakePipeline()
+    session = _session(
+        cast(WaypointInferencePipeline, fake),
+        controls=(WaypointControl(),),
+    )
+    session.init()
+    loop = cast(WaypointModelLoop, session.model_loop)
+    loop.state.seed_frames.requires_grad_()
+
+    seed = loop.step(0, _empty_events())[0]
+    generated = loop.step(1, _empty_events())[0]
+
+    assert loop.state.seed_frames.requires_grad
+    assert fake.last_output is not None and fake.last_output.requires_grad
+    assert not seed.output.requires_grad
+    assert seed.output.grad_fn is None
+    assert not generated.output.requires_grad
+    assert generated.output.grad_fn is None
 
 
 def test_reset_rebuilds_cache_and_replays_first_action_deterministically() -> None:

--- a/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
+++ b/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
@@ -17,6 +17,9 @@ from numpy import uint64
 from torch import Tensor
 from waypoint import WaypointControl
 from waypoint.pipeline import WaypointInferencePipeline
+from waypoint_v2.app import WaypointApplication, load_seed_display_frames
+from waypoint_v2.control_events import ControlEventAdapter
+from waypoint_v2.session import WaypointModelLoop, WaypointSession
 
 from flashdreams.api_v2.user_input_event_data import UserInputEventData
 from flashdreams.runtime_v2.mp4_client_window import Mp4ClientWindow
@@ -36,9 +39,6 @@ from flashdreams.runtime_v2.user_input_event import (
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
-from waypoint_v2.app import WaypointApplication, load_seed_display_frames
-from waypoint_v2.control_events import ControlEventAdapter
-from waypoint_v2.session import WaypointModelLoop, WaypointSession
 
 pytestmark = pytest.mark.ci_cpu
 

--- a/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
+++ b/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
@@ -59,7 +59,7 @@ class _FakePipeline:
         self.generate_calls: list[tuple[int, WaypointControl]] = []
 
     def initialize_cache(self, *, seed_pixels: Tensor) -> dict[str, Any]:
-        assert seed_pixels.shape == (1, 4, 3, 512, 1024)
+        assert seed_pixels.shape == (1, 4, 3, 4, 8)
         assert seed_pixels.dtype is torch.float32
         cache: dict[str, Any] = {"autoregressive_index": 0}
         self.initialized_caches.append(cache)
@@ -76,7 +76,7 @@ class _FakePipeline:
         self.generate_calls.append((autoregressive_index, control))
         random_value = torch.rand((), generator=self.diffusion_model.rng)
         control_value = sum(control.buttons) / 1000
-        return (random_value + control_value).expand(1, 4, 3, 2, 4).clone()
+        return (random_value + control_value).expand(1, 4, 3, 4, 8).clone()
 
     def finalize(
         self, autoregressive_index: int, cache: dict[str, Any]
@@ -145,8 +145,8 @@ def test_application_description_is_cheap_and_mp4_complete() -> None:
     app = WaypointApplication()
     session_desc = app.session_desc()
     assert session_desc.output_layout is VideoTensorLayout.tchw
-    assert session_desc.video_width == 1280
-    assert session_desc.video_height == 720
+    assert session_desc.video_width == 1024
+    assert session_desc.video_height == 512
     assert session_desc.frames_per_second_for_step == 60
     assert session_desc.backpressure_mode.value == "block"
     assert session_desc.presentation_mode.value == "only_present_new"
@@ -172,7 +172,7 @@ def test_invalid_session_contract_precedes_image_or_model_work() -> None:
     app.init(["--seed-image", "missing.png", "--seed", "11"])
     with pytest.raises(ValueError, match="tchw"):
         app.create_session(SessionDesc(output_layout=VideoTensorLayout.bcthw))
-    with pytest.raises(ValueError, match="1280x720"):
+    with pytest.raises(ValueError, match="1024x512"):
         app.create_session(
             SessionDesc(
                 output_layout=VideoTensorLayout.tchw,
@@ -192,7 +192,7 @@ def test_application_loads_one_pipeline_for_two_sessions(tmp_path: Path) -> None
     )
     factory_calls: list[tuple[int, torch.device, bool]] = []
     fake_pipeline = _pipeline(19)
-    seed_frames = torch.zeros(1).expand(4, 3, 720, 1280)
+    seed_frames = torch.zeros(1).expand(4, 3, 512, 1024)
 
     def pipeline_factory(
         seed: int, device: torch.device, profile: bool
@@ -226,13 +226,13 @@ def test_application_loads_one_pipeline_for_two_sessions(tmp_path: Path) -> None
 
 
 def test_seed_loader_normalizes_rgb_and_repeats_four_frames(tmp_path: Path) -> None:
-    """Pillow input becomes the exact normalized 720p seed display contract."""
+    """Pillow input becomes the exact normalized native seed display contract."""
     from PIL import Image
 
     path = tmp_path / "seed.png"
     Image.new("RGB", (2, 1), color=(255, 0, 127)).save(path)
     frames = load_seed_display_frames(path)
-    assert frames.shape == (4, 3, 720, 1280)
+    assert frames.shape == (4, 3, 512, 1024)
     assert frames.dtype is torch.float32
     assert torch.equal(frames[0], frames[3])
     assert frames[0, 0, 0, 0].item() == pytest.approx(1.0)

--- a/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
+++ b/integrations_v2/waypoint/waypoint_v2/tests/test_waypoint_v2.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import threading
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -18,10 +19,10 @@ from torch import Tensor
 from waypoint import WaypointControl
 from waypoint.pipeline import WaypointInferencePipeline
 from waypoint_v2.app import WaypointApplication, load_seed_display_frames
-from waypoint_v2.control_events import ControlEventAdapter
+from waypoint_v2.control_events import WaypointControlEventAdapter
 from waypoint_v2.session import WaypointModelLoop, WaypointSession
 
-from flashdreams.api_v2.user_input_event_data import UserInputEventData
+from flashdreams.api_v2.user_input_event import UserInputEvent
 from flashdreams.runtime_v2.mp4_client_window import Mp4ClientWindow
 from flashdreams.runtime_v2.session_desc import (
     BackpressureMode,
@@ -30,12 +31,11 @@ from flashdreams.runtime_v2.session_desc import (
 )
 from flashdreams.runtime_v2.session_runner import run_session
 from flashdreams.runtime_v2.user_input_event import (
-    FocusUserInputEventData,
+    FocusUserInputEvent,
     KeyboardInputState,
-    KeyboardUserInputEventData,
-    MouseUserInputEventData,
-    ResetUserInputEventData,
-    UserInputEvent,
+    KeyboardUserInputEvent,
+    MouseUserInputEvent,
+    ResetUserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -146,12 +146,9 @@ def _session(
     )
 
 
-def _events(*data: UserInputEventData) -> UserInputEvents:
+def _events(*events: UserInputEvent) -> UserInputEvents:
     return UserInputEvents(
-        [
-            UserInputEvent(timestamp=uint64(index), event_data=event_data)
-            for index, event_data in enumerate(data)
-        ]
+        [replace(event, timestamp=uint64(index)) for index, event in enumerate(events)]
     )
 
 
@@ -272,7 +269,11 @@ def test_file_session_emits_seed_then_exactly_four_frames_per_action() -> None:
     seed = loop.step(0, _empty_events())[0]
     first = loop.step(
         1,
-        _events(KeyboardUserInputEventData(key="d", state=KeyboardInputState.PRESSED)),
+        _events(
+            KeyboardUserInputEvent(
+                timestamp=uint64(0), key="d", state=KeyboardInputState.PRESSED
+            )
+        ),
     )[0]
     second = loop.step(2, _empty_events())[0]
 
@@ -389,9 +390,11 @@ def test_live_session_coalesces_events_for_each_generated_action() -> None:
     loop.step(
         1,
         _events(
-            KeyboardUserInputEventData(key="w", state=KeyboardInputState.PRESSED),
-            MouseUserInputEventData(action="move", x=0.25, y=0.5),
-            MouseUserInputEventData(action="move", x=0.5, y=0.25),
+            KeyboardUserInputEvent(
+                timestamp=uint64(0), key="w", state=KeyboardInputState.PRESSED
+            ),
+            MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.25, y=0.5),
+            MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.5, y=0.25),
         ),
     )
     loop.step(2, _empty_events())
@@ -424,15 +427,21 @@ def test_control_adapter_uses_canonical_waypoint_keycodes(
     key: str, expected: int
 ) -> None:
     """Browser key strings map to the official Biome/Waypoint numeric IDs."""
-    adapter = ControlEventAdapter(video_width=100, video_height=50)
+    adapter = WaypointControlEventAdapter(video_width=100, video_height=50)
     pressed = adapter.consume(
-        _events(KeyboardUserInputEventData(key=key, state=KeyboardInputState.PRESSED))
+        _events(
+            KeyboardUserInputEvent(
+                timestamp=uint64(0), key=key, state=KeyboardInputState.PRESSED
+            )
+        )
     )
     held = adapter.consume(_empty_events())
     released = adapter.consume(
         _events(
-            KeyboardUserInputEventData(
-                key=key.swapcase(), state=KeyboardInputState.RELEASED
+            KeyboardUserInputEvent(
+                timestamp=uint64(0),
+                key=key.swapcase(),
+                state=KeyboardInputState.RELEASED,
             )
         )
     )
@@ -442,21 +451,30 @@ def test_control_adapter_uses_canonical_waypoint_keycodes(
 
 def test_control_adapter_maps_mouse_motion_buttons_and_wheel() -> None:
     """Absolute pointer events become accumulated deltas and canonical button IDs."""
-    adapter = ControlEventAdapter(
+    adapter = WaypointControlEventAdapter(
         video_width=100, video_height=50, mouse_sensitivity=2.0
     )
     first = adapter.consume(
-        _events(MouseUserInputEventData(action="move", x=0.25, y=0.5))
+        _events(MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.25, y=0.5))
     )
     second = adapter.consume(
         _events(
-            MouseUserInputEventData(
-                action="button", x=0.25, y=0.5, button=1, pressed=True
+            MouseUserInputEvent(
+                timestamp=uint64(0),
+                action="button",
+                x=0.25,
+                y=0.5,
+                button=1,
+                pressed=True,
             ),
-            MouseUserInputEventData(action="move", x=0.5, y=0.25),
-            MouseUserInputEventData(action="move", x=0.6, y=0.5),
-            MouseUserInputEventData(action="wheel", x=0.6, y=0.5, wheel_y=1.0),
-            MouseUserInputEventData(action="wheel", x=0.6, y=0.5, wheel_y=-0.25),
+            MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.5, y=0.25),
+            MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.6, y=0.5),
+            MouseUserInputEvent(
+                timestamp=uint64(0), action="wheel", x=0.6, y=0.5, wheel_y=1.0
+            ),
+            MouseUserInputEvent(
+                timestamp=uint64(0), action="wheel", x=0.6, y=0.5, wheel_y=-0.25
+            ),
         )
     )
     assert first == WaypointControl()
@@ -470,27 +488,33 @@ def test_control_adapter_maps_mouse_motion_buttons_and_wheel() -> None:
 
 def test_focus_loss_and_reset_clear_held_state_and_pointer_origin() -> None:
     """Lifecycle edges prevent stuck controls and discard pending pointer history."""
-    adapter = ControlEventAdapter(video_width=100, video_height=50)
+    adapter = WaypointControlEventAdapter(video_width=100, video_height=50)
     adapter.consume(
         _events(
-            KeyboardUserInputEventData(key="w", state=KeyboardInputState.PRESSED),
-            MouseUserInputEventData(action="button", button=0, pressed=True),
-            MouseUserInputEventData(action="move", x=0.2, y=0.3),
+            KeyboardUserInputEvent(
+                timestamp=uint64(0), key="w", state=KeyboardInputState.PRESSED
+            ),
+            MouseUserInputEvent(
+                timestamp=uint64(0), action="button", button=0, pressed=True
+            ),
+            MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.2, y=0.3),
         )
     )
     unfocused = adapter.consume(
         _events(
-            MouseUserInputEventData(action="move", x=0.4, y=0.5),
-            FocusUserInputEventData(focused=False),
+            MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.4, y=0.5),
+            FocusUserInputEvent(timestamp=uint64(0), focused=False),
         )
     )
     after_focus = adapter.consume(
-        _events(MouseUserInputEventData(action="move", x=0.8, y=0.9))
+        _events(MouseUserInputEvent(timestamp=uint64(0), action="move", x=0.8, y=0.9))
     )
     reset = adapter.consume(
         _events(
-            KeyboardUserInputEventData(key="d", state=KeyboardInputState.PRESSED),
-            ResetUserInputEventData(),
+            KeyboardUserInputEvent(
+                timestamp=uint64(0), key="d", state=KeyboardInputState.PRESSED
+            ),
+            ResetUserInputEvent(timestamp=uint64(0)),
         )
     )
     assert unfocused == after_focus == reset == WaypointControl()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ extraPaths = [
     "integrations/self_forcing",
     "integrations/wan21",
     "integrations/wan22",
+    "integrations/waypoint",
     "integrations_v2/color_fade",
     "integrations_v2/cam2v_lingbot",
     "integrations_v2/null_model",
@@ -71,6 +72,7 @@ extraPaths = [
     "integrations_v2/t2v_self_forcing",
     "integrations_v2/t2v_wan21",
     "integrations_v2/slangpy_ui_demo",
+    "integrations_v2/waypoint",
 ]
 # For pyright to pickup the correct python.
 venvPath = "."
@@ -96,6 +98,7 @@ extra-paths = [
     "integrations/self_forcing",
     "integrations/wan21",
     "integrations/wan22",
+    "integrations/waypoint",
     "integrations_v2/color_fade",
     "integrations_v2/cam2v_lingbot",
     "integrations_v2/null_model",
@@ -106,6 +109,7 @@ extra-paths = [
     "integrations_v2/t2v_self_forcing",
     "integrations_v2/t2v_wan21",
     "integrations_v2/slangpy_ui_demo",
+    "integrations_v2/waypoint",
 ]
 
 [tool.ty.src]

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,8 @@ members = [
     "flashdreams-t2v-wan21",
     "flashdreams-wan21",
     "flashdreams-wan22",
+    "flashdreams-waypoint",
+    "flashdreams-waypoint-v2",
     "ludus-renderer",
 ]
 overrides = [
@@ -1660,6 +1662,43 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "flashdreams-waypoint"
+version = "0.1.0"
+source = { editable = "integrations/waypoint" }
+dependencies = [
+    { name = "flashdreams" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "flashdreams", editable = "flashdreams" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "flashdreams-waypoint-v2"
+version = "0.1.0"
+source = { editable = "integrations_v2/waypoint" }
+dependencies = [
+    { name = "flashdreams" },
+    { name = "flashdreams-waypoint" },
+    { name = "pillow" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "flashdreams", editable = "flashdreams" },
+    { name = "flashdreams-waypoint", editable = "integrations/waypoint" },
+    { name = "pillow", specifier = ">=10" },
+]
 
 [[package]]
 name = "flip-evaluator"


### PR DESCRIPTION
## Summary

Adds Waypoint 1.5 1B inference to FlashDreams as the `waypoint-1-5-1b` V2
application. This integrates the model work from #464 and ports it to the
current inference, application, session, event, and presentation APIs.

The integration supports deterministic MP4 rollouts and interactive browser
control through the V2 WebRTC runtime.

## What changed

- Add the independently packaged Waypoint model pipeline,
  published-checkpoint loading, four-step scheduler, control encoding,
  transformer, and autoregressive cache.
- Extend the shared Hunyuan Video 1.5 TAEHV recipe for the streaming
  32-channel latent format, including a guard against incomplete meta-device
  checkpoint loads.
- Add a V2 `WaypointApplication` and `WaypointSession` with reusable
  application-level model state and isolated per-session cache, controls, and
  RNG state.
- Support finite JSON control timelines, bundled example data, deterministic
  seeds, profiling, reset, and live keyboard, mouse, and wheel events.
- Present seed and generated frames directly on the native 1024x512 canvas,
  avoiding an intermediate 1280x720 resize and a second seed resample.
- Reuse fixed-attention masks by cache visibility pattern and reuse each Q/K
  FP32 RoPE promotion.
- Detach seed and generated presentation tensors at the model-loop boundary.
- Add a design-review architecture reference with use-case, component,
  class/ownership, and sequence diagrams.
- Add a public model card with the support matrix, measured performance,
  official-reference parity, limitations, safety, and provenance.

Waypoint emits four RGB frames per action at 60 FPS playback timing. The
published checkpoint has no text-conditioning path, so the application is
driven by a seed image and controls.

## Validation

- Full pre-commit gate passed: Ruff fix/check, Ruff format, lockfile/version
  checks, and `ty`.
- Warning-as-error Sphinx build passed for the complete documentation site,
  including the new model card and gallery/homepage registrations.
- Changed-code CPU suites: 52 passed across TAEHV, Waypoint inference, and
  Waypoint V2.
- Broad CPU tier: 1,584 passed, 2 skipped, 337 deselected after excluding only
  the unrelated Omnidreams interactive-drive directory whose optional packages
  were not installed in this worktree.
- CUDA fixed-cache FlexAttention equivalence and mask reuse over local/global
  layers and eight autoregressive frames: 2 passed.
- Published-weight one-action and 40-action inference completed on an NVIDIA
  RTX PRO 6000 Blackwell Workstation Edition.
- The final 40-action MP4 is native 1024x512 with exactly 164 frames.
- Actions 20-40 improved from 88.427 ms median to 68.887 ms median per four
  generated frames. The before/after 40-action MP4s are byte-identical.
- Earlier extended validation ran all 15 available Biome seeds for 40 actions
  and the pinned example for all 118 actions. Full-schedule parity with the
  pinned official implementation reached 0.999869 cosine similarity for the
  clean latent.

Detailed commands, checkpoint revisions and hashes, latency samples, output
hashes, and parity measurements are recorded in
`integrations_v2/waypoint/VALIDATION.md`.

## Design-review references

- `integrations/waypoint/README.md` — scope, decisions, four static/dynamic
  diagrams, tensor contracts, ownership, concurrency, and cache semantics.
- `docs/source/models/waypoint.rst` — user-facing model card with modalities,
  requirements, commands, measured performance, parity, limitations, and
  provenance.
- `integrations_v2/waypoint/ADR-1-control-events.md` — browser-to-model input
  and reset/focus semantics.

## Design notes

- `integrations/waypoint` owns model inference and remains independent of
  runtime orchestration.
- `integrations_v2/waypoint` owns CLI parsing, lifecycle, event adaptation,
  and finite/live presentation behavior.
- File-driven controls take precedence over live input for deterministic
  rollouts.
- One application intentionally serializes shared model and RNG work while
  preserving per-session cache and RNG state.
