### PR TITLE
Add multi-session lifecycle support to the v2 runtime

### DIFF
--- a/apps/cam2v/tests/test_application.py
+++ b/apps/cam2v/tests/test_application.py
@@ -165,7 +165,7 @@ def test_model_loop_maps_wasd_to_shared_camera_input_and_metrics() -> None:
         failure_queue=failure_queue,
     )
     ui_loop.register_session_ui_loop_objects(
-        output_layout=VideoTensorLayout.tchw,
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
         presentation_manager=presentation_manager,
     )
     state = Cam2VModelState(
@@ -345,7 +345,7 @@ def test_slangpy_continuous_redraw_expires_recent_model_rate(
         failure_queue=queue.Queue(),
     )
     ui_loop.register_session_ui_loop_objects(
-        output_layout=VideoTensorLayout.tchw,
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
         presentation_manager=PresentationManager(),
     )
     ui = SimpleNamespace(
@@ -501,7 +501,7 @@ def test_slangpy_overlay_tracks_controls_and_model_status() -> None:
         failure_queue=queue.Queue(),
     )
     ui_loop.register_session_ui_loop_objects(
-        output_layout=VideoTensorLayout.tchw,
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
         presentation_manager=presentation_manager,
     )
     pressed = UserInputEvents(

--- a/apps/cam2v/tests/test_ui_cuda.py
+++ b/apps/cam2v/tests/test_ui_cuda.py
@@ -13,6 +13,7 @@ import torch
 from cam2v import Cam2VSlangPyUILoop, Cam2VUIState
 
 from flashdreams.runtime_v2.presentation_manager import PresentationManager
+from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -95,7 +96,7 @@ def test_slangpy_composite_records_high_priority_output_readiness() -> None:
         failure_queue=queue.Queue(),
     )
     loop.register_session_ui_loop_objects(
-        output_layout=VideoTensorLayout.tchw,
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
         presentation_manager=manager,
     )
 

--- a/apps/crazy_robotaxi/tests/test_ui.py
+++ b/apps/crazy_robotaxi/tests/test_ui.py
@@ -36,6 +36,7 @@ from omnidreams_game_engine.types import CameraCalibration
 
 from flashdreams.api_v2.loop import IModelLoop
 from flashdreams.runtime_v2.presentation_manager import PresentationManager
+from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import (
     GamepadUserInputEvent,
@@ -646,7 +647,7 @@ def test_imgui_ui_loop_draws_waypoints_and_bev_in_the_ui_overlay() -> None:
         failure_queue=queue.Queue(),
     )
     loop.register_session_ui_loop_objects(
-        output_layout=VideoTensorLayout.tchw,
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
         presentation_manager=presentation,
     )
 

--- a/apps/t2v/README.md
+++ b/apps/t2v/README.md
@@ -13,9 +13,11 @@ packages own one root `config.py`; their entry points and adapters live under
 
 ## Controls
 
-T2V has no live controls. Inputs are fixed for a session: `--prompt` is always
-required, and model adapters may add startup inputs such as a first-frame image.
-Use `--seed` to make sampling repeatable when the model supports it.
+An interactive WebRTC run shows an ImGui prompt field over the latest generated
+frame. Submitting it starts a fresh session and rollout cache without unloading
+the model. Reaching `--total-blocks` leaves the final frame and prompt UI active.
+Model adapters may also add startup inputs such as a first-frame image. Use
+`--seed` to make sampling repeatable when the model supports it.
 
 ## Usage
 
@@ -28,9 +30,19 @@ uv run --package flashdreams-self-forcing flashdreams-run-v2 \
   --prompt "A cat surfing" --total-blocks 7 --no-compile
 ```
 
+To keep the model resident and submit prompts from a browser:
+
+```bash
+uv run --package flashdreams-causal-forcing flashdreams-run-v2 \
+  t2v-causal-forcing-wan2.1-t2v-1.3b-chunkwise --mode webrtc --port 8080
+```
+
+Open `http://localhost:8080`. An initial `--prompt` is optional for interactive
+runs; the prompt UI can start the first and subsequent sessions.
+
 Shared application arguments are:
 
-- `--prompt TEXT` — required; its empty default is rejected.
+- `--prompt TEXT` — optional initial text; explicitly empty text is rejected.
 - `--total-blocks N` — autoregressive blocks to generate; defaults to the model
   adapter value (one for bidirectional models).
 - `--device DEVICE` — model device; defaults to `cuda`.

--- a/apps/t2v/t2v/application.py
+++ b/apps/t2v/t2v/application.py
@@ -23,14 +23,14 @@ _FRAMES_PER_SECOND_FOR_UI = 60
 class T2VSessionConfig:
     """What one command line resolved to, shared by every session it creates."""
 
-    prompt: str
-    """Text every session generates from."""
+    prompt: str | None
+    """Default text for a session, when its request does not provide one."""
 
     device: str
     """Device the pipeline is built on."""
 
     total_blocks: int
-    """Blocks a rollout generates, which is what ends a run."""
+    """Blocks generated before a rollout's model loop finishes."""
 
 
 class T2VApplication(IApplication):
@@ -41,8 +41,9 @@ class T2VApplication(IApplication):
     command line for all of them. An integration supplies
     :class:`T2VApplicationDefaults` and inherits the rest.
 
-    The model is loaded once, on the first session, and shared by every session
-    after it, since loading reads a checkpoint of several gigabytes.
+    :meth:`init` loads the model once after resolving its command-line options.
+    The application keeps it resident and shares it with every session, since
+    loading reads a checkpoint of several gigabytes.
     """
 
     session_type: type[T2VSession] = T2VSession
@@ -65,21 +66,27 @@ class T2VApplication(IApplication):
         return self._pipeline_config
 
     def init(self, commandline_args: Sequence[str]) -> None:
-        """Parse what to generate, how much of it, and where.
+        """Parse application options and load the shared model.
 
         Not what size or rate to generate at: that describes the session, which
-        the caller asks for. The model is not loaded here either.
+        the caller asks for. An interactive session may receive its prompt from
+        the UI after initialization.
 
         Raises:
-            ValueError: No prompt was given, or the rollout length is not one
-                this model can generate.
+            ValueError: An explicitly provided prompt is empty, or the rollout
+                length is not one this model can generate.
         """
         parser = argparse.ArgumentParser(
             prog="flashdreams-run-v2 SLUG --",
             description="Generate video from text.",
         )
         parser.add_argument(
-            "--prompt", default="", help="Text to generate from. Required."
+            "--prompt",
+            default=None,
+            help=(
+                "Default text to generate from. An interactive client may "
+                "instead provide one for each session."
+            ),
         )
         parser.add_argument(
             "--device",
@@ -117,8 +124,8 @@ class T2VApplication(IApplication):
         self._configure_argument_parser(parser)
         args = parser.parse_args(list(commandline_args))
 
-        if not args.prompt.strip():
-            raise ValueError("--prompt is required, and cannot be empty.")
+        if args.prompt is not None and not args.prompt.strip():
+            raise ValueError("--prompt cannot be empty.")
         self._validate_total_blocks(args.total_blocks)
         self._apply_parsed_arguments(args)
 
@@ -130,11 +137,14 @@ class T2VApplication(IApplication):
             self._pipeline_config = self._apply_seed_override(
                 self._pipeline_config, args.seed
             )
-        self._config = T2VSessionConfig(
+        config = T2VSessionConfig(
             prompt=args.prompt,
             device=args.device,
             total_blocks=args.total_blocks,
         )
+        pipeline = self._pipeline_config.setup().to(config.device).eval()
+        self._config = config
+        self._pipeline = pipeline
 
     def session_desc(self) -> SessionDesc:
         """Return the description of a session this application uses.
@@ -144,7 +154,7 @@ class T2VApplication(IApplication):
         """
         return SessionDesc(
             output_layout=self.defaults.output_layout,
-            presentation_mode=PresentationMode.ON_DEMAND,
+            presentation_mode=PresentationMode.CONTINUOUS,
             frames_per_second_for_ui=_FRAMES_PER_SECOND_FOR_UI,
             frames_per_second_for_step=self.defaults.fps,
             video_width=self.defaults.pixel_width,
@@ -152,26 +162,25 @@ class T2VApplication(IApplication):
         )
 
     def create_session(self, session_desc: SessionDesc) -> ISession:
-        """Create one uninitialized session, loading the model if needed.
+        """Create one uninitialized session against the resident model.
 
         Raises:
             RuntimeError: :meth:`init` has not run yet.
-            ValueError: The description asks for output this cannot generate.
+            ValueError: The description asks for output this cannot generate,
+                or its prompt is invalid.
         """
         config = self._config
-        if config is None:
+        pipeline = self._pipeline
+        if config is None or pipeline is None:
             raise RuntimeError(
                 f"{type(self).__name__}.init() must run before create_session()."
             )
-        # Before loading rather than after: a checkpoint of several gigabytes is
-        # a long wait for a layout this was never going to accept.
         self._validate_layout(session_desc)
-        if self._pipeline is None:
-            self._pipeline = self._pipeline_config.setup().to(config.device).eval()
-        self._validate_frame_size(session_desc, self._pipeline)
-        return self.session_type(
-            self._pipeline, config.prompt, session_desc, config.total_blocks
-        )
+        prompt = session_desc.metadata.get("prompt", config.prompt)
+        if prompt is not None and (not isinstance(prompt, str) or not prompt.strip()):
+            raise ValueError("A session prompt must be non-empty text.")
+        self._validate_frame_size(session_desc, pipeline)
+        return self.session_type(pipeline, prompt, session_desc, config.total_blocks)
 
     def close(self) -> None:
         """Release the model, and whatever memory it was holding."""

--- a/apps/t2v/t2v/session.py
+++ b/apps/t2v/t2v/session.py
@@ -11,6 +11,7 @@ from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
+from t2v.ui import T2VImGuiUILoop, T2VUIState
 
 
 @dataclass(slots=True)
@@ -18,7 +19,7 @@ class T2VModelState:
     """Mutable rollout state owned by the model loop."""
 
     pipeline: Any
-    prompt: str
+    prompt: str | None
     session_desc: SessionDesc
     total_blocks: int
     image: Any = None
@@ -55,11 +56,14 @@ class T2VModelLoop(IModelLoop[T2VModelState]):
         ]
 
     def is_finished(self) -> bool:
-        return self.state.blocks_generated >= self.state.total_blocks
+        return (
+            self.state.prompt is None
+            or self.state.blocks_generated >= self.state.total_blocks
+        )
 
     def reset(self) -> None:
         self.state.blocks_generated = 0
-        self.state.cache = _new_cache(self.state)
+        self.state.cache = None if self.state.prompt is None else _new_cache(self.state)
 
     def close(self) -> None:
         self.state.cache = None
@@ -73,15 +77,16 @@ class T2VSession(ISession):
     frames than the rest.
 
     A rollout is ``total_blocks`` long and then reports itself finished, so
-    nothing above it counts steps. What belongs to a run is the cache this
-    initializes, holding the encoded prompt and the attention state; the
+    nothing above it counts steps. An interactive session with no prompt starts
+    with an already-finished model loop while its UI waits for one. What belongs
+    to a run is the cache holding the encoded prompt and attention state; the
     pipeline belongs to the application.
     """
 
     def __init__(
         self,
         pipeline: Any,
-        prompt: str,
+        prompt: str | None,
         session_desc: SessionDesc,
         total_blocks: int,
         *,
@@ -90,7 +95,8 @@ class T2VSession(ISession):
         """
         Args:
             pipeline: Loaded pipeline, owned by the application.
-            prompt: Text to generate from.
+            prompt: Text to generate from, or ``None`` for a continuous idle
+                session waiting for its first prompt.
             session_desc: Session the application accepted, already checked
                 against what the model can produce.
             total_blocks: Blocks this rollout generates before it is finished.
@@ -114,7 +120,14 @@ class T2VSession(ISession):
             total_blocks=self._total_blocks,
             image=self._image,
         )
-        state.cache = _new_cache(state)
+        if state.prompt is not None:
+            state.cache = _new_cache(state)
+        self.register_ui_loop(
+            T2VImGuiUILoop,
+            state=T2VUIState(prompt=self._prompt or ""),
+            width=self._session_desc.video_width,
+            height=self._session_desc.video_height,
+        )
         self.register_model_loop(T2VModelLoop, state=state)
 
     @property
@@ -124,6 +137,8 @@ class T2VSession(ISession):
 
 def _new_cache(state: T2VModelState) -> Any:
     """Encode the prompt into a cache for one rollout."""
+    if state.prompt is None:
+        raise RuntimeError("Cannot initialize a text-to-video cache without a prompt.")
     if state.image is not None:
         return state.pipeline.initialize_cache(
             text=[state.prompt],

--- a/apps/t2v/t2v/testing.py
+++ b/apps/t2v/t2v/testing.py
@@ -14,6 +14,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import numpy as np
 import numpy.typing as npt
@@ -21,6 +22,9 @@ import torch
 
 from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.runtime_v2.blit_model_output_to_screen_loop import (
+    BlitModelOutputToScreenLoop,
+)
 from flashdreams.runtime_v2.mp4_output_sink import Mp4OutputSink
 from flashdreams.runtime_v2.session_desc import (
     BackpressureMode,
@@ -32,6 +36,7 @@ from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_encoder import result_to_rgb24_frames
 from t2v.application import T2VApplication
+from t2v.ui import T2VImGuiUILoop
 
 _REAL_CLIP_LUMINANCE = (16.0, 240.0)
 """Mean pixel value a real clip has to land inside, from ``0`` to ``255``.
@@ -143,12 +148,19 @@ def check_t2v_model_impl(
             backpressure_mode=BackpressureMode.BLOCK,
             presentation_mode=PresentationMode.ON_DEMAND,
         )
-        run_session(
-            application.create_session(session_desc),
-            _DiscardingClientWindow(),
-            metrics_output_sink=inspector,
-            steps=steps,
-        )
+        with patch.multiple(
+            T2VImGuiUILoop,
+            _initialize_loop_state=BlitModelOutputToScreenLoop._initialize_loop_state,
+            step=BlitModelOutputToScreenLoop.step,
+            is_finished=BlitModelOutputToScreenLoop.is_finished,
+            reset=BlitModelOutputToScreenLoop.reset,
+        ):
+            run_session(
+                application.create_session(session_desc),
+                _DiscardingClientWindow(),
+                metrics_output_sink=inspector,
+                steps=steps,
+            )
     finally:
         application.close()
 

--- a/apps/t2v/t2v/testing.py
+++ b/apps/t2v/t2v/testing.py
@@ -145,7 +145,8 @@ def check_t2v_model_impl(
         )
         run_session(
             application.create_session(session_desc),
-            _InspectingClientWindow(inspector),
+            _DiscardingClientWindow(),
+            metrics_output_sink=inspector,
             steps=steps,
         )
     finally:
@@ -371,27 +372,20 @@ class _FrameInspector(OutputSink):
             self._mp4.close()
 
 
-class _InspectingClientWindow(IClientWindow):
-    """Drive a run against the inspector, reporting no input.
-
-    What ``Mp4ClientWindow`` is for a run writing a file: the input half of a
-    window nobody is on the other end of.
-    """
-
-    def __init__(self, sink: OutputSink) -> None:
-        self._sink = sink
+class _DiscardingClientWindow(IClientWindow):
+    """Drive a checked run without retaining its composed UI output."""
 
     def get_user_input_events(self) -> UserInputEvents:
         return UserInputEvents([])
 
     def open(self, session_desc: SessionDesc) -> None:
-        self._sink.open(session_desc)
+        del session_desc
 
     def write(self, result: StepResult) -> None:
-        self._sink.write(result)
+        del result
 
     def close(self) -> None:
-        self._sink.close()
+        return
 
 
 def _compare(

--- a/apps/t2v/t2v/ui.py
+++ b/apps/t2v/t2v/ui.py
@@ -3,7 +3,7 @@
 
 """Immediate-mode prompt controls for interactive text-to-video sessions."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from torch import Tensor
@@ -45,7 +45,12 @@ class T2VImGuiUILoop(ImGuiUILoop[T2VUIState]):
                 if prompt:
                     self.state.prompt = prompt
                     self.state.message = "Starting new session…"
-                    self.request_new_session({"prompt": prompt})
+                    self.request_new_session(
+                        replace(
+                            self.session_desc,
+                            metadata={**self.session_desc.metadata, "prompt": prompt},
+                        )
+                    )
                 else:
                     self.state.message = "Enter a prompt before starting a session."
             if self.state.message:

--- a/apps/t2v/t2v/ui.py
+++ b/apps/t2v/t2v/ui.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immediate-mode prompt controls for interactive text-to-video sessions."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from torch import Tensor
+
+from flashdreams.runtime_v2.imgui_ui_loop import ImGuiUILoop
+from flashdreams.runtime_v2.user_input_events import UserInputEvents
+
+
+@dataclass(slots=True)
+class T2VUIState:
+    """Editable prompt state owned by the text-to-video UI loop."""
+
+    prompt: str = ""
+    """Prompt currently displayed in the input field."""
+
+    message: str = ""
+    """Validation or progress message displayed below the controls."""
+
+
+class T2VImGuiUILoop(ImGuiUILoop[T2VUIState]):
+    """Draw a prompt field that starts a replacement text-to-video session."""
+
+    def step_ui(
+        self,
+        imgui: Any,
+        step_index: int,
+        events: UserInputEvents,
+    ) -> Tensor | None:
+        """Draw prompt controls over the latest generated model frame."""
+        del step_index, events
+        imgui.set_next_window_pos(imgui.ImVec2(16.0, 16.0), imgui.Cond_.once)
+        imgui.set_next_window_size(imgui.ImVec2(520.0, 130.0), imgui.Cond_.once)
+        imgui.begin("Text to video")
+        try:
+            imgui.text("Prompt")
+            _, self.state.prompt = imgui.input_text("##t2v-prompt", self.state.prompt)
+            if imgui.button("New session"):
+                prompt = self.state.prompt.strip()
+                if prompt:
+                    self.state.prompt = prompt
+                    self.state.message = "Starting new session…"
+                    self.request_new_session({"prompt": prompt})
+                else:
+                    self.state.message = "Enter a prompt before starting a session."
+            if self.state.message:
+                imgui.text(self.state.message)
+        finally:
+            imgui.end()
+        return self.presented_model_frame()
+
+
+__all__ = ["T2VImGuiUILoop", "T2VUIState"]

--- a/apps/t2v/tests/test_application.py
+++ b/apps/t2v/tests/test_application.py
@@ -15,6 +15,7 @@ import pytest
 from t2v.application import T2VApplication
 from t2v.defaults import T2VApplicationDefaults
 from t2v.session import T2VSession
+from t2v.ui import T2VImGuiUILoop
 
 from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -85,7 +86,11 @@ class RecordingRollout(T2VSession):
     """Session remembering how long a rollout it was given."""
 
     def __init__(
-        self, pipeline: Any, prompt: str, session_desc: SessionDesc, total_blocks: int
+        self,
+        pipeline: Any,
+        prompt: str | None,
+        session_desc: SessionDesc,
+        total_blocks: int,
     ) -> None:
         super().__init__(pipeline, prompt, session_desc, total_blocks)
         self.blocks_to_generate = total_blocks
@@ -144,12 +149,13 @@ def _rollout_length(app: T2VApplication) -> int:
 def _session_desc(
     layout: VideoTensorLayout = VideoTensorLayout.tchw,
     *,
+    presentation_mode: PresentationMode = PresentationMode.CONTINUOUS,
     width: int = _WIDTH,
     height: int = _HEIGHT,
 ) -> SessionDesc:
     return SessionDesc(
         output_layout=layout,
-        presentation_mode=PresentationMode.ON_DEMAND,
+        presentation_mode=presentation_mode,
         frames_per_second_for_ui=60,
         frames_per_second_for_step=_FPS,
         video_width=width,
@@ -177,13 +183,26 @@ def test_the_rollout_length_can_be_overridden() -> None:
     assert _rollout_length(app) == 3
 
 
-def test_a_run_needs_something_to_generate_from() -> None:
-    app = T2VApplication(defaults=_defaults())
+@pytest.mark.parametrize("presentation_mode", tuple(PresentationMode))
+def test_an_interactive_application_can_wait_for_its_first_prompt(
+    presentation_mode: PresentationMode,
+) -> None:
+    defaults = _defaults()
+    app = T2VApplication(defaults=defaults)
 
-    with pytest.raises(ValueError, match="--prompt is required"):
-        app.init([])
-    with pytest.raises(ValueError, match="--prompt is required"):
-        app.init(["--prompt", "   "])
+    app.init([])
+    session = app.create_session(_session_desc(presentation_mode=presentation_mode))
+    session.init()
+
+    assert defaults.pipeline_config.setup_count == 1
+    assert session.session_desc.presentation_mode is presentation_mode
+    assert isinstance(session.ui_loop, T2VImGuiUILoop)
+    assert session.model_loop.is_finished()
+
+
+def test_an_explicit_prompt_cannot_be_empty() -> None:
+    with pytest.raises(ValueError, match="--prompt cannot be empty"):
+        T2VApplication(defaults=_defaults()).init(["--prompt", "   "])
 
 
 def test_a_run_that_would_generate_no_video_is_refused() -> None:
@@ -227,15 +246,14 @@ def test_closing_the_application_releases_the_model() -> None:
 ## What a model will not generate
 
 
-def test_a_layout_the_model_does_not_emit_is_refused_before_it_loads() -> None:
-    """A checkpoint of several gigabytes is a long wait for a certain refusal."""
+def test_a_layout_the_model_does_not_emit_is_refused_before_a_session_starts() -> None:
     app = _application()
     config = _pipeline_config(app)
 
     with pytest.raises(ValueError, match="only produces tchw output"):
         app.create_session(_session_desc(VideoTensorLayout.bcthw))
 
-    assert config.setup_count == 0
+    assert config.setup_count == 1
 
 
 @pytest.mark.parametrize("width,height", [(130, 64), (128, 60)])
@@ -346,7 +364,10 @@ def test_a_seed_reaches_the_model_where_a_model_keeps_one() -> None:
     draws its own noise draws the same noise twice."""
     diffusion_model = SimpleNamespace(seed=42)
     defaults = _defaults(
-        pipeline_config=SimpleNamespace(diffusion_model=diffusion_model)
+        pipeline_config=SimpleNamespace(
+            diffusion_model=diffusion_model,
+            setup=lambda: FakePipeline(),
+        )
     )
 
     app = T2VApplication(defaults=defaults)

--- a/apps/t2v/tests/test_cli.py
+++ b/apps/t2v/tests/test_cli.py
@@ -559,6 +559,35 @@ def test_the_run_goes_to_the_window_the_mode_asked_for(
     assert len(window.results) >= _TOTAL_BLOCKS * _BLOCK_FRAMES
 
 
+def test_the_command_passes_its_timeout_to_the_application_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received: list[float | None] = []
+
+    def record_run(
+        self: object,
+        session_desc: SessionDesc,
+        commandline_args: Sequence[str],
+        *,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        del self, session_desc, commandline_args
+        received.append(timeout_seconds)
+
+    _install(monkeypatch, UndescribedApplication(), ClosingWindow())
+    monkeypatch.setattr(cli.ApplicationRunner, "run", record_run)
+
+    cli.entrypoint(["stub", "--mode", "webrtc", "--timeout", "2.5"])
+
+    assert received == [2.5]
+
+
+@pytest.mark.parametrize("timeout", ["0", "-1", "nan", "inf"])
+def test_the_command_rejects_an_invalid_timeout(timeout: str) -> None:
+    with pytest.raises(SystemExit):
+        cli.entrypoint(["stub", "--mode", "webrtc", "--timeout", timeout])
+
+
 def test_the_command_needs_somewhere_to_write() -> None:
     with pytest.raises(SystemExit):
         cli.entrypoint(["stub"])

--- a/apps/t2v/tests/test_cli.py
+++ b/apps/t2v/tests/test_cli.py
@@ -24,13 +24,16 @@ from t2v.ui import T2VImGuiUILoop
 
 from flashdreams.api_v2.application import IApplication
 from flashdreams.api_v2.client_window import IClientWindow
-from flashdreams.api_v2.loop import IModelLoop, ModelInferenceState
+from flashdreams.api_v2.loop import IModelLoop
 from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2 import cli
 from flashdreams.runtime_v2.application_registry import (
     APPLICATION_ENTRY_POINT_GROUP,
     create_application,
     registered_application_slugs,
+)
+from flashdreams.runtime_v2.blit_model_output_to_screen_loop import (
+    BlitModelOutputToScreenLoop,
 )
 from flashdreams.runtime_v2.client_window_factory import ClientWindowMode
 from flashdreams.runtime_v2.session_desc import (
@@ -42,6 +45,7 @@ from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+
 pytestmark = pytest.mark.ci_cpu
 
 needs_ffmpeg = pytest.mark.skipif(
@@ -300,34 +304,26 @@ def _install(
     """
     monkeypatch.setattr(cli, "create_application", lambda slug: application)
     if isinstance(application, T2VApplication):
-        # These command-wiring tests have no interactive client to end the
-        # always-present T2V UI after its stand-in model finishes.
-        original_step_ui = T2VImGuiUILoop.step_ui
-        finished_ui_loops: set[int] = set()
-
-        def finish_after_final_frame(
-            self: T2VImGuiUILoop,
-            imgui: object,
-            step_index: int,
-            events: UserInputEvents,
-        ) -> torch.Tensor | None:
-            result = original_step_ui(self, imgui, step_index, events)
-            if (
-                self.model_inference_state is ModelInferenceState.FINISHED
-                and not self._presentation_manager.has_pending_frames()
-            ):
-                finished_ui_loops.add(id(self))
-            return result
-
+        # These command-wiring tests need neither interactive controls nor CUDA.
         monkeypatch.setattr(
             T2VImGuiUILoop,
-            "step_ui",
-            finish_after_final_frame,
+            "_initialize_loop_state",
+            BlitModelOutputToScreenLoop._initialize_loop_state,
+        )
+        monkeypatch.setattr(
+            T2VImGuiUILoop,
+            "step",
+            BlitModelOutputToScreenLoop.step,
         )
         monkeypatch.setattr(
             T2VImGuiUILoop,
             "is_finished",
-            lambda self: id(self) in finished_ui_loops,
+            BlitModelOutputToScreenLoop.is_finished,
+        )
+        monkeypatch.setattr(
+            T2VImGuiUILoop,
+            "reset",
+            BlitModelOutputToScreenLoop.reset,
         )
     if window is not None:
         monkeypatch.setattr(

--- a/apps/t2v/tests/test_cli.py
+++ b/apps/t2v/tests/test_cli.py
@@ -1,0 +1,607 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for the command line that runs a v2 application.
+
+The runs here use a stand-in for a model, so what they cover is the wiring: the
+application found, given its arguments, asked what session it would generate,
+run against the window the arguments chose, and closed.
+"""
+
+import argparse
+import json
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+import torch
+from numpy import uint64
+from t2v.application import T2VApplication
+from t2v.defaults import T2VApplicationDefaults
+from t2v.testing import FakeT2VPipeline, FakeT2VPipelineConfig
+from t2v.ui import T2VImGuiUILoop
+
+from flashdreams.api_v2.application import IApplication
+from flashdreams.api_v2.client_window import IClientWindow
+from flashdreams.api_v2.loop import IModelLoop, ModelInferenceState
+from flashdreams.api_v2.session import ISession
+from flashdreams.runtime_v2 import cli
+from flashdreams.runtime_v2.application_registry import (
+    APPLICATION_ENTRY_POINT_GROUP,
+    create_application,
+    registered_application_slugs,
+)
+from flashdreams.runtime_v2.client_window_factory import ClientWindowMode
+from flashdreams.runtime_v2.session_desc import (
+    BackpressureMode,
+    PresentationMode,
+    SessionDesc,
+)
+from flashdreams.runtime_v2.step_result import StepResult
+from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
+from flashdreams.runtime_v2.user_input_events import UserInputEvents
+from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
+pytestmark = pytest.mark.ci_cpu
+
+needs_ffmpeg = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None,
+    reason="writing an MP4 needs ffmpeg on PATH",
+)
+
+_BLOCK_FRAMES = 4
+"""Frames a step generates. Small, because these tests encode real files."""
+
+_TOTAL_BLOCKS = 3
+"""Rollout length the stand-in application says it normally generates."""
+
+_PROMPT = "A cat surfing"
+"""Prompt the tests generate from."""
+
+
+## Stand-in model
+
+
+def _stand_in(*, fail_at: int | None = None) -> FakeT2VPipeline:
+    """Return the shared stand-in, generating small blocks of one size."""
+    return FakeT2VPipeline(
+        first_block_frames=_BLOCK_FRAMES, block_frames=_BLOCK_FRAMES, fail_at=fail_at
+    )
+
+
+class StubT2VApplication(T2VApplication):
+    """A text-to-video application whose model costs nothing to load."""
+
+    def __init__(self, pipeline: FakeT2VPipeline) -> None:
+        super().__init__(
+            defaults=T2VApplicationDefaults(
+                pipeline_config=FakeT2VPipelineConfig(pipeline),
+                total_blocks=_TOTAL_BLOCKS,
+                pixel_width=pipeline.width,
+                pixel_height=pipeline.height,
+                device="cpu",
+                fps=8,
+                output_layout=VideoTensorLayout.tchw,
+            )
+        )
+
+
+class UndescribedApplication(IApplication):
+    """An application that generates whatever it is asked for.
+
+    Having no clip of its own in mind, the description it is handed is the one
+    the command line built.
+    """
+
+    def __init__(self) -> None:
+        self.asked_for: SessionDesc | None = None
+
+    def init(self, commandline_args: Sequence[str]) -> None:
+        del commandline_args
+
+    def create_session(self, session_desc: SessionDesc) -> ISession:
+        self.asked_for = session_desc
+        return OneStepSession(session_desc)
+
+
+class OneStepModelLoop(IModelLoop["OneStepSession"]):
+    def step(self, step_index: int, events: UserInputEvents) -> list[StepResult]:
+        return [self.state.step(step_index, events)]
+
+    def is_finished(self) -> bool:
+        return self.state.is_finished()
+
+
+class OneStepSession(ISession):
+    """A session generating one frame and reporting itself finished."""
+
+    def __init__(self, session_desc: SessionDesc) -> None:
+        self._session_desc = session_desc
+        self._generated = False
+
+    def init(self) -> None:
+        self.register_model_loop(OneStepModelLoop, state=self)
+
+    @property
+    def session_desc(self) -> SessionDesc:
+        return self._session_desc
+
+    def step(self, step_index: int, events: UserInputEvents) -> StepResult:
+        del events
+        self._generated = True
+        output_shape = (
+            (1, 3, 1, self._session_desc.video_height, self._session_desc.video_width)
+            if self._session_desc.output_layout is VideoTensorLayout.bcthw
+            else (1, 3, self._session_desc.video_height, self._session_desc.video_width)
+        )
+        return StepResult(
+            step_index=step_index,
+            output=torch.zeros(output_shape),
+            frame_count=1,
+            output_layout=self._session_desc.output_layout,
+        )
+
+    def is_finished(self) -> bool:
+        return self._generated
+
+
+class RecordingWindow(IClientWindow):
+    """Stand in for a window with a client, recording what it was given."""
+
+    def __init__(self) -> None:
+        self.results: list[StepResult] = []
+
+    def get_user_input_events(self) -> UserInputEvents:
+        return UserInputEvents([])
+
+    def open(self, session_desc: SessionDesc) -> None:
+        self.session_desc = session_desc
+
+    def write(self, result: StepResult) -> None:
+        self.results.append(result)
+
+    def close(self) -> None:
+        return
+
+
+class ClosingWindow(RecordingWindow):
+    """Close the run on its first input poll."""
+
+    def get_user_input_events(self) -> UserInputEvents:
+        return UserInputEvents([CloseUserInputEvent(timestamp=uint64(0))])
+
+
+## Splitting the command line
+
+
+def test_arguments_after_the_separator_belong_to_the_application() -> None:
+    own, application = cli.split_arguments(
+        ["slug", "--mode", "mp4", "--", "--prompt", "a cat", "--mode", "fancy"]
+    )
+
+    # --mode on both sides is the point: an application may declare it too.
+    assert own == ["slug", "--mode", "mp4"]
+    assert application == ["--prompt", "a cat", "--mode", "fancy"]
+
+
+def test_an_application_taking_no_arguments_needs_no_separator() -> None:
+    assert cli.split_arguments(["slug", "--mode", "mp4"]) == (
+        ["slug", "--mode", "mp4"],
+        [],
+    )
+
+
+def test_a_separator_with_nothing_after_it_is_an_empty_application_line() -> None:
+    assert cli.split_arguments(["slug", "--"]) == (["slug"], [])
+
+
+## Finding the application
+
+
+def test_an_unknown_slug_says_what_is_installed() -> None:
+    with pytest.raises(LookupError, match="No FlashDreams v2 application matches"):
+        create_application("no-such-application")
+
+
+def test_a_slug_with_no_entry_point_is_read_as_a_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An integration is reachable by the name of the package it ships, so it
+    runs straight from a checkout that has registered nothing."""
+    _write_application_module(
+        tmp_path,
+        "stub_integration",
+        "class Stub(IApplication):\n"
+        "    def init(self, commandline_args): pass\n"
+        "    def create_session(self, session_desc): raise NotImplementedError\n"
+        "def create_app():\n"
+        "    return Stub()\n",
+        monkeypatch,
+    )
+
+    application = create_application("stub-integration")
+
+    assert type(application).__name__ == "Stub"
+
+
+def test_a_module_without_a_factory_says_so(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_application_module(tmp_path, "no_factory", "", monkeypatch)
+
+    with pytest.raises(TypeError, match="does not expose create_app"):
+        create_application("no-factory")
+
+
+def test_an_application_on_the_older_contract_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A v1 application is not a v2 one, and saying what arrived is the only
+    way a reader can tell which of the two they installed."""
+    _write_application_module(
+        tmp_path,
+        "wrong_contract",
+        "def create_app():\n    return object()\n",
+        monkeypatch,
+    )
+
+    with pytest.raises(TypeError, match="returned object; expected an IApplication"):
+        create_application("wrong-contract")
+
+
+def test_an_empty_slug_is_refused() -> None:
+    with pytest.raises(ValueError, match="slug is required"):
+        create_application("  ")
+
+
+def test_what_is_installed_is_reported_in_a_stable_order() -> None:
+    slugs = registered_application_slugs()
+
+    assert slugs == tuple(sorted(set(slugs)))
+    assert APPLICATION_ENTRY_POINT_GROUP == "flashdreams.applications_v2"
+
+
+def _write_application_module(
+    root: Path, name: str, body: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Put an importable application package on the path, as an install would."""
+    package = root / name
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from flashdreams.api_v2.application import IApplication\n" + body
+    )
+    monkeypatch.syspath_prepend(root)
+
+
+## Running
+
+
+class StubMode(ClientWindowMode):
+    """A mode handing the command a window the test can look inside."""
+
+    def __init__(self, name: str, window: IClientWindow) -> None:
+        self.name = name
+        self._window = window
+
+    def create(self, parsed_args: argparse.Namespace) -> IClientWindow:
+        del parsed_args
+        return self._window
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    application: IApplication,
+    window: IClientWindow | None = None,
+) -> None:
+    """Point the command at this application, and at this window when given one.
+
+    Only a run that is not writing a file needs one; a file run builds its
+    window from the arguments like any other.
+    """
+    monkeypatch.setattr(cli, "create_application", lambda slug: application)
+    if isinstance(application, T2VApplication):
+        # These command-wiring tests have no interactive client to end the
+        # always-present T2V UI after its stand-in model finishes.
+        original_step_ui = T2VImGuiUILoop.step_ui
+        finished_ui_loops: set[int] = set()
+
+        def finish_after_final_frame(
+            self: T2VImGuiUILoop,
+            imgui: object,
+            step_index: int,
+            events: UserInputEvents,
+        ) -> torch.Tensor | None:
+            result = original_step_ui(self, imgui, step_index, events)
+            if (
+                self.model_inference_state is ModelInferenceState.FINISHED
+                and not self._presentation_manager.has_pending_frames()
+            ):
+                finished_ui_loops.add(id(self))
+            return result
+
+        monkeypatch.setattr(
+            T2VImGuiUILoop,
+            "step_ui",
+            finish_after_final_frame,
+        )
+        monkeypatch.setattr(
+            T2VImGuiUILoop,
+            "is_finished",
+            lambda self: id(self) in finished_ui_loops,
+        )
+    if window is not None:
+        monkeypatch.setattr(
+            cli,
+            "client_window_mode",
+            lambda name: StubMode(name, window),
+        )
+
+
+@needs_ffmpeg
+def test_a_run_writes_what_the_application_generated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pipeline = _stand_in()
+    _install(monkeypatch, StubT2VApplication(pipeline))
+    path = tmp_path / "clip.mp4"
+
+    cli.entrypoint(
+        [
+            "stub",
+            "--output-path",
+            str(path),
+            "--",
+            "--prompt",
+            _PROMPT,
+            "--total-blocks",
+            "2",
+        ]
+    )
+
+    assert capsys.readouterr().out.strip() == str(path)
+    assert path.stat().st_size > 0
+    assert pipeline.caches[0]["text"] == [_PROMPT]
+    assert pipeline.generated == [0, 1]
+
+
+def test_the_model_is_released_when_a_run_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A model holds most of a GPU, so a failed run still has to put it back.
+    pipeline = _stand_in(fail_at=1)
+    _install(monkeypatch, StubT2VApplication(pipeline), RecordingWindow())
+
+    with pytest.raises(RuntimeError, match="generate failed"):
+        cli.entrypoint(
+            [
+                "stub",
+                "--mode",
+                "webrtc",
+                "--presentation-mode",
+                "on_demand",
+                "--",
+                "--prompt",
+                _PROMPT,
+            ]
+        )
+
+    assert pipeline.closed
+
+
+@needs_ffmpeg
+def test_a_run_can_record_what_generating_the_clip_cost(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clip says nothing about what it took to generate, so a benchmark run
+    asks for both and the file it writes is the one the harness reads."""
+    _install(monkeypatch, StubT2VApplication(_stand_in()))
+    stats_path = tmp_path / "stats_run.json"
+    clip_path = tmp_path / "clip.mp4"
+
+    cli.entrypoint(
+        [
+            "stub",
+            "--output-path",
+            str(clip_path),
+            "--stats-path",
+            str(stats_path),
+            "--",
+            "--prompt",
+            _PROMPT,
+            "--total-blocks",
+            "2",
+        ]
+    )
+
+    # What a stats file says is the sink's business, covered in its own tests.
+    assert clip_path.stat().st_size > 0
+    payload = json.loads(stats_path.read_text(encoding="utf-8"))
+    assert [step["step_index"] for step in payload["steps"]] == [0, 1]
+    assert [step["frame_count"] for step in payload["steps"]] == [
+        _BLOCK_FRAMES,
+        _BLOCK_FRAMES,
+    ]
+
+
+@needs_ffmpeg
+def test_nothing_is_measured_unless_a_run_asks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install(monkeypatch, StubT2VApplication(_stand_in()))
+
+    cli.entrypoint(
+        [
+            "stub",
+            "--output-path",
+            str(tmp_path / "clip.mp4"),
+            "--",
+            "--prompt",
+            _PROMPT,
+            "--total-blocks",
+            "1",
+        ]
+    )
+
+    assert list(tmp_path.glob("*.json")) == []
+
+
+def test_a_continuous_application_can_wait_for_its_first_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _stand_in()
+    window = ClosingWindow()
+    _install(monkeypatch, StubT2VApplication(pipeline), window)
+
+    cli.entrypoint(["stub", "--mode", "webrtc"])
+
+    assert window.session_desc.presentation_mode is PresentationMode.CONTINUOUS
+    assert pipeline.caches == []
+
+
+## Describing the session to run
+
+
+def test_an_application_with_no_session_of_its_own_is_described_by_the_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Which is what lets this command run something that is not a model."""
+    application = UndescribedApplication()
+    _install(monkeypatch, application, ClosingWindow())
+
+    cli.entrypoint(
+        [
+            "stub",
+            "--mode",
+            "webrtc",
+            "--pixel-width",
+            "64",
+            "--pixel-height",
+            "32",
+            "--fps",
+            "12",
+            "--layout",
+            "bcthw",
+            "--backpressure-mode",
+            "block",
+            "--presentation-mode",
+            "on_demand",
+        ]
+    )
+
+    assert application.asked_for == SessionDesc(
+        output_layout=VideoTensorLayout.bcthw,
+        backpressure_mode=BackpressureMode.BLOCK,
+        presentation_mode=PresentationMode.ON_DEMAND,
+        frames_per_second_for_step=12,
+        video_width=64,
+        video_height=32,
+    )
+
+
+def test_a_model_generates_what_it_was_trained_for_unless_asked_otherwise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _stand_in()
+    window = RecordingWindow()
+    _install(monkeypatch, StubT2VApplication(pipeline), window)
+
+    cli.entrypoint(
+        [
+            "stub",
+            "--mode",
+            "webrtc",
+            "--pixel-width",
+            "64",
+            "--presentation-mode",
+            "on_demand",
+            "--",
+            "--prompt",
+            _PROMPT,
+        ]
+    )
+
+    assert window.session_desc.video_width == 64
+    # What nobody asked about is still the model's own.
+    assert window.session_desc.video_height == pipeline.height
+
+
+## The command itself
+
+
+def test_the_run_goes_to_the_window_the_mode_asked_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Which mode that is, and what it takes, is not this command's business."""
+    window = RecordingWindow()
+    asked_for: list[str] = []
+    _install(monkeypatch, StubT2VApplication(_stand_in()))
+    monkeypatch.setattr(
+        cli,
+        "client_window_mode",
+        lambda name: (asked_for.append(name), StubMode(name, window))[1],
+    )
+
+    cli.entrypoint(
+        [
+            "stub",
+            "--mode",
+            "webrtc",
+            "--presentation-mode",
+            "on_demand",
+            "--",
+            "--prompt",
+            _PROMPT,
+        ]
+    )
+
+    assert asked_for == ["webrtc"]
+    # Realtime output may repeat frames but must not skip them.
+    assert len(window.results) >= _TOTAL_BLOCKS * _BLOCK_FRAMES
+
+
+def test_the_command_needs_somewhere_to_write() -> None:
+    with pytest.raises(SystemExit):
+        cli.entrypoint(["stub"])
+
+
+class HelpfulApplication(IApplication):
+    """An application that parses its arguments, as every application does."""
+
+    def init(self, commandline_args: Sequence[str]) -> None:
+        parser = argparse.ArgumentParser(prog="flashdreams-run-v2 SLUG --")
+        parser.add_argument("--seconds", type=int, default=1, help="How long for.")
+        parser.parse_args(list(commandline_args))
+
+    def create_session(self, session_desc: SessionDesc) -> ISession:
+        return OneStepSession(session_desc)
+
+
+class RefusingMode(ClientWindowMode):
+    """A mode that fails if a run reaches its arguments or its window."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def check_arguments(self, parsed_args: argparse.Namespace) -> None:
+        del parsed_args
+        raise AssertionError("Application help must not check window arguments.")
+
+    def create(self, parsed_args: argparse.Namespace) -> IClientWindow:
+        del parsed_args
+        raise AssertionError("Application help must not create a window.")
+
+
+def test_an_application_describes_itself_without_a_window(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Only the application can say what it takes, and it needs no window to say
+    it. The default mode would otherwise refuse the run for want of an
+    ``--output-path`` that nothing was going to be written to."""
+    _install(monkeypatch, HelpfulApplication())
+    monkeypatch.setattr(cli, "client_window_mode", RefusingMode)
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.entrypoint(["stub", "--", "--help"])
+
+    assert exit_info.value.code == 0
+    assert "--seconds" in capsys.readouterr().out

--- a/apps/t2v/tests/test_structure.py
+++ b/apps/t2v/tests/test_structure.py
@@ -111,6 +111,7 @@ def test_shared_t2v_code_is_owned_by_app_package() -> None:
         "defaults.py",
         "session.py",
         "testing.py",
+        "ui.py",
     }
     assert (project / "tests").is_dir()
     readme = (project / "README.md").read_text()

--- a/apps/t2v/tests/test_ui.py
+++ b/apps/t2v/tests/test_ui.py
@@ -60,6 +60,7 @@ def test_new_session_button_submits_the_trimmed_prompt() -> None:
 
     loop.step_ui(imgui, 0, UserInputEvents([]))
     run = loop._begin_run(UserInputEvents([]), generation=0)
+    loop._finish_run(None, step_completed=False)
 
     assert state.prompt == "a cat surfing"
     assert state.message == "Starting new session…"
@@ -67,9 +68,9 @@ def test_new_session_button_submits_the_trimmed_prompt() -> None:
         loop.session_desc,
         metadata={"existing": "value", "prompt": "a cat surfing"},
     )
-    assert (
-        loop._begin_run(UserInputEvents([]), generation=0).new_session_request is None
-    )
+    second = loop._begin_run(UserInputEvents([]), generation=0)
+    loop._finish_run(None, step_completed=False)
+    assert second.new_session_request is None
     imgui.text.assert_any_call(state.message)
     imgui.end.assert_called_once_with()
 
@@ -81,6 +82,7 @@ def test_new_session_button_rejects_an_empty_prompt() -> None:
 
     loop.step_ui(imgui, 0, UserInputEvents([]))
     run = loop._begin_run(UserInputEvents([]), generation=0)
+    loop._finish_run(None, step_completed=False)
 
     assert run.new_session_request is None
     assert state.message == "Enter a prompt before starting a session."
@@ -94,17 +96,21 @@ def test_begin_run_returns_close_without_setting_the_shutdown_event() -> None:
         UserInputEvents([CloseUserInputEvent(timestamp=uint64(0))]),
         generation=0,
     )
+    loop._finish_run(None, step_completed=False)
 
     assert run.stop_requested
     assert not loop._shutdown_event.is_set()
 
 
-def test_begin_run_keeps_input_until_the_caller_runs_the_step() -> None:
+def test_finish_run_advances_and_consumes_input_when_the_step_is_skipped() -> None:
     loop = _loop(T2VUIState())
     event = NumeralKeypadUserInputEvent(timestamp=uint64(0), value=7)
 
     first = loop._begin_run(UserInputEvents([event]), generation=0)
+    loop._finish_run(None, step_completed=False)
     second = loop._begin_run(UserInputEvents([]), generation=0)
+    loop._finish_run(None, step_completed=False)
 
-    assert first.step_index == second.step_index == 0
-    assert loop.user_events.get_events() == [event]
+    assert first.step_index == 0
+    assert second.step_index == 1
+    assert loop.user_events.get_events() == []

--- a/apps/t2v/tests/test_ui.py
+++ b/apps/t2v/tests/test_ui.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU tests for interactive text-to-video prompt controls."""
+
+import queue
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from numpy import uint64
+from t2v.ui import T2VImGuiUILoop, T2VUIState
+
+from flashdreams.runtime_v2.presentation_manager import PresentationManager
+from flashdreams.runtime_v2.session_desc import SessionDesc
+from flashdreams.runtime_v2.user_input_event import (
+    CloseUserInputEvent,
+    NumeralKeypadUserInputEvent,
+)
+from flashdreams.runtime_v2.user_input_events import UserInputEvents
+pytestmark = pytest.mark.ci_cpu
+
+
+def _loop(state: T2VUIState) -> T2VImGuiUILoop:
+    loop = T2VImGuiUILoop(renderer=Mock())
+    loop.register_session_loop_objects(
+        state=state,
+        frequency=60,
+        shutdown_event=threading.Event(),
+        failure_queue=queue.Queue(),
+    )
+    loop.register_session_ui_loop_objects(
+        output_layout=SessionDesc().output_layout,
+        presentation_manager=PresentationManager(),
+    )
+    return loop
+
+
+def _imgui(*, prompt: str, submit: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        ImVec2=lambda x, y: (x, y),
+        Cond_=SimpleNamespace(once="once"),
+        set_next_window_pos=Mock(),
+        set_next_window_size=Mock(),
+        begin=Mock(),
+        end=Mock(),
+        text=Mock(),
+        input_text=Mock(return_value=(True, prompt)),
+        button=Mock(return_value=submit),
+    )
+
+
+def test_new_session_button_submits_the_trimmed_prompt() -> None:
+    state = T2VUIState(prompt="old prompt")
+    loop = _loop(state)
+    imgui = _imgui(prompt="  a cat surfing  ", submit=True)
+
+    loop.step_ui(imgui, 0, UserInputEvents([]))
+    run = loop._begin_run(UserInputEvents([]), generation=0)
+
+    assert state.prompt == "a cat surfing"
+    assert state.message == "Starting new session…"
+    assert run.new_session_request == {"prompt": "a cat surfing"}
+    assert (
+        loop._begin_run(UserInputEvents([]), generation=0).new_session_request is None
+    )
+    imgui.text.assert_any_call(state.message)
+    imgui.end.assert_called_once_with()
+
+
+def test_new_session_button_rejects_an_empty_prompt() -> None:
+    state = T2VUIState()
+    loop = _loop(state)
+    imgui = _imgui(prompt="   ", submit=True)
+
+    loop.step_ui(imgui, 0, UserInputEvents([]))
+    run = loop._begin_run(UserInputEvents([]), generation=0)
+
+    assert run.new_session_request is None
+    assert state.message == "Enter a prompt before starting a session."
+    imgui.text.assert_any_call(state.message)
+
+
+def test_begin_run_returns_close_without_setting_the_shutdown_event() -> None:
+    loop = _loop(T2VUIState())
+
+    run = loop._begin_run(
+        UserInputEvents([CloseUserInputEvent(timestamp=uint64(0))]),
+        generation=0,
+    )
+
+    assert run.stop_requested
+    assert not loop._shutdown_event.is_set()
+
+
+def test_begin_run_keeps_input_until_the_caller_runs_the_step() -> None:
+    loop = _loop(T2VUIState())
+    event = NumeralKeypadUserInputEvent(timestamp=uint64(0), value=7)
+
+    first = loop._begin_run(UserInputEvents([event]), generation=0)
+    second = loop._begin_run(UserInputEvents([]), generation=0)
+
+    assert first.step_index == second.step_index == 0
+    assert loop.user_events.get_events() == [event]

--- a/apps/t2v/tests/test_ui.py
+++ b/apps/t2v/tests/test_ui.py
@@ -20,6 +20,7 @@ from flashdreams.runtime_v2.user_input_event import (
     NumeralKeypadUserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
+
 pytestmark = pytest.mark.ci_cpu
 
 

--- a/apps/t2v/tests/test_ui.py
+++ b/apps/t2v/tests/test_ui.py
@@ -5,6 +5,7 @@
 
 import queue
 import threading
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -23,6 +24,7 @@ pytestmark = pytest.mark.ci_cpu
 
 
 def _loop(state: T2VUIState) -> T2VImGuiUILoop:
+    session_desc = SessionDesc(metadata={"existing": "value"})
     loop = T2VImGuiUILoop(renderer=Mock())
     loop.register_session_loop_objects(
         state=state,
@@ -31,7 +33,7 @@ def _loop(state: T2VUIState) -> T2VImGuiUILoop:
         failure_queue=queue.Queue(),
     )
     loop.register_session_ui_loop_objects(
-        output_layout=SessionDesc().output_layout,
+        session_desc=session_desc,
         presentation_manager=PresentationManager(),
     )
     return loop
@@ -61,7 +63,10 @@ def test_new_session_button_submits_the_trimmed_prompt() -> None:
 
     assert state.prompt == "a cat surfing"
     assert state.message == "Starting new session…"
-    assert run.new_session_request == {"prompt": "a cat surfing"}
+    assert run.new_session_request == replace(
+        loop.session_desc,
+        metadata={"existing": "value", "prompt": "a cat surfing"},
+    )
     assert (
         loop._begin_run(UserInputEvents([]), generation=0).new_session_request is None
     )

--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -202,8 +202,9 @@ For full immediate Dear ImGui controls drawn over model output, subclass
 `step_ui(imgui, step_index, events)` rather than `step`. Its `imgui` proxy
 exposes `imgui_bundle.imgui` and an image-like pixel upload convenience form. A
 UI control that needs a fresh application session calls
-`request_new_session(metadata)`; the runtime cleans the current session and
-passes a replacement description to `ApplicationRunner`.
+`request_new_session(session_desc)` with a fully resolved replacement
+description; the runtime cleans the current session and passes that description
+to `ApplicationRunner` unchanged.
 For SlangPy's smaller retained widget API, subclass `SlangPyUILoop` from
 `flashdreams.runtime_v2.slangpy_ui_loop`. The
 [`slangpy_ui_demo` integration](../../../integrations_v2/slangpy_ui_demo/README.md)

--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -188,10 +188,11 @@ model-generation-loop produces frames:
 - `PresentationMode.ON_DEMAND` runs the UI after the presentation manager
   advances to a new model frame.
 
-An `IUILoop` can read `model_inference_state` to distinguish `NOT_STARTED`,
-`RUNNING`, and `FINISHED`. An unfinished UI continues ticking after inference
-so it can remain responsive and request another session. Override `is_finished`
-when the UI has its own terminal condition.
+An `IModelLoop` owns its `inference_state`. An `IUILoop` can query that state
+through `model_inference_state` to distinguish `NOT_STARTED`, `RUNNING`, and
+`FINISHED`; it does not store a second copy. An unfinished UI continues ticking
+after inference so it can remain responsive and request another session.
+Override `is_finished` when the UI has its own terminal condition.
 
 Use `PresentationMode.ON_DEMAND` with `BackpressureMode.BLOCK` when every
 generated model frame must be selected and written exactly once in order.

--- a/flashdreams/flashdreams/api_v2/README.md
+++ b/flashdreams/flashdreams/api_v2/README.md
@@ -64,10 +64,11 @@ comes from the session description: the model loop steps at
 `frames_per_second_for_step`, and the UI ticks at `frames_per_second_for_ui`.
 
 The UI thread initially selects frames from model chunks at
-`frames_per_second_for_step`. With nonblocking `BackpressureMode.DROP_OLDEST` backpressure, the oldest chunk not-finished being processed by the ui-thread will be discarded in favor of a new chunk returned by the model-thread if presentation-manager buffer is full. With `BackpressureMode.BLOCK` backpressure, instead of discarding a chunk the model-thread will wait for an open chunk-slot to store its result in the presentation-manager before progressing to its next `step`. The goal of this backpressure model is to allow independent computation and presentation of UI (for reactivity to user inputs) separate from the backend logic of the model-thread.```
-`PresentationMode.CONTINUOUS` lets an `IUILoop` redraw every UI tick;
-`PresentationMode.ON_DEMAND` runs it only when the selected model frame changes.
-Interactive or clock-driven UIs should use continuous presentation.
+`frames_per_second_for_step`. With nonblocking `BackpressureMode.DROP_OLDEST` backpressure, the oldest chunk not-finished being processed by the ui-thread will be discarded in favor of a new chunk returned by the model-thread if presentation-manager buffer is full. With `BackpressureMode.BLOCK` backpressure, instead of discarding a chunk the model-thread will wait for an open chunk-slot to store its result in the presentation-manager before progressing to its next `step`. The goal of this backpressure model is to allow independent computation and presentation of UI (for reactivity to user inputs) separate from the backend logic of the model-thread.
+`PresentationMode.CONTINUOUS` runs an `IUILoop` every UI tick while model
+inference is active; `PresentationMode.ON_DEMAND` runs it only when the selected
+model frame changes. An unfinished UI also ticks while model inference has not
+started or has finished, independent of presentation mode.
 
 ## Loops
 
@@ -182,10 +183,15 @@ frames faster than the UI thread can consume them:
 `SessionDesc.presentation_mode` handles the UI loop ticking faster than the
 model-generation-loop produces frames:
 
-- `PresentationMode.CONTINUOUS` runs the UI every tick and may reuse
-  the newest generated model frame.
+- `PresentationMode.CONTINUOUS` runs the UI every tick and may reuse the newest
+  generated model frame.
 - `PresentationMode.ON_DEMAND` runs the UI after the presentation manager
   advances to a new model frame.
+
+An `IUILoop` can read `model_inference_state` to distinguish `NOT_STARTED`,
+`RUNNING`, and `FINISHED`. An unfinished UI continues ticking after inference
+so it can remain responsive and request another session. Override `is_finished`
+when the UI has its own terminal condition.
 
 Use `PresentationMode.ON_DEMAND` with `BackpressureMode.BLOCK` when every
 generated model frame must be selected and written exactly once in order.
@@ -193,7 +199,10 @@ generated model frame must be selected and written exactly once in order.
 For full immediate Dear ImGui controls drawn over model output, subclass
 `ImGuiUILoop` from `flashdreams.runtime_v2.imgui_ui_loop` and implement
 `step_ui(imgui, step_index, events)` rather than `step`. Its `imgui` proxy
-exposes `imgui_bundle.imgui` and an image-like pixel upload convenience form.
+exposes `imgui_bundle.imgui` and an image-like pixel upload convenience form. A
+UI control that needs a fresh application session calls
+`request_new_session(metadata)`; the runtime cleans the current session and
+passes a replacement description to `ApplicationRunner`.
 For SlangPy's smaller retained widget API, subclass `SlangPyUILoop` from
 `flashdreams.runtime_v2.slangpy_ui_loop`. The
 [`slangpy_ui_demo` integration](../../../integrations_v2/slangpy_ui_demo/README.md)

--- a/flashdreams/flashdreams/api_v2/client_window.py
+++ b/flashdreams/flashdreams/api_v2/client_window.py
@@ -14,9 +14,8 @@ class IClientWindow(InputSource, OutputSink, ABC):
 
     The runtime opens the window with a session's description, then reads input
     and writes results until the run ends. A window stays open across a session
-    reset. A reusable window may also stay open when the client asks to replace
-    the session; the runtime opens it again for the replacement and closes it
-    when the application run ends.
+    reset/replacement. A window may be opened/closed by the runtime during a session
+    reset/replacement.
 
     A window does not describe the output shape. The session does, and the window
     is given that description in :meth:`OutputSink.open`.

--- a/flashdreams/flashdreams/api_v2/client_window.py
+++ b/flashdreams/flashdreams/api_v2/client_window.py
@@ -12,9 +12,11 @@ from .output_sink import OutputSink
 class IClientWindow(InputSource, OutputSink, ABC):
     """Handle application input and output for one client window.
 
-    The runtime opens the window with the session's description, then reads input
-    and writes results until the run ends, and closes it then. A window stays open
-    across a session reset.
+    The runtime opens the window with a session's description, then reads input
+    and writes results until the run ends. A window stays open across a session
+    reset. A reusable window may also stay open when the client asks to replace
+    the session; the runtime opens it again for the replacement and closes it
+    when the application run ends.
 
     A window does not describe the output shape. The session does, and the window
     is given that description in :meth:`OutputSink.open`.

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -302,7 +302,12 @@ class IModelLoop(ILoop[StateT], ABC):
                 run = self._begin_run(events, generation)
                 if run.step_index is None:
                     break
-                last_run_started = self._pace(last_run_started)
+                if self.frequency != 0 and last_run_started is not None:
+                    earliest_start = last_run_started + 1.0 / self.frequency
+                    self._shutdown_event.wait(
+                        max(0.0, earliest_start - time.monotonic())
+                    )
+                last_run_started = time.monotonic()
                 if self._shutdown_event.is_set():
                     break
                 step_started_at = time.monotonic()

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -113,6 +113,11 @@ class ILoop(ABC, Generic[StateT]):
         self._shutdown_event = shutdown_event
         self._failure_queue = failure_queue
         self._new_session_request: dict[str, Any] | None = None
+        self._initialize_loop_state()
+
+    def _initialize_loop_state(self) -> None:
+        """Initialize state specific to this kind of loop."""
+        return
 
     @abstractmethod
     def step(
@@ -257,6 +262,24 @@ class IModelLoop(ILoop[StateT], ABC):
     """
 
     @final
+    def _initialize_loop_state(self) -> None:
+        """Initialize model-inference state."""
+        self._inference_state = ModelInferenceState.NOT_STARTED
+        self._inference_state_lock = threading.Lock()
+
+    @property
+    @final
+    def inference_state(self) -> ModelInferenceState:
+        """Return whether this model loop has started, is running, or finished."""
+        with self._inference_state_lock:
+            return self._inference_state
+
+    def _set_inference_state(self, state: ModelInferenceState) -> None:
+        """Set this model loop's inference state."""
+        with self._inference_state_lock:
+            self._inference_state = state
+
+    @final
     def _run_model_loop(
         self,
         *,
@@ -276,6 +299,7 @@ class IModelLoop(ILoop[StateT], ABC):
         """
         steps_run = 0
         last_run_started: float | None = None
+        self._set_inference_state(ModelInferenceState.RUNNING)
         try:
             while not self._shutdown_event.is_set() and (
                 max_steps is None or steps_run < max_steps
@@ -297,6 +321,7 @@ class IModelLoop(ILoop[StateT], ABC):
         except BaseException as error:
             self._failure_queue.put(error)
         finally:
+            self._set_inference_state(ModelInferenceState.FINISHED)
             try:
                 self._shutdown()
             except BaseException as error:
@@ -326,21 +351,17 @@ class IUILoop(ILoop[StateT], ABC):
         """
         self.output_layout = output_layout
         self._presentation_manager = presentation_manager
-        self._model_inference_state = ModelInferenceState.NOT_STARTED
-        self._model_inference_state_lock = threading.Lock()
+
+    @final
+    def _set_model_loop(self, model_loop: IModelLoop[Any]) -> None:
+        """Store the model loop whose inference lifecycle this UI observes."""
+        self._model_loop = model_loop
 
     @property
     @final
     def model_inference_state(self) -> ModelInferenceState:
         """Return whether model inference has started, is running, or finished."""
-        with self._model_inference_state_lock:
-            return self._model_inference_state
-
-    @final
-    def _set_model_inference_state(self, state: ModelInferenceState) -> None:
-        """Set the model-inference state visible to this UI loop."""
-        with self._model_inference_state_lock:
-            self._model_inference_state = state
+        return self._model_loop.inference_state
 
     @final
     def request_new_session(self, metadata: Mapping[str, Any]) -> None:

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -9,15 +9,20 @@ import queue
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, TypeVar, final
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
 
 from torch import Tensor
 
 from flashdreams.runtime_v2.event_buffer import EventBuffer
 from flashdreams.runtime_v2.step_result import StepResult
-from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
+from flashdreams.runtime_v2.user_input_event import (
+    CloseUserInputEvent,
+    NewSessionUserInputEvent,
+    UserInputEvent,
+)
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
@@ -25,6 +30,33 @@ if TYPE_CHECKING:
     from flashdreams.runtime_v2.presentation_manager import PresentationManager
 
 StateT = TypeVar("StateT")
+
+
+class ModelInferenceState(Enum):
+    """Lifecycle state of model inference observed by the UI loop."""
+
+    NOT_STARTED = "not_started"
+    """Model inference has not started."""
+
+    RUNNING = "running"
+    """The model loop is running."""
+
+    FINISHED = "finished"
+    """The model loop has returned or failed."""
+
+
+@dataclass(frozen=True, slots=True)
+class _LoopRunResult:
+    """Describe whether a loop should step or yield lifecycle control."""
+
+    step_index: int | None = None
+    """Index to step, or ``None`` when no step should run."""
+
+    stop_requested: bool = False
+    """Whether the session should stop without a replacement."""
+
+    new_session_request: dict[str, Any] | None = None
+    """Metadata for a replacement session, or ``None`` when none was requested."""
 
 
 @dataclass(slots=True)
@@ -71,6 +103,7 @@ class ILoop(ABC, Generic[StateT]):
         self.frequency = frequency
         self._message_queue: queue.Queue[_Message[StateT]] = queue.Queue()
         self.user_events = UserInputEvents([])
+        self._pending_user_events: list[UserInputEvent] = []
         self.latest_result: StepResult | list[StepResult] | None = None
         self._step_index = 0
         self._generation = 0
@@ -79,6 +112,7 @@ class ILoop(ABC, Generic[StateT]):
         self._lifecycle_lock = threading.Lock()
         self._shutdown_event = shutdown_event
         self._failure_queue = failure_queue
+        self._new_session_request: dict[str, Any] | None = None
 
     @abstractmethod
     def step(
@@ -141,27 +175,36 @@ class ILoop(ABC, Generic[StateT]):
         self,
         events: UserInputEvents,
         generation: int,
-    ) -> int | None:
-        """Prepare one call to :meth:`step`."""
+    ) -> _LoopRunResult:
+        """Prepare one step or return a lifecycle request to the caller."""
         self._run_message_batch()
-        self.user_events = events
-        if _contains_close(events):
-            self._shutdown_event.set()
-            return None
+        self._pending_user_events.extend(events.get_events())
+        transition = _lifecycle_transition(
+            self._pending_user_events,
+            self._new_session_request,
+        )
+        if transition is not None:
+            self._pending_user_events.clear()
+            self._new_session_request = None
+            return transition
+        if self._shutdown_event.is_set():
+            return _LoopRunResult(stop_requested=True)
+        self.user_events = UserInputEvents(list(self._pending_user_events))
         if generation != self._generation:
             self.reset()
             self.latest_result = None
             self._step_index = 0
             self._generation = generation
         if self.is_finished():
-            return None
-        return self._step_index
+            return _LoopRunResult()
+        return _LoopRunResult(step_index=self._step_index)
 
     @final
     def _finish_run(self, result: StepResult | list[StepResult] | None) -> None:
         """Save one completed step."""
         self.latest_result = result
         self._step_index += 1
+        self._pending_user_events.clear()
 
     @final
     def _shutdown(self) -> None:
@@ -189,6 +232,7 @@ class ILoop(ABC, Generic[StateT]):
             if result is not None:
                 raise TypeError("Message operations must return None.")
 
+    # TODO: We should do pace here. Remove this func
     def _pace(self, last_run_started: float | None) -> float:
         if self.frequency == 0 or last_run_started is None:
             return time.monotonic()
@@ -237,14 +281,14 @@ class IModelLoop(ILoop[StateT], ABC):
                 max_steps is None or steps_run < max_steps
             ):
                 events, generation = event_buffer.read(reader_id)
-                step_index = self._begin_run(events, generation)
-                if step_index is None:
+                run = self._begin_run(events, generation)
+                if run.step_index is None:
                     break
                 last_run_started = self._pace(last_run_started)
                 if self._shutdown_event.is_set():
                     break
                 step_started_at = time.monotonic()
-                raw_result = self.step(step_index, events)
+                raw_result = self.step(run.step_index, self.user_events)
                 step_elapsed_s = time.monotonic() - step_started_at
                 result = _model_results(raw_result)
                 self._finish_run(result)
@@ -252,13 +296,11 @@ class IModelLoop(ILoop[StateT], ABC):
                 steps_run += 1
         except BaseException as error:
             self._failure_queue.put(error)
-            self._shutdown_event.set()
         finally:
             try:
                 self._shutdown()
             except BaseException as error:
                 self._failure_queue.put(error)
-                self._shutdown_event.set()
 
 
 class IUILoop(ILoop[StateT], ABC):
@@ -284,6 +326,31 @@ class IUILoop(ILoop[StateT], ABC):
         """
         self.output_layout = output_layout
         self._presentation_manager = presentation_manager
+        self._model_inference_state = ModelInferenceState.NOT_STARTED
+        self._model_inference_state_lock = threading.Lock()
+
+    @property
+    @final
+    def model_inference_state(self) -> ModelInferenceState:
+        """Return whether model inference has started, is running, or finished."""
+        with self._model_inference_state_lock:
+            return self._model_inference_state
+
+    @final
+    def _set_model_inference_state(self, state: ModelInferenceState) -> None:
+        """Set the model-inference state visible to this UI loop."""
+        with self._model_inference_state_lock:
+            self._model_inference_state = state
+
+    @final
+    def request_new_session(self, metadata: Mapping[str, Any]) -> None:
+        """Ask the runtime to replace this session after the current UI step.
+
+        Args:
+            metadata: Application-specific values for the replacement session.
+                The runtime merges a copy into the current session description.
+        """
+        self._new_session_request = dict(metadata)
 
     @final
     def presented_model_frame(
@@ -322,8 +389,22 @@ class IUILoop(ILoop[StateT], ABC):
         return self._presentation_manager.presented_frames()
 
 
-def _contains_close(events: UserInputEvents) -> bool:
-    return any(isinstance(event, CloseUserInputEvent) for event in events.get_events())
+def _lifecycle_transition(
+    events: list[UserInputEvent],
+    new_session_request: Mapping[str, Any] | None,
+) -> _LoopRunResult | None:
+    """Return the latest terminal lifecycle request, if any."""
+    transition = (
+        None
+        if new_session_request is None
+        else _LoopRunResult(new_session_request=dict(new_session_request))
+    )
+    for event in events:
+        if isinstance(event, CloseUserInputEvent):
+            transition = _LoopRunResult(stop_requested=True)
+        elif isinstance(event, NewSessionUserInputEvent):
+            transition = _LoopRunResult(new_session_request={})
+    return transition
 
 
 def _model_results(
@@ -356,5 +437,6 @@ __all__ = [
     "ILoop",
     "IModelLoop",
     "IUILoop",
+    "ModelInferenceState",
     "invoke_async",
 ]

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -20,7 +20,6 @@ from flashdreams.runtime_v2.event_buffer import EventBuffer
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import (
     CloseUserInputEvent,
-    NewSessionUserInputEvent,
     UserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
@@ -113,7 +112,6 @@ class ILoop(ABC, Generic[StateT]):
         self._shutdown_event = shutdown_event
         self._failure_queue = failure_queue
         self._new_session_request: SessionDesc | None = None
-        self._new_session_event_desc: SessionDesc | None = None
         self._initialize_loop_state()
 
     def _initialize_loop_state(self) -> None:
@@ -185,11 +183,9 @@ class ILoop(ABC, Generic[StateT]):
         """Prepare one step or return a lifecycle request to the caller."""
         self._run_message_batch()
         self._pending_user_events.extend(events.get_events())
-        transition = _lifecycle_transition(
-            self._pending_user_events,
-            self._new_session_request,
-            self._new_session_event_desc,
-        )
+        transition = _parse_lifecycle_events(self._pending_user_events)
+        if transition is None and self._new_session_request is not None:
+            transition = _LoopRunResult(new_session_request=self._new_session_request)
         if transition is not None:
             self._pending_user_events.clear()
             self._new_session_request = None
@@ -368,7 +364,6 @@ class IUILoop(ILoop[StateT], ABC):
         self.session_desc = session_desc
         self.output_layout = session_desc.output_layout
         self._presentation_manager = presentation_manager
-        self._new_session_event_desc = session_desc
 
     @final
     def _set_model_loop(self, model_loop: IModelLoop[Any]) -> None:
@@ -427,23 +422,13 @@ class IUILoop(ILoop[StateT], ABC):
         return self._presentation_manager.presented_frames()
 
 
-def _lifecycle_transition(
+def _parse_lifecycle_events(
     events: list[UserInputEvent],
-    new_session_request: SessionDesc | None,
-    new_session_event_desc: SessionDesc | None,
 ) -> _LoopRunResult | None:
-    """Return the latest terminal lifecycle request, if any."""
-    transition = (
-        None
-        if new_session_request is None
-        else _LoopRunResult(new_session_request=new_session_request)
-    )
-    for event in events:
-        if isinstance(event, CloseUserInputEvent):
-            transition = _LoopRunResult(stop_requested=True)
-        elif isinstance(event, NewSessionUserInputEvent):
-            transition = _LoopRunResult(new_session_request=new_session_event_desc)
-    return transition
+    """Return the terminal lifecycle request, prioritizing close."""
+    if any(isinstance(event, CloseUserInputEvent) for event in events):
+        return _LoopRunResult(stop_requested=True)
+    return None
 
 
 def _model_results(

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -9,7 +9,7 @@ import queue
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
@@ -24,10 +24,10 @@ from flashdreams.runtime_v2.user_input_event import (
     UserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
-from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
 if TYPE_CHECKING:
     from flashdreams.runtime_v2.presentation_manager import PresentationManager
+    from flashdreams.runtime_v2.session_desc import SessionDesc
 
 StateT = TypeVar("StateT")
 
@@ -55,8 +55,8 @@ class _LoopRunResult:
     stop_requested: bool = False
     """Whether the session should stop without a replacement."""
 
-    new_session_request: dict[str, Any] | None = None
-    """Metadata for a replacement session, or ``None`` when none was requested."""
+    new_session_request: SessionDesc | None = None
+    """Replacement session description, or ``None`` when none was requested."""
 
 
 @dataclass(slots=True)
@@ -112,7 +112,8 @@ class ILoop(ABC, Generic[StateT]):
         self._lifecycle_lock = threading.Lock()
         self._shutdown_event = shutdown_event
         self._failure_queue = failure_queue
-        self._new_session_request: dict[str, Any] | None = None
+        self._new_session_request: SessionDesc | None = None
+        self._new_session_event_desc: SessionDesc | None = None
         self._initialize_loop_state()
 
     def _initialize_loop_state(self) -> None:
@@ -187,6 +188,7 @@ class ILoop(ABC, Generic[StateT]):
         transition = _lifecycle_transition(
             self._pending_user_events,
             self._new_session_request,
+            self._new_session_event_desc,
         )
         if transition is not None:
             self._pending_user_events.clear()
@@ -340,17 +342,19 @@ class IUILoop(ILoop[StateT], ABC):
     def register_session_ui_loop_objects(
         self,
         *,
-        output_layout: VideoTensorLayout,
+        session_desc: SessionDesc,
         presentation_manager: PresentationManager,
     ) -> None:
         """Store UI objects supplied when this loop is registered with a session.
 
         Args:
-            output_layout: Layout used for the compositing result.
+            session_desc: Description of the session this UI presents.
             presentation_manager: Buffer containing model frames.
         """
-        self.output_layout = output_layout
+        self.session_desc = session_desc
+        self.output_layout = session_desc.output_layout
         self._presentation_manager = presentation_manager
+        self._new_session_event_desc = session_desc
 
     @final
     def _set_model_loop(self, model_loop: IModelLoop[Any]) -> None:
@@ -364,14 +368,13 @@ class IUILoop(ILoop[StateT], ABC):
         return self._model_loop.inference_state
 
     @final
-    def request_new_session(self, metadata: Mapping[str, Any]) -> None:
+    def request_new_session(self, session_desc: SessionDesc) -> None:
         """Ask the runtime to replace this session after the current UI step.
 
         Args:
-            metadata: Application-specific values for the replacement session.
-                The runtime merges a copy into the current session description.
+            session_desc: Fully resolved description for the replacement session.
         """
-        self._new_session_request = dict(metadata)
+        self._new_session_request = session_desc
 
     @final
     def presented_model_frame(
@@ -412,19 +415,20 @@ class IUILoop(ILoop[StateT], ABC):
 
 def _lifecycle_transition(
     events: list[UserInputEvent],
-    new_session_request: Mapping[str, Any] | None,
+    new_session_request: SessionDesc | None,
+    new_session_event_desc: SessionDesc | None,
 ) -> _LoopRunResult | None:
     """Return the latest terminal lifecycle request, if any."""
     transition = (
         None
         if new_session_request is None
-        else _LoopRunResult(new_session_request=dict(new_session_request))
+        else _LoopRunResult(new_session_request=new_session_request)
     )
     for event in events:
         if isinstance(event, CloseUserInputEvent):
             transition = _LoopRunResult(stop_requested=True)
         elif isinstance(event, NewSessionUserInputEvent):
-            transition = _LoopRunResult(new_session_request={})
+            transition = _LoopRunResult(new_session_request=new_session_event_desc)
     return transition
 
 

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -239,14 +239,6 @@ class ILoop(ABC, Generic[StateT]):
             if result is not None:
                 raise TypeError("Message operations must return None.")
 
-    # TODO: We should do pace here. Remove this func
-    def _pace(self, last_run_started: float | None) -> float:
-        if self.frequency == 0 or last_run_started is None:
-            return time.monotonic()
-        earliest_start = last_run_started + 1.0 / self.frequency
-        self._shutdown_event.wait(max(0.0, earliest_start - time.monotonic()))
-        return time.monotonic()
-
     def _empty_message_queue(self) -> None:
         while True:
             try:

--- a/flashdreams/flashdreams/api_v2/loop.py
+++ b/flashdreams/flashdreams/api_v2/loop.py
@@ -207,9 +207,21 @@ class ILoop(ABC, Generic[StateT]):
         return _LoopRunResult(step_index=self._step_index)
 
     @final
-    def _finish_run(self, result: StepResult | list[StepResult] | None) -> None:
-        """Save one completed step."""
-        self.latest_result = result
+    def _finish_run(
+        self,
+        result: StepResult | list[StepResult] | None,
+        *,
+        step_completed: bool,
+    ) -> None:
+        """Finish one prepared run, saving its completed step when present.
+
+        Args:
+            result: Value returned by the completed step, or ``None``.
+            step_completed: Whether :meth:`step` returned successfully and
+                ``result`` should replace :attr:`latest_result`.
+        """
+        if step_completed:
+            self.latest_result = result
         self._step_index += 1
         self._pending_user_events.clear()
 
@@ -299,22 +311,27 @@ class IModelLoop(ILoop[StateT], ABC):
                 max_steps is None or steps_run < max_steps
             ):
                 events, generation = event_buffer.read(reader_id)
-                run = self._begin_run(events, generation)
-                if run.step_index is None:
-                    break
-                if self.frequency != 0 and last_run_started is not None:
-                    earliest_start = last_run_started + 1.0 / self.frequency
-                    self._shutdown_event.wait(
-                        max(0.0, earliest_start - time.monotonic())
-                    )
-                last_run_started = time.monotonic()
-                if self._shutdown_event.is_set():
-                    break
-                step_started_at = time.monotonic()
-                raw_result = self.step(run.step_index, self.user_events)
-                step_elapsed_s = time.monotonic() - step_started_at
-                result = _model_results(raw_result)
-                self._finish_run(result)
+                result: list[StepResult] | None = None
+                step_completed = False
+                try:
+                    run = self._begin_run(events, generation)
+                    if run.step_index is None:
+                        break
+                    if self.frequency != 0 and last_run_started is not None:
+                        earliest_start = last_run_started + 1.0 / self.frequency
+                        self._shutdown_event.wait(
+                            max(0.0, earliest_start - time.monotonic())
+                        )
+                    last_run_started = time.monotonic()
+                    if self._shutdown_event.is_set():
+                        break
+                    step_started_at = time.monotonic()
+                    raw_result = self.step(run.step_index, self.user_events)
+                    step_elapsed_s = time.monotonic() - step_started_at
+                    result = _model_results(raw_result)
+                    step_completed = True
+                finally:
+                    self._finish_run(result, step_completed=step_completed)
                 publish(generation, result, step_elapsed_s)
                 steps_run += 1
         except BaseException as error:

--- a/flashdreams/flashdreams/api_v2/session.py
+++ b/flashdreams/flashdreams/api_v2/session.py
@@ -100,7 +100,7 @@ class ISession(ABC):
             failure_queue=self._failure_queue,
         )
         loop.register_session_ui_loop_objects(
-            output_layout=self.session_desc.output_layout,
+            session_desc=self.session_desc,
             presentation_manager=self._presentation_manager,
         )
         self._registered_ui_loop = loop

--- a/flashdreams/flashdreams/api_v2/session.py
+++ b/flashdreams/flashdreams/api_v2/session.py
@@ -174,6 +174,7 @@ class ISession(ABC):
         model_loop = self._registered_model_loop
         if model_loop is None:
             raise RuntimeError("ISession.init() did not register a model loop.")
+        ui_loop._set_model_loop(model_loop)
         self._registrations_frozen = True
         return ui_loop, model_loop
 

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -192,9 +192,9 @@ ready:
 - `ON_DEMAND` runs the UI loop only when `advance` moves to a new model frame.
 
 While inference has not started or has finished, an unfinished UI runs every
-tick in either mode. It can read `model_inference_state`, remains active after
-model output drains, and may use `is_finished` to declare its own terminal
-condition.
+tick in either mode. The model loop owns `inference_state`; the UI can query it
+through `model_inference_state`. The UI remains active after model output drains
+and may use `is_finished` to declare its own terminal condition.
 
 For output that has to be compared frame by frame, use `BLOCK` with
 `ON_DEMAND`: together they keep every frame in the presentation manager

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -83,8 +83,8 @@ declare arguments this command also has.
 
 | Mode | Takes | Input | Ends when |
 | --- | --- | --- | --- |
-| `mp4` (default) | `--output-path` | none | the session reports itself finished |
-| `webrtc` | `--host`, `--port` | keyboard, mouse, focus, reset, close | the browser disconnects, or the session finishes |
+| `mp4` (default) | `--output-path` | none | the application UI finishes |
+| `webrtc` | `--host`, `--port` | keyboard, mouse, focus, reset, close | the application UI finishes or the client closes it |
 
 These override whatever session the application asked for:
 
@@ -187,9 +187,14 @@ full:
 `SessionDesc.presentation_mode` decides what the UI does when no new frame is
 ready:
 
-- `CONTINUOUS` runs the UI loop every tick, re-presenting the newest
-  model frame with UI redrawing.
+- `CONTINUOUS` runs the UI loop every tick while inference is active,
+  re-presenting the newest model frame when necessary.
 - `ON_DEMAND` runs the UI loop only when `advance` moves to a new model frame.
+
+While inference has not started or has finished, an unfinished UI runs every
+tick in either mode. It can read `model_inference_state`, remains active after
+model output drains, and may use `is_finished` to declare its own terminal
+condition.
 
 For output that has to be compared frame by frame, use `BLOCK` with
 `ON_DEMAND`: together they keep every frame in the presentation manager
@@ -223,18 +228,17 @@ delegates over the thing that does the work — `Mp4ClientWindow` over
 `Mp4OutputSink`, `WebRTCClientWindow` over `WebRTCServer` — and neither describes
 the output shape, because the session already did.
 
-They differ in what they can do rather than in how they are driven. The MP4
-window reports no input and never sends a close, so a session written to a file
-has to finish on its own. The WebRTC window turns browser keyboard, mouse and
-focus events into input and a disconnecting browser into a close; because those
-arrive on the server's own thread, it queues them and hands them over in batches
-when the session asks.
+They differ in what they can do rather than in how they are driven. A session
+chooses its UI independently of the client window. Browser keyboard, mouse and
+focus events arrive on the server's own thread, so it queues them and hands them
+over in batches when the session asks.
 
-The WebRTC page also sends a new-session event. `run_session` stops and cleans
-the current session, returns its resolved `SessionDesc`, and leaves the WebRTC
-window open. `ApplicationRunner` then creates the replacement from that
-description. A normal completion or close returns no replacement and keeps the
-one-session behavior used by MP4 and native windows.
+A UI loop may call `request_new_session(metadata)` during its step. `run_session`
+merges those application-specific values into the resolved `SessionDesc`, stops
+and cleans the current session, and leaves the interactive window open.
+`ApplicationRunner` creates the replacement from that description. A WebRTC
+browser disconnect releases only its peer connection, so refreshing the page
+does not stop the session, server, or application.
 
 The UI thread owns WebRTC cadence. Each `write` synchronously materializes one
 owned video frame and admits it to a two-frame FIFO of unsent frames. The WebRTC

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -101,6 +101,12 @@ the application generates. There is no argument for the UI tick rate, and none
 for `run_session`'s `steps` limit — a caller that needs to bound a run by steps
 drives the runtime from Python.
 
+`--timeout SECONDS` bounds the whole application run, including initialization
+and replacement sessions. At the deadline the UI thread signals the session's
+loops to stop and performs their normal cleanup. An in-flight model step must
+return before the process can finish cleaning up. Synchronous application or
+session initialization likewise cannot be interrupted mid-call.
+
 `--stats-path` adds a `MetricsOutputSink`. It receives the **model** loop's
 results as they are published, not the UI loop's output, so a benchmark measures
 what the model generated while the window still sees one composited frame per

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -233,12 +233,12 @@ chooses its UI independently of the client window. Browser keyboard, mouse and
 focus events arrive on the server's own thread, so it queues them and hands them
 over in batches when the session asks.
 
-A UI loop may call `request_new_session(metadata)` during its step. `run_session`
-merges those application-specific values into the resolved `SessionDesc`, stops
-and cleans the current session, and leaves the interactive window open.
-`ApplicationRunner` creates the replacement from that description. A WebRTC
-browser disconnect releases only its peer connection, so refreshing the page
-does not stop the session, server, or application.
+A UI loop may call `request_new_session(session_desc)` during its step with a
+fully resolved replacement description. `run_session` stops and cleans the
+current session, leaves the interactive window open, and returns that
+description unchanged. `ApplicationRunner` creates the replacement from it. A
+WebRTC browser disconnect releases only its peer connection, so refreshing the
+page does not stop the session, server, or application.
 
 The UI thread owns WebRTC cadence. Each `write` synchronously materializes one
 owned video frame and admits it to a two-frame FIFO of unsent frames. The WebRTC

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -230,12 +230,22 @@ focus events into input and a disconnecting browser into a close; because those
 arrive on the server's own thread, it queues them and hands them over in batches
 when the session asks.
 
+The WebRTC page also sends a new-session event. `run_session` stops and cleans
+the current session, returns its resolved `SessionDesc`, and leaves the WebRTC
+window open. `ApplicationRunner` then creates the replacement from that
+description. A normal completion or close returns no replacement and keeps the
+one-session behavior used by MP4 and native windows.
+
 The UI thread owns WebRTC cadence. Each `write` synchronously materializes one
 owned video frame and admits it to a two-frame FIFO of unsent frames. The WebRTC
 track returns queued frames to aiortc immediately: it neither sleeps to pace
 them nor repeats the latest frame. If network or encoder congestion fills the
 FIFO, the next write replaces only its oldest unsent frame; a frame already
 handed to aiortc is never overwritten.
+
+When a replacement session reopens the WebRTC window, it keeps the existing
+peer connection and discards frames still queued from the previous session. A
+replacement must keep the negotiated layout, frame rates, width, and height.
 
 What a sink expects of the pixel values it is handed is part of the result
 contract, in [`api_v2`](../api_v2/README.md#what-a-step-returns).

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -4,7 +4,9 @@
 """Application lifecycle runner for the v2 runtime."""
 
 import logging
+import math
 import sys
+import time
 from collections.abc import Sequence
 
 from flashdreams.api_v2.application import IApplication
@@ -39,7 +41,11 @@ class ApplicationRunner:
         self._metrics_output_sink = metrics_output_sink
 
     def run(
-        self, session_desc: SessionDesc, commandline_args: Sequence[str] = ()
+        self,
+        session_desc: SessionDesc,
+        commandline_args: Sequence[str] = (),
+        *,
+        timeout_seconds: float | None = None,
     ) -> None:
         """Initialize the application and run sessions until the window exits.
 
@@ -56,20 +62,40 @@ class ApplicationRunner:
         Args:
             session_desc: Output shape and timing requested for the session.
             commandline_args: Arguments owned and parsed by the application.
+            timeout_seconds: Maximum application runtime; ``None`` waits for a
+                normal lifecycle exit. The deadline includes initialization and
+                every replacement session.
+
+        Raises:
+            ValueError: ``timeout_seconds`` is not finite and greater than zero.
         """
+        if timeout_seconds is not None and (
+            not math.isfinite(timeout_seconds) or timeout_seconds <= 0
+        ):
+            raise ValueError("timeout_seconds must be finite and greater than zero.")
+
+        deadline = (
+            None if timeout_seconds is None else time.monotonic() + timeout_seconds
+        )
         session_run_started = False
         window_needs_close = True
         try:
             self._application.init(commandline_args)
             next_session_desc: SessionDesc | None = session_desc
             while next_session_desc is not None:
+                if deadline is not None and time.monotonic() >= deadline:
+                    break
                 session = self._application.create_session(next_session_desc)
                 session_run_started = True
+                remaining_seconds = (
+                    None if deadline is None else max(0.0, deadline - time.monotonic())
+                )
                 try:
                     next_session_desc = run_session(
                         session,
                         self._client_window,
                         metrics_output_sink=self._metrics_output_sink,
+                        timeout_seconds=remaining_seconds,
                     )
                 except BaseException:
                     # ``run_session`` closes the window on every failure.

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class ApplicationRunner:
-    """Create and run one application session against one client window."""
+    """Initialize one application and run its requested sessions."""
 
     def __init__(
         self,
@@ -31,7 +31,8 @@ class ApplicationRunner:
         Args:
             application: Long-lived application that creates the session.
             client_window: Window that supplies input and presents generated output.
-            metrics_output_sink: Optional sink for model-step metrics.
+            metrics_output_sink: Optional sink for model-step metrics. It is
+                opened and closed once for each session.
         """
         self._application = application
         self._client_window = client_window
@@ -40,53 +41,63 @@ class ApplicationRunner:
     def run(
         self, session_desc: SessionDesc, commandline_args: Sequence[str] = ()
     ) -> None:
-        """Initialize the application, create one session, and run it.
+        """Initialize the application and run sessions until the window exits.
 
-        The run ends when the window reports a close or the session reports that
-        it has finished.
+        A new-session request closes the current session and creates its
+        replacement from the description returned by ``run_session``. A close
+        request or a naturally completed session returns no replacement and
+        ends the run.
 
         The application is closed before this method returns or raises.
 
-        The window is closed too when the run never starts, since ``run_session``
-        is what otherwise owns it, and a window may already be serving a client
-        before the application has loaded anything.
+        The runner closes the window when the first session never starts or a
+        replacement cannot be created. ``run_session`` otherwise owns it, and
+        may leave it open only for a successful replacement handoff.
 
         Args:
             session_desc: Output shape and timing requested for the session.
             commandline_args: Arguments owned and parsed by the application.
         """
-        run_started = False
+        session_run_started = False
+        window_needs_close = True
         try:
             self._application.init(commandline_args)
-            session = self._application.create_session(session_desc)
-            run_started = True
-            run_session(
-                session,
-                self._client_window,
-                metrics_output_sink=self._metrics_output_sink,
-            )
+            next_session_desc: SessionDesc | None = session_desc
+            while next_session_desc is not None:
+                session = self._application.create_session(next_session_desc)
+                session_run_started = True
+                try:
+                    next_session_desc = run_session(
+                        session,
+                        self._client_window,
+                        metrics_output_sink=self._metrics_output_sink,
+                    )
+                except BaseException:
+                    # ``run_session`` closes the window on every failure.
+                    window_needs_close = False
+                    raise
+                window_needs_close = next_session_desc is not None
         finally:
-            if not run_started:
+            if window_needs_close:
                 _close_client_window(self._client_window)
-                if self._metrics_output_sink is not None:
-                    _close_output_sink(self._metrics_output_sink)
+            if not session_run_started and self._metrics_output_sink is not None:
+                _close_output_sink(self._metrics_output_sink)
             _close_application(
                 self._application, run_failed=sys.exc_info()[0] is not None
             )
 
 
 def _close_client_window(client_window: IClientWindow) -> None:
-    """Close a window the run never reached, so what it was serving goes with it.
+    """Close a window still owned by the application runner.
 
-    The run has already failed by the time this is called, so a failure here is
-    logged rather than raised over the top of it.
+    This covers initial setup and the gap between sessions. The run has already
+    failed by the time this is called, so a failure here is logged rather than
+    raised over the top of it.
     """
     try:
         client_window.close()
     except Exception:
-        _LOGGER.exception(
-            "The client window failed to close after a run that never started."
-        )
+        _LOGGER.exception("The client window failed to close while stopping.")
 
 
 def _close_output_sink(output_sink: OutputSink) -> None:

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -45,8 +45,7 @@ class ApplicationRunner:
 
         A new-session request closes the current session and creates its
         replacement from the description returned by ``run_session``. A close
-        request or a naturally completed session returns no replacement and
-        ends the run.
+        request or a completed session returns no replacement and ends the run.
 
         The application is closed before this method returns or raises.
 

--- a/flashdreams/flashdreams/runtime_v2/blit_model_output_to_screen_loop.py
+++ b/flashdreams/flashdreams/runtime_v2/blit_model_output_to_screen_loop.py
@@ -19,7 +19,7 @@ from typing import final
 
 from torch import Tensor
 
-from flashdreams.api_v2.loop import IUILoop
+from flashdreams.api_v2.loop import IUILoop, ModelInferenceState
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -28,6 +28,9 @@ from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 class BlitModelOutputToScreenLoop(IUILoop[None]):
     """Draw every model channel into one UI frame."""
 
+    def _initialize_loop_state(self) -> None:
+        self._last_presented_frame_count = 0
+
     @final
     def step(self, step_index: int, events: UserInputEvents) -> StepResult | None:
         """Draw the model channels in list order."""
@@ -35,6 +38,9 @@ class BlitModelOutputToScreenLoop(IUILoop[None]):
         output = None
         for frame in self.presented_model_frames():
             output = self._presentation_manager.composite(output, frame)
+        self._last_presented_frame_count = (
+            self._presentation_manager.presented_frame_count
+        )
         if output is None:
             return None
         return StepResult(
@@ -44,8 +50,16 @@ class BlitModelOutputToScreenLoop(IUILoop[None]):
             output_layout=self.output_layout,
         )
 
+    def is_finished(self) -> bool:
+        return (
+            self.model_inference_state is ModelInferenceState.FINISHED
+            and not self._presentation_manager.has_pending_frames()
+            and self._last_presented_frame_count
+            == self._presentation_manager.presented_frame_count
+        )
+
     def reset(self) -> None:
-        return
+        self._last_presented_frame_count = 0
 
 
 def _frame_to_layout(frame: Tensor, layout: VideoTensorLayout) -> Tensor:

--- a/flashdreams/flashdreams/runtime_v2/cli.py
+++ b/flashdreams/flashdreams/runtime_v2/cli.py
@@ -75,8 +75,7 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
     session_desc = _session_desc(application, parsed)
     window = mode.create(parsed)
     _report(mode.starting(window))
-    # Nothing here says how long the run is: a session reports itself finished,
-    # and a window ends the run when its client goes away.
+    # The session's UI and client input decide when the run ends.
     metrics_output_sink = (
         None if parsed.stats_path is None else MetricsOutputSink(parsed.stats_path)
     )

--- a/flashdreams/flashdreams/runtime_v2/cli.py
+++ b/flashdreams/flashdreams/runtime_v2/cli.py
@@ -14,6 +14,7 @@ argument that only one of them uses.
 """
 
 import argparse
+import math
 import sys
 from collections.abc import Sequence
 from dataclasses import replace
@@ -54,6 +55,10 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
     own_args, application_args = split_arguments(arguments)
     parser = _parser()
     parsed = parser.parse_args(own_args)
+    if parsed.timeout is not None and (
+        not math.isfinite(parsed.timeout) or parsed.timeout <= 0
+    ):
+        parser.error("--timeout must be a finite number greater than zero.")
 
     mode = client_window_mode(parsed.mode)
     # Asking an application what it takes is answered by the application alone,
@@ -83,7 +88,11 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
         application,
         window,
         metrics_output_sink=metrics_output_sink,
-    ).run(session_desc, application_args)
+    ).run(
+        session_desc,
+        application_args,
+        timeout_seconds=parsed.timeout,
+    )
     _report(mode.finished(window))
 
 
@@ -118,6 +127,13 @@ def _parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("slug", help="Application to run.")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Stop the application after this many seconds.",
+    )
     add_client_window_arguments(parser)
     _add_session_arguments(parser)
     return parser

--- a/flashdreams/flashdreams/runtime_v2/client_window_factory.py
+++ b/flashdreams/flashdreams/runtime_v2/client_window_factory.py
@@ -4,9 +4,9 @@
 """Create v2 client windows from runtime arguments.
 
 A mode is one way to watch a run: an MP4 file, a browser, whatever comes after
-them. Each mode owns the arguments it takes and what to tell the user about
-where its output went, so a command line offering the modes never has to know
-what any of them are, and adding one is adding it here.
+them. Each mode owns its arguments and user-facing messages, so a command line
+offering the modes never has to know what any of them are, and adding one is
+adding it here.
 """
 
 import argparse

--- a/flashdreams/flashdreams/runtime_v2/client_window_factory.py
+++ b/flashdreams/flashdreams/runtime_v2/client_window_factory.py
@@ -153,7 +153,8 @@ def add_client_window_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help=(
             "JSON file to record model-step measurements in, for a benchmark "
-            "to read. Nothing is measured unless this is asked for."
+            "to read. Nothing is measured unless this is asked for. If a run "
+            "replaces its session, the file contains the final session."
         ),
     )
     for mode in _MODES:

--- a/flashdreams/flashdreams/runtime_v2/metrics_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/metrics_output_sink.py
@@ -24,6 +24,9 @@ class MetricsOutputSink(OutputSink):
 
     Each result records its frame count and finite numeric metrics. Metric names
     ending in ``_ms`` are converted to seconds to match the v1 sink.
+
+    Reopening the sink starts a new record at the same path. Consequently, a
+    multi-session application run retains the final session's metrics.
     """
 
     def __init__(self, path: str | Path) -> None:

--- a/flashdreams/flashdreams/runtime_v2/serving/web/app.js
+++ b/flashdreams/flashdreams/runtime_v2/serving/web/app.js
@@ -7,6 +7,7 @@ const pointerControls = peer.createDataChannel("pointer-controls");
 peer.addTransceiver("video", {direction: "recvonly"});
 const video = document.getElementById("video");
 const status = document.getElementById("status");
+const newSessionButton = document.getElementById("new-session");
 const pressedKeys = new Map();
 const pressedButtons = new Set();
 const gamepadSnapshots = new Map();
@@ -58,6 +59,20 @@ const sendInput = (
   }
   return send(payload, channel);
 };
+
+controls.addEventListener("open", () => {
+  newSessionButton.disabled = false;
+  newSessionButton.textContent = "New session";
+});
+
+controls.addEventListener("close", () => {
+  newSessionButton.disabled = true;
+  newSessionButton.textContent = "Disconnected";
+});
+
+newSessionButton.addEventListener("click", () => {
+  sendInput({type: "new_session"});
+});
 
 controls.addEventListener("message", event => {
   if (typeof event.data !== "string") {
@@ -441,6 +456,8 @@ async function connect() {
 }
 
 connect().catch(error => {
+  newSessionButton.disabled = true;
+  newSessionButton.textContent = "Connection failed";
   console.error("Unable to start WebRTC.", error);
   showStatus(`Unable to start WebRTC: ${error.message}`, true);
 });

--- a/flashdreams/flashdreams/runtime_v2/serving/web/app.js
+++ b/flashdreams/flashdreams/runtime_v2/serving/web/app.js
@@ -7,7 +7,6 @@ const pointerControls = peer.createDataChannel("pointer-controls");
 peer.addTransceiver("video", {direction: "recvonly"});
 const video = document.getElementById("video");
 const status = document.getElementById("status");
-const newSessionButton = document.getElementById("new-session");
 const pressedKeys = new Map();
 const pressedButtons = new Set();
 const gamepadSnapshots = new Map();
@@ -59,20 +58,6 @@ const sendInput = (
   }
   return send(payload, channel);
 };
-
-controls.addEventListener("open", () => {
-  newSessionButton.disabled = false;
-  newSessionButton.textContent = "New session";
-});
-
-controls.addEventListener("close", () => {
-  newSessionButton.disabled = true;
-  newSessionButton.textContent = "Disconnected";
-});
-
-newSessionButton.addEventListener("click", () => {
-  sendInput({type: "new_session"});
-});
 
 controls.addEventListener("message", event => {
   if (typeof event.data !== "string") {
@@ -399,10 +384,6 @@ window.addEventListener("blur", () => {
   }
 });
 
-window.addEventListener("beforeunload", () => {
-  sendInput({type: "close"});
-});
-
 const waitForIceGatheringComplete = async () => {
   if (peer.iceGatheringState === "complete") {
     return;
@@ -456,8 +437,6 @@ async function connect() {
 }
 
 connect().catch(error => {
-  newSessionButton.disabled = true;
-  newSessionButton.textContent = "Connection failed";
   console.error("Unable to start WebRTC.", error);
   showStatus(`Unable to start WebRTC: ${error.message}`, true);
 });

--- a/flashdreams/flashdreams/runtime_v2/serving/web/index.html
+++ b/flashdreams/flashdreams/runtime_v2/serving/web/index.html
@@ -48,35 +48,10 @@ SPDX-License-Identifier: Apache-2.0
         color: #ff8a8a;
       }
 
-      #session-controls {
-        position: fixed;
-        top: 1rem;
-        right: 1rem;
-        z-index: 1;
-      }
-
-      #new-session {
-        border: 1px solid #777;
-        border-radius: 0.4rem;
-        padding: 0.65rem 1rem;
-        background: #f5f5f5;
-        color: #111;
-        font: inherit;
-        cursor: pointer;
-      }
-
-      #new-session:disabled {
-        background: #666;
-        color: #ddd;
-        cursor: wait;
-      }
     </style>
   </head>
   <body>
     <video id="video" autoplay muted playsinline></video>
-    <div id="session-controls">
-      <button id="new-session" type="button" disabled>Opening…</button>
-    </div>
     <div id="status" role="status" aria-live="polite">Waiting for the server…</div>
     <script src="/app.js"></script>
   </body>

--- a/flashdreams/flashdreams/runtime_v2/serving/web/index.html
+++ b/flashdreams/flashdreams/runtime_v2/serving/web/index.html
@@ -47,10 +47,36 @@ SPDX-License-Identifier: Apache-2.0
       #status.error {
         color: #ff8a8a;
       }
+
+      #session-controls {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        z-index: 1;
+      }
+
+      #new-session {
+        border: 1px solid #777;
+        border-radius: 0.4rem;
+        padding: 0.65rem 1rem;
+        background: #f5f5f5;
+        color: #111;
+        font: inherit;
+        cursor: pointer;
+      }
+
+      #new-session:disabled {
+        background: #666;
+        color: #ddd;
+        cursor: wait;
+      }
     </style>
   </head>
   <body>
     <video id="video" autoplay muted playsinline></video>
+    <div id="session-controls">
+      <button id="new-session" type="button" disabled>Opening…</button>
+    </div>
     <div id="status" role="status" aria-live="polite">Waiting for the server…</div>
     <script src="/app.js"></script>
   </body>

--- a/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
+++ b/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
@@ -58,6 +58,24 @@ _TRANSFER_STREAM_PRIORITY = -1
 _SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 2.0
 """Bound shutdown time spent waiting for aiortc's next sender request."""
 
+_AIOICE_COMPLETED_RETRY_MESSAGE = "Exception in callback Transaction.__retry()"
+"""Asyncio callback message produced by the completed STUN retry race."""
+
+
+def _handle_webrtc_loop_exception(
+    loop: asyncio.AbstractEventLoop,
+    context: dict[str, Any],
+) -> None:
+    """Suppress the completed-transaction race in ``aioice`` STUN retries."""
+    # TODO: Remove after https://github.com/aiortc/aioice/pull/100 is released.
+    if (
+        type(context.get("exception")) is asyncio.InvalidStateError
+        and isinstance(context.get("handle"), asyncio.TimerHandle)
+        and context.get("message") == _AIOICE_COMPLETED_RETRY_MESSAGE
+    ):
+        return
+    loop.default_exception_handler(context)
+
 
 class _PinnedRGBFrameBuffer:
     """One reusable host frame for the synchronous CUDA materializer."""
@@ -581,6 +599,7 @@ class WebRTCServer:
     def _run_server(self) -> None:
         """Own the WebRTC asyncio loop for the lifetime of the server."""
         loop = asyncio.new_event_loop()
+        loop.set_exception_handler(_handle_webrtc_loop_exception)
         self._loop = loop
         asyncio.set_event_loop(loop)
         try:

--- a/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
+++ b/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
@@ -331,6 +331,7 @@ class WebRTCServer:
         self._startup_error: BaseException | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._runner: web.AppRunner | None = None
+        self._offer_lock: asyncio.Lock | None = None
         self._peer_connection: RTCPeerConnection | None = None
         self._video_track: _VideoTrack | None = None
         self._final_video_track_metrics: dict[str, float | int] | None = None
@@ -619,6 +620,7 @@ class WebRTCServer:
 
     async def _start_server(self) -> None:
         """Create and bind the standalone aiohttp application."""
+        self._offer_lock = asyncio.Lock()
         app = web.Application()
         app.router.add_get("/", self._serve_browser)
         app.router.add_get("/app.js", self._serve_browser_script)
@@ -663,14 +665,8 @@ class WebRTCServer:
         """Negotiate one browser peer connection."""
         if self._closed:
             raise web.HTTPServiceUnavailable(reason="WebRTC server is closed.")
-        session_desc = self._session_desc
-        if session_desc is None:
+        if self._session_desc is None:
             raise web.HTTPConflict(reason="WebRTC server is not open.")
-        existing_peer = self._peer_connection
-        if existing_peer is not None:
-            # This server has one client slot. A new offer is a page refresh or
-            # replacement browser and therefore takes ownership of that slot.
-            await self._release_peer_connection(existing_peer)
 
         try:
             payload = await request.json()
@@ -685,62 +681,110 @@ class WebRTCServer:
                 reason="WebRTC offer requires string sdp and type."
             )
 
-        peer_connection = RTCPeerConnection()
-        self._media_connected.clear()
-        video_track = _VideoTrack(session_desc.frames_per_second_for_ui)
-        self._final_video_track_metrics = None
-        peer_connection.addTrack(video_track)
-        self._peer_connection = peer_connection
-        self._video_track = video_track
+        offer_lock = self._offer_lock
+        if offer_lock is None:
+            raise web.HTTPServiceUnavailable(reason="WebRTC server is not ready.")
+        async with offer_lock:
+            if self._closed:
+                raise web.HTTPServiceUnavailable(reason="WebRTC server is closed.")
+            session_desc = self._session_desc
+            if session_desc is None:
+                raise web.HTTPConflict(reason="WebRTC server is not open.")
 
-        @peer_connection.on("datachannel")
-        def on_datachannel(channel: Any) -> None:
-            is_reliable_control = channel.label == "controls"
-            if is_reliable_control:
-                self._client_connected = True
+            peer_connection = RTCPeerConnection()
+            video_track = _VideoTrack(session_desc.frames_per_second_for_ui)
+            peer_connection.addTrack(video_track)
+            has_reliable_control = False
 
-            @channel.on("message")
-            def on_message(message: Any) -> None:
-                try:
-                    self._buffer_browser_message(
-                        message,
-                    )
-                except ValueError as error:
-                    channel.send(json.dumps({"type": "error", "message": str(error)}))
-
-            @channel.on("close")
-            async def on_close() -> None:
+            @peer_connection.on("datachannel")
+            def on_datachannel(channel: Any) -> None:
+                nonlocal has_reliable_control
+                is_reliable_control = channel.label == "controls"
                 if is_reliable_control:
+                    has_reliable_control = True
+                    if self._peer_connection is peer_connection:
+                        self._client_connected = True
+
+                @channel.on("message")
+                def on_message(message: Any) -> None:
+                    if self._peer_connection is not peer_connection:
+                        return
+                    try:
+                        self._buffer_browser_message(message)
+                    except ValueError as error:
+                        channel.send(
+                            json.dumps({"type": "error", "message": str(error)})
+                        )
+
+                @channel.on("close")
+                async def on_close() -> None:
+                    if is_reliable_control:
+                        await self._release_peer_connection(peer_connection)
+
+            @peer_connection.on("connectionstatechange")
+            async def on_connectionstatechange() -> None:
+                if self._peer_connection is not peer_connection:
+                    return
+                if peer_connection.connectionState == "connected":
+                    self._media_connected.set()
+                elif peer_connection.connectionState == "disconnected":
+                    self._media_connected.clear()
+                elif peer_connection.connectionState in {"failed", "closed"}:
                     await self._release_peer_connection(peer_connection)
 
-        @peer_connection.on("connectionstatechange")
-        async def on_connectionstatechange() -> None:
+            try:
+                await peer_connection.setRemoteDescription(
+                    RTCSessionDescription(sdp=sdp, type=offer_type)
+                )
+                await peer_connection.setLocalDescription(
+                    await peer_connection.createAnswer()
+                )
+            except ValueError as error:
+                await self._release_peer_connection(
+                    peer_connection,
+                    detached_video_track=video_track,
+                )
+                raise web.HTTPBadRequest(reason="Invalid WebRTC offer.") from error
+            except BaseException:
+                await self._release_peer_connection(
+                    peer_connection,
+                    detached_video_track=video_track,
+                )
+                raise
+
+            local_description = peer_connection.localDescription
+            if local_description is None:
+                await self._release_peer_connection(
+                    peer_connection,
+                    detached_video_track=video_track,
+                )
+                raise web.HTTPInternalServerError(
+                    reason="WebRTC peer did not create an answer."
+                )
+
+            existing_peer = self._peer_connection
+            if existing_peer is not None:
+                # This server has one client slot. A valid new offer is a page
+                # refresh or replacement browser and takes ownership of it.
+                try:
+                    await self._release_peer_connection(existing_peer)
+                except BaseException:
+                    await self._release_peer_connection(
+                        peer_connection,
+                        detached_video_track=video_track,
+                    )
+                    raise
+
+            self._media_connected.clear()
+            self._final_video_track_metrics = None
+            self._peer_connection = peer_connection
+            self._video_track = video_track
+            self._client_connected = has_reliable_control
             if peer_connection.connectionState == "connected":
                 self._media_connected.set()
-            elif peer_connection.connectionState == "disconnected":
-                self._media_connected.clear()
-            elif peer_connection.connectionState in {"failed", "closed"}:
-                await self._release_peer_connection(peer_connection)
-
-        try:
-            await peer_connection.setRemoteDescription(
-                RTCSessionDescription(sdp=sdp, type=offer_type)
+            return web.json_response(
+                {"sdp": local_description.sdp, "type": local_description.type}
             )
-            await peer_connection.setLocalDescription(
-                await peer_connection.createAnswer()
-            )
-        except BaseException:
-            await self._release_peer_connection(peer_connection)
-            raise
-
-        local_description = peer_connection.localDescription
-        if local_description is None:
-            raise web.HTTPInternalServerError(
-                reason="WebRTC peer did not create an answer."
-            )
-        return web.json_response(
-            {"sdp": local_description.sdp, "type": local_description.type}
-        )
 
     def _buffer_browser_message(
         self,
@@ -921,25 +965,32 @@ class WebRTCServer:
     async def _release_peer_connection(
         self,
         peer_connection: RTCPeerConnection,
+        *,
+        detached_video_track: _VideoTrack | None = None,
     ) -> None:
         """Release one disconnected peer while leaving the server open."""
-        if self._peer_connection is not peer_connection:
+        is_active = self._peer_connection is peer_connection
+        if not is_active and detached_video_track is None:
             return
-        self._peer_connection = None
-        self._media_connected.clear()
-        self._client_connected = False
-        track = self._video_track
-        self._video_track = None
+        if is_active:
+            self._peer_connection = None
+            self._media_connected.clear()
+            self._client_connected = False
+            track = self._video_track
+            self._video_track = None
+        else:
+            track = detached_video_track
         failures: list[BaseException] = []
         if track is not None:
             try:
                 await track.close()
             except BaseException as error:
                 failures.append(error)
-            try:
-                self._final_video_track_metrics = track.metrics_snapshot()
-            except BaseException as error:
-                failures.append(error)
+            if is_active:
+                try:
+                    self._final_video_track_metrics = track.metrics_snapshot()
+                except BaseException as error:
+                    failures.append(error)
         if peer_connection.connectionState != "closed":
             try:
                 await peer_connection.close()

--- a/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
+++ b/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
@@ -437,7 +437,9 @@ class WebRTCServer:
         track = self._video_track
         loop = self._loop
         if track is not None and loop is not None:
-            future = asyncio.run_coroutine_threadsafe(track.start_session(), loop)
+            future = asyncio.run_coroutine_threadsafe(
+                self._start_session_if_active(track), loop
+            )
             try:
                 future.result(timeout=self._startup_timeout_seconds)
             except BaseException:
@@ -664,8 +666,11 @@ class WebRTCServer:
         session_desc = self._session_desc
         if session_desc is None:
             raise web.HTTPConflict(reason="WebRTC server is not open.")
-        if self._peer_connection is not None:
-            raise web.HTTPConflict(reason="A WebRTC client is already connected.")
+        existing_peer = self._peer_connection
+        if existing_peer is not None:
+            # This server has one client slot. A new offer is a page refresh or
+            # replacement browser and therefore takes ownership of that slot.
+            await self._release_peer_connection(existing_peer)
 
         try:
             payload = await request.json()
@@ -704,9 +709,9 @@ class WebRTCServer:
                     channel.send(json.dumps({"type": "error", "message": str(error)}))
 
             @channel.on("close")
-            def on_close() -> None:
+            async def on_close() -> None:
                 if is_reliable_control:
-                    self._record_client_disconnect()
+                    await self._release_peer_connection(peer_connection)
 
         @peer_connection.on("connectionstatechange")
         async def on_connectionstatechange() -> None:
@@ -715,8 +720,7 @@ class WebRTCServer:
             elif peer_connection.connectionState == "disconnected":
                 self._media_connected.clear()
             elif peer_connection.connectionState in {"failed", "closed"}:
-                self._media_connected.clear()
-                self._record_client_disconnect()
+                await self._release_peer_connection(peer_connection)
 
         try:
             await peer_connection.setRemoteDescription(
@@ -725,12 +729,8 @@ class WebRTCServer:
             await peer_connection.setLocalDescription(
                 await peer_connection.createAnswer()
             )
-        except Exception:
-            self._peer_connection = None
-            self._video_track = None
-            self._media_connected.clear()
-            await video_track.close()
-            await peer_connection.close()
+        except BaseException:
+            await self._release_peer_connection(peer_connection)
             raise
 
         local_description = peer_connection.localDescription
@@ -918,16 +918,45 @@ class WebRTCServer:
             raise RuntimeError("WebRTC input callback is not registered.")
         callback(event)
 
-    def _record_client_disconnect(self) -> None:
-        """Buffer one close event when the active browser disconnects."""
-        self._media_connected.clear()
-        if not self._client_connected:
+    async def _release_peer_connection(
+        self,
+        peer_connection: RTCPeerConnection,
+    ) -> None:
+        """Release one disconnected peer while leaving the server open."""
+        if self._peer_connection is not peer_connection:
             return
+        self._peer_connection = None
+        self._media_connected.clear()
         self._client_connected = False
-        if not self._closed:
-            timestamp_us = self._timestamp_us()
-            if timestamp_us is not None:
-                self._append_event(CloseUserInputEvent(timestamp=timestamp_us))
+        track = self._video_track
+        self._video_track = None
+        failures: list[BaseException] = []
+        if track is not None:
+            try:
+                await track.close()
+            except BaseException as error:
+                failures.append(error)
+            try:
+                self._final_video_track_metrics = track.metrics_snapshot()
+            except BaseException as error:
+                failures.append(error)
+        if peer_connection.connectionState != "closed":
+            try:
+                await peer_connection.close()
+            except BaseException as error:
+                failures.append(error)
+        if failures:
+            primary = failures[0]
+            for secondary in failures[1:]:
+                logger.opt(exception=secondary).warning(
+                    "Additional WebRTC peer cleanup failure"
+                )
+            raise primary
+
+    async def _start_session_if_active(self, track: _VideoTrack) -> None:
+        """Reset ``track`` only if it still belongs to the active peer."""
+        if self._video_track is track:
+            await track.start_session()
 
     def _timestamp_us(self) -> np.uint64 | None:
         """Return the current server-relative event timestamp."""
@@ -940,8 +969,13 @@ class WebRTCServer:
         """Release async server resources on their owning loop."""
         failures: list[BaseException] = []
         peer_connection = self._peer_connection
-        self._peer_connection = None
+        if peer_connection is not None:
+            try:
+                await self._release_peer_connection(peer_connection)
+            except BaseException as error:
+                failures.append(error)
         self._media_connected.clear()
+        self._client_connected = False
         track = self._video_track
         self._video_track = None
         if track is not None:
@@ -951,11 +985,6 @@ class WebRTCServer:
                 failures.append(error)
             try:
                 self._final_video_track_metrics = track.metrics_snapshot()
-            except BaseException as error:
-                failures.append(error)
-        if peer_connection is not None:
-            try:
-                await peer_connection.close()
             except BaseException as error:
                 failures.append(error)
         runner = self._runner

--- a/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
+++ b/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from fractions import Fraction
 from importlib.resources import files
-from typing import Any, Literal, TypeAlias, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 import torch
@@ -37,6 +37,7 @@ from flashdreams.runtime_v2.user_input_event import (
     KeyboardInputState,
     KeyboardUserInputEvent,
     MouseUserInputEvent,
+    NewSessionUserInputEvent,
     ResetUserInputEvent,
     TouchUserInputEvent,
     UserInputEvent,
@@ -139,6 +140,7 @@ class _VideoTrack(MediaStreamTrack):
         self._enqueued_count = 0
         self._handed_off_count = 0
         self._dropped_for_lag = 0
+        self._discarded_on_session_change_count = 0
         self._discarded_on_close_count = 0
         self._first_enqueued_at: float | None = None
         self._next_pts = 0
@@ -159,6 +161,9 @@ class _VideoTrack(MediaStreamTrack):
                 "webrtc_sender_enqueued_count": self._enqueued_count,
                 "webrtc_sender_handed_off_count": self._handed_off_count,
                 "webrtc_sender_dropped_for_lag_count": self._dropped_for_lag,
+                "webrtc_sender_discarded_on_session_change_count": (
+                    self._discarded_on_session_change_count
+                ),
                 "webrtc_sender_discarded_on_close_count": (
                     self._discarded_on_close_count
                 ),
@@ -205,6 +210,19 @@ class _VideoTrack(MediaStreamTrack):
     def wait_until_drained(self, timeout_s: float) -> bool:
         """Wait until aiortc requests another frame after the latest handoff."""
         return self._sender_drained.wait(timeout_s)
+
+    async def start_session(self) -> None:
+        """Discard queued frames that belong to the replaced session."""
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("Cannot start a session on a closed video track.")
+            discarded_count = len(self._frames)
+            self._frames.clear()
+            self._first_enqueued_at = None
+            self._discarded_on_session_change_count += discarded_count
+            if not self._frame_in_flight:
+                self._sender_drained.set()
+        self._frame_available.clear()
 
     async def _recv_one(self) -> VideoFrame:
         """Return the next send-ready frame immediately when aiortc requests it."""
@@ -300,7 +318,7 @@ class WebRTCServer:
         self._final_video_track_metrics: dict[str, float | int] | None = None
         self._media_connected = threading.Event()
         self._session_desc: SessionDesc | None = None
-        self._session_start_ns: int | None = None
+        self._event_origin_ns: int | None = None
         self._transfer_streams: dict[int, torch.cuda.Stream] = {}
         self._materialization_buffer = _PinnedRGBFrameBuffer()
         self._materialization_count = 0
@@ -348,6 +366,7 @@ class WebRTCServer:
                 "webrtc_sender_enqueued_count": 0,
                 "webrtc_sender_handed_off_count": 0,
                 "webrtc_sender_dropped_for_lag_count": 0,
+                "webrtc_sender_discarded_on_session_change_count": 0,
                 "webrtc_sender_discarded_on_close_count": 0,
                 "webrtc_sender_oldest_queue_age_s": 0.0,
             }
@@ -356,23 +375,61 @@ class WebRTCServer:
             "webrtc_sender_materialized_count": self._materialization_count,
         }
 
+    def event_timestamp_us(self) -> np.uint64:
+        """Return the current timestamp relative to this server's first session.
+
+        Raises:
+            RuntimeError: The server has not opened a session.
+        """
+        timestamp_us = self._timestamp_us()
+        if timestamp_us is None:
+            raise RuntimeError("Open the WebRTC server before reading its clock.")
+        return timestamp_us
+
     def open(self, session_desc: SessionDesc) -> None:
         """Configure the server for one session's generated video.
+
+        A replacement session may open an active server again when its stream
+        format is unchanged. The peer connection stays up and frames still
+        queued from the previous session are discarded.
 
         Args:
             session_desc: Resolved dimensions, frame rate, and tensor layout.
 
         Raises:
-            RuntimeError: The server is closed or already open.
+            RuntimeError: The server is closed or has no input callback.
+            TimeoutError: The active video track cannot begin the replacement
+                before the server timeout.
+            ValueError: A replacement changes the negotiated stream format.
         """
         if self._closed:
             raise RuntimeError("Cannot open a closed WebRTC server.")
-        if self._session_desc is not None:
-            raise RuntimeError("WebRTC server is already open.")
         if self._input_callback is None:
             raise RuntimeError("Register an input callback before opening WebRTC.")
+        current_session_desc = self._session_desc
+        if current_session_desc is not None and not _same_stream_format(
+            current_session_desc,
+            session_desc,
+        ):
+            raise ValueError(
+                "A replacement WebRTC session must keep the same stream format: "
+                "output layout, frame rates, width, and height."
+            )
+
+        track = self._video_track
+        loop = self._loop
+        if track is not None and loop is not None:
+            future = asyncio.run_coroutine_threadsafe(track.start_session(), loop)
+            try:
+                future.result(timeout=self._startup_timeout_seconds)
+            except BaseException:
+                future.cancel()
+                raise
         self._session_desc = session_desc
-        self._session_start_ns = time.monotonic_ns()
+        if self._event_origin_ns is None:
+            # Keep timestamps comparable across sessions so events buffered
+            # during a handoff retain their real order.
+            self._event_origin_ns = time.monotonic_ns()
 
     def register_input_callback(
         self, callback: Callable[[UserInputEvent], None]
@@ -827,6 +884,8 @@ class WebRTCServer:
             )
         elif event_type == "reset":
             event = ResetUserInputEvent(timestamp=timestamp_us)
+        elif event_type == "new_session":
+            event = NewSessionUserInputEvent(timestamp=timestamp_us)
         elif event_type == "close":
             event = CloseUserInputEvent(timestamp=timestamp_us)
         else:
@@ -852,11 +911,11 @@ class WebRTCServer:
                 self._append_event(CloseUserInputEvent(timestamp=timestamp_us))
 
     def _timestamp_us(self) -> np.uint64 | None:
-        """Return the current session-relative event timestamp."""
-        session_start_ns = self._session_start_ns
-        if session_start_ns is None:
+        """Return the current server-relative event timestamp."""
+        event_origin_ns = self._event_origin_ns
+        if event_origin_ns is None:
             return None
-        return np.uint64((time.monotonic_ns() - session_start_ns) // 1_000)
+        return np.uint64((time.monotonic_ns() - event_origin_ns) // 1_000)
 
     async def _shutdown(self) -> None:
         """Release async server resources on their owning loop."""
@@ -894,6 +953,17 @@ class WebRTCServer:
                     "Additional WebRTC cleanup failure"
                 )
             raise primary
+
+
+def _same_stream_format(first: SessionDesc, second: SessionDesc) -> bool:
+    """Return whether two sessions can share one negotiated video track."""
+    return (
+        first.output_layout == second.output_layout
+        and first.frames_per_second_for_ui == second.frames_per_second_for_ui
+        and first.frames_per_second_for_step == second.frames_per_second_for_step
+        and first.video_width == second.video_width
+        and first.video_height == second.video_height
+    )
 
 
 def _finite_number(value: object, *, label: str) -> float:

--- a/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
+++ b/flashdreams/flashdreams/runtime_v2/serving/webrtc_server.py
@@ -37,7 +37,6 @@ from flashdreams.runtime_v2.user_input_event import (
     KeyboardInputState,
     KeyboardUserInputEvent,
     MouseUserInputEvent,
-    NewSessionUserInputEvent,
     ResetUserInputEvent,
     TouchUserInputEvent,
     UserInputEvent,
@@ -947,8 +946,6 @@ class WebRTCServer:
             )
         elif event_type == "reset":
             event = ResetUserInputEvent(timestamp=timestamp_us)
-        elif event_type == "new_session":
-            event = NewSessionUserInputEvent(timestamp=timestamp_us)
         elif event_type == "close":
             event = CloseUserInputEvent(timestamp=timestamp_us)
         else:

--- a/flashdreams/flashdreams/runtime_v2/session_desc.py
+++ b/flashdreams/flashdreams/runtime_v2/session_desc.py
@@ -22,7 +22,7 @@ class BackpressureMode(Enum):
 
 
 class PresentationMode(Enum):
-    """What the UI loop does when no new model frame is ready."""
+    """Control what the UI loop does when no new model frame is ready."""
 
     ON_DEMAND = "on_demand"
     """Present only when there is a new model frame and it is selected."""
@@ -62,7 +62,7 @@ class SessionDesc:
     """Output video height in pixels."""
 
     metadata: dict[str, Any] = field(default_factory=dict)
-    """Extra values a runtime and an application agree on. Nothing here reads it."""
+    """Runtime and application extension values, including reserved runtime keys."""
 
     def __post_init__(self) -> None:
         if not isinstance(self.backpressure_mode, BackpressureMode):
@@ -89,4 +89,8 @@ class SessionDesc:
             raise ValueError("SessionDesc.video_height must be > 0 when set.")
 
 
-__all__ = ["BackpressureMode", "PresentationMode", "SessionDesc"]
+__all__ = [
+    "BackpressureMode",
+    "PresentationMode",
+    "SessionDesc",
+]

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -154,27 +154,14 @@ def run_session(
                 for result in results:
                     metrics_output_sink.write(result)
 
-        def run_model() -> None:
-            assert ui_loop is not None
-            assert model_loop is not None
-            ui_loop._set_model_inference_state(ModelInferenceState.RUNNING)
-            try:
-                model_loop._run_model_loop(
-                    event_buffer=event_buffer,
-                    reader_id=_MODEL_READER_ID,
-                    publish=publish_model_results,
-                    max_steps=steps,
-                )
-            finally:
-                ui_loop._set_model_inference_state(ModelInferenceState.FINISHED)
-
         def tick_ui() -> None:
             # ensure that the HIGH PRIORITY presentation context is default for UI loop
             with presentation_manager.presentation_context():
                 assert ui_loop is not None
+                assert model_loop is not None
                 generation = event_buffer.generation
                 model_advanced, _ = presentation_manager.advance(generation)
-                inference_state = ui_loop.model_inference_state
+                inference_state = model_loop.inference_state
                 if model_advanced:
                     step_requested = True
                 elif inference_state is ModelInferenceState.RUNNING:
@@ -226,7 +213,13 @@ def run_session(
 
         if not stop.is_set():
             model_thread_handle = threading.Thread(
-                target=run_model,
+                target=model_loop._run_model_loop,
+                kwargs={
+                    "event_buffer": event_buffer,
+                    "reader_id": _MODEL_READER_ID,
+                    "publish": publish_model_results,
+                    "max_steps": steps,
+                },
                 name=_MODEL_THREAD_NAME,
             )
             model_thread_handle.start()

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -6,7 +6,7 @@
 import logging
 import threading
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 
 from flashdreams.api_v2.client_window import IClientWindow
@@ -117,23 +117,17 @@ def run_session(
                 return
             events, generation = event_buffer.read(_UI_READER_ID)
 
-            loopResult = ui_loop._begin_run(events, generation)
-            if loopResult.stop_requested:
+            loop_result = ui_loop._begin_run(events, generation)
+            if loop_result.stop_requested:
                 stop.set()
                 return
-            if loopResult.new_session_request is not None:
-                next_session_desc = replace(
-                    session_desc,
-                    metadata={
-                        **session_desc.metadata,
-                        **loopResult.new_session_request,
-                    },
-                )
+            if loop_result.new_session_request is not None:
+                next_session_desc = loop_result.new_session_request
                 stop.set()
                 return
-            if loopResult.step_index is None or not step_requested:
+            if loop_result.step_index is None or not step_requested:
                 return
-            result = ui_loop.step(loopResult.step_index, ui_loop.user_events)
+            result = ui_loop.step(loop_result.step_index, ui_loop.user_events)
             if result is not None and not isinstance(result, StepResult):
                 raise TypeError("A UI loop must return StepResult or None.")
             ui_loop._finish_run(result)
@@ -225,21 +219,26 @@ def run_session(
             model_thread_handle.start()
             next_tick_at = time.monotonic() + tick_seconds
 
-            while not stop.is_set():
+            def should_end_ui() -> bool:
+                if model_thread_handle.is_alive():
+                    return False
+                if presentation_manager.has_pending_frames():
+                    return False
+
                 if (
-                    not model_thread_handle.is_alive()
-                    and not presentation_manager.has_pending_frames()
-                    and (
-                        not session._failure_queue.empty()
-                        or steps is not None
-                        or ui_loop.is_finished()
-                    )
+                    session._failure_queue.empty()
+                    and steps is None
+                    and not ui_loop.is_finished()
                 ):
-                    # Input may have arrived with the final presented frame.
-                    # Establish the terminal boundary before deciding that a
-                    # naturally completed session has no replacement.
-                    collect_input()
-                    run_ui_once(step_requested=False)
+                    # If there are no failures, no steps limit, and the UI is not finished,
+                    # the run should continue.
+                    return False
+                collect_input()
+                run_ui_once(step_requested=False)
+                return True
+
+            while not stop.is_set():
+                if should_end_ui():
                     break
                 wait_seconds = max(0.0, next_tick_at - time.monotonic())
                 if stop.wait(wait_seconds):

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -4,6 +4,7 @@
 """Run a session with a client window."""
 
 import logging
+import math
 import threading
 import time
 from dataclasses import dataclass
@@ -48,6 +49,7 @@ def run_session(
     *,
     metrics_output_sink: OutputSink | None = None,
     steps: int | None = None,
+    timeout_seconds: float | None = None,
 ) -> SessionDesc | None:
     """Run a session's UI and model loops.
 
@@ -68,19 +70,27 @@ def run_session(
             the model loop's results rather than the UI loop's.
         steps: Maximum model steps before ending the session; ``None`` leaves
             session completion to the UI or client window.
+        timeout_seconds: Maximum session runtime; ``None`` waits for another
+            lifecycle exit. Expiration signals both registered loops to stop.
 
     Returns:
         The resolved description for a requested replacement session, or
         ``None`` when the application run should end.
 
     Raises:
-        ValueError: ``steps`` is negative.
+        ValueError: ``steps`` is negative, or ``timeout_seconds`` is invalid.
         BaseException: A loop's failure if one was queued, otherwise this
             function's own, otherwise the first cleanup failure. The rest are
             logged.
     """
     if steps is not None and steps < 0:
         raise ValueError(f"steps must be >= 0 or None, got {steps}.")
+    if timeout_seconds is not None and (
+        not math.isfinite(timeout_seconds) or timeout_seconds < 0
+    ):
+        raise ValueError("timeout_seconds must be finite and non-negative.")
+
+    deadline = None if timeout_seconds is None else time.monotonic() + timeout_seconds
 
     event_buffer = EventBuffer()
     model_thread_handle: threading.Thread | None = None
@@ -205,6 +215,8 @@ def run_session(
         collect_input()
         tick_ui()
 
+        if deadline is not None and time.monotonic() >= deadline:
+            stop.set()
         if not stop.is_set():
             model_thread_handle = threading.Thread(
                 target=model_loop._run_model_loop,
@@ -238,10 +250,21 @@ def run_session(
                 return True
 
             while not stop.is_set():
+                if deadline is not None and time.monotonic() >= deadline:
+                    stop.set()
+                    break
                 if should_end_ui():
                     break
                 wait_seconds = max(0.0, next_tick_at - time.monotonic())
+                if deadline is not None:
+                    wait_seconds = min(
+                        wait_seconds,
+                        max(0.0, deadline - time.monotonic()),
+                    )
                 if stop.wait(wait_seconds):
+                    break
+                if deadline is not None and time.monotonic() >= deadline:
+                    stop.set()
                     break
                 collect_input()
                 tick_ui()

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -6,18 +6,20 @@
 import logging
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.loop import IModelLoop, IUILoop
 from flashdreams.api_v2.output_sink import OutputSink
 from flashdreams.api_v2.session import ISession
-from flashdreams.api_v2.user_input_event import UserInputEvent
 from flashdreams.runtime_v2.event_buffer import EventBuffer
-from flashdreams.runtime_v2.session_desc import PresentationMode
+from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
-from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
+from flashdreams.runtime_v2.user_input_event import (
+    CloseUserInputEvent,
+    NewSessionUserInputEvent,
+)
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,9 +42,37 @@ class _ChunkTraceLog:
     previous_propagate: bool
 
 
-def _contains(events: UserInputEvents, event_type: type[UserInputEvent]) -> bool:
-    """Return whether ``events`` contains an instance of ``event_type``."""
-    return any(isinstance(event, event_type) for event in events.get_events())
+def _session_transition(
+    events: UserInputEvents,
+    current_session_desc: SessionDesc,
+) -> tuple[bool, SessionDesc | None]:
+    """Return the last session transition in an ordered input batch.
+
+    A new-session request copies the current session's resolved description,
+    including a fresh metadata dictionary. If close and replacement arrive
+    together, the event with the later timestamp wins.
+
+    Args:
+        events: Input events sorted from oldest to newest.
+        current_session_desc: Resolved description to use for a replacement.
+
+    Returns:
+        Whether the batch contains a transition and its replacement
+        description. The description is ``None`` when close is last.
+    """
+    transition_found = False
+    next_session_desc: SessionDesc | None = None
+    for event in events.get_events():
+        if isinstance(event, CloseUserInputEvent):
+            transition_found = True
+            next_session_desc = None
+        elif isinstance(event, NewSessionUserInputEvent):
+            transition_found = True
+            next_session_desc = replace(
+                current_session_desc,
+                metadata=dict(current_session_desc.metadata),
+            )
+    return transition_found, next_session_desc
 
 
 def _log_secondary_failure(message: str, error: BaseException) -> None:
@@ -56,16 +86,17 @@ def run_session(
     *,
     metrics_output_sink: OutputSink | None = None,
     steps: int | None = None,
-) -> None:
+) -> SessionDesc | None:
     """Run a session's UI and model loops.
 
     The calling UI thread handles the window and UI. A model thread runs the
-    model loop. Returns when the client closes the window, when the
-    model loop has finished and no generated frames are still waiting, or when
-    either loop fails.
+    model loop. Returns when the client closes the window, requests a new
+    session, when the model loop has finished and no generated frames are still
+    waiting, or when either loop fails.
 
-    Both loops are shut down, every sink opened is closed, and the session is
-    closed, before this returns or raises.
+    Both loops, the metrics sink, and the session are closed before this returns
+    or raises. The client window stays open only when a clean replacement was
+    requested; otherwise it is closed.
 
     Args:
         session: Session to run.
@@ -73,6 +104,10 @@ def run_session(
         metrics_output_sink: Sink for model measurements, if requested. Receives
             the model loop's results rather than the UI loop's.
         steps: Maximum model steps; ``None`` runs until stopped.
+
+    Returns:
+        The resolved description for a requested replacement session, or
+        ``None`` when the application run should end.
 
     Raises:
         ValueError: ``steps`` is negative.
@@ -83,82 +118,90 @@ def run_session(
     if steps is not None and steps < 0:
         raise ValueError(f"steps must be >= 0 or None, got {steps}.")
 
-    session_desc = session.session_desc
-    tick_seconds = 1.0 / session_desc.frames_per_second_for_ui
     event_buffer = EventBuffer()
-    stop = session._shutdown_event
-    presentation_manager = session._presentation_manager
-    trace_chunk_lifecycle = session_desc.metadata.get(_TRACE_METADATA_KEY) is True
-    presentation_manager.configure(
-        backpressure_mode=session_desc.backpressure_mode,
-        stop=stop,
-        put_timeout=tick_seconds,
-        trace_chunk_lifecycle=trace_chunk_lifecycle,
-        frames_per_second=session_desc.frames_per_second_for_step,
-        maximum_frames_per_second=session_desc.frames_per_second_for_ui,
-    )
     model_thread_handle: threading.Thread | None = None
     ui_loop: IUILoop[object] | None = None
     model_loop: IModelLoop[object] | None = None
     high_level_failures: BaseException | None = None
     cleanup_failures: list[BaseException] = []
-    attempted_output_sinks: list[OutputSink] = []
-
-    def collect_input() -> None:
-        events = window.get_user_input_events()
-        event_buffer.append(events)
-        if _contains(events, CloseUserInputEvent):
-            stop.set()
-
-    def run_ui_once() -> None:
-        """Run one UI step and write every result it produces."""
-        if ui_loop is None:
-            return
-        events, generation = event_buffer.read(_UI_READER_ID)
-
-        step_index = ui_loop._begin_run(events, generation)
-        if step_index is None or stop.is_set():
-            return
-        result = ui_loop.step(step_index, events)
-        if result is not None and not isinstance(result, StepResult):
-            raise TypeError("A UI loop must return StepResult or None.")
-        ui_loop._finish_run(result)
-        if result is not None:
-            window.write(result)
-
-    def publish_model_results(
-        generation: int,
-        results: list[StepResult],
-        step_elapsed_s: float,
-    ) -> None:
-        presentation_manager.publish(
-            generation,
-            results,
-            step_elapsed_s=step_elapsed_s,
-        )
-        if metrics_output_sink is not None:
-            for result in results:
-                metrics_output_sink.write(result)
-
-    def tick_ui() -> None:
-        # ensure that the HIGH PRIORITY presentation context is default for UI loop
-        with session._presentation_manager.presentation_context():
-            assert ui_loop is not None
-            generation = event_buffer.generation
-            model_advanced, _ = presentation_manager.advance(generation)
-            if model_advanced:
-                run_ui_once()
-                return
-            if session_desc.presentation_mode is PresentationMode.ON_DEMAND:
-                return
-            run_ui_once()
-
-    trace_log = (
-        _open_chunk_trace(session_desc.metadata.get(_TRACE_PATH_METADATA_KEY))
-        if trace_chunk_lifecycle
-        else None
-    )
+    next_session_desc: SessionDesc | None = None
+    stop: threading.Event | None = None
+    presentation_manager = None
+    trace_log: _ChunkTraceLog | None = None
     try:
+        session_desc = session.session_desc
+        tick_seconds = 1.0 / session_desc.frames_per_second_for_ui
+        stop = session._shutdown_event
+        presentation_manager = session._presentation_manager
+        trace_chunk_lifecycle = session_desc.metadata.get(_TRACE_METADATA_KEY) is True
+        presentation_manager.configure(
+            backpressure_mode=session_desc.backpressure_mode,
+            stop=stop,
+            put_timeout=tick_seconds,
+            trace_chunk_lifecycle=trace_chunk_lifecycle,
+            frames_per_second=session_desc.frames_per_second_for_step,
+            maximum_frames_per_second=session_desc.frames_per_second_for_ui,
+        )
+
+        def collect_input() -> None:
+            nonlocal next_session_desc
+            events = window.get_user_input_events()
+            event_buffer.append(events)
+            transition_found, next_session_desc = _session_transition(
+                events,
+                session_desc,
+            )
+            if transition_found:
+                stop.set()
+
+        def run_ui_once() -> None:
+            """Run one UI step and write every result it produces."""
+            if ui_loop is None:
+                return
+            events, generation = event_buffer.read(_UI_READER_ID)
+
+            step_index = ui_loop._begin_run(events, generation)
+            if step_index is None or stop.is_set():
+                return
+            result = ui_loop.step(step_index, events)
+            if result is not None and not isinstance(result, StepResult):
+                raise TypeError("A UI loop must return StepResult or None.")
+            ui_loop._finish_run(result)
+            if result is not None:
+                window.write(result)
+
+        def publish_model_results(
+            generation: int,
+            results: list[StepResult],
+            step_elapsed_s: float,
+        ) -> None:
+            presentation_manager.publish(
+                generation,
+                results,
+                step_elapsed_s=step_elapsed_s,
+            )
+            if metrics_output_sink is not None:
+                for result in results:
+                    metrics_output_sink.write(result)
+
+        def tick_ui() -> None:
+            # ensure that the HIGH PRIORITY presentation context is default for UI loop
+            with presentation_manager.presentation_context():
+                assert ui_loop is not None
+                generation = event_buffer.generation
+                model_advanced, _ = presentation_manager.advance(generation)
+                if model_advanced:
+                    run_ui_once()
+                    return
+                if session_desc.presentation_mode is PresentationMode.ON_DEMAND:
+                    return
+                run_ui_once()
+
+        trace_log = (
+            _open_chunk_trace(session_desc.metadata.get(_TRACE_PATH_METADATA_KEY))
+            if trace_chunk_lifecycle
+            else None
+        )
         if trace_chunk_lifecycle:
             _TRACE_LOGGER.info(
                 "%s phase=session_config time_ns=%d backpressure=%s "
@@ -182,10 +225,8 @@ def run_session(
         event_buffer.register(_UI_READER_ID)
         event_buffer.register(_MODEL_READER_ID)
 
-        attempted_output_sinks.append(window)
         window.open(session_desc)
         if metrics_output_sink is not None:
-            attempted_output_sinks.append(metrics_output_sink)
             metrics_output_sink.open(session_desc)
         collect_input()
         tick_ui()
@@ -212,6 +253,10 @@ def run_session(
                     not model_thread_handle.is_alive()
                     and not presentation_manager.has_pending_frames()
                 ):
+                    # Input may have arrived with the final presented frame.
+                    # Establish the terminal boundary before deciding that a
+                    # naturally completed session has no replacement.
+                    collect_input()
                     break
                 wait_seconds = max(0.0, next_tick_at - time.monotonic())
                 if stop.wait(wait_seconds):
@@ -228,17 +273,19 @@ def run_session(
     except BaseException as error:
         high_level_failures = error
     finally:
-        stop.set()
+        if stop is not None:
+            stop.set()
         if model_thread_handle is not None:
             try:
                 model_thread_handle.join()
             except BaseException as error:
                 cleanup_failures.append(error)
 
-        try:
-            presentation_manager.close()
-        except BaseException as error:
-            cleanup_failures.append(error)
+        if presentation_manager is not None:
+            try:
+                presentation_manager.close()
+            except BaseException as error:
+                cleanup_failures.append(error)
         cleanup_failures.extend(session._shutdown_registered_loops())
         try:
             event_buffer.unregister(_UI_READER_ID)
@@ -247,9 +294,14 @@ def run_session(
         except BaseException as error:
             cleanup_failures.append(error)
 
-        for output_sink in attempted_output_sinks:
+        if metrics_output_sink is not None:
             try:
-                output_sink.close()
+                metrics_output_sink.close()
+            except BaseException as error:
+                cleanup_failures.append(error)
+        if next_session_desc is None:
+            try:
+                window.close()
             except BaseException as error:
                 cleanup_failures.append(error)
         try:
@@ -268,23 +320,32 @@ def run_session(
     primary_failure = loop_failures or high_level_failures
     if primary_failure is None and cleanup_failures:
         primary_failure = cleanup_failures.pop(0)
+
+    # A replacement may take ownership of the window only after every resource
+    # owned by the old session has been released successfully.
+    if next_session_desc is not None and primary_failure is not None:
+        try:
+            window.close()
+        except BaseException as error:
+            cleanup_failures.append(error)
     for error in cleanup_failures:
         _log_secondary_failure(
             "Cleanup failed after the session had already failed.", error
         )
 
-    if presentation_manager.dropped_for_space:
+    if presentation_manager is not None and presentation_manager.dropped_for_space:
         _LOGGER.warning(
             "Dropped %d model chunks the window could not keep up with.",
             presentation_manager.dropped_for_space,
         )
-    if presentation_manager.discarded_at_reset:
+    if presentation_manager is not None and presentation_manager.discarded_at_reset:
         _LOGGER.info(
             "Discarded %d model chunks generated before a reset.",
             presentation_manager.discarded_at_reset,
         )
     if primary_failure is not None:
         raise primary_failure
+    return next_session_desc
 
 
 def _open_chunk_trace(path_value: object) -> _ChunkTraceLog:

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -10,17 +10,12 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from flashdreams.api_v2.client_window import IClientWindow
-from flashdreams.api_v2.loop import IModelLoop, IUILoop
+from flashdreams.api_v2.loop import IModelLoop, IUILoop, ModelInferenceState
 from flashdreams.api_v2.output_sink import OutputSink
 from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2.event_buffer import EventBuffer
 from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
-from flashdreams.runtime_v2.user_input_event import (
-    CloseUserInputEvent,
-    NewSessionUserInputEvent,
-)
-from flashdreams.runtime_v2.user_input_events import UserInputEvents
 
 _LOGGER = logging.getLogger(__name__)
 _MODEL_THREAD_NAME = "flashdreams-model-generation-thread"
@@ -42,39 +37,6 @@ class _ChunkTraceLog:
     previous_propagate: bool
 
 
-def _session_transition(
-    events: UserInputEvents,
-    current_session_desc: SessionDesc,
-) -> tuple[bool, SessionDesc | None]:
-    """Return the last session transition in an ordered input batch.
-
-    A new-session request copies the current session's resolved description,
-    including a fresh metadata dictionary. If close and replacement arrive
-    together, the event with the later timestamp wins.
-
-    Args:
-        events: Input events sorted from oldest to newest.
-        current_session_desc: Resolved description to use for a replacement.
-
-    Returns:
-        Whether the batch contains a transition and its replacement
-        description. The description is ``None`` when close is last.
-    """
-    transition_found = False
-    next_session_desc: SessionDesc | None = None
-    for event in events.get_events():
-        if isinstance(event, CloseUserInputEvent):
-            transition_found = True
-            next_session_desc = None
-        elif isinstance(event, NewSessionUserInputEvent):
-            transition_found = True
-            next_session_desc = replace(
-                current_session_desc,
-                metadata=dict(current_session_desc.metadata),
-            )
-    return transition_found, next_session_desc
-
-
 def _log_secondary_failure(message: str, error: BaseException) -> None:
     """Log a cleanup failure that cannot replace an earlier exception."""
     _LOGGER.error(message, exc_info=error)
@@ -91,8 +53,9 @@ def run_session(
 
     The calling UI thread handles the window and UI. A model thread runs the
     model loop. Returns when the client closes the window, requests a new
-    session, when the model loop has finished and no generated frames are still
-    waiting, or when either loop fails.
+    session, when the UI finishes, or when either loop fails. While the model
+    is not running, an unfinished UI ticks regardless of presentation mode so
+    it can request another session.
 
     Both loops, the metrics sink, and the session are closed before this returns
     or raises. The client window stays open only when a clean replacement was
@@ -103,7 +66,8 @@ def run_session(
         window: Source of input and destination for UI output.
         metrics_output_sink: Sink for model measurements, if requested. Receives
             the model loop's results rather than the UI loop's.
-        steps: Maximum model steps; ``None`` runs until stopped.
+        steps: Maximum model steps before ending the session; ``None`` leaves
+            session completion to the UI or client window.
 
     Returns:
         The resolved description for a requested replacement session, or
@@ -144,26 +108,32 @@ def run_session(
         )
 
         def collect_input() -> None:
-            nonlocal next_session_desc
-            events = window.get_user_input_events()
-            event_buffer.append(events)
-            transition_found, next_session_desc = _session_transition(
-                events,
-                session_desc,
-            )
-            if transition_found:
-                stop.set()
+            event_buffer.append(window.get_user_input_events())
 
-        def run_ui_once() -> None:
-            """Run one UI step and write every result it produces."""
+        def run_ui_once(*, step_requested: bool = True) -> None:
+            """Process UI lifecycle control and run a requested UI step."""
+            nonlocal next_session_desc
             if ui_loop is None:
                 return
             events, generation = event_buffer.read(_UI_READER_ID)
 
-            step_index = ui_loop._begin_run(events, generation)
-            if step_index is None or stop.is_set():
+            loopResult = ui_loop._begin_run(events, generation)
+            if loopResult.stop_requested:
+                stop.set()
                 return
-            result = ui_loop.step(step_index, events)
+            if loopResult.new_session_request is not None:
+                next_session_desc = replace(
+                    session_desc,
+                    metadata={
+                        **session_desc.metadata,
+                        **loopResult.new_session_request,
+                    },
+                )
+                stop.set()
+                return
+            if loopResult.step_index is None or not step_requested:
+                return
+            result = ui_loop.step(loopResult.step_index, ui_loop.user_events)
             if result is not None and not isinstance(result, StepResult):
                 raise TypeError("A UI loop must return StepResult or None.")
             ui_loop._finish_run(result)
@@ -184,18 +154,41 @@ def run_session(
                 for result in results:
                     metrics_output_sink.write(result)
 
+        def run_model() -> None:
+            assert ui_loop is not None
+            assert model_loop is not None
+            ui_loop._set_model_inference_state(ModelInferenceState.RUNNING)
+            try:
+                model_loop._run_model_loop(
+                    event_buffer=event_buffer,
+                    reader_id=_MODEL_READER_ID,
+                    publish=publish_model_results,
+                    max_steps=steps,
+                )
+            finally:
+                ui_loop._set_model_inference_state(ModelInferenceState.FINISHED)
+
         def tick_ui() -> None:
             # ensure that the HIGH PRIORITY presentation context is default for UI loop
             with presentation_manager.presentation_context():
                 assert ui_loop is not None
                 generation = event_buffer.generation
                 model_advanced, _ = presentation_manager.advance(generation)
+                inference_state = ui_loop.model_inference_state
                 if model_advanced:
-                    run_ui_once()
-                    return
-                if session_desc.presentation_mode is PresentationMode.ON_DEMAND:
-                    return
-                run_ui_once()
+                    step_requested = True
+                elif inference_state is ModelInferenceState.RUNNING:
+                    step_requested = (
+                        session_desc.presentation_mode is PresentationMode.CONTINUOUS
+                    )
+                elif inference_state is ModelInferenceState.NOT_STARTED:
+                    step_requested = True
+                else:
+                    step_requested = (
+                        not presentation_manager.has_pending_frames()
+                        and session._failure_queue.empty()
+                    )
+                run_ui_once(step_requested=step_requested)
 
         trace_log = (
             _open_chunk_trace(session_desc.metadata.get(_TRACE_PATH_METADATA_KEY))
@@ -233,37 +226,32 @@ def run_session(
 
         if not stop.is_set():
             model_thread_handle = threading.Thread(
-                target=model_loop._run_model_loop,
-                kwargs={
-                    "event_buffer": event_buffer,
-                    "reader_id": _MODEL_READER_ID,
-                    "publish": publish_model_results,
-                    "max_steps": steps,
-                },
+                target=run_model,
                 name=_MODEL_THREAD_NAME,
             )
             model_thread_handle.start()
             next_tick_at = time.monotonic() + tick_seconds
 
-            # Keep servicing input and presenting queued frames until shutdown,
-            # or until the model finishes and no generated frames remain.
-            # A finished UI loop produces no further window output.
             while not stop.is_set():
                 if (
                     not model_thread_handle.is_alive()
                     and not presentation_manager.has_pending_frames()
+                    and (
+                        not session._failure_queue.empty()
+                        or steps is not None
+                        or ui_loop.is_finished()
+                    )
                 ):
                     # Input may have arrived with the final presented frame.
                     # Establish the terminal boundary before deciding that a
                     # naturally completed session has no replacement.
                     collect_input()
+                    run_ui_once(step_requested=False)
                     break
                 wait_seconds = max(0.0, next_tick_at - time.monotonic())
                 if stop.wait(wait_seconds):
                     break
                 collect_input()
-                if stop.is_set():
-                    break
                 tick_ui()
                 event_buffer.collect_garbage()
                 next_tick_at += tick_seconds

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -126,21 +126,26 @@ def run_session(
             if ui_loop is None:
                 return
             events, generation = event_buffer.read(_UI_READER_ID)
-
-            loop_result = ui_loop._begin_run(events, generation)
-            if loop_result.stop_requested:
-                stop.set()
-                return
-            if loop_result.new_session_request is not None:
-                next_session_desc = loop_result.new_session_request
-                stop.set()
-                return
-            if loop_result.step_index is None or not step_requested:
-                return
-            result = ui_loop.step(loop_result.step_index, ui_loop.user_events)
-            if result is not None and not isinstance(result, StepResult):
-                raise TypeError("A UI loop must return StepResult or None.")
-            ui_loop._finish_run(result)
+            result: StepResult | None = None
+            step_completed = False
+            try:
+                loop_result = ui_loop._begin_run(events, generation)
+                if loop_result.stop_requested:
+                    stop.set()
+                    return
+                if loop_result.new_session_request is not None:
+                    next_session_desc = loop_result.new_session_request
+                    stop.set()
+                    return
+                if loop_result.step_index is None or not step_requested:
+                    return
+                raw_result = ui_loop.step(loop_result.step_index, ui_loop.user_events)
+                if raw_result is not None and not isinstance(raw_result, StepResult):
+                    raise TypeError("A UI loop must return StepResult or None.")
+                result = raw_result
+                step_completed = True
+            finally:
+                ui_loop._finish_run(result, step_completed=step_completed)
             if result is not None:
                 window.write(result)
 

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -70,8 +70,7 @@ def run_session(
             the model loop's results rather than the UI loop's.
         steps: Maximum model steps before ending the session; ``None`` leaves
             session completion to the UI or client window.
-        timeout_seconds: Maximum session runtime; ``None`` waits for another
-            lifecycle exit. Expiration signals both registered loops to stop.
+        timeout_seconds: Maximum session runtime; ``None`` means session does not have a time-limit. Timeout expiry signals both registered loops to stop.
 
     Returns:
         The resolved description for a requested replacement session, or

--- a/flashdreams/flashdreams/runtime_v2/user_input_event.py
+++ b/flashdreams/flashdreams/runtime_v2/user_input_event.py
@@ -63,21 +63,6 @@ class CloseUserInputEvent(UserInputEvent):
 
 
 @dataclass(frozen=True, slots=True, eq=False)
-class NewSessionUserInputEvent(UserInputEvent):
-    """The client asked to replace the current session.
-
-    ``run_session`` stops and cleans the current session, then returns its
-    resolved session description. ``ApplicationRunner`` uses that description
-    to create the replacement while leaving a reusable client window open.
-    """
-
-    @classmethod
-    def get_type_name(cls) -> str:
-        """Return the event type name."""
-        return "new_session"
-
-
-@dataclass(frozen=True, slots=True, eq=False)
 class ResetUserInputEvent(UserInputEvent):
     """The client asked to start the run over.
 

--- a/flashdreams/flashdreams/runtime_v2/user_input_event.py
+++ b/flashdreams/flashdreams/runtime_v2/user_input_event.py
@@ -63,6 +63,21 @@ class CloseUserInputEvent(UserInputEvent):
 
 
 @dataclass(frozen=True, slots=True, eq=False)
+class NewSessionUserInputEvent(UserInputEvent):
+    """The client asked to replace the current session.
+
+    ``run_session`` stops and cleans the current session, then returns its
+    resolved session description. ``ApplicationRunner`` uses that description
+    to create the replacement while leaving a reusable client window open.
+    """
+
+    @classmethod
+    def get_type_name(cls) -> str:
+        """Return the event type name."""
+        return "new_session"
+
+
+@dataclass(frozen=True, slots=True, eq=False)
 class ResetUserInputEvent(UserInputEvent):
     """The client asked to start the run over.
 

--- a/flashdreams/flashdreams/runtime_v2/webrtc_client_window.py
+++ b/flashdreams/flashdreams/runtime_v2/webrtc_client_window.py
@@ -25,13 +25,14 @@ class WebRTCClientWindow(IClientWindow):
     server's own thread, so they are queued here and handed over in batches when
     the session asks, as the protocol requires.
 
-    The server timestamps arrivals against one stable clock so events buffered
-    during a session handoff cannot be reordered. This window rebases them when
-    they are drained, preserving the public session-relative timestamp contract.
-    Events that arrived during the handoff become time zero for the new session.
+    The server timestamps arrivals against one stable clock. This window clears
+    input buffered during a session handoff, then rebases later events to the
+    new session's clock. Input aimed at a completed UI cannot accidentally act
+    on its replacement.
 
-    A browser that disconnects becomes a close event, so a run through this
-    window ends on its own even when the session would generate forever.
+    Disconnecting releases only that browser's peer connection. The server and
+    current session stay available for a refreshed or replacement client until
+    the application is explicitly stopped.
     """
 
     def __init__(
@@ -78,6 +79,7 @@ class WebRTCClientWindow(IClientWindow):
         self.server.open(session_desc)
         session_event_offset_us = self.server.event_timestamp_us()
         with self._input_lock:
+            self._input_events.clear()
             self._session_event_offset_us = session_event_offset_us
 
     def get_user_input_events(self) -> UserInputEvents:

--- a/flashdreams/flashdreams/runtime_v2/webrtc_client_window.py
+++ b/flashdreams/flashdreams/runtime_v2/webrtc_client_window.py
@@ -5,12 +5,15 @@
 
 import threading
 from collections import deque
+from dataclasses import replace
+
+from numpy import uint64
 
 from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.runtime_v2.serving.webrtc_server import WebRTCServer
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
-from flashdreams.runtime_v2.user_input_event import MouseUserInputEvent, UserInputEvent
+from flashdreams.runtime_v2.user_input_event import UserInputEvent
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 
 
@@ -21,6 +24,11 @@ class WebRTCClientWindow(IClientWindow):
     :class:`WebRTCServer`, which does the serving. Browser events arrive on the
     server's own thread, so they are queued here and handed over in batches when
     the session asks, as the protocol requires.
+
+    The server timestamps arrivals against one stable clock so events buffered
+    during a session handoff cannot be reordered. This window rebases them when
+    they are drained, preserving the public session-relative timestamp contract.
+    Events that arrived during the handoff become time zero for the new session.
 
     A browser that disconnects becomes a close event, so a run through this
     window ends on its own even when the session would generate forever.
@@ -45,6 +53,8 @@ class WebRTCClientWindow(IClientWindow):
         """
         self._input_events: deque[UserInputEvent] = deque()
         self._input_lock = threading.Lock()
+        # Offset from the server's stable clock to the current session's clock.
+        self._session_event_offset_us = uint64(0)
         self.server = WebRTCServer(
             host=host,
             port=port,
@@ -54,7 +64,8 @@ class WebRTCClientWindow(IClientWindow):
         def handle_input(event: UserInputEvent) -> None:
             """Buffer one backend event for the ``InputSource`` protocol."""
             # TODO: do we really need to buffer all events? Some mouse moves may be superseded by later ones.
-            self._input_events.append(event)
+            with self._input_lock:
+                self._input_events.append(event)
 
         self.server.register_input_callback(handle_input)
 
@@ -65,6 +76,9 @@ class WebRTCClientWindow(IClientWindow):
             session_desc: Resolved dimensions, frame rate, and tensor layout.
         """
         self.server.open(session_desc)
+        session_event_offset_us = self.server.event_timestamp_us()
+        with self._input_lock:
+            self._session_event_offset_us = session_event_offset_us
 
     def get_user_input_events(self) -> UserInputEvents:
         """Implement ``InputSource.get_user_input_events`` for browser input.
@@ -75,7 +89,21 @@ class WebRTCClientWindow(IClientWindow):
         with self._input_lock:
             events = list(self._input_events)
             self._input_events.clear()
-        return UserInputEvents(events)
+            session_event_offset_us = int(self._session_event_offset_us)
+        return UserInputEvents(
+            [
+                replace(
+                    event,
+                    timestamp=uint64(
+                        max(
+                            0,
+                            int(event.get_timestamp()) - session_event_offset_us,
+                        )
+                    ),
+                )
+                for event in events
+            ]
+        )
 
     def write(self, result: StepResult) -> None:
         """Materialize and queue one UI-composited frame for the browser.

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -13,15 +13,12 @@ from numpy import uint64
 
 from flashdreams.api_v2.application import IApplication
 from flashdreams.api_v2.client_window import IClientWindow
-from flashdreams.api_v2.loop import IModelLoop
+from flashdreams.api_v2.loop import IModelLoop, IUILoop
 from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2.application_runner import ApplicationRunner
 from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
-from flashdreams.runtime_v2.user_input_event import (
-    CloseUserInputEvent,
-    NewSessionUserInputEvent,
-)
+from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
@@ -38,9 +35,23 @@ class _ModelLoop(IModelLoop["_Session"]):
         return self.state.is_finished()
 
 
+class _ReplacementUILoop(IUILoop["_Session"]):
+    def step(self, step_index: int, events: UserInputEvents) -> None:
+        del step_index, events
+        self.request_new_session(self.session_desc)
+
+    def reset(self) -> None:
+        return
+
+
 class _Session(ISession):
     def __init__(
-        self, session_desc: SessionDesc, calls: list[str], *, length: int | None = None
+        self,
+        session_desc: SessionDesc,
+        calls: list[str],
+        *,
+        length: int | None = None,
+        request_replacement: bool = False,
     ) -> None:
         """
         Args:
@@ -48,14 +59,18 @@ class _Session(ISession):
             calls: Shared log every fake records into.
             length: Steps to generate before reporting that it has finished, or
                 ``None`` for a session that runs until its window ends it.
+            request_replacement: Whether the UI requests one replacement session.
         """
         self._session_desc = session_desc
         self._calls = calls
         self._length = length
+        self._request_replacement = request_replacement
         self._generated = 0
 
     def init(self) -> None:
         self._calls.append("session.init")
+        if self._request_replacement:
+            self.register_ui_loop(_ReplacementUILoop, state=self)
         self.register_model_loop(_ModelLoop, state=self)
 
     @property
@@ -88,11 +103,13 @@ class _Application(IApplication):
         fail_to_init: bool = False,
         fail_to_close: bool = False,
         session_length: int | None = None,
+        replace_first_session: bool = False,
     ) -> None:
         self._calls = calls
         self._fail_to_init = fail_to_init
         self._fail_to_close = fail_to_close
         self._session_length = session_length
+        self._replace_first_session = replace_first_session
         self.requested_session_descs: list[SessionDesc] = []
         self.sessions: list[_Session] = []
 
@@ -104,7 +121,12 @@ class _Application(IApplication):
     def create_session(self, session_desc: SessionDesc) -> ISession:
         self._calls.append("application.create_session")
         self.requested_session_descs.append(session_desc)
-        session = _Session(session_desc, self._calls, length=self._session_length)
+        session = _Session(
+            session_desc,
+            self._calls,
+            length=self._session_length,
+            request_replacement=self._replace_first_session and not self.sessions,
+        )
         self.sessions.append(session)
         return session
 
@@ -164,17 +186,21 @@ class _ClosingAfterWritesWindow(_SilentWindow):
         return UserInputEvents([])
 
 
-class _ReplacingWindow(_Window):
-    """Request one replacement, then close its session."""
+class _SecondSessionClosingWindow(_Window):
+    """Stay open for one replacement, then close its session."""
 
     def __init__(self, calls: list[str]) -> None:
         super().__init__(calls)
-        self._events = [NewSessionUserInputEvent, CloseUserInputEvent]
+        self._sessions_opened = 0
 
     def get_user_input_events(self) -> UserInputEvents:
-        if not self._events:
+        if self._sessions_opened < 2:
             return UserInputEvents([])
-        return UserInputEvents([self._events.pop(0)(timestamp=uint64(0))])
+        return super().get_user_input_events()
+
+    def open(self, session_desc: SessionDesc) -> None:
+        super().open(session_desc)
+        self._sessions_opened += 1
 
 
 class _MetricsSink:
@@ -296,8 +322,8 @@ def test_application_runner_keeps_metrics_output_separate_from_the_window() -> N
 
 def test_application_runner_replaces_a_session_before_closing_the_window() -> None:
     calls: list[str] = []
-    application = _Application(calls)
-    window = _ReplacingWindow(calls)
+    application = _Application(calls, replace_first_session=True)
+    window = _SecondSessionClosingWindow(calls)
     metrics = _MetricsSink(calls)
     session_desc = _session_desc()
 
@@ -340,8 +366,8 @@ def test_application_runner_closes_a_preserved_window_if_replacement_fails() -> 
 
     with pytest.raises(RuntimeError, match="replacement failed"):
         ApplicationRunner(
-            FailingReplacementApplication(calls),
-            _ReplacingWindow(calls),
+            FailingReplacementApplication(calls, replace_first_session=True),
+            _SecondSessionClosingWindow(calls),
         ).run(_session_desc())
 
     assert calls.count("application.create_session") == 2
@@ -360,8 +386,8 @@ def test_replacement_stops_if_per_session_metrics_fail_to_close() -> None:
 
     with pytest.raises(RuntimeError, match="metrics close failed"):
         ApplicationRunner(
-            _Application(calls),
-            _ReplacingWindow(calls),
+            _Application(calls, replace_first_session=True),
+            _SecondSessionClosingWindow(calls),
             metrics_output_sink=FailingMetricsSink(calls),
         ).run(_session_desc())
 

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -293,7 +293,7 @@ def test_application_runner_replaces_a_session_before_closing_the_window() -> No
     assert calls.count("metrics.open") == 2
     assert calls.count("metrics.close") == 2
     assert application.requested_session_descs == [session_desc, session_desc]
-    assert application.requested_session_descs[1] is not session_desc
+    assert application.requested_session_descs[1] is session_desc
     assert calls.count("application.init([])") == 1
     assert calls.count("application.close") == 1
 

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -148,6 +148,19 @@ class _SilentWindow(_Window):
         return UserInputEvents([])
 
 
+class _ClosingAfterWritesWindow(_SilentWindow):
+    """Close after receiving the expected model output."""
+
+    def __init__(self, calls: list[str], expected_writes: int) -> None:
+        super().__init__(calls)
+        self._expected_writes = expected_writes
+
+    def get_user_input_events(self) -> UserInputEvents:
+        if len(self.results) == self._expected_writes:
+            return _Window.get_user_input_events(self)
+        return UserInputEvents([])
+
+
 class _ReplacingWindow(_Window):
     """Request one replacement, then close its session."""
 
@@ -219,22 +232,24 @@ def test_application_runner_closes_both_when_the_run_never_starts() -> None:
     assert calls == ["application.init([])", "window.close", "application.close"]
 
 
-def test_application_runner_ends_a_run_a_window_cannot_end() -> None:
-    """A window with no client never reports a close, so the session ends it."""
+def test_application_runner_keeps_running_until_the_window_closes() -> None:
+    """Completing model inference does not bypass the client lifecycle."""
     calls: list[str] = []
-    window = _SilentWindow(calls)
+    window = _ClosingAfterWritesWindow(calls, 3)
 
     ApplicationRunner(_Application(calls, session_length=3), window).run(
         _session_desc()
     )
 
-    assert [result.step_index for result in window.results] == [0, 1, 2]
+    # The UI ticks once while inference is NOT_STARTED, then presents the three
+    # model frames on its following ticks.
+    assert [result.step_index for result in window.results] == [1, 2, 3]
     assert calls[-3:] == ["window.close", "session.close", "application.close"]
 
 
 def test_application_runner_keeps_metrics_output_separate_from_the_window() -> None:
     calls: list[str] = []
-    window = _SilentWindow(calls)
+    window = _ClosingAfterWritesWindow(calls, 2)
     metrics = _MetricsSink(calls)
 
     ApplicationRunner(
@@ -243,7 +258,7 @@ def test_application_runner_keeps_metrics_output_separate_from_the_window() -> N
         metrics_output_sink=metrics,
     ).run(_session_desc())
 
-    assert [result.step_index for result in window.results] == [0, 1]
+    assert [result.step_index for result in window.results] == [1, 2]
     assert [result.step_index for result in metrics.results] == [0, 1]
     assert calls.index("metrics.open") < calls.index("metrics.write(0)")
     assert calls.index("metrics.write(1)") < calls.index("metrics.close")

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -5,6 +5,7 @@
 
 import logging
 from collections.abc import Sequence
+from dataclasses import replace
 
 import pytest
 import torch
@@ -19,6 +20,7 @@ from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import (
     CloseUserInputEvent,
+    NewSessionUserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
@@ -91,6 +93,7 @@ class _Application(IApplication):
         self._fail_to_init = fail_to_init
         self._fail_to_close = fail_to_close
         self._session_length = session_length
+        self.requested_session_descs: list[SessionDesc] = []
 
     def init(self, commandline_args: Sequence[str]) -> None:
         self._calls.append(f"application.init({list(commandline_args)!r})")
@@ -99,6 +102,7 @@ class _Application(IApplication):
 
     def create_session(self, session_desc: SessionDesc) -> ISession:
         self._calls.append("application.create_session")
+        self.requested_session_descs.append(session_desc)
         return _Session(session_desc, self._calls, length=self._session_length)
 
     def close(self) -> None:
@@ -142,6 +146,19 @@ class _SilentWindow(_Window):
 
     def get_user_input_events(self) -> UserInputEvents:
         return UserInputEvents([])
+
+
+class _ReplacingWindow(_Window):
+    """Request one replacement, then close its session."""
+
+    def __init__(self, calls: list[str]) -> None:
+        super().__init__(calls)
+        self._events = [NewSessionUserInputEvent, CloseUserInputEvent]
+
+    def get_user_input_events(self) -> UserInputEvents:
+        if not self._events:
+            return UserInputEvents([])
+        return UserInputEvents([self._events.pop(0)(timestamp=uint64(0))])
 
 
 class _MetricsSink:
@@ -230,6 +247,107 @@ def test_application_runner_keeps_metrics_output_separate_from_the_window() -> N
     assert [result.step_index for result in metrics.results] == [0, 1]
     assert calls.index("metrics.open") < calls.index("metrics.write(0)")
     assert calls.index("metrics.write(1)") < calls.index("metrics.close")
+
+
+def test_application_runner_replaces_a_session_before_closing_the_window() -> None:
+    calls: list[str] = []
+    application = _Application(calls)
+    window = _ReplacingWindow(calls)
+    metrics = _MetricsSink(calls)
+    session_desc = _session_desc()
+
+    ApplicationRunner(
+        application,
+        window,
+        metrics_output_sink=metrics,
+    ).run(session_desc)
+
+    create_indexes = [
+        index
+        for index, call in enumerate(calls)
+        if call == "application.create_session"
+    ]
+    close_indexes = [
+        index for index, call in enumerate(calls) if call == "session.close"
+    ]
+    assert len(create_indexes) == 2
+    assert len(close_indexes) == 2
+    assert close_indexes[0] < create_indexes[1]
+    assert calls.count("window.open") == 2
+    assert calls.count("window.close") == 1
+    assert calls.count("metrics.open") == 2
+    assert calls.count("metrics.close") == 2
+    assert application.requested_session_descs == [session_desc, session_desc]
+    assert application.requested_session_descs[1] is not session_desc
+    assert calls.count("application.init([])") == 1
+    assert calls.count("application.close") == 1
+
+
+def test_application_runner_closes_a_preserved_window_if_replacement_fails() -> None:
+    calls: list[str] = []
+
+    class FailingReplacementApplication(_Application):
+        def create_session(self, session_desc: SessionDesc) -> ISession:
+            if calls.count("application.create_session") == 1:
+                calls.append("application.create_session")
+                raise RuntimeError("replacement failed")
+            return super().create_session(session_desc)
+
+    with pytest.raises(RuntimeError, match="replacement failed"):
+        ApplicationRunner(
+            FailingReplacementApplication(calls),
+            _ReplacingWindow(calls),
+        ).run(_session_desc())
+
+    assert calls.count("application.create_session") == 2
+    assert calls.count("session.close") == 1
+    assert calls.count("window.close") == 1
+    assert calls[-1] == "application.close"
+
+
+def test_replacement_stops_if_per_session_metrics_fail_to_close() -> None:
+    calls: list[str] = []
+
+    class FailingMetricsSink(_MetricsSink):
+        def close(self) -> None:
+            super().close()
+            raise RuntimeError("metrics close failed")
+
+    with pytest.raises(RuntimeError, match="metrics close failed"):
+        ApplicationRunner(
+            _Application(calls),
+            _ReplacingWindow(calls),
+            metrics_output_sink=FailingMetricsSink(calls),
+        ).run(_session_desc())
+
+    assert calls.count("application.create_session") == 1
+    assert calls.count("session.close") == 1
+    assert calls.count("window.close") == 1
+    assert calls[-1] == "application.close"
+
+
+def test_setup_failure_closes_every_runner_owned_resource() -> None:
+    calls: list[str] = []
+    bad_trace_desc = replace(
+        _session_desc(),
+        metadata={"trace_chunk_lifecycle": True},
+    )
+
+    with pytest.raises(TypeError, match="trace_chunk_lifecycle_path"):
+        ApplicationRunner(
+            _Application(calls),
+            _Window(calls),
+            metrics_output_sink=_MetricsSink(calls),
+        ).run(bad_trace_desc)
+
+    assert calls == [
+        "application.init([])",
+        "application.create_session",
+        "metrics.close",
+        "window.close",
+        "session.close",
+        "application.close",
+    ]
 
 
 def test_application_runner_reports_the_run_rather_than_the_close(

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -86,7 +86,7 @@ class _Session(ISession):
         self._generated += 1
         return StepResult(
             step_index=step_index,
-            output=torch.zeros((1, 3, 1, 2, 2)),
+            output=torch.full((1, 3, 1, 2, 2), step_index),
             frame_count=1,
             output_layout=VideoTensorLayout.bcthw,
         )
@@ -270,9 +270,9 @@ def test_application_runner_keeps_running_until_the_window_closes() -> None:
         _session_desc()
     )
 
-    # The UI ticks once while inference is NOT_STARTED, then presents the three
-    # model frames on its following ticks.
-    assert [result.step_index for result in window.results] == [1, 2, 3]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1, 2]
     assert calls[-3:] == ["window.close", "session.close", "application.close"]
 
 
@@ -314,7 +314,9 @@ def test_application_runner_keeps_metrics_output_separate_from_the_window() -> N
         metrics_output_sink=metrics,
     ).run(_session_desc())
 
-    assert [result.step_index for result in window.results] == [1, 2]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1]
     assert [result.step_index for result in metrics.results] == [0, 1]
     assert calls.index("metrics.open") < calls.index("metrics.write(0)")
     assert calls.index("metrics.write(1)") < calls.index("metrics.close")

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -94,6 +94,7 @@ class _Application(IApplication):
         self._fail_to_close = fail_to_close
         self._session_length = session_length
         self.requested_session_descs: list[SessionDesc] = []
+        self.sessions: list[_Session] = []
 
     def init(self, commandline_args: Sequence[str]) -> None:
         self._calls.append(f"application.init({list(commandline_args)!r})")
@@ -103,7 +104,9 @@ class _Application(IApplication):
     def create_session(self, session_desc: SessionDesc) -> ISession:
         self._calls.append("application.create_session")
         self.requested_session_descs.append(session_desc)
-        return _Session(session_desc, self._calls, length=self._session_length)
+        session = _Session(session_desc, self._calls, length=self._session_length)
+        self.sessions.append(session)
+        return session
 
     def close(self) -> None:
         self._calls.append("application.close")
@@ -245,6 +248,33 @@ def test_application_runner_keeps_running_until_the_window_closes() -> None:
     # model frames on its following ticks.
     assert [result.step_index for result in window.results] == [1, 2, 3]
     assert calls[-3:] == ["window.close", "session.close", "application.close"]
+
+
+def test_application_timeout_signals_the_session_and_closes_everything() -> None:
+    calls: list[str] = []
+    application = _Application(calls)
+
+    ApplicationRunner(application, _SilentWindow(calls)).run(
+        _session_desc(),
+        timeout_seconds=0.02,
+    )
+
+    assert len(application.sessions) == 1
+    assert application.sessions[0]._shutdown_event.is_set()
+    assert calls[-3:] == ["window.close", "session.close", "application.close"]
+
+
+@pytest.mark.parametrize("timeout", [0.0, -1.0, float("nan"), float("inf")])
+def test_application_timeout_must_be_positive_and_finite(timeout: float) -> None:
+    calls: list[str] = []
+
+    with pytest.raises(ValueError, match="finite and greater than zero"):
+        ApplicationRunner(_Application(calls), _SilentWindow(calls)).run(
+            _session_desc(),
+            timeout_seconds=timeout,
+        )
+
+    assert calls == []
 
 
 def test_application_runner_keeps_metrics_output_separate_from_the_window() -> None:

--- a/flashdreams/test_v2/test_imgui_ui_renderer.py
+++ b/flashdreams/test_v2/test_imgui_ui_renderer.py
@@ -20,6 +20,7 @@ from flashdreams.runtime_v2.imgui_ui_renderer import (
     _route_imgui_input_events,
 )
 from flashdreams.runtime_v2.presentation_manager import PresentationManager
+from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import (
     KeyboardInputState,
@@ -168,7 +169,7 @@ def test_imgui_loop_composites_over_the_presented_model_frame() -> None:
         failure_queue=queue.Queue(),
     )
     loop.register_session_ui_loop_objects(
-        output_layout=VideoTensorLayout.tchw,
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
         presentation_manager=presentation,
     )
 

--- a/flashdreams/test_v2/test_metrics_output_sink.py
+++ b/flashdreams/test_v2/test_metrics_output_sink.py
@@ -213,6 +213,23 @@ def test_closing_twice_writes_once(tmp_path: Path) -> None:
     assert path.read_text(encoding="utf-8") == written
 
 
+def test_reopening_the_sink_replaces_the_previous_session_record(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "stats_run.json"
+    sink = MetricsOutputSink(path)
+    sink.open(_session_desc())
+    sink.write(_result(0, {"total_ms": 10.0}))
+    sink.close()
+
+    sink.open(_session_desc())
+    sink.write(_result(7, {"total_ms": 20.0}))
+    sink.close()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert [step["step_index"] for step in payload["steps"]] == [7]
+
+
 def test_nothing_can_be_recorded_before_a_session_is_open(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="open.. must run before write"):
         MetricsOutputSink(tmp_path / "stats_run.json").write(_result())

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -44,7 +44,6 @@ from flashdreams.runtime_v2.user_input_event import (
     CloseUserInputEvent,
     KeyboardInputState,
     KeyboardUserInputEvent,
-    NewSessionUserInputEvent,
     ResetUserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
@@ -1066,41 +1065,25 @@ def test_run_session_stops_when_the_window_reports_a_close(
     assert log.calls[-2:] == ["window.close", "session.close"]
 
 
-def test_run_session_returns_a_replacement_after_cleaning_the_session() -> None:
+def test_run_session_returns_a_ui_requested_replacement_after_cleanup() -> None:
     log = CallLog()
     resolved = replace(_session_desc(), metadata={"application": "value"})
-    session = FakeSession(resolved, log)
-    window = RecordingClientWindow(
-        log,
-        [_lifecycle_event(NewSessionUserInputEvent)],
-    )
+    replacement = replace(resolved, metadata={"application": "replacement"})
+
+    class RequestingSession(FakeSession):
+        def init(self) -> None:
+            super().init()
+            self.ui_loop.request_new_session(replacement)
+
+    session = RequestingSession(resolved, log)
+    window = RecordingClientWindow(log)
 
     next_session_desc = run_session(session, window, steps=None)
 
-    assert next_session_desc is not None
-    assert next_session_desc == resolved
-    assert next_session_desc is resolved
+    assert next_session_desc == replacement
+    assert next_session_desc is replacement
     assert "session.step(0)" not in log.calls
     assert log.calls[-1] == "session.close"
-    assert "window.close" not in log.calls
-
-
-def test_run_session_polls_for_a_replacement_after_the_final_frame() -> None:
-    log = CallLog()
-
-    class RequestingWindow(RecordingClientWindow):
-        def write(self, result: StepResult) -> None:
-            super().write(result)
-            with self._lock:
-                self._scripted.append(_lifecycle_event(NewSessionUserInputEvent))
-
-    session = FiniteSession(_session_desc(), log, length=1)
-    window = RequestingWindow(log)
-
-    next_session_desc = run_session(session, window, steps=None)
-
-    assert next_session_desc == session.session_desc
-    assert [result.step_index for result in window.results] == [1]
     assert "window.close" not in log.calls
 
 
@@ -1160,49 +1143,37 @@ def test_interactive_ui_can_replace_an_already_finished_session() -> None:
     assert log.calls[-1] == "session.close"
 
 
-@pytest.mark.parametrize(
-    ("events", "expects_replacement"),
-    [
-        (
-            [
-                CloseUserInputEvent(timestamp=uint64(0)),
-                NewSessionUserInputEvent(timestamp=uint64(1)),
-            ],
-            True,
-        ),
-        (
-            [
-                NewSessionUserInputEvent(timestamp=uint64(0)),
-                CloseUserInputEvent(timestamp=uint64(1)),
-            ],
-            False,
-        ),
-    ],
-)
-def test_latest_session_transition_in_a_batch_wins(
-    events: list[UserInputEvent],
-    expects_replacement: bool,
-) -> None:
+def test_close_event_wins_over_a_ui_new_session_request() -> None:
     log = CallLog()
     resolved = _session_desc()
-    window = RecordingClientWindow(log, [UserInputEvents(events)])
 
-    next_session_desc = run_session(FakeSession(resolved, log), window)
+    class RequestingSession(FakeSession):
+        def init(self) -> None:
+            super().init()
+            self.ui_loop.request_new_session(resolved)
 
-    assert (next_session_desc is not None) is expects_replacement
-    if next_session_desc is not None:
-        assert next_session_desc == resolved
-        assert next_session_desc is resolved
-    assert ("window.close" not in log.calls) is expects_replacement
+    window = RecordingClientWindow(
+        log,
+        [_lifecycle_event(CloseUserInputEvent)],
+    )
+
+    next_session_desc = run_session(RequestingSession(resolved, log), window)
+
+    assert next_session_desc is None
+    assert "window.close" in log.calls
 
 
 def test_replacement_request_closes_the_window_when_session_cleanup_fails() -> None:
     log = CallLog()
-    session = FakeSession(_session_desc(), log, fail_to_close=True)
-    window = RecordingClientWindow(
-        log,
-        [_lifecycle_event(NewSessionUserInputEvent)],
-    )
+    resolved = _session_desc()
+
+    class RequestingSession(FakeSession):
+        def init(self) -> None:
+            super().init()
+            self.ui_loop.request_new_session(resolved)
+
+    session = RequestingSession(resolved, log, fail_to_close=True)
+    window = RecordingClientWindow(log)
 
     with pytest.raises(RuntimeError, match="session close failed"):
         run_session(session, window)

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -553,7 +553,12 @@ def test_run_session_presents_every_step_in_order() -> None:
 
     run_session(session, window, steps=3)
 
-    assert [result.step_index for result in window.results] == [1, 2, 3]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1, 2]
+    assert [result.step_index for result in window.results] == sorted(
+        result.step_index for result in window.results
+    )
     assert window.results[-1] is session.ui_loop.latest_result
     steps = [call for call in log.calls if call.startswith("session.step(")]
     assert steps == ["session.step(0)", "session.step(1)", "session.step(2)"]
@@ -931,7 +936,9 @@ def test_default_ui_does_not_redraw_an_unchanged_model_frame() -> None:
 
     run_session(session, window, steps=3)
 
-    assert [result.step_index for result in window.results] == [1, 2, 3]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1, 2]
 
 
 def test_drop_oldest_finishes_active_chunk_before_newest_waiting_chunk() -> None:
@@ -1031,14 +1038,30 @@ def test_run_session_gives_the_first_step_input_already_collected() -> None:
     assert len(session.observed_events[0].get_events()) == 1
 
 
-def test_run_session_stops_when_the_window_reports_a_close() -> None:
+def test_run_session_stops_when_the_window_reports_a_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     log = CallLog()
     session = FakeSession(_session_desc(), log)
     window = RecordingClientWindow(log, [_lifecycle_event(CloseUserInputEvent)])
+    completed: list[bool] = []
+    original_finish = FakeUILoop._finish_run
+
+    def record_finish(
+        self: FakeUILoop,
+        result: StepResult | list[StepResult] | None,
+        *,
+        step_completed: bool,
+    ) -> None:
+        completed.append(step_completed)
+        original_finish(self, result, step_completed=step_completed)
+
+    monkeypatch.setattr(FakeUILoop, "_finish_run", record_finish)
 
     # No step count at all: the close is the only thing that ends this run.
     run_session(session, window, steps=None)
 
+    assert completed == [False]
     assert "session.step(0)" not in log.calls
     assert log.calls[-2:] == ["window.close", "session.close"]
 
@@ -1201,7 +1224,9 @@ def test_run_session_resets_the_session_and_the_step_index() -> None:
     assert calls == ["session.reset", "session.step(0)", "session.step(1)"]
     assert log.calls.index("session.reset") < log.calls.index("session.step(0)")
     # A reset restarts both loops without granting extra model steps.
-    assert [result.step_index for result in window.results] == [1, 2]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1]
 
 
 def test_run_session_keeps_the_ui_alive_after_model_inference_finishes() -> None:
@@ -1219,7 +1244,9 @@ def test_run_session_keeps_the_ui_alive_after_model_inference_finishes() -> None
 
     run_session(session, window, steps=None)
 
-    assert [result.step_index for result in window.results] == [1, 2]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1]
     assert session.is_finished()
 
 
@@ -1231,7 +1258,9 @@ def test_run_session_ends_at_whichever_comes_first() -> None:
 
     run_session(session, window, steps=2)
 
-    assert [result.step_index for result in window.results] == [1, 2]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1]
 
 
 def test_run_session_lets_a_reset_restart_a_finished_session() -> None:
@@ -1338,7 +1367,9 @@ def test_run_session_drops_a_result_the_reset_interrupted() -> None:
     # what it produced belongs to a generation nobody is watching any more. Only
     # the step from after the reset reaches the window.
     assert log.calls.count("session.step(0)") == 2
-    assert [result.step_index for result in window.results] == [0]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0]
 
 
 def test_equality_eval_preserves_every_frame_when_model_is_faster() -> None:
@@ -1495,16 +1526,32 @@ def test_run_session_with_no_steps_still_opens_and_closes() -> None:
     assert window.results == []
 
 
-def test_run_session_closes_both_when_a_step_raises() -> None:
+def test_run_session_closes_both_when_a_step_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     log = CallLog()
     session = FakeSession(_session_desc(), log, fail_at=1)
     window = RecordingClientWindow(log)
+    completed: list[bool] = []
+    original_finish = FakeModelLoop._finish_run
+
+    def record_finish(
+        self: FakeModelLoop,
+        result: StepResult | list[StepResult] | None,
+        *,
+        step_completed: bool,
+    ) -> None:
+        completed.append(step_completed)
+        original_finish(self, result, step_completed=step_completed)
+
+    monkeypatch.setattr(FakeModelLoop, "_finish_run", record_finish)
 
     with pytest.raises(RuntimeError, match="step failed"):
         run_session(session, window, steps=4)
 
     # A failed step must not leak the window or the session, and must not be
     # presented as a result.
+    assert completed == [True, False]
     assert log.calls[-2:] == ["window.close", "session.close"]
     assert [result.step_index for result in window.results] == [1]
 
@@ -1519,7 +1566,9 @@ def test_run_session_reports_a_window_that_fails_to_close() -> None:
     with pytest.raises(RuntimeError, match="close failed"):
         run_session(session, window, steps=2)
 
-    assert [result.step_index for result in window.results] == [1, 2]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1]
     assert log.calls[-2:] == ["window.close", "session.close"]
 
 
@@ -1565,7 +1614,9 @@ def test_run_session_reports_a_session_that_fails_to_close() -> None:
     with pytest.raises(RuntimeError, match="session close failed"):
         run_session(session, window, steps=2)
 
-    assert [result.step_index for result in window.results] == [1, 2]
+    assert [
+        result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
+    ] == [0, 1]
 
 
 def test_run_session_reports_the_step_rather_than_the_session_close(

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -9,6 +9,7 @@ import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import replace
 
 import pytest
 import torch
@@ -38,6 +39,7 @@ from flashdreams.runtime_v2.user_input_event import (
     CloseUserInputEvent,
     KeyboardInputState,
     KeyboardUserInputEvent,
+    NewSessionUserInputEvent,
     ResetUserInputEvent,
 )
 from flashdreams.runtime_v2.user_input_events import UserInputEvents
@@ -1030,6 +1032,95 @@ def test_run_session_stops_when_the_window_reports_a_close() -> None:
     assert log.calls[-2:] == ["window.close", "session.close"]
 
 
+def test_run_session_returns_a_replacement_after_cleaning_the_session() -> None:
+    log = CallLog()
+    resolved = replace(_session_desc(), metadata={"application": "value"})
+    session = FakeSession(resolved, log)
+    window = RecordingClientWindow(
+        log,
+        [_lifecycle_event(NewSessionUserInputEvent)],
+    )
+
+    next_session_desc = run_session(session, window, steps=None)
+
+    assert next_session_desc is not None
+    assert next_session_desc == resolved
+    assert next_session_desc is not resolved
+    assert next_session_desc.metadata is not resolved.metadata
+    assert "session.step(0)" not in log.calls
+    assert log.calls[-1] == "session.close"
+    assert "window.close" not in log.calls
+
+
+def test_run_session_polls_for_a_replacement_after_the_final_frame() -> None:
+    log = CallLog()
+
+    class RequestingWindow(RecordingClientWindow):
+        def write(self, result: StepResult) -> None:
+            super().write(result)
+            with self._lock:
+                self._scripted.append(_lifecycle_event(NewSessionUserInputEvent))
+
+    session = FiniteSession(_session_desc(), log, length=1)
+    window = RequestingWindow(log)
+
+    next_session_desc = run_session(session, window, steps=None)
+
+    assert next_session_desc == session.session_desc
+    assert [result.step_index for result in window.results] == [0]
+    assert "window.close" not in log.calls
+
+
+@pytest.mark.parametrize(
+    ("events", "expects_replacement"),
+    [
+        (
+            [
+                CloseUserInputEvent(timestamp=uint64(0)),
+                NewSessionUserInputEvent(timestamp=uint64(1)),
+            ],
+            True,
+        ),
+        (
+            [
+                NewSessionUserInputEvent(timestamp=uint64(0)),
+                CloseUserInputEvent(timestamp=uint64(1)),
+            ],
+            False,
+        ),
+    ],
+)
+def test_latest_session_transition_in_a_batch_wins(
+    events: list[UserInputEvent],
+    expects_replacement: bool,
+) -> None:
+    log = CallLog()
+    resolved = _session_desc()
+    window = RecordingClientWindow(log, [UserInputEvents(events)])
+
+    next_session_desc = run_session(FakeSession(resolved, log), window)
+
+    assert (next_session_desc is not None) is expects_replacement
+    if next_session_desc is not None:
+        assert next_session_desc == resolved
+        assert next_session_desc is not resolved
+    assert ("window.close" not in log.calls) is expects_replacement
+
+
+def test_replacement_request_closes_the_window_when_session_cleanup_fails() -> None:
+    log = CallLog()
+    session = FakeSession(_session_desc(), log, fail_to_close=True)
+    window = RecordingClientWindow(
+        log,
+        [_lifecycle_event(NewSessionUserInputEvent)],
+    )
+
+    with pytest.raises(RuntimeError, match="session close failed"):
+        run_session(session, window)
+
+    assert log.calls[-2:] == ["session.close", "window.close"]
+
+
 def test_run_session_resets_the_session_and_the_step_index() -> None:
     log = CallLog()
     session = FakeSession(_session_desc(), log)
@@ -1097,9 +1188,9 @@ def test_run_session_closes_a_session_that_failed_to_init() -> None:
     with pytest.raises(RuntimeError, match="init failed"):
         run_session(session, window, steps=1)
 
-    # A session that got halfway through starting still has to be released, and
-    # the window is never opened for a session that cannot run.
-    assert log.calls == ["session.init", "session.close"]
+    # A session that got halfway through starting still has to be released. The
+    # window may already serve a remote client even though open was not reached.
+    assert log.calls == ["session.init", "window.close", "session.close"]
 
 
 def test_run_session_gives_the_step_after_a_reset_the_whole_batch() -> None:

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -16,7 +16,12 @@ import torch
 from numpy import uint64
 
 from flashdreams.api_v2.client_window import IClientWindow
-from flashdreams.api_v2.loop import IModelLoop, IUILoop, invoke_async
+from flashdreams.api_v2.loop import (
+    IModelLoop,
+    IUILoop,
+    ModelInferenceState,
+    invoke_async,
+)
 from flashdreams.api_v2.session import ISession
 from flashdreams.api_v2.user_input_event import UserInputEvent
 from flashdreams.runtime_v2.blit_model_output_to_screen_loop import (
@@ -321,6 +326,8 @@ class FakeSession(ISession):
         self._release_writes = release_writes
         self._release_writes_at = release_writes_at
         self.observed_events: list[UserInputEvents] = []
+        self.ui_steps = 0
+        self.ui_model_states: list[ModelInferenceState] = []
 
     def init(self) -> None:
         self._log.record("session.init")
@@ -544,7 +551,7 @@ def test_run_session_presents_every_step_in_order() -> None:
 
     run_session(session, window, steps=3)
 
-    assert [result.step_index for result in window.results] == [0, 1, 2]
+    assert [result.step_index for result in window.results] == [1, 2, 3]
     assert window.results[-1] is session.ui_loop.latest_result
     steps = [call for call in log.calls if call.startswith("session.step(")]
     assert steps == ["session.step(0)", "session.step(1)", "session.step(2)"]
@@ -560,7 +567,7 @@ def test_run_session_opens_before_writing_and_closes_after() -> None:
     calls = log.calls
     # Interleaving between the threads varies, but these orderings cannot.
     assert calls[0] == "session.init"
-    assert calls.index("window.open") < calls.index("window.write(0)")
+    assert calls.index("window.open") < calls.index("window.write(1)")
     assert calls[-2:] == ["window.close", "session.close"]
 
 
@@ -575,7 +582,7 @@ def test_run_session_touches_the_window_only_from_the_ui_thread() -> None:
     ui_thread_name = threading.current_thread().name
     for call in ("window.open", "window.get_user_input_events", "window.close"):
         assert log.threads_for(call) == {ui_thread_name}
-    assert log.threads_for("window.write(0)") == {ui_thread_name}
+    assert log.threads_for("window.write(1)") == {ui_thread_name}
 
 
 def test_run_session_calls_ui_run_on_the_ui_thread() -> None:
@@ -600,6 +607,7 @@ def test_continuous_ui_processes_input_while_model_generation_waits() -> None:
             return super().step(step_index, events)
 
         def run_ui(self, step_index: int, events: UserInputEvents) -> StepResult | None:
+            self.ui_model_states.append(self.ui_loop.model_inference_state)
             if events.get_events():
                 input_processed.set()
             return super().run_ui(step_index, events)
@@ -620,6 +628,7 @@ def test_continuous_ui_processes_input_while_model_generation_waits() -> None:
     run_session(session, window, steps=1)
 
     assert input_processed.is_set()
+    assert ModelInferenceState.RUNNING in session.ui_model_states
     assert "ui_loop.step" in log.calls
 
 
@@ -920,7 +929,7 @@ def test_default_ui_does_not_redraw_an_unchanged_model_frame() -> None:
 
     run_session(session, window, steps=3)
 
-    assert [result.step_index for result in window.results] == [0, 1, 2]
+    assert [result.step_index for result in window.results] == [1, 2, 3]
 
 
 def test_drop_oldest_finishes_active_chunk_before_newest_waiting_chunk() -> None:
@@ -1067,8 +1076,54 @@ def test_run_session_polls_for_a_replacement_after_the_final_frame() -> None:
     next_session_desc = run_session(session, window, steps=None)
 
     assert next_session_desc == session.session_desc
-    assert [result.step_index for result in window.results] == [0]
+    assert [result.step_index for result in window.results] == [1]
     assert "window.close" not in log.calls
+
+
+def test_interactive_ui_can_replace_an_already_finished_session() -> None:
+    log = CallLog()
+
+    class RequestingUILoop(FakeUILoop):
+        def step(self, step_index: int, events: UserInputEvents) -> StepResult | None:
+            self.state.ui_model_states.append(self.model_inference_state)
+            self.state.ui_steps += 1
+            if self.state.ui_steps == 2:
+                self.request_new_session({"prompt": "a new prompt"})
+                return StepResult(
+                    step_index=step_index,
+                    output=torch.zeros((1, 3, 1, 2, 2)),
+                    frame_count=1,
+                    output_layout=self.state.session_desc.output_layout,
+                )
+            return super().step(step_index, events)
+
+    class RequestingSession(FiniteSession):
+        def init(self) -> None:
+            self._log.record("session.init")
+            self.register_ui_loop(RequestingUILoop, state=self)
+            self.register_model_loop(FakeModelLoop, state=self)
+
+    resolved = replace(
+        _session_desc(presentation_mode=PresentationMode.ON_DEMAND),
+        metadata={"existing": "value"},
+    )
+    session = RequestingSession(resolved, log, length=0)
+    window = RecordingClientWindow(log)
+
+    next_session_desc = run_session(session, window)
+
+    assert next_session_desc == replace(
+        resolved,
+        metadata={"existing": "value", "prompt": "a new prompt"},
+    )
+    assert session.ui_steps == 2
+    assert session.ui_model_states == [
+        ModelInferenceState.NOT_STARTED,
+        ModelInferenceState.FINISHED,
+    ]
+    assert len(window.results) == 1
+    assert "window.close" not in log.calls
+    assert log.calls[-1] == "session.close"
 
 
 @pytest.mark.parametrize(
@@ -1135,18 +1190,26 @@ def test_run_session_resets_the_session_and_the_step_index() -> None:
     assert calls == ["session.reset", "session.step(0)", "session.step(1)"]
     assert log.calls.index("session.reset") < log.calls.index("session.step(0)")
     # A reset restarts both loops without granting extra model steps.
-    assert [result.step_index for result in window.results] == [0, 1]
+    assert [result.step_index for result in window.results] == [1, 2]
 
 
-def test_run_session_stops_when_the_session_says_it_has_finished() -> None:
-    """A model that knows its own length ends its own run, uncounted."""
+def test_run_session_keeps_the_ui_alive_after_model_inference_finishes() -> None:
+    """Model completion alone does not end an interactive session."""
     log = CallLog()
     session = FiniteSession(_session_desc(), log, length=2)
-    window = RecordingClientWindow(log)
+
+    class ClosingAfterFinalFrame(RecordingClientWindow):
+        def get_user_input_events(self) -> UserInputEvents:
+            if len(self.results) == 2:
+                return _lifecycle_event(CloseUserInputEvent)
+            return super().get_user_input_events()
+
+    window = ClosingAfterFinalFrame(log)
 
     run_session(session, window, steps=None)
 
-    assert [result.step_index for result in window.results] == [0, 1]
+    assert [result.step_index for result in window.results] == [1, 2]
+    assert session.is_finished()
 
 
 def test_run_session_ends_at_whichever_comes_first() -> None:
@@ -1157,7 +1220,7 @@ def test_run_session_ends_at_whichever_comes_first() -> None:
 
     run_session(session, window, steps=2)
 
-    assert [result.step_index for result in window.results] == [0, 1]
+    assert [result.step_index for result in window.results] == [1, 2]
 
 
 def test_run_session_lets_a_reset_restart_a_finished_session() -> None:
@@ -1170,7 +1233,7 @@ def test_run_session_lets_a_reset_restart_a_finished_session() -> None:
 
     # Finished before the run began, so without the reset nothing would be
     # generated. It is applied before the session runs its length again.
-    assert [result.step_index for result in window.results] == [0]
+    assert [result.step_index for result in window.results] == [1]
     assert "session.reset" in log.calls
 
 
@@ -1274,7 +1337,7 @@ def test_equality_eval_preserves_every_frame_when_model_is_faster() -> None:
 
     run_session(session, window, steps=4)
 
-    assert [result.step_index for result in window.results] == [0, 1, 2, 3]
+    assert [result.step_index for result in window.results] == [1, 2, 3, 4]
     assert [
         result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
     ] == [0, 1, 2, 3]
@@ -1327,13 +1390,13 @@ def test_ui_stall_does_not_burst_multiple_frames_per_input_tick() -> None:
     assert max(writes_per_input_tick) == 1
 
 
-def test_on_demand_runs_ui_once_per_new_frame() -> None:
+def test_on_demand_runs_ui_before_inference_and_once_per_new_frame() -> None:
     log = CallLog()
     session = FakeSession(_session_desc(ui_fps=1_000, model_fps=20), log)
     window = RecordingClientWindow(log)
     run_session(session, window, steps=3)
 
-    assert log.calls.count("ui_loop.step") == 3
+    assert log.calls.count("ui_loop.step") == 4
     assert [
         result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
     ] == [0, 1, 2]
@@ -1432,7 +1495,7 @@ def test_run_session_closes_both_when_a_step_raises() -> None:
     # A failed step must not leak the window or the session, and must not be
     # presented as a result.
     assert log.calls[-2:] == ["window.close", "session.close"]
-    assert [result.step_index for result in window.results] == [0]
+    assert [result.step_index for result in window.results] == [1]
 
 
 def test_run_session_reports_a_window_that_fails_to_close() -> None:
@@ -1445,7 +1508,7 @@ def test_run_session_reports_a_window_that_fails_to_close() -> None:
     with pytest.raises(RuntimeError, match="close failed"):
         run_session(session, window, steps=2)
 
-    assert [result.step_index for result in window.results] == [0, 1]
+    assert [result.step_index for result in window.results] == [1, 2]
     assert log.calls[-2:] == ["window.close", "session.close"]
 
 
@@ -1491,7 +1554,7 @@ def test_run_session_reports_a_session_that_fails_to_close() -> None:
     with pytest.raises(RuntimeError, match="session close failed"):
         run_session(session, window, steps=2)
 
-    assert [result.step_index for result in window.results] == [0, 1]
+    assert [result.step_index for result in window.results] == [1, 2]
 
 
 def test_run_session_reports_the_step_rather_than_the_session_close(

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -223,6 +223,7 @@ def test_model_loop_excludes_publish_stalls_from_step_timing(
         shutdown_event=threading.Event(),
         failure_queue=failure_queue,
     )
+    assert model_loop.inference_state is ModelInferenceState.NOT_STARTED
     event_buffer = EventBuffer()
     event_buffer.register(0)
     step_timings: list[float] = []
@@ -246,6 +247,7 @@ def test_model_loop_excludes_publish_stalls_from_step_timing(
 
     assert failure_queue.empty()
     assert step_timings == pytest.approx([0.9, 0.9])
+    assert model_loop.inference_state is ModelInferenceState.FINISHED
 
 
 class CallLog:

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -707,6 +707,49 @@ def test_default_ui_composites_channels_and_holds_the_latest_frame() -> None:
     assert ui.step(2, UserInputEvents([])) is None
 
 
+def test_default_ui_finishes_only_after_drawing_the_final_model_frame() -> None:
+    manager = PresentationManager(device=torch.device("cpu"))
+    stop = threading.Event()
+    failures: queue.Queue[BaseException] = queue.Queue()
+    model = FakeModelLoop()
+    model.register_session_loop_objects(
+        state=FakeSession(_session_desc(), CallLog()),
+        frequency=30,
+        shutdown_event=stop,
+        failure_queue=failures,
+    )
+    ui = BlitModelOutputToScreenLoop()
+    ui.register_session_loop_objects(
+        state=None,
+        frequency=30,
+        shutdown_event=stop,
+        failure_queue=failures,
+    )
+    ui.register_session_ui_loop_objects(
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
+        presentation_manager=manager,
+    )
+    ui._set_model_loop(model)
+    manager.publish(
+        0,
+        [
+            StepResult(
+                step_index=0,
+                output=torch.zeros((1, 3, 1, 1)),
+                frame_count=1,
+                output_layout=VideoTensorLayout.tchw,
+            )
+        ],
+    )
+    model._set_inference_state(ModelInferenceState.FINISHED)
+
+    assert not ui.is_finished()
+    assert manager.advance(0, now=1.0)[0]
+    assert not ui.is_finished()
+    assert ui.step(0, UserInputEvents([])) is not None
+    assert ui.is_finished()
+
+
 def test_presentation_manager_defaults_to_one_pending_chunk() -> None:
     manager = PresentationManager(device=torch.device("cpu"))
 

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -686,7 +686,7 @@ def test_default_ui_composites_channels_and_holds_the_latest_frame() -> None:
     )
     ui = BlitModelOutputToScreenLoop()
     ui.register_session_ui_loop_objects(
-        output_layout=VideoTensorLayout.tchw,
+        session_desc=SessionDesc(output_layout=VideoTensorLayout.tchw),
         presentation_manager=manager,
     )
 
@@ -1056,8 +1056,7 @@ def test_run_session_returns_a_replacement_after_cleaning_the_session() -> None:
 
     assert next_session_desc is not None
     assert next_session_desc == resolved
-    assert next_session_desc is not resolved
-    assert next_session_desc.metadata is not resolved.metadata
+    assert next_session_desc is resolved
     assert "session.step(0)" not in log.calls
     assert log.calls[-1] == "session.close"
     assert "window.close" not in log.calls
@@ -1090,7 +1089,16 @@ def test_interactive_ui_can_replace_an_already_finished_session() -> None:
             self.state.ui_model_states.append(self.model_inference_state)
             self.state.ui_steps += 1
             if self.state.ui_steps == 2:
-                self.request_new_session({"prompt": "a new prompt"})
+                self.request_new_session(
+                    replace(
+                        self.session_desc,
+                        video_width=4,
+                        metadata={
+                            **self.session_desc.metadata,
+                            "prompt": "a new prompt",
+                        },
+                    )
+                )
                 return StepResult(
                     step_index=step_index,
                     output=torch.zeros((1, 3, 1, 2, 2)),
@@ -1116,6 +1124,7 @@ def test_interactive_ui_can_replace_an_already_finished_session() -> None:
 
     assert next_session_desc == replace(
         resolved,
+        video_width=4,
         metadata={"existing": "value", "prompt": "a new prompt"},
     )
     assert session.ui_steps == 2
@@ -1160,7 +1169,7 @@ def test_latest_session_transition_in_a_batch_wins(
     assert (next_session_desc is not None) is expects_replacement
     if next_session_desc is not None:
         assert next_session_desc == resolved
-        assert next_session_desc is not resolved
+        assert next_session_desc is resolved
     assert ("window.close" not in log.calls) is expects_replacement
 
 

--- a/flashdreams/test_v2/test_webrtc_client_window.py
+++ b/flashdreams/test_v2/test_webrtc_client_window.py
@@ -115,6 +115,12 @@ async def _connect_browser(
 @pytest.mark.asyncio
 async def test_window_buffers_browser_events_until_drained() -> None:
     window = WebRTCClientWindow()
+    server_loop = window.server._loop
+    assert server_loop is not None
+    assert (
+        server_loop.get_exception_handler()
+        is webrtc_server._handle_webrtc_loop_exception
+    )
     assert window.metrics_snapshot() == {
         "webrtc_sender_queue_depth_count": 0,
         "webrtc_sender_queue_capacity_count": 2,
@@ -292,6 +298,31 @@ async def test_window_buffers_browser_events_until_drained() -> None:
         if peer is not None:
             await peer.close()
         window.close()
+
+
+def test_webrtc_loop_suppresses_only_the_aioice_completed_retry_race() -> None:
+    loop = Mock(spec=asyncio.AbstractEventLoop)
+    context: dict[str, Any] = {
+        "message": webrtc_server._AIOICE_COMPLETED_RETRY_MESSAGE,
+        "exception": asyncio.InvalidStateError("invalid state"),
+        "handle": Mock(spec=asyncio.TimerHandle),
+    }
+
+    webrtc_server._handle_webrtc_loop_exception(loop, context)
+
+    loop.default_exception_handler.assert_not_called()
+
+    near_matches = (
+        {**context, "exception": RuntimeError("invalid state")},
+        {**context, "message": "Exception in callback another retry"},
+        {**context, "handle": Mock(spec=asyncio.Handle)},
+    )
+    for near_match in near_matches:
+        loop.reset_mock()
+
+        webrtc_server._handle_webrtc_loop_exception(loop, near_match)
+
+        loop.default_exception_handler.assert_called_once_with(near_match)
 
 
 @pytest.mark.asyncio

--- a/flashdreams/test_v2/test_webrtc_client_window.py
+++ b/flashdreams/test_v2/test_webrtc_client_window.py
@@ -413,6 +413,40 @@ async def test_browser_can_reconnect_without_restarting_the_server() -> None:
 
 
 @pytest.mark.asyncio
+async def test_malformed_offer_does_not_replace_the_active_browser() -> None:
+    window = WebRTCClientWindow()
+    peer: RTCPeerConnection | None = None
+    try:
+        window.open(_session_desc())
+        peer, _, _ = await _connect_browser(window)
+        server_peer = window.server._peer_connection
+        server_track = window.server._video_track
+        assert server_peer is not None
+        assert server_track is not None
+
+        async with ClientSession() as client:
+            async with client.post(
+                f"{window.server.url}api/webrtc/offer",
+                data="{",
+                headers={"Content-Type": "application/json"},
+            ) as response:
+                assert response.status == 400
+            async with client.post(
+                f"{window.server.url}api/webrtc/offer",
+                json={"sdp": "not an SDP", "type": "offer"},
+            ) as response:
+                assert response.status == 400
+
+        assert window.server._peer_connection is server_peer
+        assert window.server._video_track is server_track
+        assert peer.connectionState == "connected"
+    finally:
+        if peer is not None:
+            await peer.close()
+        window.close()
+
+
+@pytest.mark.asyncio
 async def test_write_delivers_a_video_frame_to_the_browser() -> None:
     window = WebRTCClientWindow()
     peer: RTCPeerConnection | None = None

--- a/flashdreams/test_v2/test_webrtc_client_window.py
+++ b/flashdreams/test_v2/test_webrtc_client_window.py
@@ -41,7 +41,6 @@ from flashdreams.runtime_v2.user_input_event import (
     KeyboardInputState,
     KeyboardUserInputEvent,
     MouseUserInputEvent,
-    NewSessionUserInputEvent,
     TouchUserInputEvent,
     XRControllerUserInputEvent,
 )
@@ -146,7 +145,6 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 assert 'id="activate"' not in browser_page
                 assert 'id="reset"' not in browser_page
                 assert '<video id="video" autoplay muted playsinline>' in browser_page
-                assert 'id="new-session"' not in browser_page
                 assert 'id="status"' in browser_page
                 assert '<script src="/app.js"></script>' in browser_page
             async with client.get(f"{window.server.url}app.js") as response:
@@ -154,8 +152,6 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 assert response.status == 200
                 assert "activationPressed" not in browser_script
                 assert 'type: "reset"' not in browser_script
-                assert 'type: "new_session"' not in browser_script
-                assert "newSessionButton" not in browser_script
                 assert "beforeunload" not in browser_script
                 assert "waitForIceGatheringComplete" in browser_script
                 assert 'peer.iceGatheringState === "complete"' in browser_script
@@ -238,16 +234,14 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 }
             )
         )
-        channel.send(json.dumps({"type": "new_session"}))
-
         events = []
         for _ in range(100):
             events.extend(window.get_user_input_events().get_events())
-            if len(events) == 9:
+            if len(events) == 8:
                 break
             await asyncio.sleep(0.01)
 
-        assert len(events) == 9
+        assert len(events) == 8
         keyboard_events = [
             event for event in events if isinstance(event, KeyboardUserInputEvent)
         ]
@@ -290,7 +284,6 @@ async def test_window_buffers_browser_events_until_drained() -> None:
         assert xr.handedness == "right"
         assert xr.position == (1.0, 2.0, 3.0)
         assert xr.orientation == (0.0, 0.0, 0.0, 1.0)
-        assert any(isinstance(event, NewSessionUserInputEvent) for event in events)
         assert window.get_user_input_events().get_events() == []
     finally:
         if peer is not None:
@@ -736,12 +729,12 @@ def test_window_discards_events_buffered_during_a_session_handoff() -> None:
 
         window.server._buffer_browser_message(json.dumps({"type": "close"}))
         window.open(_session_desc())
-        window.server._buffer_browser_message(json.dumps({"type": "new_session"}))
+        window.server._buffer_browser_message(
+            json.dumps({"type": "focus", "focused": True})
+        )
 
         replacement_events = window.get_user_input_events().get_events()
-        assert [type(event) for event in replacement_events] == [
-            NewSessionUserInputEvent
-        ]
+        assert [type(event) for event in replacement_events] == [FocusUserInputEvent]
         assert (
             replacement_events[0].get_timestamp() < first_session_event.get_timestamp()
         )

--- a/flashdreams/test_v2/test_webrtc_client_window.py
+++ b/flashdreams/test_v2/test_webrtc_client_window.py
@@ -35,7 +35,6 @@ from flashdreams.runtime_v2.serving.webrtc_server import _VideoTrack
 from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import (
-    CloseUserInputEvent,
     FocusUserInputEvent,
     GamepadUserInputEvent,
     GameWheelUserInputEvent,
@@ -147,8 +146,7 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 assert 'id="activate"' not in browser_page
                 assert 'id="reset"' not in browser_page
                 assert '<video id="video" autoplay muted playsinline>' in browser_page
-                assert 'id="new-session"' in browser_page
-                assert "Opening…" in browser_page
+                assert 'id="new-session"' not in browser_page
                 assert 'id="status"' in browser_page
                 assert '<script src="/app.js"></script>' in browser_page
             async with client.get(f"{window.server.url}app.js") as response:
@@ -156,9 +154,9 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 assert response.status == 200
                 assert "activationPressed" not in browser_script
                 assert 'type: "reset"' not in browser_script
-                assert 'type: "new_session"' in browser_script
-                assert 'newSessionButton.textContent = "New session"' in browser_script
-                assert 'newSessionButton.textContent = "Disconnected"' in browser_script
+                assert 'type: "new_session"' not in browser_script
+                assert "newSessionButton" not in browser_script
+                assert "beforeunload" not in browser_script
                 assert "waitForIceGatheringComplete" in browser_script
                 assert 'peer.iceGatheringState === "complete"' in browser_script
                 assert "Unable to start WebRTC" in browser_script
@@ -386,10 +384,31 @@ async def test_peer_state_distinguishes_recovery_from_terminal_close(
 
         assert not window.server._media_connected.is_set()
         assert not window.server._client_connected
-        events = window.get_user_input_events().get_events()
-        assert len(events) == 1
-        assert isinstance(events[0], CloseUserInputEvent)
+        assert window.server._peer_connection is None
+        assert window.server._video_track is None
+        assert window.get_user_input_events().get_events() == []
+        peer.close.assert_awaited_once()
     finally:
+        window.close()
+
+
+@pytest.mark.asyncio
+async def test_browser_can_reconnect_without_restarting_the_server() -> None:
+    window = WebRTCClientWindow()
+    first_peer: RTCPeerConnection | None = None
+    second_peer: RTCPeerConnection | None = None
+    try:
+        window.open(_session_desc())
+        first_peer, _, _ = await _connect_browser(window)
+        second_peer, _, _ = await _connect_browser(window)
+
+        assert window.server._peer_connection is not None
+        assert window.get_user_input_events().get_events() == []
+    finally:
+        if first_peer is not None:
+            await first_peer.close()
+        if second_peer is not None:
+            await second_peer.close()
         window.close()
 
 
@@ -670,7 +689,7 @@ def test_server_reopens_only_for_the_same_stream_format() -> None:
         window.close()
 
 
-def test_window_rebases_buffered_events_for_a_replacement_session() -> None:
+def test_window_discards_events_buffered_during_a_session_handoff() -> None:
     window = WebRTCClientWindow()
     try:
         window.open(_session_desc())
@@ -687,12 +706,10 @@ def test_window_rebases_buffered_events_for_a_replacement_session() -> None:
 
         replacement_events = window.get_user_input_events().get_events()
         assert [type(event) for event in replacement_events] == [
-            CloseUserInputEvent,
-            NewSessionUserInputEvent,
+            NewSessionUserInputEvent
         ]
-        assert replacement_events[0].get_timestamp() == 0
         assert (
-            replacement_events[1].get_timestamp() < first_session_event.get_timestamp()
+            replacement_events[0].get_timestamp() < first_session_event.get_timestamp()
         )
     finally:
         window.close()

--- a/flashdreams/test_v2/test_webrtc_client_window.py
+++ b/flashdreams/test_v2/test_webrtc_client_window.py
@@ -8,6 +8,7 @@
 import asyncio
 import json
 import time
+from dataclasses import replace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
@@ -41,6 +42,7 @@ from flashdreams.runtime_v2.user_input_event import (
     KeyboardInputState,
     KeyboardUserInputEvent,
     MouseUserInputEvent,
+    NewSessionUserInputEvent,
     TouchUserInputEvent,
     XRControllerUserInputEvent,
 )
@@ -119,6 +121,7 @@ async def test_window_buffers_browser_events_until_drained() -> None:
         "webrtc_sender_enqueued_count": 0,
         "webrtc_sender_handed_off_count": 0,
         "webrtc_sender_dropped_for_lag_count": 0,
+        "webrtc_sender_discarded_on_session_change_count": 0,
         "webrtc_sender_discarded_on_close_count": 0,
         "webrtc_sender_oldest_queue_age_s": 0.0,
         "webrtc_sender_materialized_count": 0,
@@ -138,6 +141,8 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 assert 'id="activate"' not in browser_page
                 assert 'id="reset"' not in browser_page
                 assert '<video id="video" autoplay muted playsinline>' in browser_page
+                assert 'id="new-session"' in browser_page
+                assert "Opening…" in browser_page
                 assert 'id="status"' in browser_page
                 assert '<script src="/app.js"></script>' in browser_page
             async with client.get(f"{window.server.url}app.js") as response:
@@ -145,6 +150,9 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 assert response.status == 200
                 assert "activationPressed" not in browser_script
                 assert 'type: "reset"' not in browser_script
+                assert 'type: "new_session"' in browser_script
+                assert 'newSessionButton.textContent = "New session"' in browser_script
+                assert 'newSessionButton.textContent = "Disconnected"' in browser_script
                 assert "waitForIceGatheringComplete" in browser_script
                 assert 'peer.iceGatheringState === "complete"' in browser_script
                 assert "Unable to start WebRTC" in browser_script
@@ -226,15 +234,16 @@ async def test_window_buffers_browser_events_until_drained() -> None:
                 }
             )
         )
+        channel.send(json.dumps({"type": "new_session"}))
 
         events = []
         for _ in range(100):
             events.extend(window.get_user_input_events().get_events())
-            if len(events) == 8:
+            if len(events) == 9:
                 break
             await asyncio.sleep(0.01)
 
-        assert len(events) == 8
+        assert len(events) == 9
         keyboard_events = [
             event for event in events if isinstance(event, KeyboardUserInputEvent)
         ]
@@ -277,6 +286,7 @@ async def test_window_buffers_browser_events_until_drained() -> None:
         assert xr.handedness == "right"
         assert xr.position == (1.0, 2.0, 3.0)
         assert xr.orientation == (0.0, 0.0, 0.0, 1.0)
+        assert any(isinstance(event, NewSessionUserInputEvent) for event in events)
         assert window.get_user_input_events().get_events() == []
     finally:
         if peer is not None:
@@ -360,6 +370,13 @@ async def test_write_delivers_a_video_frame_to_the_browser() -> None:
         window.open(_session_desc())
         peer, _, video_track = await _connect_browser(window)
         track = await asyncio.wait_for(video_track, timeout=5)
+        server_peer = window.server._peer_connection
+        server_track = window.server._video_track
+
+        window.open(_session_desc())
+
+        assert window.server._peer_connection is server_peer
+        assert window.server._video_track is server_track
 
         window.write(
             StepResult(
@@ -580,6 +597,77 @@ async def test_video_track_overflow_retains_the_two_newest_frames() -> None:
 
 
 @pytest.mark.asyncio
+async def test_video_track_discards_queued_frames_between_sessions() -> None:
+    track = _VideoTrack(frames_per_second=60)
+    try:
+        track.enqueue(_video_frame(10))
+        track.enqueue(_video_frame(20))
+
+        await track.start_session()
+
+        metrics = track.metrics_snapshot()
+        assert metrics["webrtc_sender_queue_depth_count"] == 0
+        assert metrics["webrtc_sender_discarded_on_session_change_count"] == 2
+        track.enqueue(_video_frame(30))
+        assert _frame_mean(await track.recv()) == 30.0
+    finally:
+        await track.close()
+
+
+def test_server_reopens_only_for_the_same_stream_format() -> None:
+    window = WebRTCClientWindow()
+    session_desc = _session_desc()
+    session_starts: list[str] = []
+
+    class ReusableTrack:
+        async def start_session(self) -> None:
+            session_starts.append("start")
+
+    try:
+        window.open(session_desc)
+        event_origin_ns = window.server._event_origin_ns
+        window.server._video_track = cast(Any, ReusableTrack())
+
+        window.open(session_desc)
+
+        assert session_starts == ["start"]
+        assert window.server._event_origin_ns == event_origin_ns
+        with pytest.raises(ValueError, match="same stream format"):
+            window.open(replace(session_desc, video_width=32))
+    finally:
+        window.server._video_track = None
+        window.close()
+
+
+def test_window_rebases_buffered_events_for_a_replacement_session() -> None:
+    window = WebRTCClientWindow()
+    try:
+        window.open(_session_desc())
+        time.sleep(0.01)
+        window.server._buffer_browser_message(
+            json.dumps({"type": "keyboard", "key": "w", "pressed": True})
+        )
+        first_session_event = window.get_user_input_events().get_events()[0]
+        assert first_session_event.get_timestamp() > 0
+
+        window.server._buffer_browser_message(json.dumps({"type": "close"}))
+        window.open(_session_desc())
+        window.server._buffer_browser_message(json.dumps({"type": "new_session"}))
+
+        replacement_events = window.get_user_input_events().get_events()
+        assert [type(event) for event in replacement_events] == [
+            CloseUserInputEvent,
+            NewSessionUserInputEvent,
+        ]
+        assert replacement_events[0].get_timestamp() == 0
+        assert (
+            replacement_events[1].get_timestamp() < first_session_event.get_timestamp()
+        )
+    finally:
+        window.close()
+
+
+@pytest.mark.asyncio
 async def test_video_track_commits_a_frame_once_dequeued(monkeypatch: Any) -> None:
     track = _VideoTrack(frames_per_second=60)
     dequeued = asyncio.Event()
@@ -753,6 +841,7 @@ def test_server_close_drains_without_inventing_a_frame() -> None:
         "webrtc_sender_enqueued_count": 3,
         "webrtc_sender_handed_off_count": 3,
         "webrtc_sender_dropped_for_lag_count": 0,
+        "webrtc_sender_discarded_on_session_change_count": 0,
         "webrtc_sender_discarded_on_close_count": 0,
         "webrtc_sender_oldest_queue_age_s": 0.0,
     }

--- a/integrations_v2/fastvideo_causal_wan22/tests/test_stand_in_model.py
+++ b/integrations_v2/fastvideo_causal_wan22/tests/test_stand_in_model.py
@@ -13,7 +13,7 @@ from fastvideo_causal_wan22.apps.t2v.adapter import (
     FASTVIDEO_CAUSAL_WAN22_T2V_DEFAULTS,
     FastvideoCausalWan22T2VApplication,
 )
-from t2v.testing import FakeT2VPipelineConfig
+from t2v.testing import FakeT2VPipeline, FakeT2VPipelineConfig
 
 from flashdreams.runtime_v2.video_tensor import VideoTensorLayout
 
@@ -38,14 +38,18 @@ def test_the_model_says_what_it_generates_without_being_told() -> None:
     assert app.defaults.total_blocks == FASTVIDEO_CAUSAL_WAN22_T2V_DEFAULTS.total_blocks
 
 
-def test_compilation_is_turned_off_for_both_noise_level_transformers() -> None:
+def test_compilation_is_turned_off_for_both_noise_level_transformers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Half a compiled model is the failure this integration has to avoid.
 
     The real config compiles by default, which costs minutes on first use. This
     model splits denoising across two transformers, and the shared override
-    reaches only one of them, so it is overridden here.
+    reaches only one of them, so it is overridden here. Only setup is replaced,
+    keeping the checkpoint out of this CPU test.
     """
     app = FastvideoCausalWan22T2VApplication()
+    monkeypatch.setattr(type(app.pipeline_config), "setup", lambda _: FakeT2VPipeline())
 
     app.init(["--prompt", _PROMPT, "--no-compile"])
 

--- a/integrations_v2/imgui_ui_demo/imgui_ui_demo/tests/test_imgui_ui_demo.py
+++ b/integrations_v2/imgui_ui_demo/imgui_ui_demo/tests/test_imgui_ui_demo.py
@@ -28,7 +28,7 @@ def test_text_input_updates_ui_owned_state() -> None:
         failure_queue=queue.Queue(),
     )
     loop.register_session_ui_loop_objects(
-        output_layout=SessionDesc().output_layout,
+        session_desc=SessionDesc(),
         presentation_manager=PresentationManager(),
     )
     imgui = SimpleNamespace(

--- a/integrations_v2/self_forcing/tests/test_stand_in_model.py
+++ b/integrations_v2/self_forcing/tests/test_stand_in_model.py
@@ -52,11 +52,14 @@ def test_the_model_says_what_it_generates_without_being_told() -> None:
     assert app.defaults.total_blocks == SELF_FORCING_T2V_DEFAULTS.total_blocks
 
 
-def test_compilation_can_be_turned_off_for_a_run() -> None:
+def test_compilation_can_be_turned_off_for_a_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Run against the real config rather than a stand-in, since what this
-    covers is the override landing where this model keeps the setting. No model
-    is loaded to answer it."""
+    covers is the override landing where this model keeps the setting. Only its
+    setup call is replaced, so answering does not load the checkpoint."""
     app = SelfForcingT2VApplication()
+    monkeypatch.setattr(type(app.pipeline_config), "setup", lambda _: FakeT2VPipeline())
 
     app.init(["--prompt", _PROMPT, "--no-compile"])
 
@@ -99,5 +102,8 @@ def test_a_run_writes_every_generated_frame_to_an_mp4(tmp_path: Path) -> None:
     )
 
     assert result.passed, result.failures
-    assert result.frames_per_step == (1,) * expected_frame_count
+    assert result.frames_per_step == (
+        pipeline.first_block_frames,
+        *((pipeline.block_frames,) * (steps - 1)),
+    )
     assert path.stat().st_size > 0

--- a/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
+++ b/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
@@ -84,12 +84,14 @@ def test_invoke_async_toggles_model_owned_color_on_w_press() -> None:
     assert run.step_index == 0
     blue_results = model_loop.step(run.step_index, UserInputEvents([]))
     blue = blue_results[0].read_output()
-    model_loop._finish_run(blue_results)
+    model_loop._finish_run(blue_results, step_completed=True)
 
     ui_loop.step_ui(ui, 1, w_pressed)
     run = model_loop._begin_run(UserInputEvents([]), generation=0)
     assert run.step_index == 1
-    red_again = model_loop.step(run.step_index, UserInputEvents([]))[0].read_output()
+    red_results = model_loop.step(run.step_index, UserInputEvents([]))
+    red_again = red_results[0].read_output()
+    model_loop._finish_run(red_results, step_completed=True)
 
     assert not model_state.blue
     assert torch.equal(red[0, :, 0, 0], torch.tensor([1.0, -1.0, -1.0]))

--- a/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
+++ b/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
@@ -80,16 +80,16 @@ def test_invoke_async_toggles_model_owned_color_on_w_press() -> None:
     ui_loop.step_ui(ui, 0, w_pressed)
     assert not model_state.blue
 
-    step_index = model_loop._begin_run(UserInputEvents([]), generation=0)
-    assert step_index == 0
-    blue_results = model_loop.step(step_index, UserInputEvents([]))
+    run = model_loop._begin_run(UserInputEvents([]), generation=0)
+    assert run.step_index == 0
+    blue_results = model_loop.step(run.step_index, UserInputEvents([]))
     blue = blue_results[0].read_output()
     model_loop._finish_run(blue_results)
 
     ui_loop.step_ui(ui, 1, w_pressed)
-    step_index = model_loop._begin_run(UserInputEvents([]), generation=0)
-    assert step_index == 1
-    red_again = model_loop.step(step_index, UserInputEvents([]))[0].read_output()
+    run = model_loop._begin_run(UserInputEvents([]), generation=0)
+    assert run.step_index == 1
+    red_again = model_loop.step(run.step_index, UserInputEvents([]))[0].read_output()
 
     assert not model_state.blue
     assert torch.equal(red[0, :, 0, 0], torch.tensor([1.0, -1.0, -1.0]))

--- a/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
+++ b/integrations_v2/slangpy_ui_demo/slangpy_ui_demo/tests/test_slangpy_ui_demo.py
@@ -58,7 +58,7 @@ def test_invoke_async_toggles_model_owned_color_on_w_press() -> None:
         failure_queue=failure_queue,
     )
     ui_loop.register_session_ui_loop_objects(
-        output_layout=desc.output_layout,
+        session_desc=desc,
         presentation_manager=PresentationManager(),
     )
     ui = SimpleNamespace(
@@ -109,7 +109,7 @@ def test_text_input_updates_ui_owned_state() -> None:
         failure_queue=queue.Queue(),
     )
     loop.register_session_ui_loop_objects(
-        output_layout=SessionDesc().output_layout,
+        session_desc=SessionDesc(),
         presentation_manager=PresentationManager(),
     )
     ui = SimpleNamespace(

--- a/integrations_v2/wan22/tests/test_adapter.py
+++ b/integrations_v2/wan22/tests/test_adapter.py
@@ -34,13 +34,19 @@ def test_factory_exposes_single_block_ti2v_defaults() -> None:
     assert application.defaults.fps == 16
 
 
-def test_application_requires_prompt_and_existing_first_frame(tmp_path: Path) -> None:
-    """Reject missing static conditioning before loading the checkpoint."""
-    application = Wan22TI2VApplication()
+def test_application_accepts_deferred_prompt_and_requires_existing_first_frame(
+    tmp_path: Path,
+) -> None:
+    """Allow an interactive prompt while rejecting a missing first frame."""
     first_frame = _first_frame(tmp_path)
+    application = Wan22TI2VApplication(
+        pipeline_config=FakeT2VPipelineConfig(FakeT2VPipeline())
+    )
 
-    with pytest.raises(ValueError, match="--prompt is required"):
-        application.init(["--image-path", str(first_frame)])
+    application.init(["--image-path", str(first_frame), "--device", "cpu"])
+    application.close()
+
+    application = Wan22TI2VApplication()
     with pytest.raises(SystemExit):
         application.init(["--prompt", "A waterfall"])
     with pytest.raises(FileNotFoundError, match="first-frame image does not exist"):


### PR DESCRIPTION
## Summary

- Add multi-session lifecycle support while keeping the application, model
  weights, and client window alive between sessions.
- Add an ImGui prompt UI for T2V applications that can request new sessions
  before or after inference.
- Keep UI processing active after model completion and across WebRTC
  reconnects.
- Make `IModelLoop` the single source of inference lifecycle state.
- Suppress the known non-fatal `aioice` STUN retry race without hiding other
  asyncio errors.
  
  fixes https://github.com/NVIDIA/flashdreams/issues/502