### PR TITLE
Presentation Clock Ownership And Backlog Pacing

### DIFF
--- a/apps/cam2v/tests/test_application.py
+++ b/apps/cam2v/tests/test_application.py
@@ -458,6 +458,11 @@ def test_slangpy_overlay_tracks_controls_and_model_status() -> None:
     """Keep immediate input display in UI-loop-owned state."""
     state = Cam2VUIState(total_blocks=4, target_fps=16, warmup_blocks=1)
     presentation_manager = PresentationManager()
+    presentation_manager.configure(
+        backpressure_mode=BackpressureMode.BLOCK,
+        stop=threading.Event(),
+        put_timeout=0.01,
+    )
     presentation_manager.publish(
         0,
         [
@@ -469,7 +474,7 @@ def test_slangpy_overlay_tracks_controls_and_model_status() -> None:
             )
         ],
     )
-    assert presentation_manager.advance(0)[0]
+    assert presentation_manager.advance(0, now=1.0)[0]
     ui = SimpleNamespace(
         screen=object(),
         Window=Mock(return_value=object()),
@@ -606,7 +611,7 @@ def test_slangpy_overlay_tracks_controls_and_model_status() -> None:
     assert not state.held_keys
     assert state.active_keys_widget.text == "Active keys: none"
 
-    assert presentation_manager.advance(0)[0]
+    assert presentation_manager.advance(0, now=1.1)[0]
     ui_loop.step(6, UserInputEvents([]))
     displayed = [widget.text for widget in state.status_widgets]
     assert "Presented: 2 frames (24 generated)" in displayed

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -150,10 +150,15 @@ neither thread waits on the other to notice.
 
 ## `PresentationManager`
 
-The model thread publishes a list of channels per step into a bounded queue
-(`max_pending`, two by default). The UI thread calls `advance` once per tick,
-which walks the frames within the chunk it is already showing before taking
-another off the queue.
+The model thread publishes a list of channels per step into a bounded chunk
+queue. The queue holds one pending chunk by default. Once the UI thread takes
+that chunk, its remaining frames live in the active presented chunk rather than
+the queue; an empty queue with an active chunk means presentation is keeping up.
+
+`publish` observes model-step timing for cadence, and the UI thread calls
+`advance` once per tick so the manager can decide whether the next presentable
+model frame is due. If the pending chunk queue is full, `advance` ignores the
+normal cadence and drains the active chunk so backlog does not build behind it.
 
 When CUDA is available, the default `PresentationManager` creates a stream at
 the device's highest available priority. `run_session` keeps that one stream
@@ -188,10 +193,9 @@ ready:
 
 For output that has to be compared frame by frame, use `BLOCK` with
 `ON_DEMAND`: together they keep every frame in the presentation manager
-and present each exactly once in order. Steps that could not be kept are counted
+and present each exactly once in order. Chunks that could not be kept are counted
 in `dropped_for_space` and `discarded_at_reset`, and logged when the run ends.
-Both count model steps rather than frames, so one step of twelve frames counts
-once.
+Both counters use model chunks as their unit.
 
 ## Presenting and writing
 

--- a/flashdreams/flashdreams/runtime_v2/presentation_manager.py
+++ b/flashdreams/flashdreams/runtime_v2/presentation_manager.py
@@ -14,6 +14,7 @@ import torch
 from torch import Tensor
 
 from flashdreams.runtime_v2.cuda_utils import resolve_cuda_device
+from flashdreams.runtime_v2.recent_frame_rate import RecentFrameRateTracker
 from flashdreams.runtime_v2.session_desc import BackpressureMode
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -21,23 +22,137 @@ from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 _PRESENTATION_STREAM_PRIORITY = -1
 """Prefer short presentation work over queued model kernels."""
 
+_MODEL_FPS_WINDOW_SECONDS = 2.0
+"""Wall-time window used to estimate generated-frame throughput."""
+
+_PRESENTATION_DRAIN_MARGIN = 0.9
+"""Present slightly faster than recent model FPS when possible."""
+
 _TRACE_LOGGER = logging.getLogger("flashdreams.runtime_v2.chunk_trace")
 _TRACE_PREFIX = "[runtime-v2-chunk-trace]"
+
+
+class _PresentationClock:
+    """Schedule model-frame advances at recent model-step throughput."""
+
+    def __init__(
+        self,
+        frames_per_second: int,
+        maximum_frames_per_second: int | None = None,
+    ) -> None:
+        maximum_frames_per_second = maximum_frames_per_second or frames_per_second
+        self._minimum_frame_interval = 1.0 / maximum_frames_per_second
+        self._fallback_frame_interval = max(
+            1.0 / frames_per_second,
+            self._minimum_frame_interval,
+        )
+        self._frame_interval = self._fallback_frame_interval
+        self._next_frame_at: float | None = None
+        self._generation: int | None = None
+        self._model_frame_rate = RecentFrameRateTracker(
+            window_seconds=_MODEL_FPS_WINDOW_SECONDS
+        )
+        self._has_completion_baseline = False
+        self._last_completion_at: float | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def frames_per_second(self) -> float:
+        """Return the current model-frame presentation rate."""
+        with self._lock:
+            return 1.0 / self._frame_interval
+
+    def observe_model_output(
+        self,
+        *,
+        now: float,
+        generation: int,
+        frame_count: int,
+        step_elapsed_s: float,
+    ) -> None:
+        """Add one completed model chunk to the rolling FPS estimate.
+
+        Args:
+            now: Monotonic completion time for the chunk.
+            generation: Session generation that produced the chunk.
+            frame_count: Number of generated frames in the chunk.
+            step_elapsed_s: Time spent running the model step, excluding loop
+                pacing and downstream publication backpressure.
+
+        Raises:
+            TypeError: ``frame_count`` is not an integer.
+            ValueError: An observation value is invalid or ``now`` precedes
+                the latest observation.
+        """
+        with self._lock:
+            if self._generation is None or generation > self._generation:
+                self._reset_generation(generation)
+            elif generation < self._generation:
+                return
+
+            if self._last_completion_at is not None and now < self._last_completion_at:
+                raise ValueError("now must not precede the latest observation.")
+            frames_per_second = self._model_frame_rate.observe(
+                completed_at=now,
+                frame_count=frame_count,
+                elapsed_s=step_elapsed_s,
+            )
+            self._last_completion_at = now
+            if not self._has_completion_baseline:
+                # Keep the configured cadence for the first chunk and avoid
+                # letting one-time model warmup set the steady presentation rate.
+                self._has_completion_baseline = True
+                self._model_frame_rate.reset()
+                return
+            self._frame_interval = max(
+                (1.0 / frames_per_second) * _PRESENTATION_DRAIN_MARGIN,
+                self._minimum_frame_interval,
+            )
+
+    def is_due(self, now: float, generation: int, *, backlog: bool = False) -> bool:
+        """Return whether the next model frame may be selected."""
+        with self._lock:
+            if generation != self._generation:
+                self._reset_generation(generation)
+            return backlog or self._next_frame_at is None or now >= self._next_frame_at
+
+    def mark_advanced(self, now: float, *, backlog: bool = False) -> None:
+        """Record one selected frame without catching up after a long stall."""
+        frame_interval = (
+            self._minimum_frame_interval if backlog else self._frame_interval
+        )
+        with self._lock:
+            if backlog:
+                self._next_frame_at = now + frame_interval
+                return
+            next_frame_at = self._next_frame_at
+            if next_frame_at is None or now - next_frame_at >= frame_interval:
+                self._next_frame_at = now + frame_interval
+            else:
+                self._next_frame_at = next_frame_at + frame_interval
+
+    def _reset_generation(self, generation: int) -> None:
+        self._generation = generation
+        self._frame_interval = self._fallback_frame_interval
+        self._next_frame_at = None
+        self._model_frame_rate.reset()
+        self._has_completion_baseline = False
+        self._last_completion_at = None
 
 
 class PresentationManager:
     """Buffer model output for a session's UI thread.
 
     The model thread publishes a chunk of channels per step into a bounded
-    queue; the UI thread calls :meth:`advance` once per tick to move to
-    the next frame. A chunk holding several frames is walked frame by frame
-    before another is taken, so a step that generated twelve frames is
-    presented over twelve ticks rather than eleven being skipped.
+    chunk queue; the UI thread calls :meth:`advance` once per tick to select
+    the next frame. The queue holds at most one chunk; once the UI thread takes
+    that chunk, the remaining frames stay in the active presented chunk and no
+    longer count as backlog.
 
     :class:`BackpressureMode` decides what publishing does when the queue is
     full. Chunks that could not be kept are counted in
     :attr:`dropped_for_space` and :attr:`discarded_at_reset` rather than lost
-    silently, one count per chunk however many frames it held.
+    silently.
 
     :meth:`presentation_context` keeps the complete UI presentation path on one
     high-priority CUDA stream, separate from model inference.
@@ -53,7 +168,10 @@ class PresentationManager:
         Raises:
             ValueError: ``device`` is neither a CPU nor CUDA device.
         """
-        self._buffer: queue.Queue[tuple[int, list[StepResult]]] = queue.Queue(maxsize=2)
+        self._bufferedChunks: queue.Queue[tuple[int, list[StepResult]]] = queue.Queue(
+            maxsize=1
+        )
+        self._presentation_clock = _PresentationClock(frames_per_second=30)
         self._backpressure_mode = BackpressureMode.BLOCK
         self._stop = threading.Event()
         self._put_timeout = 1.0 / 30.0
@@ -83,31 +201,32 @@ class PresentationManager:
     def configure(
         self,
         *,
-        max_pending: int,
         backpressure_mode: BackpressureMode,
         stop: threading.Event,
         put_timeout: float,
         trace_chunk_lifecycle: bool = False,
+        frames_per_second: int = 30,
+        maximum_frames_per_second: int | None = None,
     ) -> None:
-        """Set the queue size and backpressure mode.
+        """Set presentation timing and backpressure mode.
 
         Called by ``run_session`` before either thread uses this.
 
         Args:
-            max_pending: Model steps that may wait to be shown. Replaces the
-                queue, so anything already buffered is discarded.
             backpressure_mode: What :meth:`publish` does when the queue is full.
             stop: Session shutdown event, so a blocked publish gives up.
             put_timeout: How long a blocked publish waits before rechecking
                 ``stop``, in seconds.
             trace_chunk_lifecycle: Emit chunk lifecycle diagnostics.
-
-        Raises:
-            ValueError: ``max_pending`` is not positive.
+            frames_per_second: Initial video presentation rate.
+            maximum_frames_per_second: Upper bound for presentation cadence;
+                ``None`` uses ``frames_per_second``.
         """
-        if max_pending <= 0:
-            raise ValueError(f"max_pending must be > 0, got {max_pending}.")
-        self._buffer = queue.Queue(maxsize=max_pending)
+        self._reset_buffered_chunks()
+        self._presentation_clock = _PresentationClock(
+            frames_per_second=frames_per_second,
+            maximum_frames_per_second=maximum_frames_per_second,
+        )
         self._backpressure_mode = backpressure_mode
         self._stop = stop
         self._put_timeout = put_timeout
@@ -117,6 +236,8 @@ class PresentationManager:
         self,
         generation: int,
         chunk: list[StepResult],
+        *,
+        step_elapsed_s: float | None = None,
     ) -> None:
         """Add one completed model step to the presentation queue.
 
@@ -128,6 +249,8 @@ class PresentationManager:
             generation: Reset generation the chunk was generated in. A chunk
                 from an earlier one is discarded rather than presented.
             chunk: One :class:`StepResult` per model channel.
+            step_elapsed_s: Time spent running the model step; ``None`` leaves
+                the presentation cadence unchanged.
 
         Raises:
             ValueError: ``chunk`` is empty, or its channels disagree about
@@ -147,6 +270,13 @@ class PresentationManager:
                 None,
             )
         )
