### PR TITLE
Add flashdreams.accelerated support for Wan recipe and LingBot integration

### DIFF
--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/modules.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Literal
 
 import torch
@@ -26,12 +27,43 @@ import torch.nn as nn
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
+from flashdreams.accelerated.common.non_persistent_linear import (
+    NonPersistentLinear,
+)
+from flashdreams.accelerated.multi_head_attention import (
+    AttentionConfig,
+    AttentionType,
+    QKNormScope,
+    RoPEConfig,
+    RoPEScope,
+    RoPEStyle,
+)
+from flashdreams.accelerated.multi_head_attention.optimized import (
+    OptimizedImplConfig,
+    OptimizedMultiHeadAttention,
+    QKVFusionOption,
+    SDPABackend,
+)
+from flashdreams.accelerated.quantization.linear import (
+    QuantizedNonPersistentLinear,
+)
+from flashdreams.accelerated.quantization.quantizer import Granularity
 from flashdreams.core.attention import (
     BlockKVCache,
     ContextParallelAttention,
     NativeAttention,
 )
 from flashdreams.core.attention.rope import apply_rope_freqs
+
+
+class AttentionBackend(str, Enum):
+    """Attention implementation used by a Wan DiT block."""
+
+    TORCH = "torch"
+    """Use the PyTorch attention implementation."""
+
+    OPTIMIZED = "optimized"
+    """Use accelerated multi-head attention."""
 
 
 def sinusoidal_embedding_1d(dim: int, position: Tensor) -> Tensor:
@@ -386,6 +418,134 @@ class SelfAttention(MultiHeadAttention):
         return super().forward(x, kv_cache, rope_freqs=rope_freqs, update_kv_cache=True)
 
 
+class OptimizedSelfAttention(OptimizedMultiHeadAttention):
+    """Accelerated self-attention adapted to the Wan checkpoint layout."""
+
+    @property
+    def query_projection(self) -> nn.Linear:
+        """Return the checkpoint-native query projection."""
+        return self.q
+
+    @property
+    def key_projection(self) -> nn.Linear:
+        """Return the checkpoint-native key projection."""
+        return self.k
+
+    @property
+    def value_projection(self) -> nn.Linear:
+        """Return the checkpoint-native value projection."""
+        return self.v
+
+    @property
+    def output_projection(self) -> nn.Linear:
+        """Return the checkpoint-native output projection."""
+        return self.o
+
+    @property
+    def query_norm(self) -> nn.Module:
+        """Return the checkpoint-native query normalization."""
+        return self.norm_q
+
+    @property
+    def key_norm(self) -> nn.Module:
+        """Return the checkpoint-native key normalization."""
+        return self.norm_k
+
+    def __init__(
+        self,
+        query_dim: int,
+        context_dim: int | None = None,
+        n_heads: int = 8,
+        head_dim: int = 64,
+        eps: float = 1e-6,
+        apply_rope_before_kvcache: bool = True,
+        cp_method: Literal["ring", "ulysses"] = "ring",
+        optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FULL,
+            sdpa_backend=SDPABackend.FA2,
+        ),
+    ) -> None:
+        """Initialize optimized Wan self-attention.
+
+        Args:
+            query_dim: Feature dimension of input and output tokens.
+            context_dim: Self-attention context width; ``None`` uses
+                ``query_dim``.
+            n_heads: Number of attention heads.
+            head_dim: Per-head feature dimension.
+            eps: Epsilon for inner-width Q/K RMS normalization.
+            apply_rope_before_kvcache: Apply interleaved RoPE before cache
+                storage when ``True`` and to visible cached keys otherwise.
+            cp_method: Ignored context-parallel method retained for constructor
+                compatibility with Wan attention.
+            optimized_impl_config: Projection and attention implementation policy.
+        """
+        del cp_method
+        context_dim = query_dim if context_dim is None else context_dim
+        super().__init__(
+            attention_type=AttentionType.SELF_ATTENTION,
+            attention_config=AttentionConfig(
+                query_dim=query_dim,
+                context_dim=context_dim,
+                n_heads=n_heads,
+                head_dim=head_dim,
+                qk_norm_scope=QKNormScope.INNER,
+                qk_norm_eps=eps,
+                rope_config=RoPEConfig(
+                    style=RoPEStyle.INTERLEAVED,
+                    scope=(
+                        RoPEScope.BEFORE_KV_CACHE
+                        if apply_rope_before_kvcache
+                        else RoPEScope.AFTER_KV_CACHE
+                    ),
+                ),
+            ),
+            optimized_impl_config=optimized_impl_config,
+        )
+        inner_dim = self.attention_config.inner_dim
+        self.q = nn.Linear(query_dim, inner_dim)
+        self.k = nn.Linear(context_dim, inner_dim)
+        self.v = nn.Linear(context_dim, inner_dim)
+        self.o = nn.Linear(inner_dim, query_dim)
+        self.norm_q = nn.RMSNorm(inner_dim, eps=eps)
+        self.norm_k = nn.RMSNorm(inner_dim, eps=eps)
+        self._initialize_derived_weights()
+
+    def initialize_cache(
+        self,
+        batch_size: int,
+        chunk_size: int,
+        window_size: int,
+        sink_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> BlockKVCache:
+        """Allocate a rolling K/V cache for streaming self-attention."""
+        return self.allocate_kv_cache(
+            batch_size,
+            chunk_size,
+            window_size,
+            sink_size,
+            device,
+            dtype,
+        )
+
+    def set_context_parallel_group(self, cp_group: ProcessGroup | None) -> None:
+        """Reject context parallelism unsupported by optimized attention."""
+        if cp_group is not None:
+            raise NotImplementedError(
+                "Optimized attention does not support context parallelism"
+            )
+
+    def is_context_parallel_enabled(self) -> bool:
+        """Return whether context parallelism is enabled."""
+        return False
+
+    def context_parallel_size(self) -> int:
+        """Return the singleton context-parallel world size."""
+        return 1
+
+
 @dataclass
 class CrossAttnCache:
     """Cache container for cross-attention."""
@@ -482,6 +642,249 @@ class CrossAttention(MultiHeadAttention):
         return self.o(out)
 
 
+class OptimizedCrossAttention(OptimizedMultiHeadAttention):
+    """Accelerated static-context attention with optional Wan I2V context."""
+
+    @property
+    def query_projection(self) -> nn.Linear:
+        """Return the checkpoint-native query projection."""
+        return self.q
+
+    @property
+    def key_projection(self) -> nn.Linear:
+        """Return the checkpoint-native text-key projection."""
+        return self.k
+
+    @property
+    def value_projection(self) -> nn.Linear:
+        """Return the checkpoint-native text-value projection."""
+        return self.v
+
+    @property
+    def output_projection(self) -> nn.Linear:
+        """Return the checkpoint-native output projection."""
+        return self.o
+
+    @property
+    def query_norm(self) -> nn.Module:
+        """Return the checkpoint-native query normalization."""
+        return self.norm_q
+
+    @property
+    def key_norm(self) -> nn.Module:
+        """Return the checkpoint-native text-key normalization."""
+        return self.norm_k
+
+    def __init__(
+        self,
+        query_dim: int,
+        context_dim: int | None = None,
+        n_heads: int = 8,
+        head_dim: int = 64,
+        eps: float = 1e-6,
+        i2v: bool = False,
+        cp_method: Literal["ring", "ulysses"] = "ring",
+        optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FUSE_KV,
+            sdpa_backend=SDPABackend.FA2,
+        ),
+    ) -> None:
+        """Initialize optimized Wan cross-attention.
+
+        Args:
+            query_dim: Feature dimension of query and output tokens.
+            context_dim: Context token width; ``None`` uses ``query_dim``.
+            n_heads: Number of attention heads.
+            head_dim: Per-head feature dimension.
+            eps: Epsilon for inner-width Q/K RMS normalization.
+            i2v: Build the additional image-context K/V projections.
+            cp_method: Ignored context-parallel method retained for constructor
+                compatibility with Wan attention.
+            optimized_impl_config: Projection and attention implementation policy.
+        """
+        del cp_method
+        context_dim = query_dim if context_dim is None else context_dim
+        super().__init__(
+            attention_type=AttentionType.CROSS_ATTENTION,
+            attention_config=AttentionConfig(
+                query_dim=query_dim,
+                context_dim=context_dim,
+                n_heads=n_heads,
+                head_dim=head_dim,
+                qk_norm_scope=QKNormScope.INNER,
+                qk_norm_eps=eps,
+            ),
+            optimized_impl_config=optimized_impl_config,
+        )
+        inner_dim = self.attention_config.inner_dim
+        self.i2v = i2v
+        self.q = nn.Linear(query_dim, inner_dim)
+        self.k = nn.Linear(context_dim, inner_dim)
+        self.v = nn.Linear(context_dim, inner_dim)
+        self.o = nn.Linear(inner_dim, query_dim)
+        self.norm_q = nn.RMSNorm(inner_dim, eps=eps)
+        self.norm_k = nn.RMSNorm(inner_dim, eps=eps)
+        if i2v:
+            self.k_img = nn.Linear(context_dim, inner_dim)
+            self.v_img = nn.Linear(context_dim, inner_dim)
+            self.norm_k_img = nn.RMSNorm(inner_dim, eps=eps)
+        self._initialize_derived_weights()
+
+    @torch.no_grad()
+    def _refresh_derived_weights(self, *args: object) -> None:
+        super()._refresh_derived_weights(*args)
+        self.fused_kv_img: NonPersistentLinear | None = None
+        self.quantized_key_projection_img: QuantizedNonPersistentLinear | None = None
+        self.quantized_value_projection_img: QuantizedNonPersistentLinear | None = None
+        if not getattr(self, "i2v", False):
+            return
+
+        projection_dtype = self.optimized_impl_config.quantization.projection
+        image_biases = (self.k_img.bias, self.v_img.bias)
+        present_biases = tuple(bias for bias in image_biases if bias is not None)
+        if present_biases and len(present_biases) != len(image_biases):
+            raise ValueError(
+                "image key and value projections must either both have biases "
+                "or both omit biases"
+            )
+
+        if self.qkv_fusion_option is QKVFusionOption.NONE:
+            if projection_dtype is not None:
+                self.quantized_key_projection_img = self._new_quantized_projection(
+                    self.k_img.weight, self.k_img.bias, projection_dtype
+                )
+                self.quantized_value_projection_img = self._new_quantized_projection(
+                    self.v_img.weight, self.v_img.bias, projection_dtype
+                )
+            return
+
+        fused_weight = torch.cat((self.k_img.weight, self.v_img.weight), dim=0)
+        fused_bias = torch.cat(present_biases, dim=0) if present_biases else None
+        if projection_dtype is None:
+            self.fused_kv_img = NonPersistentLinear(
+                fused_weight.detach().contiguous(),
+                None if fused_bias is None else fused_bias.detach(),
+            )
+        else:
+            self.fused_kv_img = self._new_quantized_projection(
+                fused_weight.detach().contiguous(),
+                None if fused_bias is None else fused_bias.detach(),
+                projection_dtype,
+            )
+
+    def _project_image_kv(self, context: Tensor) -> tuple[Tensor, Tensor]:
+        assert self.attention_config.context_dim is not None
+        self._validate_tokens(context, self.attention_config.context_dim, "context")
+        sequence_length = context.shape[-2]
+        head_shape = (
+            -1,
+            sequence_length,
+            self.attention_config.n_heads,
+            self.attention_config.head_dim,
+        )
+        projection_dtype = self.optimized_impl_config.quantization.projection
+        if self.qkv_fusion_option is QKVFusionOption.NONE:
+            if projection_dtype is None:
+                projected_key = self.k_img(context)
+                projected_value = self.v_img(context)
+            else:
+                if (
+                    self.quantized_key_projection_img is None
+                    or self.quantized_value_projection_img is None
+                ):
+                    raise RuntimeError(
+                        "quantized image K/V projections are not initialized"
+                    )
+                quantized_context, context_scale = self._prequantize_projection_input(
+                    context
+                )
+                projected_key = self.quantized_key_projection_img(
+                    quantized_context, context_scale, out_dtype=context.dtype
+                )
+                projected_value = self.quantized_value_projection_img(
+                    quantized_context, context_scale, out_dtype=context.dtype
+                )
+            key = projected_key.reshape(head_shape)
+            value = projected_value.reshape(head_shape)
+        else:
+            if self.fused_kv_img is None:
+                raise RuntimeError("fused image K/V projection is not initialized")
+            if projection_dtype is None:
+                projected_kv = self.fused_kv_img(context)
+            else:
+                assert isinstance(self.fused_kv_img, QuantizedNonPersistentLinear)
+                projected_kv = self.fused_kv_img(
+                    context, Granularity.SLICE, out_dtype=context.dtype
+                )
+            projected_kv = projected_kv.reshape(
+                -1,
+                sequence_length,
+                2,
+                self.attention_config.n_heads,
+                self.attention_config.head_dim,
+            )
+            key, value = projected_kv.unbind(dim=2)
+        return self._apply_qk_norm(key, self.norm_k_img), value
+
+    @torch.no_grad()
+    def compute_kv_image(self, context: Tensor) -> BlockKVCache:
+        """Project image context into a reusable static K/V cache."""
+        key, value = self._project_image_kv(context)
+        if self.optimized_impl_config.quantization.quantized_sdpa:
+            key = key.to(torch.float8_e4m3fn)
+            value = value.to(torch.float8_e4m3fn)
+        return BlockKVCache.from_tensor(key, value, seq_dim=1)
+
+    def initialize_cache(
+        self,
+        context_text: Tensor,
+        context_img: Tensor | None = None,
+    ) -> CrossAttnCache:
+        """Initialize text and optional image cross-attention caches."""
+        text_cache = self.compute_kv(context_text)
+        if self.i2v:
+            assert context_img is not None, (
+                "context_img must be provided when i2v is enabled"
+            )
+            img_cache = self.compute_kv_image(context_img)
+        else:
+            img_cache = None
+        return CrossAttnCache(text=text_cache, img=img_cache)
+
+    @torch.no_grad()
+    def forward(self, x: Tensor, kv_cache: CrossAttnCache) -> Tensor:
+        """Attend to static text and optional image context."""
+        query = self._compute_query(x, rope_freqs=None)
+        if self.optimized_impl_config.quantization.quantized_sdpa:
+            query = query.to(torch.float8_e4m3fn)
+
+        self._validate_cache(kv_cache.text, x)
+        output = self._attention(
+            query,
+            kv_cache.text.cached_k(),
+            kv_cache.text.cached_v(),
+            output_dtype=x.dtype,
+        )
+        if self.i2v:
+            assert kv_cache.img is not None, (
+                "image K/V cache must be provided when i2v is enabled"
+            )
+            self._validate_cache(kv_cache.img, x)
+            output = output + self._attention(
+                query,
+                kv_cache.img.cached_k(),
+                kv_cache.img.cached_v(),
+                output_dtype=x.dtype,
+            )
+
+        sequence_length = x.shape[-2]
+        output = output.reshape(-1, sequence_length, self.attention_config.inner_dim)
+        output = self._project_output(output)
+        return output.reshape(
+            x.shape[:-2] + (sequence_length, self.attention_config.query_dim)
+        )
+
+
 @dataclass
 class BlockCache:
     """Per-block cache container for self-attention and cross-attention."""
