### PR TITLE
[Quantization] -- Add quantized output projection support to OptimizedMHA

### DIFF
--- a/flashdreams/flashdreams/accelerated/multi_head_attention/optimized.py
+++ b/flashdreams/flashdreams/accelerated/multi_head_attention/optimized.py
@@ -89,6 +89,9 @@ class QuantizationOption:
     projection: torch.dtype | None = None
     """Q/K/V projection dtype; ``None`` preserves native precision."""
 
+    output_projection: torch.dtype | None = None
+    """Output projection dtype; ``None`` preserves native precision."""
+
     quantized_sdpa: bool = False
     """Use unscaled FP8 e4m3 Q/K/V in scaled-dot-product attention.
 
@@ -102,10 +105,18 @@ class QuantizationOption:
     """
 
     def __post_init__(self) -> None:
-        """Validate the projection quantization dtype."""
+        """Validate the projection quantization dtypes."""
         if self.projection is not None and self.projection not in DTYPE_MAX:
             raise ValueError(
                 f"unsupported projection quantization dtype: {self.projection}"
+            )
+        if (
+            self.output_projection is not None
+            and self.output_projection not in DTYPE_MAX
+        ):
+            raise ValueError(
+                "unsupported output projection quantization dtype: "
+                f"{self.output_projection}"
             )
         if not isinstance(self.quantized_sdpa, bool):
             raise TypeError(
@@ -216,6 +227,9 @@ class OptimizedMultiHeadAttention(MultiHeadAttention[BlockKVCache]):
     quantized_value_projection: QuantizedNonPersistentLinear | None
     """Nonpersistent quantized value projection."""
 
+    quantized_output_projection: QuantizedNonPersistentLinear | None
+    """Nonpersistent quantized output projection."""
+
     _validated_cuda_device_index: int | None
     """CUDA device whose compute capability has passed validation."""
 
@@ -281,6 +295,7 @@ class OptimizedMultiHeadAttention(MultiHeadAttention[BlockKVCache]):
         self.quantized_query_projection = None
         self.quantized_key_projection = None
         self.quantized_value_projection = None
+        self.quantized_output_projection = None
         self._refresh_derived_weights()
         self.register_load_state_dict_post_hook(self._refresh_derived_weights)
 
@@ -311,6 +326,7 @@ class OptimizedMultiHeadAttention(MultiHeadAttention[BlockKVCache]):
         self.quantized_query_projection = None
         self.quantized_key_projection = None
         self.quantized_value_projection = None
+        self.quantized_output_projection = None
 
         projection_dtype = self.optimized_impl_config.quantization.projection
         projection_biases = (
@@ -342,6 +358,16 @@ class OptimizedMultiHeadAttention(MultiHeadAttention[BlockKVCache]):
                     self.value_projection.bias,
                     projection_dtype,
                 )
+
+        output_projection_dtype = (
+            self.optimized_impl_config.quantization.output_projection
+        )
+        if output_projection_dtype is not None:
+            self.quantized_output_projection = self._new_quantized_projection(
+                self.output_projection.weight,
+                self.output_projection.bias,
+                output_projection_dtype,
+            )
 
         if self.qkv_fusion_option is QKVFusionOption.FULL:
             fused_weight = (
@@ -1106,8 +1132,17 @@ class OptimizedMultiHeadAttention(MultiHeadAttention[BlockKVCache]):
         return query, key, value
 
     def _project_output(self, x: Tensor) -> Tensor:
-        """Apply the FP16/BF16 output projection."""
-        return self.output_projection(x)
+        """Apply the output projection, quantized when configured."""
+        output_projection_dtype = (
+            self.optimized_impl_config.quantization.output_projection
+        )
+        if output_projection_dtype is None:
+            return self.output_projection(x)
+        if self.quantized_output_projection is None:
+            raise RuntimeError("quantized output projection is not initialized")
+        return self.quantized_output_projection(
+            x, Granularity.SLICE, out_dtype=x.dtype
+        )
 
 
 __all__ = [

--- a/flashdreams/flashdreams/accelerated/multi_head_attention/optimized.py
+++ b/flashdreams/flashdreams/accelerated/multi_head_attention/optimized.py
@@ -92,6 +92,9 @@ class QuantizationOption:
     output_projection: torch.dtype | None = None
     """Output projection dtype; ``None`` preserves native precision."""
 
+    output_granularity: Granularity = Granularity.SLICE
+    """Activation quantization granularity for the output projection."""
+
     quantized_sdpa: bool = False
     """Use unscaled FP8 e4m3 Q/K/V in scaled-dot-product attention.
 
@@ -1141,7 +1144,9 @@ class OptimizedMultiHeadAttention(MultiHeadAttention[BlockKVCache]):
         if self.quantized_output_projection is None:
             raise RuntimeError("quantized output projection is not initialized")
         return self.quantized_output_projection(
-            x, Granularity.SLICE, out_dtype=x.dtype
+            x,
+            self.optimized_impl_config.quantization.output_granularity,
+            out_dtype=x.dtype,
         )
 
 

--- a/flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py
+++ b/flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py
@@ -562,17 +562,21 @@ def test_mha_optimized_quantized_projections_match_torch(
     "attention_type", tuple(AttentionType), ids=lambda value: value.value
 )
 @pytest.mark.parametrize(
-    "output_projection_dtype",
+    "qkv_fusion_option", tuple(QKVFusionOption), ids=lambda value: value.value
+)
+@pytest.mark.parametrize(
+    "projection_dtype",
     tuple(DTYPE_MAX),
     ids=lambda dtype: str(dtype).removeprefix("torch."),
 )
 @torch.inference_mode()
-def test_mha_optimized_quantized_output_projection_matches_torch(
+def test_mha_optimized_combined_quantization_matches_torch(
     cuda_device: torch.device,
     attention_type: AttentionType,
-    output_projection_dtype: torch.dtype,
+    qkv_fusion_option: QKVFusionOption,
+    projection_dtype: torch.dtype,
 ) -> None:
-    """Match quantized output projection against native-precision attention."""
+    """Match Q/K/V + output projection quantized together against native precision."""
     attention_config = AttentionConfig(
         query_dim=_QUERY_DIM,
         n_heads=_N_HEADS,
@@ -580,7 +584,10 @@ def test_mha_optimized_quantized_output_projection_matches_torch(
         qk_norm_scope=QKNormScope.HEAD,
     )
     optimized_impl_config = OptimizedImplConfig(
-        quantization=QuantizationOption(output_projection=output_projection_dtype),
+        qkv_fusion_option=qkv_fusion_option,
+        quantization=QuantizationOption(
+            projection=projection_dtype, output_projection=projection_dtype
+        ),
         sdpa_backend=SDPABackend.CUDNN,
         use_tma=False,
     )
@@ -592,16 +599,16 @@ def test_mha_optimized_quantized_output_projection_matches_torch(
     actual.to(device=cuda_device, dtype=torch.bfloat16).eval()
 
     assert set(actual.state_dict()) == set(reference.state_dict())
+    assert isinstance(actual.quantized_query_projection, QuantizedNonPersistentLinear)
     assert isinstance(
         actual.quantized_output_projection, QuantizedNonPersistentLinear
     )
-    assert actual.quantized_output_projection.dtype is output_projection_dtype
-    assert actual.quantized_query_projection is None
+    assert actual.quantized_output_projection.dtype is projection_dtype
 
     quantization_tolerance = (
-        torch.finfo(output_projection_dtype).eps
-        if output_projection_dtype.is_floating_point
-        else 5 / DTYPE_MAX[output_projection_dtype]
+        torch.finfo(projection_dtype).eps
+        if projection_dtype.is_floating_point
+        else 5 / DTYPE_MAX[projection_dtype]
     )
     tolerance = max(2e-2, quantization_tolerance)
     generator = torch.Generator(device=cuda_device).manual_seed(19)

--- a/flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py
+++ b/flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py
@@ -473,6 +473,9 @@ def test_mha_optimized_matches_torch(
 
 
 @pytest.mark.parametrize(
+    "quantize_output_projection", (False, True), ids=("qkv-only", "combined")
+)
+@pytest.mark.parametrize(
     "attention_type", tuple(AttentionType), ids=lambda value: value.value
 )
 @pytest.mark.parametrize(
@@ -489,8 +492,9 @@ def test_mha_optimized_quantized_projections_match_torch(
     attention_type: AttentionType,
     qkv_fusion_option: QKVFusionOption,
     projection_dtype: torch.dtype,
+    quantize_output_projection: bool,
 ) -> None:
-    """Match quantized Q/K/V projections against native-precision attention."""
+    """Match quantized Q/K/V (and optionally output) projections against native precision."""
     attention_config = AttentionConfig(
         query_dim=_QUERY_DIM,
         n_heads=_N_HEADS,
@@ -499,7 +503,10 @@ def test_mha_optimized_quantized_projections_match_torch(
     )
     optimized_impl_config = OptimizedImplConfig(
         qkv_fusion_option=qkv_fusion_option,
-        quantization=QuantizationOption(projection=projection_dtype),
+        quantization=QuantizationOption(
+            projection=projection_dtype,
+            output_projection=projection_dtype if quantize_output_projection else None,
+        ),
         sdpa_backend=SDPABackend.CUDNN,
         use_tma=False,
     )
@@ -530,80 +537,13 @@ def test_mha_optimized_quantized_projections_match_torch(
             assert actual.fused_qkv.dtype is projection_dtype
         else:
             assert actual.fused_qkv is None
-
-    quantization_tolerance = (
-        torch.finfo(projection_dtype).eps
-        if projection_dtype.is_floating_point
-        else 5 / DTYPE_MAX[projection_dtype]
-    )
-    tolerance = max(2e-2, quantization_tolerance)
-    generator = torch.Generator(device=cuda_device).manual_seed(19)
-    if attention_type is AttentionType.SELF_ATTENTION:
-        _check_self_attention(
-            reference,
-            actual,
-            attention_config,
-            generator,
-            cuda_device,
-            tolerance,
+    if quantize_output_projection:
+        assert isinstance(
+            actual.quantized_output_projection, QuantizedNonPersistentLinear
         )
+        assert actual.quantized_output_projection.dtype is projection_dtype
     else:
-        _check_cross_attention(
-            reference,
-            actual,
-            attention_config,
-            generator,
-            cuda_device,
-            tolerance,
-        )
-
-
-@pytest.mark.parametrize(
-    "attention_type", tuple(AttentionType), ids=lambda value: value.value
-)
-@pytest.mark.parametrize(
-    "qkv_fusion_option", tuple(QKVFusionOption), ids=lambda value: value.value
-)
-@pytest.mark.parametrize(
-    "projection_dtype",
-    tuple(DTYPE_MAX),
-    ids=lambda dtype: str(dtype).removeprefix("torch."),
-)
-@torch.inference_mode()
-def test_mha_optimized_combined_quantization_matches_torch(
-    cuda_device: torch.device,
-    attention_type: AttentionType,
-    qkv_fusion_option: QKVFusionOption,
-    projection_dtype: torch.dtype,
-) -> None:
-    """Match Q/K/V + output projection quantized together against native precision."""
-    attention_config = AttentionConfig(
-        query_dim=_QUERY_DIM,
-        n_heads=_N_HEADS,
-        head_dim=_HEAD_DIM,
-        qk_norm_scope=QKNormScope.HEAD,
-    )
-    optimized_impl_config = OptimizedImplConfig(
-        qkv_fusion_option=qkv_fusion_option,
-        quantization=QuantizationOption(
-            projection=projection_dtype, output_projection=projection_dtype
-        ),
-        sdpa_backend=SDPABackend.CUDNN,
-        use_tma=False,
-    )
-    torch.manual_seed(17)
-    reference = _TorchMHA(attention_type, attention_config)
-    actual = _OptimizedMHA(attention_type, attention_config, optimized_impl_config)
-    actual.load_state_dict(reference.state_dict(), strict=True)
-    reference.to(device=cuda_device, dtype=torch.bfloat16).eval()
-    actual.to(device=cuda_device, dtype=torch.bfloat16).eval()
-
-    assert set(actual.state_dict()) == set(reference.state_dict())
-    assert isinstance(actual.quantized_query_projection, QuantizedNonPersistentLinear)
-    assert isinstance(
-        actual.quantized_output_projection, QuantizedNonPersistentLinear
-    )
-    assert actual.quantized_output_projection.dtype is projection_dtype
+        assert actual.quantized_output_projection is None
 
     quantization_tolerance = (
         torch.finfo(projection_dtype).eps

--- a/flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py
+++ b/flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py
@@ -561,6 +561,73 @@ def test_mha_optimized_quantized_projections_match_torch(
 @pytest.mark.parametrize(
     "attention_type", tuple(AttentionType), ids=lambda value: value.value
 )
+@pytest.mark.parametrize(
+    "output_projection_dtype",
+    tuple(DTYPE_MAX),
+    ids=lambda dtype: str(dtype).removeprefix("torch."),
+)
+@torch.inference_mode()
+def test_mha_optimized_quantized_output_projection_matches_torch(
+    cuda_device: torch.device,
+    attention_type: AttentionType,
+    output_projection_dtype: torch.dtype,
+) -> None:
+    """Match quantized output projection against native-precision attention."""
+    attention_config = AttentionConfig(
+        query_dim=_QUERY_DIM,
+        n_heads=_N_HEADS,
+        head_dim=_HEAD_DIM,
+        qk_norm_scope=QKNormScope.HEAD,
+    )
+    optimized_impl_config = OptimizedImplConfig(
+        quantization=QuantizationOption(output_projection=output_projection_dtype),
+        sdpa_backend=SDPABackend.CUDNN,
+        use_tma=False,
+    )
+    torch.manual_seed(17)
+    reference = _TorchMHA(attention_type, attention_config)
+    actual = _OptimizedMHA(attention_type, attention_config, optimized_impl_config)
+    actual.load_state_dict(reference.state_dict(), strict=True)
+    reference.to(device=cuda_device, dtype=torch.bfloat16).eval()
+    actual.to(device=cuda_device, dtype=torch.bfloat16).eval()
+
+    assert set(actual.state_dict()) == set(reference.state_dict())
+    assert isinstance(
+        actual.quantized_output_projection, QuantizedNonPersistentLinear
+    )
+    assert actual.quantized_output_projection.dtype is output_projection_dtype
+    assert actual.quantized_query_projection is None
+
+    quantization_tolerance = (
+        torch.finfo(output_projection_dtype).eps
+        if output_projection_dtype.is_floating_point
+        else 5 / DTYPE_MAX[output_projection_dtype]
+    )
+    tolerance = max(2e-2, quantization_tolerance)
+    generator = torch.Generator(device=cuda_device).manual_seed(19)
+    if attention_type is AttentionType.SELF_ATTENTION:
+        _check_self_attention(
+            reference,
+            actual,
+            attention_config,
+            generator,
+            cuda_device,
+            tolerance,
+        )
+    else:
+        _check_cross_attention(
+            reference,
+            actual,
+            attention_config,
+            generator,
+            cuda_device,
+            tolerance,
+        )
+
+
+@pytest.mark.parametrize(
+    "attention_type", tuple(AttentionType), ids=lambda value: value.value
+)
 @pytest.mark.parametrize("rope_scope", tuple(RoPEScope), ids=lambda value: value.value)
 @pytest.mark.parametrize(
     "sdpa_backend", tuple(SDPABackend), ids=lambda value: value.value


### PR DESCRIPTION

Closes #575 

Quantization support for the output projection 

### **What is the current Quantization Flow?** 

<img width="1180" height="1400" alt="image" src="https://github.com/user-attachments/assets/86a0695e-03eb-4c23-ac12-4bbb87c26a69" />

### **What this PR changed (The green part)** : 

<img width="1180" height="1560" alt="image" src="https://github.com/user-attachments/assets/6147529e-5ad3-4005-b47c-ff8545b30807" />

### **How this PR is tested**


| Mode | Config | Covered by |
|---|---|---|
| QKV only | `QuantizationOption(projection=dtype)` | `test_mha_optimized_quantized_projections_match_torch[...-qkv-only]` |
| Output only | `QuantizationOption(output_projection=dtype)` | not separately tested — see combined below |
| Combined (QKV + output) | `QuantizationOption(projection=dtype, output_projection=dtype)` | `test_mha_optimized_quantized_projections_match_torch[...-combined]` |

# QKV only (18 cases)
pytest flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py -k "quantized_projections and qkv-only" -v

# Combined (18 cases)
pytest flashdreams/tests/accelerated/multi_head_attention/test_mha_optimized.py -k "quantized_projections and combined" -v




