### PR TITLE
[API - Temporary] Change how we record metrics to be consistent

### DIFF
--- a/.github/workflows/lingbot-demo-runtime.yml
+++ b/.github/workflows/lingbot-demo-runtime.yml
@@ -148,6 +148,7 @@ jobs:
             frun "${APP_ID}" \
               --mode mp4 \
               --output-path "${output_dir}/lingbot-demo-replay.mp4" \
+              --stats-path "${output_dir}/lingbot-demo-replay-stats.json" \
               --pixel-height "${HEIGHT}" \
               --pixel-width "${WIDTH}" \
               --fps "${FPS}" \
@@ -159,7 +160,6 @@ jobs:
               --example-idx 0 \
               --total-blocks "${BLOCKS}" \
               --warmup-blocks 0 \
-              --sync-and-profile \
               --no-ui
 
       - name: Validate LingBot demo artifacts

--- a/apps/action2v/action2v/session.py
+++ b/apps/action2v/action2v/session.py
@@ -107,10 +107,6 @@ class Action2VModelLoop(IModelLoop[Action2VModelState]):
                     output=frames.detach(),
                     frame_count=frames.shape[0],
                     output_layout=state.session_desc.output_layout,
-                    metrics={
-                        "autoregressive_index": 0,
-                        "seed_frames": frames.shape[0],
-                    },
                 )
             ]
 
@@ -130,7 +126,7 @@ class Action2VModelLoop(IModelLoop[Action2VModelState]):
                 cache=cache,
                 input=action,
             )
-            stats = state.pipeline.finalize(
+            finalize_metrics = state.pipeline.finalize(
                 autoregressive_index=step_index,
                 cache=cache,
             )
@@ -138,16 +134,13 @@ class Action2VModelLoop(IModelLoop[Action2VModelState]):
 
         frames = _presentation_frames(video, state.session_desc)
         state.actions_generated += 1
-        metrics: dict[str, float | int] = dict(stats or {})
-        metrics.setdefault("autoregressive_index", step_index)
-        metrics.setdefault("generated_frames", frames.shape[0])
         return [
             StepResult(
                 step_index=step_index,
                 output=frames,
                 frame_count=frames.shape[0],
                 output_layout=state.session_desc.output_layout,
-                metrics=metrics,
+                metrics=finalize_metrics,
             )
         ]
 

--- a/apps/action2v/tests/test_application.py
+++ b/apps/action2v/tests/test_application.py
@@ -221,11 +221,6 @@ def test_shared_session_emits_seed_then_live_actions_and_resets() -> None:
         ActionSnapshot(keys=frozenset({"W"})),
         ActionSnapshot(keys=frozenset({"W"})),
     ]
-    assert first.metrics == {
-        "model_step": 1,
-        "autoregressive_index": 1,
-        "generated_frames": 4,
-    }
     assert not loop.is_finished()
     loop.reset()
     assert len(pipeline.initialized_caches) == 2
@@ -271,7 +266,6 @@ def test_dummy_application_runs_without_a_model() -> None:
             320,
         )
     )
-    assert generated.metrics["dummy_step"] == 1
     assert loop.is_finished()
 
 

--- a/apps/cam2v/README.md
+++ b/apps/cam2v/README.md
@@ -66,7 +66,6 @@ Cam2V application arguments, after `--`:
 | `--warmup-blocks INT` | Set chunks excluded from steady-state FPS |
 | `--ui`, `--no-ui` | Enable or disable the controls/status overlay |
 | `--compile`, `--no-compile` | Enable or disable model compilation |
-| `--sync-and-profile`, `--no-sync-and-profile` | Enable or disable synchronized per-stage pipeline timings |
 | `--postprocess-comparison-ui`, `--no-postprocess-comparison-ui` | Show synchronized original and post-processed panes; requires a postprocessor and UI |
 | `--seed INT` | Override the diffusion seed |
 
@@ -110,9 +109,8 @@ default to unset. HY-WorldPlay falls back to its built-in prompt and computed
 intrinsics; Lingbot requires an image and intrinsics, and also a pose trace when
 `--world-scale` is not given. SANA-WM can download its official image and prompt
 with `--example-data`; intrinsics
-default to a 90-degree horizontal field of view. `--compile`,
-`--sync-and-profile`, and `--seed` default to the selected pipeline
-configuration values.
+default to a 90-degree horizontal field of view. `--compile` and `--seed`
+default to the selected pipeline configuration values.
 
 For UI development without loading a model:
 

--- a/apps/cam2v/cam2v/application.py
+++ b/apps/cam2v/cam2v/application.py
@@ -127,12 +127,6 @@ class Cam2VApplication(IApplication):
             action=argparse.BooleanOptionalAction,
             default=None,
         )
-        parser.add_argument(
-            "--sync-and-profile",
-            action=argparse.BooleanOptionalAction,
-            default=None,
-            help="Synchronize CUDA and log per-stage pipeline timings.",
-        )
         postprocess_presets = discover_postprocess_presets()
         parser.add_argument(
             "--postprocess-preset",
@@ -182,11 +176,6 @@ class Cam2VApplication(IApplication):
             self._pipeline_config = derive_config(
                 self._pipeline_config,
                 diffusion_model={"transformer": {"compile_network": args.compile}},
-            )
-        if args.sync_and_profile is not None:
-            self._pipeline_config = derive_config(
-                self._pipeline_config,
-                enable_sync_and_profile=args.sync_and_profile,
             )
         if args.seed is not None:
             self._pipeline_config = derive_config(

--- a/apps/cam2v/cam2v/session.py
+++ b/apps/cam2v/cam2v/session.py
@@ -270,12 +270,11 @@ class Cam2VModelLoop(IModelLoop[Cam2VModelState]):
             state.cache,
             camera_input,
         )
-        metrics = _numeric_metrics(
-            state.pipeline.finalize(
-                autoregressive_index=step_index,
-                cache=state.cache,
-            )
+        finalize_metrics = state.pipeline.finalize(
+            autoregressive_index=step_index,
+            cache=state.cache,
         )
+        metrics = _numeric_metrics(finalize_metrics)
         _synchronize_output(frames)
         model_completed_at = time.perf_counter()
         model_step_wall_s = model_completed_at - step_started_at
@@ -387,7 +386,7 @@ class Cam2VModelLoop(IModelLoop[Cam2VModelState]):
                 output=output_frames,
                 frame_count=output_frame_count,
                 output_layout=state.session_desc.output_layout,
-                metrics=metrics,
+                metrics=finalize_metrics,
             )
         ]
 

--- a/apps/cam2v/tests/test_application.py
+++ b/apps/cam2v/tests/test_application.py
@@ -156,7 +156,7 @@ def _conditioning() -> Cam2VConditioning:
     )
 
 
-def test_model_loop_maps_wasd_to_shared_camera_input_and_metrics() -> None:
+def test_model_loop_maps_wasd_to_shared_camera_input_and_updates_status() -> None:
     """Keep keyboard-to-pose conversion outside concrete integrations."""
     pipeline = _Pipeline()
     ui_state = Cam2VUIState(total_blocks=1, target_fps=16, warmup_blocks=0)
@@ -214,19 +214,14 @@ def test_model_loop_maps_wasd_to_shared_camera_input_and_metrics() -> None:
     result = model_loop.step(0, events)[0]
 
     assert result.frame_count == 2
-    assert result.metrics["model_step_s"] == 1.0
-    assert result.metrics["steady_state_fps"] > 0
-    assert result.metrics["recent_model_fps"] == pytest.approx(
-        result.metrics["chunk_fps"]
-    )
-    assert result.metrics["model_step_wall_s"] > 0
+    assert result.metrics == {"model_step_s": 1.0}
     ui_loop._run_message_batch()
     assert ui_state.status is not None
     assert ui_state.status.completed_blocks == 1
     assert ui_state.status.frames_generated == 2
     assert ui_state.status.recent_model_rate_snapshot is not None
     assert ui_state.status.recent_model_fps() == pytest.approx(
-        result.metrics["recent_model_fps"]
+        ui_state.status.chunk_fps
     )
     assert pipeline.camera_input is not None
     assert pipeline.camera_input.poses.shape == (2, 4, 4)