+        if step_elapsed_s is not None:
+            self._presentation_clock.observe_model_output(
+                now=time.monotonic(),
+                generation=generation,
+                frame_count=frame_count,
+                step_elapsed_s=step_elapsed_s,
+            )
         started_ns: int | None = None
         if self._trace_chunk_lifecycle:
             started_ns = time.monotonic_ns()
@@ -155,8 +285,8 @@ class PresentationManager:
                 generation=generation,
                 step=chunk[0].step_index,
                 frames=frame_count,
-                queue_depth=self._buffer.qsize(),
-                queue_capacity=self._buffer.maxsize,
+                buffered_chunks=self.buffered_chunk_count,
+                chunk_capacity=self.buffered_chunk_capacity,
             )
         pending = (generation, chunk)
         if self._backpressure_mode is BackpressureMode.DROP_OLDEST:
@@ -165,7 +295,7 @@ class PresentationManager:
             return
         while not self._stop.is_set():
             try:
-                self._buffer.put(pending, timeout=self._put_timeout)
+                self._bufferedChunks.put(pending, timeout=self._put_timeout)
                 self._trace_publish_completed(pending, started_ns)
                 return
             except queue.Full:
@@ -176,7 +306,8 @@ class PresentationManager:
                 generation=generation,
                 step=chunk[0].step_index,
                 wait_ms=(time.monotonic_ns() - started_ns) / 1_000_000.0,
