### PR TITLE
Add typed tensor artifact outputs to V2

### DIFF
--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -125,6 +125,10 @@ Set it to `None` when the artifact may be emitted only once per session
 generation. Each output tensor must have the declared rank and reuse the exact
 declared schema.
 
+The standard `TensorArtifactOutputSink` saves tensor values in `.npy` files and
+preserves dimension names, concatenation axes, dtypes, and shapes in the
+directory's **tensor_artifacts.json** manifest.
+
 A model step is one complete list of result channels. An artifact name may occur
 at most once across that whole list, so attach it to exactly one channel. These
 outputs are not video channels, are not composited by the UI, and UI-loop

--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -112,6 +112,24 @@ Every channel in one model step must report the same `frame_count`, and a
 mismatch raises `ValueError`. A step may generate several frames at once; the
 runtime presents them one per UI tick rather than dropping all but the last.
 
+A model `StepResult` may also carry auxiliary outputs. `metrics` holds scalar
+measurements. `tensor_artifacts` holds `TensorArtifactOutput` values, each
+pairing a tensor with a `TensorArtifactSchema`. The application declares every
+available schema in `SessionDesc.tensor_artifact_schemas`; each declared
+artifact is optional on every step.
+
+Artifact names are unique, portable filename stems. Dimension names are
+non-empty and unique, and define the tensor rank and storage order.
+`concatenate_axis` must name one of those dimensions; its default is axis zero.
+Set it to `None` when the artifact may be emitted only once per session
+generation. Each output tensor must have the declared rank and reuse the exact
+declared schema.
+
+A model step is one complete list of result channels. An artifact name may occur
+at most once across that whole list, so attach it to exactly one channel. These
+outputs are not video channels, are not composited by the UI, and UI-loop
+results do not reach model-output sinks.
+
 A UI loop reads what the model produced through `presented_model_frame` and
 `presented_model_frames`, which return `[C, H, W]` frames with one, three or
 four channels. Four channels is RGBA, and composites over what is beneath it.

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -100,17 +100,26 @@ must declare at least one tensor artifact in its natural session description;
 otherwise the command exits with a usage error before it initializes the
 application or creates a window.
 
-At close, the sink writes one `<artifact-name>.npy` file for each declared
-artifact that was emitted. It concatenates successive chunks on the schema's
+At `open`, the sink creates the directory and atomically installs a
+**tensor_artifacts.json** manifest with `complete: false`. Invalid or unwritable
+destinations therefore fail before model generation starts.
+
+A successful close writes one `<artifact-name>.npy` file for each emitted
+artifact. It concatenates successive chunks on the schema's
 `concatenate_axis`; `None` permits one chunk only. Chunks must have identical
 dtypes and identical non-concatenated dimensions, and their dtype must be
-representable by NumPy. Each file is staged in the target directory and
-installed with an atomic replace. If no artifact was emitted, the directory is
-not created.
+representable by NumPy. The completed manifest records every declared name,
+whether it was emitted, its dimension names and concatenation axis, and the
+saved file's dtype and shape. Consumers should accept the directory only when
+the manifest says `complete: true`. It is installed last, after atomic array
+replaces and removal of stale files for declared artifacts omitted by this run.
+If any publication step fails, the sink restores the prior declared artifact
+files before re-raising and leaves the manifest incomplete.
 
 Only the newest session generation is persisted. The first result from a newer
 generation clears buffered older results, and a late result from an older
-generation is ignored.
+generation is ignored. If model execution fails, buffered arrays are discarded
+and the incomplete manifest remains as the commit marker.
 
 ## Starting and stopping a run
 
@@ -190,6 +199,10 @@ number and the complete sequence of channels for every published model step, on
 the model thread. It is therefore independent of what the presentation queue
 keeps and what the UI composites. The metrics sink retains its original
 per-result interface through an adapter to this path.
+
+At shutdown, `close(commit=True)` means model execution completed; execution
+failures call `close(commit=False)` so transactional sinks can discard partial
+outputs. Streaming sinks may ignore the flag.
 
 The default UI loop, `BlitModelOutputToScreenLoop`, composites every model
 channel in list order as if they were image layers and reshapes the result into

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -34,8 +34,11 @@ Running a session:
 - `presentation_manager.py` buffers generated frames between the two threads and
   decides which one the UI sees.
 - `session_desc.py` describes the session being run: frame size, rates, layout,
-  and the two policy knobs below.
-- `step_result.py` is what one generation step produces.
+  named tensor artifacts, and the two policy knobs below.
+- `step_result.py` is what one generation step produces;
+  `tensor_artifact.py` defines its typed non-video outputs.
+- `model_output_sink.py` defines the batch-and-generation-aware sink contract
+  for outputs taken directly from model steps.
 
 Presenting it:
 
@@ -44,8 +47,9 @@ Presenting it:
 - `slangpy_ui_loop.py` and `slangpy_ui_renderer.py` are the UI loop for
   applications that draw widgets over the model output.
 - `mp4_client_window.py` and `webrtc_client_window.py` are the two windows.
-- `mp4_output_sink.py`, `metrics_output_sink.py`, `video_encoder.py` and
-  `video_tensor.py` are what output is written through.
+- `mp4_output_sink.py`, `metrics_output_sink.py`,
+  `tensor_artifact_output_sink.py`, `video_encoder.py` and `video_tensor.py`
+  are what output is written through.
 - `serving/` is the HTTP and WebRTC server behind the browser window.
 
 Input:
@@ -91,6 +95,23 @@ what the model generated while the window still sees one composited frame per
 tick. See [`configs/v2_model_benchmarks.json`](../../../configs/v2_model_benchmarks.json)
 and the [benchmark README](../../tools/benchmarks/README.md) for the suite.
 
+`--tensor-artifact-dir DIR` adds a `TensorArtifactOutputSink`. The application
+must declare at least one tensor artifact in its natural session description;
+otherwise the command exits with a usage error before it initializes the
+application or creates a window.
+
+At close, the sink writes one `<artifact-name>.npy` file for each declared
+artifact that was emitted. It concatenates successive chunks on the schema's
+`concatenate_axis`; `None` permits one chunk only. Chunks must have identical
+dtypes and identical non-concatenated dimensions, and their dtype must be
+representable by NumPy. Each file is staged in the target directory and
+installed with an atomic replace. If no artifact was emitted, the directory is
+not created.
+
+Only the newest session generation is persisted. The first result from a newer
+generation clears buffered older results, and a late result from an older
+generation is ignored.
+
 ## Starting and stopping a run
 
 `ApplicationRunner.run` calls `init`, `create_session` and `run_session` in
@@ -99,11 +120,11 @@ succeeded. It also closes the window itself when the run never started, because
 `run_session` is what otherwise owns the window, and a WebRTC window may already
 be serving a browser before the application has finished loading.
 
-`run_session` then opens the window and any metrics sink, collects one batch of
-input, presents one tick, and only then starts the model thread — so a client that
-closed during startup is never generated for. Its main loop services input and
-presents frames until the shutdown event is set, or until the model thread has
-finished and no frames are still pending.
+`run_session` then opens the window and requested auxiliary sinks, collects
+one batch of input, presents one tick, and only then starts the model thread —
+so a client that closed during startup is never generated for. Its main loop
+services input and presents frames until the shutdown event is set, or until
+the model thread has finished and no frames are still pending.
 
 On the way out it sets the shutdown event, joins the model thread, shuts both
 loops down, clears the presentation buffer, unregisters the readers, closes every
@@ -120,8 +141,8 @@ that reader has not seen and moves its cursor to the end, and
 reader 0 and the model loop is reader 1.
 
 Appending also counts resets. Every `ResetUserInputEvent` in a batch bumps
-the generation number that loops and the presentation manager compare against
-their own.
+the generation number that loops, the presentation manager, and model-output
+sinks use to separate old work from the restarted session.
 
 A close event is handled twice over, deliberately: `run_session` sets the
 shutdown event when it sees one in a collected batch, and `ILoop._begin_run` sets
@@ -163,6 +184,12 @@ than frames, so one step of twelve frames counts once.
 A UI loop reads model frames through `presented_model_frame` and
 `presented_model_frames`, composites whatever it wants, and returns one
 `StepResult` that `run_session` writes to the window.
+
+Model outputs take a separate path. A `ModelOutputSink` receives the generation
+number and the complete sequence of channels for every published model step, on
+the model thread. It is therefore independent of what the presentation queue
+keeps and what the UI composites. The metrics sink retains its original
+per-result interface through an adapter to this path.
 
 The default UI loop, `BlitModelOutputToScreenLoop`, composites every model
 channel in list order as if they were image layers and reshapes the result into

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from flashdreams.api_v2.application import IApplication
 from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.runtime_v2.model_output_sink import ModelOutputSink
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.session_runner import run_session
 
@@ -26,19 +27,20 @@ class ApplicationRunner:
         client_window: IClientWindow,
         *,
         metrics_output_sink: OutputSink | None = None,
-        tensor_artifact_output_sink: OutputSink | None = None,
+        model_output_sinks: Sequence[ModelOutputSink] = (),
     ) -> None:
         """
         Args:
             application: Long-lived application that creates the session.
             client_window: Window that supplies input and presents generated output.
             metrics_output_sink: Optional sink for model-step metrics.
-            tensor_artifact_output_sink: Optional sink for named tensor outputs.
+                Kept for compatibility with callers using the per-result sink.
+            model_output_sinks: Sinks receiving complete model result batches.
         """
         self._application = application
         self._client_window = client_window
         self._metrics_output_sink = metrics_output_sink
-        self._tensor_artifact_output_sink = tensor_artifact_output_sink
+        self._model_output_sinks = tuple(model_output_sinks)
 
     def run(
         self, session_desc: SessionDesc, commandline_args: Sequence[str] = ()
@@ -67,15 +69,15 @@ class ApplicationRunner:
                 session,
                 self._client_window,
                 metrics_output_sink=self._metrics_output_sink,
-                tensor_artifact_output_sink=self._tensor_artifact_output_sink,
+                model_output_sinks=self._model_output_sinks,
             )
         finally:
             if not run_started:
                 _close_client_window(self._client_window)
                 if self._metrics_output_sink is not None:
                     _close_output_sink(self._metrics_output_sink)
-                if self._tensor_artifact_output_sink is not None:
-                    _close_output_sink(self._tensor_artifact_output_sink)
+                for model_output_sink in self._model_output_sinks:
+                    _close_output_sink(model_output_sink)
             _close_application(
                 self._application, run_failed=sys.exc_info()[0] is not None
             )
@@ -95,7 +97,7 @@ def _close_client_window(client_window: IClientWindow) -> None:
         )
 
 
-def _close_output_sink(output_sink: OutputSink) -> None:
+def _close_output_sink(output_sink: OutputSink | ModelOutputSink) -> None:
     """Close an auxiliary sink after a run that never reached it."""
     try:
         output_sink.close()

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -77,7 +77,7 @@ class ApplicationRunner:
                 if self._metrics_output_sink is not None:
                     _close_output_sink(self._metrics_output_sink)
                 for model_output_sink in self._model_output_sinks:
-                    _close_output_sink(model_output_sink)
+                    _close_model_output_sink(model_output_sink)
             _close_application(
                 self._application, run_failed=sys.exc_info()[0] is not None
             )
@@ -97,13 +97,23 @@ def _close_client_window(client_window: IClientWindow) -> None:
         )
 
 
-def _close_output_sink(output_sink: OutputSink | ModelOutputSink) -> None:
+def _close_output_sink(output_sink: OutputSink) -> None:
     """Close an auxiliary sink after a run that never reached it."""
     try:
         output_sink.close()
     except Exception:
         _LOGGER.exception(
             "An auxiliary output sink failed to close after a run that never started."
+        )
+
+
+def _close_model_output_sink(output_sink: ModelOutputSink) -> None:
+    """Discard a model sink after a run that never reached it."""
+    try:
+        output_sink.close(commit=False)
+    except Exception:
+        _LOGGER.exception(
+            "A model output sink failed to close after a run that never started."
         )
 
 

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -26,16 +26,19 @@ class ApplicationRunner:
         client_window: IClientWindow,
         *,
         metrics_output_sink: OutputSink | None = None,
+        tensor_artifact_output_sink: OutputSink | None = None,
     ) -> None:
         """
         Args:
             application: Long-lived application that creates the session.
             client_window: Window that supplies input and presents generated output.
             metrics_output_sink: Optional sink for model-step metrics.
+            tensor_artifact_output_sink: Optional sink for named tensor outputs.
         """
         self._application = application
         self._client_window = client_window
         self._metrics_output_sink = metrics_output_sink