@@ -367,9 +362,7 @@ def test_model_loop_waits_for_postprocessing_in_presentation_timing(
 
     assert len(synchronized) == 2
     assert torch.equal(synchronized[1], torch.ones((2, 3, 1, 1)))
-    assert result.metrics["model_step_wall_s"] == 1.0
-    assert result.metrics["postprocess_step_wall_s"] == 2.0
-    assert result.metrics["model_loop_wall_s"] == 3.0
+    assert result.metrics == {"model_step_s": 1.0}
 
 
 def test_model_loop_keeps_postprocessing_running_when_presentation_is_disabled() -> (
@@ -402,8 +395,6 @@ def test_model_loop_keeps_postprocessing_running_when_presentation_is_disabled()
     assert postprocess_stream.calls == 1
     assert torch.equal(result.read_output(), torch.zeros((2, 3, 2, 2)))
     assert result_to_rgb24_tensor(result, state.session_desc).shape == (2, 2, 2, 3)
-    assert result.metrics["postprocess_enabled"] == 0
-    assert result.metrics["postprocess_output_frames"] == 2
 
 
 @pytest.mark.parametrize(
@@ -463,7 +454,6 @@ def test_model_loop_flushes_postprocessing_even_when_presentation_is_disabled() 
 
     assert postprocess_stream.finish_calls == 1
     assert torch.equal(result.read_output(), torch.zeros((2, 3, 1, 1)))
-    assert result.metrics["postprocess_output_frames"] == 3
 
 
 def test_model_loop_pairs_original_and_postprocessed_frames_for_comparison() -> None:
@@ -1027,25 +1017,6 @@ def test_application_owns_pipeline_and_resolves_inputs_per_session_desc() -> Non
     assert pipeline_config.pipeline.closed
 
 
-def test_application_overrides_shared_pipeline_profiling() -> None:
-    """Expose shared streaming-pipeline profiling without changing defaults."""
-    pipeline_config = _PipelineConfig()
-    app = Cam2VApplication(
-        defaults=Cam2VApplicationDefaults(
-            pipeline_config=pipeline_config,
-            input_resolver=lambda values: _conditioning(),
-            total_blocks=1,
-            pixel_width=1,
-            pixel_height=1,
-            first_frame_dtype=torch.float32,
-            first_frame_interpolation="linear",
-        )
-    )
-
-    app.init(["--sync-and-profile"])
-
-    assert app.pipeline_config.enable_sync_and_profile is True
-    assert pipeline_config.enable_sync_and_profile is False
 
 
 @dataclass(kw_only=True)

--- a/apps/cam2v/tests/test_application.py
+++ b/apps/cam2v/tests/test_application.py
@@ -1017,8 +1017,6 @@ def test_application_owns_pipeline_and_resolves_inputs_per_session_desc() -> Non
     assert pipeline_config.pipeline.closed
 
 
-
-
 @dataclass(kw_only=True)
 class _ChunkedPostprocessorConfig(VideoPostProcessorConfig):
     chunk_size: int = 16

--- a/apps/crazy_robotaxi/crazy_robotaxi/application.py
+++ b/apps/crazy_robotaxi/crazy_robotaxi/application.py
@@ -256,10 +256,6 @@ class CrazyRobotaxiApplication(IApplication):
                 pipeline_config,
                 diffusion_model={"seed": int(game_settings.taxi.seed)},
             )
-        pipeline_config = derive_config(
-            pipeline_config,
-            enable_sync_and_profile=bool(engine_settings.world_model.profile_pipeline),
-        )
         game_settings = replace(
             game_settings, live_edit=resolve_live_edit_assets(game_settings.live_edit)
         )
@@ -565,7 +561,7 @@ def _parser(
     parser.add_argument(
         "--profile-pipeline",
         action="store_true",
-        help="synchronize each chunk and emit diagnostic GPU stage timings",
+        help="emit diagnostic model-loop timings and realtime-budget warnings",
     )
     parser.add_argument(
         "--prewarm-blocks",

--- a/apps/crazy_robotaxi/crazy_robotaxi/session.py
+++ b/apps/crazy_robotaxi/crazy_robotaxi/session.py
@@ -427,6 +427,7 @@ class CrazyRobotaxiModelLoop(IModelLoop[ModelState]):
                 vehicle.speed_mps for vehicle in engine_step.trajectory.vehicle_states
             )
             bev = engine_step.condition.bev_tchw
+            finalize_metrics = generated.finalize_metrics
             metrics = dict(generated.metrics)
             if state.blocks_generated == 1 and state.prewarm_wall_ms > 0.0:
                 metrics["startup_prewarm_wall_ms"] = state.prewarm_wall_ms
@@ -443,6 +444,7 @@ class CrazyRobotaxiModelLoop(IModelLoop[ModelState]):
             poses = state.last_pose[None, ...]
             speeds_mps = (state.last_speed_mps,)
             bev = state.last_bev
+            finalize_metrics = {}
             metrics = {}
             transition_timestamps_us = (None,) * int(video.shape[0])
 
@@ -525,7 +527,7 @@ class CrazyRobotaxiModelLoop(IModelLoop[ModelState]):
                 output=video,
                 frame_count=count,
                 output_layout=VideoTensorLayout.tchw,
-                metrics=metrics,
+                metrics=finalize_metrics,
             ),
         ]
         if bev is not None:
@@ -535,6 +537,7 @@ class CrazyRobotaxiModelLoop(IModelLoop[ModelState]):
                     output=bev,
                     frame_count=count,
                     output_layout=VideoTensorLayout.tchw,
+                    metrics=finalize_metrics,
                 )
             )
         return results

--- a/apps/crazy_robotaxi/tests/test_application.py
+++ b/apps/crazy_robotaxi/tests/test_application.py
@@ -446,7 +446,7 @@ def test_leaderboard_does_not_finish_the_v2_model_loop() -> None:
         (["--profile-pipeline"], True),
     ],
 )
