### PR TITLE
Add LingBot Cam2V scenarios to the v2 model benchmarks

### DIFF
--- a/configs/v2_model_benchmarks.json
+++ b/configs/v2_model_benchmarks.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "description": "Model comparison scenarios on the v2 API, through flashdreams-run-v2. Every model runs the same prompt at the size it was trained for, so the clips can be put side by side. The quality scenarios are roughly 10-second seeded rollouts for looking at, and the one-minute scenarios are the longer clips PAI-Bench scores, collected with performance metrics and runtime stats. Models that generate their whole clip in one block cannot reach either length, so they have one scenario each at the length they do generate. PAI-Bench takes the scenario name as its prompt, so the dimensions it is run with here are the ones that do not read it. Only the text-to-video models are wired up so far; this file is where the rest go as they move onto the v2 API.",
+  "description": "Model comparison scenarios on the v2 API, through flashdreams-run-v2. Every text-to-video model runs the same prompt at the size it was trained for, so the clips can be put side by side. The quality scenarios are roughly 10-second seeded rollouts for looking at, and the one-minute scenarios are the longer clips PAI-Bench scores, collected with performance metrics and runtime stats. Models that generate their whole clip in one block cannot reach either length, so they have one scenario each at the length they do generate. PAI-Bench takes the scenario name as its prompt, so the dimensions it is run with here are the ones that do not read it. The camera-to-video models are conditioned on a first frame rather than a prompt alone, so they are comparable across runs of themselves rather than against the text-to-video clips. This file is where the rest go as they move onto the v2 API.",
   "scenarios": [
     {
       "id": "t2v-self-forcing-quality-10s",
@@ -409,6 +409,110 @@
       "requires_runtime_stats": true,
       "quality_compare_region": "full",
       "timeout_s": 7200
+    },
+    {
+      "id": "cam2v-lingbot-quality-10s",
+      "name": "LingBot World Fast Cam2V seeded quality clip",
+      "description": "Roughly 10-second LingBot World rollout with an explicit seed and strict PyTorch deterministic settings. 14 blocks decode 9 + 13 * 12 = 165 frames, which is 10.3 seconds at 16 frames per second, at 832x464. Conditioned on bundled example 0, whose first frame and prompt belong together, so this scenario keeps that pair rather than the shared text-to-video prompt. The overlay is off so the clip holds the model's own frames instead of live timing text drawn over them, and nothing sends keys to an MP4 run, so the camera holds still while the scene moves.",
+      "report_group": {
+        "id": "cam2v-lingbot",
+        "name": "LingBot World Fast Cam2V"
+      },
+      "tags": [
+        "manual",
+        "gpu",
+        "real-model",
+        "api-v2",
+        "cam2v",
+        "lingbot",
+        "quality",
+        "seeded",
+        "quality-10s"
+      ],
+      "env": {
+        "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
+      },
+      "command": [
+        "uv",
+        "run",
+        "--project",
+        "integrations_v2/cam2v_lingbot",
+        "python",
+        "-m",
+        "tools.benchmarks.strict_run",
+        "--entrypoint",
+        "flashdreams-run-v2",
+        "--",
+        "cam2v-lingbot",
+        "--output-path",
+        "{output_dir}/cam2v-lingbot-quality-10s.mp4",
+        "--stats-path",
+        "{output_dir}/stats_cam2v_lingbot_quality_10s.json",
+        "--",
+        "--example-data",
+        "--example-idx",
+        "0",
+        "--no-ui",
+        "--total-blocks",
+        "14",
+        "--seed",
+        "1"
+      ],
+      "output_dir_arg": null,
+      "warmup_steps": 1,
+      "requires_runtime_stats": true,
+      "quality_compare_region": "full",
+      "timeout_s": 7200
+    },
+    {
+      "id": "cam2v-lingbot-one-minute",
+      "name": "LingBot World Fast Cam2V one-minute rollout",
+      "description": "81 blocks decode 9 + 80 * 12 = 969 frames, which is 60.6 seconds at 16 frames per second. Run without strict deterministic algorithms, which cost time this is measuring, and seeded so the clip is still repeatable. The same bundled example 0 conditioning and overlay-free output as the shorter clip. The application's own steady_state_fps excludes its default five warmup blocks, alongside the harness metrics this records.",
+      "report_group": {
+        "id": "cam2v-lingbot",
+        "name": "LingBot World Fast Cam2V"
+      },
+      "tags": [
+        "manual",
+        "gpu",
+        "real-model",
+        "api-v2",
+        "cam2v",
+        "lingbot",
+        "one-minute",
+        "performance",
+        "review"
+      ],
+      "env": {
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
+      },
+      "command": [
+        "uv",
+        "run",
+        "--project",
+        "integrations_v2/cam2v_lingbot",
+        "flashdreams-run-v2",
+        "cam2v-lingbot",
+        "--output-path",
+        "{output_dir}/cam2v-lingbot-one-minute.mp4",
+        "--stats-path",
+        "{output_dir}/stats_cam2v_lingbot_one_minute.json",
+        "--",
+        "--example-data",
+        "--example-idx",
+        "0",
+        "--no-ui",
+        "--total-blocks",
+        "81",
+        "--seed",
+        "1"
+      ],
+      "output_dir_arg": null,
+      "warmup_steps": 1,
+      "requires_runtime_stats": true,
+      "quality_baseline_compare": false,
+      "timeout_s": 21600
     }
   ]
 }