+        self._tensor_artifact_output_sink = tensor_artifact_output_sink
 
     def run(
         self, session_desc: SessionDesc, commandline_args: Sequence[str] = ()
@@ -64,12 +67,15 @@ class ApplicationRunner:
                 session,
                 self._client_window,
                 metrics_output_sink=self._metrics_output_sink,
+                tensor_artifact_output_sink=self._tensor_artifact_output_sink,
             )
         finally:
             if not run_started:
                 _close_client_window(self._client_window)
                 if self._metrics_output_sink is not None:
                     _close_output_sink(self._metrics_output_sink)
+                if self._tensor_artifact_output_sink is not None:
+                    _close_output_sink(self._tensor_artifact_output_sink)
             _close_application(
                 self._application, run_failed=sys.exc_info()[0] is not None
             )
@@ -90,12 +96,12 @@ def _close_client_window(client_window: IClientWindow) -> None:
 
 
 def _close_output_sink(output_sink: OutputSink) -> None:
-    """Close a metrics sink after a run that never reached it."""
+    """Close an auxiliary sink after a run that never reached it."""
     try:
         output_sink.close()
     except Exception:
         _LOGGER.exception(
-            "The metrics output sink failed to close after a run that never started."
+            "An auxiliary output sink failed to close after a run that never started."
         )
 
 

--- a/flashdreams/flashdreams/runtime_v2/cli.py
+++ b/flashdreams/flashdreams/runtime_v2/cli.py
@@ -30,6 +30,7 @@ from flashdreams.runtime_v2.client_window_factory import (
     client_window_mode,
 )
 from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
+from flashdreams.runtime_v2.model_output_sink import ModelOutputSink
 from flashdreams.runtime_v2.session_desc import (
     BackpressureMode,
     PresentationMode,
@@ -76,6 +77,13 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
         application.init(application_args)
         return
     session_desc = _session_desc(application, parsed)
+    if parsed.tensor_artifact_dir is not None and not (
+        session_desc.tensor_artifact_schemas
+    ):
+        parser.error(
+            "--tensor-artifact-dir was requested, but the application declares "
+            "no tensor artifacts."
+        )
     window = mode.create(parsed)
     _report(mode.starting(window))
     # Nothing here says how long the run is: a session reports itself finished,
@@ -83,16 +91,14 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
     metrics_output_sink = (
         None if parsed.stats_path is None else MetricsOutputSink(parsed.stats_path)
     )
-    tensor_artifact_output_sink = (
-        None
-        if parsed.tensor_artifact_dir is None
-        else TensorArtifactOutputSink(parsed.tensor_artifact_dir)
-    )
+    model_output_sinks: list[ModelOutputSink] = []
+    if parsed.tensor_artifact_dir is not None:
+        model_output_sinks.append(TensorArtifactOutputSink(parsed.tensor_artifact_dir))
     ApplicationRunner(
         application,
         window,
         metrics_output_sink=metrics_output_sink,
-        tensor_artifact_output_sink=tensor_artifact_output_sink,
+        model_output_sinks=model_output_sinks,
     ).run(session_desc, application_args)
     _report(mode.finished(window))
 

--- a/flashdreams/flashdreams/runtime_v2/cli.py
+++ b/flashdreams/flashdreams/runtime_v2/cli.py
@@ -35,6 +35,9 @@ from flashdreams.runtime_v2.session_desc import (
     PresentationMode,
     SessionDesc,
 )
+from flashdreams.runtime_v2.tensor_artifact_output_sink import (
+    TensorArtifactOutputSink,
+)
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 _ARGUMENT_SEPARATOR = "--"
@@ -80,10 +83,16 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
     metrics_output_sink = (
         None if parsed.stats_path is None else MetricsOutputSink(parsed.stats_path)
     )
+    tensor_artifact_output_sink = (
+        None
+        if parsed.tensor_artifact_dir is None
+        else TensorArtifactOutputSink(parsed.tensor_artifact_dir)
+    )
     ApplicationRunner(
         application,
         window,
         metrics_output_sink=metrics_output_sink,
+        tensor_artifact_output_sink=tensor_artifact_output_sink,
     ).run(session_desc, application_args)
     _report(mode.finished(window))
 

--- a/flashdreams/flashdreams/runtime_v2/client_window_factory.py
+++ b/flashdreams/flashdreams/runtime_v2/client_window_factory.py
@@ -156,6 +156,12 @@ def add_client_window_arguments(parser: argparse.ArgumentParser) -> None:
             "to read. Nothing is measured unless this is asked for."
         ),
     )
+    parser.add_argument(
+        "--tensor-artifact-dir",
+        type=Path,
+        default=None,
+        help="Directory for named tensor outputs such as actions.",
+    )
     for mode in _MODES:
         mode.add_arguments(parser)
 

--- a/flashdreams/flashdreams/runtime_v2/client_window_factory.py
+++ b/flashdreams/flashdreams/runtime_v2/client_window_factory.py
@@ -160,7 +160,7 @@ def add_client_window_arguments(parser: argparse.ArgumentParser) -> None:
         "--tensor-artifact-dir",
         type=Path,
         default=None,
-        help="Directory for named tensor outputs such as actions.",
+        help="Directory for named tensor outputs.",
     )
     for mode in _MODES:
         mode.add_arguments(parser)

--- a/flashdreams/flashdreams/runtime_v2/model_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/model_output_sink.py
@@ -31,8 +31,14 @@ class ModelOutputSink(Protocol):
         ...
 
     @abstractmethod
-    def close(self) -> None:
-        """Finish pending writes and release resources."""
+    def close(self, *, commit: bool = True) -> None:
+        """Finish the run and release resources.
+
+        Args:
+            commit: Whether model generation completed without an execution
+                failure. Transactional sinks publish buffered outputs only
+                when this is true. Sinks that stream outputs may ignore it.
+        """
         ...
 
 