-def test_pipeline_profiling_is_an_app_local_opt_in(
+def test_diagnostics_flag_does_not_enable_pipeline_profiling(
     arguments: list[str],
     expected: bool,
 ) -> None:
@@ -461,10 +461,8 @@ def test_pipeline_profiling_is_an_app_local_opt_in(
 
     assert configured == []
     session._pipeline_factory()
-    assert configured[0].enable_sync_and_profile is expected
     assert app._config is not None
     assert app._config.pipeline_profiling is expected
-    assert OMNIDREAMS_PIPELINE_CONFIG.enable_sync_and_profile
 
 
 def test_model_adapters_keep_their_packaged_pipeline_configs() -> None:
@@ -605,7 +603,6 @@ def test_fast_perf_honors_explicit_pipeline_overrides() -> None:
     assert transformer.native_dit_acceleration == "required"
     assert transformer.skip_finalize_kv_cache is True
     assert pipeline.diffusion_model.scheduler.denoising_timesteps == [1000, 100]
-    assert pipeline.enable_sync_and_profile is True
 
 
 def test_map_context_disables_only_native_dit_on_selected_preset() -> None:

--- a/apps/interactive_drive/README.md
+++ b/apps/interactive_drive/README.md
@@ -77,7 +77,6 @@ optional and follow the `--` separator:
 | `--no-ui` | Present model output directly without creating the HUD or rendering its BEV minimap. |
 | `--game-mode` | Enable the speed limit and collisions with scene actors and static map geometry. |
 | `--postprocess-preset NAME` | Start with a registered video post-processing preset enabled. Default: none. |
-| `--world-model-profile` | Enable synchronized world-model profiling. |
 | `--world-model-device DEVICE` | Select the model device. Default: `cuda:0`. |
 | `--world-model-seed N` | Pin the seed used for each rollout. |
 | `--world-model-debug-condition-frame-dir PATH` | Override first-chunk condition frames for debugging. |

--- a/apps/interactive_drive/interactive_drive/backends/base.py
+++ b/apps/interactive_drive/interactive_drive/backends/base.py
@@ -97,6 +97,10 @@ class RenderBackend(ABC):
         """
         del enabled
 
+    def finalize(self) -> dict[str, float] | None:
+        """Finalize the most recently rendered model chunk."""
+        return {}
+
     @abstractmethod
     def render_first_chunk(self, trajectory: TrajectoryChunk) -> FrameChunk:
         raise NotImplementedError

--- a/apps/interactive_drive/interactive_drive/backends/world_model.py
+++ b/apps/interactive_drive/interactive_drive/backends/world_model.py
@@ -297,6 +297,9 @@ class WorldModelRenderBackend(RenderBackend):
         self._clear_pipeline(finalize_pending=True, recreate_output_stream=False)
         self._rasterizer.cleanup()
 
+    def finalize(self) -> dict[str, float] | None:
+        return self._finalize_pending()
+
     def _start_pipeline(
         self,
         initial_rgb: object,
@@ -357,14 +360,15 @@ class WorldModelRenderBackend(RenderBackend):
             view_names=_VIEW_NAMES,
         )
 
-    def _finalize_pending(self) -> None:
+    def _finalize_pending(self) -> dict[str, float] | None:
         if self._cache is None or self._pending_finalization_index is None:
-            return
-        self._pipeline.finalize(
+            return {}
+        metrics = self._pipeline.finalize(
             autoregressive_index=self._pending_finalization_index,
             cache=self._cache,
         )
         self._pending_finalization_index = None
+        return metrics
 
     def _clear_pipeline(
         self,

--- a/apps/interactive_drive/interactive_drive/config.py
+++ b/apps/interactive_drive/interactive_drive/config.py
@@ -97,11 +97,6 @@ class VehicleConfig:
 
 
 @dataclass(frozen=True)
-class WorldModelProfileConfig:
-    enabled: bool = False
-
-
-@dataclass(frozen=True)
 class BevConfig:
     """Straight-down HD-map view rendered for the HUD mini-map."""
 
@@ -130,7 +125,6 @@ class AppConfig:
     chunk: ChunkConfig = ChunkConfig()
     raster: RasterConfig = RasterConfig()
     vehicle: VehicleConfig = VehicleConfig()
-    world_model_profile: WorldModelProfileConfig = WorldModelProfileConfig()
     world_model_device: str = "cuda:0"
     world_model_seed: int | None = None
     world_model_debug_condition_frame_dir: Path | None = None

--- a/apps/interactive_drive/interactive_drive/core.py
+++ b/apps/interactive_drive/interactive_drive/core.py
@@ -44,7 +44,6 @@ from interactive_drive.config import (
     ChunkConfig,
     RasterConfig,
     VehicleConfig,
-    WorldModelProfileConfig,
 )
 from interactive_drive.input.keyboard import command_from_snapshot
 from interactive_drive.scene_download import download_default_scene
@@ -296,6 +295,7 @@ class InteractiveDriveModelLoop(IModelLoop[InteractiveDriveModelState]):
             if state.first_chunk
             else state.backend.render_next_chunk(trajectory)
         )
+        finalize_metrics = state.backend.finalize()
         state.vehicle = trajectory.boundary_state_after_chunk
         state.next_timestamp_us = int(
             trajectory.timestamps_us[-1] + state.config.app.chunk.frame_interval_us
@@ -314,7 +314,7 @@ class InteractiveDriveModelLoop(IModelLoop[InteractiveDriveModelState]):
                 output=output,
                 frame_count=int(output.shape[0]),
                 output_layout=state.desc.output_layout,
-                metrics={},
+                metrics=finalize_metrics,
             )
         ]
         bev_output = self._bev_chunk_tensor(chunk)
@@ -325,7 +325,7 @@ class InteractiveDriveModelLoop(IModelLoop[InteractiveDriveModelState]):
                     output=bev_output,
                     frame_count=int(bev_output.shape[0]),
                     output_layout=state.desc.output_layout,
-                    metrics={},
+                    metrics=finalize_metrics,
                 )
             )
         model_loop_ms = (time.perf_counter() - step_started_at) * 1000.0
@@ -499,11 +499,6 @@ class _InteractiveDriveApplicationBase(IApplication):
                 "A configured preset starts enabled and can be toggled in the HUD."
             ),
         )
-        parser.add_argument(
-            "--world-model-profile",
-            action="store_true",
-            help="Enable synchronized world-model profiling.",
-        )
         parser.add_argument("--world-model-device", default="cuda:0")
         parser.add_argument("--world-model-seed", type=int)
         parser.add_argument(
@@ -530,9 +525,6 @@ class _InteractiveDriveApplicationBase(IApplication):
             prompt_override=args.prompt,
             chunk=chunk,
             raster=raster,
-            world_model_profile=WorldModelProfileConfig(
-                enabled=args.world_model_profile
-            ),
             world_model_device=args.world_model_device,
             world_model_seed=args.world_model_seed,
             world_model_debug_condition_frame_dir=(
@@ -572,7 +564,6 @@ def _build_backend(
         )
     resolved_pipeline_config = derive_config(
         pipeline_config,
-        enable_sync_and_profile=config.world_model_profile.enabled,
         diffusion_model=dict(
             seed=(42 if config.world_model_seed is None else config.world_model_seed)
         ),

--- a/apps/interactive_drive/interactive_drive/tests/test_application.py
+++ b/apps/interactive_drive/interactive_drive/tests/test_application.py
@@ -177,6 +177,7 @@ def test_model_step_publishes_bev_channel_and_complete_elapsed_time(
         initial_chunk_frames=2,
         chunk_frames=2,
         render_first_chunk=lambda _: chunk,
+        finalize=lambda: {},
     )
     config = SimpleNamespace(
         total_blocks=2,

--- a/apps/omnidreams_game_engine/omnidreams_game_engine/engine_settings.py
+++ b/apps/omnidreams_game_engine/omnidreams_game_engine/engine_settings.py
@@ -58,7 +58,7 @@ class WorldModelLaunchSettings:
     """Optional override for transformer compilation."""
 
     profile_pipeline: bool = False
-    """Whether to collect synchronized pipeline stage timings."""
+    """Whether to collect model-loop timings and realtime-budget warnings."""
 
 
 @dataclass(frozen=True)

--- a/apps/omnidreams_game_engine/omnidreams_game_engine/model.py
+++ b/apps/omnidreams_game_engine/omnidreams_game_engine/model.py
@@ -62,6 +62,7 @@ class WorldModelStep:
     video_bvtchw: Tensor
     engine: EngineStep
     metrics: Mapping[str, float | int]
+    finalize_metrics: Mapping[str, float | int] | None
     _trace: _WorldModelStepTrace | None = None
 
 
@@ -148,7 +149,7 @@ class WorldModelRollout:
             generate_returned_ns = (
                 time.monotonic_ns() if self._trace_chunk_lifecycle else None
             )
-            metrics = self.pipeline.finalize(
+            finalize_metrics = self.pipeline.finalize(
                 autoregressive_index=autoregressive_index,
                 cache=self.cache,
             )
@@ -176,7 +177,7 @@ class WorldModelRollout:
             )
         if int(video.shape[2]) != expected:
             raise ValueError("Generated video does not align with the engine step")
-        step_metrics = dict(metrics or {})
+        step_metrics = dict(finalize_metrics or {})
         step_metrics.update(engine_step.metrics)
         step_metrics.update(
             {
@@ -215,6 +216,7 @@ class WorldModelRollout:
             video_bvtchw=video.detach(),
             engine=engine_step,
             metrics=step_metrics,
+            finalize_metrics=finalize_metrics,
             _trace=trace,
         )
 

--- a/apps/omnidreams_game_engine/omnidreams_game_engine/model.py
+++ b/apps/omnidreams_game_engine/omnidreams_game_engine/model.py
@@ -62,7 +62,7 @@ class WorldModelStep:
     video_bvtchw: Tensor
     engine: EngineStep
     metrics: Mapping[str, float | int]
-    finalize_metrics: Mapping[str, float | int] | None
+    finalize_metrics: dict[str, float | int] | None
     _trace: _WorldModelStepTrace | None = None
 
 

--- a/apps/t2v/t2v/session.py
+++ b/apps/t2v/t2v/session.py
@@ -42,7 +42,7 @@ class T2VModelLoop(IModelLoop[T2VModelState]):
         frames = state.pipeline.generate(
             autoregressive_index=step_index, cache=state.cache
         )
-        metrics = state.pipeline.finalize(
+        finalize_metrics = state.pipeline.finalize(
             autoregressive_index=step_index, cache=state.cache
         )
         return [
@@ -51,7 +51,7 @@ class T2VModelLoop(IModelLoop[T2VModelState]):
                 output=frames.detach(),
                 frame_count=int(frames.shape[0]),
                 output_layout=state.session_desc.output_layout,
-                metrics=dict(metrics or {}),
+                metrics=finalize_metrics,
             )
         ]
 

--- a/apps/t2v/t2v/testing.py
+++ b/apps/t2v/t2v/testing.py
@@ -21,10 +21,10 @@ import numpy.typing as npt
 import torch
 
 from flashdreams.api_v2.client_window import IClientWindow
-from flashdreams.api_v2.output_sink import OutputSink
 from flashdreams.runtime_v2.blit_model_output_to_screen_loop import (
     BlitModelOutputToScreenLoop,
 )
+from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
 from flashdreams.runtime_v2.mp4_output_sink import Mp4OutputSink
 from flashdreams.runtime_v2.session_desc import (
     BackpressureMode,
@@ -337,7 +337,7 @@ class _FakeDecoder:
         self.spatial_compression_ratio = spatial_compression_ratio
 
 
-class _FrameInspector(OutputSink):
+class _FrameInspector(MetricsOutputSink):
     """Measure what a run generates, and pass it on to a file when asked to."""
 
     def __init__(self, mp4: Mp4OutputSink | None) -> None:
@@ -364,7 +364,7 @@ class _FrameInspector(OutputSink):
             raise RuntimeError("open() must run before write().")
         frames = result_to_rgb24_frames(result, self._session_desc)
         self.frames_per_step.append(len(frames))
-        self.metrics.append(dict(result.metrics))
+        self.metrics.append(dict(result.metrics or {}))
         self.luminance_sum += float(frames.mean()) * len(frames)
         # The previous step's last frame leads this one, so the change across a
         # step boundary counts like any other.

--- a/apps/t2v/tests/test_cli.py
+++ b/apps/t2v/tests/test_cli.py
@@ -10,6 +10,7 @@ run against the window the arguments chose, and closed.
 
 import argparse
 import json
+import os
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
@@ -390,7 +391,17 @@ def test_a_run_can_record_what_generating_the_clip_cost(
 ) -> None:
     """A clip says nothing about what it took to generate, so a benchmark run
     asks for both and the file it writes is the one the harness reads."""
-    _install(monkeypatch, StubT2VApplication(_stand_in()))
+    application = StubT2VApplication(_stand_in())
+    _install(monkeypatch, application)
+    monkeypatch.setenv("FLASHDREAMS_SYNC_AND_PROFILE", "0")
+
+    def create_profiled_application(slug: str) -> IApplication:
+        del slug
+        assert os.environ["FLASHDREAMS_SYNC_AND_PROFILE"] == "1"
+        return application
+
+    monkeypatch.setattr(cli, "create_application", create_profiled_application)
+
     stats_path = tmp_path / "stats_run.json"
     clip_path = tmp_path / "clip.mp4"
 

--- a/apps/v2v/tests/test_application.py
+++ b/apps/v2v/tests/test_application.py
@@ -57,17 +57,25 @@ class _FakeProcessorSession:
     flushed: bool = False
     """Whether end-of-stream flushing has run."""
 
+    finalize_metrics: dict[str, float] | None = None
+
     def prepare(self) -> None:
         self.prepared = True
 
     def process(self, chunk: VideoChunk) -> list[VideoChunk]:
         self.inputs.append(chunk)
+        self.finalize_metrics = {"total_ms": float(len(self.inputs))}
         output = chunk.tensor.repeat_interleave(2, dim=-2).repeat_interleave(2, dim=-1)
         return [VideoChunk(tensor=output.unsqueeze(0), layout="btchw")]
 
     def flush(self) -> list[VideoChunk]:
         self.flushed = True
         return []
+
+    def pull_finalize_metrics(self) -> dict[str, float] | None:
+        metrics = self.finalize_metrics
+        self.finalize_metrics = None
+        return metrics
 
 
 @dataclass(slots=True)
@@ -214,8 +222,10 @@ def test_model_loop_transforms_cold_and_steady_chunks() -> None:
     assert cold.read_output().shape == (1, 3, 13, 128, 256)
     assert cold.output_layout is VideoTensorLayout.bcthw
     assert cold.frame_count == 13
+    assert cold.metrics == {"total_ms": 1.0}
     assert steady.read_output().shape == (1, 3, 16, 128, 256)
     assert steady.frame_count == 16
+    assert steady.metrics == {"total_ms": 2.0}
     assert model_loop.is_finished()
     assert processor_sessions[0].prepared
     assert processor_sessions[0].flushed

--- a/apps/v2v/v2v.py
+++ b/apps/v2v/v2v.py
@@ -188,10 +188,7 @@ class V2VModelLoop(IModelLoop[V2VModelState]):
                 output=output,
                 frame_count=frame_count,
                 output_layout=state.session_desc.output_layout,
-                metrics={
-                    "input_frames": size,
-                    "output_frames": frame_count,
-                },
+                metrics=state.processor_session.pull_finalize_metrics(),
             )
         ]
 

--- a/configs/deterministic_quality_benchmarks.json
+++ b/configs/deterministic_quality_benchmarks.json
@@ -21,6 +21,7 @@
         "quality-10s"
       ],
       "env": {
+        "FLASHDREAMS_SYNC_AND_PROFILE": "1",
         "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
       },
@@ -80,6 +81,7 @@
         "quality-10s"
       ],
       "env": {
+        "FLASHDREAMS_SYNC_AND_PROFILE": "1",
         "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
       },
@@ -131,6 +133,9 @@
         "performance",
         "review"
       ],
+      "env": {
+        "FLASHDREAMS_SYNC_AND_PROFILE": "1"
+      },
       "command": [
         "uv",
         "run",
@@ -181,6 +186,7 @@
         "review"
       ],
       "env": {
+        "FLASHDREAMS_SYNC_AND_PROFILE": "1",
         "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
       },

--- a/configs/one_minute_demo_benchmarks.json
+++ b/configs/one_minute_demo_benchmarks.json
@@ -18,6 +18,9 @@
         "i2v",
         "one-minute"
       ],
+      "env": {
+        "FLASHDREAMS_SYNC_AND_PROFILE": "1"
+      },
       "command": [
         "uv",
         "run",
@@ -65,6 +68,7 @@
         "one-minute"
       ],
       "env": {
+        "FLASHDREAMS_SYNC_AND_PROFILE": "1",
         "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
       },

--- a/flashdreams/flashdreams/infra/pipeline/base.py
+++ b/flashdreams/flashdreams/infra/pipeline/base.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Generic
 
@@ -77,9 +78,13 @@ class StreamInferencePipelineConfig(InstantiateConfig):
     :class:`StreamingEncoder`; one-shot encoders go on
     ``transformer.context_encoder`` instead."""
 
-    enable_sync_and_profile: bool = False
-    """Record per-stage CUDA events and log timing per AR step. Calls
-    ``torch.cuda.synchronize()`` once per step, which hurts throughput."""
+    @property
+    def enable_sync_and_profile(self) -> bool:
+        """Whether to record synchronized per-stage CUDA timings.
+
+        Enabled process-wide with ``FLASHDREAMS_SYNC_AND_PROFILE=1``
+        """
+        return os.getenv("FLASHDREAMS_SYNC_AND_PROFILE") == "1"
 
 
 @dataclass(kw_only=True)

--- a/flashdreams/flashdreams/infra/postprocess/base.py
+++ b/flashdreams/flashdreams/infra/postprocess/base.py
@@ -135,6 +135,16 @@ class VideoPostProcessorSession(ABC):
     def flush(self) -> list[VideoChunk]:
         """Return any buffered output at end-of-stream."""
 
+    def pull_finalize_metrics(self) -> dict[str, float | int] | None:
+        """Return and clear metrics from the latest finalized model chunk.
+
+        Deprecated:
+            This is an MVP escape hatch for post-processors that wrap model
+            pipelines. Replace it with per-output metrics plumbing in issue
+            #603.
+        """
+        return None
+
 
 class VideoPostProcessor(ABC, Generic[VideoPostProcessorConfigT]):
     """Factory for stateful video post-processing sessions."""

--- a/flashdreams/flashdreams/runtime_v2/README.md
+++ b/flashdreams/flashdreams/runtime_v2/README.md
@@ -117,6 +117,9 @@ presentation-queue depth/publish-wait measurements under the reserved
 `runtime_` metric prefix. UI and window timings are not folded into a later
 model record because they describe a different frame.
 
+`--stats-path` also sets `FLASHDREAMS_SYNC_AND_PROFILE=1` before constructing the
+application, enabling synchronized per-stage pipeline profiling for the run.
+
 ## Starting and stopping a run
 
 `ApplicationRunner.run` calls `init`, `create_session` and `run_session` in

--- a/flashdreams/flashdreams/runtime_v2/application_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/application_runner.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 
 from flashdreams.api_v2.application import IApplication
 from flashdreams.api_v2.client_window import IClientWindow
-from flashdreams.api_v2.output_sink import OutputSink
+from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
 from flashdreams.runtime_v2.session_desc import SessionDesc
 from flashdreams.runtime_v2.session_runner import run_session
 
@@ -27,7 +27,7 @@ class ApplicationRunner:
         application: IApplication,
         client_window: IClientWindow,
         *,
-        metrics_output_sink: OutputSink | None = None,
+        metrics_output_sink: MetricsOutputSink | None = None,
     ) -> None:
         """
         Args:
@@ -125,7 +125,7 @@ def _close_client_window(client_window: IClientWindow) -> None:
         _LOGGER.exception("The client window failed to close while stopping.")
 
 
-def _close_output_sink(output_sink: OutputSink) -> None:
+def _close_output_sink(output_sink: MetricsOutputSink) -> None:
     """Close a metrics sink after a run that never reached it."""
     try:
         output_sink.close()

--- a/flashdreams/flashdreams/runtime_v2/cli.py
+++ b/flashdreams/flashdreams/runtime_v2/cli.py
@@ -15,6 +15,7 @@ argument that only one of them uses.
 
 import argparse
 import math
+import os
 import sys
 from collections.abc import Sequence
 from dataclasses import replace
@@ -59,6 +60,8 @@ def entrypoint(argv: Sequence[str] | None = None) -> None:
         not math.isfinite(parsed.timeout) or parsed.timeout <= 0
     ):
         parser.error("--timeout must be a finite number greater than zero.")
+    if parsed.stats_path is not None:
+        os.environ["FLASHDREAMS_SYNC_AND_PROFILE"] = "1"
 
     mode = client_window_mode(parsed.mode)
     # Asking an application what it takes is answered by the application alone,

--- a/flashdreams/flashdreams/runtime_v2/client_window_factory.py
+++ b/flashdreams/flashdreams/runtime_v2/client_window_factory.py
@@ -153,8 +153,9 @@ def add_client_window_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help=(
             "JSON file to record model-step measurements in, for a benchmark "
-            "to read. Nothing is measured unless this is asked for. If a run "
-            "replaces its session, the file contains the final session."
+            "to read. This also enables synchronized per-stage pipeline "
+            "profiling. If a run replaces its session, the file contains the "
+            "final session."
         ),
     )
     for mode in _MODES:

--- a/flashdreams/flashdreams/runtime_v2/metrics_output_sink.py
+++ b/flashdreams/flashdreams/runtime_v2/metrics_output_sink.py
@@ -39,6 +39,7 @@ class MetricsOutputSink(OutputSink):
         self._steps: list[dict[str, Any]] = []
         self._samples: list[dict[str, Any]] = []
         self._written = False
+        self._step_result_index = 0
 
     def open(self, session_desc: SessionDesc) -> None:
         """Start a new benchmark record."""
@@ -46,20 +47,29 @@ class MetricsOutputSink(OutputSink):
         self._steps = []
         self._samples = []
         self._written = False
+        self._step_result_index = 0
+
+    def set_step_result_index(self, index: int) -> None:
+        """Set the position of the next result in its model-step result list."""
+        self._step_result_index = index
 
     def write(self, result: StepResult) -> None:
         """Record one model result's frame count and metrics.
+
+        Args:
+            result: One channel returned by the model loop.
 
         Raises:
             RuntimeError: Called before :meth:`open`.
         """
         if self._session_desc is None:
             raise RuntimeError("MetricsOutputSink.open() must run before write().")
-        samples = _samples_from(result)
+        samples = _samples_from(result, self._step_result_index)
         self._samples.extend(samples)
         self._steps.append(
             {
                 "step_index": result.step_index,
+                "result_index": self._step_result_index,
                 "frame_count": result.frame_count,
                 "sample_count": len(samples),
             }
@@ -90,10 +100,10 @@ class MetricsOutputSink(OutputSink):
         )
 
 
-def _samples_from(result: StepResult) -> list[dict[str, Any]]:
+def _samples_from(result: StepResult, index: int) -> list[dict[str, Any]]:
     """Return the finite numeric metrics from one result."""
     samples: list[dict[str, Any]] = []
-    for name, value in result.metrics.items():
+    for name, value in (result.metrics or {}).items():
         if not name.strip():
             continue
         if isinstance(value, bool) or not isinstance(value, int | float):
@@ -108,6 +118,7 @@ def _samples_from(result: StepResult) -> list[dict[str, Any]]:
                 "unit": unit,
                 "category": category,
                 "step_index": result.step_index,
+                "result_index": index,
                 "metadata": {"frame_count": result.frame_count},
             }
         )

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.loop import IModelLoop, IUILoop, ModelInferenceState
-from flashdreams.api_v2.output_sink import OutputSink
 from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2.event_buffer import EventBuffer
 from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
@@ -48,7 +47,7 @@ def run_session(
     session: ISession,
     window: IClientWindow,
     *,
-    metrics_output_sink: OutputSink | None = None,
+    metrics_output_sink: MetricsOutputSink | None = None,
     steps: int | None = None,
     timeout_seconds: float | None = None,
 ) -> SessionDesc | None:
@@ -170,9 +169,9 @@ def run_session(
             )
             if metrics_output_sink is not None:
                 for index, result in enumerate(results):
-                    if isinstance(metrics_output_sink, MetricsOutputSink):
-                        metrics_output_sink.set_step_result_index(index)
+                    metrics_output_sink.set_step_result_index(index)
                     metrics_output_sink.write(result)
+
         def tick_ui() -> None:
             # ensure that the HIGH PRIORITY presentation context is default for UI loop
             with presentation_manager.presentation_context():

--- a/flashdreams/flashdreams/runtime_v2/session_runner.py
+++ b/flashdreams/flashdreams/runtime_v2/session_runner.py
@@ -15,6 +15,7 @@ from flashdreams.api_v2.loop import IModelLoop, IUILoop, ModelInferenceState
 from flashdreams.api_v2.output_sink import OutputSink
 from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2.event_buffer import EventBuffer
+from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
 from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 
@@ -168,9 +169,10 @@ def run_session(
                 step_elapsed_s=step_elapsed_s,
             )
             if metrics_output_sink is not None:
-                for result in results:
+                for index, result in enumerate(results):
+                    if isinstance(metrics_output_sink, MetricsOutputSink):
+                        metrics_output_sink.set_step_result_index(index)
                     metrics_output_sink.write(result)
-
         def tick_ui() -> None:
             # ensure that the HIGH PRIORITY presentation context is default for UI loop
             with presentation_manager.presentation_context():

--- a/flashdreams/flashdreams/runtime_v2/step_result.py
+++ b/flashdreams/flashdreams/runtime_v2/step_result.py
@@ -31,9 +31,8 @@ class StepResult:
     output_layout: VideoTensorLayout
     """Layout of ``output``."""
 
-    metrics: dict[str, float | int] = field(default_factory=dict)
-    """Measurements for this step, such as timings, keyed by name. Recorded only
-    when a run asked for a metrics sink, and only from a model loop."""
+    metrics: dict[str, float | int] | None = field(default_factory=dict)
+    """Measurements for this step, or ``None`` when profiling is disabled."""
 
     _output: Tensor = field(init=False, repr=False)
     """Generated frames, laid out as ``output_layout`` says. Floating-point

--- a/flashdreams/test_v2/test_application_runner.py
+++ b/flashdreams/test_v2/test_application_runner.py
@@ -16,6 +16,7 @@ from flashdreams.api_v2.client_window import IClientWindow
 from flashdreams.api_v2.loop import IModelLoop, IUILoop
 from flashdreams.api_v2.session import ISession
 from flashdreams.runtime_v2.application_runner import ApplicationRunner
+from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
 from flashdreams.runtime_v2.session_desc import PresentationMode, SessionDesc
 from flashdreams.runtime_v2.step_result import StepResult
 from flashdreams.runtime_v2.user_input_event import CloseUserInputEvent
@@ -203,7 +204,7 @@ class _SecondSessionClosingWindow(_Window):
         self._sessions_opened += 1
 
 
-class _MetricsSink:
+class _MetricsSink(MetricsOutputSink):
     """Record model results delivered independently of the client window."""
 
     def __init__(self, calls: list[str]) -> None:

--- a/flashdreams/test_v2/test_metrics_output_sink.py
+++ b/flashdreams/test_v2/test_metrics_output_sink.py
@@ -5,12 +5,11 @@
 
 What matters is that a benchmark can read what is written: the file says what
 artifact it is, every step is accounted for, and a measurement means the same
-thing whichever model reported it. What the reader expects of the file is
+thing whenever the runtime reports it. What the reader expects of the file is
 tested against ``tools.benchmarks.metrics`` itself.
 """
 
 import json
-import math
 from pathlib import Path
 from typing import Any
 
@@ -85,22 +84,6 @@ def test_a_run_is_recorded_as_the_artifact_the_benchmark_looks_for(
     assert payload["schema_version"] == 1
 
 
-def test_every_step_is_recorded_with_the_video_it_generated(tmp_path: Path) -> None:
-    """A report divides one by the other to say how fast a model generated video."""
-    payload = _write_run(
-        tmp_path / "stats_run.json",
-        [
-            _result(0, {"total_ms": 30.0}, frames=9),
-            _result(1, {"total_ms": 20.0}, frames=12),
-        ],
-    )
-
-    assert payload["steps"] == [
-        {"step_index": 0, "frame_count": 9, "sample_count": 1},
-        {"step_index": 1, "frame_count": 12, "sample_count": 1},
-    ]
-
-
 def test_what_was_being_generated_is_recorded_alongside_the_timings(
     tmp_path: Path,
 ) -> None:
@@ -132,6 +115,7 @@ def test_a_measurement_in_milliseconds_is_recorded_in_seconds(tmp_path: Path) ->
             "unit": "s",
             "category": "timing",
             "step_index": 0,
+            "result_index": 0,
             "metadata": {"frame_count": _FRAMES},
         }
     ]
@@ -159,26 +143,6 @@ def test_a_measurement_is_labelled_with_what_its_name_says_it_is(
         category,
     )
 
-
-@pytest.mark.parametrize(
-    "metrics",
-    [
-        {"total_ms": math.nan},
-        {"finished": True},
-        {"   ": 1.0},
-    ],
-)
-def test_a_measurement_a_report_could_not_average_is_left_out(
-    tmp_path: Path, metrics: dict[str, float | int]
-) -> None:
-    """A pipeline reporting one of these is reporting something other than a
-    measurement, and a report reading it would carry the nonsense forward."""
-    payload = _write_run(tmp_path / "stats_run.json", [_result(0, metrics)])
-
-    assert payload["samples"] == []
-    assert payload["steps"] == [
-        {"step_index": 0, "frame_count": _FRAMES, "sample_count": 0}
-    ]
 
 
 ## Writing the file

--- a/flashdreams/test_v2/test_metrics_output_sink.py
+++ b/flashdreams/test_v2/test_metrics_output_sink.py
@@ -144,7 +144,6 @@ def test_a_measurement_is_labelled_with_what_its_name_says_it_is(
     )
 
 
-
 ## Writing the file
 
 

--- a/flashdreams/test_v2/test_mp4_client_window.py
+++ b/flashdreams/test_v2/test_mp4_client_window.py
@@ -77,7 +77,6 @@ class FakeSession(ISession):
             ),
             frame_count=_FRAMES_PER_STEP,
             output_layout=self._session_desc.output_layout,
-            metrics={"total_ms": 1.5},
         )
 
     def reset(self) -> None:

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -20,7 +20,6 @@ from flashdreams.api_v2.loop import (
     IModelLoop,
     IUILoop,
     ModelInferenceState,
-    UILoopRequests,
     invoke_async,
 )
 from flashdreams.api_v2.session import ISession
@@ -418,7 +417,6 @@ class FakeSession(ISession):
             output=frame.unsqueeze(0).unsqueeze(2),
             frame_count=1,
             output_layout=self.session_desc.output_layout,
-            metrics={"ui_ms": 0.25},
         )
 
     def is_finished(self) -> bool:
@@ -989,7 +987,6 @@ def test_default_ui_presents_each_frame_from_a_model_chunk() -> None:
                 output=torch.arange(36, dtype=torch.float32).reshape(1, 3, 12, 1, 1),
                 frame_count=12,
                 output_layout=self.session_desc.output_layout,
-                metrics={"total_ms": 1.5},
             )
 
     class RecordingMetricsSink:
@@ -1018,9 +1015,9 @@ def test_default_ui_presents_each_frame_from_a_model_chunk() -> None:
     assert [
         result.read_output()[0, 0, 0, 0, 0].item() for result in window.results
     ] == list(range(12))
-    assert [result.metrics for result in window.results] == [{"ui_ms": 0.25}] * 12
+    assert [result.metrics for result in window.results] == [{}] * 12
     assert len(metrics.results) == 1
-    assert metrics.results[0].metrics == {"total_ms": 1.5}
+    assert metrics.results[0].metrics == {}
 
 
 def test_default_ui_does_not_redraw_an_unchanged_model_frame() -> None:

--- a/flashdreams/test_v2/test_session_runner.py
+++ b/flashdreams/test_v2/test_session_runner.py
@@ -28,6 +28,7 @@ from flashdreams.runtime_v2.blit_model_output_to_screen_loop import (
     BlitModelOutputToScreenLoop,
 )
 from flashdreams.runtime_v2.event_buffer import EventBuffer
+from flashdreams.runtime_v2.metrics_output_sink import MetricsOutputSink
 from flashdreams.runtime_v2.presentation_manager import (
     _PRESENTATION_DRAIN_MARGIN,
     PresentationManager,
@@ -989,7 +990,7 @@ def test_default_ui_presents_each_frame_from_a_model_chunk() -> None:
                 output_layout=self.session_desc.output_layout,
             )
 
-    class RecordingMetricsSink:
+    class RecordingMetricsSink(MetricsOutputSink):
         def __init__(self) -> None:
             self.results: list[StepResult] = []
 

--- a/flashdreams/tools/benchmarks/README.md
+++ b/flashdreams/tools/benchmarks/README.md
@@ -147,9 +147,10 @@ logs filling the terminal.
 
 Copy the scenarios closest to the new model's behaviour, point `--project` and
 the application slug at its integration, and keep the prompt and the seed: a
-comparison where each model gets its own prompt compares prompts. Keep
-`--stats-path` too, which is what records the runtime metrics the report reads.
-Tag a scenario `one-minute` or `pai-bench` for PAI-Bench to score it.
+comparison where each model gets its own prompt compares prompts. Keep the
+`--stats-path` too: it enables pipeline timings and records the metrics the
+report reads. Tag a scenario `one-minute` or `pai-bench` for PAI-Bench to score
+it.
 
 A model conditioned on more than a prompt cannot take the shared one, since the
 prompt belongs with its first frame. Fix that conditioning instead, the way

--- a/integrations_v2/causal_forcing/config.py
+++ b/integrations_v2/causal_forcing/config.py
@@ -39,8 +39,6 @@ CHECKPOINT_PATH_FRAMEWISE = "https://huggingface.co/zhuhz22/Causal-Forcing/blob/
 # Causal-Forcing chunkwise Wan 2.1 1.3B T2V pipeline.
 PIPELINE_WAN21_T2V_1PT3B_CHUNKWISE = WanInferencePipelineConfig(
     name="causal-forcing-wan2.1-t2v-1.3b-chunkwise",
-    # Warning: This will slow down the e2e latency.
-    enable_sync_and_profile=True,
     encoder=None,
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(

--- a/integrations_v2/cosmos_predict2/config.py
+++ b/integrations_v2/cosmos_predict2/config.py
@@ -37,7 +37,6 @@ CHECKPOINT_PATH_POST_TRAINED_2B = (
 
 PIPELINE_COSMOS2_T2V_2B_720P = CosmosInferencePipelineConfig(
     name="cosmos2-t2v-2b-720p",
-    enable_sync_and_profile=True,
     encoder=None,
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(
@@ -65,7 +64,6 @@ PIPELINE_COSMOS2_T2V_2B_720P = CosmosInferencePipelineConfig(
 )
 PIPELINE_COSMOS2_I2V_2B_720P = CosmosInferencePipelineConfig(
     name="cosmos2-i2v-2b-720p",
-    enable_sync_and_profile=True,
     encoder=None,
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(

--- a/integrations_v2/fastvideo_causal_wan22/config.py
+++ b/integrations_v2/fastvideo_causal_wan22/config.py
@@ -58,8 +58,6 @@ def _wan22_branch(checkpoint_path: str) -> Wan21TransformerConfig:
 # Official FastVideo CausalWan 2.2 14B MoE T2V pipeline config.
 PIPELINE_WAN22_T2V_14B = WanInferencePipelineConfig(
     name="fastvideo-causal-wan2.2-t2v-14b",
-    # Warning: This will slow down the e2e latency.
-    enable_sync_and_profile=True,
     encoder=None,
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(

--- a/integrations_v2/flashvsr/README.md
+++ b/integrations_v2/flashvsr/README.md
@@ -113,9 +113,7 @@ automatically by the model adapter.
   the target resolution.
 - `color_corrector_implementation`: `"cuda"` (default; AdaIN-only
   hand-rolled kernel) or `"torch"` (pure-torch wavelet + AdaIN reference).
-- `enable_sync_and_profile`: per-AR-step CUDA-event profiling. Adds one
-  `cuda.synchronize()` per step.
-
+- Set `FLASHDREAMS_SYNC_AND_PROFILE=1` for per-AR-step CUDA-event profiling.
 ## Files
 
 | Path | Purpose |

--- a/integrations_v2/flashvsr/config.py
+++ b/integrations_v2/flashvsr/config.py
@@ -147,7 +147,6 @@ def build_flashvsr_v1_1(
     compile_network: bool = False,
     use_cuda_graph: bool = False,
     color_corrector_implementation: ColorCorrectorImplementation = "cuda",
-    enable_sync_and_profile: bool = False,
     dtype: torch.dtype = torch.bfloat16,
     seed: int = 0,
     name: str = "flashvsr-v1.1",
@@ -179,8 +178,6 @@ def build_flashvsr_v1_1(
             per-resolution once proven stable.
         color_corrector_implementation: ``"cuda"`` (hand-rolled AdaIN)
             or ``"torch"`` (wavelet + AdaIN reference).
-        enable_sync_and_profile: Per-AR-step CUDA-event profiling; adds
-            one ``cuda.synchronize()`` per step.
         dtype: Compute dtype. ``bfloat16`` matches FlashVSR-tiny weights.
         seed: Diffusion-model initial-noise RNG seed.
         name: Slug for the returned pipeline. Override per application preset.
@@ -208,7 +205,6 @@ def build_flashvsr_v1_1(
     return FlashVSRPipelineConfig(
         name=name,
         prompt_path=checkpoint_path["prompt"],
-        enable_sync_and_profile=enable_sync_and_profile,
         encoder=FlashVSREncoderConfig(
             input_H=input_H,
             input_W=input_W,
@@ -265,7 +261,6 @@ def _build_sparse_ratio_variant(sparse_ratio: float) -> FlashVSRPipelineConfig:
         sparse_ratio=sparse_ratio,
         compile_network=True,
         use_cuda_graph=True,
-        enable_sync_and_profile=True,
     )
 
 
@@ -280,5 +275,4 @@ PIPELINE_FLASHVSR_V1_1_FULL_ATTN = build_flashvsr_v1_1(
     attention_mode="full",
     compile_network=True,
     use_cuda_graph=True,
-    enable_sync_and_profile=True,
 )

--- a/integrations_v2/flashvsr/impl/pipeline.py
+++ b/integrations_v2/flashvsr/impl/pipeline.py
@@ -287,7 +287,7 @@ class FlashVSRPipeline(
             ``[-1, 1]``. ``T_out`` matches the unpadded input frame count.
 
         Note:
-            With ``enable_sync_and_profile=True``, this method contributes
+            With ``FLASHDREAMS_SYNC_AND_PROFILE=1``, this method contributes
             ``pad``, ``bicubic``, ``projector``, ``dit_concat``, ``denoise``,
             ``decoder``, and ``color`` events. The inherited
             :meth:`StreamInferencePipeline.finalize` appends ``finalize`` and

--- a/integrations_v2/flashvsr/impl/postprocess.py
+++ b/integrations_v2/flashvsr/impl/postprocess.py
@@ -87,9 +87,6 @@ class FlashVSRPostProcessorConfig(VideoPostProcessorConfig):
     color_corrector_implementation: ColorCorrectorImplementation = "cuda"
     """FlashVSR decoder color-correction backend."""
 
-    enable_sync_and_profile: bool = False
-    """Record FlashVSR CUDA-event timing. Adds synchronizations."""
-
     dtype: _DTypeName = "bfloat16"
     """FlashVSR compute dtype."""
 
@@ -150,6 +147,9 @@ class _FlashVSRPostProcessorSession(VideoPostProcessorSession):
         self._buffer: Tensor | None = None
         self._metadata_spans: list[tuple[int, dict[str, Any]]] = []
         self._ar_idx = 0
+        # ponytail: This deprecated MVP slot retains only the newest finalize
+        # result; replace it with per-output metric plumbing in issue #603.
+        self._finalize_metrics: dict[str, float | int] | None = None
 
     @torch.no_grad()
     def prepare(self) -> None:
@@ -242,6 +242,12 @@ class _FlashVSRPostProcessorSession(VideoPostProcessorSession):
         metadata = self._consume_metadata(tail_frames, source="flashvsr_tail")
         return [_bcthw_chunk(output, metadata=metadata)]
 
+    def pull_finalize_metrics(self) -> dict[str, float | int] | None:
+        """Return and clear the latest pipeline finalize metrics."""
+        metrics = self._finalize_metrics
+        self._finalize_metrics = None
+        return metrics
+
     def _chunk_to_bcthw(self, chunk: VideoChunk) -> Tensor:
         canonical = to_bvtchw(chunk.tensor, layout=chunk.layout)
         batch, views, _, channels, _, _ = canonical.shape
@@ -286,7 +292,6 @@ class _FlashVSRPostProcessorSession(VideoPostProcessorSession):
             compile_network=self._config.compile_network,
             use_cuda_graph=self._config.use_cuda_graph,
             color_corrector_implementation=self._config.color_corrector_implementation,
-            enable_sync_and_profile=self._config.enable_sync_and_profile,
             dtype=dtype,
             attention_mode=self._config.attention_mode,
             name="flashvsr-postprocess-v1.1",
@@ -303,6 +308,7 @@ class _FlashVSRPostProcessorSession(VideoPostProcessorSession):
         self._buffer = None
         self._metadata_spans.clear()
         self._ar_idx = 0
+        self._finalize_metrics = None
 
     def _append_to_buffer(self, bcthw: Tensor, *, metadata: dict[str, Any]) -> None:
         assert self._pipeline is not None
@@ -342,12 +348,15 @@ class _FlashVSRPostProcessorSession(VideoPostProcessorSession):
     def _run_flashvsr_chunk(self, clip: Tensor) -> Tensor:
         assert self._pipeline is not None
         assert self._cache is not None
+        self._finalize_metrics = None
         output = self._pipeline.generate(
             autoregressive_index=self._ar_idx,
             cache=self._cache,
             input=clip,
         )
-        self._pipeline.finalize(autoregressive_index=self._ar_idx, cache=self._cache)
+        self._finalize_metrics = self._pipeline.finalize(
+            autoregressive_index=self._ar_idx, cache=self._cache
+        )
         self._ar_idx += 1
         return output
 

--- a/integrations_v2/flashvsr/tests/parity_check/changes.patch
+++ b/integrations_v2/flashvsr/tests/parity_check/changes.patch
@@ -11,7 +11,7 @@ new file mode 100644
 +per-chunk forwards (projector / DiT / decoder / color) so we can dump a
 +per-chunk JSON whose schema matches what
 +``flashdreams.flashvsr.FlashVSRPipeline.finalize`` writes when
-+``enable_sync_and_profile=True``.
++``FLASHDREAMS_SYNC_AND_PROFILE=1``.
 +
 +We do NOT replicate the upstream chunk loop; we monkey-patch the four
 +stage forwards on the live pipeline / module and call ``pipe(...)`` once.

--- a/integrations_v2/flashvsr/tests/test_postprocess.py
+++ b/integrations_v2/flashvsr/tests/test_postprocess.py
@@ -82,8 +82,12 @@ class _FakeFlashVSRPipeline:
         self.cache_ids.append(id(cache))
         return input.repeat_interleave(2, dim=-2).repeat_interleave(2, dim=-1)
 
-    def finalize(self, autoregressive_index: int, cache: SimpleNamespace) -> None:
+    def finalize(
+        self, autoregressive_index: int, cache: SimpleNamespace
+    ) -> dict[str, float]:
+        del cache
         self.finalized.append(autoregressive_index)
+        return {"total_ms": float(autoregressive_index + 1)}
 
 
 def _install_fake_builder(
@@ -229,6 +233,7 @@ def test_flashvsr_postprocess_does_not_finalize_when_generate_raises(
     pipeline = created[0]
     assert pipeline.finalized == []
     assert len(pipeline.inputs) == 1
+    assert session.pull_finalize_metrics() is None
 
 
 def test_flashvsr_postprocess_rejects_multi_view_inputs(
@@ -267,6 +272,7 @@ def test_flashvsr_prepare_warms_both_shapes_and_resets_state(
     session = config.setup().start(VideoSpec(height=4, width=4, fps=24))
 
     session.prepare()
+    assert session.pull_finalize_metrics() is None
     output = session.process(VideoChunk(tensor=torch.ones((5, 3, 4, 4)), layout="tchw"))
 
     assert len(created) == 1

--- a/integrations_v2/hy_worldplay/config.py
+++ b/integrations_v2/hy_worldplay/config.py
@@ -51,7 +51,6 @@ assert isinstance(_BASE_NETWORK, WanDiTNetworkConfig)
 
 PIPELINE_HY_WORLDPLAY_WAN_I2V_5B = HyWorldPlayPipelineConfig(
     name="hy-worldplay-wan-i2v-5b",
-    enable_sync_and_profile=PIPELINE_WAN22_TI2V_5B.enable_sync_and_profile,
     text_encoder=copy.deepcopy(PIPELINE_WAN22_TI2V_5B.text_encoder),
     image_encoder=copy.deepcopy(PIPELINE_WAN22_TI2V_5B.image_encoder),
     encoder=HyWorldPlayWanCtrlEncoderConfig(

--- a/integrations_v2/hy_worldplay/tests/parity_check/bench_summary.py
+++ b/integrations_v2/hy_worldplay/tests/parity_check/bench_summary.py
@@ -209,7 +209,7 @@ def _render_report(
             "finalize / total_ms / mem_*_gib via flashdreams's "
             "``EventProfiler``. Native goes through the built-in "
             "``StreamInferencePipeline`` profiler "
-            "(``enable_sync_and_profile=True``); vendor uses the "
+            "(``FLASHDREAMS_SYNC_AND_PROFILE=1``); vendor uses the "
             "monkey-patched ``WanPipeline`` wrapper in "
             "``vendor_profile_patch.py`` (no ``encode`` stage on vendor "
             "since upstream's chunk loop excludes the one-time first-frame "

--- a/integrations_v2/lingbot/apps/cam2v/adapter.py
+++ b/integrations_v2/lingbot/apps/cam2v/adapter.py
@@ -24,7 +24,6 @@ from lingbot.impl.conditioning import resolve_lingbot_conditioning
 LINGBOT_CAM2V_DEFAULTS = Cam2VApplicationDefaults(
     pipeline_config=derive_config(
         PIPELINE_LINGBOT_WORLD_FAST_TAEHV_WINDOW15_SINK3,
-        enable_sync_and_profile=False,
     ),
     input_resolver=resolve_lingbot_conditioning,
     total_blocks=20,
@@ -54,9 +53,7 @@ class LingbotCam2VApplication(Cam2VApplication):
         if pipeline_config is not None:
             defaults = dataclasses.replace(
                 defaults,
-                pipeline_config=derive_config(
-                    pipeline_config, enable_sync_and_profile=False
-                ),
+                pipeline_config=derive_config(pipeline_config),
             )
         super().__init__(defaults=defaults)
 

--- a/integrations_v2/lingbot/config.py
+++ b/integrations_v2/lingbot/config.py
@@ -56,7 +56,6 @@ CHECKPOINT_PATH = LINGBOT_WORLD_V1_CHECKPOINT_PATH
 # Official LingBot-World-Fast pipeline config.
 PIPELINE_LINGBOT_WORLD_FAST = LingbotWorldInferencePipelineConfig(
     name="lingbot-world-fast",
-    enable_sync_and_profile=True,
     encoder=I2VCamCtrlEncoderConfig(
         i2v=LingbotI2VCtrlEncoderConfig(
             encoder=WanVAEEncoderConfig(),

--- a/integrations_v2/omnidreams/benchmarks/test_pipeline.py
+++ b/integrations_v2/omnidreams/benchmarks/test_pipeline.py
@@ -111,7 +111,6 @@ def _run_full_pipeline_benchmark(
         text_encoder=None,
         image_encoder=None,
         synthetic_text_max_length=_TEXT_TOKENS,
-        enable_sync_and_profile=False,
         diffusion_model={
             "seed": _SEED,
             "transformer": {

--- a/integrations_v2/omnidreams/config.py
+++ b/integrations_v2/omnidreams/config.py
@@ -51,7 +51,6 @@ OMNIDREAMS_PIPELINE_CONFIG = OmnidreamsPipelineConfig(
         use_compile=False,
         use_cuda_graph=True,
     ),
-    enable_sync_and_profile=True,
     encoder=WanVAEEncoderConfig(
         checkpoint_path=AVAILABLE_WAN_VAE_CHECKPOINT_PATHS["lightvae"],
         use_compile=False,

--- a/integrations_v2/self_forcing/config.py
+++ b/integrations_v2/self_forcing/config.py
@@ -37,8 +37,6 @@ CHECKPOINT_PATH = "https://huggingface.co/gdhe17/Self-Forcing/blob/main/checkpoi
 # Official Self-Forcing Wan 2.1 1.3B T2V pipeline config.
 PIPELINE_WAN21_T2V_1PT3B = WanInferencePipelineConfig(
     name="self-forcing-wan2.1-t2v-1.3b",
-    # Warning: This will slow down the e2e latency.
-    enable_sync_and_profile=True,
     encoder=None,
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(

--- a/integrations_v2/wan21/config.py
+++ b/integrations_v2/wan21/config.py
@@ -43,7 +43,6 @@ CHECKPOINT_PATH_I2V_14B_480P = (
 
 PIPELINE_WAN21_T2V_1PT3B_480P = WanInferencePipelineConfig(
     name="wan21-t2v-1.3b-480p",
-    enable_sync_and_profile=True,
     encoder=None,
     decoder=WanVAEDecoderConfig(),
     diffusion_model=DiffusionModelConfig(
@@ -65,7 +64,6 @@ PIPELINE_WAN21_T2V_1PT3B_480P = WanInferencePipelineConfig(
 )
 PIPELINE_WAN21_I2V_14B_480P = WanInferencePipelineConfig(
     name="wan21-i2v-14b-480p",
-    enable_sync_and_profile=True,
     encoder=WanI2VCtrlEncoderConfig(
         encoder=WanVAEEncoderConfig(),
     ),

--- a/integrations_v2/wan22/config.py
+++ b/integrations_v2/wan22/config.py
@@ -61,7 +61,6 @@ WAN22_TI2V_5B_DIT_DIFFUSERS_PATH = (
 
 PIPELINE_WAN22_TI2V_5B = WanInferencePipelineConfig(
     name="wan22-ti2v-5b",
-    enable_sync_and_profile=True,
     # Streaming I2V control encoder over the 5B VAE: AR step 0 encodes the
     # first frame into latent 0 with a one-hot stamp mask; later steps emit
     # a zero mask so the in-network ``stamp_image_latent`` blend is identity.

--- a/integrations_v2/waypoint/tests/test_action2v_app.py
+++ b/integrations_v2/waypoint/tests/test_action2v_app.py
@@ -357,8 +357,6 @@ def test_live_session_emits_seed_then_exactly_four_frames_per_action() -> None:
     assert first.metrics == {
         "diffuse_ms": 1.25,
         "finalize_ms": 0.25,
-        "autoregressive_index": 1,
-        "generated_frames": 4,
     }
     assert not loop.is_finished()
 


### PR DESCRIPTION
This is not a long term solution, refer to https://github.com/NVIDIA/flashdreams/issues/603

Changes:
- unify all metric outputs to go from pipeline.finalize(...) to a StepResult (for returning)
- use env-var to control if we are SYNC mode with StreamInferencePipeline's. Remove all hard-coded sync=true logic for pipeline-configs
- add deprecated backdoor to fetch metrics json from post-process pipeline