--- a/flashdreams/tests/test_benchmark_harness.py
+++ b/flashdreams/tests/test_benchmark_harness.py
@@ -660,9 +660,12 @@ def test_shipped_v2_model_scenarios_load(tmp_path: Path) -> None:
         assert "--stats-path" in scenario.command
         assert _command_value(scenario.command, "--seed") == "1"
 
-    # One prompt across every model, or the clips are not comparable.
+    # One prompt across every text-to-video model, or the clips are not
+    # comparable.
     prompts = {
-        _command_value(scenario.command, "--prompt") for scenario in scenarios.values()
+        _command_value(scenario.command, "--prompt")
+        for scenario in scenarios.values()
+        if "t2v" in scenario.tags
     }
     assert len(prompts) == 1
 
@@ -716,6 +719,32 @@ def test_shipped_v2_model_scenarios_load(tmp_path: Path) -> None:
         assert _command_value(single_block.command, "--total-blocks") == "1"
         assert single_block.warmup_steps == 0
         assert "pai-bench" in single_block.tags
+
+    cam2v_quality = scenarios["cam2v-lingbot-quality-10s"]
+    cam2v_one_minute = scenarios["cam2v-lingbot-one-minute"]
+    for cam2v in (cam2v_quality, cam2v_one_minute):
+        # A camera-to-video model is conditioned on a first frame its prompt
+        # belongs with, so it pins that example rather than taking the shared
+        # prompt, and the same example across both lengths.
+        assert "--prompt" not in cam2v.command
+        assert "--example-data" in cam2v.command
+        assert _command_value(cam2v.command, "--example-idx") == "0"
+        # The overlay draws live timing over the model output, which would land
+        # in the clip the comparison reads.
+        assert "--no-ui" in cam2v.command
+        assert cam2v.report_group is not None
+        assert cam2v.report_group.id == "cam2v-lingbot"
+
+    # The same block counts as the streaming text-to-video models, which reach
+    # the same lengths: three latent frames a block through a decoder
+    # compressing four to one is 9 frames then 12, at 16 frames per second.
+    assert _command_value(cam2v_quality.command, "--total-blocks") == "14"
+    assert cam2v_quality.env["CUBLAS_WORKSPACE_CONFIG"] == ":4096:8"
+    assert cam2v_quality.quality_compare_region == "full"
+    assert _command_value(cam2v_one_minute.command, "--total-blocks") == "81"
+    assert "one-minute" in cam2v_one_minute.tags
+    assert cam2v_one_minute.quality_baseline_compare is False
+    assert "CUBLAS_WORKSPACE_CONFIG" not in cam2v_one_minute.env
 
 
 def test_strict_run_can_launch_either_api() -> None:

--- a/flashdreams/tools/benchmarks/README.md
+++ b/flashdreams/tools/benchmarks/README.md
@@ -6,9 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 # Benchmarking models on the v2 API
 
 [`configs/v2_model_benchmarks.json`](../../../configs/v2_model_benchmarks.json)