--- a/flashdreams/flashdreams/runtime_v2/model_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/model_output_sink.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Protocol for outputs consumed directly from model-step result batches."""
+
+from abc import abstractmethod
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from flashdreams.runtime_v2.session_desc import SessionDesc
+from flashdreams.runtime_v2.step_result import StepResult
+
+
+@runtime_checkable
+class ModelOutputSink(Protocol):
+    """Consume complete model-step batches while a session is running.
+
+    Unlike a client window, a model-output sink sees results before UI
+    composition and receives the generation that produced them. Generations
+    increase when a session resets.
+    """
+
+    @abstractmethod
+    def open(self, session_desc: SessionDesc) -> None:
+        """Prepare to consume model results from ``session_desc``."""
+        ...
+
+    @abstractmethod
+    def write(self, generation: int, results: Sequence[StepResult]) -> None:
+        """Consume one complete model-step result batch."""
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        """Finish pending writes and release resources."""
+        ...
+
+
+__all__ = ["ModelOutputSink"]

--- a/flashdreams/flashdreams/runtime_v2/session_desc.py
+++ b/flashdreams/flashdreams/runtime_v2/session_desc.py
@@ -9,6 +9,7 @@ from enum import Enum
 from typing import Any
 
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+from flashdreams.runtime_v2.tensor_artifact import TensorArtifactSchema
 
 
 class BackpressureMode(Enum):
@@ -61,6 +62,9 @@ class SessionDesc:
     video_height: int = 720
     """Output video height in pixels."""
 
+    tensor_artifact_schemas: tuple[TensorArtifactSchema, ...] = ()
+    """Named tensor artifacts a model step may emit alongside video."""
+
     metadata: dict[str, Any] = field(default_factory=dict)
     """Extra values a runtime and an application agree on. Nothing here reads it."""
 
@@ -87,6 +91,9 @@ class SessionDesc:
             raise ValueError("SessionDesc.video_width must be > 0 when set.")
         if self.video_height <= 0:
             raise ValueError("SessionDesc.video_height must be > 0 when set.")
+        artifact_names = [schema.name for schema in self.tensor_artifact_schemas]
+        if len(set(artifact_names)) != len(artifact_names):
+            raise ValueError("SessionDesc tensor artifact names must be unique.")
 
 
 __all__ = ["BackpressureMode", "PresentationMode", "SessionDesc"]

--- a/flashdreams/flashdreams/runtime_v2/session_desc.py
+++ b/flashdreams/flashdreams/runtime_v2/session_desc.py
@@ -8,8 +8,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 from flashdreams.runtime_v2.tensor_artifact import TensorArtifactSchema
+from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 
 class BackpressureMode(Enum):

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -159,6 +159,7 @@ def run_session(
     window: IClientWindow,
     *,
     metrics_output_sink: OutputSink | None = None,
+    tensor_artifact_output_sink: OutputSink | None = None,
     steps: int | None = None,
     max_pending: int = 2,
 ) -> None:
@@ -177,6 +178,7 @@ def run_session(
         window: Source of input and destination for UI output.
         metrics_output_sink: Sink for model measurements, if requested. Receives
             the model loop's results rather than the UI loop's.
+        tensor_artifact_output_sink: Sink for named tensor outputs, if requested.
         steps: Maximum model steps; ``None`` runs until stopped.
         max_pending: Maximum model steps waiting to be shown.
 
@@ -247,6 +249,9 @@ def run_session(
         if metrics_output_sink is not None:
             for result in results:
                 metrics_output_sink.write(result)
+        if tensor_artifact_output_sink is not None:
+            for result in results:
+                tensor_artifact_output_sink.write(result)
 
     def tick_ui() -> None:
         assert ui_loop is not None
@@ -279,6 +284,9 @@ def run_session(
         if metrics_output_sink is not None:
             attempted_output_sinks.append(metrics_output_sink)
             metrics_output_sink.open(session_desc)
+        if tensor_artifact_output_sink is not None:
+            attempted_output_sinks.append(tensor_artifact_output_sink)
+            tensor_artifact_output_sink.open(session_desc)
         collect_input()
         tick_ui()
 

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -165,7 +165,8 @@ class _PerResultModelOutputSink:
         for result in results:
             self._output_sink.write(result)
 
-    def close(self) -> None:
+    def close(self, *, commit: bool = True) -> None:
+        del commit
         self._output_sink.close()
 
 
@@ -235,7 +236,9 @@ def run_session(
     model_loop: IModelLoop[object] | None = None
     high_level_failures: BaseException | None = None
     cleanup_failures: list[BaseException] = []
-    attempted_output_sinks: list[OutputSink | ModelOutputSink] = []
+    attempted_window = False
+    attempted_model_output_sinks: list[ModelOutputSink] = []
+    loop_failure: BaseException | None = None
     active_model_output_sinks = tuple(model_output_sinks)
     if metrics_output_sink is not None:
         active_model_output_sinks = (
@@ -303,10 +306,10 @@ def run_session(
         event_buffer.register(_UI_READER_ID)
         event_buffer.register(_MODEL_READER_ID)
 
-        attempted_output_sinks.append(window)
+        attempted_window = True
         window.open(session_desc)
         for model_output_sink in active_model_output_sinks:
-            attempted_output_sinks.append(model_output_sink)
+            attempted_model_output_sinks.append(model_output_sink)
             model_output_sink.open(session_desc)
         collect_input()
         tick_ui()
@@ -362,9 +365,17 @@ def run_session(
         event_buffer.unregister(_MODEL_READER_ID)
         event_buffer.clear()
 
-        for output_sink in attempted_output_sinks:
+        if not session._failure_queue.empty():
+            loop_failure = session._failure_queue.get()
+        if attempted_window:
             try:
-                output_sink.close()
+                window.close()
+            except BaseException as error:
+                cleanup_failures.append(error)
+        commit_model_outputs = loop_failure is None and high_level_failures is None
+        for model_output_sink in attempted_model_output_sinks:
+            try:
+                model_output_sink.close(commit=commit_model_outputs)
             except BaseException as error:
                 cleanup_failures.append(error)
         try:
@@ -372,10 +383,7 @@ def run_session(
         except BaseException as error:
             cleanup_failures.append(error)
 
-    loop_failures = (
-        None if session._failure_queue.empty() else session._failure_queue.get()
-    )
-    primary_failure = loop_failures or high_level_failures
+    primary_failure = loop_failure or high_level_failures
     if primary_failure is None and cleanup_failures:
         primary_failure = cleanup_failures.pop(0)
     for error in cleanup_failures:

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -7,6 +7,7 @@ import logging
 import threading
 import time
 from collections import deque
+from collections.abc import Sequence
 
 from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.loop import IModelLoop, IUILoop
@@ -14,7 +15,8 @@ from flashdreams.api_v2.output_sink import OutputSink
 from flashdreams.api_v2.session import ISession
 from flashdreams.api_v2.user_input_event import UserInputEvent
 from flashdreams.runtime_v2.event_buffer import EventBuffer
-from flashdreams.runtime_v2.session_desc import PresentationMode
+from flashdreams.runtime_v2.model_output_sink import ModelOutputSink
+from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
@@ -149,6 +151,24 @@ def _contains(events: UserInputEvents, event_type: type[UserInputEvent]) -> bool
     return any(isinstance(event, event_type) for event in events.get_events())
 
 
+class _PerResultModelOutputSink:
+    """Adapt the original per-result output contract to model batches."""
+
+    def __init__(self, output_sink: OutputSink) -> None:
+        self._output_sink = output_sink
+
+    def open(self, session_desc: SessionDesc) -> None:
+        self._output_sink.open(session_desc)
+
+    def write(self, generation: int, results: Sequence[StepResult]) -> None:
+        del generation
+        for result in results:
+            self._output_sink.write(result)
+
+    def close(self) -> None:
+        self._output_sink.close()
+
+
 def _log_secondary_failure(message: str, error: BaseException) -> None:
     """Log a cleanup failure that cannot replace an earlier exception."""
     _LOGGER.error(message, exc_info=error)
@@ -159,7 +179,7 @@ def run_session(
     window: IClientWindow,
     *,
     metrics_output_sink: OutputSink | None = None,
-    tensor_artifact_output_sink: OutputSink | None = None,
+    model_output_sinks: Sequence[ModelOutputSink] = (),
     steps: int | None = None,
     max_pending: int = 2,
 ) -> None:
@@ -177,8 +197,10 @@ def run_session(
         session: Session to run.
         window: Source of input and destination for UI output.
         metrics_output_sink: Sink for model measurements, if requested. Receives
-            the model loop's results rather than the UI loop's.
-        tensor_artifact_output_sink: Sink for named tensor outputs, if requested.
+            the model loop's results rather than the UI loop's. Kept as a
+            compatibility shim for the original per-result contract.
+        model_output_sinks: Sinks receiving each complete model result batch and
+            the generation that produced it.
         steps: Maximum model steps; ``None`` runs until stopped.
         max_pending: Maximum model steps waiting to be shown.
 
@@ -213,7 +235,13 @@ def run_session(
     model_loop: IModelLoop[object] | None = None
     high_level_failures: BaseException | None = None
     cleanup_failures: list[BaseException] = []
-    attempted_output_sinks: list[OutputSink] = []
+    attempted_output_sinks: list[OutputSink | ModelOutputSink] = []
+    active_model_output_sinks = tuple(model_output_sinks)
+    if metrics_output_sink is not None:
+        active_model_output_sinks = (
+            _PerResultModelOutputSink(metrics_output_sink),
+            *active_model_output_sinks,
+        )
 
     def collect_input() -> UserInputEvents:
         events = window.get_user_input_events()
@@ -246,12 +274,8 @@ def run_session(
                 frame_count=results[0].frame_count,
             )
         presentation_manager.publish(generation, results)
-        if metrics_output_sink is not None:
-            for result in results:
-                metrics_output_sink.write(result)
-        if tensor_artifact_output_sink is not None:
-            for result in results:
-                tensor_artifact_output_sink.write(result)
+        for model_output_sink in active_model_output_sinks:
+            model_output_sink.write(generation, results)
 
     def tick_ui() -> None:
         assert ui_loop is not None
@@ -281,12 +305,9 @@ def run_session(
 
         attempted_output_sinks.append(window)
         window.open(session_desc)
-        if metrics_output_sink is not None:
-            attempted_output_sinks.append(metrics_output_sink)
-            metrics_output_sink.open(session_desc)
-        if tensor_artifact_output_sink is not None:
-            attempted_output_sinks.append(tensor_artifact_output_sink)
-            tensor_artifact_output_sink.open(session_desc)
+        for model_output_sink in active_model_output_sinks:
+            attempted_output_sinks.append(model_output_sink)
+            model_output_sink.open(session_desc)
         collect_input()
         tick_ui()
 

--- a/flashdreams/flashdreams/runtime_v2/step_result.py
+++ b/flashdreams/flashdreams/runtime_v2/step_result.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass, field
 
 from torch import Tensor
 
-from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 from flashdreams.runtime_v2.tensor_artifact import TensorArtifactOutput
+from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 
 @dataclass(frozen=True, slots=True)

--- a/flashdreams/flashdreams/runtime_v2/step_result.py
+++ b/flashdreams/flashdreams/runtime_v2/step_result.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from torch import Tensor
 
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+from flashdreams.runtime_v2.tensor_artifact import TensorArtifactOutput
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,3 +35,5 @@ class StepResult:
     metrics: dict[str, float | int] = field(default_factory=dict)
     """Measurements for this step, such as timings, keyed by name. Recorded only
     when a run asked for a metrics sink, and only from a model loop."""
+    tensor_artifacts: tuple[TensorArtifactOutput, ...] = ()
+    """Named tensor artifacts emitted alongside the video result."""

--- a/flashdreams/flashdreams/runtime_v2/tensor_artifact.py
+++ b/flashdreams/flashdreams/runtime_v2/tensor_artifact.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed tensor artifacts emitted alongside generated video."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from torch import Tensor
+
+_ARTIFACT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+"""Portable artifact name accepted as a filename stem."""
+
+
+@dataclass(frozen=True, slots=True)
+class TensorArtifactSchema:
+    """Describe one named tensor artifact produced by a session."""
+
+    name: str
+    """Stable name used to route and persist the artifact."""
+
+    dimension_names: tuple[str, ...]
+    """Semantic names for the tensor dimensions, in storage order."""
+
+    concatenate_axis: int | None = 0
+    """Axis joining outputs from multiple steps; ``None`` permits one output."""
+
+    def __post_init__(self) -> None:
+        if not _ARTIFACT_NAME.fullmatch(self.name):
+            raise ValueError(
+                "Tensor artifact names must start with an alphanumeric character "
+                "and contain only alphanumerics, dots, underscores, or hyphens."
+            )
+        if any(not name.strip() for name in self.dimension_names):
+            raise ValueError("Tensor artifact dimension names must be non-empty.")
+        if len(set(self.dimension_names)) != len(self.dimension_names):
+            raise ValueError("Tensor artifact dimension names must be unique.")
+        if self.concatenate_axis is not None and not (
+            -len(self.dimension_names)
+            <= self.concatenate_axis
+            < len(self.dimension_names)
+        ):
+            raise ValueError(
+                "Tensor artifact concatenate_axis must identify a declared dimension."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class TensorArtifactOutput:
+    """Carry one tensor matching a declared artifact schema."""
+
+    schema: TensorArtifactSchema
+    """Schema identifying and describing the tensor."""
+
+    tensor: Tensor
+    """Artifact tensor. Sinks detach and transfer it before persistence."""
+
+    def __post_init__(self) -> None:
+        if self.tensor.ndim != len(self.schema.dimension_names):
+            raise ValueError(
+                f"Tensor artifact {self.schema.name!r} declares "
+                f"{len(self.schema.dimension_names)} dimensions but received "
+                f"shape {tuple(self.tensor.shape)}."
+            )
+
+
+__all__ = ["TensorArtifactOutput", "TensorArtifactSchema"]

--- a/flashdreams/flashdreams/runtime_v2/tensor_artifact.py
+++ b/flashdreams/flashdreams/runtime_v2/tensor_artifact.py
@@ -34,16 +34,21 @@ class TensorArtifactSchema:
                 "and contain only alphanumerics, dots, underscores, or hyphens."
             )
         if any(not name.strip() for name in self.dimension_names):
-            raise ValueError("Tensor artifact dimension names must be non-empty.")
+            raise ValueError(
+                f"Tensor artifact {self.name!r} dimension names must be non-empty."
+            )
         if len(set(self.dimension_names)) != len(self.dimension_names):
-            raise ValueError("Tensor artifact dimension names must be unique.")
+            raise ValueError(
+                f"Tensor artifact {self.name!r} dimension names must be unique."
+            )
         if self.concatenate_axis is not None and not (
             -len(self.dimension_names)
             <= self.concatenate_axis
             < len(self.dimension_names)
         ):
             raise ValueError(
-                "Tensor artifact concatenate_axis must identify a declared dimension."
+                f"Tensor artifact {self.name!r} concatenate_axis must identify "
+                "a declared dimension."
             )
 
 

--- a/flashdreams/flashdreams/runtime_v2/tensor_artifact_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/tensor_artifact_output_sink.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Output sink persisting named tensor artifacts as NumPy arrays."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import BinaryIO
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.runtime_v2.session_desc import SessionDesc
+from flashdreams.runtime_v2.step_result import StepResult
+from flashdreams.runtime_v2.tensor_artifact import TensorArtifactSchema
+
+
+class TensorArtifactOutputSink(OutputSink):
+    """Collect declared tensor outputs and atomically write one ``.npy`` per name."""
+
+    def __init__(self, output_dir: str | Path) -> None:
+        """
+        Args:
+            output_dir: Directory receiving ``<artifact-name>.npy`` files.
+        """
+        self._output_dir = Path(output_dir)
+        self._schemas: dict[str, TensorArtifactSchema] | None = None
+        self._chunks: dict[str, list[Tensor]] = {}
+
+    def open(self, session_desc: SessionDesc) -> None:
+        """Prepare to collect artifacts declared by ``session_desc``."""
+        self._schemas = {
+            schema.name: schema for schema in session_desc.tensor_artifact_schemas
+        }
+        self._chunks = {name: [] for name in self._schemas}
+
+    def write(self, result: StepResult) -> None:
+        """Collect the tensor artifacts carried by one model result.
+
+        Raises:
+            RuntimeError: Called before :meth:`open`.
+            ValueError: A result is undeclared, duplicated, or changes schema.
+        """
+        if self._schemas is None:
+            raise RuntimeError(
+                "TensorArtifactOutputSink.open() must run before write()."
+            )
+        seen: set[str] = set()
+        for artifact in result.tensor_artifacts:
+            name = artifact.schema.name
+            if name in seen:
+                raise ValueError(
+                    f"Step {result.step_index} emitted tensor artifact {name!r} twice."
+                )
+            seen.add(name)
+            expected = self._schemas.get(name)
+            if expected is None:
+                raise ValueError(
+                    f"Tensor artifact {name!r} was not declared by the session."
+                )
+            if artifact.schema != expected:
+                raise ValueError(
+                    f"Tensor artifact {name!r} does not match its session schema."
+                )
+            self._chunks[name].append(artifact.tensor.detach().to("cpu").contiguous())
+
+    def close(self) -> None:
+        """Write collected tensors and release buffered state.
+
+        Can be called before :meth:`open` or more than once.
+        """
+        schemas = self._schemas
+        if schemas is None:
+            return
+        chunks = self._chunks
+        self._schemas = None
+        self._chunks = {}
+
+        outputs: dict[str, Tensor] = {}
+        for name, artifact_chunks in chunks.items():
+            if not artifact_chunks:
+                continue
+            schema = schemas[name]
+            if schema.concatenate_axis is None:
+                if len(artifact_chunks) != 1:
+                    raise ValueError(
+                        f"Tensor artifact {name!r} permits one output but received "
+                        f"{len(artifact_chunks)}."
+                    )
+                outputs[name] = artifact_chunks[0]
+            else:
+                outputs[name] = torch.cat(artifact_chunks, dim=schema.concatenate_axis)
+        if not outputs:
+            return
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        staged: list[tuple[Path, Path]] = []
+        try:
+            for name, tensor in outputs.items():
+                destination = self._output_dir / f"{name}.npy"
+                with tempfile.NamedTemporaryFile(
+                    mode="w+b",
+                    prefix=f".{name}.",
+                    suffix=".tmp",
+                    dir=self._output_dir,
+                    delete=False,
+                ) as temporary:
+                    _write_numpy(temporary, tensor)
+                    temporary_path = Path(temporary.name)
+                staged.append((temporary_path, destination))
+            for temporary_path, destination in staged:
+                os.replace(temporary_path, destination)
+        finally:
+            for temporary_path, _ in staged:
+                temporary_path.unlink(missing_ok=True)
+
+
+def _write_numpy(file: BinaryIO, tensor: Tensor) -> None:
+    """Write ``tensor`` to an open temporary file and flush it to disk."""
+    np.save(file, tensor.numpy(), allow_pickle=False)
+    file.flush()
+    os.fsync(file.fileno())
+
+
+__all__ = ["TensorArtifactOutputSink"]

--- a/flashdreams/flashdreams/runtime_v2/tensor_artifact_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/tensor_artifact_output_sink.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
@@ -20,14 +22,21 @@ from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.tensor_artifact import TensorArtifactSchema
 
+_MANIFEST_FILENAME = "tensor_artifacts.json"
+"""Commit marker and machine-readable schema for persisted tensor artifacts."""
+
+_ARTIFACT_TYPE = "flashdreams.runtime_v2.tensor_artifacts"
+_SCHEMA_VERSION = 1
+
 
 class TensorArtifactOutputSink(ModelOutputSink):
-    """Collect the latest generation and atomically write one ``.npy`` per name."""
+    """Transactionally persist the latest generation as NumPy arrays."""
 
     def __init__(self, output_dir: str | Path) -> None:
         """
         Args:
-            output_dir: Directory receiving ``<artifact-name>.npy`` files.
+            output_dir: Directory receiving ``<artifact-name>.npy`` files and
+                their ``tensor_artifacts.json`` manifest.
         """
         self._output_dir = Path(output_dir)
         self._schemas: dict[str, TensorArtifactSchema] | None = None
@@ -36,6 +45,9 @@ class TensorArtifactOutputSink(ModelOutputSink):
 
     def open(self, session_desc: SessionDesc) -> None:
         """Prepare to collect artifacts declared by ``session_desc``.
+
+        The output directory and an incomplete commit manifest are created
+        here so invalid or unwritable destinations fail before generation.
 
         Raises:
             ValueError: The session declares no tensor artifacts.
@@ -48,6 +60,12 @@ class TensorArtifactOutputSink(ModelOutputSink):
                 "TensorArtifactOutputSink requires a session that declares at least "
                 "one tensor artifact."
             )
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        _write_manifest_atomically(
+            self._output_dir,
+            _manifest_payload(schemas, {}, generation=None, complete=False),
+        )
         self._schemas = schemas
         self._generation = None
         self._chunks = {name: [] for name in schemas}
@@ -134,18 +152,24 @@ class TensorArtifactOutputSink(ModelOutputSink):
                 f"dimensions from {tuple(first.shape)} to {tuple(tensor.shape)}."
             )
 
-    def close(self) -> None:
-        """Persist buffered tensors and release state.
+    def close(self, *, commit: bool = True) -> None:
+        """Persist buffered tensors from a successful run and release state.
 
-        Can be called before :meth:`open` or more than once.
+        Can be called before :meth:`open` or more than once. When ``commit`` is
+        false, buffered tensors are discarded and the incomplete manifest
+        written by :meth:`open` remains the directory's commit marker.
         """
         schemas = self._schemas
         if schemas is None:
             return
         chunks = self._chunks
+        generation = self._generation
         self._schemas = None
         self._generation = None
         self._chunks = {}
+
+        if not commit:
+            return
 
         outputs: dict[str, Tensor] = {}
         for name, artifact_chunks in chunks.items():
@@ -157,11 +181,9 @@ class TensorArtifactOutputSink(ModelOutputSink):
                 if schema.concatenate_axis is None
                 else torch.cat(artifact_chunks, dim=schema.concatenate_axis)
             )
-        if not outputs:
-            return
-
-        self._output_dir.mkdir(parents=True, exist_ok=True)
         staged: list[tuple[Path, Path]] = []
+        manifest_temporary_path: Path | None = None
+        backups: dict[Path, Path | None] = {}
         try:
             for name, tensor in outputs.items():
                 destination = self._output_dir / f"{name}.npy"
@@ -182,11 +204,39 @@ class TensorArtifactOutputSink(ModelOutputSink):
                     raise
                 assert temporary_path is not None
                 staged.append((temporary_path, destination))
-            for temporary_path, destination in staged:
-                os.replace(temporary_path, destination)
+
+            manifest_temporary_path = _stage_manifest(
+                self._output_dir,
+                _manifest_payload(
+                    schemas, outputs, generation=generation, complete=True
+                ),
+            )
+            for name in schemas:
+                destination = self._output_dir / f"{name}.npy"
+                backups[destination] = _stage_backup(destination)
+            try:
+                for temporary_path, destination in staged:
+                    os.replace(temporary_path, destination)
+                for name in schemas.keys() - outputs.keys():
+                    (self._output_dir / f"{name}.npy").unlink(missing_ok=True)
+                os.replace(
+                    manifest_temporary_path,
+                    self._output_dir / _MANIFEST_FILENAME,
+                )
+            except BaseException as error:
+                try:
+                    _restore_artifacts(backups)
+                except BaseException as rollback_error:
+                    raise error from rollback_error
+                raise
         finally:
             for temporary_path, _ in staged:
                 temporary_path.unlink(missing_ok=True)
+            if manifest_temporary_path is not None:
+                manifest_temporary_path.unlink(missing_ok=True)
+            for backup in backups.values():
+                if backup is not None:
+                    backup.unlink(missing_ok=True)
 
 
 def _numpy_compatible_tensor(name: str, tensor: Tensor) -> Tensor:
@@ -202,9 +252,116 @@ def _numpy_compatible_tensor(name: str, tensor: Tensor) -> Tensor:
     return result
 
 
+def _manifest_payload(
+    schemas: dict[str, TensorArtifactSchema],
+    outputs: dict[str, Tensor],
+    *,
+    generation: int | None,
+    complete: bool,
+) -> dict[str, object]:
+    """Describe declared and emitted artifacts for a run."""
+    artifacts: list[dict[str, object]] = []
+    for name, schema in schemas.items():
+        tensor = outputs.get(name)
+        artifacts.append(
+            {
+                "name": name,
+                "path": f"{name}.npy" if tensor is not None else None,
+                "emitted": tensor is not None,
+                "dimension_names": list(schema.dimension_names),
+                "concatenate_axis": schema.concatenate_axis,
+                "dtype": str(tensor.numpy().dtype) if tensor is not None else None,
+                "shape": (
+                    [int(dimension) for dimension in tensor.shape]
+                    if tensor is not None
+                    else None
+                ),
+            }
+        )
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "artifact_type": _ARTIFACT_TYPE,
+        "complete": complete,
+        "generation": generation,
+        "artifacts": artifacts,
+    }
+
+
+def _write_manifest_atomically(output_dir: Path, payload: dict[str, object]) -> None:
+    """Publish ``payload`` through an atomic replace."""
+    temporary_path = _stage_manifest(output_dir, payload)
+    try:
+        os.replace(temporary_path, output_dir / _MANIFEST_FILENAME)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _stage_manifest(output_dir: Path, payload: dict[str, object]) -> Path:
+    """Write and flush a manifest temporary file in ``output_dir``."""
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w+b",
+            prefix=".tensor-artifacts.",
+            suffix=".tmp",
+            dir=output_dir,
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            _write_json(temporary.file, payload)
+    except BaseException:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise
+    assert temporary_path is not None
+    return temporary_path
+
+
+def _stage_backup(destination: Path) -> Path | None:
+    """Copy an existing artifact to a flushed temporary backup."""
+    if not destination.exists():
+        return None
+    temporary_path: Path | None = None
+    try:
+        with destination.open("rb") as source:
+            with tempfile.NamedTemporaryFile(
+                mode="w+b",
+                prefix=f".{destination.name}.backup.",
+                suffix=".tmp",
+                dir=destination.parent,
+                delete=False,
+            ) as temporary:
+                temporary_path = Path(temporary.name)
+                shutil.copyfileobj(source, temporary.file)
+                temporary.file.flush()
+                os.fsync(temporary.file.fileno())
+    except BaseException:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise
+    assert temporary_path is not None
+    return temporary_path
+
+
+def _restore_artifacts(backups: dict[Path, Path | None]) -> None:
+    """Restore artifact destinations to their state before publication."""
+    for destination, backup in backups.items():
+        if backup is None:
+            destination.unlink(missing_ok=True)
+        else:
+            os.replace(backup, destination)
+
+
 def _write_numpy(file: IO[bytes], tensor: Tensor) -> None:
     """Write ``tensor`` to an open temporary file and flush it to disk."""
     np.save(file, tensor.numpy(), allow_pickle=False)
+    file.flush()
+    os.fsync(file.fileno())
+
+
+def _write_json(file: IO[bytes], payload: dict[str, object]) -> None:
+    """Write deterministic JSON to an open file and flush it to disk."""
+    file.write((json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8"))
     file.flush()
     os.fsync(file.fileno())
 

--- a/flashdreams/flashdreams/runtime_v2/tensor_artifact_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/tensor_artifact_output_sink.py
@@ -1,27 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Output sink persisting named tensor artifacts as NumPy arrays."""
+"""Model-output sink persisting named tensor artifacts as NumPy arrays."""
 
 from __future__ import annotations
 
 import os
 import tempfile
+from collections.abc import Sequence
 from pathlib import Path
-from typing import BinaryIO
+from typing import IO
 
 import numpy as np
 import torch
 from torch import Tensor
 
-from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.runtime_v2.model_output_sink import ModelOutputSink
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.tensor_artifact import TensorArtifactSchema
 
 
-class TensorArtifactOutputSink(OutputSink):
-    """Collect declared tensor outputs and atomically write one ``.npy`` per name."""
+class TensorArtifactOutputSink(ModelOutputSink):
+    """Collect the latest generation and atomically write one ``.npy`` per name."""
 
     def __init__(self, output_dir: str | Path) -> None:
         """
@@ -30,47 +31,111 @@ class TensorArtifactOutputSink(OutputSink):
         """
         self._output_dir = Path(output_dir)
         self._schemas: dict[str, TensorArtifactSchema] | None = None
+        self._generation: int | None = None
         self._chunks: dict[str, list[Tensor]] = {}
 
     def open(self, session_desc: SessionDesc) -> None:
-        """Prepare to collect artifacts declared by ``session_desc``."""
-        self._schemas = {
+        """Prepare to collect artifacts declared by ``session_desc``.
+
+        Raises:
+            ValueError: The session declares no tensor artifacts.
+        """
+        schemas = {
             schema.name: schema for schema in session_desc.tensor_artifact_schemas
         }
-        self._chunks = {name: [] for name in self._schemas}
+        if not schemas:
+            raise ValueError(
+                "TensorArtifactOutputSink requires a session that declares at least "
+                "one tensor artifact."
+            )
+        self._schemas = schemas
+        self._generation = None
+        self._chunks = {name: [] for name in schemas}
 
-    def write(self, result: StepResult) -> None:
-        """Collect the tensor artifacts carried by one model result.
+    def write(self, generation: int, results: Sequence[StepResult]) -> None:
+        """Collect one complete model-step result batch.
+
+        A newer generation discards all buffered older-generation chunks. A
+        late batch from an older generation is ignored.
 
         Raises:
             RuntimeError: Called before :meth:`open`.
-            ValueError: A result is undeclared, duplicated, or changes schema.
+            ValueError: An output is undeclared, duplicated across the result
+                batch, changes schema, cannot be represented by NumPy, or is
+                incompatible with an earlier chunk.
         """
-        if self._schemas is None:
+        schemas = self._schemas
+        if schemas is None:
             raise RuntimeError(
                 "TensorArtifactOutputSink.open() must run before write()."
             )
+        if self._generation is not None and generation < self._generation:
+            return
+        if self._generation is None or generation > self._generation:
+            self._generation = generation
+            self._chunks = {name: [] for name in schemas}
+
         seen: set[str] = set()
-        for artifact in result.tensor_artifacts:
-            name = artifact.schema.name
-            if name in seen:
-                raise ValueError(
-                    f"Step {result.step_index} emitted tensor artifact {name!r} twice."
-                )
-            seen.add(name)
-            expected = self._schemas.get(name)
-            if expected is None:
-                raise ValueError(
-                    f"Tensor artifact {name!r} was not declared by the session."
-                )
-            if artifact.schema != expected:
-                raise ValueError(
-                    f"Tensor artifact {name!r} does not match its session schema."
-                )
-            self._chunks[name].append(artifact.tensor.detach().to("cpu").contiguous())
+        staged: list[tuple[str, Tensor]] = []
+        for result in results:
+            for artifact in result.tensor_artifacts:
+                name = artifact.schema.name
+                if name in seen:
+                    raise ValueError(
+                        f"Model step {result.step_index} emitted tensor artifact "
+                        f"{name!r} more than once across its output channels."
+                    )
+                seen.add(name)
+                expected = schemas.get(name)
+                if expected is None:
+                    raise ValueError(
+                        f"Tensor artifact {name!r} was not declared by the session."
+                    )
+                if artifact.schema != expected:
+                    raise ValueError(
+                        f"Tensor artifact {name!r} does not match its session schema."
+                    )
+                tensor = _numpy_compatible_tensor(name, artifact.tensor)
+                self._validate_next_chunk(expected, tensor)
+                staged.append((name, tensor))
+
+        for name, tensor in staged:
+            self._chunks[name].append(tensor)
+
+    def _validate_next_chunk(
+        self, schema: TensorArtifactSchema, tensor: Tensor
+    ) -> None:
+        """Validate ``tensor`` against chunks already buffered for ``schema``."""
+        chunks = self._chunks[schema.name]
+        if not chunks:
+            return
+        if schema.concatenate_axis is None:
+            raise ValueError(
+                f"Tensor artifact {schema.name!r} permits at most one output "
+                "per generation."
+            )
+        first = chunks[0]
+        if tensor.dtype != first.dtype:
+            raise ValueError(
+                f"Tensor artifact {schema.name!r} changed dtype from "
+                f"{first.dtype} to {tensor.dtype}."
+            )
+        axis = schema.concatenate_axis % tensor.ndim
+        mismatches = [
+            dimension
+            for dimension, (expected, received) in enumerate(
+                zip(first.shape, tensor.shape, strict=True)
+            )
+            if dimension != axis and expected != received
+        ]
+        if mismatches:
+            raise ValueError(
+                f"Tensor artifact {schema.name!r} changed non-concatenated "
+                f"dimensions from {tuple(first.shape)} to {tuple(tensor.shape)}."
+            )
 
     def close(self) -> None:
-        """Write collected tensors and release buffered state.
+        """Persist buffered tensors and release state.
 
         Can be called before :meth:`open` or more than once.
         """
@@ -79,6 +144,7 @@ class TensorArtifactOutputSink(OutputSink):
             return
         chunks = self._chunks
         self._schemas = None
+        self._generation = None
         self._chunks = {}
 
         outputs: dict[str, Tensor] = {}
@@ -86,15 +152,11 @@ class TensorArtifactOutputSink(OutputSink):
             if not artifact_chunks:
                 continue
             schema = schemas[name]
-            if schema.concatenate_axis is None:
-                if len(artifact_chunks) != 1:
-                    raise ValueError(
-                        f"Tensor artifact {name!r} permits one output but received "
-                        f"{len(artifact_chunks)}."
-                    )
-                outputs[name] = artifact_chunks[0]
-            else:
-                outputs[name] = torch.cat(artifact_chunks, dim=schema.concatenate_axis)
+            outputs[name] = (
+                artifact_chunks[0]
+                if schema.concatenate_axis is None
+                else torch.cat(artifact_chunks, dim=schema.concatenate_axis)
+            )
         if not outputs:
             return
 
@@ -103,15 +165,22 @@ class TensorArtifactOutputSink(OutputSink):
         try:
             for name, tensor in outputs.items():
                 destination = self._output_dir / f"{name}.npy"
-                with tempfile.NamedTemporaryFile(
-                    mode="w+b",
-                    prefix=f".{name}.",
-                    suffix=".tmp",
-                    dir=self._output_dir,
-                    delete=False,
-                ) as temporary:
-                    _write_numpy(temporary, tensor)
-                    temporary_path = Path(temporary.name)
+                temporary_path: Path | None = None
+                try:
+                    with tempfile.NamedTemporaryFile(
+                        mode="w+b",
+                        prefix=f".{name}.",
+                        suffix=".tmp",
+                        dir=self._output_dir,
+                        delete=False,
+                    ) as temporary:
+                        temporary_path = Path(temporary.name)
+                        _write_numpy(temporary.file, tensor)
+                except BaseException:
+                    if temporary_path is not None:
+                        temporary_path.unlink(missing_ok=True)
+                    raise
+                assert temporary_path is not None
                 staged.append((temporary_path, destination))
             for temporary_path, destination in staged:
                 os.replace(temporary_path, destination)
@@ -120,7 +189,20 @@ class TensorArtifactOutputSink(OutputSink):
                 temporary_path.unlink(missing_ok=True)
 
 
-def _write_numpy(file: BinaryIO, tensor: Tensor) -> None:
+def _numpy_compatible_tensor(name: str, tensor: Tensor) -> Tensor:
+    """Detach ``tensor`` onto CPU and prove NumPy can represent its dtype."""
+    try:
+        result = tensor.detach().to("cpu").contiguous()
+        result.numpy()
+    except (RuntimeError, TypeError) as error:
+        raise ValueError(
+            f"Tensor artifact {name!r} with dtype {tensor.dtype} cannot be "
+            "stored as a NumPy array."
+        ) from error
+    return result
+
+
+def _write_numpy(file: IO[bytes], tensor: Tensor) -> None:
     """Write ``tensor`` to an open temporary file and flush it to disk."""
     np.save(file, tensor.numpy(), allow_pickle=False)
     file.flush()

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -144,6 +144,25 @@ class _SilentWindow(_Window):
         return UserInputEvents([])
 
 
+class _ModelSink:
+    """Record complete model-result batches."""
+
+    def __init__(self, calls: list[str]) -> None:
+        self._calls = calls
+        self.batches: list[tuple[int, tuple[StepResult, ...]]] = []
+
+    def open(self, session_desc: SessionDesc) -> None:
+        del session_desc
+        self._calls.append("model_output.open")
+
+    def write(self, generation: int, results: Sequence[StepResult]) -> None:
+        self.batches.append((generation, tuple(results)))
+        self._calls.append(f"model_output.write({generation})")
+
+    def close(self) -> None:
+        self._calls.append("model_output.close")
+
+
 class _MetricsSink:
     """Record model results delivered independently of the client window."""
 
@@ -195,11 +214,24 @@ def test_application_runner_closes_both_when_the_run_never_starts() -> None:
     a window may already be serving a client by then."""
     calls: list[str] = []
     application = _Application(calls, fail_to_init=True)
+    metrics = _MetricsSink(calls)
+    model_output = _ModelSink(calls)
 
     with pytest.raises(RuntimeError, match="application init failed"):
-        ApplicationRunner(application, _Window(calls)).run(_session_desc())
+        ApplicationRunner(
+            application,
+            _Window(calls),
+            metrics_output_sink=metrics,
+            model_output_sinks=[model_output],
+        ).run(_session_desc())
 
-    assert calls == ["application.init([])", "window.close", "application.close"]
+    assert calls == [
+        "application.init([])",
+        "window.close",
+        "metrics.close",
+        "model_output.close",
+        "application.close",
+    ]
 
 
 def test_application_runner_ends_a_run_a_window_cannot_end() -> None:
@@ -230,6 +262,24 @@ def test_application_runner_keeps_metrics_output_separate_from_the_window() -> N
     assert [result.step_index for result in metrics.results] == [0, 1]
     assert calls.index("metrics.open") < calls.index("metrics.write(0)")
     assert calls.index("metrics.write(1)") < calls.index("metrics.close")
+
+
+def test_application_runner_forwards_complete_model_batches() -> None:
+    calls: list[str] = []
+    sink = _ModelSink(calls)
+
+    ApplicationRunner(
+        _Application(calls, session_length=2),
+        _SilentWindow(calls),
+        model_output_sinks=[sink],
+    ).run(_session_desc())
+
+    assert [generation for generation, _ in sink.batches] == [0, 0]
+    assert [
+        tuple(result.step_index for result in batch) for _, batch in sink.batches
+    ] == [(0,), (1,)]
+    assert calls.index("model_output.open") < calls.index("model_output.write(0)")
+    assert calls.index("model_output.write(0)") < calls.index("model_output.close")
 
 
 def test_application_runner_reports_the_run_rather_than_the_close(

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -150,6 +150,7 @@ class _ModelSink:
     def __init__(self, calls: list[str]) -> None:
         self._calls = calls
         self.batches: list[tuple[int, tuple[StepResult, ...]]] = []
+        self.commits: list[bool] = []
 
     def open(self, session_desc: SessionDesc) -> None:
         del session_desc
@@ -159,7 +160,8 @@ class _ModelSink:
         self.batches.append((generation, tuple(results)))
         self._calls.append(f"model_output.write({generation})")
 
-    def close(self) -> None:
+    def close(self, *, commit: bool = True) -> None:
+        self.commits.append(commit)
         self._calls.append("model_output.close")
 
 
@@ -232,6 +234,7 @@ def test_application_runner_closes_both_when_the_run_never_starts() -> None:
         "model_output.close",
         "application.close",
     ]
+    assert model_output.commits == [False]
 
 
 def test_application_runner_ends_a_run_a_window_cannot_end() -> None:
@@ -280,6 +283,7 @@ def test_application_runner_forwards_complete_model_batches() -> None:
     ] == [(0,), (1,)]
     assert calls.index("model_output.open") < calls.index("model_output.write(0)")
     assert calls.index("model_output.write(0)") < calls.index("model_output.close")
+    assert sink.commits == [True]
 
 
 def test_application_runner_reports_the_run_rather_than_the_close(

--- a/flashdreams/test_v2/test_cli.py
+++ b/flashdreams/test_v2/test_cli.py
@@ -12,8 +12,10 @@ import argparse
 import json
 import shutil
 from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 
@@ -34,6 +36,10 @@ from flashdreams.runtime_v2.session_desc import (
     SessionDesc,
 )
 from flashdreams.runtime_v2.step_result import StepResult
+from flashdreams.runtime_v2.tensor_artifact import (
+    TensorArtifactOutput,
+    TensorArtifactSchema,
+)
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 from flashdreams.t2v_v2.application import T2VApplication
@@ -55,6 +61,12 @@ _TOTAL_BLOCKS = 3
 
 _PROMPT = "A cat surfing"
 """Prompt the tests generate from."""
+
+_TRAJECTORY = TensorArtifactSchema(
+    name="trajectory",
+    dimension_names=("sample", "coordinate"),
+)
+"""Generic tensor output exposed by the artifact stand-in."""
 
 
 ## Stand-in model
@@ -93,9 +105,11 @@ class UndescribedApplication(IApplication):
 
     def __init__(self) -> None:
         self.asked_for: SessionDesc | None = None
+        self.initialized = False
 
     def init(self, commandline_args: Sequence[str]) -> None:
         del commandline_args
+        self.initialized = True
 
     def create_session(self, session_desc: SessionDesc) -> ISession:
         self.asked_for = session_desc
@@ -141,6 +155,43 @@ class OneStepSession(ISession):
 
     def is_finished(self) -> bool:
         return self._generated
+
+
+class ArtifactSession(OneStepSession):
+    """Emit one generic tensor artifact beside the stand-in video."""
+
+    def step(self, step_index: int, events: UserInputEvents) -> StepResult:
+        return replace(
+            super().step(step_index, events),
+            tensor_artifacts=(
+                TensorArtifactOutput(
+                    schema=_TRAJECTORY,
+                    tensor=torch.tensor([[1.0, 2.0]]),
+                ),
+            ),
+        )
+
+
+class ArtifactApplication(IApplication):
+    """Declare and create the generic artifact stand-in."""
+
+    def init(self, commandline_args: Sequence[str]) -> None:
+        if commandline_args:
+            raise AssertionError("Artifact stand-in takes no arguments.")
+
+    def session_desc(self) -> SessionDesc:
+        return SessionDesc(
+            output_layout=VideoTensorLayout.bcthw,
+            presentation_mode=PresentationMode.ONLY_PRESENT_NEW,
+            frames_per_second_for_ui=100,
+            frames_per_second_for_step=30,
+            video_width=2,
+            video_height=2,
+            tensor_artifact_schemas=(_TRAJECTORY,),
+        )
+
+    def create_session(self, session_desc: SessionDesc) -> ISession:
+        return ArtifactSession(session_desc)
 
 
 class RecordingWindow(IClientWindow):
@@ -321,6 +372,64 @@ def test_a_run_writes_what_the_application_generated(
     assert path.stat().st_size > 0
     assert pipeline.caches[0]["text"] == [_PROMPT]
     assert pipeline.generated == [0, 1]
+
+
+def test_a_run_can_write_declared_tensor_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    _install(monkeypatch, ArtifactApplication(), RecordingWindow())
+
+    cli.entrypoint(
+        [
+            "stub",
+            "--mode",
+            "webrtc",
+            "--tensor-artifact-dir",
+            str(artifact_dir),
+        ]
+    )
+
+    np.testing.assert_array_equal(
+        np.load(artifact_dir / "trajectory.npy"),
+        np.array([[1.0, 2.0]], dtype=np.float32),
+    )
+
+
+def test_tensor_artifact_output_requires_a_declared_schema_before_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    application = UndescribedApplication()
+    _install(monkeypatch, application)
+
+    class NeverCreatedMode(ClientWindowMode):
+        name = "never-created"
+
+        def create(self, parsed_args: argparse.Namespace) -> IClientWindow:
+            del parsed_args
+            raise AssertionError("The CLI must reject this before creating a window.")
+
+    monkeypatch.setattr(cli, "client_window_mode", lambda name: NeverCreatedMode())
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.entrypoint(
+            [
+                "stub",
+                "--mode",
+                "webrtc",
+                "--tensor-artifact-dir",
+                str(tmp_path / "artifacts"),
+            ]
+        )
+
+    assert exit_info.value.code == 2
+    assert "application declares no tensor artifacts" in capsys.readouterr().err
+    assert not application.initialized
+    assert application.asked_for is None
+    assert not (tmp_path / "artifacts").exists()
 
 
 def test_the_model_is_released_when_a_run_fails(

--- a/flashdreams/test_v2/test_cli.py
+++ b/flashdreams/test_v2/test_cli.py
@@ -395,6 +395,10 @@ def test_a_run_can_write_declared_tensor_artifacts(
         np.load(artifact_dir / "trajectory.npy"),
         np.array([[1.0, 2.0]], dtype=np.float32),
     )
+    manifest = json.loads((artifact_dir / "tensor_artifacts.json").read_text())
+    assert manifest["complete"] is True
+    assert manifest["artifacts"][0]["dimension_names"] == ["sample", "coordinate"]
+    assert manifest["artifacts"][0]["path"] == "trajectory.npy"
 
 
 def test_tensor_artifact_output_requires_a_declared_schema_before_startup(

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -3,6 +3,7 @@
 
 """CPU test for the v2 session loop, independent of any application."""
 
+import json
 import logging
 import threading
 from collections.abc import Sequence
@@ -165,6 +166,7 @@ class RecordingModelOutputSink:
     def __init__(self, log: CallLog) -> None:
         self._log = log
         self.batches: list[tuple[int, tuple[StepResult, ...]]] = []
+        self.commits: list[bool] = []
 
     def open(self, session_desc: SessionDesc) -> None:
         del session_desc
@@ -174,7 +176,8 @@ class RecordingModelOutputSink:
         self._log.record(f"model_output.write({generation})")
         self.batches.append((generation, tuple(results)))
 
-    def close(self) -> None:
+    def close(self, *, commit: bool = True) -> None:
+        self.commits.append(commit)
         self._log.record("model_output.close")
 
 
@@ -653,10 +656,11 @@ def test_default_ui_presents_each_frame_from_a_model_chunk() -> None:
     generation, batch = model_output.batches[0]
     assert generation == 0
     assert len(batch) == 1
-    assert batch[0].frame_count == 2
+    assert batch[0].frame_count == 12
     assert batch[0].metrics == {"total_ms": 1.5}
     assert log.threads_for("model_output.write(0)") == {_STEP_THREAD_NAME}
     assert log.threads_for("model_output.open") == {threading.current_thread().name}
+    assert model_output.commits == [True]
     assert log.threads_for("model_output.close") == {threading.current_thread().name}
 
 
@@ -679,6 +683,7 @@ def test_model_output_sink_failure_still_closes_everything() -> None:
         )
 
     assert "model_output.close" in log.calls
+    assert sink.commits == [False]
     assert log.calls[-2:] == ["model_output.close", "session.close"]
 
 
@@ -980,7 +985,7 @@ def test_tensor_artifacts_keep_only_the_generation_after_an_inflight_reset(
         ArtifactSession(desc, log),
         ResettingWindow(
             log,
-            [UserInputEvents([]), _lifecycle_event(ResetUserInputEventData())],
+            [UserInputEvents([]), _lifecycle_event(ResetUserInputEvent)],
         ),
         model_output_sinks=[sink],
         steps=2,
@@ -1125,6 +1130,41 @@ def test_run_session_closes_both_when_a_step_raises() -> None:
     # presented as a result.
     assert log.calls[-2:] == ["window.close", "session.close"]
     assert [result.step_index for result in window.results] == [0]
+
+
+def test_failed_step_does_not_commit_partial_tensor_artifacts(tmp_path: Path) -> None:
+    log = CallLog()
+    trajectory = TensorArtifactSchema(
+        name="trajectory",
+        dimension_names=("sample", "coordinate"),
+    )
+
+    class ArtifactSession(FakeSession):
+        def step(self, step_index: int, events: UserInputEvents) -> StepResult:
+            return replace(
+                super().step(step_index, events),
+                tensor_artifacts=(
+                    TensorArtifactOutput(
+                        schema=trajectory,
+                        tensor=torch.full((1, 2), float(step_index)),
+                    ),
+                ),
+            )
+
+    desc = replace(_session_desc(), tensor_artifact_schemas=(trajectory,))
+    artifact_dir = tmp_path / "artifacts"
+
+    with pytest.raises(RuntimeError, match="step failed"):
+        run_session(
+            ArtifactSession(desc, log, fail_at=1),
+            RecordingClientWindow(log),
+            model_output_sinks=[TensorArtifactOutputSink(artifact_dir)],
+            steps=3,
+        )
+
+    assert not (artifact_dir / "trajectory.npy").exists()
+    manifest = json.loads((artifact_dir / "tensor_artifacts.json").read_text())
+    assert manifest["complete"] is False
 
 
 def test_run_session_reports_a_window_that_fails_to_close() -> None:

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -5,7 +5,11 @@
 
 import logging
 import threading
+from collections.abc import Sequence
+from dataclasses import replace
+from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 from numpy import uint64
@@ -25,6 +29,13 @@ from flashdreams.runtime_v2.session_desc import (
 )
 from flashdreams.runtime_v2.session_runner import _PresentationClock, run_session
 from flashdreams.runtime_v2.step_result import StepResult
+from flashdreams.runtime_v2.tensor_artifact import (
+    TensorArtifactOutput,
+    TensorArtifactSchema,
+)
+from flashdreams.runtime_v2.tensor_artifact_output_sink import (
+    TensorArtifactOutputSink,
+)
 from flashdreams.runtime_v2.user_input_event import (
     CloseUserInputEvent,
     KeyboardInputState,
@@ -146,6 +157,25 @@ class CallLog:
         """Return the names of the threads that made ``call``."""
         with self._lock:
             return {thread for made, thread in self._calls if made == call}
+
+
+class RecordingModelOutputSink:
+    """Record complete model batches independently of UI presentation."""
+
+    def __init__(self, log: CallLog) -> None:
+        self._log = log
+        self.batches: list[tuple[int, tuple[StepResult, ...]]] = []
+
+    def open(self, session_desc: SessionDesc) -> None:
+        del session_desc
+        self._log.record("model_output.open")
+
+    def write(self, generation: int, results: Sequence[StepResult]) -> None:
+        self._log.record(f"model_output.write({generation})")
+        self.batches.append((generation, tuple(results)))
+
+    def close(self) -> None:
+        self._log.record("model_output.close")
 
 
 class FakeModelLoop(IModelLoop["FakeSession"]):
@@ -603,10 +633,12 @@ def test_default_ui_presents_each_frame_from_a_model_chunk() -> None:
 
     window = RecordingClientWindow(log)
     metrics = RecordingMetricsSink()
+    model_output = RecordingModelOutputSink(log)
     run_session(
         MultiFrameSession(_session_desc(), log),
         window,
         metrics_output_sink=metrics,
+        model_output_sinks=[model_output],
         steps=1,
     )
 
@@ -617,6 +649,37 @@ def test_default_ui_presents_each_frame_from_a_model_chunk() -> None:
     assert [result.metrics for result in window.results] == [{"ui_ms": 0.25}] * 12
     assert len(metrics.results) == 1
     assert metrics.results[0].metrics == {"total_ms": 1.5}
+    assert len(model_output.batches) == 1
+    generation, batch = model_output.batches[0]
+    assert generation == 0
+    assert len(batch) == 1
+    assert batch[0].frame_count == 2
+    assert batch[0].metrics == {"total_ms": 1.5}
+    assert log.threads_for("model_output.write(0)") == {_STEP_THREAD_NAME}
+    assert log.threads_for("model_output.open") == {threading.current_thread().name}
+    assert log.threads_for("model_output.close") == {threading.current_thread().name}
+
+
+def test_model_output_sink_failure_still_closes_everything() -> None:
+    log = CallLog()
+
+    class FailingModelOutputSink(RecordingModelOutputSink):
+        def write(self, generation: int, results: Sequence[StepResult]) -> None:
+            super().write(generation, results)
+            raise RuntimeError("model output failed")
+
+    sink = FailingModelOutputSink(log)
+
+    with pytest.raises(RuntimeError, match="model output failed"):
+        run_session(
+            FakeSession(_session_desc(), log),
+            RecordingClientWindow(log),
+            model_output_sinks=[sink],
+            steps=1,
+        )
+
+    assert "model_output.close" in log.calls
+    assert log.calls[-2:] == ["model_output.close", "session.close"]
 
 
 def test_default_ui_does_not_redraw_an_unchanged_model_frame() -> None:
@@ -867,6 +930,66 @@ def test_run_session_drops_a_result_the_reset_interrupted() -> None:
     # the step from after the reset reaches the window.
     assert log.calls.count("session.step(0)") == 2
     assert [result.step_index for result in window.results] == [0]
+
+
+def test_tensor_artifacts_keep_only_the_generation_after_an_inflight_reset(
+    tmp_path: Path,
+) -> None:
+    log = CallLog()
+    reset_reported = threading.Event()
+    trajectory = TensorArtifactSchema(
+        name="trajectory",
+        dimension_names=("sample", "coordinate"),
+    )
+
+    class ArtifactSession(FakeSession):
+        def __init__(self, session_desc: SessionDesc, log: CallLog) -> None:
+            super().__init__(session_desc, log)
+            self.emissions = 0
+
+        def step(self, step_index: int, events: UserInputEvents) -> StepResult:
+            if self.emissions == 0:
+                reset_reported.wait()
+            result = super().step(step_index, events)
+            value = float(self.emissions)
+            self.emissions += 1
+            return replace(
+                result,
+                tensor_artifacts=(
+                    TensorArtifactOutput(
+                        schema=trajectory,
+                        tensor=torch.full((1, 2), value),
+                    ),
+                ),
+            )
+
+    class ResettingWindow(RecordingClientWindow):
+        def get_user_input_events(self) -> UserInputEvents:
+            events = super().get_user_input_events()
+            if events.get_events():
+                reset_reported.set()
+            return events
+
+    desc = replace(
+        _session_desc(),
+        tensor_artifact_schemas=(trajectory,),
+    )
+    artifact_dir = tmp_path / "artifacts"
+    sink = TensorArtifactOutputSink(artifact_dir)
+    run_session(
+        ArtifactSession(desc, log),
+        ResettingWindow(
+            log,
+            [UserInputEvents([]), _lifecycle_event(ResetUserInputEventData())],
+        ),
+        model_output_sinks=[sink],
+        steps=2,
+    )
+
+    np.testing.assert_array_equal(
+        np.load(artifact_dir / "trajectory.npy"),
+        np.array([[1.0, 1.0]], dtype=np.float32),
+    )
 
 
 def test_equality_eval_preserves_every_frame_when_model_is_faster() -> None:

--- a/flashdreams/test_v2/test_tensor_artifact_output_sink.py
+++ b/flashdreams/test_v2/test_tensor_artifact_output_sink.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for typed tensor artifacts and their NumPy output sink."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from flashdreams.runtime_v2.session_desc import SessionDesc
+from flashdreams.runtime_v2.step_result import StepResult
+from flashdreams.runtime_v2.tensor_artifact import (
+    TensorArtifactOutput,
+    TensorArtifactSchema,
+)
+from flashdreams.runtime_v2.tensor_artifact_output_sink import (
+    TensorArtifactOutputSink,
+)
+from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+
+pytestmark = pytest.mark.ci_cpu
+
+_ACTIONS = TensorArtifactSchema(
+    name="actions",
+    dimension_names=("step", "channel"),
+    concatenate_axis=0,
+)
+"""Robot-action-like schema used to exercise generic tensor routing."""
+
+
+def _session_desc() -> SessionDesc:
+    return SessionDesc(tensor_artifact_schemas=(_ACTIONS,))
+
+
+def _result(step_index: int, actions: torch.Tensor) -> StepResult:
+    return StepResult(
+        step_index=step_index,
+        output=torch.zeros(1, 3, 1, 2, 2),
+        frame_count=1,
+        output_layout=VideoTensorLayout.bcthw,
+        tensor_artifacts=(TensorArtifactOutput(schema=_ACTIONS, tensor=actions),),
+    )
+
+
+def test_tensor_artifact_sink_concatenates_steps_and_writes_once(
+    tmp_path: Path,
+) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    sink.write(_result(0, torch.tensor([[1.0, 2.0]])))
+    sink.write(_result(1, torch.tensor([[3.0, 4.0], [5.0, 6.0]])))
+
+    sink.close()
+    first_bytes = (tmp_path / "actions.npy").read_bytes()
+    sink.close()
+
+    np.testing.assert_array_equal(
+        np.load(tmp_path / "actions.npy"),
+        np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32),
+    )
+    assert (tmp_path / "actions.npy").read_bytes() == first_bytes
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_tensor_artifact_sink_rejects_undeclared_outputs(tmp_path: Path) -> None:
+    other = TensorArtifactSchema(
+        name="other",
+        dimension_names=("step", "channel"),
+    )
+    result = _result(0, torch.zeros(1, 2))
+    result = StepResult(
+        step_index=result.step_index,
+        output=result.output,
+        frame_count=result.frame_count,
+        output_layout=result.output_layout,
+        tensor_artifacts=(
+            TensorArtifactOutput(schema=other, tensor=torch.zeros(1, 2)),
+        ),
+    )
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+
+    with pytest.raises(ValueError, match="not declared"):
+        sink.write(result)
+
+
+def test_tensor_artifact_output_validates_its_rank() -> None:
+    with pytest.raises(ValueError, match="declares 2 dimensions"):
+        TensorArtifactOutput(schema=_ACTIONS, tensor=torch.zeros(1, 2, 3))
+
+
+def test_tensor_artifact_names_cannot_escape_the_output_directory() -> None:
+    with pytest.raises(ValueError, match="Tensor artifact names"):
+        TensorArtifactSchema(
+            name="../actions",
+            dimension_names=("step", "channel"),
+        )

--- a/flashdreams/test_v2/test_tensor_artifact_output_sink.py
+++ b/flashdreams/test_v2/test_tensor_artifact_output_sink.py
@@ -3,7 +3,9 @@
 
 """CPU tests for typed tensor artifacts and their NumPy output sink."""
 
+import json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -29,6 +31,10 @@ _TRAJECTORY = TensorArtifactSchema(
     concatenate_axis=0,
 )
 """Generic sequence schema used to exercise tensor routing."""
+
+
+def _manifest(output_dir: Path) -> dict[str, Any]:
+    return json.loads((output_dir / "tensor_artifacts.json").read_text())
 
 
 def _session_desc(
@@ -76,6 +82,23 @@ def test_sink_concatenates_steps_and_close_is_idempotent(tmp_path: Path) -> None
     )
     assert (tmp_path / "trajectory.npy").read_bytes() == first_bytes
     assert not list(tmp_path.glob("*.tmp"))
+    assert _manifest(tmp_path) == {
+        "artifact_type": "flashdreams.runtime_v2.tensor_artifacts",
+        "artifacts": [
+            {
+                "concatenate_axis": 0,
+                "dimension_names": ["sample", "coordinate"],
+                "dtype": "float32",
+                "emitted": True,
+                "name": "trajectory",
+                "path": "trajectory.npy",
+                "shape": [3, 2],
+            }
+        ],
+        "complete": True,
+        "generation": 0,
+        "schema_version": 1,
+    }
 
 
 def test_each_declared_artifact_is_optional(tmp_path: Path) -> None:
@@ -86,7 +109,46 @@ def test_each_declared_artifact_is_optional(tmp_path: Path) -> None:
 
     sink.close()
 
-    assert not output_dir.exists()
+    assert not (output_dir / "trajectory.npy").exists()
+    manifest = _manifest(output_dir)
+    assert manifest["complete"] is True
+    assert manifest["artifacts"][0]["emitted"] is False
+    assert manifest["artifacts"][0]["dimension_names"] == ["sample", "coordinate"]
+
+
+def test_successful_run_removes_a_stale_optional_artifact(tmp_path: Path) -> None:
+    destination = tmp_path / "trajectory.npy"
+    destination.write_bytes(b"stale")
+    sink = TensorArtifactOutputSink(tmp_path)
+
+    sink.open(_session_desc())
+    assert destination.exists()
+    sink.close()
+
+    assert not destination.exists()
+    assert _manifest(tmp_path)["complete"] is True
+
+
+def test_failed_run_discards_buffered_artifacts(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    sink.write(0, [_result(0, _artifact(torch.ones(1, 2)))])
+
+    sink.close(commit=False)
+
+    assert not (tmp_path / "trajectory.npy").exists()
+    manifest = _manifest(tmp_path)
+    assert manifest["complete"] is False
+    assert manifest["artifacts"][0]["emitted"] is False
+
+
+def test_open_rejects_an_invalid_output_path_before_writes(tmp_path: Path) -> None:
+    output_path = tmp_path / "not-a-directory"
+    output_path.write_text("occupied")
+    sink = TensorArtifactOutputSink(output_path)
+
+    with pytest.raises(FileExistsError):
+        sink.open(_session_desc())
 
 
 def test_sink_rejects_undeclared_outputs(tmp_path: Path) -> None:
@@ -121,8 +183,9 @@ def test_sink_rejects_duplicates_within_one_result(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="'trajectory'.*more than once"):
         sink.write(0, [_result(0, artifact, artifact)])
 
-    sink.close()
-    assert list(tmp_path.iterdir()) == []
+    sink.close(commit=False)
+    assert not (tmp_path / "trajectory.npy").exists()
+    assert _manifest(tmp_path)["complete"] is False
 
 
 def test_sink_rejects_duplicates_across_result_channels(tmp_path: Path) -> None:
@@ -138,8 +201,9 @@ def test_sink_rejects_duplicates_across_result_channels(tmp_path: Path) -> None:
             ],
         )
 
-    sink.close()
-    assert list(tmp_path.iterdir()) == []
+    sink.close(commit=False)
+    assert not (tmp_path / "trajectory.npy").exists()
+    assert _manifest(tmp_path)["complete"] is False
 
 
 def test_sink_rejects_dtype_changes(tmp_path: Path) -> None:
@@ -276,6 +340,47 @@ def test_replace_failure_removes_staged_files(
         sink.close()
 
     assert destination.read_bytes() == b"previous"
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_manifest_replace_failure_restores_prior_artifact_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optional = TensorArtifactSchema(
+        name="optional",
+        dimension_names=("sample", "coordinate"),
+    )
+    trajectory_path = tmp_path / "trajectory.npy"
+    optional_path = tmp_path / "optional.npy"
+    np.save(trajectory_path, np.array([[1.0, 2.0]], dtype=np.float32))
+    np.save(optional_path, np.array([[3.0, 4.0]], dtype=np.float32))
+    prior_trajectory = trajectory_path.read_bytes()
+    prior_optional = optional_path.read_bytes()
+
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc(_TRAJECTORY, optional))
+    sink.write(0, [_result(0, _artifact(torch.tensor([[9.0, 9.0]])))])
+
+    real_replace = artifact_sink_module.os.replace
+
+    def fail_final_manifest_replace(source: Any, destination: Any) -> None:
+        if Path(destination).name == "tensor_artifacts.json":
+            raise OSError("manifest replace failed")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(
+        artifact_sink_module.os,
+        "replace",
+        fail_final_manifest_replace,
+    )
+
+    with pytest.raises(OSError, match="manifest replace failed"):
+        sink.close()
+
+    assert trajectory_path.read_bytes() == prior_trajectory
+    assert optional_path.read_bytes() == prior_optional
+    assert _manifest(tmp_path)["complete"] is False
     assert not list(tmp_path.glob("*.tmp"))
 
 

--- a/flashdreams/test_v2/test_tensor_artifact_output_sink.py
+++ b/flashdreams/test_v2/test_tensor_artifact_output_sink.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import torch
 
+import flashdreams.runtime_v2.tensor_artifact_output_sink as artifact_sink_module
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.tensor_artifact import (
@@ -22,78 +23,318 @@ from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 pytestmark = pytest.mark.ci_cpu
 
-_ACTIONS = TensorArtifactSchema(
-    name="actions",
-    dimension_names=("step", "channel"),
+_TRAJECTORY = TensorArtifactSchema(
+    name="trajectory",
+    dimension_names=("sample", "coordinate"),
     concatenate_axis=0,
 )
-"""Robot-action-like schema used to exercise generic tensor routing."""
+"""Generic sequence schema used to exercise tensor routing."""
 
 
-def _session_desc() -> SessionDesc:
-    return SessionDesc(tensor_artifact_schemas=(_ACTIONS,))
+def _session_desc(
+    *schemas: TensorArtifactSchema,
+) -> SessionDesc:
+    return SessionDesc(tensor_artifact_schemas=schemas or (_TRAJECTORY,))
 
 
-def _result(step_index: int, actions: torch.Tensor) -> StepResult:
+def _artifact(
+    tensor: torch.Tensor,
+    schema: TensorArtifactSchema = _TRAJECTORY,
+) -> TensorArtifactOutput:
+    return TensorArtifactOutput(schema=schema, tensor=tensor)
+
+
+def _result(
+    step_index: int,
+    *artifacts: TensorArtifactOutput,
+) -> StepResult:
     return StepResult(
         step_index=step_index,
         output=torch.zeros(1, 3, 1, 2, 2),
         frame_count=1,
         output_layout=VideoTensorLayout.bcthw,
-        tensor_artifacts=(TensorArtifactOutput(schema=_ACTIONS, tensor=actions),),
+        tensor_artifacts=tuple(artifacts),
     )
 
 
-def test_tensor_artifact_sink_concatenates_steps_and_writes_once(
+def test_sink_concatenates_steps_and_close_is_idempotent(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    sink.write(0, [_result(0, _artifact(torch.tensor([[1.0, 2.0]])))])
+    sink.write(
+        0,
+        [_result(1, _artifact(torch.tensor([[3.0, 4.0], [5.0, 6.0]])))],
+    )
+
+    sink.close()
+    first_bytes = (tmp_path / "trajectory.npy").read_bytes()
+    sink.close()
+
+    np.testing.assert_array_equal(
+        np.load(tmp_path / "trajectory.npy"),
+        np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32),
+    )
+    assert (tmp_path / "trajectory.npy").read_bytes() == first_bytes
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_each_declared_artifact_is_optional(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    sink = TensorArtifactOutputSink(output_dir)
+    sink.open(_session_desc())
+    sink.write(0, [_result(0)])
+
+    sink.close()
+
+    assert not output_dir.exists()
+
+
+def test_sink_rejects_undeclared_outputs(tmp_path: Path) -> None:
+    other = TensorArtifactSchema(
+        name="other",
+        dimension_names=("sample", "coordinate"),
+    )
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+
+    with pytest.raises(ValueError, match="'other'.*not declared"):
+        sink.write(0, [_result(0, _artifact(torch.zeros(1, 2), other))])
+
+
+def test_sink_rejects_changed_schema(tmp_path: Path) -> None:
+    changed = TensorArtifactSchema(
+        name="trajectory",
+        dimension_names=("sample", "feature"),
+    )
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+
+    with pytest.raises(ValueError, match="'trajectory'.*does not match"):
+        sink.write(0, [_result(0, _artifact(torch.zeros(1, 2), changed))])
+
+
+def test_sink_rejects_duplicates_within_one_result(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    artifact = _artifact(torch.zeros(1, 2))
+
+    with pytest.raises(ValueError, match="'trajectory'.*more than once"):
+        sink.write(0, [_result(0, artifact, artifact)])
+
+    sink.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_sink_rejects_duplicates_across_result_channels(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+
+    with pytest.raises(ValueError, match="'trajectory'.*output channels"):
+        sink.write(
+            0,
+            [
+                _result(0, _artifact(torch.zeros(1, 2))),
+                _result(0, _artifact(torch.ones(1, 2))),
+            ],
+        )
+
+    sink.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_sink_rejects_dtype_changes(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    sink.write(0, [_result(0, _artifact(torch.zeros(1, 2)))])
+
+    with pytest.raises(ValueError, match="'trajectory'.*changed dtype"):
+        sink.write(
+            0,
+            [_result(1, _artifact(torch.zeros(1, 2, dtype=torch.int64)))],
+        )
+
+
+def test_sink_rejects_dtypes_numpy_cannot_store(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+
+    with pytest.raises(ValueError, match="'trajectory'.*cannot be stored"):
+        sink.write(
+            0,
+            [_result(0, _artifact(torch.zeros(1, 2, dtype=torch.bfloat16)))],
+        )
+
+
+def test_sink_rejects_non_concatenated_dimension_changes(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    sink.write(0, [_result(0, _artifact(torch.zeros(1, 2)))])
+
+    with pytest.raises(ValueError, match="'trajectory'.*non-concatenated"):
+        sink.write(0, [_result(1, _artifact(torch.zeros(3, 4)))])
+
+
+def test_sink_permits_concatenated_dimension_changes(tmp_path: Path) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    sink.write(0, [_result(0, _artifact(torch.zeros(1, 2)))])
+    sink.write(0, [_result(1, _artifact(torch.ones(3, 2)))])
+
+    sink.close()
+
+    assert np.load(tmp_path / "trajectory.npy").shape == (4, 2)
+
+
+def test_non_concatenated_artifact_permits_only_one_output(
+    tmp_path: Path,
+) -> None:
+    summary = TensorArtifactSchema(
+        name="summary",
+        dimension_names=("coordinate",),
+        concatenate_axis=None,
+    )
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc(summary))
+    sink.write(0, [_result(0, _artifact(torch.zeros(2), summary))])
+
+    with pytest.raises(ValueError, match="'summary'.*at most one"):
+        sink.write(0, [_result(1, _artifact(torch.ones(2), summary))])
+
+
+def test_new_generation_replaces_old_and_late_old_results_are_ignored(
     tmp_path: Path,
 ) -> None:
     sink = TensorArtifactOutputSink(tmp_path)
     sink.open(_session_desc())
-    sink.write(_result(0, torch.tensor([[1.0, 2.0]])))
-    sink.write(_result(1, torch.tensor([[3.0, 4.0], [5.0, 6.0]])))
-
-    sink.close()
-    first_bytes = (tmp_path / "actions.npy").read_bytes()
+    sink.write(0, [_result(0, _artifact(torch.tensor([[0.0, 0.0]])))])
+    sink.write(1, [_result(0, _artifact(torch.tensor([[1.0, 1.0]])))])
+    sink.write(0, [_result(1, _artifact(torch.tensor([[9.0, 9.0]])))])
+    sink.write(1, [_result(1, _artifact(torch.tensor([[2.0, 2.0]])))])
     sink.close()
 
     np.testing.assert_array_equal(
-        np.load(tmp_path / "actions.npy"),
-        np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32),
+        np.load(tmp_path / "trajectory.npy"),
+        np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float32),
     )
-    assert (tmp_path / "actions.npy").read_bytes() == first_bytes
+
+
+def test_sink_requires_open_and_open_requires_a_declared_schema(
+    tmp_path: Path,
+) -> None:
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.close()
+
+    with pytest.raises(RuntimeError, match=r"open\(\).*before write"):
+        sink.write(0, [_result(0)])
+
+    with pytest.raises(ValueError, match="at least one tensor artifact"):
+        sink.open(SessionDesc())
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_staging_failure_preserves_an_existing_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "trajectory.npy"
+    destination.write_bytes(b"previous")
+    sink = TensorArtifactOutputSink(tmp_path)
+    sink.open(_session_desc())
+    sink.write(0, [_result(0, _artifact(torch.zeros(1, 2)))])
+
+    def fail_write(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise OSError("write failed")
+
+    monkeypatch.setattr(artifact_sink_module, "_write_numpy", fail_write)
+
+    with pytest.raises(OSError, match="write failed"):
+        sink.close()
+
+    assert destination.read_bytes() == b"previous"
     assert not list(tmp_path.glob("*.tmp"))
 
 
-def test_tensor_artifact_sink_rejects_undeclared_outputs(tmp_path: Path) -> None:
-    other = TensorArtifactSchema(
-        name="other",
-        dimension_names=("step", "channel"),
-    )
-    result = _result(0, torch.zeros(1, 2))
-    result = StepResult(
-        step_index=result.step_index,
-        output=result.output,
-        frame_count=result.frame_count,
-        output_layout=result.output_layout,
-        tensor_artifacts=(
-            TensorArtifactOutput(schema=other, tensor=torch.zeros(1, 2)),
-        ),
-    )
+def test_replace_failure_removes_staged_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "trajectory.npy"
+    destination.write_bytes(b"previous")
     sink = TensorArtifactOutputSink(tmp_path)
     sink.open(_session_desc())
+    sink.write(0, [_result(0, _artifact(torch.zeros(1, 2)))])
 
-    with pytest.raises(ValueError, match="not declared"):
-        sink.write(result)
+    def fail_replace(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(artifact_sink_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        sink.close()
+
+    assert destination.read_bytes() == b"previous"
+    assert not list(tmp_path.glob("*.tmp"))
 
 
-def test_tensor_artifact_output_validates_its_rank() -> None:
-    with pytest.raises(ValueError, match="declares 2 dimensions"):
-        TensorArtifactOutput(schema=_ACTIONS, tensor=torch.zeros(1, 2, 3))
-
-
-def test_tensor_artifact_names_cannot_escape_the_output_directory() -> None:
+@pytest.mark.parametrize(
+    "name",
+    ["../trajectory", "/absolute", ".hidden", "contains space"],
+)
+def test_artifact_names_cannot_escape_the_output_directory(name: str) -> None:
     with pytest.raises(ValueError, match="Tensor artifact names"):
         TensorArtifactSchema(
-            name="../actions",
-            dimension_names=("step", "channel"),
+            name=name,
+            dimension_names=("sample", "coordinate"),
         )
+
+
+def test_artifact_schema_validates_dimension_names() -> None:
+    with pytest.raises(ValueError, match="'trajectory'.*non-empty"):
+        TensorArtifactSchema(name="trajectory", dimension_names=("sample", " "))
+    with pytest.raises(ValueError, match="'trajectory'.*unique"):
+        TensorArtifactSchema(
+            name="trajectory",
+            dimension_names=("sample", "sample"),
+        )
+
+
+@pytest.mark.parametrize("axis", [2, -3])
+def test_artifact_schema_validates_concatenation_axis(axis: int) -> None:
+    with pytest.raises(ValueError, match="'trajectory'.*concatenate_axis"):
+        TensorArtifactSchema(
+            name="trajectory",
+            dimension_names=("sample", "coordinate"),
+            concatenate_axis=axis,
+        )
+
+
+def test_scalar_artifact_requires_no_concatenation_axis() -> None:
+    with pytest.raises(ValueError, match="'summary'.*concatenate_axis"):
+        TensorArtifactSchema(name="summary", dimension_names=())
+
+    assert (
+        TensorArtifactSchema(
+            name="summary",
+            dimension_names=(),
+            concatenate_axis=None,
+        ).concatenate_axis
+        is None
+    )
+
+
+def test_artifact_output_validates_its_rank() -> None:
+    with pytest.raises(ValueError, match="'trajectory'.*declares 2 dimensions"):
+        TensorArtifactOutput(schema=_TRAJECTORY, tensor=torch.zeros(1, 2, 3))
+
+
+def test_session_desc_rejects_duplicate_artifact_names() -> None:
+    duplicate = TensorArtifactSchema(
+        name="trajectory",
+        dimension_names=("sample",),
+    )
+
+    with pytest.raises(ValueError, match="artifact names must be unique"):
+        SessionDesc(tensor_artifact_schemas=(_TRAJECTORY, duplicate))

--- a/integrations_v2/README.md
+++ b/integrations_v2/README.md
@@ -170,6 +170,42 @@ even when the body is one line — a browser client can ask for one at any time.
 Register no UI loop unless you need one. The default composites every model
 channel into one frame, which is what all of these except `slangpy_ui_demo` do.
 
+## Emitting tensor artifacts
+
+When a model produces structured tensors beside video, declare each one in the
+application's natural `SessionDesc` and attach a matching output to one model
+result:
+
+```python
+TRAJECTORY_SCHEMA = TensorArtifactSchema(
+    name="trajectory",
+    dimension_names=("sample", "coordinate"),
+    concatenate_axis=0,
+)
+
+SessionDesc(tensor_artifact_schemas=(TRAJECTORY_SCHEMA,))
+
+StepResult(
+    ...,
+    tensor_artifacts=(
+        TensorArtifactOutput(schema=TRAJECTORY_SCHEMA, tensor=trajectory),
+    ),
+)
+```
+
+Define each schema once and reuse it. Artifact names are stable routing and
+filename keys, dimension names define the exact rank and storage order, and the
+concatenation axis joins chunks from successive steps. Use
+`concatenate_axis=None` for a single output per session generation. Every
+declared artifact is optional, but a name may appear at most once across all
+channels returned by one model step; attach it to one channel only.
+
+Artifacts are model outputs, not video channels. A caller must request their
+persistence independently; on the command line,
+`--tensor-artifact-dir DIR` writes one NumPy file per emitted name. Test the
+declared schema, duplicate behavior, reset behavior, and the saved array's exact
+dtype, shape, and values.
+
 ## Running it
 
 ```bash

--- a/integrations_v2/README.md
+++ b/integrations_v2/README.md
@@ -201,10 +201,15 @@ declared artifact is optional, but a name may appear at most once across all
 channels returned by one model step; attach it to one channel only.
 
 Artifacts are model outputs, not video channels. A caller must request their
-persistence independently; on the command line,
-`--tensor-artifact-dir DIR` writes one NumPy file per emitted name. Test the
-declared schema, duplicate behavior, reset behavior, and the saved array's exact
-dtype, shape, and values.
+persistence independently. `--tensor-artifact-dir DIR` writes one NumPy file
+per emitted name plus **tensor_artifacts.json**. The manifest preserves every
+declared artifact's dimension names and concatenation axis and records its
+emitted path, dtype, and shape. Consume the arrays only when it says
+`complete: true`; a failed run discards buffered arrays and leaves an incomplete
+manifest, while a successful run removes stale files for optional artifacts it
+did not emit. Test the declared schema, duplicate behavior, reset and failure
+behavior, manifest metadata, and the saved array's exact dtype, shape, and
+values.
 
 ## Running it
 


### PR DESCRIPTION
## Summary

- add model-neutral typed tensor artifact schemas and outputs to the V2 session/result contracts
- add a generation-aware `ModelOutputSink` path that receives complete model-step channel batches independently of UI presentation and the legacy metrics sink
- persist requested artifacts as transactional NumPy files with a machine-readable commit manifest

## Contract details

- artifact names are unique across the complete result-channel batch for a model step
- reset generations use latest-generation-wins semantics; newer results clear buffered older output and late stale results are ignored
- schemas, ranks, NumPy-compatible dtypes, and concatenated/non-concatenated shapes are validated before a batch is accepted
- `--tensor-artifact-dir` fails before application/window startup when an application declares no artifact schemas
- the sink creates and validates its destination during `open`, before generation starts
- `tensor_artifacts.json` records completeness plus each declared artifact’s emitted state, dimension names, concatenation axis, path, dtype, and shape
- only successful model execution commits buffered arrays and a `complete: true` manifest; failed execution discards buffered arrays and leaves the manifest incomplete
- declared artifacts remain optional; a successful run removes stale files for declared artifacts it did not emit
- publication stages backups for every declared artifact and restores the prior artifact set if array replacement, stale-file removal, or final manifest promotion fails

## Validation

- `python -m pytest flashdreams/test_v2 -m ci_cpu -q` — 276 passed
- `pre-commit run --files <changed files>` — passed, including Ruff and `ty`

## Stack

This is the model-neutral prerequisite for #520. It contains no LingBot-specific code, tests, documentation, or assets. PR #520 will be rebased onto this branch and reduced to the LingBot model plus its V2 adapter.