@@ -513,6 +916,16 @@ class Block(nn.Module):
         i2v: bool = False,
         apply_rope_before_kvcache: bool = True,
         cp_method: Literal["ring", "ulysses"] = "ring",
+        self_attention_backend: AttentionBackend = AttentionBackend.TORCH,
+        cross_attention_backend: AttentionBackend = AttentionBackend.TORCH,
+        self_attn_optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FULL,
+            sdpa_backend=SDPABackend.FA2,
+        ),
+        cross_attn_optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FUSE_KV,
+            sdpa_backend=SDPABackend.FA2,
+        ),
     ) -> None:
         super().__init__()
         self.dim = dim
@@ -520,30 +933,56 @@ class Block(nn.Module):
         self.num_heads = num_heads
         self.cross_attn_norm = cross_attn_norm
         self.eps = eps
+        self.self_attention_backend = AttentionBackend(self_attention_backend)
+        self.cross_attention_backend = AttentionBackend(cross_attention_backend)
+        self.self_attn_optimized_impl_config = self_attn_optimized_impl_config
+        self.cross_attn_optimized_impl_config = cross_attn_optimized_impl_config
 
         # Core submodules
         self.norm1 = nn.LayerNorm(dim, eps=eps, elementwise_affine=False)
-        self.self_attn = SelfAttention(
-            query_dim=dim,
-            n_heads=num_heads,
-            head_dim=dim // num_heads,
-            eps=eps,
-            apply_rope_before_kvcache=apply_rope_before_kvcache,
-            cp_method=cp_method,
-        )
+        if self.self_attention_backend is AttentionBackend.TORCH:
+            self.self_attn = SelfAttention(
+                query_dim=dim,
+                n_heads=num_heads,
+                head_dim=dim // num_heads,
+                eps=eps,
+                apply_rope_before_kvcache=apply_rope_before_kvcache,
+                cp_method=cp_method,
+            )
+        else:
+            self.self_attn = OptimizedSelfAttention(
+                query_dim=dim,
+                n_heads=num_heads,
+                head_dim=dim // num_heads,
+                eps=eps,
+                apply_rope_before_kvcache=apply_rope_before_kvcache,
+                cp_method=cp_method,
+                optimized_impl_config=self_attn_optimized_impl_config,
+            )
         self.norm3 = (
             nn.LayerNorm(dim, eps, elementwise_affine=True)
             if cross_attn_norm
             else nn.Identity()
         )
-        self.cross_attn = CrossAttention(
-            query_dim=dim,
-            n_heads=num_heads,
-            head_dim=dim // num_heads,
-            i2v=i2v,
-            eps=eps,
-            cp_method=cp_method,
-        )
+        if self.cross_attention_backend is AttentionBackend.TORCH:
+            self.cross_attn = CrossAttention(
+                query_dim=dim,
+                n_heads=num_heads,
+                head_dim=dim // num_heads,
+                i2v=i2v,
+                eps=eps,
+                cp_method=cp_method,
+            )
+        else:
+            self.cross_attn = OptimizedCrossAttention(
+                query_dim=dim,
+                n_heads=num_heads,
+                head_dim=dim // num_heads,
+                i2v=i2v,
+                eps=eps,
+                cp_method=cp_method,
+                optimized_impl_config=cross_attn_optimized_impl_config,
+            )
         self.norm2 = nn.LayerNorm(dim, eps=eps, elementwise_affine=False)
         self.ffn = nn.Sequential(
             nn.Linear(dim, ffn_dim),

--- a/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
+++ b/flashdreams/flashdreams/recipes/wan/transformer/impl/network.py
@@ -26,12 +26,18 @@ from einops import rearrange
 from torch import Tensor
 from torch.distributed import ProcessGroup
 
+from flashdreams.accelerated.multi_head_attention.optimized import (
+    OptimizedImplConfig,
+    QKVFusionOption,
+    SDPABackend,
+)
 from flashdreams.core.distributed.context_parallel import (
     cat_outputs_cp,
     split_inputs_cp,
 )
 from flashdreams.infra.config import InstantiateConfig
 from flashdreams.recipes.wan.transformer.impl.modules import (
+    AttentionBackend,
     Block,
     BlockCache,
     Head,
@@ -109,6 +115,28 @@ class WanDiTNetworkConfig(InstantiateConfig):
     cp_method: Literal["ring", "ulysses"] = "ring"
     """Context-parallel attention method for transformer attention ops."""
 
+    self_attention_backend: AttentionBackend = AttentionBackend.TORCH
+    """Self-attention implementation used by every DiT block."""
+
+    cross_attention_backend: AttentionBackend = AttentionBackend.TORCH
+    """Cross-attention implementation used by every DiT block."""
+
+    self_attn_optimized_impl_config: OptimizedImplConfig = field(
+        default_factory=lambda: OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FULL,
+            sdpa_backend=SDPABackend.FA2,
+        )
+    )
+    """Optimized implementation policy used by self-attention."""
+
+    cross_attn_optimized_impl_config: OptimizedImplConfig = field(
+        default_factory=lambda: OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FUSE_KV,
+            sdpa_backend=SDPABackend.FA2,
+        )
+    )
+    """Optimized implementation policy used by cross-attention."""
+
 
 @dataclass
 class WanDiTNetwork1pt3BConfig(WanDiTNetworkConfig):
@@ -175,6 +203,10 @@ class WanDiTNetwork(nn.Module):
         self.patch_embedding_type = config.patch_embedding_type
         self.apply_rope_before_kvcache = config.apply_rope_before_kvcache
         self.cp_method = config.cp_method
+        self.self_attention_backend = config.self_attention_backend
+        self.cross_attention_backend = config.cross_attention_backend
+        self.self_attn_optimized_impl_config = config.self_attn_optimized_impl_config
+        self.cross_attn_optimized_impl_config = config.cross_attn_optimized_impl_config
 
         # Embedding layers
         in_dim = config.in_dim + 1 if self.concat_padding_mask else config.in_dim
@@ -230,6 +262,10 @@ class WanDiTNetwork(nn.Module):
             i2v=self.cross_attn_enable_img,
             apply_rope_before_kvcache=self.apply_rope_before_kvcache,
             cp_method=self.cp_method,
+            self_attention_backend=self.self_attention_backend,
+            cross_attention_backend=self.cross_attention_backend,
+            self_attn_optimized_impl_config=self.self_attn_optimized_impl_config,
+            cross_attn_optimized_impl_config=self.cross_attn_optimized_impl_config,
         )
 
     def set_context_parallel_group(self, cp_group: ProcessGroup | None = None) -> None:

--- a/integrations/lingbot/benchmarks/cases.py
+++ b/integrations/lingbot/benchmarks/cases.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared LingBot attention benchmark cases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from flashdreams.accelerated.multi_head_attention.optimized import (
+    OptimizedImplConfig,
+    QKVFusionOption,
+    QuantizationOption,
+    SDPABackend,
+)
+from flashdreams.recipes.wan.transformer.impl.modules import AttentionBackend
+
+
+@dataclass(frozen=True)
+class AttentionBenchmarkCase:
+    """Configuration for one attention benchmark implementation."""
+
+    implementation: str
+    """Stable implementation name used by pytest and pipeline setup."""
+
+    self_attention_backend: AttentionBackend
+    """Self-attention implementation configured for this case."""
+
+    cross_attention_backend: AttentionBackend
+    """Cross-attention implementation configured for this case."""
+
+    self_attn_optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+        qkv_fusion_option=QKVFusionOption.FULL,
+        sdpa_backend=SDPABackend.FA2,
+    )
+    """Optimized implementation policy used by self-attention."""
+
+    cross_attn_optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+        qkv_fusion_option=QKVFusionOption.FUSE_KV,
+        sdpa_backend=SDPABackend.FA2,
+    )
+    """Optimized implementation policy used by cross-attention."""
+
+    minimum_compute_capability: tuple[int, int] | None = None
+    """Minimum CUDA compute capability; ``None`` accepts any CUDA device."""
+
+    @property
+    def pytest_id(self) -> str:
+        """Return the readable pytest parameter identifier."""
+        return self.implementation.replace("_", "-")
+
+
+BENCHMARK_CASES = (
+    AttentionBenchmarkCase(
+        implementation="torch",
+        self_attention_backend=AttentionBackend.TORCH,
+        cross_attention_backend=AttentionBackend.TORCH,
+    ),
+    # Manually tuned performance config for RTX PRO 6000.
+    AttentionBenchmarkCase(
+        implementation="optimized-rtx-pro-6000",
+        self_attention_backend=AttentionBackend.OPTIMIZED,
+        cross_attention_backend=AttentionBackend.OPTIMIZED,
+        self_attn_optimized_impl_config=OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.NONE,
+            sdpa_backend=SDPABackend.FA2,
+            use_tma=True,
+            quantization=QuantizationOption(
+                projection=torch.float8_e4m3fn,
+                quantized_sdpa=True
+            )
+        ),
+        cross_attn_optimized_impl_config=OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.NONE,
+            sdpa_backend=SDPABackend.FA2,
+            use_tma=True,
+            quantization=QuantizationOption(
+                projection=torch.float8_e4m3fn,
+                quantized_sdpa=True
+            )
+        ),
+        minimum_compute_capability=(9, 0),
+    ),
+    # Manually tuned performance config for GB300.
+    AttentionBenchmarkCase(
+        implementation="optimized-gb300",
+        self_attention_backend=AttentionBackend.OPTIMIZED,
+        cross_attention_backend=AttentionBackend.TORCH,
+        self_attn_optimized_impl_config=OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.NONE,
+            sdpa_backend=SDPABackend.CUDNN,
+            use_tma=False,
+            quantization=QuantizationOption(
+                projection=None,
+                quantized_sdpa=True
+            )
+        ),
+        minimum_compute_capability=(9, 0),
+    ),
+)
+"""Torch baseline and isolated/combined optimized attention cases."""
+
+
+def skip_unsupported_device(
+    case: AttentionBenchmarkCase,
+    device: torch.device,
+) -> None:
+    """Skip a benchmark case when the device is older than its minimum capability."""
+    minimum = case.minimum_compute_capability
+    if minimum is None:
+        return
+    if torch.cuda.get_device_capability(device) < minimum:
+        pytest.skip(
+            f"{case.implementation} attention requires compute capability "
+            f"{minimum[0]}.{minimum[1]}+"
+        )

--- a/integrations/lingbot/benchmarks/cases.py
+++ b/integrations/lingbot/benchmarks/cases.py
@@ -81,18 +81,16 @@ BENCHMARK_CASES = (
             sdpa_backend=SDPABackend.FA2,
             use_tma=True,
             quantization=QuantizationOption(
-                projection=torch.float8_e4m3fn,
-                quantized_sdpa=True
-            )
+                projection=torch.float8_e4m3fn, quantized_sdpa=True
+            ),
         ),
         cross_attn_optimized_impl_config=OptimizedImplConfig(
             qkv_fusion_option=QKVFusionOption.NONE,
             sdpa_backend=SDPABackend.FA2,
             use_tma=True,
             quantization=QuantizationOption(
-                projection=torch.float8_e4m3fn,
-                quantized_sdpa=True
-            )
+                projection=torch.float8_e4m3fn, quantized_sdpa=True
+            ),
         ),
         minimum_compute_capability=(9, 0),
     ),
@@ -105,10 +103,7 @@ BENCHMARK_CASES = (
             qkv_fusion_option=QKVFusionOption.NONE,
             sdpa_backend=SDPABackend.CUDNN,
             use_tma=False,
-            quantization=QuantizationOption(
-                projection=None,
-                quantized_sdpa=True
-            )
+            quantization=QuantizationOption(projection=None, quantized_sdpa=True),
         ),
         minimum_compute_capability=(9, 0),
     ),