-                queue_depth=self._buffer.qsize(),
+                buffered_chunks=self.buffered_chunk_count,
+                chunk_capacity=self.buffered_chunk_capacity,
             )
 
     @contextmanager
@@ -204,20 +335,27 @@ class PresentationManager:
         self.clear()
         self._presentation_stream = None
 
-    def advance(self, generation: int) -> tuple[bool, list[StepResult] | None]:
+    def advance(
+        self,
+        generation: int,
+        *,
+        now: float | None = None,
+    ) -> tuple[bool, list[StepResult] | None]:
         """Move to the next model frame, if one is available.
 
-        Called on the UI thread, once per tick. A ``generation`` other than the
-        last one seen drops what is being presented, so nothing generated before
-        a reset survives it.
+        Called on the UI thread, once per tick. The manager advances only when
+        the presentation clock is due, unless the chunk queue is full and needs
+        to drain. A ``generation`` other than the last one seen drops what is
+        being presented, so nothing generated before a reset survives it.
 
         Args:
             generation: Current reset generation, from the event buffer.
+            now: Monotonic timestamp used for pacing; ``None`` reads the clock.
 
         Returns:
-            Whether the frame changed, and the chunk newly taken off the queue,
-            which is ``None`` when the change was to another frame of the chunk
-            already being presented.
+            Whether the frame changed, and the chunk for a newly selected chunk,
+            which is ``None`` when the selected frame belongs to the same chunk
+            as the previously presented frame.
         """
         if generation != self._generation:
             if self._presented_chunk is not None:
@@ -231,6 +369,11 @@ class PresentationManager:
             self._frame_index = -1
             self._presented_frame_count = 0
 
