### PR TITLE
feat(runtime-v2): add synchronized audio output

### DIFF
--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -62,6 +62,8 @@ self.register_model_loop(ModelLoop, state=ModelState(self._desc))
 `state` is required for a model loop and optional for a UI loop. Each loop's rate
 comes from the session description: the model loop steps at
 `frames_per_second_for_step`, and the UI ticks at `frames_per_second_for_ui`.
+Both values are strictly positive integers; this keeps file encoders, pacing,
+and WebRTC time bases on one exact public contract.
 
 The io-thread initially selects frames from model chunks at
 `frames_per_second_for_step`, then uses the model-generation-thread's rolling
@@ -119,6 +121,26 @@ four channels. Four channels is RGBA, and composites over what is beneath it.
 Output sinks read floating-point frames as `[-1, 1]` and integer frames as
 `[0, 255]`. No `SessionDesc` setting remaps this; a UI loop that works in some
 other range converts before returning.
+
+### Synchronized audio
+
+A session that emits audio sets both `SessionDesc.audio_sample_rate` and
+`SessionDesc.audio_channels`; setting only one is invalid. Mono and stereo are
+supported by the model-neutral contract. A sink that cannot consume the
+declared format rejects the session from `open`, before generation starts.
+
+`StepResult.audio` is an optional `AudioOutput`. Its floating-point `samples`
+have channel-major shape `[channels, samples]`, contain only finite normalized
+PCM in `[-1, 1]`, and carry the declared sample rate. `sample_offset` is the
+absolute zero-based position of the payload on the session audio timeline. A
+forward gap is therefore explicit silence; overlapping or backward payloads
+are invalid for the built-in MP4 sink.
+
+Only one channel in a model chunk may carry audio. The presentation manager
+makes that payload available once, with the chunk's first presented frame.
+`BlitModelOutputToScreenLoop` forwards it automatically. A custom UI loop owns
+that decision and calls `presented_model_audio()` at most once per chunk before
+attaching the returned payload to its own `StepResult`.
 
 ## A minimal application
 

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -22,6 +22,7 @@ from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 if TYPE_CHECKING:
+    from flashdreams.runtime_v2.audio_output import AudioOutput
     from flashdreams.runtime_v2.presentation_manager import PresentationManager
 
 StateT = TypeVar("StateT")
@@ -307,6 +308,11 @@ class IUILoop(ILoop[StateT], ABC):
             empty tuple before the first model result has been presented.
         """
         return self._presentation_manager.presented_frames()
+
+    @final
+    def presented_model_audio(self) -> AudioOutput | None:
+        """Return the current model chunk's audio payload at most once."""
+        return self._presentation_manager.presented_audio()
 
 
 def _contains_close(events: UserInputEvents) -> bool:

--- a/flashdreams/flashdreams/api_v2/output_sink.py
+++ b/flashdreams/flashdreams/api_v2/output_sink.py
@@ -26,6 +26,10 @@ class OutputSink(Protocol):
             session_desc: Output description declared by the session. The sink
                 configures itself from it and may reject a description it
                 cannot present.
+
+        Raises:
+            ValueError: The description declares output this sink cannot
+                consume, including audio for a video-only sink.
         """
         ...
 
@@ -44,3 +48,25 @@ class OutputSink(Protocol):
     def close(self) -> None:
         """Finish pending writes and release resources."""
         ...
+
+
+@runtime_checkable
+class AbortableOutputSink(OutputSink, Protocol):
+    """An output sink that can discard an incomplete session atomically.
+
+    Both terminal operations must be idempotent. The runtime calls ``close``
+    only for a successful run. It calls ``abort`` after cancellation or failure,
+    including when ``open``, ``write``, or ``close`` raised partway through.
+
+    Atomicity is per sink. A run with multiple abortable sinks does not provide
+    a cross-sink prepare/commit transaction, so one sink may publish before a
+    later sink's commit fails.
+    """
+
+    @abstractmethod
+    def abort(self) -> None:
+        """Release resources and discard all unpublished output."""
+        ...
+
+
+__all__ = ["AbortableOutputSink", "OutputSink"]

--- a/flashdreams/flashdreams/core/exceptions.py
+++ b/flashdreams/flashdreams/core/exceptions.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exception compatibility helpers shared across FlashDreams."""
+
+
+def add_exception_note(error: BaseException, note: str) -> None:
+    """Add diagnostic context when the running Python supports exception notes.
+
+    ``BaseException.add_note`` was added in Python 3.11, while FlashDreams
+    supports Python 3.10. Cleanup must never replace the primary failure merely
+    because that compatibility method is absent.
+    """
+    add_note = getattr(error, "add_note", None)
+    if callable(add_note):
+        add_note(note)
+
+
+__all__ = ["add_exception_note"]

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -44,8 +44,8 @@ Presenting it:
 - `slangpy_ui_loop.py` and `_slangpy_ui_renderer.py` are the UI loop for
   applications that draw widgets over the model output.
 - `mp4_client_window.py` and `webrtc_client_window.py` are the two windows.
-- `mp4_output_sink.py`, `metrics_output_sink.py`, `video_encoder.py` and
-  `video_tensor.py` are what output is written through.
+- `mp4_output_sink.py`, `mp4_audio.py`, `metrics_output_sink.py`,
+  `video_encoder.py` and `video_tensor.py` are what output is written through.
 - `serving/` is the HTTP and WebRTC server behind the browser window.
 
 Input:
@@ -166,9 +166,11 @@ A UI loop reads model frames through `presented_model_frame` and
 
 The default UI loop, `BlitModelOutputToScreenLoop`, composites every model
 channel in list order as if they were image layers and reshapes the result into
-the session's layout. `SlangPyUILoop` is the alternative, for widgets drawn over
-the model output; it returns a `[1, C, H, W]` frame, so a session using it
-declares a `tchw` layout.
+the session's layout. It also forwards a model chunk's audio payload once, on
+the first presented frame. `SlangPyUILoop` is the alternative, for widgets
+drawn over model output; it returns a `[1, C, H, W]` frame, so a session using
+it declares a `tchw` layout. A custom UI loop must explicitly forward audio by
+calling `presented_model_audio()`.
 
 `IClientWindow` is both an `InputSource` and an `OutputSink`, so a window is
 written to with the same three calls as any sink: `open` with the session
@@ -183,6 +185,29 @@ has to finish on its own. The WebRTC window turns browser keyboard, mouse and
 focus events into input and a disconnecting browser into a close; because those
 arrive on the server's own thread, it queues them and hands them over in batches
 when the session asks.