-runs the same prompt and seed through every model on the v2 API, writing a clip
-and its runtime metrics for each. Use it to compare the models against each
-other, or a change against a baseline of a previous run.
+runs every model on the v2 API at the same seed, writing a clip and its runtime
+metrics for each. Use it to compare the models against each other, or a change
+against a baseline of a previous run. The text-to-video models share one prompt
+so their clips can be put side by side; a camera-to-video model is conditioned
+on a first frame that its prompt belongs to, so it is compared against runs of
+itself rather than against the text-to-video clips.
 
 The v1 demo suites that run through `flashdreams-run` are a separate workflow,
 in [the local benchmarks guide](../../../docs/source/developer_guides/local_benchmarks.rst).
@@ -29,9 +32,14 @@ uv run --no-sync flashdreams-benchmark --list-scenarios \
     --scenario-file configs/v2_model_benchmarks.json
 ```
 
-Three streaming models have a ten-second scenario and a one-minute one; Wan 2.1
-and Cosmos Predict2 generate their whole clip in one block, so each has one
-scenario at the length it does generate.
+Three streaming text-to-video models and LingBot World have a ten-second
+scenario and a one-minute one; Wan 2.1 and Cosmos Predict2 generate their whole
+clip in one block, so each has one scenario at the length it does generate.
+
+LingBot World runs from its bundled example conditioning with the camera overlay
+off, so the clip holds the model's own frames rather than live timing text drawn
+over them. An MP4 run has nobody to send it keys, so the camera holds still while
+the scene moves: the throughput is measured at a resting camera.
 
 ## Score the clips with PAI-Bench, if you want scores
 
@@ -79,9 +87,11 @@ uv run --no-sync flashdreams-benchmark \
     --scenario t2v-fastvideo-causal-wan22-quality-10s \
     --scenario t2v-wan21-native-clip \
     --scenario t2v-cosmos-predict2-native-clip \
+    --scenario cam2v-lingbot-quality-10s \
     --scenario t2v-self-forcing-one-minute \
     --scenario t2v-causal-forcing-one-minute \
     --scenario t2v-fastvideo-causal-wan22-one-minute \
+    --scenario cam2v-lingbot-one-minute \
     --keep-going \
     --output-dir artifacts/benchmarks/v2-model-baseline \
     --quality-profile pai-bench-long \
@@ -106,9 +116,11 @@ uv run --no-sync flashdreams-benchmark \
     --scenario t2v-fastvideo-causal-wan22-quality-10s \
     --scenario t2v-wan21-native-clip \
     --scenario t2v-cosmos-predict2-native-clip \
+    --scenario cam2v-lingbot-quality-10s \
     --scenario t2v-self-forcing-one-minute \
     --scenario t2v-causal-forcing-one-minute \
     --scenario t2v-fastvideo-causal-wan22-one-minute \
+    --scenario cam2v-lingbot-one-minute \
     --keep-going \
     --output-dir artifacts/benchmarks/v2-model-candidate \
     --quality-baseline-dir artifacts/benchmarks/v2-model-baseline \
@@ -138,3 +150,10 @@ the application slug at its integration, and keep the prompt and the seed: a
 comparison where each model gets its own prompt compares prompts. Keep
 `--stats-path` too, which is what records the runtime metrics the report reads.
 Tag a scenario `one-minute` or `pai-bench` for PAI-Bench to score it.
+
+A model conditioned on more than a prompt cannot take the shared one, since the
+prompt belongs with its first frame. Fix that conditioning instead, the way
+LingBot World pins `--example-data --example-idx 0`, and the scenario still
+compares against runs of itself even though it no longer lines up with the
+text-to-video clips. Turn off anything that draws over the model output, or the
+clip records the overlay's timing text as well as the frames.


### PR DESCRIPTION
cam2v-lingbot was the only real model on the v2 API with no benchmark coverage. It gets the pair the streaming text-to-video models have, at the same block counts because it reaches the same lengths: a seeded ten-second clip for looking at, and a one-minute rollout for the runtime metrics and PAI-Bench scores. Both pin the bundled example rather than taking the shared prompt, which belongs with a first frame this model is conditioned on, and both pass --no-ui, since Cam2V is the first real model to register the SlangPy overlay and it would composite live throughput text into the frames the quality comparison reads.