+        now = time.monotonic() if now is None else float(now)
+        backlog = self.is_backlogged
+        if not self._presentation_clock.is_due(now, generation, backlog=backlog):
+            return False, None
+
         if (
             self._presented_chunk is not None
             and self._frame_index + 1 < self._presented_chunk[0].frame_count
@@ -238,6 +381,7 @@ class PresentationManager:
             self._frame_index += 1
             self._presented_frame_count += 1
             self._trace_presented_frame(generation)
+            self._presentation_clock.mark_advanced(now, backlog=backlog)
             return True, None
 
         chunk = self._take_buffered_chunk(
@@ -250,6 +394,7 @@ class PresentationManager:
         self._frame_index = 0
         self._presented_frame_count += 1
         self._trace_presented_frame(generation)
+        self._presentation_clock.mark_advanced(now, backlog=backlog)
         return True, chunk
 
     @property
@@ -278,12 +423,17 @@ class PresentationManager:
         :meth:`queue.Queue.qsize`, the value is a thread-safe point-in-time
         snapshot and may change immediately after it is returned.
         """
-        return self._buffer.qsize()
+        return self._bufferedChunks.qsize()
 
     @property
     def buffer_capacity(self) -> int:
         """Return the maximum number of chunks that may wait to be presented."""
-        return self._buffer.maxsize
+        return self._bufferedChunks.maxsize
+
+    @property
+    def buffered_chunk_capacity(self) -> int:
+        """Return maximum chunks the publish queue is configured to hold."""
+        return self._bufferedChunks.maxsize
 
     def presented_frame(
         self,
@@ -407,7 +557,12 @@ class PresentationManager:
             and self._frame_index + 1 < self._presented_chunk[0].frame_count
         ):
             return True
-        return not self._buffer.empty()
+        return not self._bufferedChunks.empty()
+
+    @property
+    def is_backlogged(self) -> bool:
+        """Return whether a whole chunk is waiting behind the active one."""
+        return self._bufferedChunks.full()
 
     def clear(self) -> None:
         """Discard buffered and currently presented model results."""
@@ -416,18 +571,23 @@ class PresentationManager:
         self._presented_frame_count = 0
         while True:
             try:
-                self._buffer.get_nowait()
+                self._bufferedChunks.get_nowait()
             except queue.Empty:
                 return
+
+    def _reset_buffered_chunks(self) -> None:
+        self._bufferedChunks = queue.Queue(maxsize=1)
 
     def _publish_latest(self, pending: tuple[int, list[StepResult]]) -> None:
         while not self._stop.is_set():
             try:
-                self._buffer.put_nowait(pending)
+                self._bufferedChunks.put_nowait(pending)
                 return
             except queue.Full:
                 try:
-                    dropped_generation, dropped_chunk = self._buffer.get_nowait()
+                    dropped_generation, dropped_chunk = (
+                        self._bufferedChunks.get_nowait()
+                    )
                     with self._counter_lock:
                         self._dropped_for_space += 1
                     self._trace_drop(
@@ -445,7 +605,7 @@ class PresentationManager:
         selected: list[StepResult] | None = None
         while True:
             try:
-                chunk_generation, chunk = self._buffer.get_nowait()
+                chunk_generation, chunk = self._bufferedChunks.get_nowait()
             except queue.Empty:
                 return selected
             if chunk_generation != generation:
@@ -484,8 +644,8 @@ class PresentationManager:
             step=chunk[0].step_index,
             frames=chunk[0].frame_count,
             wait_ms=(time.monotonic_ns() - started_ns) / 1_000_000.0,
-            queue_depth=self._buffer.qsize(),
-            queue_capacity=self._buffer.maxsize,
+            buffered_chunks=self.buffered_chunk_count,
+            chunk_capacity=self.buffered_chunk_capacity,
         )
 
     def _trace_presented_frame(self, generation: int) -> None:
@@ -509,7 +669,8 @@ class PresentationManager:
                 if self._frame_index + 1 == chunk[0].frame_count
                 else "middle"
             ),
-            queue_depth=self._buffer.qsize(),
+            buffered_chunks=self.buffered_chunk_count,
+            chunk_capacity=self.buffered_chunk_capacity,
         )
 
     def _trace_drop(
@@ -525,8 +686,9 @@ class PresentationManager:
         fields: dict[str, object] = {
             "generation": generation,
             "step": chunk[0].step_index,
+            "frames": chunk[0].frame_count,
             "reason": reason,
-            "queue_depth": self._buffer.qsize(),
+            "buffered_chunks": self.buffered_chunk_count,
         }
         if replacement is not None:
             replacement_generation, replacement_chunk = replacement

--- a/flashdreams/flashdreams/runtime_v2/session_desc.py
+++ b/flashdreams/flashdreams/runtime_v2/session_desc.py
@@ -12,13 +12,13 @@ from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 
 class BackpressureMode(Enum):
-    """What the model thread does when its output queue is full."""
+    """What the model thread does when its presentation chunk queue is full."""
 
     BLOCK = "block"
     """Wait when the presentation queue is full."""
 
     DROP_OLDEST = "drop_oldest"
-    """Drop the oldest queued model step."""
+    """Drop the oldest queued model chunk."""
 
 
 class PresentationMode(Enum):

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -15,7 +15,6 @@ from flashdreams.api_v2.output_sink import OutputSink
 from flashdreams.api_v2.session import ISession
 from flashdreams.api_v2.user_input_event import UserInputEvent
 from flashdreams.runtime_v2.event_buffer import EventBuffer
-from flashdreams.runtime_v2.recent_frame_rate import RecentFrameRateTracker
 from flashdreams.runtime_v2.session_desc import PresentationMode
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
@@ -25,8 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 _MODEL_THREAD_NAME = "flashdreams-model-generation-thread"
 _UI_READER_ID = 0
 _MODEL_READER_ID = 1
-_MODEL_FPS_WINDOW_SECONDS = 2.0
-"""Wall-time window used to estimate generated-frame throughput."""
 
 _TRACE_METADATA_KEY = "trace_chunk_lifecycle"
 _TRACE_PATH_METADATA_KEY = "trace_chunk_lifecycle_path"
@@ -41,108 +38,6 @@ class _ChunkTraceLog:
     handler: logging.FileHandler
     previous_level: int
     previous_propagate: bool
-
-
-class _PresentationClock:
-    """Schedule model-frame advances at recent model-step throughput."""
-
-    def __init__(
-        self,
-        frames_per_second: int,
-        maximum_frames_per_second: int | None = None,
-    ) -> None:
-        maximum_frames_per_second = maximum_frames_per_second or frames_per_second
-        self._minimum_frame_interval = 1.0 / maximum_frames_per_second
-        self._fallback_frame_interval = max(
-            1.0 / frames_per_second,
-            self._minimum_frame_interval,
-        )
-        self._frame_interval = self._fallback_frame_interval
-        self._next_frame_at: float | None = None
-        self._generation: int | None = None
-        self._model_frame_rate = RecentFrameRateTracker(
-            window_seconds=_MODEL_FPS_WINDOW_SECONDS
-        )
-        self._has_completion_baseline = False
-        self._last_completion_at: float | None = None
-        self._lock = threading.Lock()
-
-    @property
-    def frames_per_second(self) -> float:
-        """Return the current model-frame presentation rate."""
-        with self._lock:
-            return 1.0 / self._frame_interval
-
-    def observe_model_output(
-        self,
-        *,
-        now: float,
-        generation: int,
-        frame_count: int,
-        step_elapsed_s: float,
-    ) -> None:
-        """Add one completed model chunk to the rolling FPS estimate.
-
-        Args:
-            now: Monotonic completion time for the chunk.
-            generation: Session generation that produced the chunk.
-            frame_count: Number of generated frames in the chunk.
-            step_elapsed_s: Time spent running the model step, excluding loop
-                pacing and downstream publication backpressure.
-
-        Raises:
-            TypeError: ``frame_count`` is not an integer.
-            ValueError: An observation value is invalid or ``now`` precedes
-                the latest observation.
-        """
-        with self._lock:
-            if self._generation is None or generation > self._generation:
-                self._reset_generation(generation)
-            elif generation < self._generation:
-                return
-
-            if self._last_completion_at is not None and now < self._last_completion_at:
-                raise ValueError("now must not precede the latest observation.")
-            frames_per_second = self._model_frame_rate.observe(
-                completed_at=now,
-                frame_count=frame_count,
-                elapsed_s=step_elapsed_s,
-            )
-            self._last_completion_at = now
-            if not self._has_completion_baseline:
-                # Keep the configured cadence for the first chunk and avoid
-                # letting one-time model warmup set the steady presentation rate.
-                self._has_completion_baseline = True
-                self._model_frame_rate.reset()
-                return
-            self._frame_interval = max(
-                1.0 / frames_per_second,
-                self._minimum_frame_interval,
-            )
-
-    def is_due(self, now: float, generation: int) -> bool:
-        """Return whether the next model frame may be selected."""
-        with self._lock:
-            if generation != self._generation:
-                self._reset_generation(generation)
-            return self._next_frame_at is None or now >= self._next_frame_at
-
-    def mark_advanced(self, now: float) -> None:
-        """Record one selected frame without catching up after a long stall."""
-        with self._lock:
-            next_frame_at = self._next_frame_at
-            if next_frame_at is None or now - next_frame_at >= self._frame_interval:
-                self._next_frame_at = now + self._frame_interval
-            else:
-                self._next_frame_at = next_frame_at + self._frame_interval
-
-    def _reset_generation(self, generation: int) -> None:
-        self._generation = generation
-        self._frame_interval = self._fallback_frame_interval
-        self._next_frame_at = None
-        self._model_frame_rate.reset()
-        self._has_completion_baseline = False
-        self._last_completion_at = None
 
 
 def _contains(events: UserInputEvents, event_type: type[UserInputEvent]) -> bool:
@@ -161,7 +56,6 @@ def run_session(
     *,
     metrics_output_sink: OutputSink | None = None,
     steps: int | None = None,
-    max_pending: int = 2,
 ) -> None:
     """Run a session's UI and model loops.
 
@@ -179,35 +73,29 @@ def run_session(
         metrics_output_sink: Sink for model measurements, if requested. Receives
             the model loop's results rather than the UI loop's.
         steps: Maximum model steps; ``None`` runs until stopped.
-        max_pending: Maximum model steps waiting to be shown.
 
     Raises:
-        ValueError: ``steps`` is negative, or ``max_pending`` is not positive.
+        ValueError: ``steps`` is negative.
         BaseException: A loop's failure if one was queued, otherwise this
             function's own, otherwise the first cleanup failure. The rest are
             logged.
     """
     if steps is not None and steps < 0:
         raise ValueError(f"steps must be >= 0 or None, got {steps}.")
-    if max_pending <= 0:
-        raise ValueError(f"max_pending must be > 0, got {max_pending}.")
 
     session_desc = session.session_desc
     tick_seconds = 1.0 / session_desc.frames_per_second_for_ui
-    presentation_clock = _PresentationClock(
-        session_desc.frames_per_second_for_step,
-        maximum_frames_per_second=session_desc.frames_per_second_for_ui,
-    )
     event_buffer = EventBuffer()
     stop = session._shutdown_event
     presentation_manager = session._presentation_manager
     trace_chunk_lifecycle = session_desc.metadata.get(_TRACE_METADATA_KEY) is True
     presentation_manager.configure(
-        max_pending=max_pending,
         backpressure_mode=session_desc.backpressure_mode,
         stop=stop,
         put_timeout=tick_seconds,
         trace_chunk_lifecycle=trace_chunk_lifecycle,
+        frames_per_second=session_desc.frames_per_second_for_step,
+        maximum_frames_per_second=session_desc.frames_per_second_for_ui,
     )
     model_thread_handle: threading.Thread | None = None
     ui_loop: IUILoop[object] | None = None
@@ -243,14 +131,11 @@ def run_session(
         results: list[StepResult],
         step_elapsed_s: float,
     ) -> None:
-        if results:
-            presentation_clock.observe_model_output(
-                now=time.monotonic(),
-                generation=generation,
-                frame_count=results[0].frame_count,
-                step_elapsed_s=step_elapsed_s,
-            )
-        presentation_manager.publish(generation, results)
+        presentation_manager.publish(
+            generation,
+            results,
+            step_elapsed_s=step_elapsed_s,
+        )
         if metrics_output_sink is not None:
             for result in results:
                 metrics_output_sink.write(result)
@@ -260,12 +145,8 @@ def run_session(
         with session._presentation_manager.presentation_context():
             assert ui_loop is not None
             generation = event_buffer.generation
-            model_advanced = False
-            now = time.monotonic()
-            if presentation_clock.is_due(now, generation):
-                model_advanced, _ = presentation_manager.advance(generation)
+            model_advanced, _ = presentation_manager.advance(generation)
             if model_advanced:
-                presentation_clock.mark_advanced(now)
                 run_ui_once()
                 return
             if session_desc.presentation_mode is PresentationMode.ON_DEMAND:
@@ -281,13 +162,13 @@ def run_session(
         if trace_chunk_lifecycle:
             _TRACE_LOGGER.info(
                 "%s phase=session_config time_ns=%d backpressure=%s "
-                "presentation=%s max_pending=%d step_fps=%d ui_fps=%d "
+                "presentation=%s chunk_buffer_capacity=%d step_fps=%d ui_fps=%d "
                 "width=%d height=%d trace_path=%s",
                 _TRACE_PREFIX,
                 time.monotonic_ns(),
                 session_desc.backpressure_mode.value,
                 session_desc.presentation_mode.value,
-                max_pending,
+                presentation_manager.buffered_chunk_capacity,
                 session_desc.frames_per_second_for_step,
                 session_desc.frames_per_second_for_ui,
                 session_desc.video_width,
@@ -394,12 +275,12 @@ def run_session(
 
     if presentation_manager.dropped_for_space:
         _LOGGER.warning(
-            "Dropped %d model steps the window could not keep up with.",
+            "Dropped %d model chunks the window could not keep up with.",
             presentation_manager.dropped_for_space,
         )
     if presentation_manager.discarded_at_reset:
         _LOGGER.info(
-            "Discarded %d model steps generated before a reset.",
+            "Discarded %d model chunks generated before a reset.",
             presentation_manager.discarded_at_reset,
         )
     if primary_failure is not None:

--- a/flashdreams/test_v2/test_presentation_manager_trace.py
+++ b/flashdreams/test_v2/test_presentation_manager_trace.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.ci_cpu
 _LOGGER = "flashdreams.runtime_v2.chunk_trace"
 
 
-def _result(step_index: int, frames: int = 2) -> StepResult:
+def _result(step_index: int, frames: int = 1) -> StepResult:
     return StepResult(
         step_index=step_index,
         output=torch.zeros(frames, 3, 1, 1),
@@ -35,7 +35,6 @@ def _result(step_index: int, frames: int = 2) -> StepResult:
 def test_opt_in_trace_correlates_publish_drop_and_present(caplog) -> None:
     manager = PresentationManager(device=torch.device("cpu"))
     manager.configure(
-        max_pending=1,
         backpressure_mode=BackpressureMode.DROP_OLDEST,
         stop=threading.Event(),
         put_timeout=0.01,
@@ -48,15 +47,17 @@ def test_opt_in_trace_correlates_publish_drop_and_present(caplog) -> None:
         manager.publish(3, [_result(11)])
         manager.publish(3, [_result(12)])
         assert manager.advance(3)[0]
-        assert manager.advance(3)[0]
 
     trace = "\n".join(
         record.getMessage() for record in caplog.records if record.name == _LOGGER
     )
     assert "phase=publish_started" in trace
     assert "phase=publish_completed" in trace
+    assert "buffered_chunks=" in trace
+    assert "chunk_capacity=" in trace
     assert "phase=chunk_dropped" in trace
-    assert "step=11 reason=queue_full" in trace
+    assert "step=11" in trace
+    assert "reason=queue_full" in trace
     assert "replacement_step=12" in trace
     assert "phase=frame_presented" in trace
     assert "generation=3 step=10 frame=0" in trace
@@ -77,7 +78,6 @@ def test_trace_file_receives_records_and_closes(tmp_path) -> None:
     trace_path = tmp_path / "nested" / "input-trace.log"
     manager = PresentationManager(device=torch.device("cpu"))
     manager.configure(
-        max_pending=1,
         backpressure_mode=BackpressureMode.BLOCK,
         stop=threading.Event(),
         put_timeout=0.01,

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -22,13 +22,17 @@ from flashdreams.runtime_v2.blit_model_output_to_screen_loop import (
     BlitModelOutputToScreenLoop,
 )
 from flashdreams.runtime_v2.event_buffer import EventBuffer
-from flashdreams.runtime_v2.presentation_manager import PresentationManager
+from flashdreams.runtime_v2.presentation_manager import (
+    _PRESENTATION_DRAIN_MARGIN,
+    PresentationManager,
+    _PresentationClock,
+)
 from flashdreams.runtime_v2.session_desc import (
     BackpressureMode,
     PresentationMode,
     SessionDesc,
 )
-from flashdreams.runtime_v2.session_runner import _PresentationClock, run_session
+from flashdreams.runtime_v2.session_runner import run_session
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import (
     CloseUserInputEvent,
@@ -94,6 +98,10 @@ def _observe_model_step(
     )
 
 
+def _presentation_fps(model_fps: float) -> float:
+    return model_fps / _PRESENTATION_DRAIN_MARGIN
+
+
 def test_presentation_clock_uses_recent_model_fps() -> None:
     clock = _PresentationClock(frames_per_second=16)
 
@@ -101,12 +109,12 @@ def test_presentation_clock_uses_recent_model_fps() -> None:
     assert clock.frames_per_second == 16
 
     _observe_model_step(clock, 1.9, 12, 0.9)
-    assert clock.frames_per_second == pytest.approx(12 / 0.9)
+    assert clock.frames_per_second == pytest.approx(_presentation_fps(12 / 0.9))
 
     assert clock.is_due(now=2.0, generation=0)
     clock.mark_advanced(now=2.0)
-    assert not clock.is_due(now=2.074, generation=0)
-    assert clock.is_due(now=2.075, generation=0)
+    assert not clock.is_due(now=2.067, generation=0)
+    assert clock.is_due(now=2.068, generation=0)
 
 
 def test_presentation_clock_clamps_model_fps_to_ui_fps() -> None:
@@ -121,18 +129,35 @@ def test_presentation_clock_clamps_model_fps_to_ui_fps() -> None:
     assert clock.frames_per_second == 60
 
 
+def test_presentation_clock_allows_backlog_before_paced_deadline() -> None:
+    clock = _PresentationClock(
+        frames_per_second=30,
+        maximum_frames_per_second=60,
+    )
+
+    assert clock.is_due(now=1.0, generation=0)
+    clock.mark_advanced(now=1.0)
+    assert not clock.is_due(now=1.016, generation=0)
+
+    assert clock.is_due(now=1.016, generation=0, backlog=True)
+    clock.mark_advanced(now=1.016, backlog=True)
+
+    assert not clock.is_due(now=1.032, generation=0)
+    assert clock.is_due(now=1.033, generation=0)
+
+
 def test_presentation_clock_limits_estimate_to_recent_two_seconds() -> None:
     clock = _PresentationClock(frames_per_second=30)
 
     _observe_model_step(clock, 0.0, 10, 1.0)
     _observe_model_step(clock, 1.0, 10, 1.0)
-    assert clock.frames_per_second == pytest.approx(10.0)
+    assert clock.frames_per_second == pytest.approx(_presentation_fps(10.0))
 
     _observe_model_step(clock, 2.0, 20, 1.0)
-    assert clock.frames_per_second == pytest.approx(15.0)
+    assert clock.frames_per_second == pytest.approx(_presentation_fps(15.0))
 
     _observe_model_step(clock, 3.0, 20, 1.0)
-    assert clock.frames_per_second == pytest.approx(20.0)
+    assert clock.frames_per_second == pytest.approx(_presentation_fps(20.0))
 
 
 def test_presentation_clock_ignores_gaps_between_model_steps() -> None:
@@ -140,17 +165,17 @@ def test_presentation_clock_ignores_gaps_between_model_steps() -> None:
 
     _observe_model_step(clock, 1.0, 12, 0.9)
     _observe_model_step(clock, 1.9, 12, 0.9)
-    assert clock.frames_per_second == pytest.approx(12 / 0.9)
+    assert clock.frames_per_second == pytest.approx(_presentation_fps(12 / 0.9))
 
     _observe_model_step(clock, 6.8, 12, 0.9)
-    assert clock.frames_per_second == pytest.approx(12 / 0.9)
+    assert clock.frames_per_second == pytest.approx(_presentation_fps(12 / 0.9))
 
 
 def test_presentation_clock_resets_estimate_for_a_new_generation() -> None:
     clock = _PresentationClock(frames_per_second=16)
     _observe_model_step(clock, 1.0, 12, 1.0)
     _observe_model_step(clock, 2.0, 12, 1.0)
-    assert clock.frames_per_second == pytest.approx(12.0)
+    assert clock.frames_per_second == pytest.approx(_presentation_fps(12.0))
 
     assert clock.is_due(now=2.1, generation=1)
     assert clock.frames_per_second == 16
@@ -652,7 +677,7 @@ def test_default_ui_composites_channels_and_holds_the_latest_frame() -> None:
         presentation_manager=manager,
     )
 
-    assert manager.advance(0)[0]
+    assert manager.advance(0, now=1.0)[0]
     first = ui.step(0, UserInputEvents([]))
     assert first is not None
     assert first.read_output()[0, :, 0, 0].tolist() == [0.5, 0.25, 0.0]
@@ -663,6 +688,148 @@ def test_default_ui_composites_channels_and_holds_the_latest_frame() -> None:
     assert not manager.advance(1)[0]
     assert manager.presented_frame_count == 0
     assert ui.step(2, UserInputEvents([])) is None
+
+
+def test_presentation_manager_defaults_to_one_pending_chunk() -> None:
+    manager = PresentationManager(device=torch.device("cpu"))
+
+    assert manager.buffer_capacity == 1
+    assert manager.buffered_chunk_capacity == 1
+    assert manager.buffered_chunk_count == 0
+    assert not manager.is_backlogged
+
+
+def test_presentation_manager_reports_backlog_by_chunk_queue_capacity() -> None:
+    manager = PresentationManager(device=torch.device("cpu"))
+
+    def result(step_index: int) -> StepResult:
+        return StepResult(
+            step_index=step_index,
+            output=torch.arange(3, dtype=torch.float32)
+            .reshape(3, 1, 1, 1)
+            .expand(-1, 3, -1, -1),
+            frame_count=3,
+            output_layout=VideoTensorLayout.tchw,
+        )
+
+    manager.publish(0, [result(0)])
+
+    assert manager.buffer_capacity == 1
+    assert manager.buffered_chunk_count == 1
+    assert manager.buffered_chunk_capacity == 1
+    assert manager.is_backlogged
+
+    assert manager.advance(0, now=1.0)[0]
+
+    assert manager.buffered_chunk_count == 0
+    assert manager.has_pending_frames()
+    assert not manager.is_backlogged
+
+
+def test_presentation_manager_drains_active_chunk_frame_by_frame() -> None:
+    manager = PresentationManager(device=torch.device("cpu"))
+
+    def result(step_index: int) -> StepResult:
+        return StepResult(
+            step_index=step_index,
+            output=torch.arange(3, dtype=torch.float32)
+            .reshape(3, 1, 1, 1)
+            .expand(-1, 3, -1, -1),
+            frame_count=3,
+            output_layout=VideoTensorLayout.tchw,
+        )
+
+    manager.publish(0, [result(0)])
+
+    assert manager.buffered_chunk_count == 1
+    assert manager.buffered_chunk_capacity == 1
+    assert manager.is_backlogged
+
+    assert manager.advance(0, now=1.1)[0]
+    frame = manager.presented_frame(0)
+    assert frame is not None
+    assert frame.shape == (3, 1, 1)
+    assert frame[0, 0, 0] == 0
+    assert manager.buffered_chunk_count == 0
+    assert manager.has_pending_frames()
+    assert not manager.is_backlogged
+
+    assert manager.advance(0, now=1.2)[0]
+    frame = manager.presented_frame(0)
+    assert frame is not None
+    assert frame[0, 0, 0] == 1
+    assert manager.buffered_chunk_count == 0
+
+    assert manager.advance(0, now=1.3)[0]
+    frame = manager.presented_frame(0)
+    assert frame is not None
+    assert frame[0, 0, 0] == 2
+    assert manager.buffered_chunk_count == 0
+    assert not manager.is_backlogged
+
+
+def test_presentation_manager_advances_when_due_or_backlogged() -> None:
+    manager = PresentationManager(device=torch.device("cpu"))
+    manager.configure(
+        backpressure_mode=BackpressureMode.BLOCK,
+        stop=threading.Event(),
+        put_timeout=0.01,
+        frames_per_second=10,
+        maximum_frames_per_second=60,
+    )
+
+    def result(step_index: int, frames: int) -> StepResult:
+        return StepResult(
+            step_index=step_index,
+            output=torch.arange(frames, dtype=torch.float32)
+            .reshape(frames, 1, 1, 1)
+            .expand(-1, 3, -1, -1),
+            frame_count=frames,
+            output_layout=VideoTensorLayout.tchw,
+        )
+
+    manager.publish(0, [result(0, 2)])
+    assert manager.advance(0, now=1.0)[0]
+    assert not manager.advance(0, now=1.01)[0]
+
+    manager.publish(0, [result(1, 1)])
+    assert manager.is_backlogged
+    assert manager.advance(0, now=1.01)[0]
+
+
+def test_presentation_manager_publish_updates_presentation_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = PresentationManager(device=torch.device("cpu"))
+    manager.configure(
+        backpressure_mode=BackpressureMode.BLOCK,
+        stop=threading.Event(),
+        put_timeout=0.01,
+        frames_per_second=16,
+        maximum_frames_per_second=60,
+    )
+    completions = iter((1.0, 1.9))
+    monkeypatch.setattr(
+        "flashdreams.runtime_v2.presentation_manager.time.monotonic",
+        lambda: next(completions),
+    )
+
+    def result(step_index: int) -> StepResult:
+        return StepResult(
+            step_index=step_index,
+            output=torch.zeros((12, 3, 1, 1)),
+            frame_count=12,
+            output_layout=VideoTensorLayout.tchw,
+        )
+
+    manager.publish(0, [result(0)], step_elapsed_s=0.9)
+    assert manager._presentation_clock.frames_per_second == 16
+    manager.clear()
+
+    manager.publish(0, [result(1)], step_elapsed_s=0.9)
+    assert manager._presentation_clock.frames_per_second == pytest.approx(
+        _presentation_fps(12 / 0.9)
+    )
 
 
 def test_composite_rejects_frames_with_different_dimensions() -> None:
@@ -757,7 +924,6 @@ def test_default_ui_does_not_redraw_an_unchanged_model_frame() -> None:
 def test_drop_oldest_finishes_active_chunk_before_newest_waiting_chunk() -> None:
     manager = PresentationManager()
     manager.configure(
-        max_pending=1,
         backpressure_mode=BackpressureMode.DROP_OLDEST,
         stop=threading.Event(),
         put_timeout=0.01,
@@ -776,23 +942,26 @@ def test_drop_oldest_finishes_active_chunk_before_newest_waiting_chunk() -> None
 
     manager.publish(0, [result(0, 3)])
     assert manager.advance(0)[0]
+    first = manager.presented_frame(0)
+    assert first is not None
+    assert first[0, 0, 0] == 0
     assert manager.presented_frame_count == 1
     manager.publish(0, [result(1, 1)])
     manager.publish(0, [result(2, 1)])
 
-    assert manager.advance(0)[0]
+    assert manager.advance(0, now=1.1)[0]
     second = manager.presented_frame(0)
     assert second is not None
     assert second[0, 0, 0] == 1
     assert manager.presented_frame_count == 2
 
-    assert manager.advance(0)[0]
+    assert manager.advance(0, now=1.2)[0]
     third = manager.presented_frame(0)
     assert third is not None
     assert third[0, 0, 0] == 2
     assert manager.presented_frame_count == 3
 
-    assert manager.advance(0)[0]
+    assert manager.advance(0, now=1.3)[0]
     newest = manager.presented_frame(0)
     assert newest is not None
     assert newest[0, 0, 0] == 20
@@ -1012,7 +1181,7 @@ def test_equality_eval_preserves_every_frame_when_model_is_faster() -> None:
     session = FakeSession(_session_desc(ui_fps=30, model_fps=10_000), log)
     window = RecordingClientWindow(log)
 
-    run_session(session, window, steps=4, max_pending=1)
+    run_session(session, window, steps=4)
 
     assert [result.step_index for result in window.results] == [0, 1, 2, 3]
     assert [
@@ -1115,11 +1284,11 @@ def test_run_session_drops_the_oldest_waiting_result() -> None:
     )
     window = RecordingClientWindow(log, hold_writes=generated)
 
-    run_session(session, window, steps=4, max_pending=1)
+    run_session(session, window, steps=4)
 
     presented = [result.step_index for result in window.results]
-    # Room for one result and four generated behind a window that cannot write
-    # until the end, so what is stale is lost and the newest always arrives.
+    # The single-slot pending chunk queue fills while the window is held, so
+    # stale chunks are lost before presentation catches up.
     assert presented == sorted(presented)
     assert len(presented) < 4
     assert window.results[-1].read_output()[0, 0, 0, 0, 0].item() == 3
@@ -1140,24 +1309,13 @@ def test_run_session_discards_results_generated_before_a_reset(
     )
 
     with caplog.at_level(logging.INFO, logger=_RUNNER_LOGGER):
-        run_session(session, window, steps=None, max_pending=2)
+        run_session(session, window, steps=None)
 
     # The client asked to start over, so what the abandoned generation produced is
     # thrown away rather than presented after the restart. The runner logs this only
     # when it discarded at least one result, and the count it reports depends on how
     # far generation got before the reset landed.
     assert any("before a reset" in record.getMessage() for record in caplog.records)
-
-
-def test_run_session_rejects_a_pending_bound_of_zero() -> None:
-    log = CallLog()
-    session = FakeSession(_session_desc(), log)
-    window = RecordingClientWindow(log)
-
-    with pytest.raises(ValueError, match="max_pending"):
-        run_session(session, window, steps=1, max_pending=0)
-
-    assert log.calls == []
 
 
 def test_run_session_with_no_steps_still_opens_and_closes() -> None:

--- a/integrations_v2/red_screen/red_screen/tests/test_red_screen.py
+++ b/integrations_v2/red_screen/red_screen/tests/test_red_screen.py
@@ -228,11 +228,11 @@ def test_red_screen_turns_red_for_a_key_pressed_during_the_run() -> None:
     session = app.create_session(_session_desc(frames_per_second_for_ui=100))
     window = ScriptedClientWindow([UserInputEvents([]), _key_event(pressed=True)])
 
-    # Room for one result, so a step cannot start until a tick has presented the
-    # previous one, and every tick polls input before it presents. That makes the
-    # key reach a step rather than depending on how the threads are scheduled.
+    # The single-slot pending chunk queue means a step cannot start until a tick
+    # has presented the previous one. Every tick polls input before it presents,
+    # which makes the key reach a step deterministically.
     try:
-        run_session(session, window, steps=3, max_pending=1)
+        run_session(session, window, steps=3)
     finally:
         app.close()
 

--- a/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
+++ b/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
@@ -25,7 +25,7 @@ from slangpy_ui_demo.model_output_app import (
 from slangpy_ui_demo.text_input_app import TextInputSlangPyUILoop, TextInputState
 
 from flashdreams.runtime_v2.presentation_manager import PresentationManager
-from flashdreams.runtime_v2.session_desc import SessionDesc
+from flashdreams.runtime_v2.session_desc import BackpressureMode, SessionDesc
 from flashdreams.runtime_v2.slangpy_ui_renderer import _route_input_events
 from flashdreams.runtime_v2.user_input_event import (
     KeyboardInputState,
@@ -191,6 +191,11 @@ def test_model_output_emits_repeating_selectable_fade_channels() -> None:
         assert output[0, 3, 0, 0] == (1.0 if index == 0 else 0.5)
         assert torch.equal(output, again.read_output())
 
+    session._presentation_manager.configure(
+        backpressure_mode=BackpressureMode.BLOCK,
+        stop=threading.Event(),
+        put_timeout=0.01,
+    )
     session._presentation_manager.publish(0, chunk)
     assert session._presentation_manager.advance(0)[0]
     frame = ui_loop.presented_model_frame(1)


### PR DESCRIPTION
## Summary

Move model-frame presentation pacing into `PresentationManager`, so callers only
publish chunks and call `advance()`. The manager now owns both timing and backlog
decisions, which keeps queue pressure local to the component that consumes model
output.

## Changes

- Moved `_PresentationClock` from `session_runner` to `PresentationManager`.
- `PresentationManager.publish()` observes model-output timing, and
  `PresentationManager.advance()` automatically decides whether a model frame is
  due.
- Changed the pending presentation buffer to `_bufferedChunks`, a single-slot
  chunk queue.
- `PresentationManager` now holds at most one backlog chunk, plus one additional
  active chunk being presented and advanced frame by frame.
- A full pending chunk queue is treated as backlog, so `advance()` is allowed to
  proceed immediately and drain instead of waiting on the normal cadence.
- When not backlogged, `_PresentationClock` paces `advance()` from the recently
  observed model FPS with a drain margin, letting the UI thread recover slightly
  faster after hiccups and reducing model-frame latency.
- Removed the user-facing pending-buffer size knob and updated runtime docs,
  trace fields, and focused tests for chunk-based backlog semantics.

## Notes

- Drop and reset-discard counters are chunk-based. One chunk containing multiple
  model frames counts once.

Closes #542 