+
+MP4 publication is transactional. Video, normalized PCM, and any synchronized
+mux are written below a unique private sibling directory. The final file
+replaces the requested target atomically only after the application has closed
+successfully and every encoder has exited successfully. Exceptional exits abort
+active child processes and preserve an existing target. If an abort is
+interrupted, the runtime makes one bounded final retry. A recovered transient
+failure removes staging; a persistent failure is reported while the sink
+retains ownership for an explicit later retry.
+
+Audio is staged as interleaved `f32le`. Forward offsets become silence, and the
+complete stream is padded or truncated to
+`round(written_frames * sample_rate / fps)` before muxing. Both video encoding
+and audio muxing invoke an administrator- or user-provided `ffmpeg` executable
+on `PATH`; the runtime does not use an in-process or Python-bundled FFmpeg. An
+audio session is published as AAC-LC at 192 kbit/s. Before creating staging or
+starting inference, the MP4 sink runs a bounded one-frame encode through that
+same resolved host executable using the declared sample rate and channel
+count. The final mux deadline scales with the written media duration. On a
+timeout, terminate and kill waits are separately bounded; a child that still
+cannot be reaped remains owned by the sink for a later abort retry rather than
+having its staging removed underneath it. WebRTC output currently rejects
+audio.
 
 What a sink expects of the pixel values it is handed is part of the result
 contract, in [`api_v2`](../api_v2/README.md#what-a-step-returns).

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 
 from flashdreams.api_v2.application import IApplication
 from flashdreams.api_v2.client_window import IClientWindow
-from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.api_v2.output_sink import AbortableOutputSink, OutputSink
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.session_runner import run_session
 
@@ -56,6 +56,13 @@ class ApplicationRunner:
             commandline_args: Arguments owned and parsed by the application.
         """
         run_started = False
+        application_closed = False
+
+        def close_before_output_commit() -> None:
+            nonlocal application_closed
+            application_closed = True
+            self._application.close()
+
         try:
             self._application.init(commandline_args)
             session = self._application.create_session(session_desc)
@@ -64,25 +71,30 @@ class ApplicationRunner:
                 session,
                 self._client_window,
                 metrics_output_sink=self._metrics_output_sink,
+                before_output_commit=close_before_output_commit,
             )
         finally:
             if not run_started:
                 _close_client_window(self._client_window)
                 if self._metrics_output_sink is not None:
                     _close_output_sink(self._metrics_output_sink)
-            _close_application(
-                self._application, run_failed=sys.exc_info()[0] is not None
-            )
+            if not application_closed:
+                _close_application(
+                    self._application, run_failed=sys.exc_info()[0] is not None
+                )
 
 
 def _close_client_window(client_window: IClientWindow) -> None:
-    """Close a window the run never reached, so what it was serving goes with it.
+    """Release a window the run never reached, aborting transactions.
 
     The run has already failed by the time this is called, so a failure here is
     logged rather than raised over the top of it.
     """
     try:
-        client_window.close()
+        if isinstance(client_window, AbortableOutputSink):
+            client_window.abort()
+        else:
+            client_window.close()
     except Exception:
         _LOGGER.exception(
             "The client window failed to close after a run that never started."
@@ -90,9 +102,12 @@ def _close_client_window(client_window: IClientWindow) -> None:
 
 
 def _close_output_sink(output_sink: OutputSink) -> None:
-    """Close a metrics sink after a run that never reached it."""
+    """Release a metrics sink after a run that never reached it."""
     try:
-        output_sink.close()
+        if isinstance(output_sink, AbortableOutputSink):
+            output_sink.abort()
+        else:
+            output_sink.close()
     except Exception:
         _LOGGER.exception(
             "The metrics output sink failed to close after a run that never started."

--- a/flashdreams/flashdreams/runtime_v2/audio_output.py
+++ b/flashdreams/flashdreams/runtime_v2/audio_output.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed normalized PCM output for the v2 runtime."""
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class AudioOutput:
+    """Normalized PCM samples generated alongside video."""
+
+    samples: Tensor
+    """Channel-major PCM samples with shape ``[channels, samples]`` in ``[-1, 1]``."""
+
+    sample_rate: int
+    """Samples per second."""
+
+    sample_offset: int = 0
+    """Zero-based sample position of the first sample in the session timeline."""
+
+    def __post_init__(self) -> None:
+        _validate_samples(self.samples)
+        if (
+            isinstance(self.sample_rate, bool)
+            or not isinstance(self.sample_rate, int)
+            or self.sample_rate <= 0
+        ):
+            raise ValueError("AudioOutput.sample_rate must be a positive integer.")
+        if isinstance(self.sample_offset, bool) or not isinstance(
+            self.sample_offset, int
+        ):
+            raise ValueError(
+                "AudioOutput.sample_offset must be a non-negative integer."
+            )
+        if self.sample_offset < 0:
+            raise ValueError(
+                "AudioOutput.sample_offset must be a non-negative integer."
+            )
+
+
+def _validate_samples(samples: Tensor) -> None:
+    if not isinstance(samples, Tensor):
+        raise TypeError("AudioOutput.samples must be a torch.Tensor.")
+    if samples.ndim != 2:
+        raise ValueError(
+            "AudioOutput.samples must have shape [channels, samples], got "
+            f"{tuple(samples.shape)}."
+        )
+    if samples.shape[0] not in (1, 2):
+        raise ValueError(
+            "AudioOutput.samples must contain mono or stereo PCM, got "
+            f"{samples.shape[0]} channels."
+        )
+    if samples.shape[1] <= 0:
+        raise ValueError("AudioOutput.samples must contain at least one sample.")
+    if not samples.is_floating_point():
+        raise ValueError("AudioOutput.samples must use a floating-point dtype.")
+    if not bool(torch.isfinite(samples).all()):
+        raise ValueError("AudioOutput.samples must contain only finite values.")
+    if bool((samples < -1.0).any()) or bool((samples > 1.0).any()):
+        raise ValueError("AudioOutput.samples must stay within [-1, 1].")
+
+
+def normalized_pcm(audio: AudioOutput) -> Tensor:
+    """Return validated contiguous ``float32`` PCM on the CPU.
+
+    Args:
+        audio: Audio payload to validate and convert.
+
+    Returns:
+        Channel-major samples with shape ``[channels, samples]``.
+
+    Raises:
+        ValueError: Samples are non-floating, non-finite, or outside ``[-1, 1]``.
+    """
+    _validate_samples(audio.samples)
+    return audio.samples.detach().to(device="cpu", dtype=torch.float32).contiguous()
+
+
+__all__ = ["AudioOutput", "normalized_pcm"]

--- a/flashdreams/flashdreams/runtime_v2/blit_model_output_to_screen_loop.py
+++ b/flashdreams/flashdreams/runtime_v2/blit_model_output_to_screen_loop.py
@@ -42,6 +42,7 @@ class BlitModelOutputToScreenLoop(IUILoop[None]):
             output=_frame_to_layout(output, self.output_layout),
             frame_count=1,
             output_layout=self.output_layout,
+            audio=self.presented_model_audio(),
         )
 
     def reset(self) -> None:

--- a/flashdreams/flashdreams/runtime_v2/mp4_audio.py
+++ b/flashdreams/flashdreams/runtime_v2/mp4_audio.py
@@ -1,0 +1,397 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private PCM staging and external-FFmpeg audio muxing for MP4 output."""
+
+import math
+import shutil
+import subprocess
+from pathlib import Path
+from typing import BinaryIO
+
+from flashdreams.core.exceptions import add_exception_note
+from flashdreams.runtime_v2.audio_output import AudioOutput, normalized_pcm
+
+_FLOAT32_BYTES = 4
+"""Bytes in one staged ``f32le`` channel sample."""
+
+_AAC_FRAME_SAMPLES = 1024
+"""Samples in one AAC-LC frame used for the preflight encode."""
+
+
+_AUDIO_CODEC_ARGUMENTS = (
+    "-c:a",
+    "aac",
+    "-profile:a",
+    "aac_low",
+    "-b:a",
+    "192k",
+)
+"""Fixed public MP4 audio encoding: AAC-LC at 192 kbit/s."""
+
+
+_PREFLIGHT_TIMEOUT_SECONDS = 10
+"""Maximum time the tiny external AAC capability check may take."""
+
+_MUX_MINIMUM_TIMEOUT_SECONDS = 30.0
+"""Minimum wall time allowed for a real audio mux."""
+
+_MUX_TIMEOUT_PER_MEDIA_SECOND = 2.0
+"""Additional mux allowance per second of staged media."""
+
+_PROCESS_STOP_TIMEOUT_SECONDS = 5.0
+"""Bound for each terminate and kill wait during cleanup."""
+
+
+def preflight_audio_codec(*, sample_rate: int, channels: int) -> str:
+    """Resolve host FFmpeg and prove the exact public audio encoding works.
+
+    This check runs before model generation so a missing product dependency
+    does not waste a rollout only to fail during the final mux.
+
+    Args:
+        sample_rate: PCM sample rate the session will publish.
+        channels: PCM channel count the session will publish.
+
+    Returns:
+        Resolved path to the host ``ffmpeg`` executable.
+
+    Raises:
+        RuntimeError: FFmpeg is unavailable or cannot encode the session format
+            as AAC-LC at the approved bitrate within the timeout.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("Writing MP4 audio needs an ffmpeg executable on PATH.")
+    ffmpeg_path = str(Path(ffmpeg).resolve())
+    try:
+        completed = subprocess.run(
+            [
+                ffmpeg_path,
+                "-hide_banner",
+                "-nostdin",
+                "-loglevel",
+                "error",
+                "-f",
+                "f32le",
+                "-ar",
+                str(sample_rate),
+                "-ac",
+                str(channels),
+                "-i",
+                "pipe:0",
+                "-frames:a",
+                "1",
+                *_AUDIO_CODEC_ARGUMENTS,
+                "-f",
+                "null",
+                "-",
+            ],
+            input=b"\0" * (_AAC_FRAME_SAMPLES * channels * _FLOAT32_BYTES),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=_PREFLIGHT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(
+            "Timed out while checking the host ffmpeg AAC-LC encoder."
+        ) from error
+    except OSError as error:
+        raise RuntimeError(
+            f"Could not check the host ffmpeg AAC-LC encoder: {error}"
+        ) from error
+    if completed.returncode != 0:
+        reported = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            "Host ffmpeg cannot encode this session as AAC-LC at 192 kbit/s: "
+            f"{reported or 'no output'}"
+        )
+    return ffmpeg_path
+
+
+class F32leAudioStager:
+    """Write normalized audio to a private interleaved ``f32le`` file."""
+
+    def __init__(self, path: str | Path, *, sample_rate: int, channels: int) -> None:
+        """
+        Args:
+            path: Private staging file to create.
+            sample_rate: Sample rate every audio payload must carry.
+            channels: Channel count every audio payload must carry.
+        """
+        self._path = Path(path)
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._stream: BinaryIO | None = self._path.open("wb")
+        self._samples_written = 0
+
+    @property
+    def path(self) -> Path:
+        """Return the private staging path."""
+        return self._path
+
+    @property
+    def samples_written(self) -> int:
+        """Return the number of samples written per channel."""
+        return self._samples_written
+
+    def write(self, audio: AudioOutput) -> None:
+        """Write one channel-major PCM payload at its absolute offset.
+
+        Forward gaps become silence. Overlapping or backward payloads are
+        rejected instead of silently changing samples already staged.
+
+        Args:
+            audio: Normalized PCM and its position on the session timeline.
+
+        Raises:
+            RuntimeError: The staging file has already been finished or aborted.
+            ValueError: The payload disagrees with the declared audio format or
+                overlaps samples already written.
+        """
+        stream = self._require_stream()
+        if audio.sample_rate != self._sample_rate:
+            raise ValueError(
+                f"Expected audio at {self._sample_rate} Hz, got {audio.sample_rate} Hz."
+            )
+        pcm = normalized_pcm(audio)
+        if pcm.shape[0] != self._channels:
+            raise ValueError(
+                f"Expected {self._channels} audio channels, got {pcm.shape[0]}."
+            )
+        if audio.sample_offset < self._samples_written:
+            raise ValueError(
+                f"Audio at offset {audio.sample_offset} overlaps the "
+                f"{self._samples_written} samples already written."
+            )
+        self._write_silence(audio.sample_offset - self._samples_written, stream)
+        interleaved = pcm.transpose(0, 1).contiguous().numpy()
+        stream.write(interleaved.tobytes())
+        self._samples_written += pcm.shape[1]
+
+    def finish(self, expected_samples: int) -> None:
+        """Pad or truncate to exactly ``expected_samples`` and close the file.
+
+        Args:
+            expected_samples: Samples per channel required by the video timeline.
+
+        Raises:
+            RuntimeError: The staging file has already been finished or aborted.
+            ValueError: ``expected_samples`` is negative.
+        """
+        if expected_samples < 0:
+            raise ValueError("Expected audio sample count must be non-negative.")
+        stream = self._require_stream()
+        if self._samples_written < expected_samples:
+            self._write_silence(expected_samples - self._samples_written, stream)
+        elif self._samples_written > expected_samples:
+            stream.truncate(expected_samples * self._channels * _FLOAT32_BYTES)
+            self._samples_written = expected_samples
+        stream.close()
+        self._stream = None
+
+    def abort(self) -> None:
+        """Close the private staging file without treating it as complete."""
+        stream = self._stream
+        if stream is not None:
+            stream.close()
+            self._stream = None
+
+    def _write_silence(self, samples: int, stream: BinaryIO) -> None:
+        """Append ``samples`` of zero-valued interleaved PCM."""
+        if samples:
+            stream.write(b"\0" * (samples * self._channels * _FLOAT32_BYTES))
+            self._samples_written += samples
+
+    def _require_stream(self) -> BinaryIO:
+        """Return the open staging file or report that the transaction ended."""
+        if self._stream is None:
+            raise RuntimeError("Audio staging has already finished or aborted.")
+        return self._stream
+
+
+class Mp4AudioMuxer:
+    """Mux staged video and raw audio through the host ``ffmpeg`` executable."""
+
+    def __init__(
+        self,
+        *,
+        video_path: str | Path,
+        audio_path: str | Path,
+        output_path: str | Path,
+        sample_rate: int,
+        channels: int,
+        ffmpeg_path: str,
+        duration_seconds: float,
+    ) -> None:
+        """
+        Args:
+            video_path: Complete staged video-only MP4.
+            audio_path: Complete private interleaved ``f32le`` PCM.
+            output_path: Staged synchronized MP4 to create.
+            sample_rate: PCM sample rate.
+            channels: PCM channel count.
+            ffmpeg_path: Host executable resolved by the early exact preflight.
+            duration_seconds: Staged media duration used to scale the mux
+                deadline.
+
+        Raises:
+            ValueError: ``duration_seconds`` is negative or non-finite.
+        """
+        if not math.isfinite(duration_seconds) or duration_seconds < 0:
+            raise ValueError("Audio mux duration must be finite and non-negative.")
+        self._video_path = Path(video_path)
+        self._audio_path = Path(audio_path)
+        self._output_path = Path(output_path)
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._ffmpeg_path = ffmpeg_path
+        self._timeout_seconds = max(
+            _MUX_MINIMUM_TIMEOUT_SECONDS,
+            duration_seconds * _MUX_TIMEOUT_PER_MEDIA_SECOND,
+        )
+        self._process: subprocess.Popen[bytes] | None = None
+        self._finished = False
+
+    def close(self) -> None:
+        """Run the mux and require the external process to succeed.
+
+        Raises:
+            RuntimeError: ``ffmpeg`` is unavailable or the mux fails.
+        """
+        if self._finished:
+            return
+        try:
+            process = subprocess.Popen(
+                self._command(self._ffmpeg_path),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as error:
+            raise RuntimeError(f"Could not start ffmpeg audio mux: {error}") from error
+        self._process = process
+        try:
+            _, errors = process.communicate(timeout=self._timeout_seconds)
+        except subprocess.TimeoutExpired as error:
+            failure = RuntimeError(
+                "Timed out after "
+                f"{self._timeout_seconds:g} seconds while muxing "
+                f"{self._output_path}."
+            )
+            try:
+                self._terminate_and_reap(process)
+            except BaseException as cleanup_error:
+                add_exception_note(
+                    failure,
+                    f"FFmpeg mux timeout cleanup also failed: {cleanup_error!r}",
+                )
+            raise failure from error
+        self._process = None
+        if process.returncode != 0:
+            reported = errors.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(
+                f"ffmpeg failed while muxing {self._output_path}: "
+                f"{reported or 'no output'}"
+            )
+        self._finished = True
+
+    def abort(self) -> None:
+        """Terminate and wait for an active mux process, if any.
+
+        Each wait is bounded. Ownership is retained if the process cannot be
+        reaped, so a later abort can retry without deleting files it may use.
+        """
+        process = self._process
+        if process is None:
+            return
+        self._terminate_and_reap(process)
+
+    def _terminate_and_reap(self, process: subprocess.Popen[bytes]) -> None:
+        """Stop ``process`` with bounded terminate/kill escalation."""
+        failure: BaseException | None = None
+        reaped = False
+        if process.poll() is None:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            except BaseException as error:
+                failure = error
+        try:
+            process.communicate(timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
+            reaped = True
+        except subprocess.TimeoutExpired:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            except BaseException as error:
+                failure = _append_secondary_failure(
+                    failure, error, "Killing the ffmpeg audio mux also failed"
+                )
+            try:
+                process.communicate(timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
+                reaped = True
+            except BaseException as error:
+                failure = _append_secondary_failure(
+                    failure, error, "Reaping the killed ffmpeg audio mux also failed"
+                )
+        except BaseException as error:
+            failure = _append_secondary_failure(
+                failure, error, "Reaping the ffmpeg audio mux also failed"
+            )
+        if reaped:
+            self._process = None
+        if failure is not None:
+            raise failure
+
+    def _command(self, ffmpeg: str) -> list[str]:
+        """Return the external invocation that copies video and encodes audio."""
+        return [
+            ffmpeg,
+            "-y",
+            "-nostdin",
+            "-loglevel",
+            "error",
+            "-i",
+            str(self._video_path),
+            "-f",
+            "f32le",
+            "-ar",
+            str(self._sample_rate),
+            "-ac",
+            str(self._channels),
+            "-i",
+            str(self._audio_path),
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:a:0",
+            "-c:v",
+            "copy",
+            *_AUDIO_CODEC_ARGUMENTS,
+            "-movflags",
+            "+faststart",
+            str(self._output_path),
+        ]
+
+
+def _append_secondary_failure(
+    failure: BaseException | None,
+    error: BaseException,
+    message: str,
+) -> BaseException:
+    """Keep the first cleanup failure and annotate later ones."""
+    if failure is None:
+        return error
+    add_exception_note(failure, f"{message}: {error!r}")
+    return failure
+
+
+__all__ = [
+    "F32leAudioStager",
+    "Mp4AudioMuxer",
+    "preflight_audio_codec",
+]

--- a/flashdreams/flashdreams/runtime_v2/mp4_client_window.py
+++ b/flashdreams/flashdreams/runtime_v2/mp4_client_window.py
@@ -46,5 +46,9 @@ class Mp4ClientWindow(IClientWindow):
         self._video_sink.write(result)
 
     def close(self) -> None:
-        """Finish the MP4 file."""
+        """Finish and atomically publish the MP4 file."""
         self._video_sink.close()
+
+    def abort(self) -> None:
+        """Discard an incomplete MP4 without changing the target."""
+        self._video_sink.abort()

--- a/flashdreams/flashdreams/runtime_v2/mp4_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/mp4_output_sink.py
@@ -3,15 +3,27 @@
 
 """Output sink writing what a session generates to an MP4 file."""
 
+import logging
+import os
+import shutil
+import tempfile
 from pathlib import Path
 
-from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.api_v2.output_sink import AbortableOutputSink
+from flashdreams.core.exceptions import add_exception_note
+from flashdreams.runtime_v2.mp4_audio import (
+    F32leAudioStager,
+    Mp4AudioMuxer,
+    preflight_audio_codec,
+)
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.video_encoder import Mp4Encoder, result_to_rgb24_frames
 
+_LOGGER = logging.getLogger(__name__)
 
-class Mp4OutputSink(OutputSink):
+
+class Mp4OutputSink(AbortableOutputSink):
     """Encode results into an MP4 file.
 
     Each result is encoded as it arrives, and the run is bounded by whatever
@@ -30,6 +42,13 @@ class Mp4OutputSink(OutputSink):
         self._path = Path(path)
         self._session_desc: SessionDesc | None = None
         self._encoder: Mp4Encoder | None = None
+        self._audio_stager: F32leAudioStager | None = None
+        self._muxer: Mp4AudioMuxer | None = None
+        self._audio_ffmpeg_path: str | None = None
+        self._staging_dir: Path | None = None
+        self._staged_video_path: Path | None = None
+        self._staged_output_path: Path | None = None
+        self._frames_written = 0
 
     def open(self, session_desc: SessionDesc) -> None:
         """Prepare to encode a session's output.
@@ -43,16 +62,74 @@ class Mp4OutputSink(OutputSink):
                 becomes the rate the file plays back at.
 
         Raises:
-            ValueError: The frames are an odd number of pixels wide or high,
-                which this cannot encode.
+            ValueError: The frames are an odd number of pixels wide or high.
+            RuntimeError: The host cannot encode the declared audio format as
+                the fixed public AAC-LC encoding.
         """
-        self._session_desc = session_desc
-        self._encoder = Mp4Encoder(
-            self._path,
-            width=session_desc.video_width,
-            height=session_desc.video_height,
-            frames_per_second=session_desc.frames_per_second_for_step,
+        if self._session_desc is not None or self._staging_dir is not None:
+            raise RuntimeError("Mp4OutputSink is already open.")
+        audio_ffmpeg_path: str | None = None
+        if session_desc.audio_sample_rate is not None:
+            assert session_desc.audio_channels is not None
+            audio_ffmpeg_path = preflight_audio_codec(
+                sample_rate=session_desc.audio_sample_rate,
+                channels=session_desc.audio_channels,
+            )
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        staging_dir = Path(
+            tempfile.mkdtemp(
+                prefix=f".{self._path.name}.",
+                dir=self._path.parent,
+            )
         )
+        staged_video_path = staging_dir / "video.mp4"
+        staged_output_path = staging_dir / "output.mp4"
+        encoder: Mp4Encoder | None = None
+        audio_stager: F32leAudioStager | None = None
+        try:
+            encoder = Mp4Encoder(
+                staged_video_path,
+                width=session_desc.video_width,
+                height=session_desc.video_height,
+                frames_per_second=session_desc.frames_per_second_for_step,
+            )
+            if session_desc.audio_sample_rate is not None:
+                assert session_desc.audio_channels is not None
+                audio_stager = F32leAudioStager(
+                    staging_dir / "audio.f32le",
+                    sample_rate=session_desc.audio_sample_rate,
+                    channels=session_desc.audio_channels,
+                )
+        except BaseException as error:
+            if audio_stager is not None:
+                try:
+                    audio_stager.abort()
+                except BaseException as cleanup_error:
+                    add_exception_note(
+                        error, f"Audio staging cleanup also failed: {cleanup_error!r}"
+                    )
+            if encoder is not None:
+                try:
+                    encoder.abort()
+                except BaseException as cleanup_error:
+                    add_exception_note(
+                        error, f"Video encoder cleanup also failed: {cleanup_error!r}"
+                    )
+            try:
+                shutil.rmtree(staging_dir)
+            except BaseException as cleanup_error:
+                add_exception_note(
+                    error, f"Staging cleanup also failed: {cleanup_error!r}"
+                )
+            raise
+        self._session_desc = session_desc
+        self._encoder = encoder
+        self._audio_stager = audio_stager
+        self._audio_ffmpeg_path = audio_ffmpeg_path
+        self._staging_dir = staging_dir
+        self._staged_video_path = staged_video_path
+        self._staged_output_path = staged_output_path
+        self._frames_written = 0
 
     def write(self, result: StepResult) -> None:
         """Encode the frames in ``result``.
@@ -67,19 +144,157 @@ class Mp4OutputSink(OutputSink):
         """
         if self._session_desc is None or self._encoder is None:
             raise RuntimeError("Mp4OutputSink.open() must run before write().")
-        self._encoder.write(result_to_rgb24_frames(result, self._session_desc))
+        frames = result_to_rgb24_frames(result, self._session_desc)
+        if result.audio is not None:
+            audio_stager = self._audio_stager
+            if audio_stager is None:
+                raise ValueError(
+                    "A result carried audio for a session that declared none."
+                )
+            audio_stager.write(result.audio)
+        self._encoder.write(frames)
+        self._frames_written += len(frames)
 
     def close(self) -> None:
-        """Finish the file.
+        """Commit a complete staged MP4 atomically.
 
-        Can be called on a sink that was never opened, or twice.
+        Can be called on a sink that was never opened, or twice. An empty
+        session preserves any existing target and publishes nothing.
 
         Raises:
-            RuntimeError: The encoder failed, so the file is unusable.
+            RuntimeError: Encoding failed or did not produce its staged file.
+            OSError: The staged file could not be published atomically.
         """
-        self._session_desc = None
-        encoder = self._encoder
-        if encoder is None:
+        if self._session_desc is None:
             return
+        encoder = self._encoder
+        if encoder is not None:
+            encoder.close()
+            self._encoder = None
+        if self._frames_written == 0:
+            if self._audio_stager is not None:
+                self._audio_stager.abort()
+                self._audio_stager = None
+            self._discard_staging()
+            self._clear_transaction()
+            return
+        staged_video_path = self._staged_video_path
+        if staged_video_path is None or not staged_video_path.is_file():
+            raise RuntimeError("MP4 encoding produced no staged video file.")
+        staged_output_path = staged_video_path
+        audio_stager = self._audio_stager
+        if audio_stager is not None:
+            session_desc = self._session_desc
+            assert session_desc.audio_sample_rate is not None
+            assert session_desc.audio_channels is not None
+            assert self._audio_ffmpeg_path is not None
+            expected_samples = round(
+                self._frames_written
+                * session_desc.audio_sample_rate
+                / session_desc.frames_per_second_for_step
+            )
+            audio_stager.finish(expected_samples)
+            self._audio_stager = None
+            staged_output_path = self._staged_output_path
+            if staged_output_path is None:
+                raise RuntimeError("MP4 audio mux has no staged output path.")
+            muxer = Mp4AudioMuxer(
+                video_path=staged_video_path,
+                audio_path=audio_stager.path,
+                output_path=staged_output_path,
+                sample_rate=session_desc.audio_sample_rate,
+                channels=session_desc.audio_channels,
+                ffmpeg_path=self._audio_ffmpeg_path,
+                duration_seconds=(
+                    self._frames_written / session_desc.frames_per_second_for_step
+                ),
+            )
+            self._muxer = muxer
+            muxer.close()
+            self._muxer = None
+            if not staged_output_path.is_file():
+                raise RuntimeError("MP4 audio mux produced no staged output file.")
+        os.replace(staged_output_path, self._path)
+        self._complete_transaction()
+
+    def abort(self) -> None:
+        """Discard staged output without changing the target.
+
+        This is idempotent and is valid after a partial ``open``, ``write``, or
+        ``close`` failure. Component ownership and staging are retained when
+        cleanup fails so a later call can retry safely.
+        """
+        failure: BaseException | None = None
+        muxer = self._muxer
+        if muxer is not None:
+            try:
+                muxer.abort()
+            except BaseException as error:
+                failure = error
+            else:
+                self._muxer = None
+        encoder = self._encoder
+        if encoder is not None:
+            try:
+                encoder.abort()
+            except BaseException as error:
+                if failure is None:
+                    failure = error
+                else:
+                    add_exception_note(
+                        failure, f"Video encoder cleanup also failed: {error!r}"
+                    )
+            else:
+                self._encoder = None
+        audio_stager = self._audio_stager
+        if audio_stager is not None:
+            try:
+                audio_stager.abort()
+            except BaseException as error:
+                if failure is None:
+                    failure = error
+                else:
+                    add_exception_note(
+                        failure, f"Audio staging cleanup also failed: {error!r}"
+                    )
+            else:
+                self._audio_stager = None
+        if failure is None:
+            try:
+                self._discard_staging()
+            except BaseException as error:
+                failure = error
+        if failure is None:
+            self._clear_transaction()
+        if failure is not None:
+            raise failure
+
+    def _discard_staging(self) -> None:
+        staging_dir = self._staging_dir
+        if staging_dir is not None and staging_dir.exists():
+            shutil.rmtree(staging_dir)
+
+    def _complete_transaction(self) -> None:
+        staging_dir = self._staging_dir
+        if staging_dir is not None:
+            try:
+                shutil.rmtree(staging_dir)
+            except OSError as error:
+                _LOGGER.warning(
+                    "Committed %s but could not remove staging directory %s: %s",
+                    self._path,
+                    staging_dir,
+                    error,
+                )
+        self._clear_transaction()
+
+    def _clear_transaction(self) -> None:
+        self._session_desc = None
         self._encoder = None
-        encoder.close()
+        self._audio_stager = None
+        self._muxer = None
+        self._audio_ffmpeg_path = None
+        self._staging_dir = None
+        self._staged_video_path = None
+        self._staged_output_path = None
+        self._frames_written = 0

--- a/flashdreams/flashdreams/runtime_v2/presentation_manager.py
+++ b/flashdreams/flashdreams/runtime_v2/presentation_manager.py
@@ -9,6 +9,7 @@ import threading
 import torch
 from torch import Tensor
 
+from flashdreams.runtime_v2.audio_output import AudioOutput
 from flashdreams.runtime_v2.session_desc import BackpressureMode
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -37,6 +38,7 @@ class PresentationManager:
         self._generation = 0
         self._presented_chunk: list[StepResult] | None = None
         self._frame_index = -1
+        self._audio_presented = False
         self._presented_frame_count = 0
         self.dropped_for_space = 0
         """Chunks dropped because the UI could not keep up with the model."""
@@ -102,6 +104,13 @@ class PresentationManager:
         frame_count = chunk[0].frame_count
         if frame_count <= 0 or any(item.frame_count != frame_count for item in chunk):
             raise ValueError("Every channel in a chunk must have the same frame_count.")
+        if any(
+            item.audio is not None and not isinstance(item.audio, AudioOutput)
+            for item in chunk
+        ):
+            raise TypeError("A presented chunk's audio payload must be an AudioOutput.")
+        if sum(item.audio is not None for item in chunk) > 1:
+            raise ValueError("A presented chunk can carry only one audio payload.")
         pending = (generation, chunk)
         if self._backpressure_mode is BackpressureMode.DROP_OLDEST:
             self._publish_latest(pending)
@@ -132,6 +141,7 @@ class PresentationManager:
             self._generation = generation
             self._presented_chunk = None
             self._frame_index = -1
+            self._audio_presented = False
             self._presented_frame_count = 0
 
         if (
@@ -150,8 +160,23 @@ class PresentationManager:
             return False, None
         self._presented_chunk = chunk
         self._frame_index = 0
+        self._audio_presented = False
         self._presented_frame_count += 1
         return True, chunk
+
+    def presented_audio(self) -> AudioOutput | None:
+        """Return a chunk's audio once, with the chunk's first presented frame."""
+        if self._presented_chunk is None or self._audio_presented:
+            return None
+        self._audio_presented = True
+        return next(
+            (
+                result.audio
+                for result in self._presented_chunk
+                if result.audio is not None
+            ),
+            None,
+        )
 
     @property
     def presented_frame_count(self) -> int:
@@ -210,6 +235,7 @@ class PresentationManager:
         """Discard buffered and currently presented model results."""
         self._presented_chunk = None
         self._frame_index = -1
+        self._audio_presented = False
         self._presented_frame_count = 0
         while True:
             try:

--- a/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
+++ b/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
@@ -326,7 +326,11 @@ class WebRTCServer:
 
         Raises:
             RuntimeError: The server is closed or already open.
+            ValueError: The session declares audio, which this video-only
+                server cannot send.
         """
+        if session_desc.audio_sample_rate is not None:
+            raise ValueError("WebRTC output does not support audio.")
         if self._closed:
             raise RuntimeError("Cannot open a closed WebRTC server.")
         if self._session_desc is not None:

--- a/flashdreams/flashdreams/runtime_v2/session_desc.py
+++ b/flashdreams/flashdreams/runtime_v2/session_desc.py
@@ -3,7 +3,6 @@
 
 """Description of the session a runtime asks an application for."""
 
-import math
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -18,7 +17,11 @@ class BackpressureMode(Enum):
     """Wait when the presentation queue is full."""
 
     DROP_OLDEST = "drop_oldest"
-    """Drop the oldest queued model step."""
+    """Drop the oldest queued model step.
+
+    For synchronized audio output, a dropped step is absent from the staged PCM
+    and becomes timeline silence when the file sink pads to the video duration.
+    """
 
 
 class PresentationMode(Enum):
@@ -61,6 +64,12 @@ class SessionDesc:
     video_height: int = 720
     """Output video height in pixels."""
 
+    audio_sample_rate: int | None = None
+    """PCM sample rate, or ``None`` when the session emits no audio."""
+
+    audio_channels: int | None = None
+    """PCM channel count, or ``None`` when the session emits no audio."""
+
     metadata: dict[str, Any] = field(default_factory=dict)
     """Extra values a runtime and an application agree on. Nothing here reads it."""
 
@@ -70,23 +79,43 @@ class SessionDesc:
         if not isinstance(self.presentation_mode, PresentationMode):
             raise TypeError("SessionDesc.presentation_mode must be a PresentationMode.")
         if (
-            not math.isfinite(self.frames_per_second_for_ui)
+            isinstance(self.frames_per_second_for_ui, bool)
+            or not isinstance(self.frames_per_second_for_ui, int)
             or self.frames_per_second_for_ui <= 0
         ):
             raise ValueError(
-                "SessionDesc.frames_per_second_for_ui must be > 0 when set."
+                "SessionDesc.frames_per_second_for_ui must be a positive integer."
             )
         if (
-            not math.isfinite(self.frames_per_second_for_step)
+            isinstance(self.frames_per_second_for_step, bool)
+            or not isinstance(self.frames_per_second_for_step, int)
             or self.frames_per_second_for_step <= 0
         ):
             raise ValueError(
-                "SessionDesc.frames_per_second_for_step must be > 0 when set."
+                "SessionDesc.frames_per_second_for_step must be a positive integer."
             )
         if self.video_width <= 0:
             raise ValueError("SessionDesc.video_width must be > 0 when set.")
         if self.video_height <= 0:
             raise ValueError("SessionDesc.video_height must be > 0 when set.")
+        if (self.audio_sample_rate is None) != (self.audio_channels is None):
+            raise ValueError(
+                "SessionDesc.audio_sample_rate and audio_channels must be set together."
+            )
+        if self.audio_sample_rate is not None and (
+            isinstance(self.audio_sample_rate, bool)
+            or not isinstance(self.audio_sample_rate, int)
+            or self.audio_sample_rate <= 0
+        ):
+            raise ValueError(
+                "SessionDesc.audio_sample_rate must be a positive integer."
+            )
+        if self.audio_channels is not None and (
+            isinstance(self.audio_channels, bool)
+            or not isinstance(self.audio_channels, int)
+            or self.audio_channels not in (1, 2)
+        ):
+            raise ValueError("SessionDesc.audio_channels must be the integer 1 or 2.")
 
 
 __all__ = ["BackpressureMode", "PresentationMode", "SessionDesc"]

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -7,10 +7,11 @@ import logging
 import threading
 import time
 from collections import deque
+from collections.abc import Callable
 
 from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.loop import IModelLoop, IUILoop
-from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.api_v2.output_sink import AbortableOutputSink, OutputSink
 from flashdreams.api_v2.session import ISession
 from flashdreams.api_v2.user_input_event_data import UserInputEventData
 from flashdreams.runtime_v2.event_buffer import EventBuffer
@@ -161,6 +162,7 @@ def run_session(
     window: IClientWindow,
     *,
     metrics_output_sink: OutputSink | None = None,
+    before_output_commit: Callable[[], None] | None = None,
     steps: int | None = None,
     max_pending: int = 2,
 ) -> None:
@@ -179,6 +181,8 @@ def run_session(
         window: Source of input and destination for UI output.
         metrics_output_sink: Sink for model measurements, if requested. Receives
             the model loop's results rather than the UI loop's.
+        before_output_commit: Final application cleanup that must succeed before
+            abortable output transactions can be published.
         steps: Maximum model steps; ``None`` runs until stopped.
         max_pending: Maximum model steps waiting to be shown.
 
@@ -209,16 +213,21 @@ def run_session(
         put_timeout=tick_seconds,
     )
     model_thread_handle: threading.Thread | None = None
+    model_thread_started = False
     ui_loop: IUILoop[object] | None = None
     model_loop: IModelLoop[object] | None = None
-    high_level_failures: BaseException | None = None
+    high_level_failure: BaseException | None = None
+    loop_failures: list[BaseException] = []
+    cancelled = False
     cleanup_failures: list[BaseException] = []
     attempted_output_sinks: list[OutputSink] = []
 
     def collect_input() -> UserInputEvents:
+        nonlocal cancelled
         events = window.get_user_input_events()
         event_buffer.append(events)
         if _contains(events, CloseUserInputEventData):
+            cancelled = True
             stop.set()
         return events
 
@@ -296,6 +305,7 @@ def run_session(
                 name=_MODEL_THREAD_NAME,
             )
             model_thread_handle.start()
+            model_thread_started = True
             next_tick_at = time.monotonic() + tick_seconds
 
             # Keep servicing input and presenting queued frames until shutdown,
@@ -320,35 +330,91 @@ def run_session(
                 if next_tick_at <= completed_at:
                     next_tick_at = completed_at + tick_seconds
     except BaseException as error:
-        high_level_failures = error
+        high_level_failure = error
     finally:
         stop.set()
-        if model_thread_handle is not None:
+        if model_thread_handle is not None and model_thread_started:
             try:
                 model_thread_handle.join()
             except BaseException as error:
                 cleanup_failures.append(error)
 
         cleanup_failures.extend(session._shutdown_registered_loops())
+        while not session._failure_queue.empty():
+            loop_failures.append(session._failure_queue.get())
         presentation_manager.clear()
         event_buffer.unregister(_UI_READER_ID)
         event_buffer.unregister(_MODEL_READER_ID)
         event_buffer.clear()
 
-        for output_sink in attempted_output_sinks:
+        regular_sinks = [
+            sink
+            for sink in attempted_output_sinks
+            if not isinstance(sink, AbortableOutputSink)
+        ]
+        abortable_sinks = [
+            sink
+            for sink in attempted_output_sinks
+            if isinstance(sink, AbortableOutputSink)
+        ]
+        for output_sink in regular_sinks:
             try:
                 output_sink.close()
             except BaseException as error:
                 cleanup_failures.append(error)
+
         try:
             session.close()
         except BaseException as error:
             cleanup_failures.append(error)
 
-    loop_failures = (
-        None if session._failure_queue.empty() else session._failure_queue.get()
-    )
-    primary_failure = loop_failures or high_level_failures
+        if before_output_commit is not None:
+            try:
+                before_output_commit()
+            except BaseException as error:
+                cleanup_failures.append(error)
+
+        abort_transactions = bool(
+            cancelled or high_level_failure or loop_failures or cleanup_failures
+        )
+        abort_retry_sinks: list[AbortableOutputSink] = []
+        for output_sink in abortable_sinks:
+            if abort_transactions:
+                try:
+                    output_sink.abort()
+                except BaseException as error:
+                    cleanup_failures.append(error)
+                    abort_retry_sinks.append(output_sink)
+                continue
+            try:
+                output_sink.close()
+            except BaseException as error:
+                cleanup_failures.append(error)
+                abort_transactions = True
+                try:
+                    output_sink.abort()
+                except BaseException as abort_error:
+                    cleanup_failures.append(abort_error)
+                    abort_retry_sinks.append(output_sink)
+
+        # An abortable sink retains ownership when cleanup is interrupted. Give
+        # every failed transaction one bounded final pass after all other sinks
+        # have been serviced, so transient child waits or filesystem cleanup do
+        # not become leaked processes or staging directories.
+        for output_sink in abort_retry_sinks:
+            try:
+                output_sink.abort()
+            except BaseException as error:
+                cleanup_failures.append(error)
+
+    primary_failure: BaseException | None = None
+    if loop_failures:
+        primary_failure = loop_failures.pop(0)
+        cleanup_failures.extend(loop_failures)
+        if high_level_failure is not None:
+            cleanup_failures.append(high_level_failure)
+    else:
+        primary_failure = high_level_failure
     if primary_failure is None and cleanup_failures:
         primary_failure = cleanup_failures.pop(0)
     for error in cleanup_failures:

--- a/flashdreams/flashdreams/runtime_v2/step_result.py
+++ b/flashdreams/flashdreams/runtime_v2/step_result.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 from torch import Tensor
 
+from flashdreams.runtime_v2.audio_output import AudioOutput
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 
@@ -34,3 +35,6 @@ class StepResult:
     metrics: dict[str, float | int] = field(default_factory=dict)
     """Measurements for this step, such as timings, keyed by name. Recorded only
     when a run asked for a metrics sink, and only from a model loop."""
+
+    audio: AudioOutput | None = None
+    """Optional PCM generated on the same session timeline as these frames."""

--- a/flashdreams/flashdreams/runtime_v2/video_encoder.py
+++ b/flashdreams/flashdreams/runtime_v2/video_encoder.py
@@ -14,6 +14,7 @@ import numpy.typing as npt
 import torch
 from torch import Tensor
 
+from flashdreams.core.exceptions import add_exception_note
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -104,19 +105,93 @@ class Mp4Encoder:
         process = self._process
         if process is None:
             return
-        self._process = None
         assert process.stdin is not None
+        failure: BaseException | None = None
         try:
             process.stdin.close()
         except BrokenPipeError:
             # ffmpeg gave up first; its exit code and diagnostics say why.
             pass
-        exit_code = process.wait()
-        if self._error_reader is not None:
-            self._error_reader.join()
-            self._error_reader = None
+        except BaseException as error:
+            failure = error
+        exit_code: int | None = None
+        waited = False
+        try:
+            exit_code = process.wait()
+            waited = True
+        except BaseException as error:
+            if failure is None:
+                failure = error
+            else:
+                add_exception_note(
+                    failure, f"Waiting for ffmpeg also failed: {error!r}"
+                )
+        if waited:
+            error_reader = self._error_reader
+            if error_reader is not None:
+                try:
+                    error_reader.join()
+                    self._error_reader = None
+                except BaseException as error:
+                    if failure is None:
+                        failure = error
+                    else:
+                        add_exception_note(
+                            failure,
+                            f"Joining the ffmpeg error reader also failed: {error!r}",
+                        )
+            self._process = None
+        if failure is not None:
+            raise failure
         if exit_code != 0:
             raise RuntimeError(self._failure())
+
+    def abort(self) -> None:
+        """Terminate an active encoder without treating its file as complete.
+
+        Does nothing before the process starts or after it has stopped, and can
+        be called more than once.
+        """
+        process = self._process
+        if process is None:
+            return
+        failure: BaseException | None = None
+        waited = False
+        try:
+            if process.poll() is None:
+                try:
+                    process.terminate()
+                except ProcessLookupError:
+                    pass
+            if process.stdin is not None:
+                try:
+                    process.stdin.close()
+                except (BrokenPipeError, OSError, ValueError):
+                    pass
+            try:
+                process.wait()
+                waited = True
+            except BaseException as error:
+                failure = error
+        finally:
+            if self._error_reader is not None:
+                if waited:
+                    try:
+                        self._error_reader.join()
+                        self._error_reader = None
+                    except BaseException as error:
+                        if failure is None:
+                            failure = error
+                        else:
+                            add_exception_note(
+                                failure,
+                                "Joining the ffmpeg error reader also failed: "
+                                f"{error!r}",
+                            )
+            if waited:
+                self._process = None
+        if failure is not None:
+            raise failure
 
     def _start(self) -> subprocess.Popen[bytes]:
         """Start ffmpeg, reading raw frames from its standard input."""
@@ -127,6 +202,7 @@ class Mp4Encoder:
         process = subprocess.Popen(
             self._command(ffmpeg), stdin=subprocess.PIPE, stderr=subprocess.PIPE
         )
+        self._process = process
         # Drain the diagnostics on a thread of their own: ffmpeg blocks once
         # that pipe fills, and only a failure reads them, at the end of the run.
         self._errors = []
@@ -136,8 +212,22 @@ class Mp4Encoder:
             name="flashdreams-mp4-errors",
             daemon=True,
         )
-        self._error_reader.start()
-        self._process = process
+        try:
+            self._error_reader.start()
+        except BaseException as error:
+            self._error_reader = None
+            try:
+                if process.poll() is None:
+                    process.terminate()
+                if process.stdin is not None:
+                    process.stdin.close()
+                process.wait()
+                self._process = None
+            except BaseException as cleanup_error:
+                add_exception_note(
+                    error, f"FFmpeg startup cleanup also failed: {cleanup_error!r}"
+                )
+            raise
         return process
 
     def _command(self, ffmpeg: str) -> list[str]:

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -146,6 +146,20 @@ class _SilentWindow(_Window):
         return UserInputEvents([])
 
 
+class _AbortableWindow(_Window):
+    """Record a window whose unpublished output can be discarded."""
+
+    def abort(self) -> None:
+        self._calls.append("window.abort")
+
+
+class _SilentAbortableWindow(_AbortableWindow):
+    """Record a transactional file-style window with no client events."""
+
+    def get_user_input_events(self) -> UserInputEvents:
+        return UserInputEvents([])
+
+
 class _MetricsSink:
     """Record model results delivered independently of the client window."""
 
@@ -204,6 +218,16 @@ def test_application_runner_closes_both_when_the_run_never_starts() -> None:
     assert calls == ["application.init([])", "window.close", "application.close"]
 
 
+def test_application_start_failure_aborts_a_transactional_window() -> None:
+    calls: list[str] = []
+    application = _Application(calls, fail_to_init=True)
+
+    with pytest.raises(RuntimeError, match="application init failed"):
+        ApplicationRunner(application, _AbortableWindow(calls)).run(_session_desc())
+
+    assert calls == ["application.init([])", "window.abort", "application.close"]
+
+
 def test_application_runner_ends_a_run_a_window_cannot_end() -> None:
     """A window with no client never reports a close, so the session ends it."""
     calls: list[str] = []
@@ -215,6 +239,30 @@ def test_application_runner_ends_a_run_a_window_cannot_end() -> None:
 
     assert [result.step_index for result in window.results] == [0, 1, 2]
     assert calls[-3:] == ["window.close", "session.close", "application.close"]
+
+
+def test_application_closes_before_transactional_output_commits() -> None:
+    calls: list[str] = []
+    window = _SilentAbortableWindow(calls)
+
+    ApplicationRunner(_Application(calls, session_length=1), window).run(
+        _session_desc()
+    )
+
+    assert calls[-3:] == ["session.close", "application.close", "window.close"]
+
+
+def test_application_close_failure_aborts_transactional_output() -> None:
+    calls: list[str] = []
+    window = _SilentAbortableWindow(calls)
+    application = _Application(calls, fail_to_close=True, session_length=1)
+
+    with pytest.raises(RuntimeError, match="application close failed"):
+        ApplicationRunner(application, window).run(_session_desc())
+
+    assert "window.close" not in calls
+    assert calls.index("session.close") < calls.index("window.abort")
+    assert calls.count("application.close") == 1
 
 
 def test_application_runner_keeps_metrics_output_separate_from_the_window() -> None:

--- a/flashdreams/test_v2/test_audio_output.py
+++ b/flashdreams/test_v2/test_audio_output.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for the model-neutral v2 audio result contract."""
+
+import pytest
+import torch
+
+from flashdreams.runtime_v2.audio_output import AudioOutput, normalized_pcm
+from flashdreams.runtime_v2.session_desc import SessionDesc
+
+pytestmark = pytest.mark.ci_cpu
+
+_AUDIO_RATE = 8_000
+
+
+@pytest.mark.parametrize(
+    ("samples", "message"),
+    [
+        (torch.zeros(8), "shape"),
+        (torch.zeros(3, 8), "mono or stereo"),
+        (torch.zeros(2, 0), "at least one"),
+    ],
+)
+def test_audio_output_rejects_malformed_shapes(
+    samples: torch.Tensor, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        AudioOutput(samples=samples, sample_rate=_AUDIO_RATE)
+
+
+def test_audio_output_requires_a_tensor() -> None:
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        AudioOutput(samples=[[0.0]], sample_rate=_AUDIO_RATE)  # ty: ignore[invalid-argument-type]
+
+
+@pytest.mark.parametrize("sample_rate", [0, -1, True, 8_000.0])
+def test_audio_output_rejects_invalid_sample_rates(sample_rate: object) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        AudioOutput(
+            samples=torch.zeros(2, 8),
+            sample_rate=sample_rate,  # ty: ignore[invalid-argument-type]
+        )
+
+
+@pytest.mark.parametrize("sample_offset", [-1, True, 1.5])
+def test_audio_output_rejects_invalid_offsets(sample_offset: object) -> None:
+    with pytest.raises(ValueError, match="non-negative integer"):
+        AudioOutput(
+            samples=torch.zeros(2, 8),
+            sample_rate=_AUDIO_RATE,
+            sample_offset=sample_offset,  # ty: ignore[invalid-argument-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "samples",
+    [
+        torch.tensor([[float("nan")]]),
+        torch.tensor([[float("inf")]]),
+        torch.tensor([[1.01]]),
+        torch.ones(1, 1, dtype=torch.int16),
+    ],
+)
+def test_audio_output_rejects_invalid_samples(samples: torch.Tensor) -> None:
+    with pytest.raises(ValueError):
+        AudioOutput(samples=samples, sample_rate=_AUDIO_RATE)
+
+
+def test_normalized_pcm_revalidates_mutated_samples() -> None:
+    audio = AudioOutput(samples=torch.zeros(1, 2), sample_rate=_AUDIO_RATE)
+    audio.samples[0, 0] = torch.nan
+
+    with pytest.raises(ValueError, match="finite"):
+        normalized_pcm(audio)
+
+
+def test_normalized_pcm_returns_contiguous_cpu_float32() -> None:
+    samples = torch.zeros(8, 2, dtype=torch.float16).transpose(0, 1)
+
+    normalized = normalized_pcm(AudioOutput(samples=samples, sample_rate=_AUDIO_RATE))
+
+    assert normalized.shape == (2, 8)
+    assert normalized.device.type == "cpu"
+    assert normalized.dtype is torch.float32
+    assert normalized.is_contiguous()
+
+
+def test_session_desc_accepts_paired_audio_contract() -> None:
+    desc = SessionDesc(audio_sample_rate=_AUDIO_RATE, audio_channels=2)
+
+    assert desc.audio_sample_rate == _AUDIO_RATE
+    assert desc.audio_channels == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"audio_sample_rate": _AUDIO_RATE},
+        {"audio_channels": 2},
+        {"audio_sample_rate": 0, "audio_channels": 2},
+        {"audio_sample_rate": 8_000.0, "audio_channels": 2},
+        {"audio_sample_rate": _AUDIO_RATE, "audio_channels": 3},
+        {"audio_sample_rate": _AUDIO_RATE, "audio_channels": True},
+    ],
+)
+def test_session_desc_rejects_invalid_audio_contract(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        SessionDesc(**kwargs)  # ty: ignore[invalid-argument-type]

--- a/flashdreams/test_v2/test_mp4_audio.py
+++ b/flashdreams/test_v2/test_mp4_audio.py
@@ -1,0 +1,527 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for private PCM staging and external MP4 audio muxing."""
+
+import struct
+from pathlib import Path
+
+import pytest
+import torch
+
+import flashdreams.runtime_v2.mp4_audio as mp4_audio_module
+from flashdreams.runtime_v2.audio_output import AudioOutput
+from flashdreams.runtime_v2.mp4_audio import (
+    F32leAudioStager,
+    Mp4AudioMuxer,
+    preflight_audio_codec,
+)
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def _audio(
+    channels: list[list[float]], *, sample_rate: int = 8_000, offset: int = 0
+) -> AudioOutput:
+    """Return one normalized audio payload."""
+    return AudioOutput(
+        samples=torch.tensor(channels, dtype=torch.float32),
+        sample_rate=sample_rate,
+        sample_offset=offset,
+    )
+
+
+def _floats(path: Path) -> tuple[float, ...]:
+    """Read a little-endian float32 staging file."""
+    data = path.read_bytes()
+    return struct.unpack(f"<{len(data) // 4}f", data)
+
+
+def test_audio_stager_interleaves_channels_and_exact_offsets(tmp_path: Path) -> None:
+    path = tmp_path / "audio.f32le"
+    stager = F32leAudioStager(path, sample_rate=8_000, channels=2)
+
+    stager.write(_audio([[0.1, 0.2], [-0.1, -0.2]]))
+    stager.write(_audio([[0.3], [-0.3]], offset=2))
+    stager.finish(3)
+
+    assert _floats(path) == pytest.approx((0.1, -0.1, 0.2, -0.2, 0.3, -0.3))
+    assert stager.samples_written == 3
+
+
+def test_audio_stager_zero_fills_forward_gaps_and_padding(tmp_path: Path) -> None:
+    path = tmp_path / "audio.f32le"
+    stager = F32leAudioStager(path, sample_rate=8_000, channels=1)
+
+    stager.write(_audio([[0.5]], offset=2))
+    stager.finish(5)
+
+    assert _floats(path) == pytest.approx((0.0, 0.0, 0.5, 0.0, 0.0))
+    assert stager.samples_written == 5
+
+
+def test_audio_stager_truncates_to_the_video_timeline(tmp_path: Path) -> None:
+    path = tmp_path / "audio.f32le"
+    stager = F32leAudioStager(path, sample_rate=8_000, channels=2)
+    stager.write(_audio([[0.1, 0.2, 0.3], [-0.1, -0.2, -0.3]]))
+
+    stager.finish(2)
+
+    assert _floats(path) == pytest.approx((0.1, -0.1, 0.2, -0.2))
+    assert stager.samples_written == 2
+
+
+def test_audio_stager_rejects_overlap_without_changing_staged_audio(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "audio.f32le"
+    stager = F32leAudioStager(path, sample_rate=8_000, channels=1)
+    stager.write(_audio([[0.1, 0.2]]))
+
+    with pytest.raises(ValueError, match="overlaps"):
+        stager.write(_audio([[0.3]], offset=1))
+    stager.finish(2)
+
+    assert _floats(path) == pytest.approx((0.1, 0.2))
+
+
+@pytest.mark.parametrize(
+    ("audio", "message"),
+    [
+        (_audio([[0.1]], sample_rate=16_000), "8000 Hz"),
+        (_audio([[0.1], [0.2]]), "1 audio channels"),
+    ],
+)
+def test_audio_stager_rejects_a_payload_of_another_format(
+    tmp_path: Path, audio: AudioOutput, message: str
+) -> None:
+    stager = F32leAudioStager(tmp_path / "audio.f32le", sample_rate=8_000, channels=1)
+
+    with pytest.raises(ValueError, match=message):
+        stager.write(audio)
+    stager.abort()
+
+
+def test_audio_stager_retains_stream_when_abort_close_fails(tmp_path: Path) -> None:
+    """A later abort can retry a staging handle whose close was interrupted."""
+    calls: list[str] = []
+
+    class Stream:
+        def close(self) -> None:
+            calls.append("close")
+            if len(calls) == 1:
+                raise RuntimeError("audio close interrupted")
+
+    stager = F32leAudioStager(tmp_path / "audio.f32le", sample_rate=8_000, channels=1)
+    assert stager._stream is not None
+    stager._stream.close()
+    stream = Stream()
+    stager._stream = stream  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(RuntimeError, match="audio close interrupted"):
+        stager.abort()
+    assert stager._stream is stream
+
+    stager.abort()
+
+    assert stager._stream is None
+    assert calls == ["close", "close"]
+
+
+def test_audio_codec_preflight_encodes_the_exact_session_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class Completed:
+        returncode = 0
+        stderr = b""
+
+    def run(command: list[str], **kwargs: object) -> Completed:
+        calls.append((command, kwargs))
+        return Completed()
+
+    monkeypatch.setattr(mp4_audio_module.shutil, "which", lambda name: "/host/ffmpeg")
+    monkeypatch.setattr(mp4_audio_module.subprocess, "run", run)
+
+    assert preflight_audio_codec(sample_rate=32_000, channels=2) == "/host/ffmpeg"
+    assert calls[0][0] == [
+        "/host/ffmpeg",
+        "-hide_banner",
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-f",
+        "f32le",
+        "-ar",
+        "32000",
+        "-ac",
+        "2",
+        "-i",
+        "pipe:0",
+        "-frames:a",
+        "1",
+        "-c:a",
+        "aac",
+        "-profile:a",
+        "aac_low",
+        "-b:a",
+        "192k",
+        "-f",
+        "null",
+        "-",
+    ]
+    options = calls[0][1]
+    assert options["input"] == b"\0" * (1024 * 2 * 4)
+    assert options["stdout"] == mp4_audio_module.subprocess.DEVNULL
+    assert options["stderr"] == mp4_audio_module.subprocess.PIPE
+    assert options["timeout"] == 10
+    assert options["check"] is False
+
+
+def test_audio_codec_preflight_canonicalizes_a_relative_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+
+    class Completed:
+        returncode = 0
+        stderr = b""
+
+    def run(command: list[str], **kwargs: object) -> Completed:
+        del kwargs
+        commands.append(command)
+        return Completed()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mp4_audio_module.shutil, "which", lambda name: "bin/ffmpeg")
+    monkeypatch.setattr(mp4_audio_module.subprocess, "run", run)
+    expected = str((tmp_path / "bin/ffmpeg").resolve())
+
+    assert preflight_audio_codec(sample_rate=32_000, channels=2) == expected
+    assert commands[0][0] == expected
+
+
+def test_audio_codec_preflight_rejects_failed_aac_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Completed:
+        returncode = 1
+        stderr = b"Unknown encoder 'aac'"
+
+    monkeypatch.setattr(mp4_audio_module.shutil, "which", lambda name: "/host/ffmpeg")
+    monkeypatch.setattr(
+        mp4_audio_module.subprocess, "run", lambda *args, **kwargs: Completed()
+    )
+
+    with pytest.raises(RuntimeError, match="Unknown encoder 'aac'"):
+        preflight_audio_codec(sample_rate=32_000, channels=2)
+
+
+def test_audio_codec_preflight_rejects_a_missing_executable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mp4_audio_module.shutil, "which", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="ffmpeg executable on PATH"):
+        preflight_audio_codec(sample_rate=32_000, channels=2)
+
+
+def test_audio_codec_preflight_bounds_a_hung_external_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def hang(*args: object, **kwargs: object) -> None:
+        raise mp4_audio_module.subprocess.TimeoutExpired("ffmpeg", 10)
+
+    monkeypatch.setattr(mp4_audio_module.shutil, "which", lambda name: "/host/ffmpeg")
+    monkeypatch.setattr(mp4_audio_module.subprocess, "run", hang)
+
+    with pytest.raises(RuntimeError, match="Timed out"):
+        preflight_audio_codec(sample_rate=32_000, channels=2)
+
+
+def test_audio_codec_preflight_surfaces_an_external_spawn_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_spawn(*args: object, **kwargs: object) -> None:
+        raise OSError("process table full")
+
+    monkeypatch.setattr(mp4_audio_module.shutil, "which", lambda name: "/host/ffmpeg")
+    monkeypatch.setattr(mp4_audio_module.subprocess, "run", fail_spawn)
+
+    with pytest.raises(RuntimeError, match="process table full"):
+        preflight_audio_codec(sample_rate=32_000, channels=2)
+
+
+def test_audio_muxer_builds_external_stream_copy_command(tmp_path: Path) -> None:
+    muxer = Mp4AudioMuxer(
+        video_path=tmp_path / "video.mp4",
+        audio_path=tmp_path / "audio.f32le",
+        output_path=tmp_path / "output.mp4",
+        sample_rate=32_000,
+        channels=2,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        duration_seconds=5.0,
+    )
+
+    assert muxer._command("/usr/bin/ffmpeg") == [
+        "/usr/bin/ffmpeg",
+        "-y",
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-i",
+        str(tmp_path / "video.mp4"),
+        "-f",
+        "f32le",
+        "-ar",
+        "32000",
+        "-ac",
+        "2",
+        "-i",
+        str(tmp_path / "audio.f32le"),
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-c:v",
+        "copy",
+        "-c:a",
+        "aac",
+        "-profile:a",
+        "aac_low",
+        "-b:a",
+        "192k",
+        "-movflags",
+        "+faststart",
+        str(tmp_path / "output.mp4"),
+    ]
+
+
+def test_audio_muxer_surfaces_external_process_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class Process:
+        returncode = 7
+
+        def communicate(self, timeout: float) -> tuple[None, bytes]:
+            assert timeout == 30.0
+            return None, b"codec failed"
+
+    monkeypatch.setattr(mp4_audio_module.shutil, "which", lambda name: f"/{name}")
+    monkeypatch.setattr(
+        mp4_audio_module.subprocess, "Popen", lambda *args, **kw: Process()
+    )
+    muxer = Mp4AudioMuxer(
+        video_path=tmp_path / "video.mp4",
+        audio_path=tmp_path / "audio.f32le",
+        output_path=tmp_path / "output.mp4",
+        sample_rate=8_000,
+        channels=1,
+        ffmpeg_path="/ffmpeg",
+        duration_seconds=5.0,
+    )
+
+    with pytest.raises(RuntimeError, match="codec failed"):
+        muxer.close()
+
+
+def test_audio_muxer_abort_terminates_and_waits_for_ffmpeg(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class Process:
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            calls.append("terminate")
+
+        def communicate(self, timeout: float) -> tuple[None, bytes]:
+            calls.append(f"communicate({timeout:g})")
+            return None, b""
+
+    muxer = Mp4AudioMuxer(
+        video_path=tmp_path / "video.mp4",
+        audio_path=tmp_path / "audio.f32le",
+        output_path=tmp_path / "output.mp4",
+        sample_rate=8_000,
+        channels=1,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        duration_seconds=5.0,
+    )
+    muxer._process = Process()  # ty: ignore[invalid-assignment]
+
+    muxer.abort()
+    muxer.abort()
+
+    assert calls == ["terminate", "communicate(5)"]
+
+
+def test_audio_muxer_retains_process_when_abort_wait_fails(tmp_path: Path) -> None:
+    """A second abort can retry a child whose first wait was interrupted."""
+    calls: list[str] = []
+
+    class Process:
+        communicate_calls = 0
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            calls.append("terminate")
+
+        def communicate(self, timeout: float) -> tuple[None, bytes]:
+            calls.append(f"communicate({timeout:g})")
+            self.communicate_calls += 1
+            if self.communicate_calls == 1:
+                raise RuntimeError("mux wait interrupted")
+            return None, b""
+
+    process = Process()
+    muxer = Mp4AudioMuxer(
+        video_path=tmp_path / "video.mp4",
+        audio_path=tmp_path / "audio.f32le",
+        output_path=tmp_path / "output.mp4",
+        sample_rate=8_000,
+        channels=1,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        duration_seconds=5.0,
+    )
+    muxer._process = process  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(RuntimeError, match="mux wait interrupted"):
+        muxer.abort()
+    assert muxer._process is process
+
+    muxer.abort()
+
+    assert muxer._process is None
+    assert calls == [
+        "terminate",
+        "communicate(5)",
+        "terminate",
+        "communicate(5)",
+    ]
+
+
+def test_audio_muxer_timeout_escalates_to_kill_and_reaps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    class Process:
+        returncode = None
+        communicate_calls = 0
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            calls.append("terminate")
+
+        def kill(self) -> None:
+            calls.append("kill")
+
+        def communicate(self, timeout: float) -> tuple[None, bytes]:
+            calls.append(f"communicate({timeout:g})")
+            self.communicate_calls += 1
+            if self.communicate_calls < 3:
+                raise mp4_audio_module.subprocess.TimeoutExpired("ffmpeg", timeout)
+            return None, b""
+
+    process = Process()
+    monkeypatch.setattr(
+        mp4_audio_module.subprocess, "Popen", lambda *args, **kwargs: process
+    )
+    muxer = Mp4AudioMuxer(
+        video_path=tmp_path / "video.mp4",
+        audio_path=tmp_path / "audio.f32le",
+        output_path=tmp_path / "output.mp4",
+        sample_rate=8_000,
+        channels=1,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        duration_seconds=20.0,
+    )
+
+    with pytest.raises(RuntimeError, match="Timed out after 40 seconds"):
+        muxer.close()
+
+    assert muxer._process is None
+    assert calls == [
+        "communicate(40)",
+        "terminate",
+        "communicate(5)",
+        "kill",
+        "communicate(5)",
+    ]
+
+
+def test_audio_muxer_timeout_retains_unreaped_child_for_abort_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    class Process:
+        returncode = None
+        allow_reap = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            calls.append("terminate")
+
+        def kill(self) -> None:
+            calls.append("kill")
+
+        def communicate(self, timeout: float) -> tuple[None, bytes]:
+            calls.append(f"communicate({timeout:g})")
+            if not self.allow_reap:
+                raise mp4_audio_module.subprocess.TimeoutExpired("ffmpeg", timeout)
+            return None, b""
+
+    process = Process()
+    monkeypatch.setattr(
+        mp4_audio_module.subprocess, "Popen", lambda *args, **kwargs: process
+    )
+    muxer = Mp4AudioMuxer(
+        video_path=tmp_path / "video.mp4",
+        audio_path=tmp_path / "audio.f32le",
+        output_path=tmp_path / "output.mp4",
+        sample_rate=8_000,
+        channels=1,
+        ffmpeg_path="/usr/bin/ffmpeg",
+        duration_seconds=5.0,
+    )
+
+    with pytest.raises(RuntimeError, match="Timed out after 30 seconds"):
+        muxer.close()
+
+    assert muxer._process is process
+    process.allow_reap = True
+    muxer.abort()
+    assert muxer._process is None
+    assert calls == [
+        "communicate(30)",
+        "terminate",
+        "communicate(5)",
+        "kill",
+        "communicate(5)",
+        "terminate",
+        "communicate(5)",
+    ]
+
+
+@pytest.mark.parametrize("duration", [-1.0, float("nan"), float("inf")])
+def test_audio_muxer_rejects_invalid_duration(tmp_path: Path, duration: float) -> None:
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        Mp4AudioMuxer(
+            video_path=tmp_path / "video.mp4",
+            audio_path=tmp_path / "audio.f32le",
+            output_path=tmp_path / "output.mp4",
+            sample_rate=8_000,
+            channels=1,
+            ffmpeg_path="/usr/bin/ffmpeg",
+            duration_seconds=duration,
+        )

--- a/flashdreams/test_v2/test_mp4_client_window.py
+++ b/flashdreams/test_v2/test_mp4_client_window.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 from flashdreams.api_v2.loop import IModelLoop
+from flashdreams.api_v2.output_sink import AbortableOutputSink
 from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
 from flashdreams.runtime_v2.mp4_client_window import Mp4ClientWindow
@@ -87,6 +88,14 @@ class FakeSession(ISession):
         return
 
 
+class FailingSession(FakeSession):
+    """Fail generation after the transactional window has opened."""
+
+    def step(self, step_index: int, events: UserInputEvents) -> StepResult:
+        del step_index, events
+        raise RuntimeError("model failed")
+
+
 def _session_desc() -> SessionDesc:
     return SessionDesc(
         output_layout=VideoTensorLayout.bcthw,
@@ -124,8 +133,22 @@ def test_there_is_never_any_input_to_report(tmp_path: Path) -> None:
     """A run polls on every tick, and a file has no client to answer."""
     window = Mp4ClientWindow(tmp_path / "clip.mp4")
 
+    assert isinstance(window, AbortableOutputSink)
     assert window.get_user_input_events().get_events() == []
     assert window.get_user_input_events().get_events() == []
+
+
+def test_failed_generation_preserves_target_and_removes_staging(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "clip.mp4"
+    path.write_bytes(b"existing target")
+
+    with pytest.raises(RuntimeError, match="model failed"):
+        run_session(FailingSession(_session_desc()), Mp4ClientWindow(path), steps=1)
+
+    assert path.read_bytes() == b"existing target"
+    assert list(tmp_path.glob(f".{path.name}.*")) == []
 
 
 @needs_ffmpeg

--- a/flashdreams/test_v2/test_mp4_output_sink.py
+++ b/flashdreams/test_v2/test_mp4_output_sink.py
@@ -3,6 +3,7 @@
 
 """CPU test for the output sink that writes an MP4 file."""
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -12,9 +13,13 @@ import pytest
 import torch
 from torch import Tensor
 
+import flashdreams.runtime_v2.mp4_output_sink as mp4_sink_module
+import flashdreams.runtime_v2.video_encoder as video_encoder_module
+from flashdreams.runtime_v2.audio_output import AudioOutput
 from flashdreams.runtime_v2.mp4_output_sink import Mp4OutputSink
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
+from flashdreams.runtime_v2.video_encoder import Mp4Encoder
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 pytestmark = pytest.mark.ci_cpu
@@ -22,6 +27,11 @@ pytestmark = pytest.mark.ci_cpu
 needs_ffmpeg = pytest.mark.skipif(
     shutil.which("ffmpeg") is None,
     reason="encoding and reading an MP4 back needs ffmpeg on PATH",
+)
+
+needs_ffmpeg_and_ffprobe = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="validating synchronized MP4 output needs ffmpeg and ffprobe on PATH",
 )
 
 _WIDTH = 16
@@ -40,18 +50,160 @@ _BLACK = (-1.0, -1.0, -1.0)
 ## Helpers
 
 
+class _FakeEncoder:
+    """Write a recognizable staged file without starting ffmpeg."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        fail_write: bool = False,
+        fail_close: bool = False,
+    ) -> None:
+        self.path = Path(path)
+        self.fail_write = fail_write
+        self.fail_close = fail_close
+        self.abort_calls = 0
+        self.frames_written = 0
+
+    def write(self, frames: np.ndarray) -> None:
+        self.frames_written += len(frames)
+        self.path.write_bytes(b"partial video")
+        if self.fail_write:
+            raise RuntimeError("encode write failed")
+
+    def close(self) -> None:
+        if self.frames_written:
+            self.path.write_bytes(b"complete video")
+        if self.fail_close:
+            raise RuntimeError("encode close failed")
+
+    def abort(self) -> None:
+        self.abort_calls += 1
+
+
+class _FakeMuxer:
+    """Capture staged PCM and create a recognizable synchronized file."""
+
+    def __init__(
+        self,
+        *,
+        video_path: str | Path,
+        audio_path: str | Path,
+        output_path: str | Path,
+        duration_seconds: float,
+        fail_close: bool = False,
+        fail_abort_once: bool = False,
+        **kwargs: object,
+    ) -> None:
+        del kwargs
+        self.video_path = Path(video_path)
+        self.audio_path = Path(audio_path)
+        self.output_path = Path(output_path)
+        self.duration_seconds = duration_seconds
+        self.fail_close = fail_close
+        self.fail_abort_once = fail_abort_once
+        self.audio_bytes = b""
+        self.abort_calls = 0
+
+    def close(self) -> None:
+        self.audio_bytes = self.audio_path.read_bytes()
+        self.output_path.write_bytes(b"partial synchronized output")
+        if self.fail_close:
+            raise RuntimeError("mux close failed")
+        self.output_path.write_bytes(b"complete synchronized output")
+
+    def abort(self) -> None:
+        self.abort_calls += 1
+        if self.fail_abort_once and self.abort_calls == 1:
+            raise RuntimeError("mux abort wait failed")
+
+
+def _install_fake_encoder(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail_write: bool = False,
+    fail_close: bool = False,
+) -> list[_FakeEncoder]:
+    encoders: list[_FakeEncoder] = []
+
+    def create_encoder(path: str | Path, **kwargs: object) -> _FakeEncoder:
+        del kwargs
+        encoder = _FakeEncoder(
+            path,
+            fail_write=fail_write,
+            fail_close=fail_close,
+        )
+        encoders.append(encoder)
+        return encoder
+
+    monkeypatch.setattr(mp4_sink_module, "Mp4Encoder", create_encoder)
+
+    def preflight_audio_codec(**kwargs: int) -> str:
+        del kwargs
+        return "/host/ffmpeg"
+
+    monkeypatch.setattr(
+        mp4_sink_module,
+        "preflight_audio_codec",
+        preflight_audio_codec,
+    )
+    return encoders
+
+
+def _install_fake_muxer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail_close: bool = False,
+    fail_abort_once: bool = False,
+) -> list[_FakeMuxer]:
+    muxers: list[_FakeMuxer] = []
+
+    def create_muxer(
+        *,
+        video_path: str | Path,
+        audio_path: str | Path,
+        output_path: str | Path,
+        duration_seconds: float,
+        **kwargs: object,
+    ) -> _FakeMuxer:
+        del kwargs
+        muxer = _FakeMuxer(
+            video_path=video_path,
+            audio_path=audio_path,
+            output_path=output_path,
+            duration_seconds=duration_seconds,
+            fail_close=fail_close,
+            fail_abort_once=fail_abort_once,
+        )
+        muxers.append(muxer)
+        return muxer
+
+    monkeypatch.setattr(mp4_sink_module, "Mp4AudioMuxer", create_muxer)
+    return muxers
+
+
+def _staging_paths(path: Path) -> list[Path]:
+    return list(path.parent.glob(f".{path.name}.*"))
+
+
 def _session_desc(
     layout: VideoTensorLayout = VideoTensorLayout.bcthw,
     *,
     width: int = _WIDTH,
     height: int = _HEIGHT,
+    audio: bool = False,
+    fps: int = 30,
+    audio_sample_rate: int = 8_000,
 ) -> SessionDesc:
     return SessionDesc(
         output_layout=layout,
-        frames_per_second_for_ui=30,
-        frames_per_second_for_step=30,
+        frames_per_second_for_ui=fps,
+        frames_per_second_for_step=fps,
         video_width=width,
         video_height=height,
+        audio_sample_rate=audio_sample_rate if audio else None,
+        audio_channels=2 if audio else None,
     )
 
 
@@ -74,6 +226,7 @@ def _result(
     step_index: int = 0,
     layout: VideoTensorLayout = VideoTensorLayout.bcthw,
     dtype: torch.dtype = torch.float32,
+    audio: AudioOutput | None = None,
 ) -> StepResult:
     """Return a result of solid frames, one per colour."""
     frames = torch.zeros((len(colours), 3, _HEIGHT, _WIDTH), dtype=dtype)
@@ -85,6 +238,7 @@ def _result(
         output=_in_layout(frames, layout),
         frame_count=len(colours),
         output_layout=layout,
+        audio=audio,
     )
 
 
@@ -122,6 +276,252 @@ def _mean_colour(frame: np.ndarray) -> tuple[float, float, float]:
 ## Tests that do not encode
 
 
+def test_target_is_replaced_only_after_successful_close(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    encoders = _install_fake_encoder(monkeypatch)
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+
+    sink.open(_session_desc())
+    sink.write(_result([_RED]))
+
+    assert path.read_bytes() == b"existing target"
+    assert len(_staging_paths(path)) == 1
+
+    sink.close()
+    sink.close()
+    sink.abort()
+
+    assert path.read_bytes() == b"complete video"
+    assert _staging_paths(path) == []
+    assert encoders[0].abort_calls == 0
+
+
+def test_abort_is_idempotent_and_preserves_existing_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    encoders = _install_fake_encoder(monkeypatch)
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+    sink.open(_session_desc())
+    sink.write(_result([_RED]))
+
+    sink.abort()
+    sink.abort()
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+    assert encoders[0].abort_calls == 1
+
+
+def test_write_failure_can_be_aborted_without_publishing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_encoder(monkeypatch, fail_write=True)
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+    sink.open(_session_desc())
+
+    with pytest.raises(RuntimeError, match="encode write failed"):
+        sink.write(_result([_RED]))
+    sink.abort()
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+
+
+def test_close_failure_can_be_aborted_without_publishing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    encoders = _install_fake_encoder(monkeypatch, fail_close=True)
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+    sink.open(_session_desc())
+    sink.write(_result([_RED]))
+
+    with pytest.raises(RuntimeError, match="encode close failed"):
+        sink.close()
+    sink.abort()
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+    assert encoders[0].abort_calls == 1
+
+
+def test_atomic_replace_failure_preserves_target_and_can_be_aborted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_encoder(monkeypatch)
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+    sink.open(_session_desc())
+    sink.write(_result([_RED]))
+
+    def fail_replace(source: Path, target: Path) -> None:
+        del source, target
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(mp4_sink_module.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        sink.close()
+    sink.abort()
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+
+
+def test_encoder_abort_terminates_and_waits_for_ffmpeg(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class Stream:
+        def close(self) -> None:
+            calls.append("stdin.close")
+
+    class Process:
+        stdin = Stream()
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            calls.append("process.terminate")
+
+        def wait(self) -> int:
+            calls.append("process.wait")
+            return -15
+
+    class Reader:
+        def join(self) -> None:
+            calls.append("reader.join")
+
+    encoder = Mp4Encoder(
+        tmp_path / "staged.mp4",
+        width=_WIDTH,
+        height=_HEIGHT,
+        frames_per_second=30,
+    )
+    encoder._process = Process()  # ty: ignore[invalid-assignment]
+    encoder._error_reader = Reader()  # ty: ignore[invalid-assignment]
+
+    encoder.abort()
+    encoder.abort()
+
+    assert calls == [
+        "process.terminate",
+        "stdin.close",
+        "process.wait",
+        "reader.join",
+    ]
+
+
+def test_encoder_wait_failure_keeps_child_owned_until_abort(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class Stream:
+        def close(self) -> None:
+            calls.append("stdin.close")
+
+    class Process:
+        stdin = Stream()
+        waits = 0
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            calls.append("process.terminate")
+
+        def wait(self) -> int:
+            self.waits += 1
+            calls.append(f"process.wait({self.waits})")
+            if self.waits == 1:
+                raise InterruptedError("wait interrupted")
+            return -15
+
+    class Reader:
+        def join(self) -> None:
+            calls.append("reader.join")
+
+    encoder = Mp4Encoder(
+        tmp_path / "staged.mp4",
+        width=_WIDTH,
+        height=_HEIGHT,
+        frames_per_second=30,
+    )
+    encoder._process = Process()  # ty: ignore[invalid-assignment]
+    encoder._error_reader = Reader()  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(InterruptedError, match="wait interrupted"):
+        encoder.close()
+    encoder.abort()
+
+    assert calls == [
+        "stdin.close",
+        "process.wait(1)",
+        "process.terminate",
+        "stdin.close",
+        "process.wait(2)",
+        "reader.join",
+    ]
+
+
+def test_encoder_reader_start_failure_terminates_spawned_ffmpeg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    class Stream:
+        def close(self) -> None:
+            calls.append("stdin.close")
+
+        def write(self, data: bytes) -> None:
+            del data
+
+    class Process:
+        stdin = Stream()
+        stderr = object()
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            calls.append("process.terminate")
+
+        def wait(self) -> int:
+            calls.append("process.wait")
+            return -15
+
+    class Reader:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def start(self) -> None:
+            raise RuntimeError("reader start failed")
+
+    monkeypatch.setattr(
+        video_encoder_module.subprocess, "Popen", lambda *args, **kwargs: Process()
+    )
+    monkeypatch.setattr(video_encoder_module.threading, "Thread", Reader)
+    encoder = Mp4Encoder(
+        tmp_path / "staged.mp4",
+        width=_WIDTH,
+        height=_HEIGHT,
+        frames_per_second=30,
+    )
+
+    with pytest.raises(RuntimeError, match="reader start failed"):
+        encoder.write(np.zeros((1, _HEIGHT, _WIDTH, 3), dtype=np.uint8))
+
+    assert calls == ["process.terminate", "stdin.close", "process.wait"]
+    assert encoder._process is None
+
+
 def test_write_before_open_raises(tmp_path: Path) -> None:
     sink = Mp4OutputSink(tmp_path / "out.mp4")
 
@@ -139,6 +539,240 @@ def test_open_rejects_odd_frame_dimensions(
 
     with pytest.raises(ValueError, match=f"{width}x{height}"):
         sink.open(_session_desc(width=width, height=height))
+
+
+def test_video_only_open_does_not_preflight_an_audio_codec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def unexpected_preflight(**kwargs: int) -> str:
+        raise AssertionError(f"unexpected audio preflight: {kwargs}")
+
+    monkeypatch.setattr(
+        mp4_sink_module,
+        "preflight_audio_codec",
+        unexpected_preflight,
+    )
+    sink = Mp4OutputSink(tmp_path / "out.mp4")
+
+    sink.open(_session_desc())
+    sink.abort()
+
+
+def test_open_preflights_the_audio_codec_before_creating_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+
+    def fail_preflight(*, sample_rate: int, channels: int) -> str:
+        assert sample_rate == 8_000
+        assert channels == 2
+        raise RuntimeError("host has no AAC encoder")
+
+    monkeypatch.setattr(mp4_sink_module, "preflight_audio_codec", fail_preflight)
+
+    with pytest.raises(RuntimeError, match="no AAC encoder"):
+        sink.open(_session_desc(audio=True))
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+
+    monkeypatch.setattr(
+        mp4_sink_module,
+        "preflight_audio_codec",
+        lambda **kwargs: "/host/ffmpeg",
+    )
+    sink.open(_session_desc(audio=True))
+    sink.abort()
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+
+
+def test_audio_result_is_rejected_when_the_session_declared_none(
+    tmp_path: Path,
+) -> None:
+    sink = Mp4OutputSink(tmp_path / "out.mp4")
+    sink.open(_session_desc())
+    audio = AudioOutput(samples=torch.zeros((2, 1)), sample_rate=8_000)
+
+    with pytest.raises(ValueError, match="declared none"):
+        sink.write(_result([_RED], audio=audio))
+    sink.abort()
+
+
+@pytest.mark.parametrize(
+    ("audio", "message"),
+    [
+        (AudioOutput(samples=torch.zeros((2, 1)), sample_rate=16_000), "8000 Hz"),
+        (
+            AudioOutput(samples=torch.zeros((1, 1)), sample_rate=8_000),
+            "2 audio channels",
+        ),
+    ],
+)
+def test_audio_result_must_match_the_declared_format(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    audio: AudioOutput,
+    message: str,
+) -> None:
+    _install_fake_encoder(monkeypatch)
+    sink = Mp4OutputSink(tmp_path / "out.mp4")
+    sink.open(_session_desc(audio=True))
+
+    with pytest.raises(ValueError, match=message):
+        sink.write(_result([_RED], audio=audio))
+    sink.abort()
+
+
+@pytest.mark.parametrize(
+    ("frame_count", "native_samples", "expected_samples"),
+    [
+        (124, 165_600, 165_333),
+        (362, 482_400, 482_667),
+    ],
+)
+def test_audio_is_aligned_to_the_written_video_timeline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    frame_count: int,
+    native_samples: int,
+    expected_samples: int,
+) -> None:
+    _install_fake_encoder(monkeypatch)
+    muxers = _install_fake_muxer(monkeypatch)
+    path = tmp_path / "out.mp4"
+    sink = Mp4OutputSink(path)
+    audio = AudioOutput(
+        samples=torch.full((2, native_samples), 0.25),
+        sample_rate=32_000,
+    )
+
+    sink.open(_session_desc(audio=True, fps=24, audio_sample_rate=32_000))
+    sink.write(_result([_RED] * frame_count, audio=audio))
+    sink.close()
+
+    assert path.read_bytes() == b"complete synchronized output"
+    assert muxers[0].duration_seconds == pytest.approx(frame_count / 24)
+    assert len(muxers[0].audio_bytes) == expected_samples * 2 * 4
+    if expected_samples > native_samples:
+        assert muxers[0].audio_bytes[-(expected_samples - native_samples) * 8 :] == (
+            b"\0" * ((expected_samples - native_samples) * 8)
+        )
+    assert _staging_paths(path) == []
+
+
+def test_missing_audio_is_padded_with_timeline_silence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_encoder(monkeypatch)
+    muxers = _install_fake_muxer(monkeypatch)
+    path = tmp_path / "out.mp4"
+    sink = Mp4OutputSink(path)
+
+    sink.open(_session_desc(audio=True))
+    sink.write(_result([_RED, _BLACK, _RED]))
+    sink.close()
+
+    expected_samples = round(3 * 8_000 / 30)
+    assert muxers[0].audio_bytes == b"\0" * (expected_samples * 2 * 4)
+
+
+def test_mux_failure_preserves_target_and_can_be_aborted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_encoder(monkeypatch)
+    muxers = _install_fake_muxer(monkeypatch, fail_close=True)
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+    audio = AudioOutput(samples=torch.zeros((2, 100)), sample_rate=8_000)
+    sink.open(_session_desc(audio=True))
+    sink.write(_result([_RED], audio=audio))
+
+    with pytest.raises(RuntimeError, match="mux close failed"):
+        sink.close()
+    sink.abort()
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+    assert muxers[0].abort_calls == 1
+
+
+def test_failed_mux_abort_retains_ownership_and_staging_for_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Never delete files beneath a mux child whose wait has not completed."""
+    _install_fake_encoder(monkeypatch)
+    muxers = _install_fake_muxer(
+        monkeypatch,
+        fail_close=True,
+        fail_abort_once=True,
+    )
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+    audio = AudioOutput(samples=torch.zeros((2, 100)), sample_rate=8_000)
+    sink.open(_session_desc(audio=True))
+    sink.write(_result([_RED], audio=audio))
+    with pytest.raises(RuntimeError, match="mux close failed"):
+        sink.close()
+
+    with pytest.raises(RuntimeError, match="mux abort wait failed"):
+        sink.abort()
+
+    assert sink._muxer is muxers[0]
+    assert path.read_bytes() == b"existing target"
+    assert len(_staging_paths(path)) == 1
+
+    sink.abort()
+
+    assert sink._muxer is None
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+    assert muxers[0].abort_calls == 2
+
+
+def test_failed_audio_stager_abort_retains_transaction_for_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep private staging while an audio file handle may still be open."""
+    _install_fake_encoder(monkeypatch)
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+    sink.open(_session_desc(audio=True))
+    stager = sink._audio_stager
+    assert stager is not None and stager._stream is not None
+    real_stream = stager._stream
+    calls: list[str] = []
+
+    class Stream:
+        def close(self) -> None:
+            calls.append("close")
+            if len(calls) == 1:
+                raise RuntimeError("audio close interrupted")
+            real_stream.close()
+
+    stream = Stream()
+    stager._stream = stream  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(RuntimeError, match="audio close interrupted"):
+        sink.abort()
+
+    assert sink._audio_stager is stager
+    assert stager._stream is stream
+    assert path.read_bytes() == b"existing target"
+    assert len(_staging_paths(path)) == 1
+
+    sink.abort()
+
+    assert sink._audio_stager is None
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
+    assert calls == ["close", "close"]
 
 
 def test_write_rejects_a_layout_the_sink_was_not_opened_for(tmp_path: Path) -> None:
@@ -195,6 +829,19 @@ def test_a_run_that_generated_nothing_writes_no_file(tmp_path: Path) -> None:
     sink.close()
 
     assert not path.exists()
+    assert _staging_paths(path) == []
+
+
+def test_empty_run_preserves_an_existing_target(tmp_path: Path) -> None:
+    path = tmp_path / "out.mp4"
+    path.write_bytes(b"existing target")
+    sink = Mp4OutputSink(path)
+
+    sink.open(_session_desc())
+    sink.close()
+
+    assert path.read_bytes() == b"existing target"
+    assert _staging_paths(path) == []
 
 
 def test_close_tolerates_a_sink_that_was_never_opened(tmp_path: Path) -> None:
@@ -306,3 +953,57 @@ def test_close_can_run_twice(tmp_path: Path) -> None:
     sink.close()
 
     assert len(_decode(path)) == 1
+
+
+@needs_ffmpeg_and_ffprobe
+def test_sink_writes_synchronized_aac_lc_through_external_tools(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "synchronized.mp4"
+    sample_rate = 32_000
+    frame_count = 24
+    timeline = torch.arange(sample_rate, dtype=torch.float32) / sample_rate
+    tone = 0.25 * torch.sin(2 * torch.pi * 440 * timeline)
+    audio = AudioOutput(
+        samples=torch.stack((tone, tone)),
+        sample_rate=sample_rate,
+    )
+    sink = Mp4OutputSink(path)
+
+    sink.open(_session_desc(audio=True, fps=24, audio_sample_rate=sample_rate))
+    sink.write(_result([_RED] * frame_count, audio=audio))
+    sink.close()
+
+    completed = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-count_frames",
+            "-show_entries",
+            (
+                "stream=codec_type,codec_name,profile,sample_rate,channels,"
+                "nb_read_frames,duration"
+            ),
+            "-of",
+            "json",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    streams = json.loads(completed.stdout)["streams"]
+    video = next(stream for stream in streams if stream["codec_type"] == "video")
+    encoded_audio = next(
+        stream for stream in streams if stream["codec_type"] == "audio"
+    )
+
+    assert video["codec_name"] == "h264"
+    assert int(video["nb_read_frames"]) == frame_count
+    assert float(video["duration"]) == pytest.approx(1.0, abs=1 / 24)
+    assert encoded_audio["codec_name"] == "aac"
+    assert encoded_audio["profile"] == "LC"
+    assert int(encoded_audio["sample_rate"]) == sample_rate
+    assert int(encoded_audio["channels"]) == 2
+    assert float(encoded_audio["duration"]) == pytest.approx(1.0, abs=1 / 24)
+    assert _staging_paths(path) == []

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -5,6 +5,7 @@
 
 import logging
 import threading
+from pathlib import Path
 
 import pytest
 import torch
@@ -14,6 +15,7 @@ from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.loop import IModelLoop, IUILoop, invoke_async
 from flashdreams.api_v2.session import ISession
 from flashdreams.api_v2.user_input_event_data import UserInputEventData
+from flashdreams.runtime_v2.audio_output import AudioOutput
 from flashdreams.runtime_v2.blit_model_output_to_screen_loop import (
     BlitModelOutputToScreenLoop,
 )
@@ -55,6 +57,19 @@ def test_session_modes_are_independent() -> None:
     ]
     assert SessionDesc().backpressure_mode is BackpressureMode.BLOCK
     assert SessionDesc().presentation_mode is PresentationMode.ONLY_PRESENT_NEWEST
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["frames_per_second_for_ui", "frames_per_second_for_step"],
+)
+@pytest.mark.parametrize("value", [True, 24.0, 0, -1])
+def test_session_frame_rates_are_strict_positive_integers(
+    field: str, value: object
+) -> None:
+    """Reject values that fail later loop timing and encoder contracts."""
+    with pytest.raises(ValueError, match="positive integer"):
+        SessionDesc(**{field: value})  # ty: ignore[invalid-argument-type]
 
 
 def test_presentation_clock_paces_frames_and_reanchors_after_a_stall() -> None:
@@ -385,6 +400,39 @@ class RecordingClientWindow(IClientWindow):
             raise RuntimeError("close failed")
 
 
+class TransactionalRecordingClientWindow(RecordingClientWindow):
+    """Record an output transaction that can be committed or aborted."""
+
+    def __init__(
+        self,
+        log: CallLog,
+        scripted_events: list[UserInputEvents] | None = None,
+        *,
+        fail_to_open: bool = False,
+        fail_to_write: bool = False,
+        fail_to_close: bool = False,
+        fail_to_abort: bool = False,
+    ) -> None:
+        super().__init__(
+            log,
+            scripted_events,
+            fail_to_open=fail_to_open,
+            fail_to_close=fail_to_close,
+        )
+        self._fail_to_write = fail_to_write
+        self._fail_to_abort = fail_to_abort
+
+    def write(self, result: StepResult) -> None:
+        super().write(result)
+        if self._fail_to_write:
+            raise RuntimeError("write failed")
+
+    def abort(self) -> None:
+        self._log.record("window.abort")
+        if self._fail_to_abort:
+            raise RuntimeError("abort failed")
+
+
 def _session_desc(
     *,
     backpressure_mode: BackpressureMode = BackpressureMode.BLOCK,
@@ -573,6 +621,69 @@ def test_default_ui_composites_channels_and_holds_the_latest_frame() -> None:
     assert not manager.advance(1)[0]
     assert manager.presented_frame_count == 0
     assert ui.step(2, UserInputEvents([])) is None
+
+
+def test_default_ui_forwards_one_audio_payload_once_across_channels() -> None:
+    manager = PresentationManager()
+    audio = AudioOutput(
+        samples=torch.zeros(2, 16),
+        sample_rate=8_000,
+        sample_offset=32,
+    )
+
+    def result(*, audio_output: AudioOutput | None = None) -> StepResult:
+        return StepResult(
+            step_index=0,
+            output=torch.zeros(2, 3, 1, 1),
+            frame_count=2,
+            output_layout=VideoTensorLayout.tchw,
+            audio=audio_output,
+        )
+
+    manager.publish(0, [result(), result(audio_output=audio)])
+    ui = BlitModelOutputToScreenLoop()
+    ui.register_session_ui_loop_objects(
+        output_layout=VideoTensorLayout.tchw,
+        presentation_manager=manager,
+    )
+
+    assert manager.advance(0)[0]
+    first = ui.step(0, UserInputEvents([]))
+    assert first is not None and first.audio is audio
+    held = ui.step(1, UserInputEvents([]))
+    assert held is not None and held.audio is None
+    assert manager.advance(0)[0]
+    second = ui.step(2, UserInputEvents([]))
+    assert second is not None and second.audio is None
+
+
+def test_presentation_rejects_multiple_audio_payloads() -> None:
+    manager = PresentationManager()
+    audio = AudioOutput(samples=torch.zeros(1, 1), sample_rate=8_000)
+    result = StepResult(
+        step_index=0,
+        output=torch.zeros(1, 3, 1, 1),
+        frame_count=1,
+        output_layout=VideoTensorLayout.tchw,
+        audio=audio,
+    )
+
+    with pytest.raises(ValueError, match="only one audio"):
+        manager.publish(0, [result, result])
+
+
+def test_presentation_rejects_an_untyped_audio_payload() -> None:
+    manager = PresentationManager()
+    result = StepResult(
+        step_index=0,
+        output=torch.zeros(1, 3, 1, 1),
+        frame_count=1,
+        output_layout=VideoTensorLayout.tchw,
+        audio=object(),  # ty: ignore[invalid-argument-type]
+    )
+
+    with pytest.raises(TypeError, match="AudioOutput"):
+        manager.publish(0, [result])
 
 
 def test_default_ui_presents_each_frame_from_a_model_chunk() -> None:
@@ -980,6 +1091,226 @@ def test_run_session_rejects_a_pending_bound_of_zero() -> None:
         run_session(session, window, steps=1, max_pending=0)
 
     assert log.calls == []
+
+
+def test_success_closes_an_output_transaction_after_the_session() -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(log)
+
+    run_session(FakeSession(_session_desc(), log), window, steps=1)
+
+    assert log.calls[-2:] == ["session.close", "window.close"]
+    assert "window.abort" not in log.calls
+
+
+def test_client_cancellation_aborts_the_output_transaction() -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(
+        log,
+        [_lifecycle_event(CloseUserInputEventData())],
+    )
+
+    run_session(FakeSession(_session_desc(), log), window, steps=None)
+
+    assert log.calls[-2:] == ["session.close", "window.abort"]
+    assert "window.close" not in log.calls
+
+
+def test_model_thread_start_failure_aborts_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(log)
+
+    def fail_to_start(thread: threading.Thread) -> None:
+        del thread
+        raise RuntimeError("model start failed")
+
+    monkeypatch.setattr(threading.Thread, "start", fail_to_start)
+
+    with pytest.raises(RuntimeError, match="model start failed"):
+        run_session(FakeSession(_session_desc(), log), window, steps=1)
+
+    assert log.calls[-2:] == ["session.close", "window.abort"]
+    assert "window.close" not in log.calls
+
+
+def test_model_step_failure_aborts_output() -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(log)
+
+    with pytest.raises(RuntimeError, match="step failed"):
+        run_session(FakeSession(_session_desc(), log, fail_at=0), window, steps=1)
+
+    assert log.calls[-2:] == ["session.close", "window.abort"]
+    assert "window.close" not in log.calls
+
+
+def test_presentation_failure_aborts_output() -> None:
+    log = CallLog()
+
+    class InvalidPresentationSession(FakeSession):
+        def init(self) -> None:
+            self._log.record("session.init")
+            self.register_model_loop(FakeModelLoop, state=self)
+
+        def step(self, step_index: int, events: UserInputEvents) -> StepResult:
+            del events
+            self._log.record(f"session.step({step_index})")
+            return StepResult(
+                step_index=step_index,
+                output=torch.zeros(1, 2, 1, 1, 1),
+                frame_count=1,
+                output_layout=self.session_desc.output_layout,
+            )
+
+    window = TransactionalRecordingClientWindow(log)
+    with pytest.raises(ValueError, match="one, three, or four"):
+        run_session(InvalidPresentationSession(_session_desc(), log), window, steps=1)
+
+    assert log.calls[-2:] == ["session.close", "window.abort"]
+    assert "window.close" not in log.calls
+
+
+def test_sink_open_failure_aborts_output() -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(log, fail_to_open=True)
+
+    with pytest.raises(RuntimeError, match="open failed"):
+        run_session(FakeSession(_session_desc(), log), window, steps=1)
+
+    assert log.calls[-2:] == ["session.close", "window.abort"]
+    assert "window.close" not in log.calls
+
+
+def test_sink_write_failure_aborts_output() -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(log, fail_to_write=True)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        run_session(FakeSession(_session_desc(), log), window, steps=1)
+
+    assert log.calls[-2:] == ["session.close", "window.abort"]
+    assert "window.close" not in log.calls
+
+
+def test_sink_close_failure_falls_back_to_abort() -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(log, fail_to_close=True)
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        run_session(FakeSession(_session_desc(), log), window, steps=1)
+
+    assert log.calls[-3:] == ["session.close", "window.close", "window.abort"]
+
+
+def test_session_close_failure_aborts_output() -> None:
+    log = CallLog()
+    window = TransactionalRecordingClientWindow(log)
+
+    with pytest.raises(RuntimeError, match="session close failed"):
+        run_session(
+            FakeSession(_session_desc(), log, fail_to_close=True),
+            window,
+            steps=1,
+        )
+
+    assert log.calls[-2:] == ["session.close", "window.abort"]
+    assert "window.close" not in log.calls
+
+
+def test_first_model_failure_survives_all_cleanup_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    log = CallLog()
+
+    class FailingModelLoop(FakeModelLoop):
+        def step(self, step_index: int, events: UserInputEvents) -> list[StepResult]:
+            del step_index, events
+            raise RuntimeError("model step failed first")
+
+        def close(self) -> None:
+            raise RuntimeError("model close failed second")
+
+    class FailingCleanupSession(FakeSession):
+        def init(self) -> None:
+            self._log.record("session.init")
+            self.register_model_loop(FailingModelLoop, state=self)
+
+    session = FailingCleanupSession(
+        _session_desc(),
+        log,
+        fail_to_close=True,
+    )
+    window = TransactionalRecordingClientWindow(log, fail_to_abort=True)
+
+    with caplog.at_level(logging.ERROR, logger=_RUNNER_LOGGER):
+        with pytest.raises(RuntimeError, match="model step failed first"):
+            run_session(session, window, steps=1)
+
+    assert "model close failed second" in caplog.text
+    assert "session close failed" in caplog.text
+    assert "abort failed" in caplog.text
+    assert log.calls[-3:] == ["session.close", "window.abort", "window.abort"]
+    assert log.calls.count("window.abort") == 2
+
+
+def test_failed_abort_gets_one_final_retry(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retry retained transaction ownership and preserve the public target."""
+    log = CallLog()
+    target = tmp_path / "output.mp4"
+    target.write_bytes(b"existing")
+    staging = tmp_path / ".output.mp4.staging"
+    staging.mkdir()
+    partial = staging / "partial.mp4"
+    partial.write_bytes(b"incomplete")
+
+    class FailOnceCleanupWindow(TransactionalRecordingClientWindow):
+        abort_attempts = 0
+
+        def abort(self) -> None:
+            self._log.record("window.abort")
+            self.abort_attempts += 1
+            if self.abort_attempts == 1:
+                raise RuntimeError("abort interrupted once")
+            partial.unlink()
+            staging.rmdir()
+
+    window = FailOnceCleanupWindow(log, fail_to_write=True)
+
+    with caplog.at_level(logging.ERROR, logger=_RUNNER_LOGGER):
+        with pytest.raises(RuntimeError, match="write failed"):
+            run_session(FakeSession(_session_desc(), log), window, steps=1)
+
+    assert "abort interrupted once" in caplog.text
+    assert log.calls[-3:] == ["session.close", "window.abort", "window.abort"]
+    assert window.abort_attempts == 2
+    assert not staging.exists()
+    assert target.read_bytes() == b"existing"
+
+
+def test_queued_loop_failure_outranks_a_main_thread_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Preserve the failure priority defined by the V2 API contract."""
+    log = CallLog()
+
+    class QueuedFailureSession(FakeSession):
+        def init(self) -> None:
+            super().init()
+            self._failure_queue.put(RuntimeError("loop failed first"))
+
+    session = QueuedFailureSession(_session_desc(), log)
+    window = RecordingClientWindow(log, fail_to_open=True)
+
+    with caplog.at_level(logging.ERROR, logger=_RUNNER_LOGGER):
+        with pytest.raises(RuntimeError, match="loop failed first"):
+            run_session(session, window, steps=1)
+
+    assert "open failed" in caplog.text
 
 
 def test_run_session_with_no_steps_still_opens_and_closes() -> None:

--- a/flashdreams/test_v2/test_webrtc_client_window.py
+++ b/flashdreams/test_v2/test_webrtc_client_window.py
@@ -43,7 +43,7 @@ from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 from flashdreams.runtime_v2.webrtc_client_window import WebRTCClientWindow
 
 
-def _session_desc() -> SessionDesc:
+def _session_desc(*, audio: bool = False) -> SessionDesc:
     return SessionDesc(
         output_layout=VideoTensorLayout.tchw,
         presentation_mode=PresentationMode.ONLY_PRESENT_NEW,
@@ -51,7 +51,19 @@ def _session_desc() -> SessionDesc:
         frames_per_second_for_step=30,
         video_width=16,
         video_height=16,
+        audio_sample_rate=8_000 if audio else None,
+        audio_channels=2 if audio else None,
     )
+
+
+def test_window_rejects_audio_before_configuring_video() -> None:
+    window = WebRTCClientWindow()
+    try:
+        with pytest.raises(ValueError, match="does not support audio"):
+            window.open(_session_desc(audio=True))
+        window.open(_session_desc())
+    finally:
+        window.close()
 
 
 async def _connect_browser(

--- a/flashdreams/tests/test_core_exceptions.py
+++ b/flashdreams/tests/test_core_exceptions.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for exception compatibility helpers."""
+
+import pytest
+
+from flashdreams.core.exceptions import add_exception_note
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def test_add_exception_note_records_context_when_supported() -> None:
+    error = RuntimeError("primary failure")
+
+    add_exception_note(error, "cleanup also failed")
+
+    expected = ["cleanup also failed"] if hasattr(BaseException, "add_note") else None
+    assert getattr(error, "__notes__", None) == expected
+
+
+def test_add_exception_note_is_safe_for_python_310_like_errors() -> None:
+    class LegacyExceptionLike(Exception):
+        def __getattribute__(self, name: str) -> object:
+            if name == "add_note":
+                raise AttributeError(name)
+            return super().__getattribute__(name)
+
+    error = LegacyExceptionLike("primary failure")
+
+    add_exception_note(error, "cleanup also failed")
+    assert getattr(error, "__notes__", None) is None

--- a/integrations_v2/README.md
+++ b/integrations_v2/README.md
@@ -167,6 +167,13 @@ one channel. `is_finished` is what ends a run writing to a file, since an MP4
 window never sends a close event. And `reset` raises by default, so implement it
 even when the body is one line — a browser client can ask for one at any time.
 
+A synchronized application declares `audio_sample_rate` and `audio_channels`
+together in its `SessionDesc`, then may attach one `AudioOutput` to one channel
+in a generated chunk. Audio is channel-major normalized PCM on an absolute
+sample timeline. The default UI forwards a chunk's payload once, with its first
+presented frame; a custom UI must call `presented_model_audio()` and forward the
+result itself.
+
 Register no UI loop unless you need one. The default composites every model
 channel into one frame, which is what all of these except `slangpy_ui_demo` do.
 


### PR DESCRIPTION
## Summary

Extracted from #523 as the model-neutral prerequisite for the MiniMax H3 V2 integration. PR #523 will be stacked on this exact branch head.

- Add typed normalized-PCM audio to the V2 StepResult and SessionDesc contracts.
- Forward each model chunk audio payload exactly once through the default presentation path.
- Publish synchronized H.264/AAC-LC MP4 using external host ffmpeg and ffprobe executables.
- Align audio to the exact written-frame timeline, including forward gaps, padding, and truncation.
- Make MP4 publication transactional and preserve existing targets on inference, encode, mux, close, or cleanup failures.
- Bound mux timeouts and cleanup retries, retain unreaped child ownership, and keep Python 3.10 exception cleanup compatible.
- Reject audio sessions from WebRTC until that sink supports the declared contract.

This PR contains no MiniMax H3 or Diffusers code, adds no workspace package, and changes no dependency lock data.

## Validation

- Focused V2 audio/runtime suite with real external-ffmpeg round trips: **174 passed**.
- Exact repository CPU tier: **1,975 passed**, 2 skipped, 340 deselected.
- Full pre-commit gate: passed, including Ruff check/format, uv lock validation, package-version sync, and full-workspace ty.
- Standalone FlashDreams sdist and wheel build: passed.
- DCO: 2 / 2 commits signed off.

## Stack

- Extracted from #523.
- #523 remains the H3 integration and will use this branch as its temporary base until this prerequisite merges.