--- a/integrations/lingbot/benchmarks/test_modules.py
+++ b/integrations/lingbot/benchmarks/test_modules.py
@@ -1,0 +1,477 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Microbenchmarks for LingBot transformer modules.
+
+Run the module benchmarks with::
+
+    uv run --group test pytest \
+        integrations/lingbot/benchmarks/test_modules.py \
+        -p no:manual_marker -m manual --benchmark-only
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+import torch
+from lingbot.transformer.impl.modules import CamCtrlBlock
+from lingbot.transformer.impl.network import LingbotWorldDiTNetwork14BConfig
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+from flashdreams.accelerated.multi_head_attention.optimized import (
+    OptimizedImplConfig,
+    QKVFusionOption,
+    QuantizationOption,
+    SDPABackend,
+)
+from flashdreams.core.attention.rope import RotaryPositionEmbedding3D
+from flashdreams.recipes.wan.transformer.impl.modules import AttentionBackend
+from integrations.lingbot.benchmarks.cases import (
+    BENCHMARK_CASES,
+    AttentionBenchmarkCase,
+    skip_unsupported_device,
+)
+
+pytestmark = pytest.mark.manual
+
+_GPU_REASON = "LingBot transformer module benchmarks require CUDA"
+
+# Production 464x832 geometry becomes 58x104 latents. Wan's 2x2 spatial
+# patching produces 29x52 tokens per frame, and each chunk has three frames.
+_LATENT_HEIGHT = 58
+_LATENT_WIDTH = 104
+_CHUNK_SIZE_T = 3
+_WINDOW_SIZE_T = 15
+_SINK_SIZE_T = 3
+_TEXT_TOKENS = 512
+_WARMUP_ROUNDS = 5
+_BENCHMARK_ROUNDS = 50
+_SEED = 0
+
+
+def _implementation_id(optimized_impl_config: OptimizedImplConfig | None) -> str:
+    """Return a stable pytest identifier for an attention implementation."""
+    if optimized_impl_config is None:
+        return "torch"
+    backend = optimized_impl_config.sdpa_backend.value
+    fusion = optimized_impl_config.qkv_fusion_option.value.replace("_", "-")
+    tma = "tma" if optimized_impl_config.use_tma else "no-tma"
+    projection_dtype = optimized_impl_config.quantization.projection
+    quantization = (
+        ""
+        if projection_dtype is None
+        else f"-projection-{projection_dtype}".replace("torch.", "").replace("_", "-")
+    )
+    quantized_sdpa = (
+        "-quantized-sdpa" if optimized_impl_config.quantization.quantized_sdpa else ""
+    )
+    return f"optimized-{backend}-{fusion}-{tma}{quantization}{quantized_sdpa}"
+
+
+_CUDNN_OPTIMIZED_IMPL_CONFIGS = tuple(
+    OptimizedImplConfig(
+        sdpa_backend=SDPABackend.CUDNN,
+        qkv_fusion_option=qkv_fusion_option,
+        use_tma=False,
+        quantization=QuantizationOption(
+            projection=projection_dtype,
+            quantized_sdpa=quantized_sdpa,
+        ),
+    )
+    for qkv_fusion_option in QKVFusionOption
+    for projection_dtype in (None, torch.float8_e4m3fn)
+    for quantized_sdpa in (False, True)
+)
+"""Every cuDNN fusion and quantization policy; TMA only affects FA2 dispatch."""
+
+_FA2_OPTIMIZED_IMPL_CONFIGS = tuple(
+    OptimizedImplConfig(
+        sdpa_backend=SDPABackend.FA2,
+        qkv_fusion_option=qkv_fusion_option,
+        use_tma=use_tma,
+        quantization=QuantizationOption(
+            projection=projection_dtype,
+            quantized_sdpa=quantized_sdpa,
+        ),
+    )
+    for qkv_fusion_option in QKVFusionOption
+    for use_tma in (False, True)
+    for projection_dtype in (None, torch.float8_e4m3fn)
+    for quantized_sdpa in (False, True)
+)
+"""Every FA2 fusion, TMA, and quantization policy."""
+
+_OPTIMIZED_IMPL_CONFIGS = (
+    *_CUDNN_OPTIMIZED_IMPL_CONFIGS,
+    *_FA2_OPTIMIZED_IMPL_CONFIGS,
+)
+"""Every backend-specific policy used by the isolated attention benchmarks."""
+
+_MODULE_ATTENTION_CONFIGS = (None, *_OPTIMIZED_IMPL_CONFIGS)
+"""Torch attention plus every optimized implementation policy."""
+
+
+def _block_case(
+    self_config: OptimizedImplConfig | None,
+    cross_config: OptimizedImplConfig | None,
+) -> AttentionBenchmarkCase:
+    """Build one self/cross implementation combination for block timing."""
+    reference_config = OptimizedImplConfig(
+        qkv_fusion_option=QKVFusionOption.NONE,
+        sdpa_backend=SDPABackend.CUDNN,
+    )
+    needs_hopper = self_config is not None or cross_config is not None
+    return AttentionBenchmarkCase(
+        implementation=(
+            f"self_{_implementation_id(self_config)}_"
+            f"cross_{_implementation_id(cross_config)}"
+        ),
+        self_attention_backend=(
+            AttentionBackend.TORCH
+            if self_config is None
+            else AttentionBackend.OPTIMIZED
+        ),
+        cross_attention_backend=(
+            AttentionBackend.TORCH
+            if cross_config is None
+            else AttentionBackend.OPTIMIZED
+        ),
+        self_attn_optimized_impl_config=self_config or reference_config,
+        cross_attn_optimized_impl_config=cross_config or reference_config,
+        minimum_compute_capability=(9, 0) if needs_hopper else None,
+    )
+
+
+def _module_block_cases(full_policy_search: bool) -> tuple[AttentionBenchmarkCase, ...]:
+    """Build representative or exhaustive self/cross pairs for block timing."""
+    if not full_policy_search:
+        return BENCHMARK_CASES
+    return tuple(
+        _block_case(self_config, cross_config)
+        for self_config in _MODULE_ATTENTION_CONFIGS
+        for cross_config in _MODULE_ATTENTION_CONFIGS
+    )
+
+
+_FULL_POLICY_SEARCH = os.environ.get("FLASHDREAMS_RUN_FULL_BENCHMARK") == "1"
+"""Whether to benchmark every self/cross policy pair in the full DiT block."""
+
+_MODULE_BLOCK_CASES = _module_block_cases(_FULL_POLICY_SEARCH)
+"""Selected block cases; set ``FLASHDREAMS_RUN_FULL_BENCHMARK=1`` for all 1,369."""
+
+
+def _module_config(case: AttentionBenchmarkCase) -> LingbotWorldDiTNetwork14BConfig:
+    """Build the production network config for one module benchmark row."""
+    return LingbotWorldDiTNetwork14BConfig(
+        in_dim=36,
+        patch_embedding_type="conv3d",
+        control_type="cam",
+        cp_method="ring",
+        self_attention_backend=case.self_attention_backend,
+        cross_attention_backend=case.cross_attention_backend,
+        self_attn_optimized_impl_config=case.self_attn_optimized_impl_config,
+        cross_attn_optimized_impl_config=case.cross_attn_optimized_impl_config,
+    )
+
+
+def _make_block(
+    config: LingbotWorldDiTNetwork14BConfig,
+    case: AttentionBenchmarkCase,
+) -> CamCtrlBlock:
+    """Build a backend-selected block with shared random weights."""
+
+    def make(
+        self_backend: AttentionBackend,
+        cross_backend: AttentionBackend,
+    ) -> CamCtrlBlock:
+        return CamCtrlBlock(
+            dim=config.dim,
+            ffn_dim=config.ffn_dim,
+            num_heads=config.num_heads,
+            cross_attn_norm=config.cross_attn_norm,
+            eps=config.eps,
+            cp_method=config.cp_method,
+            self_attention_backend=self_backend,
+            cross_attention_backend=cross_backend,
+            self_attn_optimized_impl_config=config.self_attn_optimized_impl_config,
+            cross_attn_optimized_impl_config=config.cross_attn_optimized_impl_config,
+        )
+
+    torch.manual_seed(_SEED)
+    torch_block = make(AttentionBackend.TORCH, AttentionBackend.TORCH)
+    if (
+        case.self_attention_backend is AttentionBackend.TORCH
+        and case.cross_attention_backend is AttentionBackend.TORCH
+    ):
+        return torch_block
+
+    block = make(case.self_attention_backend, case.cross_attention_backend)
+    block.load_state_dict(torch_block.state_dict(), strict=True)
+    return block
+
+
+def _token_geometry(
+    config: LingbotWorldDiTNetwork14BConfig,
+) -> tuple[int, int, int, int]:
+    """Return patch height, patch width, chunk tokens, and cache tokens."""
+    patch_t = _CHUNK_SIZE_T // config.patch_size[0]
+    patch_h = _LATENT_HEIGHT // config.patch_size[1]
+    patch_w = _LATENT_WIDTH // config.patch_size[2]
+    tokens_per_frame = patch_h * patch_w
+    chunk_tokens = patch_t * tokens_per_frame
+    cache_tokens = (_SINK_SIZE_T + _WINDOW_SIZE_T) * tokens_per_frame
+    return patch_h, patch_w, chunk_tokens, cache_tokens
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason=_GPU_REASON)
+@pytest.mark.parametrize("case", _MODULE_BLOCK_CASES, ids=lambda case: case.pytest_id)
+@torch.inference_mode()
+def test_dit_block_benchmark(
+    benchmark: BenchmarkFixture,
+    case: AttentionBenchmarkCase,
+) -> None:
+    """Benchmark a production-configured camera-control block at steady state."""
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("LingBot DiT block benchmark requires bfloat16 support")
+
+    device = torch.device("cuda")
+    skip_unsupported_device(case, device)
+    dtype = torch.bfloat16
+    config = _module_config(case)
+    block = _make_block(config, case).to(device=device, dtype=dtype)
+    block.eval()
+    block.update_parameters_after_loading_checkpoint()
+    generator = torch.Generator(device=device).manual_seed(_SEED)
+
+    patch_h, patch_w, chunk_tokens, cache_tokens = _token_geometry(config)
+    x = torch.randn(
+        (chunk_tokens, config.dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    modulation = torch.randn(
+        (6, config.dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    plucker_embedding = torch.randn(
+        (chunk_tokens, config.dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    context = torch.randn(
+        (_TEXT_TOKENS, config.dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    tokens_per_frame = patch_h * patch_w
+    cache = block.initialize_cache(
+        chunk_size=chunk_tokens,
+        window_size=_WINDOW_SIZE_T * tokens_per_frame,
+        sink_size=_SINK_SIZE_T * tokens_per_frame,
+        context_text=context,
+    )
+    rope = RotaryPositionEmbedding3D(
+        head_dim=config.dim // config.num_heads,
+        len_h=patch_h,
+        len_w=patch_w,
+        len_t=_CHUNK_SIZE_T // config.patch_size[0],
+        interleaved=True,
+        device=device,
+    )
+
+    def forward(chunk_idx: int, rope_freqs: torch.Tensor) -> torch.Tensor:
+        cache.before_update(chunk_idx)
+        output = block(
+            x=x,
+            e=modulation,
+            cache=cache,
+            rope_freqs=rope_freqs,
+            plucker_embedding=plucker_embedding,
+        )
+        cache.after_update(chunk_idx)
+        return output
+
+    cache_chunks = cache_tokens // chunk_tokens
+    benchmark_chunk_idx = cache_chunks - 1
+    rope_freqs = [rope.shift_t(idx) for idx in range(cache_chunks)]
+    for chunk_idx, chunk_rope_freqs in enumerate(rope_freqs):
+        output = forward(chunk_idx, chunk_rope_freqs)
+    torch.cuda.synchronize()
+
+    benchmark.group = "lingbot-dit-block"
+
+    def synchronized_forward() -> torch.Tensor:
+        result = forward(benchmark_chunk_idx, rope_freqs[benchmark_chunk_idx])
+        torch.cuda.synchronize()
+        return result
+
+    output = benchmark.pedantic(
+        synchronized_forward,
+        iterations=1,
+        rounds=_BENCHMARK_ROUNDS,
+        warmup_rounds=_WARMUP_ROUNDS,
+    )
+
+    assert output.shape == x.shape
+    assert torch.isfinite(output).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason=_GPU_REASON)
+@pytest.mark.parametrize(
+    "optimized_impl_config",
+    _MODULE_ATTENTION_CONFIGS,
+    ids=_implementation_id,
+)
+@torch.inference_mode()
+def test_self_attention_benchmark(
+    benchmark: BenchmarkFixture,
+    optimized_impl_config: OptimizedImplConfig | None,
+) -> None:
+    """Benchmark self-attention against the full production KV cache."""
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("LingBot self-attention benchmark requires bfloat16 support")
+
+    device = torch.device("cuda")
+    case = _block_case(optimized_impl_config, None)
+    skip_unsupported_device(case, device)
+    dtype = torch.bfloat16
+    config = _module_config(case)
+    attention = _make_block(config, case).self_attn.to(device=device, dtype=dtype)
+    attention.eval()
+    generator = torch.Generator(device=device).manual_seed(_SEED)
+
+    patch_h, patch_w, chunk_tokens, cache_tokens = _token_geometry(config)
+    x = torch.randn(
+        (chunk_tokens, config.dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    cache = attention.initialize_cache(
+        batch_size=1,
+        chunk_size=chunk_tokens,
+        window_size=_WINDOW_SIZE_T * patch_h * patch_w,
+        sink_size=_SINK_SIZE_T * patch_h * patch_w,
+        device=device,
+        dtype=dtype,
+    )
+    rope = RotaryPositionEmbedding3D(
+        head_dim=config.dim // config.num_heads,
+        len_h=patch_h,
+        len_w=patch_w,
+        len_t=_CHUNK_SIZE_T // config.patch_size[0],
+        interleaved=True,
+        device=device,
+    )
+
+    cache_chunks = cache_tokens // chunk_tokens
+    benchmark_chunk_idx = cache_chunks - 1
+    rope_freqs = [rope.shift_t(idx) for idx in range(cache_chunks)]
+    for chunk_idx, chunk_rope_freqs in enumerate(rope_freqs):
+        cache.before_update(chunk_idx)
+        output = attention(x, kv_cache=cache, rope_freqs=chunk_rope_freqs)
+        cache.after_update(chunk_idx)
+    torch.cuda.synchronize()
+
+    benchmark.group = "lingbot-dit-self-attention"
+    cache.before_update(benchmark_chunk_idx)
+
+    def synchronized_forward() -> torch.Tensor:
+        result = attention(
+            x,
+            kv_cache=cache,
+            rope_freqs=rope_freqs[benchmark_chunk_idx],
+        )
+        torch.cuda.synchronize()
+        return result
+
+    output = benchmark.pedantic(
+        synchronized_forward,
+        iterations=1,
+        rounds=_BENCHMARK_ROUNDS,
+        warmup_rounds=_WARMUP_ROUNDS,
+    )
+    cache.after_update(benchmark_chunk_idx)
+
+    assert output.shape == x.shape
+    assert torch.isfinite(output).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason=_GPU_REASON)
+@pytest.mark.parametrize(
+    "optimized_impl_config",
+    _MODULE_ATTENTION_CONFIGS,
+    ids=_implementation_id,
+)
+@torch.inference_mode()
+def test_cross_attention_benchmark(
+    benchmark: BenchmarkFixture,
+    optimized_impl_config: OptimizedImplConfig | None,
+) -> None:
+    """Benchmark cross-attention including text KV projection."""
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("LingBot cross-attention benchmark requires bfloat16 support")
+
+    device = torch.device("cuda")
+    case = _block_case(None, optimized_impl_config)
+    skip_unsupported_device(case, device)
+    dtype = torch.bfloat16
+    config = _module_config(case)
+    attention = _make_block(config, case).cross_attn.to(device=device, dtype=dtype)
+    attention.eval()
+    generator = torch.Generator(device=device).manual_seed(_SEED)
+
+    _, _, chunk_tokens, _ = _token_geometry(config)
+    x = torch.randn(
+        (chunk_tokens, config.dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    context = torch.randn(
+        (_TEXT_TOKENS, config.dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    torch.cuda.synchronize()
+
+    benchmark.group = "lingbot-dit-cross-attention"
+
+    def synchronized_forward() -> torch.Tensor:
+        cache = attention.initialize_cache(context)
+        result = attention(x, kv_cache=cache)
+        torch.cuda.synchronize()
+        return result
+
+    output = benchmark.pedantic(
+        synchronized_forward,
+        iterations=1,
+        rounds=_BENCHMARK_ROUNDS,
+        warmup_rounds=_WARMUP_ROUNDS,
+    )
+
+    assert output.shape == x.shape
+    assert torch.isfinite(output).all()

--- a/integrations/lingbot/benchmarks/test_network.py
+++ b/integrations/lingbot/benchmarks/test_network.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark the complete LingBot DiT network.
+
+Run the benchmark with::
+
+    uv run --group test pytest \
+        integrations/lingbot/benchmarks/test_network.py \
+        -p no:manual_marker -m manual --benchmark-only
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import torch
+from lingbot.transformer.impl.modules import CamCtrlBlock
+from lingbot.transformer.impl.network import (
+    LingbotWorldDiTNetwork,
+    LingbotWorldDiTNetwork14BConfig,
+)
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+from flashdreams.core.attention.rope import RotaryPositionEmbedding3D
+from flashdreams.infra.acceleration import (
+    CUDAGraphDispatch,
+    cuda_graph_capture_ar_index,
+)
+from flashdreams.infra.compile import compile_module
+from integrations.lingbot.benchmarks.cases import (
+    BENCHMARK_CASES,
+    AttentionBenchmarkCase,
+    skip_unsupported_device,
+)
+
+pytestmark = pytest.mark.manual
+
+_GPU_REASON = "LingBot DiT network benchmark requires CUDA"
+
+# Production interactive geometry: 464x832 pixels become 58x104 latents.
+_LATENT_HEIGHT = 58
+_LATENT_WIDTH = 104
+_CHUNK_SIZE_T = 3
+_WINDOW_SIZE_T = 15
+_SINK_SIZE_T = 3
+_TEXT_TOKENS = 512
+_DIFFUSION_TIMESTEP = 450.0
+_WARMUP_ROUNDS = 5
+_BENCHMARK_ROUNDS = 50
+_SEED = 0
+
+
+def _build_network(
+    config: LingbotWorldDiTNetwork14BConfig,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> LingbotWorldDiTNetwork:
+    """Construct the 14B network directly on its benchmark device."""
+    previous_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(dtype)
+        with torch.device(device):
+            network = LingbotWorldDiTNetwork(config)
+    finally:
+        torch.set_default_dtype(previous_dtype)
+    return network.to(device=device, dtype=dtype)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason=_GPU_REASON)
+@pytest.mark.parametrize("case", BENCHMARK_CASES, ids=lambda case: case.pytest_id)
+@torch.inference_mode()
+def test_dit_network_benchmark(
+    benchmark: BenchmarkFixture,
+    case: AttentionBenchmarkCase,
+) -> None:
+    """Benchmark one compiled DiT attention configuration at steady state."""
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("LingBot DiT network benchmark requires bfloat16 support")
+
+    device = torch.device("cuda")
+    skip_unsupported_device(case, device)
+    dtype = torch.bfloat16
+    torch.manual_seed(_SEED)
+
+    config = LingbotWorldDiTNetwork14BConfig(
+        in_dim=36,
+        patch_embedding_type="conv3d",
+        control_type="cam",
+        cp_method="ring",
+        self_attention_backend=case.self_attention_backend,
+        cross_attention_backend=case.cross_attention_backend,
+        self_attn_optimized_impl_config=case.self_attn_optimized_impl_config,
+        cross_attn_optimized_impl_config=case.cross_attn_optimized_impl_config,
+    )
+    network = _build_network(config, device=device, dtype=dtype)
+    network.eval()
+    network.update_parameters_after_loading_checkpoint()
+    assert all(isinstance(block, CamCtrlBlock) for block in network.blocks)
+    assert all(
+        block.self_attention_backend is case.self_attention_backend
+        for block in network.blocks
+    )
+    assert all(
+        block.cross_attention_backend is case.cross_attention_backend
+        for block in network.blocks
+    )
+    assert all(
+        block.self_attn_optimized_impl_config is case.self_attn_optimized_impl_config
+        for block in network.blocks
+    )
+    assert all(
+        block.cross_attn_optimized_impl_config is case.cross_attn_optimized_impl_config
+        for block in network.blocks
+    )
+    generator = torch.Generator(device=device).manual_seed(_SEED)
+
+    patch_t = _CHUNK_SIZE_T // config.patch_size[0]
+    patch_h = _LATENT_HEIGHT // config.patch_size[1]
+    patch_w = _LATENT_WIDTH // config.patch_size[2]
+    patch_volume = config.patch_size[0] * config.patch_size[1] * config.patch_size[2]
+    tokens_per_frame = patch_h * patch_w
+    chunk_tokens = patch_t * tokens_per_frame
+    window_tokens = _WINDOW_SIZE_T * tokens_per_frame
+    sink_tokens = _SINK_SIZE_T * tokens_per_frame
+
+    x = torch.randn(
+        (chunk_tokens, config.in_dim * patch_volume),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    plucker = torch.randn(
+        (chunk_tokens, 6 * 64 * patch_volume),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    timestep = torch.tensor(_DIFFUSION_TIMESTEP, device=device, dtype=dtype)
+    text_embeddings = torch.randn(
+        (_TEXT_TOKENS, config.text_dim),
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    cache = network.initialize_cache(
+        chunk_size=chunk_tokens,
+        window_size=window_tokens,
+        sink_size=sink_tokens,
+        text_embeddings=text_embeddings,
+    )
+    rope = RotaryPositionEmbedding3D(
+        head_dim=config.dim // config.num_heads,
+        len_h=patch_h,
+        len_w=patch_w,
+        len_t=patch_t,
+        interleaved=True,
+        device=device,
+    )
+
+    network = compile_module(network)
+    capture_chunk_idx = cuda_graph_capture_ar_index(
+        sink_size_t=_SINK_SIZE_T,
+        window_size_t=_WINDOW_SIZE_T,
+        len_t=_CHUNK_SIZE_T,
+    )
+    graph_dispatch = CUDAGraphDispatch(
+        network,
+        enabled=True,
+        capture_ar_idx=capture_chunk_idx,
+        warmup_iters=2,
+    )
+
+    def forward(chunk_idx: int, rope_freqs: torch.Tensor) -> torch.Tensor:
+        return graph_dispatch.select(chunk_idx, uncond=False)(
+            x=x,
+            timesteps=timestep,
+            cache=cache,
+            rope_freqs=rope_freqs,
+            plucker=plucker,
+            current_chunk_idx=chunk_idx,
+            eager_mode=False,
+        )
+
+    # Fill the rolling cache and capture the first steady-state CUDA graph
+    # before pytest-benchmark starts its own warmups.
+    benchmark_chunk_idx = capture_chunk_idx + 1
+    rope_freqs = [
+        rope.shift_t(chunk_idx) for chunk_idx in range(benchmark_chunk_idx + 1)
+    ]
+    for chunk_idx in range(capture_chunk_idx + 1):
+        cache.before_update(chunk_idx)
+        output = forward(chunk_idx, rope_freqs[chunk_idx])
+        cache.after_update(chunk_idx)
+    torch.cuda.synchronize()
+
+    benchmark.group = "lingbot-dit-network"
+    cache.before_update(benchmark_chunk_idx)
+
+    def synchronized_forward() -> torch.Tensor:
+        result = forward(benchmark_chunk_idx, rope_freqs[benchmark_chunk_idx])
+        torch.cuda.synchronize()
+        return result
+
+    output = benchmark.pedantic(
+        synchronized_forward,
+        iterations=1,
+        rounds=_BENCHMARK_ROUNDS,
+        warmup_rounds=_WARMUP_ROUNDS,
+    )
+    cache.after_update(benchmark_chunk_idx)
+
+    assert output.shape == (chunk_tokens, config.out_dim * patch_volume)
+    assert torch.isfinite(output).all()

--- a/integrations/lingbot/benchmarks/test_pipeline.py
+++ b/integrations/lingbot/benchmarks/test_pipeline.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Steady-state full-pipeline benchmark for LingBot streaming inference.
+
+Run the benchmark with::
+
+    uv run --group test pytest \
+        integrations/lingbot/benchmarks/test_pipeline.py \
+        -p no:manual_marker -m manual --benchmark-only
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import torch
+from lingbot.config import PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3
+from lingbot.encoder.camctrl import CamCtrlInput, I2VCamCtrlEncoder
+from lingbot.pipeline import LingbotWorldInferencePipeline
+from lingbot.transformer import LingbotWorldTransformer, LingbotWorldTransformerConfig
+from lingbot.transformer.impl.network import LingbotWorldDiTNetworkConfig
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+from flashdreams.infra.config import derive_config
+from flashdreams.infra.diffusion.scheduler.fm import FlowMatchSchedulerConfig
+from flashdreams.recipes.taehv import TeahvVAEDecoder
+from flashdreams.recipes.wan.pipeline import (
+    WanInferencePipeline,
+    WanInferencePipelineCache,
+)
+from integrations.lingbot.benchmarks.cases import (
+    BENCHMARK_CASES,
+    AttentionBenchmarkCase,
+    skip_unsupported_device,
+)
+
+pytestmark = pytest.mark.manual
+
+_GPU_REASON = "LingBot full-pipeline benchmark requires CUDA"
+
+_PIXEL_HEIGHT = 464
+_PIXEL_WIDTH = 832
+_TEXT_TOKENS = 512
+_WARMUP_ROUNDS = 5
+_BENCHMARK_ROUNDS = 50
+_SEED = 0
+
+
+def _camera_input(
+    *,
+    num_frames: int,
+    start_frame: int,
+    device: torch.device,
+) -> CamCtrlInput:
+    """Build a deterministic camera trajectory for one autoregressive chunk."""
+    intrinsics = torch.tensor(
+        [_PIXEL_WIDTH, _PIXEL_WIDTH, _PIXEL_WIDTH / 2, _PIXEL_HEIGHT / 2],
+        device=device,
+        dtype=torch.float32,
+    ).expand(num_frames, -1)
+    poses = (
+        torch.eye(4, device=device, dtype=torch.float32)
+        .expand(num_frames, -1, -1)
+        .clone()
+    )
+    poses[:, 0, 3] = torch.arange(
+        start_frame,
+        start_frame + num_frames,
+        device=device,
+        dtype=torch.float32,
+    ).mul_(0.01)
+    return CamCtrlInput(intrinsics=intrinsics, poses=poses, world_scale=1.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason=_GPU_REASON)
+@pytest.mark.parametrize("case", BENCHMARK_CASES, ids=lambda case: case.pytest_id)
+def test_full_pipeline_generate_benchmark(
+    benchmark: BenchmarkFixture,
+    case: AttentionBenchmarkCase,
+) -> None:
+    """Benchmark recurring pipeline generation for one attention configuration."""
+    _run_full_pipeline_benchmark(benchmark, case=case)
+
+
+@torch.inference_mode()
+def _run_full_pipeline_benchmark(
+    benchmark: BenchmarkFixture,
+    *,
+    case: AttentionBenchmarkCase,
+) -> None:
+    """Run one full-pipeline benchmark variant."""
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("LingBot full-pipeline benchmark requires bfloat16 support")
+
+    device = torch.device("cuda")
+    skip_unsupported_device(case, device)
+    torch.manual_seed(_SEED)
+    torch.backends.cudnn.benchmark = True
+
+    # Prompt encoding runs once before streaming. Precomputed embeddings keep
+    # the measured path focused on recurring camera encoding, diffusion,
+    # decoding, and cache bookkeeping.
+    pipeline_config = derive_config(
+        PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3,
+        name=f"lingbot-full-pipeline-{case.pytest_id}-benchmark",
+        text_encoder=None,
+        enable_sync_and_profile=False,
+        diffusion_model={
+            "seed": _SEED,
+            "transformer": {
+                "init_device": str(device),
+                "compile_network": True,
+                "use_cuda_graph": True,
+                "network": {
+                    "cp_method": "ring",
+                    "self_attention_backend": case.self_attention_backend,
+                    "cross_attention_backend": case.cross_attention_backend,
+                    "self_attn_optimized_impl_config": case.self_attn_optimized_impl_config,
+                    "cross_attn_optimized_impl_config": case.cross_attn_optimized_impl_config,
+                },
+            },
+        },
+    )
+    pipeline = pipeline_config.setup().to(device=device)
+    assert isinstance(pipeline, LingbotWorldInferencePipeline)
+    pipeline.eval()
+    assert isinstance(pipeline.encoder, I2VCamCtrlEncoder)
+    assert isinstance(pipeline.decoder, TeahvVAEDecoder)
+    assert pipeline.text_encoder is None
+
+    diffusion_config = pipeline_config.diffusion_model
+    transformer_config = diffusion_config.transformer
+    scheduler_config = diffusion_config.scheduler
+    assert isinstance(transformer_config, LingbotWorldTransformerConfig)
+    assert isinstance(scheduler_config, FlowMatchSchedulerConfig)
+    network_config = transformer_config.network
+    assert isinstance(network_config, LingbotWorldDiTNetworkConfig)
+    assert network_config.self_attention_backend is case.self_attention_backend
+    assert network_config.cross_attention_backend is case.cross_attention_backend
+    assert (
+        network_config.self_attn_optimized_impl_config
+        is case.self_attn_optimized_impl_config
+    )
+    assert (
+        network_config.cross_attn_optimized_impl_config
+        is case.cross_attn_optimized_impl_config
+    )
+
+    transformer = pipeline.diffusion_model.transformer
+    assert isinstance(transformer, LingbotWorldTransformer)
+    assert transformer.config is transformer_config
+    dtype = transformer_config.dtype
+    spatial_compression = int(pipeline.decoder.spatial_compression_ratio)
+    latent_height = _PIXEL_HEIGHT // spatial_compression
+    latent_width = _PIXEL_WIDTH // spatial_compression
+
+    text_embeddings = torch.zeros(
+        (_TEXT_TOKENS, network_config.text_dim),
+        device=device,
+        dtype=dtype,
+    )
+    image = torch.zeros(
+        (1, 3, _PIXEL_HEIGHT, _PIXEL_WIDTH),
+        device=device,
+        dtype=dtype,
+    )
+    parent_cache = super(WanInferencePipeline, pipeline).initialize_cache(
+        transformer_context={
+            "height": latent_height,
+            "width": latent_width,
+            "text_embeddings": text_embeddings,
+        }
+    )
+    cache = WanInferencePipelineCache(
+        transformer_cache=parent_cache.transformer_cache,
+        encoder_cache=parent_cache.encoder_cache,
+        decoder_cache=parent_cache.decoder_cache,
+        image=image,
+    )
+    del text_embeddings
+
+    first_input_frames = pipeline.get_num_input_frames(0)
+    steady_input_frames = pipeline.get_num_input_frames(1)
+    steady_output_frames = pipeline.get_num_output_frames(1)
+    capture_ar_index = transformer._cuda_graph_capture_ar_idx
+    cache_prefill_chunks = capture_ar_index + 1
+    total_chunks = cache_prefill_chunks + _WARMUP_ROUNDS + _BENCHMARK_ROUNDS + 1
+    camera_inputs = tuple(
+        _camera_input(
+            num_frames=(first_input_frames if index == 0 else steady_input_frames),
+            start_frame=(
+                0
+                if index == 0
+                else first_input_frames + (index - 1) * steady_input_frames
+            ),
+            device=device,
+        )
+        for index in range(total_chunks)
+    )
+
+    def run_chunk(autoregressive_index: int) -> torch.Tensor:
+        output = pipeline.generate(
+            autoregressive_index=autoregressive_index,
+            cache=cache,
+            input=camera_inputs[autoregressive_index],
+        )
+        pipeline.finalize(autoregressive_index=autoregressive_index, cache=cache)
+        return output
+
+    # Fill the local KV window and capture the first steady-state graph before
+    # pytest-benchmark's warmups and measured rounds.
+    for autoregressive_index in range(cache_prefill_chunks):
+        output = run_chunk(autoregressive_index)
+    torch.cuda.synchronize()
+
+    benchmark.group = "lingbot-full-pipeline-generate"
+    next_chunk_index = cache_prefill_chunks
+
+    def synchronized_generate() -> torch.Tensor:
+        output = pipeline.generate(
+            autoregressive_index=next_chunk_index,
+            cache=cache,
+            input=camera_inputs[next_chunk_index],
+        )
+        torch.cuda.synchronize()
+        return output
+
+    def teardown_generate() -> None:
+        nonlocal next_chunk_index
+        pipeline.finalize(
+            autoregressive_index=next_chunk_index,
+            cache=cache,
+        )
+        torch.cuda.synchronize()
+        next_chunk_index += 1
+
+    output = benchmark.pedantic(
+        synchronized_generate,
+        teardown=teardown_generate,
+        iterations=1,
+        rounds=_BENCHMARK_ROUNDS,
+        warmup_rounds=_WARMUP_ROUNDS,
+    )
+
+    assert output.shape == (
+        steady_output_frames,
+        3,
+        _PIXEL_HEIGHT,
+        _PIXEL_WIDTH,
+    )
+    assert torch.isfinite(output).all()

--- a/integrations/lingbot/benchmarks/test_pipeline.py
+++ b/integrations/lingbot/benchmarks/test_pipeline.py
@@ -28,7 +28,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 import torch
-from lingbot.config import PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3
+from lingbot.config import (
+    PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3,
+)
 from lingbot.encoder.camctrl import CamCtrlInput, I2VCamCtrlEncoder
 from lingbot.pipeline import LingbotWorldInferencePipeline
 from lingbot.transformer import LingbotWorldTransformer, LingbotWorldTransformerConfig

--- a/integrations/lingbot/lingbot/config.py
+++ b/integrations/lingbot/lingbot/config.py
@@ -183,6 +183,37 @@ RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000 = LingbotWorldRunner
     pipeline=PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000,
 )
 
+PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_GB300 = derive_config(
+    PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
+    name="lingbot-world-fast-taehv-window15-sink3-gb300",
+    diffusion_model=dict(
+        transformer=dict(
+            network=dict(
+                self_attention_backend=AttentionBackend.OPTIMIZED,
+                cross_attention_backend=AttentionBackend.TORCH,
+                self_attn_optimized_impl_config=OptimizedImplConfig(
+                    qkv_fusion_option=QKVFusionOption.NONE,
+                    sdpa_backend=SDPABackend.CUDNN,
+                    use_tma=False,
+                    quantization=QuantizationOption(
+                        projection=None,
+                        quantized_sdpa=True,
+                    ),
+                ),
+            ),
+        ),
+    ),
+)
+RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_GB300 = LingbotWorldRunnerConfig(
+    runner_name=PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_GB300.name,
+    description=(
+        "LingBot-World Fast streaming camera-control I2V "
+        "(LightTAE decoder, window=15 + sink=3 streaming KV cache, "
+        "GB300 optimized self-attention)."
+    ),
+    pipeline=PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_GB300,
+)
+
 # LingBot-World v2 uses the same architecture and runtime as v1. The
 # transformer checkpoint is the only model-level substitution; it inherits
 # the bounded checkpoint loader from the v1 base config.
@@ -228,6 +259,7 @@ PIPELINE_CONFIGS: dict[str, LingbotWorldInferencePipelineConfig] = {
         PIPELINE_LINGBOT_WORLD_FAST,
         PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
         PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000,
+        PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_GB300,
         PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST,
         PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3,
     )
@@ -240,6 +272,7 @@ RUNNER_CONFIGS: dict[str, RunnerConfig] = {
         RUNNER_LINGBOT_WORLD_FAST,
         RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
         RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000,
+        RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_GB300,
         RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST,
         RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3,
     )

--- a/integrations/lingbot/lingbot/config.py
+++ b/integrations/lingbot/lingbot/config.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 
 import torch
 
+from flashdreams.accelerated.multi_head_attention.optimized import (
+    OptimizedImplConfig,
+    QKVFusionOption,
+    QuantizationOption,
+    SDPABackend,
+)
 from flashdreams.infra.config import derive_config
 from flashdreams.infra.diffusion.model import DiffusionModelConfig
 from flashdreams.infra.diffusion.scheduler.fm import FlowMatchSchedulerConfig
@@ -28,6 +34,7 @@ from flashdreams.recipes.wan.autoencoder.vae import (
     WanVAEDecoderConfig,
     WanVAEEncoderConfig,
 )
+from flashdreams.recipes.wan.transformer.impl.modules import AttentionBackend
 from lingbot.encoder.camctrl import (
     I2VCamCtrlEncoderConfig,
     LingbotI2VCtrlEncoderConfig,
@@ -136,6 +143,46 @@ RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3 = LingbotWorldRunnerConfig(
     pipeline=PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
 )
 
+PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000 = derive_config(
+    PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
+    name="lingbot-world-fast-taehv-window15-sink3-rtx-pro-6000",
+    diffusion_model=dict(
+        transformer=dict(
+            network=dict(
+                self_attention_backend=AttentionBackend.OPTIMIZED,
+                cross_attention_backend=AttentionBackend.OPTIMIZED,
+                self_attn_optimized_impl_config=OptimizedImplConfig(
+                    qkv_fusion_option=QKVFusionOption.NONE,
+                    sdpa_backend=SDPABackend.FA2,
+                    use_tma=True,
+                    quantization=QuantizationOption(
+                        projection=torch.float8_e4m3fn,
+                        quantized_sdpa=True,
+                    ),
+                ),
+                cross_attn_optimized_impl_config=OptimizedImplConfig(
+                    qkv_fusion_option=QKVFusionOption.NONE,
+                    sdpa_backend=SDPABackend.FA2,
+                    use_tma=True,
+                    quantization=QuantizationOption(
+                        projection=torch.float8_e4m3fn,
+                        quantized_sdpa=True,
+                    ),
+                ),
+            ),
+        ),
+    ),
+)
+RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000 = LingbotWorldRunnerConfig(
+    runner_name=(PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000.name),
+    description=(
+        "LingBot-World Fast streaming camera-control I2V "
+        "(LightTAE decoder, window=15 + sink=3 streaming KV cache, "
+        "RTX PRO 6000 optimized MHA)."
+    ),
+    pipeline=PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000,
+)
+
 # LingBot-World v2 uses the same architecture and runtime as v1. The
 # transformer checkpoint is the only model-level substitution; it inherits
 # the bounded checkpoint loader from the v1 base config.
@@ -180,6 +227,7 @@ PIPELINE_CONFIGS: dict[str, LingbotWorldInferencePipelineConfig] = {
     for cfg in (
         PIPELINE_LINGBOT_WORLD_FAST,
         PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
+        PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000,
         PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST,
         PIPELINE_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3,
     )
@@ -191,6 +239,7 @@ RUNNER_CONFIGS: dict[str, RunnerConfig] = {
     for cfg in (
         RUNNER_LINGBOT_WORLD_FAST,
         RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
+        RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000,
         RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST,
         RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3,
     )

--- a/integrations/lingbot/lingbot/transformer/impl/modules.py
+++ b/integrations/lingbot/lingbot/transformer/impl/modules.py
@@ -23,7 +23,13 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
+from flashdreams.accelerated.multi_head_attention.optimized import (
+    OptimizedImplConfig,
+    QKVFusionOption,
+    SDPABackend,
+)
 from flashdreams.recipes.wan.transformer.impl.modules import (
+    AttentionBackend,
     Block,
     BlockCache,
 )
@@ -40,7 +46,19 @@ class CamCtrlBlock(Block):
         cross_attn_norm: bool = True,
         eps: float = 1e-6,
         cp_method: Literal["ring", "ulysses"] = "ring",
+        self_attention_backend: AttentionBackend = AttentionBackend.TORCH,
+        cross_attention_backend: AttentionBackend = AttentionBackend.TORCH,
+        self_attn_optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FULL,
+            sdpa_backend=SDPABackend.FA2,
+        ),
+        cross_attn_optimized_impl_config: OptimizedImplConfig = OptimizedImplConfig(
+            qkv_fusion_option=QKVFusionOption.FUSE_KV,
+            sdpa_backend=SDPABackend.FA2,
+        ),
     ) -> None:
+        self_attention_backend = AttentionBackend(self_attention_backend)
+        cross_attention_backend = AttentionBackend(cross_attention_backend)
         super().__init__(
             dim=dim,
             ffn_dim=ffn_dim,
@@ -48,6 +66,10 @@ class CamCtrlBlock(Block):
             cross_attn_norm=cross_attn_norm,
             eps=eps,
             cp_method=cp_method,
+            self_attention_backend=self_attention_backend,
+            cross_attention_backend=cross_attention_backend,
+            self_attn_optimized_impl_config=self_attn_optimized_impl_config,
+            cross_attn_optimized_impl_config=cross_attn_optimized_impl_config,
         )
         self.cam_injector_layer1 = nn.Linear(dim, dim)
         self.cam_injector_layer2 = nn.Linear(dim, dim)

--- a/integrations/lingbot/lingbot/transformer/impl/network.py
+++ b/integrations/lingbot/lingbot/transformer/impl/network.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
+from flashdreams.recipes.wan.transformer.impl.modules import AttentionBackend
 from flashdreams.recipes.wan.transformer.impl.network import (
     WanDiTNetwork,
     WanDiTNetworkCache,
@@ -46,6 +47,12 @@ class LingbotWorldDiTNetworkConfig(WanDiTNetworkConfig):
         default_factory=lambda: LingbotWorldDiTNetwork
     )
     control_type: Literal["cam", "act"] = "cam"
+
+    self_attention_backend: AttentionBackend = AttentionBackend.TORCH
+    """Self-attention implementation used by every DiT block."""
+
+    cross_attention_backend: AttentionBackend = AttentionBackend.TORCH
+    """Cross-attention implementation used by every DiT block."""
 
 
 @dataclass
@@ -99,6 +106,10 @@ class LingbotWorldDiTNetwork(WanDiTNetwork):
             cross_attn_norm=self.cross_attn_norm,
             eps=self.eps,
             cp_method=self.cp_method,
+            self_attention_backend=self.self_attention_backend,
+            cross_attention_backend=self.cross_attention_backend,
+            self_attn_optimized_impl_config=self.self_attn_optimized_impl_config,
+            cross_attn_optimized_impl_config=self.cross_attn_optimized_impl_config,
         )
 
     def replace_text_embeddings(

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -53,6 +53,7 @@ lingbot-demo = "lingbot.demo.app:main"
 [project.entry-points."flashdreams.runner_configs"]
 "lingbot-world-fast" = "lingbot.config:RUNNER_LINGBOT_WORLD_FAST"
 "lingbot-world-fast-taehv-window15-sink3" = "lingbot.config:RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3"
+"lingbot-world-fast-taehv-window15-sink3-rtx-pro-6000" = "lingbot.config:RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000"
 "lingbot-world-v2-14b-causal-fast" = "lingbot.config:RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST"
 "lingbot-world-v2-14b-causal-fast-taehv-window15-sink3" = "lingbot.config:RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3"
 

--- a/integrations/lingbot/pyproject.toml
+++ b/integrations/lingbot/pyproject.toml
@@ -54,6 +54,7 @@ lingbot-demo = "lingbot.demo.app:main"
 "lingbot-world-fast" = "lingbot.config:RUNNER_LINGBOT_WORLD_FAST"
 "lingbot-world-fast-taehv-window15-sink3" = "lingbot.config:RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3"
 "lingbot-world-fast-taehv-window15-sink3-rtx-pro-6000" = "lingbot.config:RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_RTX_PRO_6000"
+"lingbot-world-fast-taehv-window15-sink3-gb300" = "lingbot.config:RUNNER_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3_GB300"
 "lingbot-world-v2-14b-causal-fast" = "lingbot.config:RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST"
 "lingbot-world-v2-14b-causal-fast-taehv-window15-sink3" = "lingbot.config:RUNNER_LINGBOT_WORLD_V2_14B_CAUSAL_FAST_TAEHV_WINDOW15_SINK3"
 

--- a/scripts/benchmark/lingbot/_plot.py
+++ b/scripts/benchmark/lingbot/_plot.py
@@ -1,0 +1,400 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared rendering for LingBot benchmark plots."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from scripts.benchmark.common import (
+    add_relative_colorbar,
+    annotate_relative_cell,
+    benchmark_median_ms,
+    benchmark_subtitle,
+    draw_relative_heatmap,
+    latency_comparison_label,
+    load_benchmark_json,
+    save_figure,
+)
+
+_ATTENTION_PANELS = (
+    ("lingbot-dit-self-attention", "Self-attention"),
+    ("lingbot-dit-cross-attention", "Cross-attention"),
+)
+_DIT_BLOCK_PANEL = ("lingbot-dit-block", "DiT block")
+_PIPELINE_GENERATE_PANEL = (
+    "lingbot-full-pipeline-generate",
+    "Pipeline generate",
+)
+_END_TO_END_PANELS = (
+    ("lingbot-dit-network", "Network eval"),
+    _PIPELINE_GENERATE_PANEL,
+)
+
+_FUSION_LABELS = {
+    "none": "None",
+    "fuse-kv": "Fuse KV",
+    "full": "Fuse QKV",
+}
+_END_TO_END_LABELS = {
+    "torch": "Torch\nself + cross",
+    "optimized-self": "Optimized self\nTorch cross",
+    "optimized-cross": "Torch self\nOptimized cross",
+    "optimized-self-cross": "Optimized\nself + cross",
+}
+
+BenchmarkValues = dict[str, dict[str, float]]
+Panel = tuple[str, str]
+
+
+def _load_results(
+    input_path: Path,
+    panels: tuple[Panel, ...],
+) -> tuple[BenchmarkValues, list[str], str]:
+    """Load median timings for the requested LingBot benchmark groups."""
+    payload, benchmark_records = load_benchmark_json(input_path)
+    values: BenchmarkValues = {group: {} for group, _ in panels}
+    configurations: list[str] = []
+
+    for record in benchmark_records:
+        if not isinstance(record, dict):
+            continue
+        group = record.get("group")
+        if not isinstance(group, str) or group not in values:
+            continue
+        implementation = record.get("param")
+        if not isinstance(implementation, str) or not implementation:
+            raise SystemExit(
+                f"Benchmark {record.get('name', '<unnamed>')} has no parameter ID"
+            )
+        if implementation in values[group]:
+            raise SystemExit(f"Duplicate benchmark for {group} and {implementation}")
+
+        values[group][implementation] = benchmark_median_ms(record)
+        if implementation not in configurations:
+            configurations.append(implementation)
+
+    missing = [group for group, results in values.items() if not results]
+    if missing:
+        raise SystemExit(
+            f"Benchmark JSON {input_path} lacks groups: {', '.join(missing)}"
+        )
+    return values, configurations, benchmark_subtitle(payload)
+
+
+def _attention_configuration_label(implementation: str) -> str:
+    """Format one isolated attention implementation as an axis label."""
+    if implementation == "torch":
+        return "Torch\nreference"
+    match = re.fullmatch(
+        r"optimized-(cudnn|fa2)-(none|full|fuse-kv)-(no-tma|tma)"
+        r"(?:-projection-(float8-e4m3fn))?(-quantized-sdpa)?",
+        implementation,
+    )
+    if match is None:
+        return "\n".join(implementation.split("-"))
+    backend, fusion, tma, projection, quantized_sdpa = match.groups()
+    labels = [
+        "Optimized",
+        "cuDNN" if backend == "cudnn" else "FA2",
+        f"Fusion: {_FUSION_LABELS[fusion]}",
+        "No TMA" if tma == "no-tma" else "TMA",
+    ]
+    if projection is not None:
+        labels.extend(("Projection:", "FP8 E4M3"))
+    if quantized_sdpa is not None:
+        labels.extend(("SDPA:", "FP8 E4M3"))
+    return "\n".join(labels)
+
+
+def _end_to_end_configuration_label(implementation: str) -> str:
+    """Format one network, pipeline, or representative block case."""
+    return _END_TO_END_LABELS.get(
+        implementation,
+        "\n".join(implementation.split("-")),
+    )
+
+
+def _bar_label(
+    latency_ms: float,
+    reference_ms: float,
+    *,
+    is_reference: bool,
+) -> str:
+    precision = 3 if latency_ms < 1 else 2 if latency_ms < 10 else 1
+    return latency_comparison_label(
+        latency_ms,
+        reference_ms,
+        is_reference=is_reference,
+        precision=precision,
+    )
+
+
+def _write_bar_figure(
+    output_path: Path,
+    title: str,
+    panels: tuple[Panel, ...],
+    values: BenchmarkValues,
+    configurations: list[str],
+    subtitle: str,
+    configuration_label: Callable[[str], str],
+    xlabel: str,
+) -> None:
+    panel_configurations = [
+        configuration
+        for configuration in configurations
+        if any(configuration in values[group] for group, _ in panels)
+    ]
+    figure, axes = plt.subplots(
+        len(panels),
+        1,
+        figsize=(max(12.0, len(panel_configurations) * 1.3), len(panels) * 5.0),
+        layout="constrained",
+    )
+    axes_list = [axes] if len(panels) == 1 else list(axes)
+    for axes_item, (group, panel_title) in zip(axes_list, panels, strict=True):
+        reference = values[group].get("torch")
+        if reference is None:
+            raise SystemExit(f"Benchmark results for {group} have no torch reference")
+        ordered_configurations = sorted(
+            panel_configurations,
+            key=lambda configuration: values[group].get(configuration, math.inf),
+        )
+        latencies = [
+            values[group].get(configuration, math.nan)
+            for configuration in ordered_configurations
+        ]
+        bars = axes_item.bar(
+            range(len(ordered_configurations)),
+            latencies,
+            color=[
+                "C2" if configuration == "torch" else "C0"
+                for configuration in ordered_configurations
+            ],
+        )
+        finite_latencies = [value for value in latencies if math.isfinite(value)]
+        axes_item.set_ylim(0, max(finite_latencies) * 1.2)
+        axes_item.set_title(panel_title)
+        axes_item.set_ylabel("Median\nlatency\n(ms)")
+
+        for index, (bar, latency, configuration) in enumerate(
+            zip(bars, latencies, ordered_configurations, strict=True)
+        ):
+            if not math.isfinite(latency):
+                bar.set_visible(False)
+                axes_item.text(
+                    index,
+                    0.02,
+                    "N/A\nnot measured",
+                    transform=axes_item.get_xaxis_transform(),
+                    ha="center",
+                    va="bottom",
+                )
+                continue
+            axes_item.annotate(
+                _bar_label(
+                    latency,
+                    reference,
+                    is_reference=configuration == "torch",
+                ),
+                xy=(bar.get_x() + bar.get_width() / 2, latency),
+                xytext=(0, 3),
+                textcoords="offset points",
+                ha="center",
+                va="bottom",
+            )
+        axes_item.set_xticks(
+            range(len(ordered_configurations)),
+            labels=[
+                configuration_label(configuration)
+                for configuration in ordered_configurations
+            ],
+        )
+
+    figure.supxlabel(xlabel)
+    figure.suptitle(f"{title}\n{subtitle}")
+    save_figure(figure, output_path)
+
+
+def _split_block_implementation(implementation: str) -> tuple[str, str]:
+    """Split a full-search block ID into self- and cross-attention IDs."""
+    if not implementation.startswith("self-"):
+        raise SystemExit(f"Unsupported DiT block parameter {implementation!r}")
+    self_implementation, separator, cross_implementation = implementation[
+        len("self-") :
+    ].partition("-cross-")
+    if not separator or not self_implementation or not cross_implementation:
+        raise SystemExit(f"Unsupported DiT block parameter {implementation!r}")
+    return self_implementation, cross_implementation
+
+
+def _write_block_heatmap(
+    output_path: Path,
+    values: BenchmarkValues,
+    subtitle: str,
+) -> None:
+    block_values = values[_DIT_BLOCK_PANEL[0]]
+    self_configurations: list[str] = []
+    cross_configurations: list[str] = []
+    latencies: dict[tuple[str, str], float] = {}
+    for implementation, latency in block_values.items():
+        self_implementation, cross_implementation = _split_block_implementation(
+            implementation
+        )
+        cell = (self_implementation, cross_implementation)
+        if cell in latencies:
+            raise SystemExit(
+                "Duplicate DiT block benchmark for "
+                f"{self_implementation} and {cross_implementation}"
+            )
+        latencies[cell] = latency
+        if self_implementation not in self_configurations:
+            self_configurations.append(self_implementation)
+        if cross_implementation not in cross_configurations:
+            cross_configurations.append(cross_implementation)
+
+    reference_key = ("torch", "torch")
+    reference = latencies.get(reference_key)
+    if reference is None:
+        raise SystemExit("DiT block results have no all-Torch reference")
+    matrix = [
+        [
+            latencies.get((self_implementation, cross_implementation), math.nan)
+            / reference
+            for cross_implementation in cross_configurations
+        ]
+        for self_implementation in self_configurations
+    ]
+    figure, axes = plt.subplots(
+        figsize=(
+            max(12.0, len(cross_configurations) * 2.0),
+            max(8.0, len(self_configurations) * 0.9),
+        ),
+        layout="constrained",
+    )
+    image = draw_relative_heatmap(axes, matrix)
+    axes.set_xticks(
+        range(len(cross_configurations)),
+        labels=[
+            _attention_configuration_label(configuration).removeprefix("Optimized\n")
+            for configuration in cross_configurations
+        ],
+    )
+    axes.set_yticks(
+        range(len(self_configurations)),
+        labels=[
+            _attention_configuration_label(configuration).removeprefix("Optimized\n")
+            for configuration in self_configurations
+        ],
+    )
+    axes.set_xlabel("Cross-attention\nimplementation")
+    axes.set_ylabel("Self-attention\nimplementation")
+    axes.set_title(f"LingBot DiT block performance\n{subtitle}")
+
+    for self_index, self_implementation in enumerate(self_configurations):
+        for cross_index, cross_implementation in enumerate(cross_configurations):
+            latency = latencies.get((self_implementation, cross_implementation))
+            label = (
+                "N/A\nnot measured"
+                if latency is None
+                else _bar_label(
+                    latency,
+                    reference,
+                    is_reference=(
+                        self_implementation,
+                        cross_implementation,
+                    )
+                    == reference_key,
+                )
+            )
+            annotate_relative_cell(
+                axes,
+                image,
+                self_index,
+                cross_index,
+                label,
+                matrix[self_index][cross_index],
+            )
+
+    add_relative_colorbar(
+        figure,
+        axes,
+        image,
+        "Runtime relative to\nall-Torch reference (×)",
+        multiline_directions=True,
+    )
+    save_figure(figure, output_path)
+
+
+def plot_modules(input_path: Path, output_dir: Path) -> None:
+    """Generate attention-module and DiT-block benchmark figures."""
+    panels = (*_ATTENTION_PANELS, _DIT_BLOCK_PANEL)
+    values, configurations, subtitle = _load_results(input_path, panels)
+
+    attention_output = output_dir / "modules.png"
+    _write_bar_figure(
+        attention_output,
+        "LingBot attention module benchmarks",
+        _ATTENTION_PANELS,
+        values,
+        configurations,
+        subtitle,
+        _attention_configuration_label,
+        "Configuration\n(SDPA backend / QKV fusion / TMA / projection dtype)",
+    )
+    print(f"Wrote {attention_output}")
+
+    block_output = output_dir / "dit_block.png"
+    if all(
+        implementation.startswith("self-")
+        for implementation in values[_DIT_BLOCK_PANEL[0]]
+    ):
+        _write_block_heatmap(block_output, values, subtitle)
+    else:
+        _write_bar_figure(
+            block_output,
+            "LingBot DiT block benchmark",
+            (_DIT_BLOCK_PANEL,),
+            values,
+            configurations,
+            subtitle,
+            _end_to_end_configuration_label,
+            "Configuration\n(self-attention + cross-attention)",
+        )
+    print(f"Wrote {block_output}")
+
+
+def plot_pipeline(
+    input_path: Path,
+    output_dir: Path,
+    *,
+    pipeline_generate_only: bool = False,
+) -> None:
+    """Generate network and pipeline benchmark figures."""
+    panels = (
+        (_PIPELINE_GENERATE_PANEL,) if pipeline_generate_only else _END_TO_END_PANELS
+    )
+    values, configurations, subtitle = _load_results(input_path, panels)
+    if pipeline_generate_only:
+        output_path = output_dir / "pipeline_generate.png"
+        title = "LingBot pipeline generate benchmark"
+    else:
+        output_path = output_dir / "network_pipeline.png"
+        title = "LingBot network and pipeline benchmarks"
+    _write_bar_figure(
+        output_path,
+        title,
+        panels,
+        values,
+        configurations,
+        subtitle,
+        _end_to_end_configuration_label,
+        "Configuration\n(self-attention + cross-attention)",
+    )
+    print(f"Wrote {output_path}")

--- a/scripts/benchmark/lingbot/plot_module.py
+++ b/scripts/benchmark/lingbot/plot_module.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plot LingBot attention-module and DiT-block benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.benchmark.common import add_plot_io_arguments, benchmark_artifact_dir
+
+from ._plot import plot_modules
+
+_DEFAULT_OUTPUT_DIR = benchmark_artifact_dir(Path("artifacts/benchmark/lingbot"))
+_DEFAULT_INPUT = _DEFAULT_OUTPUT_DIR / "module.json"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_plot_io_arguments(parser, _DEFAULT_INPUT, _DEFAULT_OUTPUT_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    plot_modules(args.input, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/lingbot/plot_pipeline.py
+++ b/scripts/benchmark/lingbot/plot_pipeline.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plot LingBot network and pipeline benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.benchmark.common import add_plot_io_arguments, benchmark_artifact_dir
+
+from ._plot import plot_pipeline
+
+_DEFAULT_OUTPUT_DIR = benchmark_artifact_dir(Path("artifacts/benchmark/lingbot"))
+_DEFAULT_INPUT = _DEFAULT_OUTPUT_DIR / "pipeline.json"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_plot_io_arguments(parser, _DEFAULT_INPUT, _DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--pipeline-generate-only",
+        action="store_true",
+        help="write only the pipeline generate benchmark figure",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    plot_pipeline(
+        args.input,
+        args.output_dir,
+        pipeline_generate_only=args.pipeline_generate_only,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/lingbot/run.sh
+++ b/scripts/benchmark/lingbot/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run and plot all default LingBot benchmarks:
+#   ./scripts/benchmark/lingbot/run.sh
+# Run and plot all full-mode LingBot benchmarks:
+#   FLASHDREAMS_RUN_FULL_BENCHMARK=1 ./scripts/benchmark/lingbot/run.sh
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+"$script_dir/run_module.sh" "$@"
+"$script_dir/run_pipeline.sh" "$@"

--- a/scripts/benchmark/lingbot/run_module.sh
+++ b/scripts/benchmark/lingbot/run_module.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run and plot the representative module benchmark:
+#   ./scripts/benchmark/lingbot/run_module.sh
+# Replot its saved results:
+#   uv run python -m scripts.benchmark.lingbot.plot_module
+#
+# Run and plot all 1,369 full-block self/cross pairs:
+#   FLASHDREAMS_RUN_FULL_BENCHMARK=1 \
+#     ./scripts/benchmark/lingbot/run_module.sh
+# Replot their saved results:
+#   FLASHDREAMS_RUN_FULL_BENCHMARK=1 \
+#     uv run python -m scripts.benchmark.lingbot.plot_module
+
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+artifact_dir=artifacts/benchmark/lingbot
+if [[ "${FLASHDREAMS_RUN_FULL_BENCHMARK:-0}" == "1" ]]; then
+    artifact_dir="$artifact_dir/full"
+fi
+mkdir -p "$artifact_dir"
+
+uv run --project integrations/lingbot --group test pytest \
+    integrations/lingbot/benchmarks/test_modules.py \
+    -p no:manual_marker -m manual --benchmark-only -v "$@" \
+    --benchmark-json="$artifact_dir/module.json"
+
+uv run python -m scripts.benchmark.lingbot.plot_module

--- a/scripts/benchmark/lingbot/run_pipeline.sh
+++ b/scripts/benchmark/lingbot/run_pipeline.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run and plot with the default benchmark artifacts:
+#   ./scripts/benchmark/lingbot/run_pipeline.sh
+# Run and plot alongside the full benchmark artifacts:
+#   FLASHDREAMS_RUN_FULL_BENCHMARK=1 \
+#     ./scripts/benchmark/lingbot/run_pipeline.sh
+
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+artifact_dir=artifacts/benchmark/lingbot
+if [[ "${FLASHDREAMS_RUN_FULL_BENCHMARK:-0}" == "1" ]]; then
+    artifact_dir="$artifact_dir/full"
+fi
+mkdir -p "$artifact_dir"
+
+uv run --project integrations/lingbot --group test pytest \
+    integrations/lingbot/benchmarks/test_network.py \
+    integrations/lingbot/benchmarks/test_pipeline.py \
+    -p no:manual_marker -m manual --benchmark-only -v "$@" \
+    --benchmark-json="$artifact_dir/pipeline.json"
+
+uv run python -m scripts.benchmark.lingbot.plot_pipeline

--- a/scripts/benchmark/lingbot/test_plot.py
+++ b/scripts/benchmark/lingbot/test_plot.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for LingBot benchmark plotting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.benchmark.lingbot._plot import plot_modules, plot_pipeline
+
+pytestmark = pytest.mark.ci_cpu
+
+
+def _record(group: str, implementation: str, median: float) -> dict[str, object]:
+    return {
+        "name": f"{group}[{implementation}]",
+        "group": group,
+        "param": implementation,
+        "stats": {"median": median},
+    }
+
+
+def _write_results(path: Path, records: list[dict[str, object]]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "benchmarks": records,
+                "commit_info": {"id": "0123456789abcdef"},
+                "datetime": "2026-08-26T12:00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_plot_representative_modules_and_pipeline(tmp_path: Path) -> None:
+    module_input = tmp_path / "module.json"
+    pipeline_input = tmp_path / "pipeline.json"
+    output_dir = tmp_path / "plots"
+    attention_implementation = "optimized-fa2-full-tma"
+    _write_results(
+        module_input,
+        [
+            _record(group, implementation, median)
+            for group in (
+                "lingbot-dit-self-attention",
+                "lingbot-dit-cross-attention",
+            )
+            for implementation, median in (
+                ("torch", 0.010),
+                (attention_implementation, 0.006),
+            )
+        ]
+        + [
+            _record("lingbot-dit-block", "torch", 0.100),
+            _record("lingbot-dit-block", "optimized-self-cross", 0.060),
+        ],
+    )
+    _write_results(
+        pipeline_input,
+        [
+            _record(group, implementation, median)
+            for group in (
+                "lingbot-dit-network",
+                "lingbot-full-pipeline-generate",
+            )
+            for implementation, median in (
+                ("torch", 1.0),
+                ("optimized-self-cross", 0.7),
+            )
+        ],
+    )
+
+    plot_modules(module_input, output_dir)
+    plot_pipeline(pipeline_input, output_dir)
+
+    assert (output_dir / "modules.png").is_file()
+    assert (output_dir / "dit_block.png").is_file()
+    assert (output_dir / "network_pipeline.png").is_file()
+
+
+def test_plot_full_block_search_as_heatmap(tmp_path: Path) -> None:
+    input_path = tmp_path / "module.json"
+    output_dir = tmp_path / "plots"
+    optimized = "optimized-cudnn-fuse-kv-no-tma"
+    _write_results(
+        input_path,
+        [
+            _record(group, "torch", 0.010)
+            for group in (
+                "lingbot-dit-self-attention",
+                "lingbot-dit-cross-attention",
+            )
+        ]
+        + [
+            _record("lingbot-dit-block", "self-torch-cross-torch", 0.100),
+            _record(
+                "lingbot-dit-block",
+                f"self-{optimized}-cross-{optimized}",
+                0.060,
+            ),
+        ],
+    )
+
+    plot_modules(input_path, output_dir)
+
+    assert (output_dir / "dit_block.png").is_file()


### PR DESCRIPTION
This PR brings flashdreams.accelerated OptimizedMultiHeadAttention to Wan family attention and use it in LingBot.

This PR should also serve as an example of how to use flashdreams.accelerated in a new integration.

Please note that the v2 runtime currently doesn't allow you to change the runner config. So you have to manually hard code it in `integrations_v2/cam2v_lingbot/cam2v_lingbot/app.py` like this:

<img width="1708" height="1312" alt="image" src="https://github.com/user-attachments/assets/40db8d5e-ad43-480a-bf4a-2df7c9bfe1c0" />
